### PR TITLE
fix: address PR review feedback on CORP, proxy, and images

### DIFF
--- a/packages/backend/controllers/imageController.ts
+++ b/packages/backend/controllers/imageController.ts
@@ -329,9 +329,8 @@ export class ImageController {
       res.setHeader('Content-Type', validation.contentType);
       res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
       res.setHeader('X-Content-Type-Options', 'nosniff');
-      // Embeddable from the Homiio frontend origin (and RN web). Helmet also
-      // sets this globally; keep it here so the image chokepoint stays correct
-      // even if helmet defaults change.
+      // Embeddable from the Homiio frontend origin (and RN web). Helmet keeps
+      // default `same-origin` CORP on other routes; only image bytes need cross-origin.
       res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
       res.status(200).end(file.buffer);
     } catch (error) {

--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -105,14 +105,10 @@ const app = express();
 // Behind AWS ALB — trust the first proxy hop so req.ip reflects the client IP
 app.set('trust proxy', 1);
 
-// CORP must be cross-origin: Homiio's web app (homiio.com / Expo web) loads
-// listing images from api.homiio.com. Helmet's default `same-origin` CORP
-// triggers `ERR_BLOCKED_BY_RESPONSE.NotSameOrigin` in <img>/canvas.
-app.use(
-  helmet({
-    crossOriginResourcePolicy: { policy: 'cross-origin' },
-  }),
-);
+// Helmet defaults keep CORP `same-origin` for API routes. Image routes set
+// `Cross-Origin-Resource-Policy: cross-origin` in imageController so listing
+// photos embed from homiio.com without weakening CORP on sensitive endpoints.
+app.use(helmet());
 
 // CORS configuration — O(1) Set lookup instead of Array.includes per request
 const allowedOriginsSet = new Set([

--- a/packages/backend/services/imageUploadService.ts
+++ b/packages/backend/services/imageUploadService.ts
@@ -130,10 +130,14 @@ export class ImageUploadService {
     this.s3Client = new S3Client({
       ...(config.s3.endpoint ? { endpoint: config.s3.endpoint, forcePathStyle: true } : {}),
       region: config.s3.region,
-      credentials: {
-        accessKeyId: config.s3.accessKeyId,
-        secretAccessKey: config.s3.secretAccessKey,
-      },
+      ...(config.s3.accessKeyId && config.s3.secretAccessKey
+        ? {
+            credentials: {
+              accessKeyId: config.s3.accessKeyId,
+              secretAccessKey: config.s3.secretAccessKey,
+            },
+          }
+        : {}),
     });
   }
 
@@ -221,7 +225,10 @@ export class ImageUploadService {
    * the document structure without the upload).
    */
   isStorageConfigured(): boolean {
-    return Boolean(config.s3.accessKeyId && config.s3.secretAccessKey);
+    const { accessKeyId, secretAccessKey } = config.s3;
+    if (accessKeyId && secretAccessKey) return true;
+    // IAM task/instance role: no static keys; bucket must be set in env (not dev default).
+    return !accessKeyId && !secretAccessKey && Boolean(process.env.AWS_S3_BUCKET);
   }
 
   /**

--- a/packages/frontend/components/property/PhotoGrid.tsx
+++ b/packages/frontend/components/property/PhotoGrid.tsx
@@ -83,7 +83,7 @@ export const PhotoGrid: React.FC<PhotoGridProps> = ({ images, t }) => {
             accessibilityLabel={tLocal('property.photos.hero', 'Open photo 1')}
           >
             <ExpoImage
-              source={getPropertyImageSource(heroImage as PropertyImage, 'large')}
+              source={getPropertyImageSource(heroImage, 'large')}
               style={styles.heroImage}
               contentFit="cover"
               transition={200}
@@ -112,7 +112,7 @@ export const PhotoGrid: React.FC<PhotoGridProps> = ({ images, t }) => {
                   )}
                 >
                   <ExpoImage
-                    source={getPropertyImageSource(image as PropertyImage, 'medium')}
+                    source={getPropertyImageSource(image, 'medium')}
                     style={styles.sideImage}
                     contentFit="cover"
                     transition={200}

--- a/packages/frontend/utils/propertyUtils.ts
+++ b/packages/frontend/utils/propertyUtils.ts
@@ -244,14 +244,20 @@ export type ImageDisplaySource = { uri: string } | typeof propertyPlaceholder;
  * Sharp renditions, then the legacy medium `url`. Mirrors city cover resolution
  * in `cityDisplay.getCityImageSource`.
  */
+const VARIANT_FALLBACK_ORDER: Record<ImageVariantName, ImageVariantName[]> = {
+  small: ['small', 'medium', 'large', 'original'],
+  medium: ['medium', 'large', 'small', 'original'],
+  large: ['large', 'medium', 'small', 'original'],
+  original: ['original', 'large', 'medium', 'small'],
+};
+
 function pickVariantUrl(
   entry: PropertyImageEntry,
   variant: ImageVariantName | undefined,
 ): string | undefined {
   const urls = entry.urls;
   if (urls && variant) {
-    const ordered: ImageVariantName[] = [variant, 'large', 'medium', 'small', 'original'];
-    for (const name of ordered) {
+    for (const name of VARIANT_FALLBACK_ORDER[variant]) {
       const candidate = urls[name];
       if (typeof candidate === 'string' && candidate.length > 0) {
         return candidate;

--- a/packages/listing-providers/src/browser.ts
+++ b/packages/listing-providers/src/browser.ts
@@ -248,11 +248,15 @@ export class PlaywrightBrowserPool implements UrlFetcher {
       const page = await context.newPage();
       if (this.blockAssets) {
         await page.route('**/*', async (route) => {
-          if (BLOCKED_BROWSER_RESOURCE_TYPES.has(route.request().resourceType())) {
-            await route.abort();
-            return;
+          try {
+            if (BLOCKED_BROWSER_RESOURCE_TYPES.has(route.request().resourceType())) {
+              await route.abort();
+              return;
+            }
+            await route.continue();
+          } catch {
+            // Context/page closed mid-intercept — ignore unhandled rejections.
           }
-          await route.continue();
         });
       }
       // External abort cancels the navigation via the context teardown below.

--- a/packages/listing-providers/src/proxy.ts
+++ b/packages/listing-providers/src/proxy.ts
@@ -48,9 +48,17 @@ export function parseResidentialProxyUrl(raw: string | undefined): ResidentialPr
   const server = `${parsed.protocol}//${parsed.host}`;
   return {
     server,
-    username: decodeURIComponent(parsed.username),
-    password: decodeURIComponent(parsed.password),
+    username: safeDecode(parsed.username),
+    password: safeDecode(parsed.password),
   };
+}
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 /** Read `LISTING_RESIDENTIAL_PROXY_URL` when set and valid. */
@@ -114,8 +122,10 @@ export function toEmbeddedProxyUrl(
     sessionId !== undefined
       ? withStickySessionUsername(config.username, sessionId)
       : config.username;
-  const host = config.server.replace(/^[^:]+:\/\//, '');
-  return `http://${encodeURIComponent(username)}:${encodeURIComponent(config.password)}@${host}`;
+  const embedded = new URL(config.server);
+  embedded.username = username;
+  embedded.password = config.password;
+  return embedded.toString();
 }
 
 interface UndiciModule {
@@ -143,28 +153,38 @@ async function loadUndici(): Promise<UndiciModule | undefined> {
 
 type ProxiedFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
+const proxiedFetchCache = new Map<string, Promise<ProxiedFetch>>();
+
 /**
  * Return a `fetch` that routes through the residential proxy. Uses Bun's native
  * `proxy` option when available; otherwise falls back to undici's ProxyAgent.
+ * Cached by embedded proxy URL so undici connection pools are reused.
  */
 export async function createProxiedFetch(
   config: ResidentialProxyConfig,
   sessionId?: string,
 ): Promise<ProxiedFetch> {
   const embedded = toEmbeddedProxyUrl(config, sessionId);
+  const cached = proxiedFetchCache.get(embedded);
+  if (cached) return cached;
 
-  if (typeof process.versions.bun === 'string') {
+  const created = (async (): Promise<ProxiedFetch> => {
+    if (typeof process.versions.bun === 'string') {
+      return (input, init) =>
+        fetch(input, { ...init, proxy: embedded } as RequestInit & { proxy: string });
+    }
+
+    const undici = await loadUndici();
+    if (!undici) {
+      throw new Error(
+        'Residential proxy HTTP fetch requires Bun or the undici package (ProxyAgent)',
+      );
+    }
+    const dispatcher = new undici.ProxyAgent(embedded);
     return (input, init) =>
-      fetch(input, { ...init, proxy: embedded } as RequestInit & { proxy: string });
-  }
+      undici.fetch(input, { ...init, dispatcher } as RequestInit & { dispatcher: unknown });
+  })();
 
-  const undici = await loadUndici();
-  if (!undici) {
-    throw new Error(
-      'Residential proxy HTTP fetch requires Bun or the undici package (ProxyAgent)',
-    );
-  }
-  const dispatcher = new undici.ProxyAgent(embedded);
-  return (input, init) =>
-    undici.fetch(input, { ...init, dispatcher } as RequestInit & { dispatcher: unknown });
+  proxiedFetchCache.set(embedded, created);
+  return created;
 }


### PR DESCRIPTION
## Summary
- Scope `Cross-Origin-Resource-Policy: cross-origin` to image routes only (remove global Helmet override)
- Cache undici `ProxyAgent` pools by embedded proxy URL; harden credential decoding and preserve proxy protocol
- Wrap Playwright route interception in try/catch to avoid unhandled rejections on context close
- Use proximity-aware Sharp variant fallback order; drop redundant PhotoGrid casts
- Omit empty S3 credentials so IAM task roles work; broaden `isStorageConfigured` for `AWS_S3_BUCKET`-only env

## Test plan
- [x] `tsc` clean on listing-providers, backend, frontend
- [ ] Verify listing images load cross-origin on homiio.com web
- [ ] Worker proxy HTTP fetch reuses connection pool across retries


Made with [Cursor](https://cursor.com)