### PR TITLE
fix(media+docker): native AWS S3 + Playwright image path

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -51,17 +51,18 @@ TELEGRAM_GROUP_DEFAULT=-1002750613848
 # Optional US group chat id. [optional]
 TELEGRAM_GROUP_US=
 
-# --- Object storage (S3 / DigitalOcean Spaces) ------------------------------
-# S3-compatible endpoint (omit/region-default for native AWS S3). [optional]
-AWS_ENDPOINT_URL=https://nyc3.digitaloceanspaces.com
-# Region of the bucket. [optional]
-AWS_REGION=nyc3
+# --- Object storage (AWS S3) ------------------------------------------------
+# Leave AWS_ENDPOINT_URL unset for native AWS S3 (production). Only set it for
+# S3-compatible mocks (MinIO, localstack). [optional]
+AWS_ENDPOINT_URL=
+# Region of the bucket (production: us-west-2). [optional]
+AWS_REGION=us-west-2
 # Access key id. [SECRET]
 AWS_ACCESS_KEY_ID=
 # Secret access key. [SECRET]
 AWS_SECRET_ACCESS_KEY=
-# Bucket name for uploaded images. [optional]
-AWS_S3_BUCKET=homiio-images
+# Bucket name for uploaded images (production: oxy-homiio-media-usw2-…). [optional]
+AWS_S3_BUCKET=oxy-homiio-media-usw2-237343248947
 
 # --- Stripe (billing / subscriptions) ---------------------------------------
 # Secret API key (sk_live_... / sk_test_...). [SECRET]

--- a/packages/backend/config.ts
+++ b/packages/backend/config.ts
@@ -60,6 +60,7 @@ export interface Config {
     password?: string;
   };
   s3: {
+    /** Custom S3-compatible endpoint. Empty = native AWS S3. */
     endpoint: string;
     region: string;
     accessKeyId: string;
@@ -213,10 +214,12 @@ const config: Config = {
     password: process.env.EMAIL_PASSWORD,
   },
   
-  // S3 Configuration (DigitalOcean Spaces)
+  // Object storage — native AWS S3 in production (oxy-infra media bucket).
+  // Set AWS_ENDPOINT_URL only for S3-compatible mocks / local MinIO; leave
+  // unset for real AWS so the SDK uses the regional endpoint.
   s3: {
-    endpoint: process.env.AWS_ENDPOINT_URL || 'https://nyc3.digitaloceanspaces.com',
-    region: process.env.AWS_REGION || 'nyc3',
+    endpoint: (process.env.AWS_ENDPOINT_URL || '').trim(),
+    region: process.env.AWS_REGION || 'us-west-2',
     accessKeyId: process.env.AWS_ACCESS_KEY_ID || '',
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || '',
     bucketName: process.env.AWS_S3_BUCKET || 'homiio-images',

--- a/packages/backend/services/imageUploadService.ts
+++ b/packages/backend/services/imageUploadService.ts
@@ -124,14 +124,16 @@ export class ImageUploadService {
   ];
 
   constructor() {
+    // Native AWS S3 when AWS_ENDPOINT_URL is unset; custom endpoint (MinIO /
+    // local mocks) only when explicitly configured. forcePathStyle is for
+    // S3-compatible stores — never for real AWS (virtual-hosted-style).
     this.s3Client = new S3Client({
-      endpoint: config.s3.endpoint,
+      ...(config.s3.endpoint ? { endpoint: config.s3.endpoint, forcePathStyle: true } : {}),
       region: config.s3.region,
       credentials: {
         accessKeyId: config.s3.accessKeyId,
         secretAccessKey: config.s3.secretAccessKey,
       },
-      forcePathStyle: true, // Use path-style URLs for DigitalOcean Spaces
     });
   }
 
@@ -378,7 +380,11 @@ export class ImageUploadService {
     if (!this.isStorageConfigured()) {
       return `${config.publicUrl}${LOCAL_IMAGE_ROUTE}/${key}`;
     }
-    return `${config.s3.endpoint}/${config.s3.bucketName}/${key}`;
+    if (config.s3.endpoint) {
+      return `${config.s3.endpoint.replace(/\/$/, '')}/${config.s3.bucketName}/${key}`;
+    }
+    // Native AWS virtual-hosted-style URL.
+    return `https://${config.s3.bucketName}.s3.${config.s3.region}.amazonaws.com/${key}`;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Native AWS S3 (no DigitalOcean Spaces default) so listing media ingest hits `oxy-homiio-media-usw2-…`.
- Playwright Chromium install uses hoisted `/app/node_modules/.bin/playwright`.
- Unblocks API boot image (prior PR) + worker browser tier + fixture image URLs.

## Test plan
- [ ] Deploy builds image successfully
- [ ] `homiio` API RUNNING; `api.homiio.com` 200
- [ ] Worker `browserTier: true`; fixture images are S3 URLs

Made with [Cursor](https://cursor.com)