### PR TITLE
Fix roommates pages connection to backend

### DIFF
--- a/packages/frontend/app/roommates/index.tsx
+++ b/packages/frontend/app/roommates/index.tsx
@@ -19,6 +19,9 @@ import { RoommateMatch } from '@/components/RoommateMatch';
 import { RoommateRequestComponent } from '@/components/RoommateRequest';
 import { RoommateRelationshipComponent } from '@/components/RoommateRelationship';
 import { useRoommate } from '@/hooks/useRoommate';
+import { useOxy } from '@oxyhq/services';
+import { roommateService } from '@/services/roommateService';
+import { useProfileStore } from '@/store/profileStore';
 
 // Type assertion for Ionicons compatibility
 const IconComponent = Ionicons as any;
@@ -40,6 +43,8 @@ export default function RoommatesPage() {
         declineRequest,
         endRelationship,
     } = useRoommate();
+
+    const { oxyServices, activeSessionId } = useOxy();
 
     const { primaryProfile } = useProfile();
     const hasRoommateMatching = primaryProfile?.personalProfile?.settings?.roommate?.enabled || false;
@@ -80,8 +85,12 @@ export default function RoommatesPage() {
     };
 
     const handleToggleMatching = async () => {
+        if (!oxyServices || !activeSessionId) return;
         try {
-            Alert.alert('Coming Soon', 'Toggle functionality will be available soon!');
+            await roommateService.toggleRoommateMatching(true, oxyServices, activeSessionId);
+            await useProfileStore.getState().fetchPrimaryProfile(oxyServices, activeSessionId);
+            await fetchProfiles();
+            Alert.alert('Success', 'Roommate matching enabled');
         } catch (error) {
             Alert.alert('Error', 'Failed to toggle roommate matching');
         }

--- a/packages/frontend/app/roommates/preferences.tsx
+++ b/packages/frontend/app/roommates/preferences.tsx
@@ -14,6 +14,9 @@ import { useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { colors } from '@/styles/colors';
 import { useProfile } from '@/context/ProfileContext';
+import { useOxy } from '@oxyhq/services';
+import { roommateService } from '@/services/roommateService';
+import { useProfileStore } from '@/store/profileStore';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import Button from '@/components/Button';
 
@@ -55,12 +58,14 @@ export default function RoommatePreferencesPage() {
         }
     }, [primaryProfile]);
 
+    const { oxyServices, activeSessionId } = useOxy();
+
     const handleToggleRoommateMatching = async (enabled: boolean) => {
         setIsSaving(true);
         try {
-            // Simulate API call
-            await new Promise(resolve => setTimeout(resolve, 1000));
+            await roommateService.toggleRoommateMatching(enabled, oxyServices, activeSessionId);
             setRoommateEnabled(enabled);
+            await useProfileStore.getState().fetchPrimaryProfile(oxyServices, activeSessionId);
             Alert.alert('Success', `Roommate matching ${enabled ? 'enabled' : 'disabled'}`);
         } catch (error) {
             Alert.alert('Error', 'Failed to update roommate matching settings');
@@ -72,8 +77,8 @@ export default function RoommatePreferencesPage() {
     const handleSavePreferences = async () => {
         setIsSaving(true);
         try {
-            // Simulate API call
-            await new Promise(resolve => setTimeout(resolve, 1000));
+            await roommateService.updateRoommatePreferences(preferences, oxyServices, activeSessionId);
+            await useProfileStore.getState().fetchPrimaryProfile(oxyServices, activeSessionId);
             Alert.alert('Success', 'Preferences saved successfully');
         } catch (error) {
             Alert.alert('Error', 'Failed to save preferences');

--- a/packages/frontend/context/ProfileContext.tsx
+++ b/packages/frontend/context/ProfileContext.tsx
@@ -23,30 +23,33 @@ export function ProfileProvider({ children }: { children: React.ReactNode }) {
         error,
         setPrimaryProfile,
         setAllProfiles,
-        setLoading,
         setError
     } = useProfileStore();
 
     useEffect(() => {
+        const loadProfiles = async () => {
+            try {
+                await useProfileStore.getState().fetchPrimaryProfile(oxyServices, activeSessionId);
+                await useProfileStore.getState().fetchUserProfiles(oxyServices, activeSessionId);
+            } catch (err: any) {
+                setError(err.message || 'Failed to load profiles');
+            }
+        };
+
         if (oxyServices && activeSessionId) {
-            // TODO: Implement fetch logic with Zustand
-            // For now, just set loading state
-            setLoading(true);
-            // You'll need to implement the actual fetch logic here
-            // or use a separate service/hook for API calls
+            loadProfiles();
         } else {
             setPrimaryProfile(null);
             setAllProfiles([]);
         }
-    }, [oxyServices, activeSessionId, setPrimaryProfile, setAllProfiles, setLoading]);
+    }, [oxyServices, activeSessionId, setPrimaryProfile, setAllProfiles, setError]);
 
     const hasPrimaryProfile = !!primaryProfile;
 
     const refetch = () => {
         if (oxyServices && activeSessionId) {
-            // TODO: Implement refetch logic with Zustand
-            setLoading(true);
-            // You'll need to implement the actual fetch logic here
+            useProfileStore.getState().fetchPrimaryProfile(oxyServices, activeSessionId);
+            useProfileStore.getState().fetchUserProfiles(oxyServices, activeSessionId);
         }
     };
 

--- a/packages/frontend/services/roommateService.ts
+++ b/packages/frontend/services/roommateService.ts
@@ -50,12 +50,19 @@ class RoommateService {
     totalPages: number;
   }> {
     try {
-      const response = await api.get(this.baseUrl, { 
+      const response = await api.get(this.baseUrl, {
         params: filters,
         oxyServices,
         activeSessionId,
       });
-      return response.data;
+      const data = response.data;
+      if (Array.isArray(data?.profiles)) {
+        data.profiles = data.profiles.map((p: any) => ({
+          ...p,
+          matchScore: p.matchPercentage ?? p.matchScore,
+        }));
+      }
+      return data;
     } catch (error) {
       console.error('Error fetching roommate profiles:', error);
       return { profiles: [], total: 0, page: 1, totalPages: 1 };
@@ -126,7 +133,20 @@ class RoommateService {
         oxyServices,
         activeSessionId,
       });
-      return response.data.data;
+      const data = response.data.data;
+      if (Array.isArray(data?.sent)) {
+        data.sent = data.sent.map((r: any) => ({
+          ...r,
+          matchScore: r.matchPercentage ?? r.matchScore,
+        }));
+      }
+      if (Array.isArray(data?.received)) {
+        data.received = data.received.map((r: any) => ({
+          ...r,
+          matchScore: r.matchPercentage ?? r.matchScore,
+        }));
+      }
+      return data;
     } catch (error) {
       console.error('Error fetching roommate requests:', error);
       return { sent: [], received: [] };
@@ -170,7 +190,14 @@ class RoommateService {
         oxyServices,
         activeSessionId,
       });
-      return response.data;
+      const data = response.data;
+      if (Array.isArray(data?.data)) {
+        data.data = data.data.map((r: any) => ({
+          ...r,
+          matchScore: r.matchPercentage ?? r.matchScore,
+        }));
+      }
+      return data;
     } catch (error) {
       console.error('Error fetching roommate relationships:', error);
       return { data: [] };


### PR DESCRIPTION
## Summary
- connect roommates preferences page to use roommate API and oxy auth
- allow enabling matching from roommates page via backend API
- map match percentages from backend to matchScore for display
- automatically load profile data on mount so personal profile is created if missing

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eaa4d8db08328bbba6cf384df9c92