### PR TITLE
fix: cross-origin listing images + Sharp variant mapping

### DIFF
--- a/packages/backend/controllers/imageController.ts
+++ b/packages/backend/controllers/imageController.ts
@@ -329,6 +329,10 @@ export class ImageController {
       res.setHeader('Content-Type', validation.contentType);
       res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
       res.setHeader('X-Content-Type-Options', 'nosniff');
+      // Embeddable from the Homiio frontend origin (and RN web). Helmet also
+      // sets this globally; keep it here so the image chokepoint stays correct
+      // even if helmet defaults change.
+      res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
       res.status(200).end(file.buffer);
     } catch (error) {
       res.status(500).json({

--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -105,7 +105,14 @@ const app = express();
 // Behind AWS ALB — trust the first proxy hop so req.ip reflects the client IP
 app.set('trust proxy', 1);
 
-app.use(helmet());
+// CORP must be cross-origin: Homiio's web app (homiio.com / Expo web) loads
+// listing images from api.homiio.com. Helmet's default `same-origin` CORP
+// triggers `ERR_BLOCKED_BY_RESPONSE.NotSameOrigin` in <img>/canvas.
+app.use(
+  helmet({
+    crossOriginResourcePolicy: { policy: 'cross-origin' },
+  }),
+);
 
 // CORS configuration — O(1) Set lookup instead of Array.includes per request
 const allowedOriginsSet = new Set([

--- a/packages/frontend/components/PropertyCard.tsx
+++ b/packages/frontend/components/PropertyCard.tsx
@@ -268,7 +268,7 @@ export function PropertyCard({
     offeringKind: primaryOffering.kind,
     offeringLabel: primaryOffering.label,
     type: property.type === 'room' ? 'apartment' : property.type === 'studio' ? 'apartment' : property.type,
-    imageSource: getPropertyImageSource(property),
+    imageSource: getPropertyImageSource(property, variant === 'compact' ? 'small' : 'medium'),
     bedrooms: property.bedrooms || 0,
     bathrooms: property.bathrooms || 0,
     size: property.squareFootage || 0,

--- a/packages/frontend/components/property/HeaderSection.tsx
+++ b/packages/frontend/components/property/HeaderSection.tsx
@@ -25,7 +25,7 @@ export const HeaderSection: React.FC<HeaderSectionProps> = ({
     return (
         <>
             <Image
-                source={getPropertyImageSource(images[0])}
+                source={getPropertyImageSource(images[0], 'large')}
                 style={Platform.OS === 'web' ? styles.mainImageWeb : styles.mainImage}
                 resizeMode="cover"
             />

--- a/packages/frontend/components/property/ImageGalleryModal.tsx
+++ b/packages/frontend/components/property/ImageGalleryModal.tsx
@@ -301,7 +301,7 @@ export const ImageGalleryModal: React.FC<ImageGalleryModalProps> = ({
                                     <GestureDetector gesture={composedGesture}>
                                         <Animated.View style={styles.imageWrapper}>
                                             <Animated.Image
-                                                source={getPropertyImageSource(item)}
+                                                source={getPropertyImageSource(item, 'large')}
                                                 style={[styles.image, animatedStyle]}
                                                 resizeMode="contain"
                                             />
@@ -310,7 +310,7 @@ export const ImageGalleryModal: React.FC<ImageGalleryModalProps> = ({
                                 ) : (
                                     <View style={styles.imageWrapper}>
                                         <Image
-                                            source={getPropertyImageSource(item)}
+                                            source={getPropertyImageSource(item, 'large')}
                                             style={styles.image}
                                             resizeMode="contain"
                                         />
@@ -385,7 +385,7 @@ export const ImageGalleryModal: React.FC<ImageGalleryModalProps> = ({
                                 }}
                             >
                                 <Image
-                                    source={getPropertyImageSource(item)}
+                                    source={getPropertyImageSource(item, 'small')}
                                     style={styles.thumbnailImage}
                                     resizeMode="cover"
                                 />

--- a/packages/frontend/components/property/PhotoGallery.tsx
+++ b/packages/frontend/components/property/PhotoGallery.tsx
@@ -52,7 +52,7 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ images, onOpen, t })
                             onPress={() => handleImagePress(index)}
                             activeOpacity={0.8}
                         >
-                            <Image source={getPropertyImageSource(image)} style={styles.galleryImage} resizeMode="cover" />
+                            <Image source={getPropertyImageSource(image, 'medium')} style={styles.galleryImage} resizeMode="cover" />
                             {index === MAX_THUMBS - 1 && images.length > MAX_THUMBS && (
                                 <View style={styles.moreImagesOverlay}>
                                     <BloomText style={styles.moreImagesText}>+{images.length - MAX_THUMBS}</BloomText>

--- a/packages/frontend/components/property/PhotoGrid.tsx
+++ b/packages/frontend/components/property/PhotoGrid.tsx
@@ -83,7 +83,7 @@ export const PhotoGrid: React.FC<PhotoGridProps> = ({ images, t }) => {
             accessibilityLabel={tLocal('property.photos.hero', 'Open photo 1')}
           >
             <ExpoImage
-              source={getPropertyImageSource(heroImage as PropertyImage)}
+              source={getPropertyImageSource(heroImage as PropertyImage, 'large')}
               style={styles.heroImage}
               contentFit="cover"
               transition={200}
@@ -112,7 +112,7 @@ export const PhotoGrid: React.FC<PhotoGridProps> = ({ images, t }) => {
                   )}
                 >
                   <ExpoImage
-                    source={getPropertyImageSource(image as PropertyImage)}
+                    source={getPropertyImageSource(image as PropertyImage, 'medium')}
                     style={styles.sideImage}
                     contentFit="cover"
                     transition={200}

--- a/packages/frontend/components/property/PropertyImageCarousel.tsx
+++ b/packages/frontend/components/property/PropertyImageCarousel.tsx
@@ -266,7 +266,7 @@ export const PropertyImageCarousel: React.FC<PropertyImageCarouselProps> = ({
   children,
 }) => {
   const sources = useMemo<ImageDisplaySource[]>(
-    () => getPropertyImageSources(images, coverIndex),
+    () => getPropertyImageSources(images, coverIndex, 'medium'),
     [images, coverIndex],
   );
 

--- a/packages/frontend/utils/propertyUtils.ts
+++ b/packages/frontend/utils/propertyUtils.ts
@@ -1,8 +1,24 @@
 import { generatePropertyTitle, TitleFormat } from './propertyTitleGenerator';
-import { OfferingType, PriceUnit, Property, PropertyAddress, PropertyImage } from '@homiio/shared-types';
+import {
+  OfferingType,
+  PriceUnit,
+  Property,
+  PropertyAddress,
+  PropertyImage,
+  type ImageVariantName,
+} from '@homiio/shared-types';
 import type { BrowseMode } from '@/components/search/types';
 import propertyPlaceholder from '@/assets/images/property_placeholder.jpg';
 import { resolveBackendImageUrl } from '@/utils/imageUrl';
+
+/**
+ * Image entry that may carry the full Sharp variant map (`urls`) from
+ * {@link PropertyImageRef}. Legacy `{ url }` entries still work — `url` is the
+ * medium variant.
+ */
+type PropertyImageEntry = PropertyImage & {
+  urls?: Partial<Record<ImageVariantName, string>>;
+};
 
 /** The rental experience the user is currently browsing in. */
 export type RentalMode = 'long_term' | 'vacation';
@@ -224,17 +240,46 @@ const BROWSE_MODE_TO_OFFERING: Record<BrowseMode, OfferingType> = {
 export type ImageDisplaySource = { uri: string } | typeof propertyPlaceholder;
 
 /**
+ * Prefer `urls[variant]` when present, then fall back across the remaining
+ * Sharp renditions, then the legacy medium `url`. Mirrors city cover resolution
+ * in `cityDisplay.getCityImageSource`.
+ */
+function pickVariantUrl(
+  entry: PropertyImageEntry,
+  variant: ImageVariantName | undefined,
+): string | undefined {
+  const urls = entry.urls;
+  if (urls && variant) {
+    const ordered: ImageVariantName[] = [variant, 'large', 'medium', 'small', 'original'];
+    for (const name of ordered) {
+      const candidate = urls[name];
+      if (typeof candidate === 'string' && candidate.length > 0) {
+        return candidate;
+      }
+    }
+  }
+  return entry.url.length > 0 ? entry.url : undefined;
+}
+
+/**
  * Narrow a single image entry (URL string or `PropertyImage`) to its URL,
  * re-homing backend-served URLs onto the active API origin (see
  * {@link resolveBackendImageUrl}) so DB images that baked in a dev/emulator host
  * resolve on web/device/emulator alike. External/scraped URLs pass through.
+ *
+ * When `variant` is set and the entry carries `urls`, the matching Sharp
+ * rendition is preferred (cards → medium/small, detail hero/lightbox → large).
  */
-function imageEntryToUrl(entry: string | PropertyImage): string | undefined {
+function imageEntryToUrl(
+  entry: string | PropertyImageEntry,
+  variant?: ImageVariantName,
+): string | undefined {
   if (typeof entry === 'string') {
     return entry.length > 0 ? resolveBackendImageUrl(entry) : undefined;
   }
   if (entry && typeof entry === 'object' && 'url' in entry) {
-    return entry.url.length > 0 ? resolveBackendImageUrl(entry.url) : undefined;
+    const raw = pickVariantUrl(entry, variant);
+    return raw !== undefined ? resolveBackendImageUrl(raw) : undefined;
   }
   return undefined;
 }
@@ -341,10 +386,13 @@ export function getDetailedPropertyTitle(property: Property): string {
  * to read the index from.
  *
  * @param property - Property object, images array (string[] or PropertyImage[]), or single image (string or PropertyImage)
+ * @param variant - Optional Sharp rendition (`small` / `medium` / `large` / `original`).
+ *   Defaults to the embedded medium `url` when omitted or when `urls` is absent.
  * @returns The property image source (remote URI wrapper or the bundled placeholder)
  */
 export function getPropertyImageSource(
   property: Property | string[] | PropertyImage[] | string | PropertyImage | undefined,
+  variant?: ImageVariantName,
 ): ImageDisplaySource {
   if (!property) {
     return propertyPlaceholder;
@@ -352,24 +400,24 @@ export function getPropertyImageSource(
 
   // If property is a single string URL
   if (typeof property === 'string') {
-    const url = imageEntryToUrl(property);
+    const url = imageEntryToUrl(property, variant);
     return url !== undefined ? { uri: url } : propertyPlaceholder;
   }
 
   // If property is an array of images
   if (Array.isArray(property)) {
-    return getPropertyImageSources(property)[0];
+    return getPropertyImageSources(property, undefined, variant)[0];
   }
 
   // If property is a single PropertyImage object
   if ('url' in property) {
-    const url = imageEntryToUrl(property);
+    const url = imageEntryToUrl(property, variant);
     return url !== undefined ? { uri: url } : propertyPlaceholder;
   }
 
   // If property is a Property object, honour the host's cover photo choice.
   if ('images' in property) {
-    return getPropertyImageSources(property.images, property.coverImageIndex)[0];
+    return getPropertyImageSources(property.images, property.coverImageIndex, variant)[0];
   }
 
   return propertyPlaceholder;
@@ -392,17 +440,20 @@ export function getPropertyImageSource(
  * @param images - A property's `images` field, a pre-built image array, or undefined.
  * @param coverIndex - Optional index into `images` of the host's cover photo
  *   (`Property.coverImageIndex`). Ignored when undefined/non-integer/out of range.
+ * @param variant - Optional Sharp rendition for every entry (see
+ *   {@link getPropertyImageSource}).
  */
 export function getPropertyImageSources(
   images: Property['images'] | (string | PropertyImage)[] | undefined,
   coverIndex?: number,
+  variant?: ImageVariantName,
 ): ImageDisplaySource[] {
   if (!images || images.length === 0) {
     return [propertyPlaceholder];
   }
 
   const sources = moveCoverToFront(images, coverIndex)
-    .map(imageEntryToUrl)
+    .map((entry) => imageEntryToUrl(entry as string | PropertyImageEntry, variant))
     .filter((url): url is string => typeof url === 'string')
     .map((uri): ImageDisplaySource => ({ uri }));
 


### PR DESCRIPTION
## Summary
- Fix `ERR_BLOCKED_BY_RESPONSE.NotSameOrigin` by setting Helmet `Cross-Origin-Resource-Policy: cross-origin` (and the same header on `serveLocalImage`) so `api.homiio.com` images load from `homiio.com` / Expo web.
- Wire frontend to Sharp variants: cards → medium (compact → small), detail hero/lightbox → large, gallery thumbs → small/medium. No new sizes — existing 300/600/1200/original is enough.

## Evidence
- External listings already store Homiio S3-backed `/api/images/file/...` URLs (not portal CDNs).
- S3 objects present in `oxy-homiio-media-usw2-237343248947` with distinct small/medium/large/original sizes.

## Test plan
- [ ] `curl -sI` a fixture image URL after deploy — expect `cross-origin-resource-policy: cross-origin`
- [ ] Open property cards + detail on homiio.com web — images load (no NotSameOrigin)
- [ ] Network tab: cards request `*-medium.webp` / compact `*-small.webp`; hero/lightbox `*-large.webp`

Made with [Cursor](https://cursor.com)