### PR TITLE
chore(deps): refresh ajv/bn.js natively via bun

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "homiio-monorepo",
       "devDependencies": {
         "@types/node": "^22.10.0",
-        "ajv": "^8.17.1",
+        "ajv": "^8.18.0",
         "ajv-keywords": "^5.1.0",
         "prettier-plugin-tailwindcss": "^0.6.14",
         "tailwindcss": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.0",
-    "ajv": "^8.17.1",
+    "ajv": "^8.18.0",
     "ajv-keywords": "^5.1.0",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "tailwindcss": "4.2.2",


### PR DESCRIPTION
Applies the equivalent of the two open dependabot PRs natively against `bun.lock`, since this repo tracks `bun.lock` and does **not** track `package-lock.json` (dependabot's npm updater would add a stray, unused npm lockfile).

## Changes
- `ajv` devDependency floor `^8.17.1` -> `^8.18.0` (intent of #91). Resolves to `8.20.0`.
- `bn.js@4.12.3` is already present transitively via `elliptic` in `bun.lock` (intent of #92) - no change needed.

## Notes
- No resolved-version changes vs `main` (functionally a no-op).
- `bun install --frozen-lockfile` passes (no drift).
- `bun run build` (shared-types + backend + Expo web export) and `bun run test` (backend 48, frontend 30) all green.

Closes the stale `dependabot/npm_and_yarn/*` PRs #91 and #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)