### PR TITLE
Introduce Redux bottomSheet slice

### DIFF
--- a/packages/frontend/context/BottomSheetContext.tsx
+++ b/packages/frontend/context/BottomSheetContext.tsx
@@ -1,7 +1,12 @@
-import React, { createContext, useState, ReactNode, useRef, useCallback } from 'react';
-import { StyleSheet, ScrollView, View } from 'react-native';
+import React, { createContext, ReactNode, useRef, useCallback, useEffect } from 'react';
+import { StyleSheet } from 'react-native';
 import { BottomSheetModal, BottomSheetView, BottomSheetBackdrop, BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
-import CustomBackground from '@/components/BottomSheet/CustomBackground';
+import { useDispatch, useSelector } from 'react-redux';
+import type { RootState, AppDispatch } from '@/store/store';
+import {
+    openBottomSheet as openBottomSheetAction,
+    setBottomSheetContent as setBottomSheetContentAction,
+} from '@/store/reducers/bottomSheetReducer';
 
 interface BottomSheetContextProps {
     openBottomSheet: (isOpen: boolean) => void;
@@ -16,7 +21,9 @@ export const BottomSheetContext = createContext<BottomSheetContextProps>({
 });
 
 export const BottomSheetProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-    const [bottomSheetContent, setBottomSheetContent] = useState<ReactNode>(null);
+    const dispatch = useDispatch<AppDispatch>();
+    const bottomSheetContent = useSelector((state: RootState) => state.bottomSheet.content);
+    const isOpen = useSelector((state: RootState) => state.bottomSheet.isOpen);
     const bottomSheetModalRef = useRef<BottomSheetModal>(null);
 
     const renderBackdrop = useCallback(
@@ -31,13 +38,21 @@ export const BottomSheetProvider: React.FC<{ children: ReactNode }> = ({ childre
         []
     );
 
-    const openBottomSheet = (isOpen: boolean) => {
+    const openBottomSheet = (open: boolean) => {
+        dispatch(openBottomSheetAction(open));
+    };
+
+    const setBottomSheetContent = (content: ReactNode) => {
+        dispatch(setBottomSheetContentAction(content));
+    };
+
+    useEffect(() => {
         if (isOpen) {
             bottomSheetModalRef.current?.present();
         } else {
             bottomSheetModalRef.current?.dismiss();
         }
-    };
+    }, [isOpen]);
 
     return (
         <BottomSheetContext.Provider value={{ openBottomSheet, setBottomSheetContent, bottomSheetRef: bottomSheetModalRef }}>

--- a/packages/frontend/store/reducers/bottomSheetReducer.ts
+++ b/packages/frontend/store/reducers/bottomSheetReducer.ts
@@ -1,0 +1,29 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import React from 'react';
+
+interface BottomSheetState {
+  isOpen: boolean;
+  content: React.ReactNode | null;
+}
+
+const initialState: BottomSheetState = {
+  isOpen: false,
+  content: null,
+};
+
+const bottomSheetSlice = createSlice({
+  name: 'bottomSheet',
+  initialState,
+  reducers: {
+    openBottomSheet(state, action: PayloadAction<boolean>) {
+      state.isOpen = action.payload;
+    },
+    setBottomSheetContent(state, action: PayloadAction<React.ReactNode | null>) {
+      state.content = action.payload;
+    },
+  },
+});
+
+export const { openBottomSheet, setBottomSheetContent } = bottomSheetSlice.actions;
+
+export default bottomSheetSlice.reducer;

--- a/packages/frontend/store/reducers/profileReducer.ts
+++ b/packages/frontend/store/reducers/profileReducer.ts
@@ -1,0 +1,81 @@
+import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import profileService, { Profile } from '@/services/profileService';
+import { OxyServices } from '@oxyhq/services';
+
+interface ProfileState {
+  primaryProfile: Profile | null;
+  allProfiles: Profile[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+const initialState: ProfileState = {
+  primaryProfile: null,
+  allProfiles: [],
+  isLoading: false,
+  error: null,
+};
+
+export const fetchPrimaryProfile = createAsyncThunk(
+  'profile/fetchPrimaryProfile',
+  async (
+    { oxyServices, activeSessionId }: { oxyServices?: OxyServices; activeSessionId?: string },
+  ) => {
+    const profile = await profileService.getOrCreatePrimaryProfile(oxyServices, activeSessionId);
+    return profile;
+  },
+);
+
+export const fetchUserProfiles = createAsyncThunk(
+  'profile/fetchUserProfiles',
+  async (
+    { oxyServices, activeSessionId }: { oxyServices?: OxyServices; activeSessionId?: string },
+  ) => {
+    const profiles = await profileService.getUserProfiles(oxyServices, activeSessionId);
+    return profiles;
+  },
+);
+
+const profileSlice = createSlice({
+  name: 'profile',
+  initialState,
+  reducers: {
+    setPrimaryProfile(state, action: PayloadAction<Profile | null>) {
+      state.primaryProfile = action.payload;
+    },
+    setAllProfiles(state, action: PayloadAction<Profile[]>) {
+      state.allProfiles = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchPrimaryProfile.pending, (state) => {
+        state.isLoading = true;
+        state.error = null;
+      })
+      .addCase(fetchPrimaryProfile.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.primaryProfile = action.payload;
+      })
+      .addCase(fetchPrimaryProfile.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = action.error.message || 'Failed to fetch primary profile';
+      })
+      .addCase(fetchUserProfiles.pending, (state) => {
+        state.isLoading = true;
+        state.error = null;
+      })
+      .addCase(fetchUserProfiles.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.allProfiles = action.payload;
+      })
+      .addCase(fetchUserProfiles.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = action.error.message || 'Failed to fetch profiles';
+      });
+  },
+});
+
+export const { setPrimaryProfile, setAllProfiles } = profileSlice.actions;
+
+export default profileSlice.reducer;

--- a/packages/frontend/store/store.ts
+++ b/packages/frontend/store/store.ts
@@ -1,10 +1,14 @@
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import trendsReducer from "./reducers/trendsReducer";
 import analyticsReducer from "./reducers/analyticsReducer";
+import profileReducer from "./reducers/profileReducer";
+import bottomSheetReducer from "./reducers/bottomSheetReducer";
 
 const rootReducer = combineReducers({
   trends: trendsReducer,
   analytics: analyticsReducer,
+  profile: profileReducer,
+  bottomSheet: bottomSheetReducer,
 });
 
 export const store = configureStore({


### PR DESCRIPTION
## Summary
- add bottom sheet slice for open state and content
- register bottomSheet reducer
- wire BottomSheetProvider to Redux slice for control

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p packages/frontend/tsconfig.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68596ace85b4832890db2ff3ae6dcd9a