### PR TITLE
chore(frontend): route tenant application create() through the linked client

### DIFF
--- a/packages/frontend/services/applicationService.ts
+++ b/packages/frontend/services/applicationService.ts
@@ -5,12 +5,13 @@
  * applicant flow (apply, view my applications, withdraw) and the landlord
  * inbox (review submissions, approve / reject).
  *
- * Multipart uploads bypass the JSON `api` helper and go through a direct
- * authenticated `fetch` so the browser/native runtime can set the multipart
- * boundary header automatically.
+ * Every request — including the multipart document upload — goes through the
+ * shared `api` helper, which is backed by the Oxy-linked backend client. The
+ * linked client keeps the bearer token in lockstep with the session, delegates
+ * preflight/401 refresh to the session owner, and detects `FormData` bodies to
+ * let the browser/native runtime set the multipart boundary header itself.
  */
 import { Platform } from 'react-native';
-import { oxyClient } from '@oxyhq/core';
 import {
   EmploymentStatus,
   ReferenceRelationship,
@@ -20,7 +21,6 @@ import {
 } from '@homiio/shared-types';
 
 import { api, ApiError, ApiResponse } from '@/utils/api';
-import { API_URL } from '@/config';
 
 export type ApplicationReferenceInput = {
   name: string;
@@ -69,17 +69,6 @@ export type ApplicationListResponse = {
 
 const API_BASE_PATH = '/api/applications';
 
-async function getAuthHeader(): Promise<Record<string, string>> {
-  try {
-    const token = await oxyClient.getAccessToken();
-    if (!token) throw new ApiError('Authentication required', 401);
-    return { Authorization: `Bearer ${token}` };
-  } catch (error) {
-    if (error instanceof ApiError) throw error;
-    throw new ApiError('Authentication required', 401);
-  }
-}
-
 async function appendFileToFormData(
   formData: FormData,
   field: string,
@@ -106,19 +95,6 @@ async function appendFileToFormData(
     name: doc.filename,
     type: doc.mimeType || 'application/octet-stream',
   } as unknown as Blob);
-}
-
-function extractErrorMessage(payload: unknown, status: number): string {
-  if (payload && typeof payload === 'object') {
-    const data = payload as Record<string, unknown>;
-    if (typeof data.message === 'string' && data.message.trim()) return data.message;
-    if (typeof data.error === 'string' && data.error.trim()) return data.error;
-    if (data.error && typeof data.error === 'object') {
-      const err = data.error as Record<string, unknown>;
-      if (typeof err.message === 'string' && err.message.trim()) return err.message;
-    }
-  }
-  return `HTTP ${status}`;
 }
 
 export const applicationService = {
@@ -148,24 +124,13 @@ export const applicationService = {
       }
     }
 
-    const headers = await getAuthHeader();
-    const response = await fetch(`${API_URL}${API_BASE_PATH}`, {
-      method: 'POST',
-      headers,
-      body: formData,
-    });
-
-    const payload = await response.json().catch(() => null);
-    if (!response.ok) {
-      throw new ApiError(
-        extractErrorMessage(payload, response.status),
-        response.status,
-        payload,
-      );
-    }
-    const created = (payload as ApiResponse<TenantApplication> | null)?.data;
+    const response = await api.post<ApiResponse<TenantApplication>>(
+      API_BASE_PATH,
+      formData,
+    );
+    const created = response.data?.data;
     if (!created) {
-      throw new ApiError('Empty application response', response.status, payload);
+      throw new ApiError('Empty application response', 500, response.data);
     }
     return created;
   },


### PR DESCRIPTION
## What

Migrates the tenant application submission path off hand-rolled `Authorization: Bearer` plumbing and onto the Oxy-linked backend client, per the Oxy rule: *RP backend clients use `oxyServices.createLinkedClient({ baseURL })` — no app-local token plumbing.*

Flagged during the wave-2 SDK bump. Two frontend paths were called out; one is migrated, the other is a documented can't-migrate.

## `applicationService.create()` — migrated ✅

`create()` previously built a raw `fetch` to `${API_URL}/api/applications` and attached the token via a bespoke `getAuthHeader()` → `oxyClient.getAccessToken()`. Its sibling methods (`list`/`getById`/`update`) already went through the shared `api` helper, which is backed by `createLinkedClient` (`packages/frontend/utils/api.ts`).

The multipart upload now goes through `api.post()` too. The linked `HttpService` detects `FormData` bodies and lets the runtime set the multipart boundary (React Native routes through XHR, as before). This deletes the bespoke `getAuthHeader()` + `extractErrorMessage()` helpers and the direct `oxyClient` / `API_URL` imports (−35 net lines).

Behavior preserved: same endpoint, same FormData assembly (`appendFileToFormData` unchanged), same `{ success, data }` envelope read, same `ApiError` (status + message) surface. The linked client already extracts the API's structured error message and numeric status, and adds preflight/401 refresh + session invalidation for free.

## `useSindiAuthenticatedFetch` — deliberately NOT migrated (flagged) ⚠️

The Sindi AI fetch targets Homiio's **own** backend (`${API_URL}/api/ai/stream`, `/analyze-file`), so it is not an external-service exception. It genuinely cannot use the linked client because it is a **streaming** endpoint: `useChat` / the AI SDK consume a live `ReadableStream`, and the linked `HttpService` buffers the full JSON/blob/text body — it cannot return a stream.

The only public linked-client method usable from a raw fetch is `refreshAccessToken()`, which forces an *unconditional* refresh (a network round-trip on every message). The near-expiry **preflight** refresh (`getAuthHeader`) and the unrefreshable-401 **invalidation** both live in the **private** `request()` path. Reproducing them in the app would be exactly the "app-local token providers / manual Authorization header plumbing / local invalidation" the Oxy SDK rules forbid.

**Recommended upstream fix (separate, `@oxyhq/core`):** expose a public accessor on the linked `HttpService` that returns a preflight-refreshed `Authorization` value (and a way to report an unrefreshable 401 so the owner session is invalidated). Then `useSindiAuthenticatedFetch` can delegate auth to the linked client while keeping its raw streaming fetch. This is a reusable capability every Oxy app with AI streaming needs. Happy to drive that via the oxy-core agent if desired.

## Gates

- `tsc --noEmit` (frontend): clean.
- `jest --ci` (frontend): 3 suites / 30 tests pass.
- Frontend-only change; backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)