### PR TITLE
feat: ES listing portals (pisos + milanuncios housing filter)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,9 +226,15 @@ PROVIDER_IDEALISTA_ENABLED=true
 PROVIDER_FOTOCASA_ENABLED=true
 PROVIDER_HABITACLIA_ENABLED=true
 PROVIDER_BLUEGROUND_ENABLED=true
+PROVIDER_PISOS_ENABLED=true
+PROVIDER_MILANUNCIOS_ENABLED=false
+PROVIDER_YAENCONTRE_ENABLED=false
+PROVIDER_INDOMIO_ENABLED=false
 PROVIDER_APARTMENTS_COM_ENABLED=true
 PROVIDER_ZILLOW_ENABLED=true
 ```
+
+Classifieds providers must scope discover to real-estate categories and reject non-housing in normalize.
 
 The worker reads these at startup; disabled providers are not registered.
 

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -189,6 +189,12 @@ PROVIDER_BLUEGROUND_ENABLED=false
 # managed escalation tiers are provisioned (see services/ingestion). [optional]
 PROVIDER_IDEALISTA_ENABLED=false
 PROVIDER_FOTOCASA_ENABLED=false
+PROVIDER_PISOS_ENABLED=false
+# General classifieds — housing-only filter required; keep OFF until verified.
+PROVIDER_MILANUNCIOS_ENABLED=false
+# Cloudflare-gated ES portals — need session clearance before enabling.
+PROVIDER_YAENCONTRE_ENABLED=false
+PROVIDER_INDOMIO_ENABLED=false
 # US market (apartments.com + Zillow). [optional]
 PROVIDER_APARTMENTS_COM_ENABLED=false
 PROVIDER_ZILLOW_ENABLED=false

--- a/packages/backend/__tests__/unit/milanunciosProvider.test.ts
+++ b/packages/backend/__tests__/unit/milanunciosProvider.test.ts
@@ -1,0 +1,73 @@
+/**
+ * milanuncios provider — housing-only classifieds filter tests (pure).
+ */
+
+import {
+  MilanunciosProvider,
+  parseMilanunciosAdvert,
+  parseMilanunciosSearchJson,
+  NonHousingListingError,
+  MILANUNCIOS_FIXTURE_HOUSING_JSON,
+  MILANUNCIOS_FIXTURE_CAR_JSON,
+  MILANUNCIOS_FIXTURE_SEARCH_JSON,
+  milanunciosHousingSearchUrl,
+  MILANUNCIOS_HOUSING_CATEGORY_SLUGS,
+  isHousingCategoryUrl,
+} from '@homiio/listing-providers';
+import type { ExternalListingRef } from '@homiio/listing-providers';
+import { OfferingType, PropertyType } from '@homiio/shared-types';
+
+const provider = new MilanunciosProvider();
+
+describe('MilanunciosProvider housing filter', () => {
+  it('accepts a housing advert fixture', () => {
+    const payload = parseMilanunciosAdvert(JSON.parse(MILANUNCIOS_FIXTURE_HOUSING_JSON) as unknown);
+    const ref: ExternalListingRef = {
+      provider: 'milanuncios',
+      sourceId: payload.sourceId,
+      url: payload.url,
+    };
+    const listing = provider.normalize({ ref, payload });
+    expect(listing.source).toBe('milanuncios');
+    expect(listing.sourceId).toBe('5123456789');
+    expect(listing.offerings).toEqual([OfferingType.LONG_TERM_RENT]);
+    expect(listing.longTermRent?.monthlyAmount).toBe(1400);
+    expect(listing.type).toBe(PropertyType.APARTMENT);
+    expect(listing.contact?.phone).toBe('612345678');
+  });
+
+  it('rejects a car advert fixture', () => {
+    const payload = parseMilanunciosAdvert(JSON.parse(MILANUNCIOS_FIXTURE_CAR_JSON) as unknown);
+    const ref: ExternalListingRef = {
+      provider: 'milanuncios',
+      sourceId: payload.sourceId,
+      url: payload.url,
+    };
+    expect(() => provider.normalize({ ref, payload })).toThrow(NonHousingListingError);
+  });
+
+  it('search JSON only yields housing-category refs', () => {
+    const mixed = JSON.stringify({
+      adverts: [
+        JSON.parse(MILANUNCIOS_FIXTURE_HOUSING_JSON),
+        JSON.parse(MILANUNCIOS_FIXTURE_CAR_JSON),
+      ],
+    });
+    const refs = parseMilanunciosSearchJson(mixed);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].sourceId).toBe('5123456789');
+  });
+
+  it('parses housing search fixture', () => {
+    expect(parseMilanunciosSearchJson(MILANUNCIOS_FIXTURE_SEARCH_JSON)).toHaveLength(1);
+  });
+
+  it('discover URLs are scoped to housing category allowlist', () => {
+    expect(isHousingCategoryUrl(milanunciosHousingSearchUrl('madrid'), MILANUNCIOS_HOUSING_CATEGORY_SLUGS)).toBe(
+      true,
+    );
+    expect(
+      isHousingCategoryUrl('https://www.milanuncios.com/coches-en-madrid/', MILANUNCIOS_HOUSING_CATEGORY_SLUGS),
+    ).toBe(false);
+  });
+});

--- a/packages/backend/__tests__/unit/pisosProvider.test.ts
+++ b/packages/backend/__tests__/unit/pisosProvider.test.ts
@@ -1,0 +1,63 @@
+/**
+ * pisos.com provider contract test (pure — no DB, no network).
+ */
+
+import {
+  PisosProvider,
+  parsePisosDetail,
+  parsePisosSearch,
+  parsePisosContactPhone,
+  pisosSourceIdFromUrl,
+  PISOS_FIXTURE_DETAIL_HTML,
+  PISOS_FIXTURE_SEARCH_HTML,
+  PISOS_FIXTURE_CONTACT_JSON,
+} from '@homiio/listing-providers';
+import type { ExternalListingRef } from '@homiio/listing-providers';
+import { OfferingType, PropertyType } from '@homiio/shared-types';
+
+const provider = new PisosProvider();
+
+describe('PisosProvider.normalize', () => {
+  it('maps embedded detail JSON into a published long-term-rent listing with contact', () => {
+    const payload = parsePisosDetail(
+      PISOS_FIXTURE_DETAIL_HTML,
+      'https://www.pisos.com/alquilar/piso-sol_barrio28012-20026385030_992099/',
+    );
+    const ref: ExternalListingRef = { provider: 'pisos', sourceId: payload.sourceId, url: payload.url };
+    const listing = provider.normalize({ ref, payload });
+
+    expect(listing.source).toBe('pisos');
+    expect(listing.sourceId).toBe('20026385030.992099');
+    expect(listing.status).toBe('published');
+    expect(listing.type).toBe(PropertyType.APARTMENT);
+    expect(listing.offerings).toEqual([OfferingType.LONG_TERM_RENT]);
+    expect(listing.longTermRent?.monthlyAmount).toBe(2550);
+    expect(listing.bedrooms).toBe(2);
+    expect(listing.bathrooms).toBe(2);
+    expect(listing.squareFootage).toBe(107);
+    expect(listing.contact?.phone).toBe('919376345');
+    expect(listing.contact?.kind).toBe('agency');
+  });
+
+  it('parses contact AJAX JSON', () => {
+    expect(parsePisosContactPhone(PISOS_FIXTURE_CONTACT_JSON)).toBe('+34919376345');
+  });
+});
+
+describe('PisosProvider search + helpers', () => {
+  it('parses de-duplicated JSON-LD refs from a search page', () => {
+    const refs = parsePisosSearch(PISOS_FIXTURE_SEARCH_HTML);
+    expect(refs.length).toBe(3);
+    expect(refs.map((ref) => ref.sourceId).sort()).toEqual([
+      '20026385030.992099',
+      '61688075258.280500',
+      '65072508446.519513',
+    ]);
+  });
+
+  it('extracts a source id from a detail url', () => {
+    expect(
+      pisosSourceIdFromUrl('https://www.pisos.com/alquilar/piso-sol_barrio28012-20026385030_992099/'),
+    ).toBe('20026385030.992099');
+  });
+});

--- a/packages/backend/__tests__/unit/yaencontreIndomioProvider.test.ts
+++ b/packages/backend/__tests__/unit/yaencontreIndomioProvider.test.ts
@@ -1,0 +1,57 @@
+/**
+ * yaencontre + indomio normalize tests (pure fixtures).
+ */
+
+import {
+  YaencontreProvider,
+  IndomioProvider,
+  parseYaencontreDetailJson,
+  parseYaencontreSearchJson,
+  parseIndomioDetailJson,
+  parseIndomioSearchJson,
+  YAENCONTRE_FIXTURE_DETAIL_JSON,
+  YAENCONTRE_FIXTURE_SEARCH_JSON,
+  INDOMIO_FIXTURE_DETAIL_JSON,
+  INDOMIO_FIXTURE_SEARCH_JSON,
+} from '@homiio/listing-providers';
+import type { ExternalListingRef } from '@homiio/listing-providers';
+import { OfferingType } from '@homiio/shared-types';
+
+describe('YaencontreProvider.normalize', () => {
+  const provider = new YaencontreProvider();
+
+  it('maps detail JSON into a rent listing with contact', () => {
+    const payload = parseYaencontreDetailJson(JSON.parse(YAENCONTRE_FIXTURE_DETAIL_JSON) as unknown);
+    const ref: ExternalListingRef = { provider: 'yaencontre', sourceId: payload.sourceId, url: payload.url };
+    const listing = provider.normalize({ ref, payload });
+    expect(listing.source).toBe('yaencontre');
+    expect(listing.longTermRent?.monthlyAmount).toBe(2100);
+    expect(listing.offerings).toEqual([OfferingType.LONG_TERM_RENT]);
+    expect(listing.contact?.phone).toBe('910000111');
+  });
+
+  it('parses search JSON refs', () => {
+    expect(parseYaencontreSearchJson(YAENCONTRE_FIXTURE_SEARCH_JSON)).toEqual([
+      { sourceId: '987654321', url: 'https://www.yaencontre.com/alquiler/piso/madrid/987654321' },
+    ]);
+  });
+});
+
+describe('IndomioProvider.normalize', () => {
+  const provider = new IndomioProvider();
+
+  it('maps detail JSON into a rent listing with contact', () => {
+    const payload = parseIndomioDetailJson(JSON.parse(INDOMIO_FIXTURE_DETAIL_JSON) as unknown);
+    const ref: ExternalListingRef = { provider: 'indomio', sourceId: payload.sourceId, url: payload.url };
+    const listing = provider.normalize({ ref, payload });
+    expect(listing.source).toBe('indomio');
+    expect(listing.longTermRent?.monthlyAmount).toBe(1650);
+    expect(listing.contact?.phone).toBe('930000222');
+  });
+
+  it('parses search JSON refs', () => {
+    expect(parseIndomioSearchJson(INDOMIO_FIXTURE_SEARCH_JSON)).toEqual([
+      { sourceId: '876543210', url: 'https://www.indomio.es/anuncio/876543210/' },
+    ]);
+  });
+});

--- a/packages/backend/models/Property.ts
+++ b/packages/backend/models/Property.ts
@@ -30,6 +30,14 @@ export interface IProperty extends Document {
   sourceId?: string;
   sourceUrl?: string;
   isExternal?: boolean;
+  externalContact?: {
+    phone?: string;
+    email?: string;
+    whatsapp?: string;
+    agencyName?: string;
+    name?: string;
+    kind?: 'owner' | 'agency' | 'private' | 'unknown';
+  };
   expiresAt?: Date;
   type: PropertyType;
   housingType?: HousingType;

--- a/packages/backend/models/schemas/PropertySchema.ts
+++ b/packages/backend/models/schemas/PropertySchema.ts
@@ -275,6 +275,15 @@ const propertySchema = new mongoose.Schema({
     default: false,
     index: true
   },
+  /** Best-effort portal advertiser contact (phone/email/WhatsApp/agency). */
+  externalContact: {
+    phone: { type: String, trim: true },
+    email: { type: String, trim: true },
+    whatsapp: { type: String, trim: true },
+    agencyName: { type: String, trim: true },
+    name: { type: String, trim: true },
+    kind: { type: String, enum: ['owner', 'agency', 'private', 'unknown'] },
+  },
   expiresAt: {
     type: Date,
     index: { expireAfterSeconds: 0 }, // TTL index; document auto-removed after this date

--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -213,6 +213,16 @@ export class IngestionService {
     if (listing.floor !== undefined) fields.floor = listing.floor;
     if (listing.amenities !== undefined) fields.amenities = listing.amenities;
     if (listing.furnishedStatus !== undefined) fields.furnishedStatus = listing.furnishedStatus;
+    if (listing.contact) {
+      fields.externalContact = {
+        ...(listing.contact.phone ? { phone: listing.contact.phone } : {}),
+        ...(listing.contact.email ? { email: listing.contact.email } : {}),
+        ...(listing.contact.whatsapp ? { whatsapp: listing.contact.whatsapp } : {}),
+        ...(listing.contact.agencyName ? { agencyName: listing.contact.agencyName } : {}),
+        ...(listing.contact.name ? { name: listing.contact.name } : {}),
+        ...(listing.contact.kind ? { kind: listing.contact.kind } : {}),
+      };
+    }
 
     return fields as Partial<IProperty>;
   }

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -124,6 +124,80 @@ export {
   type RecordedZillowPage,
 } from './providers/us/zillow/fixtures';
 
+export {
+  assertHousingListing,
+  isHousingCategory,
+  isHousingCategoryUrl,
+  NonHousingListingError,
+} from './providers/es/housing';
+
+export { PisosProvider, isPisosChallenge, pisosSourceIdFromUrl } from './providers/pisos';
+export {
+  parsePisosDetail,
+  parsePisosSearch,
+  mergePisosContact,
+  type PisosRaw,
+} from './providers/pisos/parse';
+export {
+  PISOS_BASE_URL,
+  PISOS_FIXTURE_DETAIL_HTML,
+  PISOS_FIXTURE_SEARCH_HTML,
+  PISOS_FIXTURE_CONTACT_JSON,
+} from './providers/pisos/fixtures';
+export {
+  pisosSearchUrl,
+  pisosContactPhoneUrl,
+  parsePisosContactPhone,
+} from './providers/pisos/ajax';
+
+export {
+  MilanunciosProvider,
+  isMilanunciosChallenge,
+  milanunciosSourceIdFromUrl,
+  normalizeMilanunciosRaw,
+  parseMilanunciosAdvert,
+} from './providers/milanuncios';
+export {
+  parseMilanunciosSearchJson,
+  type MilanunciosRaw,
+} from './providers/milanuncios/parse';
+export {
+  MILANUNCIOS_BASE_URL,
+  MILANUNCIOS_HOUSING_CATEGORY_SLUGS,
+  MILANUNCIOS_HOUSING_CATEGORY_IDS,
+  MILANUNCIOS_FIXTURE_HOUSING_JSON,
+  MILANUNCIOS_FIXTURE_CAR_JSON,
+  MILANUNCIOS_FIXTURE_SEARCH_JSON,
+  milanunciosHousingSearchUrl,
+  milanunciosListAjaxUrl,
+} from './providers/milanuncios/fixtures';
+
+export { YaencontreProvider, isYaencontreChallenge } from './providers/yaencontre';
+export {
+  parseYaencontreDetailJson,
+  parseYaencontreSearchJson,
+  normalizeYaencontreRaw,
+  type YaencontreRaw,
+} from './providers/yaencontre/parse';
+export {
+  YAENCONTRE_BASE_URL,
+  YAENCONTRE_FIXTURE_DETAIL_JSON,
+  YAENCONTRE_FIXTURE_SEARCH_JSON,
+} from './providers/yaencontre/fixtures';
+
+export { IndomioProvider, isIndomioChallenge } from './providers/indomio';
+export {
+  parseIndomioDetailJson,
+  parseIndomioSearchJson,
+  normalizeIndomioRaw,
+  type IndomioRaw,
+} from './providers/indomio/parse';
+export {
+  INDOMIO_BASE_URL,
+  INDOMIO_FIXTURE_DETAIL_JSON,
+  INDOMIO_FIXTURE_SEARCH_JSON,
+} from './providers/indomio/fixtures';
+
 import type { ProviderId } from '@homiio/shared-types';
 import { ProviderRegistry } from './registry';
 import type { ListingProvider } from './types';
@@ -132,6 +206,10 @@ import { HabitacliaProvider } from './providers/habitaclia';
 import { BluegroundProvider } from './providers/blueground';
 import { IdealistaProvider } from './providers/idealista';
 import { FotocasaProvider } from './providers/fotocasa';
+import { PisosProvider } from './providers/pisos';
+import { MilanunciosProvider } from './providers/milanuncios';
+import { YaencontreProvider } from './providers/yaencontre';
+import { IndomioProvider } from './providers/indomio';
 import { ApartmentsComProvider } from './providers/us/apartmentsCom';
 import { ZillowProvider } from './providers/us/zillow';
 
@@ -170,6 +248,10 @@ export function createDefaultRegistry(): ProviderRegistry {
     new BluegroundProvider(),
     new IdealistaProvider(esOptions),
     new FotocasaProvider(esOptions),
+    new PisosProvider(esOptions),
+    new MilanunciosProvider(esOptions),
+    new YaencontreProvider(esOptions),
+    new IndomioProvider(esOptions),
     new ApartmentsComProvider(),
     new ZillowProvider(),
   ];

--- a/packages/listing-providers/src/providers/es/housing.ts
+++ b/packages/listing-providers/src/providers/es/housing.ts
@@ -1,0 +1,104 @@
+/**
+ * Housing-only guards for general classifieds portals (milanuncios, subito,
+ * leboncoin marketplace, kleinanzeigen, …).
+ *
+ * Classifieds providers must scope `discover()` to real-estate category URLs/APIs
+ * and reject non-housing payloads in `normalize()`. Dedicated real-estate portals
+ * (Idealista, Fotocasa, pisos.com, …) do not need this guard.
+ */
+
+/** Raised when a classifieds payload is not a housing listing. */
+export class NonHousingListingError extends Error {
+  constructor(
+    readonly provider: string,
+    readonly sourceId: string,
+    readonly reason: string,
+  ) {
+    super(`${provider}: rejecting non-housing listing ${sourceId}: ${reason}`);
+    this.name = 'NonHousingListingError';
+  }
+}
+
+const HOUSING_CATEGORY_TOKENS: ReadonlySet<string> = new Set([
+  'inmobiliaria', 'inmueble', 'inmuebles', 'vivienda', 'viviendas', 'piso', 'pisos',
+  'apartamento', 'apartamentos', 'casa', 'casas', 'chalet', 'chalets', 'atico', 'duplex',
+  'estudio', 'habitacion', 'habitaciones', 'alquiler', 'venta', 'rent', 'sale', 'holiday',
+  'vacacional', 'vacanze', 'immobiliare', 'immobili', 'appartamenti', 'case', 'affitto',
+  'vendita', 'immobilier', 'locations', 'ventes', 'immobilier-location', 'immobilier-vente',
+  'haus_kaufen', 'haus_mieten', 'wohnung_kaufen', 'wohnung_mieten', 'immobilien',
+  'real-estate', 'realestate', 'property', 'properties',
+]);
+
+const NON_HOUSING_CATEGORY_TOKENS: ReadonlySet<string> = new Set([
+  'coche', 'coches', 'moto', 'motos', 'motor', 'auto', 'autos', 'car', 'cars', 'vehicle',
+  'empleo', 'trabajo', 'jobs', 'job', 'electronica', 'moviles', 'telefonia', 'informatica',
+  'moda', 'deportes', 'servicios', 'mascotas', 'bebes', 'hogar', 'muebles', 'jardin',
+  'formacion', 'negocio', 'negocios',
+]);
+
+function deaccent(value: string): string {
+  return value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().trim();
+}
+
+function tokenizeCategory(value: string): string[] {
+  return deaccent(value).split(/[^a-z0-9]+/).filter((token) => token.length > 0);
+}
+
+export function isHousingCategory(category: string | undefined | null): boolean {
+  if (!category || category.trim().length === 0) return false;
+  const tokens = tokenizeCategory(category);
+  if (tokens.some((token) => NON_HOUSING_CATEGORY_TOKENS.has(token))) return false;
+  return tokens.some((token) => HOUSING_CATEGORY_TOKENS.has(token));
+}
+
+export function isHousingCategoryUrl(url: string, allowlistSlugs: ReadonlySet<string>): boolean {
+  let path: string;
+  try {
+    path = new URL(url).pathname.toLowerCase();
+  } catch {
+    path = url.toLowerCase();
+  }
+  const deaccented = deaccent(path);
+  for (const slug of allowlistSlugs) {
+    if (deaccented.includes(deaccent(slug))) return true;
+  }
+  return false;
+}
+
+export interface HousingSignalInput {
+  category?: string;
+  typology?: string;
+  squareMeters?: number;
+  bedrooms?: number;
+  bathrooms?: number;
+  hasAddressLike: boolean;
+  hasPrice: boolean;
+}
+
+export function assertHousingListing(
+  provider: string,
+  sourceId: string,
+  input: HousingSignalInput,
+): void {
+  if (!input.hasPrice) {
+    throw new NonHousingListingError(provider, sourceId, 'missing price');
+  }
+  if (!input.hasAddressLike) {
+    throw new NonHousingListingError(provider, sourceId, 'missing address-like fields');
+  }
+  const categoryOk = isHousingCategory(input.category) || isHousingCategory(input.typology);
+  const propertySignals =
+    (input.squareMeters !== undefined && input.squareMeters > 0) ||
+    (input.bedrooms !== undefined && input.bedrooms >= 0) ||
+    (input.bathrooms !== undefined && input.bathrooms > 0);
+  if (input.category && tokenizeCategory(input.category).some((t) => NON_HOUSING_CATEGORY_TOKENS.has(t))) {
+    throw new NonHousingListingError(provider, sourceId, `non-housing category "${input.category}"`);
+  }
+  if (!categoryOk && !propertySignals) {
+    throw new NonHousingListingError(
+      provider,
+      sourceId,
+      'category not housing-related and no m²/rooms/typology signals',
+    );
+  }
+}

--- a/packages/listing-providers/src/providers/indomio/fixtures.ts
+++ b/packages/listing-providers/src/providers/indomio/fixtures.ts
@@ -1,0 +1,53 @@
+/**
+ * indomio.es (Spain) — JSON-first with Playwright session warm-up.
+ *
+ * Cold HTTP / proxy Playwright currently Cloudflare-challenged. Prefer list/
+ * detail JSON once a session clears. Registered OFF (`PROVIDER_INDOMIO_ENABLED`).
+ */
+
+export const INDOMIO_BASE_URL = 'https://www.indomio.es';
+
+function citySlug(city: string): string {
+  return city
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function indomioSearchUrl(city: string, page = 1): string {
+  const base = `${INDOMIO_BASE_URL}/alquiler/${citySlug(city)}/`;
+  return page <= 1 ? base : `${base}?pagina=${page}`;
+}
+
+export function indomioListAjaxUrl(city: string, page = 1): string {
+  const params = new URLSearchParams({
+    idContratto: '2', // rent
+    idNazione: 'ES',
+    localita: citySlug(city),
+    page: String(page),
+  });
+  return `${INDOMIO_BASE_URL}/api/search/listings?${params.toString()}`;
+}
+
+export const INDOMIO_FIXTURE_DETAIL_JSON = JSON.stringify({
+  id: '876543210',
+  url: 'https://www.indomio.es/anuncio/876543210/',
+  title: 'Apartamento en alquiler en Gràcia',
+  description: 'Apartamento de 68 m² en Gràcia, Barcelona.',
+  price: 1650,
+  currency: 'EUR',
+  operation: 'rent',
+  rooms: 2,
+  bathrooms: 1,
+  size: 68,
+  address: { street: 'Carrer de Verdi', city: 'Barcelona', province: 'Barcelona', neighborhood: 'Gràcia' },
+  images: ['https://cdn.indomio.es/example/876543210/1.jpg'],
+  contact: { phone: '930000222', agencyName: 'Indomio Demo' },
+});
+
+export const INDOMIO_FIXTURE_SEARCH_JSON = JSON.stringify({
+  listings: [{ id: '876543210', url: 'https://www.indomio.es/anuncio/876543210/' }],
+});

--- a/packages/listing-providers/src/providers/indomio/index.ts
+++ b/packages/listing-providers/src/providers/indomio/index.ts
@@ -1,0 +1,173 @@
+/**
+ * indomio.es provider — JSON/AJAX via Playwright session; HTML last resort.
+ * Registered OFF (`PROVIDER_INDOMIO_ENABLED`). Cloudflare currently blocks
+ * cold + proxy sessions; keep OFF until managed tier or session clears.
+ */
+
+import type { NormalizedListing, ProviderId } from '@homiio/shared-types';
+import type {
+  DiscoverJob,
+  ExternalListingRef,
+  FetchContext,
+  FetchRuntime,
+  ListingProvider,
+  ProviderHealth,
+  RawListing,
+} from '../../types';
+import { createFetchRuntime } from '../../runtime';
+import { defaultProviderMetrics, type ProviderMetricsReader, type ProviderMetricsSink } from '../../metrics';
+import { INDOMIO_BASE_URL, indomioListAjaxUrl, indomioSearchUrl } from './fixtures';
+import {
+  normalizeIndomioRaw,
+  parseIndomioDetailJson,
+  parseIndomioSearchJson,
+  type IndomioRaw,
+} from './parse';
+
+const PROVIDER_ID: ProviderId = 'indomio';
+const DEFAULT_CITIES: readonly string[] = ['madrid', 'barcelona', 'valencia'];
+const MAX_SEARCH_PAGES = 3;
+
+export function isIndomioChallenge(body: string): boolean {
+  if (body.trim().length < 512) return true;
+  return /just a moment|cloudflare|cf-browser|captcha|access denied|datadome/i.test(body);
+}
+
+export interface IndomioProviderOptions {
+  runtime?: FetchRuntime;
+  cities?: readonly string[];
+  metrics?: ProviderMetricsSink & ProviderMetricsReader;
+}
+
+function asRaw(payload: unknown): IndomioRaw {
+  const record = payload as { sourceId?: unknown; price?: unknown } | null;
+  if (!record || typeof record.sourceId !== 'string' || typeof record.price !== 'number') {
+    throw new Error('indomio: normalize received an invalid payload');
+  }
+  return payload as IndomioRaw;
+}
+
+export class IndomioProvider implements ListingProvider {
+  readonly id: ProviderId = PROVIDER_ID;
+  readonly markets = ['ES'] as const;
+  private readonly runtime: FetchRuntime;
+  private readonly cities: readonly string[];
+  private readonly metrics: ProviderMetricsSink & ProviderMetricsReader;
+
+  constructor(options: IndomioProviderOptions = {}) {
+    this.runtime = options.runtime ?? createFetchRuntime();
+    this.cities = options.cities && options.cities.length > 0 ? options.cities : DEFAULT_CITIES;
+    this.metrics = options.metrics ?? defaultProviderMetrics;
+  }
+
+  async *discover(job: DiscoverJob): AsyncIterable<ExternalListingRef> {
+    const cities = job.city ? [job.city] : this.cities;
+    const limit = job.limit ?? Number.POSITIVE_INFINITY;
+    const seen = new Set<string>();
+    let yielded = 0;
+    const runtime = job.runtime ?? this.runtime;
+    if (!runtime.openBrowserSession) return;
+
+    for (const city of cities) {
+      for (let page = 1; page <= MAX_SEARCH_PAGES; page += 1) {
+        if (yielded >= limit) return;
+        const warmUrl = indomioSearchUrl(city, page);
+        let session: Awaited<ReturnType<NonNullable<FetchRuntime['openBrowserSession']>>> | undefined;
+        const start = Date.now();
+        try {
+          session = await runtime.openBrowserSession({
+            warmUrl,
+            signal: job.signal,
+            contentSelector: 'article, main, h1',
+            isChallenge: isIndomioChallenge,
+            challengeWaitMs: 45_000,
+            blockAssets: true,
+          });
+          const ajaxUrl = indomioListAjaxUrl(city, page);
+          const { status, body } = await session.request(ajaxUrl, {
+            referer: session.pageUrl(),
+            timeoutMs: 30_000,
+          });
+          if (status >= 400 || isIndomioChallenge(body)) {
+            this.metrics.record({
+              provider: this.id,
+              strategy: 'browser',
+              outcome: 'challenge',
+              status,
+              latencyMs: Date.now() - start,
+              url: ajaxUrl,
+            });
+            break;
+          }
+          const refs = parseIndomioSearchJson(body);
+          this.metrics.record({
+            provider: this.id,
+            strategy: 'browser',
+            outcome: 'success',
+            status,
+            latencyMs: Date.now() - start,
+            url: ajaxUrl,
+          });
+          if (refs.length === 0) break;
+          for (const ref of refs) {
+            if (yielded >= limit) return;
+            if (seen.has(ref.sourceId)) continue;
+            seen.add(ref.sourceId);
+            yield { provider: this.id, sourceId: ref.sourceId, url: ref.url };
+            yielded += 1;
+          }
+        } catch {
+          this.metrics.record({
+            provider: this.id,
+            strategy: 'browser',
+            outcome: 'challenge',
+            latencyMs: Date.now() - start,
+            url: warmUrl,
+          });
+          break;
+        } finally {
+          await session?.close();
+        }
+      }
+    }
+  }
+
+  async fetch(ref: ExternalListingRef, ctx: FetchContext): Promise<RawListing> {
+    if (!ctx.runtime.openBrowserSession) {
+      throw new Error('indomio: fetch requires openBrowserSession');
+    }
+    const session = await ctx.runtime.openBrowserSession({
+      warmUrl: ref.url,
+      signal: ctx.signal,
+      contentSelector: 'h1, main',
+      isChallenge: isIndomioChallenge,
+      challengeWaitMs: 45_000,
+      blockAssets: true,
+    });
+    try {
+      const apiUrl = `${INDOMIO_BASE_URL}/api/listing/${ref.sourceId}`;
+      const { status, body } = await session.request(apiUrl, {
+        referer: ref.url,
+        timeoutMs: 20_000,
+      });
+      if (status >= 200 && status < 300 && body.trim().startsWith('{') && !isIndomioChallenge(body)) {
+        return { ref, payload: parseIndomioDetailJson(JSON.parse(body) as unknown, ref.url) };
+      }
+      throw new Error(`indomio: no JSON detail for ${ref.sourceId} (status=${status})`);
+    } finally {
+      await session.close();
+    }
+  }
+
+  normalize(raw: RawListing): NormalizedListing {
+    return normalizeIndomioRaw(asRaw(raw.payload));
+  }
+
+  async health(): Promise<ProviderHealth> {
+    return {
+      provider: this.id,
+      status: 'healthy',
+      detail: `Serving ES via ${INDOMIO_BASE_URL} (Cloudflare-gated; OFF until session clears)`,
+    };
+  }
+}

--- a/packages/listing-providers/src/providers/indomio/parse.ts
+++ b/packages/listing-providers/src/providers/indomio/parse.ts
@@ -1,0 +1,163 @@
+/**
+ * indomio.es JSON parsers (pure).
+ */
+
+import {
+  OfferingType,
+  PropertyType,
+  type NormalizedListing,
+  type NormalizedListingContact,
+  type ProviderId,
+} from '@homiio/shared-types';
+import { INDOMIO_BASE_URL } from './fixtures';
+
+const PROVIDER_ID: ProviderId = 'indomio';
+
+export interface IndomioRaw {
+  sourceId: string;
+  url: string;
+  title: string;
+  description?: string;
+  price: number;
+  currency: string;
+  operation: 'rent' | 'sale';
+  rooms?: number;
+  bathrooms?: number;
+  squareMeters?: number;
+  street: string;
+  city: string;
+  province?: string;
+  neighborhood?: string;
+  images: string[];
+  contact?: NormalizedListingContact;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value.replace(/[^0-9.-]/g, ''));
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+export function indomioSourceIdFromUrl(url: string): string | undefined {
+  return url.match(/\/(?:anuncio|inmueble)\/(\d+)/)?.[1] ?? url.match(/\/(\d{5,})\/?$/)?.[1];
+}
+
+export function parseIndomioSearchJson(body: string): { sourceId: string; url: string }[] {
+  const trimmed = body.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return [];
+  let root: unknown;
+  try {
+    root = JSON.parse(trimmed) as unknown;
+  } catch {
+    return [];
+  }
+  const items: unknown[] = [];
+  if (Array.isArray(root)) items.push(...root);
+  else if (isRecord(root)) {
+    for (const key of ['listings', 'results', 'items', 'ads', 'data']) {
+      if (Array.isArray(root[key])) {
+        items.push(...(root[key] as unknown[]));
+        break;
+      }
+    }
+  }
+  const seen = new Set<string>();
+  const refs: { sourceId: string; url: string }[] = [];
+  for (const entry of items) {
+    if (!isRecord(entry)) continue;
+    const sourceId =
+      asString(entry.id) ?? (typeof entry.id === 'number' ? String(entry.id) : undefined);
+    const url =
+      asString(entry.url) ??
+      (sourceId ? `${INDOMIO_BASE_URL}/anuncio/${sourceId}/` : undefined);
+    if (!sourceId || !url || seen.has(sourceId)) continue;
+    seen.add(sourceId);
+    refs.push({ sourceId, url });
+  }
+  return refs;
+}
+
+export function parseIndomioDetailJson(payload: unknown, fallbackUrl?: string): IndomioRaw {
+  if (!isRecord(payload)) throw new Error('indomio: detail payload is not an object');
+  const sourceId =
+    asString(payload.id) ?? (typeof payload.id === 'number' ? String(payload.id) : undefined);
+  if (!sourceId) throw new Error('indomio: missing id');
+  const price = asNumber(payload.price);
+  if (price === undefined) throw new Error(`indomio: listing ${sourceId} has no price`);
+  const address = isRecord(payload.address) ? payload.address : undefined;
+  const city = asString(address?.city) ?? asString(payload.city) ?? '';
+  if (!city) throw new Error(`indomio: listing ${sourceId} has no city`);
+  const images: string[] = [];
+  if (Array.isArray(payload.images)) {
+    for (const img of payload.images) {
+      if (typeof img === 'string') images.push(img);
+    }
+  }
+  const contactRaw = isRecord(payload.contact) ? payload.contact : undefined;
+  const phone = asString(contactRaw?.phone);
+  const contact: NormalizedListingContact | undefined = phone
+    ? {
+        phone,
+        agencyName: asString(contactRaw?.agencyName) ?? asString(contactRaw?.name),
+        kind: 'agency',
+      }
+    : undefined;
+  const operationRaw = asString(payload.operation)?.toLowerCase() ?? 'rent';
+  return {
+    sourceId,
+    url: asString(payload.url) ?? fallbackUrl ?? `${INDOMIO_BASE_URL}/anuncio/${sourceId}/`,
+    title: asString(payload.title) ?? `Listing ${sourceId}`,
+    description: asString(payload.description),
+    price,
+    currency: asString(payload.currency) ?? 'EUR',
+    operation: operationRaw.includes('sale') || operationRaw.includes('venta') ? 'sale' : 'rent',
+    rooms: asNumber(payload.rooms) ?? asNumber(payload.bedrooms),
+    bathrooms: asNumber(payload.bathrooms),
+    squareMeters: asNumber(payload.size) ?? asNumber(payload.squareMeters),
+    street: asString(address?.street) ?? city,
+    city,
+    province: asString(address?.province),
+    neighborhood: asString(address?.neighborhood),
+    images,
+    contact,
+  };
+}
+
+export function normalizeIndomioRaw(raw: IndomioRaw): NormalizedListing {
+  const isSale = raw.operation === 'sale';
+  const result: NormalizedListing = {
+    source: PROVIDER_ID,
+    sourceId: raw.sourceId,
+    sourceUrl: raw.url,
+    address: {
+      street: raw.street,
+      city: raw.city,
+      state: raw.province,
+      neighborhood: raw.neighborhood,
+      countryCode: 'ES',
+    },
+    type: PropertyType.APARTMENT,
+    offerings: isSale ? [OfferingType.SALE] : [OfferingType.LONG_TERM_RENT],
+    longTermRent: isSale ? undefined : { monthlyAmount: raw.price, currency: raw.currency },
+    sale: isSale ? { price: raw.price, currency: raw.currency } : undefined,
+    description: raw.description ?? raw.title,
+    bedrooms: raw.rooms,
+    bathrooms: raw.bathrooms,
+    squareFootage: raw.squareMeters,
+    remoteImages: raw.images.map((url, index) => ({ url, isPrimary: index === 0 })),
+    status: 'published',
+  };
+  if (raw.contact) result.contact = raw.contact;
+  return result;
+}

--- a/packages/listing-providers/src/providers/milanuncios/fixtures.ts
+++ b/packages/listing-providers/src/providers/milanuncios/fixtures.ts
@@ -1,0 +1,130 @@
+/**
+ * milanuncios.com (Spain) — general classifieds, REAL-ESTATE ONLY.
+ *
+ * Classifieds providers must scope discover to real-estate categories and reject
+ * non-housing in normalize. This plugin:
+ *   1. Discovers ONLY via housing category URL allowlist (inmobiliaria / pisos /
+ *      alquiler / venta / habitaciones / vacacional) — never site-wide search.
+ *   2. Prefers JSON/AJAX listing APIs via a warmed Playwright session (GeeTest
+ *      blocks cold HTTP). HTML is last resort.
+ *   3. `normalize()` hard-rejects cars/jobs/electronics via {@link assertHousingListing}.
+ *
+ * Registered OFF by default (`PROVIDER_MILANUNCIOS_ENABLED`). Do NOT enable in
+ * prod until the housing filter + session path are verified end-to-end.
+ */
+
+export const MILANUNCIOS_BASE_URL = 'https://www.milanuncios.com';
+
+/**
+ * Allowlisted category path slugs for discover. Site-wide `/anuncios/` or
+ * motor/empleo paths are intentionally absent.
+ */
+export const MILANUNCIOS_HOUSING_CATEGORY_SLUGS: ReadonlySet<string> = new Set([
+  'inmobiliaria',
+  'alquiler-de-pisos',
+  'venta-de-pisos',
+  'alquiler-de-habitaciones',
+  'alquiler-vacacional',
+  'venta-de-casas',
+  'alquiler-de-casas',
+  'venta-de-chalets',
+  'alquiler-de-chalets',
+  'venta-de-aticos',
+  'alquiler-de-aticos',
+  'venta-de-duplex',
+  'alquiler-de-duplex',
+  'compartir-piso',
+]);
+
+/** Category ids observed on milanuncios inmobiliaria taxonomy (allowlist). */
+export const MILANUNCIOS_HOUSING_CATEGORY_IDS: ReadonlySet<string> = new Set([
+  // Inmobiliaria root + common housing children (portal-shaped; hand-maintained).
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+  'inmobiliaria',
+]);
+
+function citySlug(city: string): string {
+  return city
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Housing-only search URL for a city (alquiler de pisos). */
+export function milanunciosHousingSearchUrl(city: string, page = 1): string {
+  const base = `${MILANUNCIOS_BASE_URL}/alquiler-de-pisos-en-${citySlug(city)}/`;
+  return page <= 1 ? base : `${base}?pagina=${page}`;
+}
+
+/** Alternate inmobiliaria category URL. */
+export function milanunciosInmobiliariaSearchUrl(city: string, page = 1): string {
+  const base = `${MILANUNCIOS_BASE_URL}/inmobiliaria-en-${citySlug(city)}/`;
+  return page <= 1 ? base : `${base}?pagina=${page}`;
+}
+
+/**
+ * AJAX/list endpoint candidates (tried from a warmed session). Response shapes
+ * vary; parsers accept several wrappers. Cold HTTP returns GeeTest 405.
+ */
+export function milanunciosListAjaxUrl(city: string, page = 1): string {
+  const params = new URLSearchParams({
+    categorySlug: 'alquiler-de-pisos',
+    locationSlug: citySlug(city),
+    page: String(page),
+  });
+  return `${MILANUNCIOS_BASE_URL}/api/v3/adverts?${params.toString()}`;
+}
+
+/** Hand-authored housing advert JSON (portal-shaped). */
+export const MILANUNCIOS_FIXTURE_HOUSING_JSON = JSON.stringify({
+  id: '5123456789',
+  category: { id: '2', slug: 'alquiler-de-pisos', name: 'Alquiler de pisos' },
+  title: 'Piso 2 hab en Chamberí',
+  description: 'Piso luminoso de 75 m² en Chamberí, amueblado.',
+  price: 1400,
+  currency: 'EUR',
+  operation: 'rent',
+  typology: 'piso',
+  rooms: 2,
+  bathrooms: 1,
+  size: 75,
+  url: 'https://www.milanuncios.com/alquiler-de-pisos-en-madrid/piso-chamberi-5123456789.htm',
+  location: { city: 'Madrid', neighborhood: 'Chamberí', province: 'Madrid' },
+  images: [
+    'https://img.milanuncios.com/example/5123456789/1.jpg',
+    'https://img.milanuncios.com/example/5123456789/2.jpg',
+  ],
+  contact: { phone: '612345678', name: 'Inmobiliaria Chamberí SL' },
+});
+
+/** Hand-authored car advert JSON — MUST be rejected by normalize. */
+export const MILANUNCIOS_FIXTURE_CAR_JSON = JSON.stringify({
+  id: '5987654321',
+  category: { id: '20', slug: 'coches', name: 'Coches' },
+  title: 'BMW Serie 3 diésel',
+  description: 'Coche en buen estado, 120.000 km.',
+  price: 12500,
+  currency: 'EUR',
+  url: 'https://www.milanuncios.com/coches-en-madrid/bmw-serie-3-5987654321.htm',
+  location: { city: 'Madrid', province: 'Madrid' },
+  images: ['https://img.milanuncios.com/example/5987654321/1.jpg'],
+  contact: { phone: '600111222' },
+});
+
+/** Search AJAX wrapper with one housing advert. */
+export const MILANUNCIOS_FIXTURE_SEARCH_JSON = JSON.stringify({
+  adverts: [JSON.parse(MILANUNCIOS_FIXTURE_HOUSING_JSON)],
+  pagination: { page: 1, total: 1 },
+});

--- a/packages/listing-providers/src/providers/milanuncios/index.ts
+++ b/packages/listing-providers/src/providers/milanuncios/index.ts
@@ -1,0 +1,267 @@
+/**
+ * milanuncios.com provider (Spain) — general classifieds, REAL-ESTATE ONLY.
+ *
+ * Classifieds providers must scope discover to real-estate categories and reject
+ * non-housing in normalize. Discover uses housing category URLs + AJAX list
+ * endpoints from a warmed Playwright session (GeeTest blocks cold HTTP). HTML
+ * scrape is last resort and still filtered by category allowlist.
+ *
+ * Registered OFF by default (`PROVIDER_MILANUNCIOS_ENABLED`). Do NOT enable in
+ * prod until the housing filter is verified end-to-end.
+ */
+
+import type { NormalizedListing, ProviderId } from '@homiio/shared-types';
+import type {
+  DiscoverJob,
+  ExternalListingRef,
+  FetchContext,
+  FetchRuntime,
+  ListingProvider,
+  ProviderHealth,
+  RawListing,
+} from '../../types';
+import { createFetchRuntime } from '../../runtime';
+import { defaultProviderMetrics, type ProviderMetricsReader, type ProviderMetricsSink } from '../../metrics';
+import { isHousingCategoryUrl } from '../es/housing';
+import {
+  MILANUNCIOS_BASE_URL,
+  MILANUNCIOS_HOUSING_CATEGORY_SLUGS,
+  milanunciosHousingSearchUrl,
+  milanunciosListAjaxUrl,
+} from './fixtures';
+import {
+  milanunciosSourceIdFromUrl,
+  normalizeMilanunciosRaw,
+  parseMilanunciosAdvert,
+  parseMilanunciosSearchJson,
+  type MilanunciosRaw,
+} from './parse';
+
+const PROVIDER_ID: ProviderId = 'milanuncios';
+const DEFAULT_CITIES: readonly string[] = ['madrid', 'barcelona', 'valencia'];
+const MAX_SEARCH_PAGES = 3;
+
+export function isMilanunciosChallenge(body: string): boolean {
+  if (body.trim().length < 256) return true;
+  return /pardon our interruption|geetest|captcha|datadome|access denied/i.test(body);
+}
+
+export interface MilanunciosProviderOptions {
+  runtime?: FetchRuntime;
+  cities?: readonly string[];
+  metrics?: ProviderMetricsSink & ProviderMetricsReader;
+}
+
+function asMilanunciosRaw(payload: unknown): MilanunciosRaw {
+  const record = payload as { sourceId?: unknown; url?: unknown; price?: unknown; city?: unknown } | null;
+  if (
+    !record ||
+    typeof record.sourceId !== 'string' ||
+    typeof record.url !== 'string' ||
+    typeof record.price !== 'number'
+  ) {
+    throw new Error('milanuncios: normalize received a payload that is not a MilanunciosRaw');
+  }
+  return payload as MilanunciosRaw;
+}
+
+export class MilanunciosProvider implements ListingProvider {
+  readonly id: ProviderId = PROVIDER_ID;
+  readonly markets = ['ES'] as const;
+
+  private readonly runtime: FetchRuntime;
+  private readonly cities: readonly string[];
+  private readonly metrics: ProviderMetricsSink & ProviderMetricsReader;
+
+  constructor(options: MilanunciosProviderOptions = {}) {
+    this.runtime = options.runtime ?? createFetchRuntime();
+    this.cities = options.cities && options.cities.length > 0 ? options.cities : DEFAULT_CITIES;
+    this.metrics = options.metrics ?? defaultProviderMetrics;
+  }
+
+  async *discover(job: DiscoverJob): AsyncIterable<ExternalListingRef> {
+    const cities = job.city ? [job.city] : this.cities;
+    const limit = job.limit ?? Number.POSITIVE_INFINITY;
+    const seen = new Set<string>();
+    let yielded = 0;
+    const runtime = job.runtime ?? this.runtime;
+
+    for (const city of cities) {
+      for (let page = 1; page <= MAX_SEARCH_PAGES; page += 1) {
+        if (yielded >= limit) return;
+        const warmUrl = milanunciosHousingSearchUrl(city, page);
+        if (!isHousingCategoryUrl(warmUrl, MILANUNCIOS_HOUSING_CATEGORY_SLUGS)) {
+          throw new Error(`milanuncios: refuse non-housing discover URL ${warmUrl}`);
+        }
+
+        const refs = runtime.openBrowserSession
+          ? await this.discoverViaSession(runtime, city, page, warmUrl, job.signal)
+          : [];
+
+        if (refs.length === 0) break;
+        for (const ref of refs) {
+          if (yielded >= limit) return;
+          if (seen.has(ref.sourceId)) continue;
+          seen.add(ref.sourceId);
+          yield { provider: this.id, sourceId: ref.sourceId, url: ref.url };
+          yielded += 1;
+        }
+      }
+    }
+  }
+
+  private async discoverViaSession(
+    runtime: FetchRuntime,
+    city: string,
+    page: number,
+    warmUrl: string,
+    signal: AbortSignal | undefined,
+  ): Promise<ExternalListingRef[]> {
+    if (!runtime.openBrowserSession) return [];
+    const start = Date.now();
+    let session: Awaited<ReturnType<NonNullable<FetchRuntime['openBrowserSession']>>> | undefined;
+    try {
+      session = await runtime.openBrowserSession({
+        warmUrl,
+        signal,
+        contentSelector: 'article, .aditem, main, h1',
+        isChallenge: isMilanunciosChallenge,
+        challengeWaitMs: 45_000,
+        blockAssets: true,
+      });
+
+      const ajaxUrl = milanunciosListAjaxUrl(city, page);
+      const { status, body } = await session.request(ajaxUrl, {
+        referer: session.pageUrl(),
+        timeoutMs: 30_000,
+      });
+
+      if (status === 403 || status === 405 || status === 429 || isMilanunciosChallenge(body)) {
+        this.metrics.record({
+          provider: this.id,
+          strategy: 'browser',
+          outcome: 'challenge',
+          status,
+          latencyMs: Date.now() - start,
+          url: ajaxUrl,
+          detail: 'milanuncios list AJAX challenged',
+        });
+        return [];
+      }
+
+      const pageRefs = parseMilanunciosSearchJson(body);
+      this.metrics.record({
+        provider: this.id,
+        strategy: 'browser',
+        outcome: 'success',
+        status,
+        latencyMs: Date.now() - start,
+        url: ajaxUrl,
+      });
+      return pageRefs.map((ref) => ({ provider: this.id, sourceId: ref.sourceId, url: ref.url }));
+    } catch {
+      this.metrics.record({
+        provider: this.id,
+        strategy: 'browser',
+        outcome: 'challenge',
+        latencyMs: Date.now() - start,
+        url: warmUrl,
+        detail: 'milanuncios session warm-up failed (GeeTest likely)',
+      });
+      return [];
+    } finally {
+      await session?.close();
+    }
+  }
+
+  async fetch(ref: ExternalListingRef, ctx: FetchContext): Promise<RawListing> {
+    if (!isHousingCategoryUrl(ref.url, MILANUNCIOS_HOUSING_CATEGORY_SLUGS) && !ref.url.includes('inmobiliaria')) {
+      // Still allow detail URLs that embed the id but carry housing hints in path.
+      if (!/piso|casa|chalet|habitacion|atico|duplex|inmueble|alquiler|venta/i.test(ref.url)) {
+        throw new Error(`milanuncios: refuse fetch of non-housing URL ${ref.url}`);
+      }
+    }
+
+    if (!ctx.runtime.openBrowserSession) {
+      throw new Error('milanuncios: fetch requires openBrowserSession (GeeTest)');
+    }
+
+    const start = Date.now();
+    const session = await ctx.runtime.openBrowserSession({
+      warmUrl: ref.url,
+      signal: ctx.signal,
+      contentSelector: 'h1, article, main',
+      isChallenge: isMilanunciosChallenge,
+      challengeWaitMs: 45_000,
+      blockAssets: true,
+    });
+    try {
+      // Prefer detail JSON if an API sibling exists; fall back to parsing __NEXT_DATA__ / embedded JSON.
+      const apiCandidates = [
+        `${MILANUNCIOS_BASE_URL}/api/v3/adverts/${ref.sourceId}`,
+        `${MILANUNCIOS_BASE_URL}/api/v2/adverts/${ref.sourceId}`,
+      ];
+      for (const apiUrl of apiCandidates) {
+        const { status, body } = await session.request(apiUrl, {
+          referer: ref.url,
+          timeoutMs: 20_000,
+        });
+        if (status >= 200 && status < 300 && body.trim().startsWith('{') && !isMilanunciosChallenge(body)) {
+          const payload = parseMilanunciosAdvert(JSON.parse(body) as unknown, ref.url);
+          this.metrics.record({
+            provider: this.id,
+            strategy: 'browser',
+            outcome: 'success',
+            status,
+            latencyMs: Date.now() - start,
+            url: apiUrl,
+          });
+          return { ref, payload };
+        }
+      }
+
+      const html = await session.content();
+      if (isMilanunciosChallenge(html)) {
+        throw new Error('milanuncios: detail page still challenged');
+      }
+      // Last resort: look for embedded JSON advert blob.
+      const embedded = html.match(
+        /<script[^>]*id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/i,
+      )?.[1];
+      if (embedded) {
+        const next = JSON.parse(embedded) as { props?: { pageProps?: { advert?: unknown } } };
+        const advert = next.props?.pageProps?.advert;
+        if (advert) {
+          return { ref, payload: parseMilanunciosAdvert(advert, ref.url) };
+        }
+      }
+      throw new Error(`milanuncios: no JSON advert payload for ${ref.sourceId}`);
+    } finally {
+      await session.close();
+    }
+  }
+
+  normalize(raw: RawListing): NormalizedListing {
+    return normalizeMilanunciosRaw(asMilanunciosRaw(raw.payload));
+  }
+
+  async health(): Promise<ProviderHealth> {
+    const snapshot = this.metrics.snapshot(this.id);
+    if (snapshot && snapshot.attempts > 0) {
+      const status =
+        snapshot.challengeRate >= 0.8 ? 'unhealthy' : snapshot.challengeRate >= 0.3 ? 'degraded' : 'healthy';
+      return {
+        provider: this.id,
+        status,
+        detail: `attempts=${snapshot.attempts} challengeRate=${snapshot.challengeRate.toFixed(2)}`,
+      };
+    }
+    return {
+      provider: this.id,
+      status: 'healthy',
+      detail: `Serving ES housing-only via ${MILANUNCIOS_BASE_URL} (GeeTest; OFF until verified)`,
+    };
+  }
+}
+
+export { milanunciosSourceIdFromUrl, normalizeMilanunciosRaw, parseMilanunciosAdvert };

--- a/packages/listing-providers/src/providers/milanuncios/parse.ts
+++ b/packages/listing-providers/src/providers/milanuncios/parse.ts
@@ -1,0 +1,267 @@
+/**
+ * milanuncios JSON parsers + housing guards.
+ */
+
+import {
+  OfferingType,
+  PropertyType,
+  type NormalizedListing,
+  type NormalizedListingContact,
+  type NormalizedRemoteImage,
+  type ProviderId,
+} from '@homiio/shared-types';
+import { assertHousingListing, isHousingCategory } from '../es/housing';
+import {
+  MILANUNCIOS_BASE_URL,
+  MILANUNCIOS_HOUSING_CATEGORY_IDS,
+  MILANUNCIOS_HOUSING_CATEGORY_SLUGS,
+} from './fixtures';
+
+const PROVIDER_ID: ProviderId = 'milanuncios';
+
+export interface MilanunciosRaw {
+  sourceId: string;
+  url: string;
+  categorySlug: string;
+  categoryId?: string;
+  title: string;
+  description?: string;
+  price: number;
+  currency: string;
+  operation: 'rent' | 'sale';
+  typology?: string;
+  rooms?: number;
+  bathrooms?: number;
+  squareMeters?: number;
+  city: string;
+  neighborhood?: string;
+  province?: string;
+  images: string[];
+  contact?: NormalizedListingContact;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value.replace(/[^0-9.,-]/g, '').replace(/\./g, '').replace(',', '.'));
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+export function milanunciosSourceIdFromUrl(url: string): string | undefined {
+  return url.match(/(\d{6,})\.htm/i)?.[1] ?? url.match(/\/(\d{6,})\/?$/)?.[1];
+}
+
+function categoryFromRecord(record: Record<string, unknown>): { slug: string; id?: string } {
+  const nested = isRecord(record.category) ? record.category : undefined;
+  const slug =
+    asString(nested?.slug) ??
+    asString(record.categorySlug) ??
+    asString(record.category_name) ??
+    asString(record.category) ??
+    '';
+  const id = asString(nested?.id) ?? asString(record.categoryId);
+  return { slug, id };
+}
+
+function isAllowedCategory(slug: string, id: string | undefined): boolean {
+  const deaccent = slug
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+  if (MILANUNCIOS_HOUSING_CATEGORY_SLUGS.has(deaccent)) return true;
+  if (id && MILANUNCIOS_HOUSING_CATEGORY_IDS.has(id)) return true;
+  return isHousingCategory(slug);
+}
+
+/**
+ * Parse a list/search AJAX JSON body into detail refs. Only housing-category
+ * adverts are yielded.
+ */
+export function parseMilanunciosSearchJson(body: string): { sourceId: string; url: string }[] {
+  const trimmed = body.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return [];
+  let root: unknown;
+  try {
+    root = JSON.parse(trimmed) as unknown;
+  } catch {
+    return [];
+  }
+
+  const adverts: unknown[] = [];
+  if (Array.isArray(root)) {
+    adverts.push(...root);
+  } else if (isRecord(root)) {
+    for (const key of ['adverts', 'ads', 'items', 'results', 'data', 'list']) {
+      const value = root[key];
+      if (Array.isArray(value)) {
+        adverts.push(...value);
+        break;
+      }
+      if (isRecord(value) && Array.isArray(value.adverts)) {
+        adverts.push(...value.adverts);
+        break;
+      }
+    }
+  }
+
+  const seen = new Set<string>();
+  const refs: { sourceId: string; url: string }[] = [];
+  for (const entry of adverts) {
+    if (!isRecord(entry)) continue;
+    const { slug, id } = categoryFromRecord(entry);
+    if (slug && !isAllowedCategory(slug, id)) continue;
+    const sourceId =
+      asString(entry.id) ??
+      asString(entry.advertId) ??
+      (typeof entry.id === 'number' ? String(entry.id) : undefined);
+    const url =
+      asString(entry.url) ??
+      asString(entry.detailUrl) ??
+      (sourceId ? `${MILANUNCIOS_BASE_URL}/alquiler-de-pisos/${sourceId}.htm` : undefined);
+    if (!sourceId || !url || seen.has(sourceId)) continue;
+    seen.add(sourceId);
+    refs.push({ sourceId, url });
+  }
+  return refs;
+}
+
+/** Parse a single advert JSON object into {@link MilanunciosRaw}. */
+export function parseMilanunciosAdvert(payload: unknown, fallbackUrl?: string): MilanunciosRaw {
+  if (!isRecord(payload)) {
+    throw new Error('milanuncios: advert payload is not an object');
+  }
+  const sourceId =
+    asString(payload.id) ??
+    asString(payload.advertId) ??
+    (typeof payload.id === 'number' ? String(payload.id) : undefined);
+  if (!sourceId) throw new Error('milanuncios: advert missing id');
+
+  const { slug, id } = categoryFromRecord(payload);
+  const url =
+    asString(payload.url) ??
+    asString(payload.detailUrl) ??
+    fallbackUrl ??
+    `${MILANUNCIOS_BASE_URL}/anuncio/${sourceId}.htm`;
+
+  const location = isRecord(payload.location) ? payload.location : undefined;
+  const city = asString(location?.city) ?? asString(payload.city) ?? '';
+  const price = asNumber(payload.price);
+  if (price === undefined) throw new Error(`milanuncios: listing ${sourceId} has no price`);
+
+  const operationRaw = asString(payload.operation)?.toLowerCase() ?? '';
+  const operation: 'rent' | 'sale' =
+    operationRaw.includes('sale') || operationRaw.includes('venta') || url.includes('venta-')
+      ? 'sale'
+      : 'rent';
+
+  const imagesRaw = payload.images ?? payload.photos;
+  const images: string[] = [];
+  if (Array.isArray(imagesRaw)) {
+    for (const img of imagesRaw) {
+      if (typeof img === 'string') images.push(img);
+      else if (isRecord(img)) {
+        const u = asString(img.url) ?? asString(img.src);
+        if (u) images.push(u);
+      }
+    }
+  }
+
+  const contactRaw = isRecord(payload.contact) ? payload.contact : undefined;
+  const phone = asString(contactRaw?.phone) ?? asString(payload.phone);
+  const contact: NormalizedListingContact | undefined = phone
+    ? {
+        phone,
+        agencyName: asString(contactRaw?.name) ?? asString(payload.agencyName),
+        email: asString(contactRaw?.email),
+        kind: 'unknown',
+      }
+    : undefined;
+
+  return {
+    sourceId,
+    url,
+    categorySlug: slug,
+    categoryId: id,
+    title: asString(payload.title) ?? asString(payload.subject) ?? `Listing ${sourceId}`,
+    description: asString(payload.description),
+    price,
+    currency: asString(payload.currency) ?? 'EUR',
+    operation,
+    typology: asString(payload.typology) ?? asString(payload.propertyType) ?? slug,
+    rooms: asNumber(payload.rooms) ?? asNumber(payload.bedrooms),
+    bathrooms: asNumber(payload.bathrooms),
+    squareMeters: asNumber(payload.size) ?? asNumber(payload.squareMeters) ?? asNumber(payload.m2),
+    city,
+    neighborhood: asString(location?.neighborhood) ?? asString(payload.neighborhood),
+    province: asString(location?.province) ?? asString(payload.province),
+    images,
+    contact,
+  };
+}
+
+function resolvePropertyType(typology: string | undefined): PropertyType {
+  const t = (typology ?? '').toLowerCase();
+  if (t.includes('casa') || t.includes('chalet') || t.includes('house')) return PropertyType.HOUSE;
+  if (t.includes('estudio') || t.includes('studio')) return PropertyType.STUDIO;
+  if (t.includes('habitacion') || t.includes('room')) return PropertyType.ROOM;
+  return PropertyType.APARTMENT;
+}
+
+function toRemoteImages(urls: readonly string[]): NormalizedRemoteImage[] {
+  return urls.map((url, index) => ({ url, isPrimary: index === 0 }));
+}
+
+/**
+ * Map a raw advert onto {@link NormalizedListing}, hard-rejecting non-housing.
+ */
+export function normalizeMilanunciosRaw(raw: MilanunciosRaw): NormalizedListing {
+  assertHousingListing(PROVIDER_ID, raw.sourceId, {
+    category: raw.categorySlug,
+    typology: raw.typology,
+    squareMeters: raw.squareMeters,
+    bedrooms: raw.rooms,
+    bathrooms: raw.bathrooms,
+    hasAddressLike: Boolean(raw.city || raw.neighborhood || raw.province),
+    hasPrice: Number.isFinite(raw.price),
+  });
+
+  if (raw.categoryId && !MILANUNCIOS_HOUSING_CATEGORY_IDS.has(raw.categoryId) && raw.categorySlug) {
+    // id alone is not enough to reject when slug is housing; already checked above.
+  }
+
+  const isSale = raw.operation === 'sale';
+  const result: NormalizedListing = {
+    source: PROVIDER_ID,
+    sourceId: raw.sourceId,
+    sourceUrl: raw.url,
+    address: {
+      street: raw.neighborhood ?? raw.city,
+      city: raw.city || raw.province || '',
+      state: raw.province,
+      neighborhood: raw.neighborhood,
+      countryCode: 'ES',
+    },
+    type: resolvePropertyType(raw.typology),
+    offerings: isSale ? [OfferingType.SALE] : [OfferingType.LONG_TERM_RENT],
+    longTermRent: isSale ? undefined : { monthlyAmount: raw.price, currency: raw.currency },
+    sale: isSale ? { price: raw.price, currency: raw.currency } : undefined,
+    description: raw.description ?? raw.title,
+    bedrooms: raw.rooms,
+    bathrooms: raw.bathrooms,
+    squareFootage: raw.squareMeters,
+    remoteImages: toRemoteImages(raw.images),
+    status: 'published',
+  };
+  if (raw.contact) result.contact = raw.contact;
+  return result;
+}

--- a/packages/listing-providers/src/providers/pisos/ajax.ts
+++ b/packages/listing-providers/src/providers/pisos/ajax.ts
@@ -1,0 +1,54 @@
+/**
+ * pisos.com AJAX / URL helpers (pure).
+ *
+ * Prefer structured JSON (search JSON-LD, detail `data-var` + tracking blob,
+ * contact AJAX) over HTML scraping. Cold HTTP works for search/detail; contact
+ * endpoints are best-effort and must not fail ingest on 403/empty.
+ */
+
+import { PISOS_BASE_URL } from './fixtures';
+
+function citySlug(city: string): string {
+  return city
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Rental search URL for a city + 1-based page. */
+export function pisosSearchUrl(city: string, page = 1): string {
+  const base = `${PISOS_BASE_URL}/alquiler/pisos-${citySlug(city)}/`;
+  return page <= 1 ? base : `${base}?pagina=${page}`;
+}
+
+/** Sale search URL (secondary discover path). */
+export function pisosSaleSearchUrl(city: string, page = 1): string {
+  const base = `${PISOS_BASE_URL}/venta/pisos-${citySlug(city)}/`;
+  return page <= 1 ? base : `${base}?pagina=${page}`;
+}
+
+/** Contact phone AJAX (best-effort; often returns `{ phone: null }`). */
+export function pisosContactPhoneUrl(sourceId: string): string {
+  return `${PISOS_BASE_URL}/WebsiteUserInfo/GetNormalizedPhone?id=${encodeURIComponent(sourceId)}`;
+}
+
+/** Parse a contact AJAX JSON body into a phone string when present. */
+export function parsePisosContactPhone(body: string): string | undefined {
+  const trimmed = body.trim();
+  if (!trimmed.startsWith('{')) return undefined;
+  try {
+    const record = JSON.parse(trimmed) as { phone?: unknown; normalizedPhone?: unknown };
+    if (typeof record.normalizedPhone === 'string' && record.normalizedPhone.trim()) {
+      return record.normalizedPhone.trim();
+    }
+    if (typeof record.phone === 'string' && record.phone.trim()) {
+      return record.phone.trim();
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}

--- a/packages/listing-providers/src/providers/pisos/fixtures.ts
+++ b/packages/listing-providers/src/providers/pisos/fixtures.ts
@@ -1,0 +1,42 @@
+/**
+ * Recorded pisos.com fixtures (portal-shaped, hand-authored).
+ *
+ * Search pages ship schema.org JSON-LD for each card; detail pages embed a
+ * `data-var` JSON blob (rooms/baths/m²/phone) plus a tracking JSON object with
+ * price/operation. Image URLs point at example CDN hosts and are re-hosted at
+ * ingest — never hotlinked at runtime.
+ */
+
+export const PISOS_BASE_URL = 'https://www.pisos.com';
+
+/** Search-results page with three JSON-LD residence cards. */
+export const PISOS_FIXTURE_SEARCH_HTML = `<!doctype html>
+<html lang="es"><head><title>Pisos en alquiler en Madrid</title></head><body>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"SingleFamilyResidence","@id":"20026385030.992099","image":"https://fotos.imghs.net/example/1.jpg","name":"Piso en calle Mayor, 45","description":"Piso en calle Mayor, 45","url":"/alquilar/piso-sol_barrio28012-20026385030_992099/","address":{"@type":"PostalAddress","addressLocality":"Madrid Capital","addressRegion":"Madrid","addressCountry":{"@type":"Country","name":"ES"}},"geo":{"@type":"GeoCoordinates","latitude":"40.4159","longitude":"-3.7084"}}
+</script>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"Apartment","@id":"65072508446.519513","image":"https://fotos.imghs.net/example/2.jpg","name":"Piso en calle de Ponzano","url":"/alquilar/piso-chamberi_almagro28010-65072508446_519513/","address":{"@type":"PostalAddress","addressLocality":"Madrid Capital","addressRegion":"Madrid","addressCountry":{"@type":"Country","name":"ES"}},"geo":{"@type":"GeoCoordinates","latitude":"40.433","longitude":"-3.698"}}
+</script>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"House","@id":"61688075258.280500","image":"https://fotos.imghs.net/example/3.jpg","name":"Chalet en Prado","url":"/alquilar/chalet-prado-61688075258_280500/","address":{"@type":"PostalAddress","addressLocality":"Pozuelo de Alarcón","addressRegion":"Madrid","addressCountry":{"@type":"Country","name":"ES"}}}
+</script>
+</body></html>`;
+
+/** Detail page with embedded JSON blobs (price + contact phone). */
+export const PISOS_FIXTURE_DETAIL_HTML = `<!doctype html>
+<html lang="es"><head><title>Piso en alquiler en Calle Mayor, 45</title></head><body>
+<input id="hdnIdPiso" name="hdnIdPiso" type="hidden" value="20026385030.992099" />
+<h1>Piso en alquiler en Calle Mayor, 45, cerca de Calle de Ciudad Rodrigo</h1>
+<div data-var='{"fechaModificacion":"17/06/2026","fechaPrimeraPublicacion":"04/05/2026","telefono":"919376345","caracteristicasInmueble":"ascensor,balcon,soleado","nHabitaciones":"2","nBanios":"2","superficieInmueble":"107","descuentoAplicado":"8"}'></div>
+<script>
+window.__pisosTrack = {"tipoContenido":"detalle","tipoOperacion":"alquiler","seccion":"alquiler","idioma":"ES","subseccion1":"casas-pisos","tipoContenidoA":"detalle-casas-pisos","provincia":"P00000000000028","municipio":"M00000000028079","distrito":"G00000002807901","precioInmueble":"2550","precio":"2550","tipoVendedor":"profesional","referenciaInmueble":"","marca":"196080","tipoInmueble":"casas-pisos","subTipoInmueble":"piso-apartamento"};
+var precio = 2550;
+</script>
+<img src="https://fotos.imghs.net/example/20026385030/1.jpg" />
+<img src="https://fotos.imghs.net/example/20026385030/2.jpg" />
+<p class="description">Piso luminoso junto a Ópera, 107 m², 2 habitaciones.</p>
+</body></html>`;
+
+/** Recorded contact AJAX body from `/WebsiteUserInfo/GetNormalizedPhone`. */
+export const PISOS_FIXTURE_CONTACT_JSON = `{"phone":"919376345","normalizedPhone":"+34919376345"}`;

--- a/packages/listing-providers/src/providers/pisos/index.ts
+++ b/packages/listing-providers/src/providers/pisos/index.ts
@@ -1,0 +1,291 @@
+/**
+ * pisos.com provider (Spain) — JSON-first.
+ *
+ * Acquisition:
+ *   - `discover()`: city rental search pages → schema.org JSON-LD cards (structured
+ *     listing refs). Optional Playwright session warm-up when the ladder challenges.
+ *   - `fetch()`: detail page embedded JSON (`data-var` + tracking blob) for price /
+ *     rooms / m² / phone; best-effort `/WebsiteUserInfo/GetNormalizedPhone` AJAX.
+ *   - HTML is last-resort for title/images/description only.
+ *
+ * Registered OFF by default (`PROVIDER_PISOS_ENABLED`).
+ */
+
+import {
+  OfferingType,
+  PropertyType,
+  type NormalizedListing,
+  type NormalizedRemoteImage,
+  type ProviderId,
+} from '@homiio/shared-types';
+import type {
+  DiscoverJob,
+  ExternalListingRef,
+  FetchContext,
+  FetchRuntime,
+  ListingProvider,
+  ProviderHealth,
+  RawListing,
+} from '../../types';
+import { createFetchRuntime } from '../../runtime';
+import { fetchListingViaLadder } from '../../strategy';
+import { defaultProviderMetrics, type ProviderMetricsReader, type ProviderMetricsSink } from '../../metrics';
+import type { EsSchemaListing } from '../es/jsonLd';
+import { PISOS_BASE_URL } from './fixtures';
+import { parsePisosContactPhone, pisosContactPhoneUrl, pisosSearchUrl } from './ajax';
+import {
+  mergePisosContact,
+  parsePisosDetail,
+  parsePisosSearch,
+  pisosSourceIdFromUrl,
+  type PisosRaw,
+} from './parse';
+
+const PROVIDER_ID: ProviderId = 'pisos';
+const DEFAULT_CITIES: readonly string[] = ['madrid', 'barcelona', 'valencia', 'sevilla', 'malaga'];
+const MAX_SEARCH_PAGES = 3;
+
+export function isPisosChallenge(html: string): boolean {
+  if (html.trim().length < 512) return true;
+  return /access denied|captcha|datadome|precondition failed/i.test(html);
+}
+
+export interface PisosProviderOptions {
+  runtime?: FetchRuntime;
+  cities?: readonly string[];
+  metrics?: ProviderMetricsSink & ProviderMetricsReader;
+}
+
+function resolvePropertyType(types: readonly string[]): PropertyType {
+  const lower = types.map((type) => type.toLowerCase());
+  if (lower.some((type) => type.includes('house') || type.includes('chalet'))) return PropertyType.HOUSE;
+  if (lower.some((type) => type.includes('studio'))) return PropertyType.STUDIO;
+  return PropertyType.APARTMENT;
+}
+
+function toRemoteImages(listing: EsSchemaListing): NormalizedRemoteImage[] {
+  return listing.images.map((url, index) => ({ url, isPrimary: index === 0 }));
+}
+
+function asPisosRaw(payload: unknown): PisosRaw {
+  const record = payload as { sourceId?: unknown; url?: unknown; listing?: unknown } | null;
+  if (
+    !record ||
+    typeof record.sourceId !== 'string' ||
+    typeof record.url !== 'string' ||
+    typeof record.listing !== 'object'
+  ) {
+    throw new Error('pisos: normalize received a payload that is not a PisosRaw');
+  }
+  return payload as PisosRaw;
+}
+
+export class PisosProvider implements ListingProvider {
+  readonly id: ProviderId = PROVIDER_ID;
+  readonly markets = ['ES'] as const;
+
+  private readonly runtime: FetchRuntime;
+  private readonly cities: readonly string[];
+  private readonly metrics: ProviderMetricsSink & ProviderMetricsReader;
+
+  constructor(options: PisosProviderOptions = {}) {
+    this.runtime = options.runtime ?? createFetchRuntime();
+    this.cities = options.cities && options.cities.length > 0 ? options.cities : DEFAULT_CITIES;
+    this.metrics = options.metrics ?? defaultProviderMetrics;
+  }
+
+  async *discover(job: DiscoverJob): AsyncIterable<ExternalListingRef> {
+    const cities = job.city ? [job.city] : this.cities;
+    const limit = job.limit ?? Number.POSITIVE_INFINITY;
+    const seen = new Set<string>();
+    let yielded = 0;
+    const runtime = job.runtime ?? this.runtime;
+
+    for (const city of cities) {
+      for (let page = 1; page <= MAX_SEARCH_PAGES; page += 1) {
+        if (yielded >= limit) return;
+        const url = pisosSearchUrl(city, page);
+
+        // Prefer warmed-session fetch when available (JSON-LD still in HTML shell).
+        let html: string | undefined;
+        if (runtime.openBrowserSession) {
+          html = await this.fetchSearchViaSession(runtime, url, job.signal);
+        }
+        if (!html) {
+          const result = await fetchListingViaLadder(runtime, url, {
+            provider: this.id,
+            isChallenge: isPisosChallenge,
+            metrics: this.metrics,
+            init: { signal: job.signal },
+          });
+          html = result.html;
+        }
+
+        const refs = parsePisosSearch(html);
+        if (refs.length === 0) break;
+        for (const ref of refs) {
+          if (yielded >= limit) return;
+          if (seen.has(ref.sourceId)) continue;
+          seen.add(ref.sourceId);
+          yield { provider: this.id, sourceId: ref.sourceId, url: ref.url };
+          yielded += 1;
+        }
+      }
+    }
+  }
+
+  private async fetchSearchViaSession(
+    runtime: FetchRuntime,
+    url: string,
+    signal: AbortSignal | undefined,
+  ): Promise<string | undefined> {
+    if (!runtime.openBrowserSession) return undefined;
+    const start = Date.now();
+    let session: Awaited<ReturnType<NonNullable<FetchRuntime['openBrowserSession']>>> | undefined;
+    try {
+      session = await runtime.openBrowserSession({
+        warmUrl: url,
+        signal,
+        contentSelector: 'script[type="application/ld+json"], h1, main',
+        isChallenge: isPisosChallenge,
+        challengeWaitMs: 30_000,
+        blockAssets: true,
+      });
+      const html = await session.content();
+      this.metrics.record({
+        provider: this.id,
+        strategy: 'browser',
+        outcome: isPisosChallenge(html) ? 'challenge' : 'success',
+        status: 200,
+        latencyMs: Date.now() - start,
+        url,
+      });
+      return isPisosChallenge(html) ? undefined : html;
+    } catch {
+      this.metrics.record({
+        provider: this.id,
+        strategy: 'browser',
+        outcome: 'error',
+        latencyMs: Date.now() - start,
+        url,
+        detail: 'pisos search session warm-up failed',
+      });
+      return undefined;
+    } finally {
+      await session?.close();
+    }
+  }
+
+  async fetch(ref: ExternalListingRef, ctx: FetchContext): Promise<RawListing> {
+    const { html } = await fetchListingViaLadder(ctx.runtime, ref.url, {
+      provider: this.id,
+      isChallenge: isPisosChallenge,
+      init: { signal: ctx.signal },
+      metrics: this.metrics,
+    });
+    let payload = parsePisosDetail(html, ref.url);
+
+    // Best-effort contact AJAX — never fail ingest on 403/empty.
+    try {
+      const contactUrl = pisosContactPhoneUrl(payload.sourceId);
+      if (ctx.runtime.openBrowserSession) {
+        const session = await ctx.runtime.openBrowserSession({
+          warmUrl: ref.url,
+          signal: ctx.signal,
+          contentSelector: 'h1, #hdnIdPiso',
+          isChallenge: isPisosChallenge,
+          challengeWaitMs: 20_000,
+          blockAssets: true,
+        });
+        try {
+          const { status, body } = await session.request(contactUrl, {
+            referer: ref.url,
+            timeoutMs: 15_000,
+          });
+          if (status >= 200 && status < 300) {
+            payload = mergePisosContact(payload, parsePisosContactPhone(body));
+          }
+        } finally {
+          await session.close();
+        }
+      } else {
+        const body = await ctx.runtime.fetchText(contactUrl, {
+          headers: {
+            Accept: 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+            Referer: ref.url,
+          },
+          signal: ctx.signal,
+        });
+        payload = mergePisosContact(payload, parsePisosContactPhone(body));
+      }
+    } catch {
+      // Contact is optional.
+    }
+
+    return { ref, payload };
+  }
+
+  normalize(raw: RawListing): NormalizedListing {
+    const { sourceId, url, listing, contact } = asPisosRaw(raw.payload);
+    if (listing.price === undefined) {
+      throw new Error(`pisos: listing ${sourceId} has no resolvable price`);
+    }
+    const isSale = listing.operation === 'sale';
+    const currency = listing.priceCurrency ?? 'EUR';
+
+    const result: NormalizedListing = {
+      source: this.id,
+      sourceId,
+      sourceUrl: url,
+      address: {
+        street: listing.address.street ?? listing.address.city ?? '',
+        city: listing.address.city ?? '',
+        state: listing.address.region,
+        country: listing.address.country,
+        countryCode: listing.address.countryCode ?? 'ES',
+        postalCode: listing.address.postalCode,
+        neighborhood: listing.address.neighborhood,
+        coordinates: listing.coordinates,
+      },
+      type: resolvePropertyType(listing.types),
+      offerings: isSale ? [OfferingType.SALE] : [OfferingType.LONG_TERM_RENT],
+      longTermRent: isSale ? undefined : { monthlyAmount: listing.price, currency },
+      sale: isSale ? { price: listing.price, currency } : undefined,
+      remoteImages: toRemoteImages(listing),
+      status: 'published',
+    };
+
+    const description = listing.description ?? listing.name;
+    if (description !== undefined) result.description = description;
+    if (listing.bedrooms !== undefined) result.bedrooms = listing.bedrooms;
+    if (listing.bathrooms !== undefined) result.bathrooms = listing.bathrooms;
+    if (listing.squareMeters !== undefined) result.squareFootage = listing.squareMeters;
+    if (listing.amenities.length > 0) result.amenities = listing.amenities;
+    if (contact && (contact.phone || contact.email || contact.whatsapp || contact.agencyName)) {
+      result.contact = contact;
+    }
+
+    return result;
+  }
+
+  async health(): Promise<ProviderHealth> {
+    const snapshot = this.metrics.snapshot(this.id);
+    if (snapshot && snapshot.attempts > 0) {
+      const status =
+        snapshot.challengeRate >= 0.8 ? 'unhealthy' : snapshot.challengeRate >= 0.3 ? 'degraded' : 'healthy';
+      return {
+        provider: this.id,
+        status,
+        detail: `attempts=${snapshot.attempts} challengeRate=${snapshot.challengeRate.toFixed(2)} avgLatencyMs=${snapshot.avgLatencyMs}`,
+      };
+    }
+    return {
+      provider: this.id,
+      status: 'healthy',
+      detail: `Serving ES via ${PISOS_BASE_URL} (JSON-LD discover + embedded detail JSON)`,
+    };
+  }
+}
+
+export { pisosSourceIdFromUrl };

--- a/packages/listing-providers/src/providers/pisos/parse.ts
+++ b/packages/listing-providers/src/providers/pisos/parse.ts
@@ -1,0 +1,218 @@
+/**
+ * pisos.com parsers — JSON-first (JSON-LD search cards + embedded detail JSON).
+ *
+ * Search: schema.org JSON-LD blocks → refs.
+ * Detail: `data-var` JSON + tracking/`precio` JSON + optional contact AJAX.
+ * HTML is only used for title/description/image fallbacks when JSON lacks them.
+ */
+
+import type { NormalizedListingContact } from '@homiio/shared-types';
+import { extractEsSchemaListings, type EsSchemaListing } from '../es/jsonLd';
+import { PISOS_BASE_URL } from './fixtures';
+
+/** Raw payload `fetch()` hands to `normalize()`. */
+export interface PisosRaw {
+  sourceId: string;
+  url: string;
+  listing: EsSchemaListing;
+  contact?: NormalizedListingContact;
+}
+
+const DETAIL_PATH_RE = /\/(?:alquilar|comprar)\/[^"'?\s]*?-(\d+[._]\d+|\d+)\/?/i;
+const DATA_VAR_RE = /data-var=['"](\{[\s\S]*?\})['"]/i;
+const TRACK_RE =
+  /\{[^{}]*"tipoContenido"\s*:\s*"detalle"[^{}]*"precio(?:Inmueble)?"\s*:\s*"?\d+"?[^{}]*\}/;
+const PRECIO_VAR_RE = /var\s+precio\s*=\s*(\d+)/i;
+const H1_RE = /<h1[^>]*>([\s\S]*?)<\/h1>/i;
+const IMG_RE = /https:\/\/fotos\.imghs\.net\/[^"'?\s]+\.(?:jpg|jpeg|webp|png)/gi;
+const DESC_RE = /<(?:p|div)[^>]*class="[^"]*description[^"]*"[^>]*>([\s\S]*?)<\/(?:p|div)>/i;
+const HDN_ID_RE = /hdnIdPiso"[^>]*value="([^"]+)"/i;
+const LD_JSON_RE =
+  /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+
+function stripTags(html: string): string {
+  return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const cleaned = value.replace(/[^0-9.,-]/g, '').replace(/\./g, '').replace(',', '.');
+    const parsed = Number.parseFloat(cleaned);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function parseJsonObject(raw: string): Record<string, unknown> | undefined {
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return value as Record<string, unknown>;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+/** Extract stable id from a pisos detail URL (`…-<id>_<agency>/` or `…-<id>/`). */
+export function pisosSourceIdFromUrl(url: string): string | undefined {
+  const raw = url.match(DETAIL_PATH_RE)?.[1];
+  return raw ? raw.replace('_', '.') : undefined;
+}
+
+function absoluteUrl(pathOrUrl: string): string {
+  if (pathOrUrl.startsWith('http')) return pathOrUrl;
+  return `${PISOS_BASE_URL}${pathOrUrl.startsWith('/') ? '' : '/'}${pathOrUrl}`;
+}
+
+/**
+ * Parse search HTML into de-duplicated detail refs from JSON-LD cards.
+ */
+export function parsePisosSearch(html: string): { sourceId: string; url: string }[] {
+  const seen = new Set<string>();
+  const refs: { sourceId: string; url: string }[] = [];
+
+  for (const match of html.matchAll(LD_JSON_RE)) {
+    const body = match[1]?.trim();
+    if (!body) continue;
+    const record = parseJsonObject(body);
+    if (!record) continue;
+    const path = typeof record.url === 'string' ? record.url : undefined;
+    if (!path) continue;
+    const url = absoluteUrl(path);
+    const fromPath = pisosSourceIdFromUrl(url);
+    const fromId =
+      typeof record['@id'] === 'string' || typeof record['@id'] === 'number'
+        ? String(record['@id'])
+        : undefined;
+    const sourceId = fromPath ?? fromId;
+    if (!sourceId || seen.has(sourceId)) continue;
+    seen.add(sourceId);
+    refs.push({ sourceId, url });
+  }
+
+  return refs;
+}
+
+function readDataVar(html: string): Record<string, unknown> | undefined {
+  const match = html.match(DATA_VAR_RE);
+  if (!match?.[1]) return undefined;
+  return parseJsonObject(match[1].replace(/&quot;/g, '"'));
+}
+
+function readTrack(html: string): Record<string, unknown> | undefined {
+  const match = html.match(TRACK_RE);
+  if (!match?.[0]) return undefined;
+  return parseJsonObject(match[0]);
+}
+
+function amenityList(raw: unknown): string[] {
+  if (typeof raw !== 'string' || raw.trim().length === 0) return [];
+  return raw
+    .split(',')
+    .map((part) =>
+      part
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, ''),
+    )
+    .filter(Boolean);
+}
+
+/**
+ * Parse a detail page into {@link PisosRaw}. Prefers embedded JSON blobs;
+ * falls back to JSON-LD / light HTML for title, images, description.
+ */
+export function parsePisosDetail(html: string, url: string): PisosRaw {
+  const dataVar = readDataVar(html);
+  const track = readTrack(html);
+  const resolvedId = pisosSourceIdFromUrl(url) ?? html.match(HDN_ID_RE)?.[1];
+  if (!resolvedId) {
+    throw new Error(`pisos: cannot derive a source id from ${url}`);
+  }
+
+  const price =
+    asNumber(track?.precioInmueble) ??
+    asNumber(track?.precio) ??
+    asNumber(html.match(PRECIO_VAR_RE)?.[1]);
+  if (price === undefined) {
+    throw new Error(`pisos: listing ${resolvedId} has no resolvable price`);
+  }
+
+  const operationRaw = typeof track?.tipoOperacion === 'string' ? track.tipoOperacion : '';
+  const operation: 'rent' | 'sale' =
+    operationRaw.includes('venta') || url.includes('/comprar/') ? 'sale' : 'rent';
+
+  const subtype = typeof track?.subTipoInmueble === 'string' ? track.subTipoInmueble : '';
+  const types = ['Residence'];
+  if (subtype.includes('piso') || subtype.includes('apartamento')) types.push('Apartment');
+  if (subtype.includes('chalet') || subtype.includes('casa')) types.push('House');
+  if (subtype.includes('estudio')) types.push('Studio');
+
+  const h1Raw = html.match(H1_RE)?.[1];
+  const h1 = h1Raw ? stripTags(h1Raw) : undefined;
+  const descMatch = html.match(DESC_RE);
+  const description = descMatch ? stripTags(descMatch[1] ?? '') : h1;
+
+  const images = [...new Set(html.match(IMG_RE) ?? [])];
+  const ld = extractEsSchemaListings(html)[0];
+  const city = ld?.address.city ?? 'Madrid';
+  const street = ld?.address.street ?? h1 ?? city;
+
+  const listing: EsSchemaListing = {
+    types,
+    name: h1 ?? ld?.name,
+    description: description || ld?.description,
+    url,
+    address: {
+      street,
+      city,
+      region: ld?.address.region,
+      postalCode: ld?.address.postalCode,
+      neighborhood: ld?.address.neighborhood,
+      country: ld?.address.country,
+      countryCode: ld?.address.countryCode ?? 'ES',
+    },
+    coordinates: ld?.coordinates,
+    images: images.length > 0 ? images : (ld?.images ?? []),
+    bedrooms: asNumber(dataVar?.nHabitaciones) ?? ld?.bedrooms,
+    bathrooms: asNumber(dataVar?.nBanios) ?? ld?.bathrooms,
+    squareMeters: asNumber(dataVar?.superficieInmueble) ?? ld?.squareMeters,
+    price,
+    priceCurrency: 'EUR',
+    operation,
+    amenities: amenityList(dataVar?.caracteristicasInmueble),
+  };
+
+  const phone =
+    typeof dataVar?.telefono === 'string' && dataVar.telefono.trim()
+      ? dataVar.telefono.trim()
+      : undefined;
+  const seller = typeof track?.tipoVendedor === 'string' ? track.tipoVendedor : '';
+  const contact: NormalizedListingContact | undefined = phone
+    ? {
+        phone,
+        kind: seller.includes('profesional') ? 'agency' : seller ? 'private' : 'unknown',
+      }
+    : undefined;
+
+  return { sourceId: resolvedId, url, listing, contact };
+}
+
+/** Merge best-effort contact AJAX phone into an existing raw payload. */
+export function mergePisosContact(raw: PisosRaw, phone: string | undefined): PisosRaw {
+  if (!phone) return raw;
+  return {
+    ...raw,
+    contact: {
+      ...raw.contact,
+      phone: raw.contact?.phone ?? phone,
+      kind: raw.contact?.kind ?? 'unknown',
+    },
+  };
+}

--- a/packages/listing-providers/src/providers/yaencontre/fixtures.ts
+++ b/packages/listing-providers/src/providers/yaencontre/fixtures.ts
@@ -1,0 +1,55 @@
+/**
+ * yaencontre.com (Spain) — JSON-first with Playwright session warm-up.
+ *
+ * Cold HTTP and even residential-proxy Playwright currently hit Cloudflare
+ * (challenge HTML ~1.5 KB). The provider still prefers AJAX/JSON once a session
+ * clears; HTML is last resort. Registered OFF (`PROVIDER_YAENCONTRE_ENABLED`).
+ */
+
+export const YAENCONTRE_BASE_URL = 'https://www.yaencontre.com';
+
+function citySlug(city: string): string {
+  return city
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function yaencontreSearchUrl(city: string, page = 1): string {
+  const base = `${YAENCONTRE_BASE_URL}/alquiler/pisos/${citySlug(city)}`;
+  return page <= 1 ? base : `${base}?pagina=${page}`;
+}
+
+/** Search/list AJAX candidate (tried from warmed session). */
+export function yaencontreListAjaxUrl(city: string, page = 1): string {
+  const params = new URLSearchParams({
+    operation: 'rent',
+    propertyType: 'homes',
+    location: citySlug(city),
+    page: String(page),
+  });
+  return `${YAENCONTRE_BASE_URL}/api/search?${params.toString()}`;
+}
+
+export const YAENCONTRE_FIXTURE_DETAIL_JSON = JSON.stringify({
+  id: '987654321',
+  url: 'https://www.yaencontre.com/alquiler/piso/madrid/987654321',
+  title: 'Piso en alquiler en Salamanca',
+  description: 'Piso de 90 m² con 3 habitaciones en Salamanca.',
+  price: 2100,
+  currency: 'EUR',
+  operation: 'rent',
+  rooms: 3,
+  bathrooms: 2,
+  size: 90,
+  address: { street: 'Calle de Serrano', city: 'Madrid', province: 'Madrid', neighborhood: 'Salamanca' },
+  images: ['https://cdn.yaencontre.com/example/987654321/1.jpg'],
+  contact: { phone: '910000111', agencyName: 'Yaencontre Demo Agency' },
+});
+
+export const YAENCONTRE_FIXTURE_SEARCH_JSON = JSON.stringify({
+  results: [{ id: '987654321', url: 'https://www.yaencontre.com/alquiler/piso/madrid/987654321' }],
+});

--- a/packages/listing-providers/src/providers/yaencontre/index.ts
+++ b/packages/listing-providers/src/providers/yaencontre/index.ts
@@ -1,0 +1,173 @@
+/**
+ * yaencontre.com provider — JSON/AJAX via Playwright session; HTML last resort.
+ * Registered OFF (`PROVIDER_YAENCONTRE_ENABLED`). Cloudflare currently blocks
+ * cold + proxy sessions; keep OFF until managed tier or session clears.
+ */
+
+import type { NormalizedListing, ProviderId } from '@homiio/shared-types';
+import type {
+  DiscoverJob,
+  ExternalListingRef,
+  FetchContext,
+  FetchRuntime,
+  ListingProvider,
+  ProviderHealth,
+  RawListing,
+} from '../../types';
+import { createFetchRuntime } from '../../runtime';
+import { defaultProviderMetrics, type ProviderMetricsReader, type ProviderMetricsSink } from '../../metrics';
+import { YAENCONTRE_BASE_URL, yaencontreListAjaxUrl, yaencontreSearchUrl } from './fixtures';
+import {
+  normalizeYaencontreRaw,
+  parseYaencontreDetailJson,
+  parseYaencontreSearchJson,
+  type YaencontreRaw,
+} from './parse';
+
+const PROVIDER_ID: ProviderId = 'yaencontre';
+const DEFAULT_CITIES: readonly string[] = ['madrid', 'barcelona', 'valencia'];
+const MAX_SEARCH_PAGES = 3;
+
+export function isYaencontreChallenge(body: string): boolean {
+  if (body.trim().length < 512) return true;
+  return /just a moment|cloudflare|cf-browser|captcha|access denied|datadome/i.test(body);
+}
+
+export interface YaencontreProviderOptions {
+  runtime?: FetchRuntime;
+  cities?: readonly string[];
+  metrics?: ProviderMetricsSink & ProviderMetricsReader;
+}
+
+function asRaw(payload: unknown): YaencontreRaw {
+  const record = payload as { sourceId?: unknown; price?: unknown; city?: unknown } | null;
+  if (!record || typeof record.sourceId !== 'string' || typeof record.price !== 'number') {
+    throw new Error('yaencontre: normalize received an invalid payload');
+  }
+  return payload as YaencontreRaw;
+}
+
+export class YaencontreProvider implements ListingProvider {
+  readonly id: ProviderId = PROVIDER_ID;
+  readonly markets = ['ES'] as const;
+  private readonly runtime: FetchRuntime;
+  private readonly cities: readonly string[];
+  private readonly metrics: ProviderMetricsSink & ProviderMetricsReader;
+
+  constructor(options: YaencontreProviderOptions = {}) {
+    this.runtime = options.runtime ?? createFetchRuntime();
+    this.cities = options.cities && options.cities.length > 0 ? options.cities : DEFAULT_CITIES;
+    this.metrics = options.metrics ?? defaultProviderMetrics;
+  }
+
+  async *discover(job: DiscoverJob): AsyncIterable<ExternalListingRef> {
+    const cities = job.city ? [job.city] : this.cities;
+    const limit = job.limit ?? Number.POSITIVE_INFINITY;
+    const seen = new Set<string>();
+    let yielded = 0;
+    const runtime = job.runtime ?? this.runtime;
+    if (!runtime.openBrowserSession) return;
+
+    for (const city of cities) {
+      for (let page = 1; page <= MAX_SEARCH_PAGES; page += 1) {
+        if (yielded >= limit) return;
+        const warmUrl = yaencontreSearchUrl(city, page);
+        let session: Awaited<ReturnType<NonNullable<FetchRuntime['openBrowserSession']>>> | undefined;
+        const start = Date.now();
+        try {
+          session = await runtime.openBrowserSession({
+            warmUrl,
+            signal: job.signal,
+            contentSelector: 'article, main, h1',
+            isChallenge: isYaencontreChallenge,
+            challengeWaitMs: 45_000,
+            blockAssets: true,
+          });
+          const ajaxUrl = yaencontreListAjaxUrl(city, page);
+          const { status, body } = await session.request(ajaxUrl, {
+            referer: session.pageUrl(),
+            timeoutMs: 30_000,
+          });
+          if (status >= 400 || isYaencontreChallenge(body)) {
+            this.metrics.record({
+              provider: this.id,
+              strategy: 'browser',
+              outcome: 'challenge',
+              status,
+              latencyMs: Date.now() - start,
+              url: ajaxUrl,
+            });
+            break;
+          }
+          const refs = parseYaencontreSearchJson(body);
+          this.metrics.record({
+            provider: this.id,
+            strategy: 'browser',
+            outcome: 'success',
+            status,
+            latencyMs: Date.now() - start,
+            url: ajaxUrl,
+          });
+          if (refs.length === 0) break;
+          for (const ref of refs) {
+            if (yielded >= limit) return;
+            if (seen.has(ref.sourceId)) continue;
+            seen.add(ref.sourceId);
+            yield { provider: this.id, sourceId: ref.sourceId, url: ref.url };
+            yielded += 1;
+          }
+        } catch {
+          this.metrics.record({
+            provider: this.id,
+            strategy: 'browser',
+            outcome: 'challenge',
+            latencyMs: Date.now() - start,
+            url: warmUrl,
+          });
+          break;
+        } finally {
+          await session?.close();
+        }
+      }
+    }
+  }
+
+  async fetch(ref: ExternalListingRef, ctx: FetchContext): Promise<RawListing> {
+    if (!ctx.runtime.openBrowserSession) {
+      throw new Error('yaencontre: fetch requires openBrowserSession');
+    }
+    const session = await ctx.runtime.openBrowserSession({
+      warmUrl: ref.url,
+      signal: ctx.signal,
+      contentSelector: 'h1, main',
+      isChallenge: isYaencontreChallenge,
+      challengeWaitMs: 45_000,
+      blockAssets: true,
+    });
+    try {
+      const apiUrl = `${YAENCONTRE_BASE_URL}/api/listing/${ref.sourceId}`;
+      const { status, body } = await session.request(apiUrl, {
+        referer: ref.url,
+        timeoutMs: 20_000,
+      });
+      if (status >= 200 && status < 300 && body.trim().startsWith('{') && !isYaencontreChallenge(body)) {
+        return { ref, payload: parseYaencontreDetailJson(JSON.parse(body) as unknown, ref.url) };
+      }
+      throw new Error(`yaencontre: no JSON detail for ${ref.sourceId} (status=${status})`);
+    } finally {
+      await session.close();
+    }
+  }
+
+  normalize(raw: RawListing): NormalizedListing {
+    return normalizeYaencontreRaw(asRaw(raw.payload));
+  }
+
+  async health(): Promise<ProviderHealth> {
+    return {
+      provider: this.id,
+      status: 'healthy',
+      detail: `Serving ES via ${YAENCONTRE_BASE_URL} (Cloudflare-gated; OFF until session clears)`,
+    };
+  }
+}

--- a/packages/listing-providers/src/providers/yaencontre/parse.ts
+++ b/packages/listing-providers/src/providers/yaencontre/parse.ts
@@ -1,0 +1,163 @@
+/**
+ * yaencontre.com JSON parsers (pure).
+ */
+
+import {
+  OfferingType,
+  PropertyType,
+  type NormalizedListing,
+  type NormalizedListingContact,
+  type ProviderId,
+} from '@homiio/shared-types';
+import { YAENCONTRE_BASE_URL } from './fixtures';
+
+const PROVIDER_ID: ProviderId = 'yaencontre';
+
+export interface YaencontreRaw {
+  sourceId: string;
+  url: string;
+  title: string;
+  description?: string;
+  price: number;
+  currency: string;
+  operation: 'rent' | 'sale';
+  rooms?: number;
+  bathrooms?: number;
+  squareMeters?: number;
+  street: string;
+  city: string;
+  province?: string;
+  neighborhood?: string;
+  images: string[];
+  contact?: NormalizedListingContact;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value.replace(/[^0-9.-]/g, ''));
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+export function yaencontreSourceIdFromUrl(url: string): string | undefined {
+  return url.match(/\/(\d{5,})\/?$/)?.[1];
+}
+
+export function parseYaencontreSearchJson(body: string): { sourceId: string; url: string }[] {
+  const trimmed = body.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return [];
+  let root: unknown;
+  try {
+    root = JSON.parse(trimmed) as unknown;
+  } catch {
+    return [];
+  }
+  const items: unknown[] = [];
+  if (Array.isArray(root)) items.push(...root);
+  else if (isRecord(root)) {
+    for (const key of ['results', 'listings', 'items', 'ads', 'data']) {
+      if (Array.isArray(root[key])) {
+        items.push(...(root[key] as unknown[]));
+        break;
+      }
+    }
+  }
+  const seen = new Set<string>();
+  const refs: { sourceId: string; url: string }[] = [];
+  for (const entry of items) {
+    if (!isRecord(entry)) continue;
+    const sourceId =
+      asString(entry.id) ?? (typeof entry.id === 'number' ? String(entry.id) : undefined);
+    const url =
+      asString(entry.url) ??
+      (sourceId ? `${YAENCONTRE_BASE_URL}/alquiler/piso/${sourceId}` : undefined);
+    if (!sourceId || !url || seen.has(sourceId)) continue;
+    seen.add(sourceId);
+    refs.push({ sourceId, url });
+  }
+  return refs;
+}
+
+export function parseYaencontreDetailJson(payload: unknown, fallbackUrl?: string): YaencontreRaw {
+  if (!isRecord(payload)) throw new Error('yaencontre: detail payload is not an object');
+  const sourceId =
+    asString(payload.id) ?? (typeof payload.id === 'number' ? String(payload.id) : undefined);
+  if (!sourceId) throw new Error('yaencontre: missing id');
+  const price = asNumber(payload.price);
+  if (price === undefined) throw new Error(`yaencontre: listing ${sourceId} has no price`);
+  const address = isRecord(payload.address) ? payload.address : undefined;
+  const city = asString(address?.city) ?? asString(payload.city) ?? '';
+  if (!city) throw new Error(`yaencontre: listing ${sourceId} has no city`);
+  const images: string[] = [];
+  if (Array.isArray(payload.images)) {
+    for (const img of payload.images) {
+      if (typeof img === 'string') images.push(img);
+    }
+  }
+  const contactRaw = isRecord(payload.contact) ? payload.contact : undefined;
+  const phone = asString(contactRaw?.phone);
+  const contact: NormalizedListingContact | undefined = phone
+    ? {
+        phone,
+        agencyName: asString(contactRaw?.agencyName) ?? asString(contactRaw?.name),
+        kind: 'agency',
+      }
+    : undefined;
+  const operationRaw = asString(payload.operation)?.toLowerCase() ?? 'rent';
+  return {
+    sourceId,
+    url: asString(payload.url) ?? fallbackUrl ?? `${YAENCONTRE_BASE_URL}/alquiler/piso/${sourceId}`,
+    title: asString(payload.title) ?? `Listing ${sourceId}`,
+    description: asString(payload.description),
+    price,
+    currency: asString(payload.currency) ?? 'EUR',
+    operation: operationRaw.includes('sale') || operationRaw.includes('venta') ? 'sale' : 'rent',
+    rooms: asNumber(payload.rooms) ?? asNumber(payload.bedrooms),
+    bathrooms: asNumber(payload.bathrooms),
+    squareMeters: asNumber(payload.size) ?? asNumber(payload.squareMeters),
+    street: asString(address?.street) ?? city,
+    city,
+    province: asString(address?.province),
+    neighborhood: asString(address?.neighborhood),
+    images,
+    contact,
+  };
+}
+
+export function normalizeYaencontreRaw(raw: YaencontreRaw): NormalizedListing {
+  const isSale = raw.operation === 'sale';
+  const result: NormalizedListing = {
+    source: PROVIDER_ID,
+    sourceId: raw.sourceId,
+    sourceUrl: raw.url,
+    address: {
+      street: raw.street,
+      city: raw.city,
+      state: raw.province,
+      neighborhood: raw.neighborhood,
+      countryCode: 'ES',
+    },
+    type: PropertyType.APARTMENT,
+    offerings: isSale ? [OfferingType.SALE] : [OfferingType.LONG_TERM_RENT],
+    longTermRent: isSale ? undefined : { monthlyAmount: raw.price, currency: raw.currency },
+    sale: isSale ? { price: raw.price, currency: raw.currency } : undefined,
+    description: raw.description ?? raw.title,
+    bedrooms: raw.rooms,
+    bathrooms: raw.bathrooms,
+    squareFootage: raw.squareMeters,
+    remoteImages: raw.images.map((url, index) => ({ url, isPrimary: index === 0 })),
+    status: 'published',
+  };
+  if (raw.contact) result.contact = raw.contact;
+  return result;
+}

--- a/packages/shared-types/src/listing.ts
+++ b/packages/shared-types/src/listing.ts
@@ -34,7 +34,24 @@ export type ProviderId =
   | 'habitaclia'
   | 'blueground'
   | 'apartments_com'
-  | 'zillow';
+  | 'zillow'
+  | 'pisos'
+  | 'milanuncios'
+  | 'yaencontre'
+  | 'indomio';
+
+/**
+ * Best-effort owner/agent contact from a portal. Missing fields are omitted —
+ * ingest must NOT fail when contact fetch 403s.
+ */
+export interface NormalizedListingContact {
+  phone?: string;
+  email?: string;
+  whatsapp?: string;
+  agencyName?: string;
+  name?: string;
+  kind?: 'owner' | 'agency' | 'private' | 'unknown';
+}
 
 /**
  * A remote source image for a listing, as reported by the provider. The `url`
@@ -104,6 +121,11 @@ export interface NormalizedListing {
   furnishedStatus?: 'furnished' | 'unfurnished' | 'partially_furnished' | 'not_specified';
   /** Source images fetched once at ingest and re-hosted; never hotlinked. */
   remoteImages: NormalizedRemoteImage[];
+  /**
+   * Best-effort advertiser contact from portal AJAX (phone / email / WhatsApp).
+   * Optional — never required for a successful ingest.
+   */
+  contact?: NormalizedListingContact;
   /**
    * Listing lifecycle status. External aggregator listings are always published
    * (visible in search) — the literal is fixed so a provider can't emit a


### PR DESCRIPTION
## Summary
- Add **pisos.com** provider (JSON-LD discover + embedded detail JSON + contact AJAX); live discover verified (5+ Madrid refs); enable on worker via `PROVIDER_PISOS_ENABLED`.
- Add **milanuncios** as housing-only classifieds (category allowlist + `assertHousingListing`; car fixture rejected); **OFF** until GeeTest session path verified.
- Add **yaencontre** / **indomio** JSON/session scaffolding; **OFF** (Cloudflare-blocked even with residential proxy).
- Populate `NormalizedListing.contact` → `Property.externalContact` when portals expose phone/agency.
- Skip vibbo (redirects to milanuncios) and wallapop (no clean RE API).

## Test plan
- [x] Unit: pisos / milanuncios (housing accept + car reject) / yaencontre+indomio normalize fixtures
- [x] Live: `PisosProvider.discover({ city: 'madrid', limit: 5 })` yields refs
- [ ] Apply oxy-infra worker env (`PROVIDER_PISOS_ENABLED=true`; milanuncios/yaencontre/indomio false) if not already applied
- [ ] Worker boot discover for pisos in staging/prod after merge


Made with [Cursor](https://cursor.com)