### PR TITLE
fix: fetch properties with session

### DIFF
--- a/packages/frontend/app/properties/index.tsx
+++ b/packages/frontend/app/properties/index.tsx
@@ -18,7 +18,7 @@ import Button from '@/components/Button';
 import { Property } from '@homiio/shared-types';
 import { Ionicons } from '@expo/vector-icons';
 import { useSavedProperties } from '@/hooks/useSavedProperties';
-import { useOxy } from '@oxyhq/services';
+import { useSavedPropertiesContext } from '@/context/SavedPropertiesContext';
 import { ThemedText } from '@/components/ThemedText';
 import { PropertyListSkeleton } from '@/components/ui/skeletons/PropertyListSkeleton';
 
@@ -30,7 +30,6 @@ export default function PropertiesScreen() {
   const { t } = useTranslation();
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { oxyServices, activeSessionId } = useOxy();
   const [viewMode, setViewMode] = useState<'list' | 'grid'>(isMobile ? 'grid' : 'list');
   const [fadeAnim] = useState(new Animated.Value(1));
   const [isLoading, setIsLoading] = useState(false);
@@ -42,11 +41,14 @@ export default function PropertiesScreen() {
 
   const { properties: allProperties, loading, loadProperties } = useProperties();
   const { isSaved, toggleSaved } = useSavedProperties();
+  const { isInitialized } = useSavedPropertiesContext();
 
   // Combine properties with saved status
   const propertiesWithSavedStatus = allProperties.map((property) => ({
     ...property,
-    isSaved: isSaved(property._id || property.id || ''),
+    isSaved: isInitialized
+      ? isSaved(property._id || property.id || '')
+      : (property as any)?.isSaved,
   }));
 
   useEffect(() => {

--- a/packages/frontend/components/PropertyCard.tsx
+++ b/packages/frontend/components/PropertyCard.tsx
@@ -200,7 +200,11 @@ export function PropertyCard({
 
   const isEco = Boolean(property.isEcoFriendly);
   const isFeatured = variant === 'featured';
-  const isPropertySavedState = propertyData.id && isInitialized ? isPropertySaved(propertyData.id) : false;
+  const isPropertySavedState = propertyData.id
+    ? isInitialized
+      ? isPropertySaved(propertyData.id)
+      : (property as any)?.isSaved || false
+    : false;
 
   // Get variant-specific styles
   const variantStyles = getVariantStyles(variant);

--- a/packages/frontend/components/SaveButton.tsx
+++ b/packages/frontend/components/SaveButton.tsx
@@ -98,14 +98,25 @@ export function SaveButton({
     unsaveProperty,
     isLoading: contextLoading,
     isPropertySaved,
-    savedProperties
+    savedProperties,
+    isInitialized
   } = useSavedPropertiesContext();
 
   // Determine property ID
   const propertyId = property?._id || property?.id;
 
-  // Use context's isPropertySaved method for reliable state
-  const isSaved = propertyId ? isPropertySaved(propertyId) : propIsSaved;
+  // Determine initial saved state from prop or property object
+  const initialSavedState =
+    typeof propIsSaved === 'boolean'
+      ? propIsSaved
+      : (property as any)?.isSaved;
+
+  // Use context state when initialized, otherwise fall back to initial state
+  const isSaved = propertyId
+    ? isInitialized
+      ? isPropertySaved(propertyId)
+      : initialSavedState
+    : initialSavedState;
 
   // Calculate saved properties count from context
   const savedCount = savedProperties.length;

--- a/packages/frontend/hooks/usePropertyQueries.ts
+++ b/packages/frontend/hooks/usePropertyQueries.ts
@@ -11,12 +11,14 @@ export const useProperties = () => {
   const { properties, loading, error, pagination } = usePropertySelectors();
   const { setProperties, clearError, setFilters, clearFilters, setPagination } = usePropertyStore();
   const queryClient = useQueryClient();
+  const { oxyServices, activeSessionId } = useOxy();
 
   const loadProperties = useCallback(
     async (filters?: PropertyFilters) => {
       const result = await queryClient.fetchQuery({
         queryKey: ['properties', { filters: filters ?? null }],
-        queryFn: async () => propertyService.getProperties(filters),
+        queryFn: async () =>
+          propertyService.getProperties(filters, oxyServices, activeSessionId || ''),
         staleTime: 1000 * 30,
         gcTime: 1000 * 60 * 10,
       });
@@ -30,7 +32,7 @@ export const useProperties = () => {
       if (filters) setFilters(filters);
       return result;
     },
-    [queryClient, setPagination, setProperties, setFilters],
+    [queryClient, setPagination, setProperties, setFilters, oxyServices, activeSessionId],
   );
 
   const clearErrorAction = useCallback(() => {


### PR DESCRIPTION
## Summary
- fetch property lists with user session so backend returns saved flags
- remove unused session variables from properties screen

## Testing
- `npm test` *(fails: jest not found / no test specified)*
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68aee03aab248328a737dc6fac42b90b