### PR TITLE
feat(listing-providers): env-gated browser/managed fetch escalation tiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@ interface ListingProvider {
 
 `FetchRuntime` (shared, not per-plugin) owns: rate limiting, retries, circuit breaker, Playwright pool, proxy/managed ladder, challenge/CAPTCHA detection → requeue or escalate.
 
+- **Escalation tiers are WORKER-ONLY and env-gated (default OFF).** Build the worker runtime with `createListingFetchRuntimeFromEnv()` (never in the API). Browser tier: `LISTING_BROWSER_ENABLED=true` + Playwright installed (it is an OPTIONAL peer of `@homiio/listing-providers`, loaded via dynamic `import()`; absent → tier skipped, logged, CI still green). Managed tier: `LISTING_MANAGED_FETCH_URL` (+ optional `LISTING_MANAGED_FETCH_KEY`/`*_KEY_HEADER`/`*_KEY_PARAM`/`*_URL_PARAM`); unset → rung does not exist (never faked). The ladder keys tier availability off method presence, so an unprovisioned rung is skipped, not attempted-and-failed. Worker must `await runtimeHandle.shutdown()` to close the browser pool.
+
 ### BullMQ queues (Valkey via `REDIS_URL`)
 
 | Queue | Purpose |

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -126,6 +126,39 @@ LISTING_FETCH_CONCURRENCY=2
 # Unset → each provider falls back to its own default city list. [optional]
 LISTING_ES_CITIES=madrid,barcelona,valencia
 
+# --- Fetch escalation tiers (WORKER ONLY — the API never scrapes) -----------
+# The shared fetch ladder is HTTP → browser → managed. Both escalation rungs are
+# OFF by default; a rung the worker did not provision is simply skipped.
+#
+# Browser tier (Playwright, headless Chromium). Playwright is an OPTIONAL peer of
+# @homiio/listing-providers — install it in the worker image to enable this:
+#   bun add -D playwright && bunx playwright install --with-deps chromium
+# When "true" but Playwright is NOT installed, the tier is skipped (logged), so
+# CI/hosts without a browser keep working. [optional]
+LISTING_BROWSER_ENABLED=false
+# Max concurrent headless contexts (a browser is memory-heavy — keep small). [optional]
+LISTING_BROWSER_MAX_CONCURRENCY=2
+# Hard per-navigation timeout in ms. [optional]
+LISTING_BROWSER_TIMEOUT_MS=45000
+#
+# Managed tier (residential-proxy / anti-bot fetch service, e.g. ScraperAPI,
+# ScrapingBee, Zyte). Enabled ONLY when LISTING_MANAGED_FETCH_URL is set; unset =
+# the managed rung does not exist (never faked). The target URL is passed as the
+# `LISTING_MANAGED_FETCH_URL_PARAM` query param (default `url`); the key is sent
+# as the `LISTING_MANAGED_FETCH_KEY_HEADER` header (default `X-Api-Key`), OR as a
+# query param when LISTING_MANAGED_FETCH_KEY_PARAM is set instead.
+LISTING_MANAGED_FETCH_URL=
+# API key for the managed service. [SECRET, optional]
+LISTING_MANAGED_FETCH_KEY=
+# Query param the target URL is passed in. [optional]
+LISTING_MANAGED_FETCH_URL_PARAM=url
+# Header the API key is sent in (ignored when LISTING_MANAGED_FETCH_KEY_PARAM set). [optional]
+LISTING_MANAGED_FETCH_KEY_HEADER=X-Api-Key
+# When set, send the key as this query param instead of a header. [optional]
+LISTING_MANAGED_FETCH_KEY_PARAM=
+# Hard per-request timeout in ms for managed fetches. [optional]
+LISTING_MANAGED_FETCH_TIMEOUT_MS=60000
+
 # --- Listing provider feature flags -----------------------------------------
 # Per-portal ingest toggles, read as `PROVIDER_<ID>_ENABLED`. Each defaults OFF;
 # a portal only discovers/ingests when its flag is exactly "true". The Phase-0

--- a/packages/backend/__tests__/unit/listingFetchTiers.test.ts
+++ b/packages/backend/__tests__/unit/listingFetchTiers.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Escalation-tier tests: the composed runtime, the ladder escalating all the way
+ * to the managed tier, the managed-service client, and the Playwright pool — all
+ * with mocks/fakes. NO real browser and NO live portal hits, so this runs in CI
+ * without Playwright installed.
+ */
+
+import {
+  createListingFetchRuntime,
+  createManagedFetcher,
+  createBrowserFetcher,
+  ManagedFetcher,
+  PlaywrightBrowserPool,
+  fetchListingViaLadder,
+  HostRateLimiter,
+  InMemoryProviderMetrics,
+  type PlaywrightModule,
+  type UrlFetcher,
+} from '@homiio/listing-providers';
+
+const noDelay = { rateLimiter: new HostRateLimiter(0), maxRetries: 0 };
+const BIG_OK_HTML = `<!doctype html><html><body>${'<p>ok</p>'.repeat(80)}</body></html>`;
+
+const originalFetch = global.fetch;
+afterEach(() => {
+  (global as { fetch: typeof originalFetch }).fetch = originalFetch;
+  jest.restoreAllMocks();
+});
+
+/* -------------------------------------------------------------------------- */
+/* createListingFetchRuntime — tiers attach only when provided                */
+/* -------------------------------------------------------------------------- */
+
+describe('createListingFetchRuntime', () => {
+  it('omits fetchViaBrowser/fetchViaManaged when no tiers are provided', () => {
+    const { runtime } = createListingFetchRuntime();
+    expect(runtime.fetchViaBrowser).toBeUndefined();
+    expect(runtime.fetchViaManaged).toBeUndefined();
+  });
+
+  it('attaches only the provided tiers and shutdown closes them', async () => {
+    const browserClose = jest.fn(async () => undefined);
+    const managedClose = jest.fn(async () => undefined);
+    const browser: UrlFetcher = { fetch: async () => '<browser/>', close: browserClose };
+    const managed: UrlFetcher = { fetch: async () => '<managed/>', close: managedClose };
+
+    const { runtime, shutdown } = createListingFetchRuntime({ browser, managed });
+    expect(typeof runtime.fetchViaBrowser).toBe('function');
+    expect(typeof runtime.fetchViaManaged).toBe('function');
+    await expect(runtime.fetchViaBrowser?.('https://x/')).resolves.toBe('<browser/>');
+    await expect(runtime.fetchViaManaged?.('https://x/')).resolves.toBe('<managed/>');
+
+    await shutdown();
+    expect(browserClose).toHaveBeenCalledTimes(1);
+    expect(managedClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Ladder escalates HTTP → browser → managed                                  */
+/* -------------------------------------------------------------------------- */
+
+describe('fetchListingViaLadder — managed rung', () => {
+  it('escalates past a blocked HTTP + browser to the managed tier', async () => {
+    // HTTP tier: bare 403 (forbidden). Browser tier: DataDome challenge body.
+    (global as { fetch: unknown }).fetch = jest.fn(async () => ({ status: 403, text: async () => 'Forbidden' }));
+    const runtime = createListingFetchRuntime({
+      browser: { fetch: async () => '<html>datadome captcha-delivery</html>' },
+      managed: { fetch: async () => BIG_OK_HTML },
+    }).runtime;
+    const metrics = new InMemoryProviderMetrics();
+
+    const result = await fetchListingViaLadder(runtime, 'https://portal.example/deep', {
+      provider: 'idealista',
+      metrics,
+      ...noDelay,
+    });
+
+    expect(result.tier).toBe('managed');
+    const snapshot = metrics.snapshot('idealista');
+    expect(snapshot?.attempts).toBe(3);
+    expect(snapshot?.forbidden).toBe(1);
+    expect(snapshot?.challenge).toBe(1);
+    expect(snapshot?.success).toBe(1);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* ManagedFetcher — request shape + auth modes                                */
+/* -------------------------------------------------------------------------- */
+
+describe('ManagedFetcher', () => {
+  it('sends the key as a header and the target as the url query param', async () => {
+    const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+    (global as { fetch: unknown }).fetch = jest.fn(async (url: string, opts: { headers: Record<string, string> }) => {
+      calls.push({ url, headers: opts.headers });
+      return { ok: true, status: 200, text: async () => '<html>ok</html>' };
+    });
+
+    const fetcher = new ManagedFetcher({ endpoint: 'https://managed.test/fetch', apiKey: 'secret-key' });
+    const html = await fetcher.fetch('https://portal.example/listing/1?x=2');
+
+    expect(html).toBe('<html>ok</html>');
+    const parsed = new URL(calls[0].url);
+    expect(parsed.origin + parsed.pathname).toBe('https://managed.test/fetch');
+    expect(parsed.searchParams.get('url')).toBe('https://portal.example/listing/1?x=2');
+    expect(calls[0].headers['X-Api-Key']).toBe('secret-key');
+  });
+
+  it('sends the key as a query param when keyParam is configured', async () => {
+    let requestedUrl = '';
+    (global as { fetch: unknown }).fetch = jest.fn(async (url: string) => {
+      requestedUrl = url;
+      return { ok: true, status: 200, text: async () => 'ok' };
+    });
+
+    const fetcher = new ManagedFetcher({
+      endpoint: 'https://managed.test/',
+      apiKey: 'k123',
+      keyParam: 'api_key',
+      urlParam: 'target',
+      extraParams: { render: 'true' },
+    });
+    await fetcher.fetch('https://portal.example/x');
+
+    const parsed = new URL(requestedUrl);
+    expect(parsed.searchParams.get('target')).toBe('https://portal.example/x');
+    expect(parsed.searchParams.get('api_key')).toBe('k123');
+    expect(parsed.searchParams.get('render')).toBe('true');
+  });
+
+  it('throws on a non-2xx managed response', async () => {
+    (global as { fetch: unknown }).fetch = jest.fn(async () => ({ ok: false, status: 502, text: async () => 'bad gateway' }));
+    const fetcher = new ManagedFetcher({ endpoint: 'https://managed.test/fetch' });
+    await expect(fetcher.fetch('https://portal.example/x')).rejects.toThrow(/Managed fetch failed/);
+  });
+
+  it('createManagedFetcher returns undefined without an endpoint', () => {
+    expect(createManagedFetcher(undefined)).toBeUndefined();
+    expect(createManagedFetcher({ endpoint: '' })).toBeUndefined();
+    expect(createManagedFetcher({ endpoint: 'https://managed.test/' })).toBeInstanceOf(ManagedFetcher);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* PlaywrightBrowserPool — orchestration against a fake Playwright module      */
+/* -------------------------------------------------------------------------- */
+
+interface FakeCounters {
+  launches: number;
+  contexts: number;
+  closes: number;
+  gotos: string[];
+}
+
+function fakePlaywright(html: string): { module: PlaywrightModule; counters: FakeCounters } {
+  const counters: FakeCounters = { launches: 0, contexts: 0, closes: 0, gotos: [] };
+  const module: PlaywrightModule = {
+    chromium: {
+      launch: async () => {
+        counters.launches += 1;
+        return {
+          isConnected: () => true,
+          close: async () => undefined,
+          newContext: async () => {
+            counters.contexts += 1;
+            return {
+              close: async () => {
+                counters.closes += 1;
+              },
+              newPage: async () => ({
+                goto: async (url: string) => {
+                  counters.gotos.push(url);
+                  return null;
+                },
+                content: async () => html,
+              }),
+            };
+          },
+        };
+      },
+    },
+  };
+  return { module, counters };
+}
+
+describe('PlaywrightBrowserPool', () => {
+  it('launches once, uses an isolated context per fetch, and closes each context', async () => {
+    const { module, counters } = fakePlaywright('<html>rendered</html>');
+    const pool = new PlaywrightBrowserPool(module, { maxConcurrency: 2 });
+
+    const a = await pool.fetch('https://portal.example/a');
+    const b = await pool.fetch('https://portal.example/b');
+
+    expect(a).toBe('<html>rendered</html>');
+    expect(b).toBe('<html>rendered</html>');
+    expect(counters.launches).toBe(1); // shared browser
+    expect(counters.contexts).toBe(2); // isolated per fetch
+    expect(counters.closes).toBe(2); // each context torn down
+    expect(counters.gotos).toEqual(['https://portal.example/a', 'https://portal.example/b']);
+
+    await pool.close();
+  });
+
+  it('rejects fetch after close', async () => {
+    const { module } = fakePlaywright('<html/>');
+    const pool = new PlaywrightBrowserPool(module, {});
+    await pool.close();
+    await expect(pool.fetch('https://portal.example/x')).rejects.toThrow(/closed/);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* createBrowserFetcher — env/availability gating                             */
+/* -------------------------------------------------------------------------- */
+
+describe('createBrowserFetcher', () => {
+  it('returns undefined when disabled', async () => {
+    expect(await createBrowserFetcher({ enabled: false })).toBeUndefined();
+  });
+
+  it('returns a pool when an injected Playwright module is provided', async () => {
+    const { module } = fakePlaywright('<html/>');
+    const fetcher = await createBrowserFetcher({ enabled: true, playwright: module });
+    expect(fetcher).toBeInstanceOf(PlaywrightBrowserPool);
+  });
+
+  it('returns undefined and logs when Playwright is not installed', async () => {
+    const logs: string[] = [];
+    // No injected module + Playwright is not a dependency here → dynamic import fails.
+    const fetcher = await createBrowserFetcher({ enabled: true, onLog: (m) => logs.push(m) });
+    expect(fetcher).toBeUndefined();
+    expect(logs.some((m) => m.includes('Playwright'))).toBe(true);
+  });
+});

--- a/packages/backend/worker.ts
+++ b/packages/backend/worker.ts
@@ -17,9 +17,10 @@ require('dotenv').config();
 import { Queue, Worker, type Job } from 'bullmq';
 import {
   createDefaultRegistry,
-  HttpFetchRuntime,
+  createListingFetchRuntimeFromEnv,
   type ExternalListingRef,
   type FetchRuntime,
+  type ListingFetchRuntimeHandle,
   type ProviderRegistry,
 } from '@homiio/listing-providers';
 import config from './config';
@@ -41,8 +42,16 @@ const logger = new Logger('ListingWorker');
 const FETCH_CONCURRENCY = parseInt(process.env.LISTING_FETCH_CONCURRENCY || '2', 10);
 
 const registry: ProviderRegistry = createDefaultRegistry();
-const runtime: FetchRuntime = new HttpFetchRuntime();
 const ingestionService = new IngestionService();
+
+/**
+ * Shared fetch runtime (HTTP + optional browser/managed escalation tiers),
+ * assembled from env in {@link main} before any job runs. The browser tier is
+ * gated on `LISTING_BROWSER_ENABLED` + an installed Playwright; the managed tier
+ * on `LISTING_MANAGED_FETCH_URL`. Absent tiers are skipped by the shared ladder.
+ */
+let runtimeHandle: ListingFetchRuntimeHandle;
+let runtime: FetchRuntime;
 
 /** Fetch + normalize a single listing ref and ingest the result. */
 async function processFetchRef(ref: ExternalListingRef): Promise<void> {
@@ -156,9 +165,15 @@ function startBullMq(): () => Promise<void> {
 
 async function main(): Promise<void> {
   await database.connect();
+  runtimeHandle = await createListingFetchRuntimeFromEnv({
+    onLog: (message) => logger.warn(message),
+  });
+  runtime = runtimeHandle.runtime;
   logger.info('Listing worker connected to database', {
     providers: registry.ids(),
     redis: config.listingWorker.redisConfigured,
+    browserTier: Boolean(runtime.fetchViaBrowser),
+    managedTier: Boolean(runtime.fetchViaManaged),
   });
 
   let closer: (() => Promise<void>) | undefined;
@@ -169,6 +184,7 @@ async function main(): Promise<void> {
   } else if (config.listingWorker.discoverOnBoot) {
     await runInlinePass();
     logger.info('Inline pass complete; no Redis configured, exiting');
+    await runtimeHandle.shutdown();
     await database.disconnect?.();
     return;
   } else {
@@ -178,6 +194,7 @@ async function main(): Promise<void> {
   const shutdown = async (signal: string): Promise<void> => {
     logger.info(`Received ${signal}, shutting down listing worker`);
     if (closer) await closer();
+    await runtimeHandle.shutdown();
     await database.disconnect?.();
     process.exit(0);
   };

--- a/packages/listing-providers/package.json
+++ b/packages/listing-providers/package.json
@@ -23,6 +23,14 @@
   "dependencies": {
     "@homiio/shared-types": "workspace:*"
   },
+  "peerDependencies": {
+    "playwright": ">=1.40.0"
+  },
+  "peerDependenciesMeta": {
+    "playwright": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.0",
     "@types/node": "^22.10.0",

--- a/packages/listing-providers/src/browser.ts
+++ b/packages/listing-providers/src/browser.ts
@@ -1,0 +1,258 @@
+/**
+ * Headless-browser escalation tier (Playwright).
+ *
+ * The second rung of the shared fetch ladder (HTTP → **browser** → managed). It
+ * exists so JS-rendered pages and simple bot walls resolve to real HTML when the
+ * plain HTTP tier is blocked. It is deliberately OPTIONAL:
+ *
+ *   - Playwright is NOT a hard dependency of this package — it is an optional
+ *     peer, loaded via a dynamic `import()`. When it is not installed (e.g. CI
+ *     without browsers), {@link createBrowserFetcher} resolves to `undefined`
+ *     and the ladder simply skips the browser tier.
+ *   - It is env-gated behind `LISTING_BROWSER_ENABLED=true`. Disabled → skipped.
+ *
+ * The pool keeps ONE shared Chromium instance (lazily launched, relaunched if it
+ * crashes) and runs each fetch in a fresh, ISOLATED {@link PwBrowserContext}
+ * (no shared cookies/storage between listings) under a hard per-request timeout
+ * and a small concurrency cap — portals are rate sensitive and a browser is
+ * memory-heavy, so we keep the footprint small.
+ */
+
+import { DEFAULT_USER_AGENT } from './http';
+import type { FetchRuntimeInit, UrlFetcher } from './types';
+
+/** Hard per-navigation timeout when a caller does not pass one (ms). */
+const DEFAULT_BROWSER_TIMEOUT_MS = 45_000;
+/** Default concurrent-context cap (a browser is memory-heavy — keep it small). */
+const DEFAULT_MAX_CONCURRENCY = 2;
+
+/* -------------------------------------------------------------------------- */
+/* Minimal structural view of the parts of the Playwright API we depend on.   */
+/* Declared locally so this package does not need `@types/playwright` and so   */
+/* the dynamic import stays type-safe without `any`.                          */
+/* -------------------------------------------------------------------------- */
+
+interface PwLaunchOptions {
+  headless: boolean;
+  args: string[];
+}
+
+interface PwContextOptions {
+  userAgent: string;
+  locale: string;
+  viewport: { width: number; height: number };
+  extraHTTPHeaders?: Record<string, string>;
+  javaScriptEnabled: boolean;
+}
+
+interface PwGotoOptions {
+  timeout: number;
+  waitUntil: 'domcontentloaded' | 'load' | 'networkidle' | 'commit';
+}
+
+interface PwPage {
+  goto(url: string, options: PwGotoOptions): Promise<unknown>;
+  content(): Promise<string>;
+}
+
+interface PwBrowserContext {
+  newPage(): Promise<PwPage>;
+  close(): Promise<void>;
+}
+
+interface PwBrowser {
+  newContext(options: PwContextOptions): Promise<PwBrowserContext>;
+  isConnected(): boolean;
+  close(): Promise<void>;
+}
+
+interface PwChromium {
+  launch(options: PwLaunchOptions): Promise<PwBrowser>;
+}
+
+export interface PlaywrightModule {
+  chromium: PwChromium;
+}
+
+function isPlaywrightModule(value: unknown): value is PlaywrightModule {
+  if (typeof value !== 'object' || value === null) return false;
+  const chromium = (value as { chromium?: unknown }).chromium;
+  if (typeof chromium !== 'object' || chromium === null) return false;
+  return typeof (chromium as { launch?: unknown }).launch === 'function';
+}
+
+/**
+ * Load Playwright via a dynamic import, or `undefined` when it is not installed.
+ * The specifier is a variable so the compiler does not try to resolve the module
+ * type at build time — this package intentionally does NOT depend on Playwright.
+ */
+export async function loadPlaywright(): Promise<PlaywrightModule | undefined> {
+  const specifier = 'playwright';
+  try {
+    const mod: unknown = await import(specifier);
+    if (isPlaywrightModule(mod)) return mod;
+    // Some bundlers wrap CJS interop under `.default`.
+    const wrapped = (mod as { default?: unknown }).default;
+    return isPlaywrightModule(wrapped) ? wrapped : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Options for {@link PlaywrightBrowserPool}. */
+export interface BrowserPoolOptions {
+  /** Hard per-navigation timeout (ms). Overridden per request by `init.timeoutMs`. */
+  timeoutMs?: number;
+  /** Max concurrent browser contexts (default {@link DEFAULT_MAX_CONCURRENCY}). */
+  maxConcurrency?: number;
+  /** User-Agent applied to every isolated context. */
+  userAgent?: string;
+  /** Extra Chromium launch args (merged after the hardened defaults). */
+  launchArgs?: string[];
+}
+
+/** Chromium flags that keep the headless browser lean and container-friendly. */
+const DEFAULT_LAUNCH_ARGS: readonly string[] = [
+  '--no-sandbox',
+  '--disable-setuid-sandbox',
+  '--disable-dev-shm-usage',
+  '--disable-gpu',
+];
+
+/**
+ * A small, self-managing Playwright pool exposing the {@link UrlFetcher}
+ * contract. One shared browser, isolated context per fetch, hard timeouts and a
+ * concurrency gate. Accepts the loaded {@link PlaywrightModule} by injection so
+ * it can be unit-tested with a fake module (no real browser needed).
+ */
+export class PlaywrightBrowserPool implements UrlFetcher {
+  private readonly timeoutMs: number;
+  private readonly maxConcurrency: number;
+  private readonly userAgent: string;
+  private readonly launchArgs: string[];
+
+  private browser?: PwBrowser;
+  private launching?: Promise<PwBrowser>;
+  private active = 0;
+  private readonly waiters: Array<() => void> = [];
+  private closed = false;
+
+  constructor(
+    private readonly playwright: PlaywrightModule,
+    options: BrowserPoolOptions = {},
+  ) {
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_BROWSER_TIMEOUT_MS;
+    this.maxConcurrency = Math.max(1, options.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY);
+    this.userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
+    this.launchArgs = [...DEFAULT_LAUNCH_ARGS, ...(options.launchArgs ?? [])];
+  }
+
+  /** Lazily launch (or relaunch after a crash) the single shared browser. */
+  private async ensureBrowser(): Promise<PwBrowser> {
+    if (this.browser && this.browser.isConnected()) return this.browser;
+    if (this.launching) return this.launching;
+    this.launching = this.playwright.chromium
+      .launch({ headless: true, args: this.launchArgs })
+      .then((browser) => {
+        this.browser = browser;
+        this.launching = undefined;
+        return browser;
+      })
+      .catch((error) => {
+        this.launching = undefined;
+        throw error;
+      });
+    return this.launching;
+  }
+
+  /** Acquire a concurrency slot, waiting when the pool is saturated. */
+  private async acquire(): Promise<void> {
+    if (this.active < this.maxConcurrency) {
+      this.active += 1;
+      return;
+    }
+    await new Promise<void>((resolve) => this.waiters.push(resolve));
+    this.active += 1;
+  }
+
+  /** Release a slot and wake the next waiter, if any. */
+  private release(): void {
+    this.active -= 1;
+    const next = this.waiters.shift();
+    if (next) next();
+  }
+
+  async fetch(url: string, init?: FetchRuntimeInit): Promise<string> {
+    if (this.closed) throw new Error('PlaywrightBrowserPool is closed');
+    const timeout = init?.timeoutMs ?? this.timeoutMs;
+    await this.acquire();
+    let context: PwBrowserContext | undefined;
+    try {
+      const browser = await this.ensureBrowser();
+      context = await browser.newContext({
+        userAgent: this.userAgent,
+        locale: 'es-ES',
+        viewport: { width: 1366, height: 900 },
+        extraHTTPHeaders: init?.headers,
+        javaScriptEnabled: true,
+      });
+      const page = await context.newPage();
+      // External abort cancels the navigation via the context teardown below.
+      const onAbort = (): void => {
+        void context?.close().catch(() => undefined);
+      };
+      if (init?.signal) {
+        if (init.signal.aborted) onAbort();
+        else init.signal.addEventListener('abort', onAbort, { once: true });
+      }
+      try {
+        await page.goto(url, { timeout, waitUntil: 'domcontentloaded' });
+        return await page.content();
+      } finally {
+        if (init?.signal) init.signal.removeEventListener('abort', onAbort);
+      }
+    } finally {
+      if (context) await context.close().catch(() => undefined);
+      this.release();
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    const browser = this.browser;
+    this.browser = undefined;
+    if (browser) await browser.close().catch(() => undefined);
+  }
+}
+
+/** Env/behaviour options for {@link createBrowserFetcher}. */
+export interface CreateBrowserFetcherOptions extends BrowserPoolOptions {
+  /**
+   * Whether the browser tier is enabled. When false the factory resolves to
+   * `undefined` and the ladder skips the browser tier entirely.
+   */
+  enabled?: boolean;
+  /** Optional structured log sink for the "Playwright not installed" notice. */
+  onLog?: (message: string) => void;
+  /** Injected module for tests; when omitted, Playwright is dynamically loaded. */
+  playwright?: PlaywrightModule;
+}
+
+/**
+ * Build the browser-tier {@link UrlFetcher}, or `undefined` when it is disabled
+ * or Playwright is not installed. Probes Playwright ONCE at construction so the
+ * ladder never attempts a tier that cannot run.
+ */
+export async function createBrowserFetcher(
+  options: CreateBrowserFetcherOptions = {},
+): Promise<UrlFetcher | undefined> {
+  if (options.enabled === false) return undefined;
+  const playwright = options.playwright ?? (await loadPlaywright());
+  if (!playwright) {
+    options.onLog?.(
+      'LISTING_BROWSER_ENABLED is set but Playwright is not installed — browser fetch tier disabled. Run `bun add -D playwright && bunx playwright install chromium` in packages/backend to enable it.',
+    );
+    return undefined;
+  }
+  return new PlaywrightBrowserPool(playwright, options);
+}

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -10,6 +10,8 @@
 
 export * from './types';
 export * from './runtime';
+export * from './browser';
+export * from './managed';
 export * from './registry';
 export * from './metrics';
 export * from './strategy';

--- a/packages/listing-providers/src/managed.ts
+++ b/packages/listing-providers/src/managed.ts
@@ -1,0 +1,110 @@
+/**
+ * Managed anti-bot escalation tier.
+ *
+ * The final rung of the shared fetch ladder (HTTP → browser → **managed**). It
+ * forwards the target URL to a configured managed fetch service (residential
+ * proxies / CAPTCHA solving — e.g. ScraperAPI, ScrapingBee, Zyte) and returns
+ * the HTML that service resolved. It is deliberately OPTIONAL and config-driven:
+ * when `LISTING_MANAGED_FETCH_URL` is unset the factory returns `undefined` and
+ * the ladder SKIPS this rung entirely — we never fake or stub a managed fetch.
+ *
+ * The contract is intentionally generic so any GET-proxy-style service fits
+ * without a per-vendor plugin:
+ *   - the target URL is passed as a query param (name from `urlParam`, default
+ *     `url`);
+ *   - the API key is sent either as a header (`keyHeader`, default `X-Api-Key`)
+ *     or, when `keyParam` is set, as a query param instead;
+ *   - the response BODY is the fetched HTML. A non-2xx response throws so the
+ *     ladder records an `error` and gives up (there is no rung after this).
+ */
+
+import { DEFAULT_TIMEOUT_MS, DEFAULT_USER_AGENT, withAbortTimeout } from './http';
+import type { FetchRuntimeInit, UrlFetcher } from './types';
+
+/** Managed-fetch endpoint + auth configuration. */
+export interface ManagedFetcherConfig {
+  /** Managed fetch service endpoint. REQUIRED — absent config → no fetcher. */
+  endpoint: string;
+  /** API key for the service. */
+  apiKey?: string;
+  /** Query param the target URL is passed in (default `url`). */
+  urlParam?: string;
+  /** Header the API key is sent in (default `X-Api-Key`). Ignored if `keyParam` set. */
+  keyHeader?: string;
+  /** When set, the API key is sent as this query param instead of a header. */
+  keyParam?: string;
+  /** Extra static query params forwarded on every managed request. */
+  extraParams?: Record<string, string>;
+  /** Hard per-request timeout (ms). */
+  timeoutMs?: number;
+}
+
+const DEFAULT_URL_PARAM = 'url';
+const DEFAULT_KEY_HEADER = 'X-Api-Key';
+
+/** A managed anti-bot service client exposing the {@link UrlFetcher} contract. */
+export class ManagedFetcher implements UrlFetcher {
+  private readonly endpoint: string;
+  private readonly apiKey?: string;
+  private readonly urlParam: string;
+  private readonly keyHeader: string;
+  private readonly keyParam?: string;
+  private readonly extraParams: Record<string, string>;
+  private readonly timeoutMs: number;
+
+  constructor(config: ManagedFetcherConfig) {
+    this.endpoint = config.endpoint;
+    this.apiKey = config.apiKey;
+    this.urlParam = config.urlParam ?? DEFAULT_URL_PARAM;
+    this.keyHeader = config.keyHeader ?? DEFAULT_KEY_HEADER;
+    this.keyParam = config.keyParam;
+    this.extraParams = config.extraParams ?? {};
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  /** Build the managed request URL (target + optional key + extra params). */
+  private buildRequestUrl(target: string): string {
+    const requestUrl = new URL(this.endpoint);
+    requestUrl.searchParams.set(this.urlParam, target);
+    for (const [key, value] of Object.entries(this.extraParams)) {
+      requestUrl.searchParams.set(key, value);
+    }
+    if (this.apiKey && this.keyParam) {
+      requestUrl.searchParams.set(this.keyParam, this.apiKey);
+    }
+    return requestUrl.toString();
+  }
+
+  async fetch(target: string, init?: FetchRuntimeInit): Promise<string> {
+    const timeoutMs = init?.timeoutMs ?? this.timeoutMs;
+    const headers: Record<string, string> = {
+      'User-Agent': DEFAULT_USER_AGENT,
+      ...init?.headers,
+    };
+    if (this.apiKey && !this.keyParam) {
+      headers[this.keyHeader] = this.apiKey;
+    }
+    return withAbortTimeout(timeoutMs, init?.signal, async (signal) => {
+      const response = await fetch(this.buildRequestUrl(target), {
+        signal,
+        redirect: 'follow',
+        headers,
+      });
+      const body = await response.text();
+      if (!response.ok) {
+        throw new Error(`Managed fetch failed for ${target}: HTTP ${response.status}`);
+      }
+      return body;
+    });
+  }
+}
+
+/**
+ * Build the managed-tier {@link UrlFetcher} from config, or `undefined` when no
+ * endpoint is configured (the ladder then skips the managed rung). We never
+ * fabricate a managed fetch — an unset endpoint means the rung does not exist.
+ */
+export function createManagedFetcher(config: ManagedFetcherConfig | undefined): UrlFetcher | undefined {
+  if (!config?.endpoint) return undefined;
+  return new ManagedFetcher(config);
+}

--- a/packages/listing-providers/src/providers/es/jsonLd.ts
+++ b/packages/listing-providers/src/providers/es/jsonLd.ts
@@ -196,14 +196,6 @@ function readAmenities(value: unknown): { amenities: string[]; furnished?: boole
   return { amenities, furnished };
 }
 
-/** Map a schema.org `@type` list onto a coarse property category string. */
-function readPropertyType(types: string[]): string {
-  const lower = types.map((type) => type.toLowerCase());
-  if (lower.some((type) => type.includes('house') || type.includes('singlefamily'))) return 'house';
-  if (lower.some((type) => type.includes('studio'))) return 'studio';
-  return 'apartment';
-}
-
 function toListing(node: Record<string, unknown>): EsSchemaListing {
   const offer = readOffer(node.offers);
   const { amenities, furnished } = readAmenities(node.amenityFeature);

--- a/packages/listing-providers/src/providers/fixture/index.ts
+++ b/packages/listing-providers/src/providers/fixture/index.ts
@@ -19,7 +19,6 @@ import {
 import type {
   DiscoverJob,
   ExternalListingRef,
-  FetchContext,
   ListingProvider,
   ProviderHealth,
   RawListing,
@@ -83,7 +82,7 @@ export class FixtureProvider implements ListingProvider {
     }
   }
 
-  async fetch(ref: ExternalListingRef, _ctx: FetchContext): Promise<RawListing> {
+  async fetch(ref: ExternalListingRef): Promise<RawListing> {
     const listing = this.listings.find((item) => item.id === ref.sourceId);
     if (!listing) {
       throw new Error(`fixture provider has no listing for sourceId "${ref.sourceId}"`);

--- a/packages/listing-providers/src/runtime.ts
+++ b/packages/listing-providers/src/runtime.ts
@@ -10,7 +10,9 @@
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import type { FetchRuntime, FetchRuntimeInit } from './types';
+import type { FetchRuntime, FetchRuntimeInit, UrlFetcher } from './types';
+import { createBrowserFetcher } from './browser';
+import { createManagedFetcher, type ManagedFetcherConfig } from './managed';
 
 /** Default per-request abort budget (ms). */
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -111,4 +113,104 @@ export class HttpFetchRuntime implements FetchRuntime {
 /** Convenience factory for the default HTTP runtime. */
 export function createFetchRuntime(options?: HttpFetchRuntimeOptions): FetchRuntime {
   return new HttpFetchRuntime(options);
+}
+
+/** Options for {@link createListingFetchRuntime}. */
+export interface ListingFetchRuntimeOptions extends HttpFetchRuntimeOptions {
+  /** Optional browser-tier fetcher; when omitted `fetchViaBrowser` is absent. */
+  browser?: UrlFetcher;
+  /** Optional managed-tier fetcher; when omitted `fetchViaManaged` is absent. */
+  managed?: UrlFetcher;
+}
+
+/**
+ * A composed runtime plus a shutdown that disposes any escalation-tier
+ * resources (the browser pool, managed-client sockets). The worker holds this so
+ * it can close the browser cleanly on SIGTERM/SIGINT.
+ */
+export interface ListingFetchRuntimeHandle {
+  runtime: FetchRuntime;
+  shutdown(): Promise<void>;
+}
+
+/**
+ * Compose the full listing fetch runtime: the HTTP base plus whichever
+ * escalation tiers were provided. Crucially, `fetchViaBrowser`/`fetchViaManaged`
+ * are attached ONLY when their fetcher is present, so the shared ladder skips a
+ * tier the deployment did not provision (it keys availability off method
+ * presence).
+ */
+export function createListingFetchRuntime(
+  options: ListingFetchRuntimeOptions = {},
+): ListingFetchRuntimeHandle {
+  const http = new HttpFetchRuntime(options);
+  const { browser, managed } = options;
+
+  const runtime: FetchRuntime = {
+    fetchJson: (url, init) => http.fetchJson(url, init),
+    fetchText: (url, init) => http.fetchText(url, init),
+    loadFixture: (key) => http.loadFixture(key),
+  };
+  if (browser) runtime.fetchViaBrowser = (url, init) => browser.fetch(url, init);
+  if (managed) runtime.fetchViaManaged = (url, init) => managed.fetch(url, init);
+
+  return {
+    runtime,
+    shutdown: async () => {
+      await browser?.close?.();
+      await managed?.close?.();
+    },
+  };
+}
+
+/** Read a positive integer env var, falling back when unset/invalid. */
+function envInt(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/** Assemble the managed-fetch config from env, or `undefined` when unconfigured. */
+function managedConfigFromEnv(): ManagedFetcherConfig | undefined {
+  const endpoint = process.env.LISTING_MANAGED_FETCH_URL?.trim();
+  if (!endpoint) return undefined;
+  const config: ManagedFetcherConfig = { endpoint };
+  const apiKey = process.env.LISTING_MANAGED_FETCH_KEY?.trim();
+  if (apiKey) config.apiKey = apiKey;
+  const urlParam = process.env.LISTING_MANAGED_FETCH_URL_PARAM?.trim();
+  if (urlParam) config.urlParam = urlParam;
+  const keyHeader = process.env.LISTING_MANAGED_FETCH_KEY_HEADER?.trim();
+  if (keyHeader) config.keyHeader = keyHeader;
+  const keyParam = process.env.LISTING_MANAGED_FETCH_KEY_PARAM?.trim();
+  if (keyParam) config.keyParam = keyParam;
+  config.timeoutMs = envInt('LISTING_MANAGED_FETCH_TIMEOUT_MS', 60_000);
+  return config;
+}
+
+/** Options for {@link createListingFetchRuntimeFromEnv}. */
+export interface ListingFetchRuntimeFromEnvOptions {
+  /** Structured log sink for operational notices (e.g. Playwright missing). */
+  onLog?: (message: string) => void;
+}
+
+/**
+ * Build the worker's fetch runtime from environment variables:
+ *   - browser tier: enabled by `LISTING_BROWSER_ENABLED=true`, tuned by
+ *     `LISTING_BROWSER_MAX_CONCURRENCY` / `LISTING_BROWSER_TIMEOUT_MS`. Skipped
+ *     (with a log notice) when Playwright is not installed.
+ *   - managed tier: enabled by `LISTING_MANAGED_FETCH_URL` (+ optional key/param
+ *     vars). Skipped when the endpoint is unset.
+ *
+ * The API/Express process must never call this — only the worker.
+ */
+export async function createListingFetchRuntimeFromEnv(
+  options: ListingFetchRuntimeFromEnvOptions = {},
+): Promise<ListingFetchRuntimeHandle> {
+  const browser = await createBrowserFetcher({
+    enabled: process.env.LISTING_BROWSER_ENABLED === 'true',
+    maxConcurrency: envInt('LISTING_BROWSER_MAX_CONCURRENCY', 2),
+    timeoutMs: envInt('LISTING_BROWSER_TIMEOUT_MS', 45_000),
+    onLog: options.onLog,
+  });
+  const managed = createManagedFetcher(managedConfigFromEnv());
+  return createListingFetchRuntime({ browser, managed });
 }

--- a/packages/listing-providers/src/types.ts
+++ b/packages/listing-providers/src/types.ts
@@ -122,6 +122,21 @@ export interface FetchRuntimeInit {
 }
 
 /**
+ * A single escalation-tier fetcher: takes a URL, returns the fetched HTML body.
+ * The shared runtime's OPTIONAL {@link FetchRuntime.fetchViaBrowser} /
+ * {@link FetchRuntime.fetchViaManaged} tiers are backed by one of these. Kept
+ * separate from the runtime so a browser pool or a managed-service client can be
+ * built (and disposed via {@link UrlFetcher.close}) independently, then composed
+ * into a runtime by {@link createListingFetchRuntime}.
+ */
+export interface UrlFetcher {
+  /** Fetch a URL through this tier and return the raw HTML body. */
+  fetch(url: string, init?: FetchRuntimeInit): Promise<string>;
+  /** Release any owned resources (browser pool, sockets). Optional/idempotent. */
+  close?(): Promise<void>;
+}
+
+/**
  * A listing provider plugin. Implementations are pure w.r.t. persistence: they
  * never touch Mongo or S3 — they only turn a portal into a
  * {@link NormalizedListing} for the backend `IngestionService`.


### PR DESCRIPTION
## Summary

Completes the Listing Provider Plugins system with **worker-only, env-gated escalation tiers** for blocked portal fetches.

### Architecture (already on main via #105 / d6e4fb5)

- **`@homiio/listing-providers`** — plugin contract (`ListingProvider`), `ProviderRegistry`, shared `FetchRuntime` (rate limit, retries, circuit breaker, strategy ladder), and six portal plugins (Idealista, Fotocasa, Habitaclia, Blueground, apartments.com, Zillow) plus a fixture provider for tests.
- **Backend ingestion** — `IngestionService` + `ExternalMediaIngest` normalize listings → canonical Address → Property upsert (`isExternal: true`) → Sharp → S3 image pipeline. No portal CDN hotlinks at runtime.
- **Worker** — `worker.ts` + BullMQ queues (`listing-discover`, `listing-fetch`, `listing-media`) on Valkey; dedup job ids via sha256; legacy Fotocasa cron retired.
- **Admin-only scraper routes** — `/api/scraper/*` gated; TTL cleanup + health reporting via `scraperService`.
- **Tests** — provider normalize fixtures, strategy ladder, external ingest integration (72 tests green locally).

### This PR adds

- **`createListingFetchRuntimeFromEnv()`** — assembles HTTP + optional browser (Playwright) + optional managed-fetch rungs from env; absent tiers are skipped (not attempted-and-failed).
- **`browser.ts`** — Playwright pool (optional peer dep, dynamic import; absent → tier skipped, CI still green).
- **`managed.ts`** — managed fetch proxy tier (`LISTING_MANAGED_FETCH_URL` + optional key/header/param config).
- **Worker wiring** — replaces bare `HttpFetchRuntime` with env-assembled runtime + `shutdown()` on exit.
- **Unit tests** — `listingFetchTiers.test.ts` covers tier gating and ladder behavior.
- **Docs** — AGENTS.md escalation tier rules; `.env.example` worker env vars.

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run build:shared-types` + `@homiio/listing-providers build` + `build:backend`
- [x] 72 listing-provider Jest tests pass (`listingFetchTiers`, `strategyLadder`, all provider fixtures, `externalIngest`)


Made with [Cursor](https://cursor.com)