### PR TITLE
Fix profile edit initialization

### DIFF
--- a/packages/frontend/app/profile/edit.tsx
+++ b/packages/frontend/app/profile/edit.tsx
@@ -21,6 +21,17 @@ export default function ProfileEditScreen() {
     const [activeSection, setActiveSection] = useState('personal');
     const [isFormInitialized, setIsFormInitialized] = useState(false);
 
+    // Track previous profile to detect changes
+    const prevProfileIdRef = React.useRef<string | null>(null);
+
+    // Reset initialization when a different profile loads
+    useEffect(() => {
+        if (activeProfile?.id && activeProfile.id !== prevProfileIdRef.current) {
+            prevProfileIdRef.current = activeProfile.id;
+            setIsFormInitialized(false);
+        }
+    }, [activeProfile?.id]);
+
     // Get profile type to determine which UI to show
     const profileType = activeProfile?.profileType || 'personal';
 


### PR DESCRIPTION
## Summary
- ensure edit form re-initializes when a different profile loads

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` in `packages/frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d74225908328b7af1efddb78ee21