### PR TITLE
HomeCategoryStrip: tighter gaps + persistent card background

### DIFF
--- a/packages/frontend/components/HomeCategoryStrip.tsx
+++ b/packages/frontend/components/HomeCategoryStrip.tsx
@@ -179,12 +179,10 @@ export const HomeCategoryStrip: React.FC<HomeCategoryStripProps> = ({
   const framed = isWeb && isScreenNotMobile;
 
   /**
-   * Web-only `position: sticky` lives outside the RN style system. We
-   * inject it via the style object and rely on react-native-web to
-   * pass it through to the underlying div. On native, this is a no-op.
-   * Opaque fill must match ContentPanel's `bg-card` (not pure white) so
-   * scrolled content doesn't flash a competing surface under the strip.
-   * `top` stays numeric from PANEL_TOP_INSET when framed.
+   * Solid card surface on web + native so scrolled feed content never
+   * shows through the strip. Web-only `position: sticky` lives outside
+   * the RN style system — inject via style and rely on react-native-web
+   * to pass it through. `top` stays numeric from PANEL_TOP_INSET when framed.
    */
   const stickyStyle =
     sticky && isWeb
@@ -192,14 +190,16 @@ export const HomeCategoryStrip: React.FC<HomeCategoryStripProps> = ({
           position: 'sticky',
           top: framed ? PANEL_TOP_INSET : 0,
           zIndex: 30,
-          backgroundColor: themeColors.card,
           borderBottomWidth: 1,
           borderBottomColor: colors.border,
         } as unknown as object)
       : null;
 
   return (
-    <View className={className ?? 'w-full py-1'} style={stickyStyle}>
+    <View
+      className={className ?? 'w-full py-1'}
+      style={[{ backgroundColor: themeColors.card }, stickyStyle]}
+    >
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}

--- a/packages/frontend/components/HomeCategoryStrip.tsx
+++ b/packages/frontend/components/HomeCategoryStrip.tsx
@@ -6,8 +6,8 @@
  * Visual language:
  *   - Compact 40px isometric PNG render per category (full-color, never tinted)
  *     clipped to a `radius.lg` rounded square so it reads as a premium tile.
- *   - 12px label sitting just under the image, on a fixed-width item so
- *     labels line up across the row.
+ *   - 12px label flush under the image (no tile/label gap), on a fixed-width
+ *     item so labels line up across the row.
  *   - Active state = a soft rounded background highlight behind the whole
  *     item (icon + label) plus a dark + bold label and the image at full
  *     opacity; inactive = transparent background, muted label, image at
@@ -71,7 +71,7 @@ const VACATION_CATEGORIES: CategoryDef[] = [
 /** Edge length of the isometric tile — compact so more categories fit on screen. */
 const TILE_SIZE = 40;
 /** Fixed item width keeps labels aligned across the row regardless of label length. */
-const ITEM_WIDTH = 68;
+const ITEM_WIDTH = 64;
 
 const resolveCategoryImage = (id: HomeCategory): ImageSourcePropType =>
   getIconArt(id) ?? ICON_ART_PLACEHOLDER;
@@ -117,8 +117,8 @@ const CategoryItem: React.FC<CategoryItemProps> = ({ active, label, image, onPre
       onHoverOut={() => setHovered(false)}
       className={
         active
-          ? 'items-center justify-center rounded-2xl bg-secondary px-1.5 py-1.5'
-          : 'items-center justify-center rounded-2xl bg-transparent px-1.5 py-1.5'
+          ? 'items-center justify-center rounded-2xl bg-secondary px-1 py-1'
+          : 'items-center justify-center rounded-2xl bg-transparent px-1 py-1'
       }
       accessibilityRole="button"
       accessibilityState={{ selected: active }}
@@ -126,7 +126,7 @@ const CategoryItem: React.FC<CategoryItemProps> = ({ active, label, image, onPre
       style={{ width: ITEM_WIDTH, transform: [{ scale }] }}
     >
       <View
-        className="mb-0.5 items-center justify-center overflow-hidden rounded-2xl"
+        className="items-center justify-center overflow-hidden rounded-2xl"
         style={{ width: TILE_SIZE, height: TILE_SIZE }}
       >
         <Image
@@ -199,13 +199,13 @@ export const HomeCategoryStrip: React.FC<HomeCategoryStripProps> = ({
       : null;
 
   return (
-    <View className={className ?? 'w-full py-2'} style={stickyStyle}>
+    <View className={className ?? 'w-full py-1'} style={stickyStyle}>
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
         decelerationRate={isWeb ? 'normal' : 'fast'}
         snapToAlignment="start"
-        contentContainerClassName={isWeb ? 'gap-2 px-6' : 'gap-1.5 px-4'}
+        contentContainerClassName={isWeb ? 'gap-1 px-4' : 'gap-0.5 px-3'}
       >
         {items.map((item) => (
           <CategoryItem


### PR DESCRIPTION
## Summary
- Tighten HomeCategoryStrip horizontal padding and item gaps (web + native).
- Apply a persistent `themeColors.card` background on the strip wrapper (web + native) so the category row reads as a solid bar; sticky web mode keeps the border-bottom separator.

## Test plan
- [x] `bun run build:frontend` passes
- [ ] Verify home feed category strip shows opaque card surface when scrolling (web framed + native)
- [ ] Confirm sticky border-bottom still appears on wide web when `sticky` is enabled
- [ ] Confirm category tile size (40px) and icon art unchanged


Made with [Cursor](https://cursor.com)