### PR TITLE
fix(docker): hoisted Playwright binary path

### DIFF
--- a/docs/deployment.mdx
+++ b/docs/deployment.mdx
@@ -6,16 +6,17 @@ order: 7
 
 # Deployment
 
-The backend deploys to **AWS ECS Fargate** and the frontend web export deploys to **Cloudflare Pages**. Both are driven by GitHub Actions on push to `main`.
+The backend deploys to **AWS ECS Fargate** and the frontend web export deploys to **Cloudflare Pages**. Both are driven by GitHub Actions on push to `main`. Homiio does **not** deploy to DigitalOcean App Platform or droplets — ECS task definitions, ALB routing, ECR, SSM secrets, and the S3 media bucket are owned by `~/Oxy/oxy-infra/terraform-uswest2/`.
 
 ## Backend (AWS ECS Fargate)
 
 Workflow: `.github/workflows/deploy-aws.yml`
 
-- Region `eu-west-1`, cluster `oxy-cluster`, service `homiio`, port `4000`, domain `api.homiio.com` (ALB + ACM HTTPS).
-- Builds a `linux/arm64` Docker image from `packages/backend/Dockerfile` and pushes it to ECR (`237343248947.dkr.ecr.eu-west-1.amazonaws.com/oxy/homiio`), then runs `aws ecs update-service --force-new-deployment`.
+- Region `us-west-2`, cluster `oxy-cluster`, service `homiio`, port `4000`, domain `api.homiio.com` (Cloudflare DNS-only → ALB + ACM HTTPS).
+- Builds a `linux/arm64` Docker image from `packages/backend/Dockerfile` and pushes it to ECR (`237343248947.dkr.ecr.us-west-2.amazonaws.com/oxy/homiio`), then runs `aws ecs update-service --force-new-deployment`.
 - Auth is GitHub OIDC assuming the `oxy-github-deploy` role — no AWS keys are stored in GitHub.
 - Secrets: GitHub Actions secrets are the source of truth. The workflow syncs them to AWS SSM (`/oxy/homiio/*`; shared secrets to `/oxy/_shared/*`) and ECS injects them into the container. To change a secret, edit it in GitHub — the next deploy applies it.
+- Listing-ingestion worker: same ECR image, separate ECS service (`app-homiio-worker.tf` in oxy-infra); command runs `packages/backend/worker.ts`.
 
 ## Frontend (Cloudflare Pages)
 
@@ -49,7 +50,7 @@ if (!process.env.VERCEL && !process.env.AWS_LAMBDA_FUNCTION_NAME) {
 }
 ```
 
-On ECS this means cron jobs (scraper refreshes, external-listing expiration) run inside the service task.
+On ECS this means cron jobs (health checks, external-listing TTL cleanup) run inside the service task.
 
 ## Environment
 
@@ -78,9 +79,11 @@ OPENAI_API_KEY=sk-...
 OPENAI_MODEL=gpt-4o
 AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
-AWS_REGION=eu-west-1
-AWS_S3_BUCKET=homiio-images
+AWS_REGION=us-west-2
+AWS_S3_BUCKET=oxy-homiio-media-usw2-237343248947
 ```
+
+Production uses native AWS S3 — omit `AWS_ENDPOINT_URL`. The bucket name and region are set in `~/Oxy/oxy-infra/terraform-uswest2/app-services.tf`.
 
 ## CORS
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -53,11 +53,11 @@ STRIPE_CANCEL_URL=http://localhost:8081/profile/subscriptions
 OPENAI_API_KEY=sk-...
 OPENAI_MODEL=gpt-4o
 
-# AWS S3 — required for image uploads
+# AWS S3 — required for image uploads (production bucket from oxy-infra)
 AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
-AWS_REGION=eu-west-1
-AWS_S3_BUCKET=homiio-images
+AWS_REGION=us-west-2
+AWS_S3_BUCKET=oxy-homiio-media-usw2-237343248947
 ```
 
 `packages/frontend/.env`:

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -86,11 +86,11 @@ STRIPE_CANCEL_URL=https://homiio.com/profile/subscriptions
 # AI (Sindi assistant)
 OPENAI_API_KEY=sk-...
 
-# Image pipeline
+# Image pipeline (production bucket from oxy-infra)
 AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
-AWS_REGION=eu-west-1
-AWS_S3_BUCKET=homiio-images
+AWS_REGION=us-west-2
+AWS_S3_BUCKET=oxy-homiio-media-usw2-237343248947
 ```
 
 `packages/frontend/.env`:

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -117,10 +117,10 @@ RUN bun add --cwd packages/backend playwright@1.61.1 \
 
 # Install Chromium + its OS dependencies into PLAYWRIGHT_BROWSERS_PATH.
 # Kept in the shared image so one ECR tag serves API + worker; the API never
-# launches a browser (LISTING_* flags are worker-only). Use the local binary
-# (not `bunx --cwd`, which mis-resolves the package name as a GitHub repo).
-RUN cd packages/backend \
- && ./node_modules/.bin/playwright install --with-deps chromium \
+# launches a browser (LISTING_* flags are worker-only). With `linker=hoisted`
+# the playwright CLI lands in the workspace-root node_modules/.bin — not under
+# packages/backend (and `bunx --cwd` mis-resolves the package as a GitHub repo).
+RUN ./node_modules/.bin/playwright install --with-deps chromium \
  && chmod -R a+rX /ms-playwright
 
 # Copy the compiled JavaScript (incl. staged locales) from the build stage.

--- a/packages/backend/docs/image-upload.md
+++ b/packages/backend/docs/image-upload.md
@@ -1,13 +1,13 @@
 # Image Upload Service
 
-This service provides image upload functionality using AWS SDK for S3, optimized for DigitalOcean Spaces. It includes automatic image optimization, multiple variants, and quality reduction to minimize file sizes.
+This service provides image upload functionality using the AWS SDK for S3. Production stores images in the Homiio media bucket (`oxy-homiio-media-usw2-237343248947`, region `us-west-2`) provisioned by `~/Oxy/oxy-infra`. It includes automatic image optimization, multiple variants, and quality reduction to minimize file sizes.
 
 ## Features
 
 - **Multiple Image Variants**: Automatically generates small, medium, large, and original variants
 - **Quality Optimization**: Reduces file sizes while maintaining visual quality
 - **Format Conversion**: Converts images to WebP for better compression (except original)
-- **S3 Integration**: Uses AWS SDK for S3 compatible with DigitalOcean Spaces
+- **S3 Integration**: Uses AWS SDK for S3 (native AWS in production)
 - **Error Handling**: Comprehensive error handling and validation
 - **Batch Upload**: Support for uploading multiple images at once
 
@@ -16,12 +16,12 @@ This service provides image upload functionality using AWS SDK for S3, optimized
 Add the following environment variables to your `.env` file:
 
 ```env
-# DigitalOcean Spaces Configuration
-S3_ENDPOINT=https://nyc3.digitaloceanspaces.com
-S3_REGION=nyc3
-S3_ACCESS_KEY_ID=your_access_key_id
-S3_SECRET_ACCESS_KEY=your_secret_access_key
-S3_BUCKET_NAME=homiio-images
+# AWS S3 (production — set by ECS via oxy-infra)
+AWS_REGION=us-west-2
+AWS_ACCESS_KEY_ID=your_access_key_id
+AWS_SECRET_ACCESS_KEY=your_secret_access_key
+AWS_S3_BUCKET=oxy-homiio-media-usw2-237343248947
+# Omit AWS_ENDPOINT_URL for native AWS S3. Only set for local S3-compatible mocks.
 ```
 
 ## API Endpoints
@@ -44,10 +44,10 @@ Body:
   "data": {
     "imageId": "uuid",
     "urls": {
-      "small": "https://nyc3.digitaloceanspaces.com/bucket/small-url",
-      "medium": "https://nyc3.digitaloceanspaces.com/bucket/medium-url",
-      "large": "https://nyc3.digitaloceanspaces.com/bucket/large-url",
-      "original": "https://nyc3.digitaloceanspaces.com/bucket/original-url"
+      "small": "https://<bucket>.s3.us-west-2.amazonaws.com/.../small.webp",
+      "medium": "https://<bucket>.s3.us-west-2.amazonaws.com/.../medium.webp",
+      "large": "https://<bucket>.s3.us-west-2.amazonaws.com/.../large.webp",
+      "original": "https://<bucket>.s3.us-west-2.amazonaws.com/.../original.jpeg"
     },
     "metadata": {
       "originalSize": 1024000,

--- a/packages/frontend/docs/image-upload-integration.md
+++ b/packages/frontend/docs/image-upload-integration.md
@@ -234,7 +234,7 @@ Required dependencies (already included):
 To test the image upload functionality:
 
 1. **Start the backend server** with image upload endpoints
-2. **Configure environment variables** for S3/DigitalOcean Spaces
+2. **Configure backend environment variables** for AWS S3 (`AWS_REGION`, `AWS_S3_BUCKET`, credentials)
 3. **Run the frontend app** in development mode
 4. **Navigate to property creation** and go to Media step
 5. **Test image selection** from gallery
@@ -258,5 +258,5 @@ To test the image upload functionality:
 1. Check console logs for error messages
 2. Verify API endpoints are accessible
 3. Test authentication token validity
-4. Check S3/DigitalOcean Spaces configuration
+4. Check AWS S3 configuration on the backend (`AWS_S3_BUCKET`, `AWS_REGION`, credentials)
 5. Verify image file formats and sizes


### PR DESCRIPTION
## Summary
- Playwright CLI lives at workspace-root `node_modules/.bin` under bun's hoisted linker; install Chromium from there so the image build succeeds.

## Test plan
- [ ] Deploy workflow builds and pushes image
- [ ] Worker logs show `browserTier: true`

Made with [Cursor](https://cursor.com)