### PR TITLE
Use page background on HomeCategoryStrip

### DIFF
--- a/packages/frontend/components/HomeCategoryStrip.tsx
+++ b/packages/frontend/components/HomeCategoryStrip.tsx
@@ -179,9 +179,9 @@ export const HomeCategoryStrip: React.FC<HomeCategoryStripProps> = ({
   const framed = isWeb && isScreenNotMobile;
 
   /**
-   * Solid muted surface on web + native so scrolled feed content never
-   * shows through the strip (`backgroundTertiary` → Bloom `--muted` /
-   * NativeWind `bg-muted`). Web-only `position: sticky` lives outside
+   * Solid page background on web + native so scrolled feed content never
+   * shows through the strip (`background` → Bloom `--background` /
+   * NativeWind `bg-background`). Web-only `position: sticky` lives outside
    * the RN style system — inject via style and rely on react-native-web
    * to pass it through. `top` stays numeric from PANEL_TOP_INSET when framed.
    */
@@ -199,7 +199,7 @@ export const HomeCategoryStrip: React.FC<HomeCategoryStripProps> = ({
   return (
     <View
       className={className ?? 'w-full py-1'}
-      style={[{ backgroundColor: themeColors.backgroundTertiary }, stickyStyle]}
+      style={[{ backgroundColor: themeColors.background }, stickyStyle]}
     >
       <ScrollView
         horizontal


### PR DESCRIPTION
## Summary
- Switch `HomeCategoryStrip` outer wrapper from `themeColors.backgroundTertiary` (muted) to `themeColors.background` so the strip matches the page shell.
- Sticky web behavior, icon sizes, and spacing are unchanged.

## Test plan
- [ ] Open home on web (wide + narrow): category strip stays sticky and uses page background, not muted gray.
- [ ] Open home on native: strip background matches page; category selection/highlight unchanged.
- [ ] Toggle long-term vs vacation mode: categories still render and filter correctly.


Made with [Cursor](https://cursor.com)