### PR TITLE
chore: gitignore Playwright probes and listing-worker artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,10 @@ build/
 .next/
 out/
 
-# Environment variables
+# Environment variables (keep .env.example tracked)
 .env
 .env.local
+.env.*.local
 .env.development.local
 .env.test.local
 .env.production.local
@@ -100,6 +101,27 @@ ios/Pods/
 # Temporary files
 tmp/
 temp/
+.scratch/
+
+# Playwright / browser session (listing worker probes)
+playwright-report/
+test-results/
+blob-report/
+.playwright/
+playwright/.cache/
+**/storageState*.json
+**/session-dump*.json
+
+# Portal probe / debug dumps (scripts stay tracked; outputs do not)
+**/probe-*.html
+**/probe-*.json
+
+# Accidental tsc emit alongside listing-providers sources (build → dist/)
+packages/listing-providers/src/**/*.js
+packages/listing-providers/src/**/*.d.ts
+
+# Agent / IDE worktree noise
+.cursor/
 
 # TypeScript
 *.tsbuildinfo


### PR DESCRIPTION
## Summary
- Ignore Playwright report/cache dirs, browser `storageState` / session dumps, and portal probe HTML/JSON outputs from listing-provider worker work.
- Ignore accidental `tsc` emit (`*.js` / `*.d.ts`) under `packages/listing-providers/src/` (build output belongs in `dist/`).
- Broaden env ignore with `.env.*.local`; add `.scratch/` and `.cursor/` for local probe/agent noise.
- Provider source, fixtures, and `.env.example` remain tracked.

## Test plan
- [x] `git status` no longer surfaces ~111 accidental `listing-providers/src/**/*.js` emit files
- [x] `.env.example` still tracked (`git check-ignore -v packages/backend/.env.example` → not ignored)

Made with [Cursor](https://cursor.com)