### PR TITLE
fix: use backend save state on load

### DIFF
--- a/packages/frontend/app/properties/index.tsx
+++ b/packages/frontend/app/properties/index.tsx
@@ -18,6 +18,7 @@ import Button from '@/components/Button';
 import { Property } from '@homiio/shared-types';
 import { Ionicons } from '@expo/vector-icons';
 import { useSavedProperties } from '@/hooks/useSavedProperties';
+import { useSavedPropertiesContext } from '@/context/SavedPropertiesContext';
 import { useOxy } from '@oxyhq/services';
 import { ThemedText } from '@/components/ThemedText';
 import { PropertyListSkeleton } from '@/components/ui/skeletons/PropertyListSkeleton';
@@ -42,11 +43,14 @@ export default function PropertiesScreen() {
 
   const { properties: allProperties, loading, loadProperties } = useProperties();
   const { isSaved, toggleSaved } = useSavedProperties();
+  const { isInitialized } = useSavedPropertiesContext();
 
   // Combine properties with saved status
   const propertiesWithSavedStatus = allProperties.map((property) => ({
     ...property,
-    isSaved: isSaved(property._id || property.id || ''),
+    isSaved: isInitialized
+      ? isSaved(property._id || property.id || '')
+      : (property as any)?.isSaved,
   }));
 
   useEffect(() => {

--- a/packages/frontend/components/PropertyCard.tsx
+++ b/packages/frontend/components/PropertyCard.tsx
@@ -200,7 +200,11 @@ export function PropertyCard({
 
   const isEco = Boolean(property.isEcoFriendly);
   const isFeatured = variant === 'featured';
-  const isPropertySavedState = propertyData.id && isInitialized ? isPropertySaved(propertyData.id) : false;
+  const isPropertySavedState = propertyData.id
+    ? isInitialized
+      ? isPropertySaved(propertyData.id)
+      : (property as any)?.isSaved || false
+    : false;
 
   // Get variant-specific styles
   const variantStyles = getVariantStyles(variant);

--- a/packages/frontend/components/SaveButton.tsx
+++ b/packages/frontend/components/SaveButton.tsx
@@ -98,14 +98,25 @@ export function SaveButton({
     unsaveProperty,
     isLoading: contextLoading,
     isPropertySaved,
-    savedProperties
+    savedProperties,
+    isInitialized
   } = useSavedPropertiesContext();
 
   // Determine property ID
   const propertyId = property?._id || property?.id;
 
-  // Use context's isPropertySaved method for reliable state
-  const isSaved = propertyId ? isPropertySaved(propertyId) : propIsSaved;
+  // Determine initial saved state from prop or property object
+  const initialSavedState =
+    typeof propIsSaved === 'boolean'
+      ? propIsSaved
+      : (property as any)?.isSaved;
+
+  // Use context state when initialized, otherwise fall back to initial state
+  const isSaved = propertyId
+    ? isInitialized
+      ? isPropertySaved(propertyId)
+      : initialSavedState
+    : initialSavedState;
 
   // Calculate saved properties count from context
   const savedCount = savedProperties.length;


### PR DESCRIPTION
## Summary
- use property and backend data to initialize saved buttons before context loads
- respect backend save flags in property card and property list

## Testing
- `npm test` *(fails: Error: no test specified; jest not found)*
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68aee03aab248328a737dc6fac42b90b