### PR TITLE
Refactor Sindi chat routing

### DIFF
--- a/packages/backend/models/schemas/ProfileSchema.ts
+++ b/packages/backend/models/schemas/ProfileSchema.ts
@@ -371,22 +371,34 @@ const personalProfileSchema = new mongoose.Schema({
       default: "USD",
     },
   },
-  // Sindi chat history
-  chatHistory: [
+  // Sindi chat conversations (grouped messages)
+  chatConversations: [
     {
-      role: {
-        type: String,
-        enum: ['user', 'assistant', 'system'],
-        required: true,
+      _id: {
+        type: mongoose.Schema.Types.ObjectId,
+        auto: true,
       },
-      content: {
-        type: String,
-        required: true,
-      },
-      timestamp: {
+      startedAt: {
         type: Date,
         default: Date.now,
       },
+      messages: [
+        {
+          role: {
+            type: String,
+            enum: ['user', 'assistant', 'system'],
+            required: true,
+          },
+          content: {
+            type: String,
+            required: true,
+          },
+          timestamp: {
+            type: Date,
+            default: Date.now,
+          },
+        },
+      ],
     },
   ],
 }, { _id: false });

--- a/packages/frontend/app/settings/sindi.tsx
+++ b/packages/frontend/app/settings/sindi.tsx
@@ -131,7 +131,7 @@ export default function SindiSettingsScreen() {
                                     {/* Reopen button */}
                                     <TouchableOpacity
                                         style={[styles.actionButton, { marginTop: 8, alignSelf: 'flex-end' }]}
-                                        onPress={() => router.push(`/sindi?conversationId=${conv._id}`)}
+                                        onPress={() => router.push(`/sindi/${conv._id}`)}
                                     >
                                         <Ionicons name="chatbubbles-outline" size={16} color={colors.sindiColor} style={{ marginRight: 6 }} />
                                         <Text style={styles.actionText}>{t('sindi.settings.reopen', 'Reopen')}</Text>

--- a/packages/frontend/app/sindi/[conversationId].tsx
+++ b/packages/frontend/app/sindi/[conversationId].tsx
@@ -8,7 +8,7 @@ const IconComponent = Ionicons as any;
 import { colors } from '@/styles/colors';
 import MarkdownDisplay from 'react-native-markdown-display';
 const Markdown = MarkdownDisplay as unknown as React.ComponentType<any>;
-import { useRouter } from 'expo-router';
+import { useRouter, useLocalSearchParams } from 'expo-router';
 import { PropertyCard } from '@/components/PropertyCard';
 import { SindiIcon } from '@/assets/icons';
 import { ThemedView } from '@/components/ThemedView';
@@ -18,12 +18,12 @@ import { useTranslation } from 'react-i18next';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as DocumentPicker from 'expo-document-picker';
 import React from 'react';
-import { sindiApi } from '@/utils/api';
 import { useSindiChatStore } from '@/store/sindiChatStore';
 
 export default function sindi() {
   const { oxyServices, activeSessionId } = useOxy();
   const router = useRouter();
+  const { conversationId } = useLocalSearchParams<{ conversationId: string }>();
   const { t } = useTranslation();
   const [attachedFile, setAttachedFile] = React.useState<any>(null);
 
@@ -32,7 +32,7 @@ export default function sindi() {
     messages: sindiMessages,
     isLoading: sindiLoading,
     error: sindiError,
-    fetchHistory,
+    fetchConversation,
     sendMessage,
     clearHistory,
     addMessage,
@@ -96,10 +96,10 @@ export default function sindi() {
 
   // Fetch chat history on mount or auth change
   React.useEffect(() => {
-    if (isAuthenticated) {
-      fetchHistory(oxyServices, activeSessionId);
+    if (isAuthenticated && conversationId) {
+      fetchConversation(conversationId as string, oxyServices, activeSessionId);
     }
-  }, [isAuthenticated, oxyServices, activeSessionId, fetchHistory]);
+  }, [isAuthenticated, oxyServices, activeSessionId, conversationId, fetchConversation]);
 
   const handleAttachFile = async () => {
     try {

--- a/packages/frontend/app/sindi/index.tsx
+++ b/packages/frontend/app/sindi/index.tsx
@@ -1,0 +1,140 @@
+import { generateAPIUrl } from '@/utils/generateAPIUrl';
+import { useChat } from '@ai-sdk/react';
+import { fetch as expoFetch } from 'expo/fetch';
+import { View, TextInput, Text, SafeAreaView, TouchableOpacity, StyleSheet } from 'react-native';
+import { useOxy } from '@oxyhq/services';
+import { Ionicons } from '@expo/vector-icons';
+import { colors } from '@/styles/colors';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import React from 'react';
+import { sindiApi } from '@/utils/api';
+import { useSindiChatStore } from '@/store/sindiChatStore';
+
+const IconComponent = Ionicons as any;
+
+export default function SindiMain() {
+  const { oxyServices, activeSessionId } = useOxy();
+  const router = useRouter();
+  const { t } = useTranslation();
+
+  const { addMessage } = useSindiChatStore();
+
+  const isAuthenticated = !!oxyServices && !!activeSessionId;
+
+  const authenticatedFetch = async (url: string, options: RequestInit = {}) => {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(options.headers as Record<string, string> || {}),
+    };
+    if (oxyServices && activeSessionId) {
+      try {
+        const tokenData = await oxyServices.getTokenBySession(activeSessionId);
+        if (tokenData) {
+          headers['Authorization'] = `Bearer ${tokenData.accessToken}`;
+        }
+      } catch (error) {
+        console.error('Failed to get authentication token:', error);
+      }
+    }
+    const { body, ...otherOptions } = options;
+    const fetchOptions = {
+      ...otherOptions,
+      headers,
+      ...(body !== null && { body }),
+    };
+    return expoFetch(url, fetchOptions as any);
+  };
+
+  const { messages, handleInputChange, input, handleSubmit, isLoading } = useChat({
+    fetch: authenticatedFetch as unknown as typeof globalThis.fetch,
+    api: generateAPIUrl('/api/ai/stream'),
+    onError: (error: any) => console.error(error, 'ERROR'),
+    enabled: isAuthenticated,
+  } as any);
+
+  const startConversation = async () => {
+    if (!input.trim()) return;
+    const now = new Date().toISOString();
+    addMessage({ role: 'user', content: input, timestamp: now });
+    await handleSubmit();
+    if (oxyServices && activeSessionId) {
+      try {
+        const res = await sindiApi.getSindiChatHistory(oxyServices, activeSessionId);
+        const conv = res.conversations && res.conversations[0];
+        if (conv && (conv._id || conv.id)) {
+          router.replace(`/sindi/${conv._id || conv.id}`);
+        }
+      } catch (err) {
+        console.error('Failed to fetch conversation id:', err);
+      }
+    }
+  };
+
+  if (!isAuthenticated) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <Text style={styles.authText}>{t('sindi.auth.required')}</Text>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.inputWrapper}>
+        <TextInput
+          style={styles.textInput}
+          placeholder={t('sindi.chat.placeholder')}
+          placeholderTextColor="rgba(0,0,0,0.4)"
+          value={input}
+          onChangeText={(text) => handleInputChange({ target: { value: text } } as any)}
+          onSubmitEditing={startConversation}
+          multiline
+        />
+        <TouchableOpacity style={[styles.sendButton, !input.trim() && styles.sendButtonDisabled]} onPress={startConversation} disabled={!input.trim() || isLoading}>
+          <IconComponent name={isLoading ? 'hourglass' : 'send'} size={20} color={input.trim() ? 'white' : 'rgba(255,255,255,0.4)'} />
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 16,
+    backgroundColor: '#f8f9fa',
+  },
+  authText: {
+    textAlign: 'center',
+    color: colors.COLOR_BLACK,
+  },
+  inputWrapper: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    backgroundColor: 'rgba(0,0,0,0.05)',
+    borderRadius: 24,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  textInput: {
+    flex: 1,
+    fontSize: 16,
+    maxHeight: 100,
+    paddingVertical: 8,
+    color: colors.COLOR_BLACK,
+  },
+  sendButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: colors.primaryColor,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginLeft: 8,
+  },
+  sendButtonDisabled: {
+    backgroundColor: 'rgba(0,0,0,0.1)',
+  },
+});

--- a/packages/frontend/store/sindiChatStore.ts
+++ b/packages/frontend/store/sindiChatStore.ts
@@ -13,6 +13,7 @@ interface SindiChatState {
   isLoading: boolean;
   error: string | null;
   fetchHistory: (oxyServices: OxyServices, activeSessionId: string) => Promise<void>;
+  fetchConversation: (conversationId: string, oxyServices: OxyServices, activeSessionId: string) => Promise<void>;
   sendMessage: (userMessage: string, assistantMessage: string, oxyServices: OxyServices, activeSessionId: string) => Promise<void>;
   clearHistory: (oxyServices: OxyServices, activeSessionId: string) => Promise<void>;
   addMessage: (msg: SindiChatMessage) => void;
@@ -29,6 +30,15 @@ export const useSindiChatStore = create<SindiChatState>((set, get) => ({
       set({ messages: res.history || [], isLoading: false });
     } catch (err: any) {
       set({ error: err.message || 'Failed to load chat history', isLoading: false });
+    }
+  },
+  fetchConversation: async (conversationId, oxyServices, activeSessionId) => {
+    set({ isLoading: true, error: null });
+    try {
+      const res = await sindiApi.getSindiConversation(conversationId, oxyServices, activeSessionId);
+      set({ messages: res.conversation?.messages || [], isLoading: false });
+    } catch (err: any) {
+      set({ error: err.message || 'Failed to load conversation', isLoading: false });
     }
   },
   sendMessage: async (userMessage, assistantMessage, oxyServices, activeSessionId) => {

--- a/packages/frontend/store/sindiChatStore.ts
+++ b/packages/frontend/store/sindiChatStore.ts
@@ -1,0 +1,62 @@
+import { create } from 'zustand';
+import { sindiApi } from '@/utils/api';
+import {               } from '@oxyhq/services';
+
+export interface SindiChatMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  timestamp: string;
+}
+
+interface SindiChatState {
+  messages: SindiChatMessage[];
+  isLoading: boolean;
+  error: string | null;
+  fetchHistory: (oxyServices: OxyServices, activeSessionId: string) => Promise<void>;
+  sendMessage: (userMessage: string, assistantMessage: string, oxyServices: OxyServices, activeSessionId: string) => Promise<void>;
+  clearHistory: (oxyServices: OxyServices, activeSessionId: string) => Promise<void>;
+  addMessage: (msg: SindiChatMessage) => void;
+}
+
+export const useSindiChatStore = create<SindiChatState>((set, get) => ({
+  messages: [],
+  isLoading: false,
+  error: null,
+  fetchHistory: async (oxyServices, activeSessionId) => {
+    set({ isLoading: true, error: null });
+    try {
+      const res = await sindiApi.getSindiChatHistory(oxyServices, activeSessionId);
+      set({ messages: res.history || [], isLoading: false });
+    } catch (err: any) {
+      set({ error: err.message || 'Failed to load chat history', isLoading: false });
+    }
+  },
+  sendMessage: async (userMessage, assistantMessage, oxyServices, activeSessionId) => {
+    set({ isLoading: true, error: null });
+    try {
+      await sindiApi.saveSindiChatHistory(userMessage, assistantMessage, oxyServices, activeSessionId);
+      // Add both user and assistant messages to local state
+      const now = new Date().toISOString();
+      set((state) => ({
+        messages: [
+          ...state.messages,
+          { role: 'user', content: userMessage, timestamp: now },
+          { role: 'assistant', content: assistantMessage, timestamp: now },
+        ],
+        isLoading: false,
+      }));
+    } catch (err: any) {
+      set({ error: err.message || 'Failed to send message', isLoading: false });
+    }
+  },
+  clearHistory: async (oxyServices, activeSessionId) => {
+    set({ isLoading: true, error: null });
+    try {
+      await sindiApi.clearSindiChatHistory(oxyServices, activeSessionId);
+      set({ messages: [], isLoading: false });
+    } catch (err: any) {
+      set({ error: err.message || 'Failed to clear chat history', isLoading: false });
+    }
+  },
+  addMessage: (msg) => set((state) => ({ messages: [...state.messages, msg] })),
+})); 

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -605,6 +605,24 @@ export const sindiApi = {
     });
     return response.data;
   },
+
+  // Get a specific conversation by id
+  async getSindiConversation(conversationId: string, oxyServices: OxyServices, activeSessionId: string): Promise<{ conversation: any }> {
+    const response = await api.get<{ conversation: any }>(`/api/ai/conversation/${conversationId}` as any, {
+      oxyServices,
+      activeSessionId,
+    });
+    return response.data;
+  },
+
+  // Append messages to a conversation
+  async appendSindiConversation(conversationId: string, messages: any[], oxyServices: OxyServices, activeSessionId: string): Promise<{ conversation: any }> {
+    const response = await api.post<{ conversation: any }>(`/api/ai/conversation/${conversationId}` as any, { messages }, {
+      oxyServices,
+      activeSessionId,
+    });
+    return response.data;
+  },
 };
 
 // Export the API configuration for external use

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -576,9 +576,9 @@ export const healthApi = {
  * Sindi chat history API functions
  */
 export const sindiApi = {
-  // Get Sindi chat history (authenticated)
-  async getSindiChatHistory(oxyServices: OxyServices, activeSessionId: string): Promise<{ history: any[] }> {
-    const response = await api.get<{ history: any[] }>('/api/ai/history', {
+  // Get Sindi chat conversations (authenticated)
+  async getSindiChatHistory(oxyServices: OxyServices, activeSessionId: string): Promise<{ conversations: any[] }> {
+    const response = await api.get<{ conversations: any[] }>('/api/ai/history', {
       oxyServices,
       activeSessionId,
     });


### PR DESCRIPTION
## Summary
- move conversation screen to `/sindi/[conversationId]`
- add new `/sindi` entry page that starts a conversation then routes to new id
- update settings page links
- expose conversation helpers in API utility and store

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68768cf199f88328a744db305256989e