### PR TITLE
fix(media): drop S3 ACL for Homiio media uploads

### DIFF
--- a/packages/backend/services/imageUploadService.ts
+++ b/packages/backend/services/imageUploadService.ts
@@ -345,12 +345,13 @@ export class ImageUploadService {
   }
 
   private async uploadToS3(buffer: Buffer, key: string, contentType: string): Promise<void> {
+    // Homiio media buckets use BucketOwnerEnforced (ACLs disabled). Do not set
+    // ACL — public delivery is via signed URL / CDN, not object ACLs.
     const command = new PutObjectCommand({
       Bucket: config.s3.bucketName,
       Key: key,
       Body: buffer,
       ContentType: contentType,
-      ACL: 'public-read',
       CacheControl: 'public, max-age=31536000', // 1 year cache
     });
 


### PR DESCRIPTION
## Summary
- Homiio S3 buckets use `BucketOwnerEnforced` + block public ACLs. `PutObject` with `ACL: public-read` caused fixture/media ingest to skip every image.
- Upload without ACL so listing media lands in S3.

## Test plan
- [ ] Fixture re-ingest shows `imageCount > 0` and S3 URLs (not portal CDN)

Made with [Cursor](https://cursor.com)