### PR TITLE
fix(docker): Playwright install path for listing worker image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,14 @@ Expo/RN frontend + Express backend. Agent: `homiio`.
 
 ## Deployment
 
-- **Port**: `4000` | **Domain**: `api.homiio.com` | **ECR**: `oxy/homiio`
+Homiio runs on **AWS ECS Fargate** — not DigitalOcean App Platform or droplets. Infra (ECS task defs, ALB, ECR, SSM, S3 bucket) lives in `~/Oxy/oxy-infra/terraform-uswest2/`.
+
+- **Port**: `4000` | **Domain**: `api.homiio.com` | **ECR**: `oxy/homiio` | **Region**: `us-west-2`
 - Build: `linux/arm64` Dockerfile in `packages/backend/`.
+- Deploy: push to `main` → `.github/workflows/deploy-aws.yml` (OIDC `oxy-github-deploy`, no AWS keys in GitHub).
+- Secrets: GitHub repo secrets → SSM `/oxy/homiio/*` and `/oxy/_shared/*` → injected by ECS at task launch.
+- Media: S3 bucket `oxy-homiio-media-usw2-237343248947` (set via `AWS_S3_BUCKET` in ECS env).
+- Worker: same ECR image, separate ECS service (`app-homiio-worker.tf`); entrypoint `packages/backend/worker.ts`.
 
 ## Commands
 

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -117,8 +117,10 @@ RUN bun add --cwd packages/backend playwright@1.61.1 \
 
 # Install Chromium + its OS dependencies into PLAYWRIGHT_BROWSERS_PATH.
 # Kept in the shared image so one ECR tag serves API + worker; the API never
-# launches a browser (LISTING_* flags are worker-only).
-RUN bunx --cwd packages/backend playwright install --with-deps chromium \
+# launches a browser (LISTING_* flags are worker-only). Use the local binary
+# (not `bunx --cwd`, which mis-resolves the package name as a GitHub repo).
+RUN cd packages/backend \
+ && ./node_modules/.bin/playwright install --with-deps chromium \
  && chmod -R a+rX /ms-playwright
 
 # Copy the compiled JavaScript (incl. staged locales) from the build stage.


### PR DESCRIPTION
## Summary
- Fix Docker build: use `./node_modules/.bin/playwright install` instead of broken `bunx --cwd`.
- Document Homiio ECS/worker deploy in AGENTS.md.

## Test plan
- [ ] Deploy workflow builds and pushes image
- [ ] `homiio` API stays RUNNING
- [ ] `homiio-worker` browserTier=true in logs