### PR TITLE
Improve backend performance and fix profile cache

### DIFF
--- a/packages/backend/controllers/profileController.js
+++ b/packages/backend/controllers/profileController.js
@@ -81,8 +81,8 @@ class ProfileController {
       let profile = this.getCachedProfile(oxyUserId, 'primary');
       
       if (!profile) {
-        // Try to find existing primary profile with minimal fields for faster query
-        profile = await Profile.findPrimaryByOxyUserId(oxyUserId, 'oxyUserId profileType isPrimary isActive createdAt updatedAt');
+        // Try to find existing primary profile
+        profile = await Profile.findPrimaryByOxyUserId(oxyUserId);
         
         if (!profile) {
           // Create a new personal profile as primary
@@ -119,9 +119,9 @@ class ProfileController {
           // Fetch the complete profile after creation
           profile = await Profile.findById(newProfile._id);
         } else {
-          // If profile exists, fetch complete data only if needed
-          const needsFullData = req.query.full === 'true' || req.query.details === 'true';
-          if (needsFullData) {
+          // Always return full profile data unless explicitly requesting minimal
+          const minimal = req.query.minimal === 'true';
+          if (!minimal) {
             profile = await Profile.findById(profile._id);
           }
         }

--- a/packages/backend/models/schemas/PropertySchema.js
+++ b/packages/backend/models/schemas/PropertySchema.js
@@ -284,6 +284,14 @@ propertySchema.index({ 'rent.amount': 1 });
 propertySchema.index({ bedrooms: 1, bathrooms: 1 });
 propertySchema.index({ amenities: 1 });
 propertySchema.index({ createdAt: -1 });
+// Text index for search functionality across multiple fields
+propertySchema.index({
+  title: 'text',
+  description: 'text',
+  'address.city': 'text',
+  'address.state': 'text',
+  'address.street': 'text'
+});
 
 // Virtual for full address
 propertySchema.virtual('fullAddress').get(function() {


### PR DESCRIPTION
## Summary
- add MongoDB text indexes and search for properties
- always load full profile data unless explicitly minimal
- refresh cached profile data after updates to show changes immediately

## Testing
- `npm test` *(fails: Missing script)*
- `(cd packages/backend && npm test)` *(fails: command failed)*

------
https://chatgpt.com/codex/tasks/task_e_6856795a226083288c589840d3ca58b5