### PR TITLE
Use muted background on HomeCategoryStrip

### DIFF
--- a/packages/frontend/components/HomeCategoryStrip.tsx
+++ b/packages/frontend/components/HomeCategoryStrip.tsx
@@ -179,8 +179,9 @@ export const HomeCategoryStrip: React.FC<HomeCategoryStripProps> = ({
   const framed = isWeb && isScreenNotMobile;
 
   /**
-   * Solid card surface on web + native so scrolled feed content never
-   * shows through the strip. Web-only `position: sticky` lives outside
+   * Solid muted surface on web + native so scrolled feed content never
+   * shows through the strip (`backgroundTertiary` → Bloom `--muted` /
+   * NativeWind `bg-muted`). Web-only `position: sticky` lives outside
    * the RN style system — inject via style and rely on react-native-web
    * to pass it through. `top` stays numeric from PANEL_TOP_INSET when framed.
    */
@@ -198,7 +199,7 @@ export const HomeCategoryStrip: React.FC<HomeCategoryStripProps> = ({
   return (
     <View
       className={className ?? 'w-full py-1'}
-      style={[{ backgroundColor: themeColors.card }, stickyStyle]}
+      style={[{ backgroundColor: themeColors.backgroundTertiary }, stickyStyle]}
     >
       <ScrollView
         horizontal


### PR DESCRIPTION
## Summary
- Switch `HomeCategoryStrip` outer wrapper from `themeColors.card` to `themeColors.backgroundTertiary` (Bloom `--muted` / NativeWind `bg-muted`).
- Sticky behavior, z-index, border-bottom, icon sizes, and spacing unchanged.

## Test plan
- [x] Frontend build passes
- [ ] Verify home category strip renders with muted background on web (light + dark)
- [ ] Confirm sticky sub-header still pins correctly on wide web breakpoints

Made with [Cursor](https://cursor.com)