### PR TITLE
feat(i18n): complete Homiio frontend i18n remediation

### DIFF
--- a/packages/frontend/app/(tabs)/inbox/index.tsx
+++ b/packages/frontend/app/(tabs)/inbox/index.tsx
@@ -159,33 +159,23 @@ export default function InboxScreen() {
   const handleDeleteNotification = useCallback(
     (notification: Notification) => {
       Alert.alert(
-        t('notification.delete.title', 'Delete Notification'),
-        t(
-          'notification.delete.message',
-          'Are you sure you want to delete this notification?',
-        ),
+        t('notification.delete.title'),
+        t('notification.delete.message'),
         [
-          { text: t('common.cancel', 'Cancel'), style: 'cancel' },
+          { text: t('common.cancel'), style: 'cancel' },
           {
-            text: t('common.delete', 'Delete'),
+            text: t('common.delete'),
             style: 'destructive',
             onPress: async () => {
               try {
                 await deleteNotification(notification.id);
-                toast.success(
-                  t('notification.delete.success', 'Notification deleted'),
-                );
+                toast.success(t('notification.delete.success'));
               } catch (deleteError: unknown) {
                 logger.error(
                   'Failed to delete notification:',
                   deleteError,
                 );
-                toast.error(
-                  t(
-                    'notification.delete.error',
-                    'Failed to delete notification',
-                  ),
-                );
+                toast.error(t('notification.delete.error'));
               }
             },
           },
@@ -198,14 +188,10 @@ export default function InboxScreen() {
   const handleMarkAllAsRead = useCallback(async () => {
     try {
       await markAllAsRead();
-      toast.success(
-        t('notification.markAllRead.success', 'All notifications marked as read'),
-      );
+      toast.success(t('notification.markAllRead.success'));
     } catch (markError: unknown) {
       logger.error('Failed to mark all notifications as read:', markError);
-      toast.error(
-        t('notification.markAllRead.error', 'Failed to mark all as read'),
-      );
+      toast.error(t('notification.markAllRead.error'));
     }
   }, [markAllAsRead, t]);
 
@@ -213,22 +199,16 @@ export default function InboxScreen() {
     try {
       const granted = await requestPermissions();
       if (granted) {
-        toast.success(
-          t('notification.permissions.granted', 'Notification permissions granted'),
-        );
+        toast.success(t('notification.permissions.granted'));
       } else {
-        toast.error(
-          t('notification.permissions.denied', 'Notification permissions denied'),
-        );
+        toast.error(t('notification.permissions.denied'));
       }
     } catch (permissionError: unknown) {
       logger.error(
         'Failed to request notification permissions:',
         permissionError,
       );
-      toast.error(
-        t('notification.permissions.error', 'Failed to request permissions'),
-      );
+      toast.error(t('notification.permissions.error'));
     }
   }, [requestPermissions, t]);
 
@@ -250,7 +230,7 @@ export default function InboxScreen() {
   const header = (
     <Header
       options={{
-        title: t('inbox.title', 'Inbox'),
+        title: t('inbox.title'),
         titlePosition: 'left',
         rightComponents: [
           unreadCount > 0 ? (
@@ -258,10 +238,7 @@ export default function InboxScreen() {
               key="mark-all"
               icon="checkmark-done"
               color={colors.primaryColor}
-              accessibilityLabel={t(
-                'notification.markAllRead.action',
-                'Mark all as read',
-              )}
+              accessibilityLabel={t('notification.markAllRead.action')}
               onPress={handleMarkAllAsRead}
             />
           ) : null,
@@ -269,10 +246,7 @@ export default function InboxScreen() {
             key="settings"
             icon="settings-outline"
             color={colors.COLOR_BLACK_LIGHT_2}
-            accessibilityLabel={t(
-              'notification.settings.title',
-              'Notification Settings',
-            )}
+            accessibilityLabel={t('notification.settings.title')}
             onPress={() => router.push('/settings/notifications')}
           />,
         ],
@@ -297,13 +271,10 @@ export default function InboxScreen() {
           </View>
           <View style={styles.permissionText}>
             <BloomText style={styles.permissionTitle}>
-              {t('notification.permissions.title', 'Enable Notifications')}
+              {t('notification.permissions.title')}
             </BloomText>
             <BloomText style={styles.permissionMessage}>
-              {t(
-                'notification.permissions.message',
-                'Get notified about new properties, messages, and important updates.',
-              )}
+              {t('notification.permissions.message')}
             </BloomText>
           </View>
           <Ionicons
@@ -318,7 +289,7 @@ export default function InboxScreen() {
         <View style={styles.scheduledSection}>
           <View style={styles.sectionHeaderRow}>
             <H3 style={styles.sectionTitle}>
-              {t('notification.scheduled.title', 'Scheduled Notifications')}
+              {t('notification.scheduled.title')}
             </H3>
             <Pressable
               onPress={cancelAllLocalNotifications}
@@ -326,7 +297,7 @@ export default function InboxScreen() {
               hitSlop={8}
             >
               <BloomText style={styles.clearAllText}>
-                {t('notification.scheduled.clearAll', 'Clear All')}
+                {t('notification.scheduled.clearAll')}
               </BloomText>
             </Pressable>
           </View>
@@ -335,10 +306,7 @@ export default function InboxScreen() {
               key={item.identifier}
               request={item}
               onCancel={() => cancelLocalNotification(item.identifier)}
-              scheduledLabel={t(
-                'notification.scheduled.label',
-                'Scheduled notification',
-              )}
+              scheduledLabel={t('notification.scheduled.label')}
             />
           ))}
         </View>
@@ -353,27 +321,27 @@ export default function InboxScreen() {
       <View style={styles.controls}>
         <SearchInput
           value={searchQuery}
-          label={t('notification.search.placeholder', 'Search notifications')}
+          label={t('notification.search.placeholder')}
           onChangeText={setSearchQuery}
           onClearText={() => setSearchQuery('')}
         />
 
         <SegmentedControl<InboxFilter>
-          label={t('notification.filter.label', 'Filter notifications')}
+          label={t('notification.filter.label')}
           type="tabs"
           value={filter}
           onChange={setFilter}
         >
           <SegmentedControlItem value="all">
             <SegmentedControlItemText>
-              {t('notification.filter.all', 'All')}
+              {t('notification.filter.all')}
             </SegmentedControlItemText>
           </SegmentedControlItem>
           <SegmentedControlItem value="unread">
             <SegmentedControlItemText>
               {unreadCount > 0
-                ? `${t('notification.filter.unread', 'Unread')} · ${unreadCount}`
-                : t('notification.filter.unread', 'Unread')}
+                ? `${t('notification.filter.unread')} · ${unreadCount}`
+                : t('notification.filter.unread')}
             </SegmentedControlItemText>
           </SegmentedControlItem>
         </SegmentedControl>
@@ -386,13 +354,13 @@ export default function InboxScreen() {
       ) : error ? (
         <View style={styles.stateWrap}>
           <ErrorState
-            title={t('error.load_notifications', "We couldn't load your inbox")}
+            title={t('error.loadNotifications')}
             description={
               typeof error === 'string'
                 ? error
-                : t('common.tryAgain', 'Please try again.')
+                : t('common.tryAgain')
             }
-            retryLabel={t('common.retry', 'Retry')}
+            retryLabel={t('common.retry')}
             onRetry={handleRefresh}
           />
         </View>
@@ -416,11 +384,8 @@ export default function InboxScreen() {
               <View style={styles.emptyWrap}>
                 <EmptyState
                   icon="filter-outline"
-                  title={t('notification.empty.filteredTitle', 'No matches')}
-                  description={t(
-                    'notification.empty.filtered',
-                    'No notifications match your current filter',
-                  )}
+                  title={t('notification.empty.filteredTitle')}
+                  description={t('notification.empty.filtered')}
                 />
               </View>
             ) : (
@@ -432,13 +397,10 @@ export default function InboxScreen() {
                   accessibilityIgnoresInvertColors
                 />
                 <H3 style={styles.illustrationTitle}>
-                  {t('notification.empty.title', 'No notifications')}
+                  {t('notification.empty.title')}
                 </H3>
                 <BloomText style={styles.illustrationMessage}>
-                  {t(
-                    'notification.empty.message',
-                    "You're all caught up! New notifications will appear here.",
-                  )}
+                  {t('notification.empty.message')}
                 </BloomText>
               </View>
             )

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -252,7 +252,7 @@ export default function HomePage() {
     const queryPlace = activeQuery.location?.shortLabel || activeQuery.location?.label;
     if (queryPlace) return queryPlace;
     const fallbackCountry = cities.map((c) => cityCountryName(c)).find(Boolean);
-    return fallbackCountry ?? t('home.cityShowcase.defaultPlace', 'Spain');
+    return fallbackCountry ?? t('home.cityShowcase.defaultPlace');
   }, [userLocation, citiesByDistance, activeQuery.location, cities, t]);
 
   // Fetch properties for the two closest cities. The nearbyCities array
@@ -353,15 +353,15 @@ export default function HomePage() {
    */
   const featuredGridTitle = useMemo(() => {
     if (browseOffering === OfferingType.SALE) {
-      return t('home.featured.gridBuy', 'Homes for sale in Barcelona');
+      return t('home.featured.gridBuy');
     }
     if (browseOffering === OfferingType.EXCHANGE) {
-      return t('home.featured.gridExchange', 'Home exchanges in Spain');
+      return t('home.featured.gridExchange');
     }
     if (browseOffering === OfferingType.SHORT_TERM_RENT) {
-      return t('home.featured.gridVacation', 'Beach apartments in València');
+      return t('home.featured.gridVacation');
     }
-    return t('home.featured.gridLongTerm', 'Studios in Barcelona');
+    return t('home.featured.gridLongTerm');
   }, [browseOffering, t]);
 
   const handleNavigateToCity = useCallback(
@@ -381,9 +381,9 @@ export default function HomePage() {
 
   const footerChunks = useMemo(
     () => [
-      t('home.footerStrip.verified', 'Verified listings'),
-      t('home.footerStrip.fair', 'Fair agreements'),
-      t('home.footerStrip.support', 'Real support, real people'),
+      t('home.footerStrip.verified'),
+      t('home.footerStrip.fair'),
+      t('home.footerStrip.support'),
     ],
     [t],
   );
@@ -439,7 +439,7 @@ export default function HomePage() {
             <Pressable
               onPress={openMobileDrawer}
               accessibilityRole="button"
-              accessibilityLabel={t('sidebar.open', { defaultValue: 'Open menu' })}
+              accessibilityLabel={t('sidebar.open')}
               hitSlop={spacing.sm}
               className="absolute left-4 z-10 h-10 w-10 items-center justify-center rounded-full"
               style={{
@@ -519,7 +519,7 @@ export default function HomePage() {
         {/* === Featured Properties carousel === */}
         {featuredProperties.length > 0 ? (
           <HomeCarouselSection
-            title={t('home.featured.title', 'Top picks for you')}
+            title={t('home.featured.title')}
             items={featuredProperties}
             loading={propertiesLoading}
             renderItem={(property) => (
@@ -538,10 +538,7 @@ export default function HomePage() {
         {/* === City Showcase (DB cities, adaptive region/country title) === */}
         {cities.length > 0 ? (
           <CityShowcaseSection
-            title={t('home.cityShowcase.title', {
-              defaultValue: 'Explore {{place}}',
-              place: explorePlace,
-            })}
+            title={t('home.cityShowcase.title', { place: explorePlace })}
             items={cities}
             onPressCity={handleNavigateToCity}
           />
@@ -561,7 +558,7 @@ export default function HomePage() {
         {/* === Continue browsing (Recently Viewed) === */}
         {recentlyViewedProperties && recentlyViewedProperties.length > 0 ? (
           <HomeCarouselSection
-            title={t('home.recentlyViewed.continue', 'Continue browsing')}
+            title={t('home.recentlyViewed.continue')}
             items={recentlyViewedProperties}
             loading={false}
             renderItem={(property) => (
@@ -580,7 +577,7 @@ export default function HomePage() {
         {/* === Saved Properties === */}
         {savedProperties && savedProperties.length > 0 ? (
           <HomeCarouselSection<Property>
-            title={t('home.saved.title') || 'Saved properties'}
+            title={t('home.saved.title')}
             items={savedProperties as Property[]}
             loading={savedLoading}
             renderItem={(property) => (
@@ -604,7 +601,7 @@ export default function HomePage() {
           return (
             <HomeCarouselSection
               key={cityId}
-              title={t('home.nearby.title', { city: city.name }) || `Homes in ${city.name}`}
+              title={t('home.nearby.title', { city: city.name })}
               items={cityProperties}
               loading={false}
               renderItem={(property) => (
@@ -633,41 +630,35 @@ export default function HomePage() {
           <View className="flex-row items-stretch gap-6 px-8 md:gap-8">
             <HostCtaBanner
               fill
-              title={t('home.hostCta.title', 'List your space, find a great tenant')}
-              subtitle={t(
-                'home.hostCta.subtitle',
-                'Reach verified renters across Spain — free to list, fair fees, real human support.',
-              )}
-              ctaLabel={t('home.hostCta.cta', 'Become a host')}
+              title={t('home.hostCta.title')}
+              subtitle={t('home.hostCta.subtitle')}
+              ctaLabel={t('home.hostCta.cta')}
               imageUrl={HOST_CTA_IMAGE}
               onPress={handleBecomeHost}
             />
             <AgentCtaBanner
               fill
-              title={t('agent.banner.title', 'Start today. No license needed.')}
-              subtitle={t('agent.banner.subtitle', 'Turn the homes around you into income.')}
-              ctaLabel={t('agent.banner.cta', 'Become an agent')}
-              trustLine={t('agent.banner.trust', 'No license needed. Work from your phone.')}
+              title={t('agent.banner.title')}
+              subtitle={t('agent.banner.subtitle')}
+              ctaLabel={t('agent.banner.cta')}
+              trustLine={t('agent.banner.trust')}
               onPress={handleBecomeAgent}
             />
           </View>
         ) : (
           <>
             <HostCtaBanner
-              title={t('home.hostCta.title', 'List your space, find a great tenant')}
-              subtitle={t(
-                'home.hostCta.subtitle',
-                'Reach verified renters across Spain — free to list, fair fees, real human support.',
-              )}
-              ctaLabel={t('home.hostCta.cta', 'Become a host')}
+              title={t('home.hostCta.title')}
+              subtitle={t('home.hostCta.subtitle')}
+              ctaLabel={t('home.hostCta.cta')}
               imageUrl={HOST_CTA_IMAGE}
               onPress={handleBecomeHost}
             />
             <AgentCtaBanner
-              title={t('agent.banner.title', 'Start today. No license needed.')}
-              subtitle={t('agent.banner.subtitle', 'Turn the homes around you into income.')}
-              ctaLabel={t('agent.banner.cta', 'Become an agent')}
-              trustLine={t('agent.banner.trust', 'No license needed. Work from your phone.')}
+              title={t('agent.banner.title')}
+              subtitle={t('agent.banner.subtitle')}
+              ctaLabel={t('agent.banner.cta')}
+              trustLine={t('agent.banner.trust')}
               onPress={handleBecomeAgent}
             />
           </>

--- a/packages/frontend/app/(tabs)/profile/[profileId].tsx
+++ b/packages/frontend/app/(tabs)/profile/[profileId].tsx
@@ -130,7 +130,7 @@ export default function PublicProfileScreen() {
     <View style={styles.container}>
       <Header
         options={{
-          title: t('profile.title', 'Profile'),
+          title: t('profile.title'),
           showBackButton: true,
           rightComponents: [
             profileId ? (
@@ -168,7 +168,7 @@ export default function PublicProfileScreen() {
               <Text style={styles.handleText}>@{String(profile._id).slice(-6)}</Text>
               {listingsTotal > 0 ? (
                 <Text style={styles.profileMeta}>
-                  {listingsTotal} {t('profile.listings', 'Listings')}
+                  {listingsTotal} {t('profile.listings')}
                 </Text>
               ) : null}
             </View>
@@ -187,14 +187,14 @@ export default function PublicProfileScreen() {
               ).map((tab) => {
                 const label =
                   tab === 'all'
-                    ? t('common.all', 'All')
+                    ? t('common.all')
                     : tab === PropertyType.APARTMENT
-                      ? t('properties.titles.types.apartment', 'Apartment')
+                      ? t('properties.titles.types.apartment')
                       : tab === PropertyType.HOUSE
-                        ? t('properties.titles.types.house', 'House')
+                        ? t('properties.titles.types.house')
                         : tab === PropertyType.STUDIO
-                          ? t('properties.titles.types.studio', 'Studio')
-                          : t('properties.titles.types.room', 'Room');
+                          ? t('properties.titles.types.studio')
+                          : t('properties.titles.types.room');
                 return (
                   <TouchableOpacity
                     key={String(tab)}
@@ -279,7 +279,7 @@ export default function PublicProfileScreen() {
               style={[styles.tabItem, activeTab === 'listings' && styles.tabItemActive]}
             >
               <Text style={[styles.tabText, activeTab === 'listings' && styles.tabTextActive]}>
-                {t('profile.tabs.listings', 'Listings')}
+                {t('profile.tabs.listings')}
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
@@ -287,7 +287,7 @@ export default function PublicProfileScreen() {
               style={[styles.tabItem, activeTab === 'about' && styles.tabItemActive]}
             >
               <Text style={[styles.tabText, activeTab === 'about' && styles.tabTextActive]}>
-                {t('profile.tabs.about', 'About')}
+                {t('profile.tabs.about')}
               </Text>
             </TouchableOpacity>
           </View>
@@ -362,38 +362,38 @@ export default function PublicProfileScreen() {
           {/* About details by type */}
           {profile && profile.profileType === ProfileType.PERSONAL && (
             <View style={styles.aboutCard}>
-              <Text style={styles.aboutTitle}>{t('profile.about', 'About')}</Text>
+              <Text style={styles.aboutTitle}>{t('profile.about')}</Text>
               {profile.personalProfile?.personalInfo?.bio ? (
                 <Text style={styles.aboutItem}>{profile.personalProfile.personalInfo.bio}</Text>
               ) : null}
               {profile.personalProfile?.personalInfo?.occupation ? (
                 <Text style={styles.aboutItem}>
-                  {t('profile.occupation', 'Occupation')}:{' '}
+                  {t('profile.occupation')}:{' '}
                   {profile.personalProfile.personalInfo.occupation}
                 </Text>
               ) : null}
               {profile.personalProfile?.personalInfo?.employer ? (
                 <Text style={styles.aboutItem}>
-                  {t('profile.employer', 'Employer')}:{' '}
+                  {t('profile.employer')}:{' '}
                   {profile.personalProfile.personalInfo.employer}
                 </Text>
               ) : null}
               {typeof profile.personalProfile?.preferences?.maxRent === 'number' ? (
                 <Text style={styles.aboutItem}>
-                  {t('profile.budget', 'Budget')}: ${profile.personalProfile.preferences.maxRent}
+                  {t('profile.budget')}: ${profile.personalProfile.preferences.maxRent}
                 </Text>
               ) : null}
               {profile.personalProfile?.preferences?.minBedrooms ||
                 profile.personalProfile?.preferences?.minBathrooms ? (
                 <Text style={styles.aboutItem}>
-                  {t('profile.preferences', 'Preferences')}:{' '}
+                  {t('profile.preferences')}:{' '}
                   {profile.personalProfile?.preferences?.minBedrooms ?? 0} bd •{' '}
                   {profile.personalProfile?.preferences?.minBathrooms ?? 0} ba
                 </Text>
               ) : null}
               {profile.personalProfile?.trustScore?.score ? (
                 <Text style={styles.aboutItem}>
-                  {t('profile.trustScore', 'Trust score')}:{' '}
+                  {t('profile.trustScore')}:{' '}
                   {profile.personalProfile.trustScore.score}
                 </Text>
               ) : null}
@@ -404,7 +404,7 @@ export default function PublicProfileScreen() {
               profile.profileType === ProfileType.BUSINESS ||
               profile.profileType === ProfileType.COOPERATIVE) && (
               <View style={styles.aboutCard}>
-                <Text style={styles.aboutTitle}>{t('profile.about', 'About')}</Text>
+                <Text style={styles.aboutTitle}>{t('profile.about')}</Text>
                 {profile.agencyProfile?.description ? (
                   <Text style={styles.aboutItem}>{profile.agencyProfile.description}</Text>
                 ) : null}
@@ -414,13 +414,13 @@ export default function PublicProfileScreen() {
                 {/* Service areas / specialties if present */}
                 {profile.agencyProfile?.businessDetails?.specialties?.length ? (
                   <Text style={styles.aboutItem}>
-                    {t('profile.specialties', 'Specialties')}:{' '}
+                    {t('profile.specialties')}:{' '}
                     {profile.agencyProfile.businessDetails.specialties.join(', ')}
                   </Text>
                 ) : null}
                 {profile.agencyProfile?.businessDetails?.serviceAreas?.length ? (
                   <Text style={styles.aboutItem}>
-                    {t('profile.serviceAreas', 'Service areas')}:{' '}
+                    {t('profile.serviceAreas')}:{' '}
                     {profile.agencyProfile.businessDetails.serviceAreas
                       .map((s) => s.city)
                       .filter(Boolean)
@@ -429,7 +429,7 @@ export default function PublicProfileScreen() {
                 ) : null}
                 {profile.agencyProfile?.businessDetails?.yearEstablished ? (
                   <Text style={styles.aboutItem}>
-                    {t('profile.established', 'Established')}:{' '}
+                    {t('profile.established')}:{' '}
                     {profile.agencyProfile.businessDetails.yearEstablished}
                   </Text>
                 ) : null}

--- a/packages/frontend/app/(tabs)/profile/create.tsx
+++ b/packages/frontend/app/(tabs)/profile/create.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { View, StyleSheet, TouchableOpacity, TextInput, ScrollView } from 'react-native';
 import { ThemedText } from '@/components/ThemedText';
 import { useTranslation } from 'react-i18next';
@@ -17,8 +17,44 @@ type ProfileType = 'agency' | 'business' | 'cooperative';
 
 type EmployeeCount = NonNullable<BusinessDetails['employeeCount']>;
 
+const AGENCY_BUSINESS_TYPES = [
+  BusinessType.REAL_ESTATE_AGENCY,
+  BusinessType.PROPERTY_MANAGEMENT,
+  BusinessType.BROKERAGE,
+  BusinessType.DEVELOPER,
+  BusinessType.OTHER,
+] as const;
+
+const BUSINESS_BUSINESS_TYPES = [
+  BusinessType.SMALL_BUSINESS,
+  BusinessType.STARTUP,
+  BusinessType.FREELANCER,
+  BusinessType.CONSULTANT,
+  BusinessType.OTHER,
+] as const;
+
+const AGENCY_SPECIALTIES = [
+  'residential',
+  'commercial',
+  'investment',
+  'rental',
+  'new_construction',
+] as const;
+
+const BUSINESS_SPECIALTIES = [
+  'consulting',
+  'technology',
+  'design',
+  'marketing',
+  'finance',
+  'healthcare',
+  'education',
+  'retail',
+  'services',
+] as const;
+
 export default function ProfileCreateScreen() {
-  useTranslation();
+  const { t } = useTranslation();
   const router = useRouter();
   const { mutateAsync: createProfile, isPending: isCreatingMut } = useCreateProfileMutation();
   const [isCreating, setIsCreating] = useState(false);
@@ -37,81 +73,58 @@ export default function ProfileCreateScreen() {
     legalName: '',
   });
 
-  const profileTypes: { type: ProfileType; title: string; description: string; icon: IoniconName }[] = [
-    {
-      type: 'agency',
-      title: 'Agency Profile',
-      description: 'For real estate agencies and property management',
-      icon: 'business-outline',
-    },
-    {
-      type: 'business',
-      title: 'Business Profile',
-      description: 'For small businesses and freelancers',
-      icon: 'briefcase-outline',
-    },
-    {
-      type: 'cooperative',
-      title: 'Cooperative Profile',
-      description: 'For housing or member-owned cooperatives',
-      icon: 'people-outline',
-    },
-  ];
+  const profileTypes = useMemo(
+    (): { type: ProfileType; title: string; description: string; icon: IoniconName }[] => [
+      {
+        type: 'agency',
+        title: t('profile.create.types.agency.title'),
+        description: t('profile.create.types.agency.description'),
+        icon: 'business-outline',
+      },
+      {
+        type: 'business',
+        title: t('profile.create.types.business.title'),
+        description: t('profile.create.types.business.description'),
+        icon: 'briefcase-outline',
+      },
+      {
+        type: 'cooperative',
+        title: t('profile.create.types.cooperative.title'),
+        description: t('profile.create.types.cooperative.description'),
+        icon: 'people-outline',
+      },
+    ],
+    [t],
+  );
 
   const handleCreateProfile = async () => {
     if (!selectedType) {
-      toast.error('Please select a profile type.');
+      toast.error(t('profile.create.selectType'));
       return;
     }
 
     setIsCreating(true);
     try {
-      const toSharedType = (t: ProfileType): SharedProfileType =>
+      const toSharedType = (profileType: ProfileType): SharedProfileType =>
         ({
           agency: SharedProfileType.AGENCY,
           business: SharedProfileType.BUSINESS,
           cooperative: SharedProfileType.COOPERATIVE,
-        } as const)[t];
+        } as const)[profileType];
 
       const profileData: CreateProfileData = {
         profileType: toSharedType(selectedType),
         data: {},
       };
 
-      // Add type-specific data
-      if (selectedType === 'agency') {
-        // Validate required fields
+      if (selectedType === 'agency' || selectedType === 'business') {
         if (!formData.businessType) {
-          toast.error('Please select a business type.');
+          toast.error(t('profile.create.selectBusinessType'));
           return;
         }
 
         const yearEstablished = formData.businessDetails.yearEstablished
-          ? parseInt(formData.businessDetails.yearEstablished)
-          : undefined;
-        const employeeCount = formData.businessDetails.employeeCount || undefined;
-
-        profileData.data = {
-          businessType: formData.businessType,
-          description: formData.description,
-          businessDetails: {
-            licenseNumber: formData.businessDetails.licenseNumber || undefined,
-            taxId: formData.businessDetails.taxId || undefined,
-            yearEstablished,
-            employeeCount,
-            specialties: formData.businessDetails.specialties,
-          },
-          legalCompanyName: formData.legalCompanyName,
-        };
-      } else if (selectedType === 'business') {
-        // Validate required fields
-        if (!formData.businessType) {
-          toast.error('Please select a business type.');
-          return;
-        }
-
-        const yearEstablished = formData.businessDetails.yearEstablished
-          ? parseInt(formData.businessDetails.yearEstablished)
+          ? parseInt(formData.businessDetails.yearEstablished, 10)
           : undefined;
         const employeeCount = formData.businessDetails.employeeCount || undefined;
 
@@ -129,7 +142,7 @@ export default function ProfileCreateScreen() {
         };
       } else if (selectedType === 'cooperative') {
         if (!formData.legalName) {
-          toast.error('Please enter a legal name for the cooperative.');
+          toast.error(t('profile.create.cooperativeLegalNameRequired'));
           return;
         }
         profileData.data = {
@@ -138,14 +151,16 @@ export default function ProfileCreateScreen() {
         };
       }
 
-  await createProfile(profileData);
+      await createProfile(profileData);
       toast.success(
-        `${profileTypes.find((p) => p.type === selectedType)?.title} created successfully!`,
+        t('profile.create.createdSuccess', {
+          type: profileTypes.find((p) => p.type === selectedType)?.title ?? '',
+        }),
       );
       router.back();
     } catch (error: unknown) {
       const message =
-        error instanceof Error ? error.message : 'Failed to create profile. Please try again.';
+        error instanceof Error ? error.message : t('profile.toast.createFailed');
       toast.error(message);
     } finally {
       setIsCreating(false);
@@ -164,16 +179,207 @@ export default function ProfileCreateScreen() {
     }));
   };
 
-  const employeeCountOptions: EmployeeCount[] = ['1-10', '11-50', '51-200', '200+'];
+  const agencyEmployeeCounts: EmployeeCount[] = ['1-10', '11-50', '51-200', '200+'];
+  const businessEmployeeCounts = ['1-5', '6-10', '11-25', '26+'] as const satisfies readonly EmployeeCount[];
+
+  const businessTypeLabel = (type: BusinessType, profileType: 'agency' | 'business') => {
+    const namespace =
+      profileType === 'agency'
+        ? 'profile.edit.options.agencyBusinessType'
+        : 'profile.edit.options.businessType';
+    return t(`${namespace}.${type}`);
+  };
+
+  const specialtyLabel = (specialty: string, profileType: 'agency' | 'business') => {
+    const namespace =
+      profileType === 'agency'
+        ? 'profile.create.options.agencySpecialty'
+        : 'profile.create.options.businessSpecialty';
+    return t(`${namespace}.${specialty}`);
+  };
+
+  const renderBusinessForm = (profileType: 'agency' | 'business') => {
+    const businessTypes =
+      profileType === 'agency' ? AGENCY_BUSINESS_TYPES : BUSINESS_BUSINESS_TYPES;
+    const employeeCounts =
+      profileType === 'agency' ? agencyEmployeeCounts : businessEmployeeCounts;
+    const specialties =
+      profileType === 'agency' ? AGENCY_SPECIALTIES : BUSINESS_SPECIALTIES;
+    const sectionKey =
+      profileType === 'agency' ? 'profile.create.sections.agencyInfo' : 'profile.create.sections.businessInfo';
+    const descriptionPlaceholder =
+      profileType === 'agency'
+        ? t('profile.create.placeholders.agencyDescription')
+        : t('profile.create.placeholders.businessDescription');
+
+    return (
+      <View style={styles.section}>
+        <ThemedText style={styles.sectionTitle}>{t(sectionKey)}</ThemedText>
+
+        <View style={styles.inputGroup}>
+          <ThemedText style={styles.label}>{t('profile.edit.labels.businessType')}</ThemedText>
+          <View style={styles.radioGroup}>
+            {businessTypes.map((type) => (
+              <TouchableOpacity
+                key={type}
+                style={[
+                  styles.radioButton,
+                  formData.businessType === type && styles.radioButtonSelected,
+                ]}
+                onPress={() => setFormData((prev) => ({ ...prev, businessType: type }))}
+              >
+                <ThemedText
+                  style={[
+                    styles.radioButtonText,
+                    formData.businessType === type && styles.radioButtonTextSelected,
+                  ]}
+                >
+                  {businessTypeLabel(type, profileType)}
+                </ThemedText>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+
+        <View style={styles.inputGroup}>
+          <ThemedText style={styles.label}>{t('profile.edit.labels.description')}</ThemedText>
+          <TextInput
+            style={[styles.input, styles.textArea]}
+            value={formData.description}
+            onChangeText={(text) => setFormData((prev) => ({ ...prev, description: text }))}
+            placeholder={descriptionPlaceholder}
+            multiline
+            numberOfLines={4}
+          />
+        </View>
+
+        <View style={styles.inputGroup}>
+          <ThemedText style={styles.label}>{t('profile.edit.labels.licenseNumber')}</ThemedText>
+          <TextInput
+            style={styles.input}
+            value={formData.businessDetails.licenseNumber}
+            onChangeText={(text) =>
+              setFormData((prev) => ({
+                ...prev,
+                businessDetails: { ...prev.businessDetails, licenseNumber: text },
+              }))
+            }
+            placeholder={
+              profileType === 'business'
+                ? t('profile.create.placeholders.licenseOptional')
+                : t('profile.edit.placeholders.licenseNumber')
+            }
+          />
+        </View>
+
+        <View style={styles.inputGroup}>
+          <ThemedText style={styles.label}>{t('profile.edit.labels.taxId')}</ThemedText>
+          <TextInput
+            style={styles.input}
+            value={formData.businessDetails.taxId}
+            onChangeText={(text) =>
+              setFormData((prev) => ({
+                ...prev,
+                businessDetails: { ...prev.businessDetails, taxId: text },
+              }))
+            }
+            placeholder={t('profile.edit.placeholders.taxId')}
+          />
+        </View>
+
+        <View style={styles.inputGroup}>
+          <ThemedText style={styles.label}>{t('profile.edit.labels.yearEstablished')}</ThemedText>
+          <TextInput
+            style={styles.input}
+            value={formData.businessDetails.yearEstablished}
+            onChangeText={(text) =>
+              setFormData((prev) => ({
+                ...prev,
+                businessDetails: { ...prev.businessDetails, yearEstablished: text },
+              }))
+            }
+            placeholder={t('profile.edit.placeholders.yearEstablished')}
+            keyboardType="numeric"
+          />
+        </View>
+
+        <View style={styles.inputGroup}>
+          <ThemedText style={styles.label}>{t('profile.edit.labels.employeeCount')}</ThemedText>
+          <View style={styles.radioGroup}>
+            {employeeCounts.map((count) => (
+              <TouchableOpacity
+                key={count}
+                style={[
+                  styles.radioButton,
+                  formData.businessDetails.employeeCount === count && styles.radioButtonSelected,
+                ]}
+                onPress={() =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    businessDetails: { ...prev.businessDetails, employeeCount: count },
+                  }))
+                }
+              >
+                <ThemedText
+                  style={[
+                    styles.radioButtonText,
+                    formData.businessDetails.employeeCount === count &&
+                      styles.radioButtonTextSelected,
+                  ]}
+                >
+                  {count}
+                </ThemedText>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+
+        <View style={styles.inputGroup}>
+          <ThemedText style={styles.label}>{t('profile.edit.labels.specialties')}</ThemedText>
+          <View style={styles.checkboxGroup}>
+            {specialties.map((specialty) => (
+              <TouchableOpacity
+                key={specialty}
+                style={[
+                  styles.checkbox,
+                  formData.businessDetails.specialties.includes(specialty) && styles.checkboxSelected,
+                ]}
+                onPress={() => toggleSpecialty(specialty)}
+              >
+                <ThemedText
+                  style={[
+                    styles.checkboxText,
+                    formData.businessDetails.specialties.includes(specialty) &&
+                      styles.checkboxTextSelected,
+                  ]}
+                >
+                  {specialtyLabel(specialty, profileType)}
+                </ThemedText>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+
+        <View style={styles.inputGroup}>
+          <ThemedText style={styles.label}>{t('profile.edit.labels.legalCompanyName')}</ThemedText>
+          <TextInput
+            style={styles.input}
+            value={formData.legalCompanyName}
+            onChangeText={(text) => setFormData((prev) => ({ ...prev, legalCompanyName: text }))}
+            placeholder={t('profile.edit.placeholders.legalCompanyName')}
+          />
+        </View>
+      </View>
+    );
+  };
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
-      {/* Header */}
       <View style={styles.header}>
         <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
           <Ionicons name="arrow-back" size={24} color={colors.COLOR_BLACK} />
         </TouchableOpacity>
-        <ThemedText style={styles.headerTitle}>Create Profile</ThemedText>
+        <ThemedText style={styles.headerTitle}>{t('profile.create.headerTitle')}</ThemedText>
         <TouchableOpacity
           onPress={handleCreateProfile}
           style={[styles.createButton, !selectedType && styles.createButtonDisabled]}
@@ -182,15 +388,14 @@ export default function ProfileCreateScreen() {
           {isCreating || isCreatingMut ? (
             <Ionicons name="refresh" size={20} color={colors.primaryForeground} />
           ) : (
-            <ThemedText style={styles.createButtonText}>Create</ThemedText>
+            <ThemedText style={styles.createButtonText}>{t('profile.create.createButton')}</ThemedText>
           )}
         </TouchableOpacity>
       </View>
 
       <ScrollView style={styles.content}>
-        {/* Profile Type Selection */}
         <View style={styles.section}>
-          <ThemedText style={styles.sectionTitle}>Choose Business Profile Type</ThemedText>
+          <ThemedText style={styles.sectionTitle}>{t('profile.create.chooseType')}</ThemedText>
 
           {profileTypes.map((profileType, index) => (
             <TouchableOpacity
@@ -224,389 +429,46 @@ export default function ProfileCreateScreen() {
                   </ThemedText>
                 </View>
               </View>
-              {selectedType === profileType.type && (
+              {selectedType === profileType.type ? (
                 <Ionicons name="checkmark" size={20} color={colors.primaryColor} />
-              )}
+              ) : null}
             </TouchableOpacity>
           ))}
         </View>
 
-        {/* Agency-specific form */}
-        {selectedType === 'agency' && (
+        {selectedType === 'agency' ? renderBusinessForm('agency') : null}
+        {selectedType === 'business' ? renderBusinessForm('business') : null}
+
+        {selectedType === 'cooperative' ? (
           <View style={styles.section}>
-            <ThemedText style={styles.sectionTitle}>Agency Information</ThemedText>
-
+            <ThemedText style={styles.sectionTitle}>
+              {t('profile.create.sections.cooperativeInfo')}
+            </ThemedText>
             <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Business Type *</ThemedText>
-              <View style={styles.radioGroup}>
-                {[
-                  BusinessType.REAL_ESTATE_AGENCY,
-                  BusinessType.PROPERTY_MANAGEMENT,
-                  BusinessType.BROKERAGE,
-                  BusinessType.DEVELOPER,
-                  BusinessType.OTHER,
-                ].map((type) => (
-                  <TouchableOpacity
-                    key={type}
-                    style={[
-                      styles.radioButton,
-                      formData.businessType === type && styles.radioButtonSelected,
-                    ]}
-                    onPress={() => setFormData((prev) => ({ ...prev, businessType: type }))}
-                  >
-                    <ThemedText
-                      style={[
-                        styles.radioButtonText,
-                        formData.businessType === type && styles.radioButtonTextSelected,
-                      ]}
-                    >
-                      {type.replace('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase())}
-                    </ThemedText>
-                  </TouchableOpacity>
-                ))}
-              </View>
-            </View>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Description</ThemedText>
-              <TextInput
-                style={[styles.input, styles.textArea]}
-                value={formData.description}
-                onChangeText={(text) => setFormData((prev) => ({ ...prev, description: text }))}
-                placeholder="Describe your agency..."
-                multiline
-                numberOfLines={4}
-              />
-            </View>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>License Number</ThemedText>
-              <TextInput
-                style={styles.input}
-                value={formData.businessDetails.licenseNumber}
-                onChangeText={(text) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    businessDetails: { ...prev.businessDetails, licenseNumber: text },
-                  }))
-                }
-                placeholder="Enter license number"
-              />
-            </View>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Tax ID</ThemedText>
-              <TextInput
-                style={styles.input}
-                value={formData.businessDetails.taxId}
-                onChangeText={(text) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    businessDetails: { ...prev.businessDetails, taxId: text },
-                  }))
-                }
-                placeholder="Enter tax ID"
-              />
-            </View>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Year Established</ThemedText>
-              <TextInput
-                style={styles.input}
-                value={formData.businessDetails.yearEstablished}
-                onChangeText={(text) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    businessDetails: { ...prev.businessDetails, yearEstablished: text },
-                  }))
-                }
-                placeholder="e.g., 2020"
-                keyboardType="numeric"
-              />
-            </View>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Number of Employees</ThemedText>
-              <View style={styles.radioGroup}>
-                {employeeCountOptions.map((count) => (
-                  <TouchableOpacity
-                    key={count}
-                    style={[
-                      styles.radioButton,
-                      formData.businessDetails.employeeCount === count &&
-                        styles.radioButtonSelected,
-                    ]}
-                    onPress={() =>
-                      setFormData((prev) => ({
-                        ...prev,
-                        businessDetails: { ...prev.businessDetails, employeeCount: count },
-                      }))
-                    }
-                  >
-                    <ThemedText
-                      style={[
-                        styles.radioButtonText,
-                        formData.businessDetails.employeeCount === count &&
-                          styles.radioButtonTextSelected,
-                      ]}
-                    >
-                      {count}
-                    </ThemedText>
-                  </TouchableOpacity>
-                ))}
-              </View>
-            </View>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Specialties</ThemedText>
-              <View style={styles.checkboxGroup}>
-                {['residential', 'commercial', 'investment', 'rental', 'new_construction'].map(
-                  (specialty) => (
-                    <TouchableOpacity
-                      key={specialty}
-                      style={[
-                        styles.checkbox,
-                        formData.businessDetails.specialties.includes(specialty) &&
-                          styles.checkboxSelected,
-                      ]}
-                      onPress={() => toggleSpecialty(specialty)}
-                    >
-                      <ThemedText
-                        style={[
-                          styles.checkboxText,
-                          formData.businessDetails.specialties.includes(specialty) &&
-                            styles.checkboxTextSelected,
-                        ]}
-                      >
-                        {specialty.replace('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase())}
-                      </ThemedText>
-                    </TouchableOpacity>
-                  ),
-                )}
-              </View>
-            </View>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Legal Company Name *</ThemedText>
-              <TextInput
-                style={styles.input}
-                value={formData.legalCompanyName}
-                onChangeText={(text) =>
-                  setFormData((prev) => ({ ...prev, legalCompanyName: text }))
-                }
-                placeholder="Enter your legal company name"
-              />
-            </View>
-          </View>
-        )}
-
-        {/* Business-specific form */}
-        {selectedType === 'business' && (
-          <View style={styles.section}>
-            <ThemedText style={styles.sectionTitle}>Business Information</ThemedText>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Business Type *</ThemedText>
-              <View style={styles.radioGroup}>
-                {[
-                  BusinessType.SMALL_BUSINESS,
-                  BusinessType.STARTUP,
-                  BusinessType.FREELANCER,
-                  BusinessType.CONSULTANT,
-                  BusinessType.OTHER,
-                ].map((type) => (
-                  <TouchableOpacity
-                    key={type}
-                    style={[
-                      styles.radioButton,
-                      formData.businessType === type && styles.radioButtonSelected,
-                    ]}
-                    onPress={() => setFormData((prev) => ({ ...prev, businessType: type }))}
-                  >
-                    <ThemedText
-                      style={[
-                        styles.radioButtonText,
-                        formData.businessType === type && styles.radioButtonTextSelected,
-                      ]}
-                    >
-                      {type.replace('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase())}
-                    </ThemedText>
-                  </TouchableOpacity>
-                ))}
-              </View>
-            </View>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Description</ThemedText>
-              <TextInput
-                style={[styles.input, styles.textArea]}
-                value={formData.description}
-                onChangeText={(text) => setFormData((prev) => ({ ...prev, description: text }))}
-                placeholder="Describe your business..."
-                multiline
-                numberOfLines={4}
-              />
-            </View>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>License Number</ThemedText>
-              <TextInput
-                style={styles.input}
-                value={formData.businessDetails.licenseNumber}
-                onChangeText={(text) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    businessDetails: { ...prev.businessDetails, licenseNumber: text },
-                  }))
-                }
-                placeholder="Enter license number (if applicable)"
-              />
-            </View>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Tax ID</ThemedText>
-              <TextInput
-                style={styles.input}
-                value={formData.businessDetails.taxId}
-                onChangeText={(text) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    businessDetails: { ...prev.businessDetails, taxId: text },
-                  }))
-                }
-                placeholder="Enter tax ID"
-              />
-            </View>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Year Established</ThemedText>
-              <TextInput
-                style={styles.input}
-                value={formData.businessDetails.yearEstablished}
-                onChangeText={(text) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    businessDetails: { ...prev.businessDetails, yearEstablished: text },
-                  }))
-                }
-                placeholder="e.g., 2020"
-                keyboardType="numeric"
-              />
-            </View>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Number of Employees</ThemedText>
-              <View style={styles.radioGroup}>
-                {(['1-5', '6-10', '11-25', '26+'] satisfies EmployeeCount[]).map((count) => (
-                  <TouchableOpacity
-                    key={count}
-                    style={[
-                      styles.radioButton,
-                      formData.businessDetails.employeeCount === count &&
-                        styles.radioButtonSelected,
-                    ]}
-                    onPress={() =>
-                      setFormData((prev) => ({
-                        ...prev,
-                        businessDetails: { ...prev.businessDetails, employeeCount: count },
-                      }))
-                    }
-                  >
-                    <ThemedText
-                      style={[
-                        styles.radioButtonText,
-                        formData.businessDetails.employeeCount === count &&
-                          styles.radioButtonTextSelected,
-                      ]}
-                    >
-                      {count}
-                    </ThemedText>
-                  </TouchableOpacity>
-                ))}
-              </View>
-            </View>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Specialties</ThemedText>
-              <View style={styles.checkboxGroup}>
-                {[
-                  'consulting',
-                  'technology',
-                  'design',
-                  'marketing',
-                  'finance',
-                  'healthcare',
-                  'education',
-                  'retail',
-                  'services',
-                ].map((specialty) => (
-                  <TouchableOpacity
-                    key={specialty}
-                    style={[
-                      styles.checkbox,
-                      formData.businessDetails.specialties.includes(specialty) &&
-                        styles.checkboxSelected,
-                    ]}
-                    onPress={() => toggleSpecialty(specialty)}
-                  >
-                    <ThemedText
-                      style={[
-                        styles.checkboxText,
-                        formData.businessDetails.specialties.includes(specialty) &&
-                          styles.checkboxTextSelected,
-                      ]}
-                    >
-                      {specialty.replace('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase())}
-                    </ThemedText>
-                  </TouchableOpacity>
-                ))}
-              </View>
-            </View>
-
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Legal Company Name *</ThemedText>
-              <TextInput
-                style={styles.input}
-                value={formData.legalCompanyName}
-                onChangeText={(text) =>
-                  setFormData((prev) => ({ ...prev, legalCompanyName: text }))
-                }
-                placeholder="Enter your legal company name"
-              />
-            </View>
-          </View>
-        )}
-
-        {/* Cooperative-specific form */}
-        {selectedType === 'cooperative' && (
-          <View style={styles.section}>
-            <ThemedText style={styles.sectionTitle}>Cooperative Information</ThemedText>
-            <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Legal Name *</ThemedText>
+              <ThemedText style={styles.label}>{t('profile.edit.labels.legalName')}</ThemedText>
               <TextInput
                 style={styles.input}
                 value={formData.legalName}
                 onChangeText={(text) => setFormData((prev) => ({ ...prev, legalName: text }))}
-                placeholder="Cooperative Legal Name"
+                placeholder={t('profile.create.placeholders.cooperativeLegalName')}
               />
             </View>
             <View style={styles.inputGroup}>
-              <ThemedText style={styles.label}>Description</ThemedText>
+              <ThemedText style={styles.label}>{t('profile.edit.labels.description')}</ThemedText>
               <TextInput
                 style={[styles.input, { height: 80 }]}
                 value={formData.description}
                 onChangeText={(text) => setFormData((prev) => ({ ...prev, description: text }))}
-                placeholder="Describe the cooperative"
+                placeholder={t('profile.create.placeholders.cooperativeDescription')}
                 multiline
               />
             </View>
           </View>
-        )}
+        ) : null}
 
-        {/* Profile Type Info */}
-        {selectedType && (
+        {selectedType ? (
           <View style={styles.section}>
-            <ThemedText style={styles.sectionTitle}>What&apos;s Next?</ThemedText>
+            <ThemedText style={styles.sectionTitle}>{t('profile.create.sections.whatsNext')}</ThemedText>
             <View style={[styles.settingItem, styles.firstSettingItem, styles.lastSettingItem]}>
               <View style={styles.settingInfo}>
                 <Ionicons
@@ -616,16 +478,17 @@ export default function ProfileCreateScreen() {
                   style={styles.settingIcon}
                 />
                 <View style={styles.infoContent}>
-                  <ThemedText style={styles.settingLabel}>Profile Setup</ThemedText>
+                  <ThemedText style={styles.settingLabel}>
+                    {t('profile.create.sections.profileSetup')}
+                  </ThemedText>
                   <ThemedText style={styles.settingDescription}>
-                    After creating your {selectedType} profile, you can customize preferences, add
-                    verification documents, and build your trust score.
+                    {t('profile.create.whatsNext.description', { type: selectedType })}
                   </ThemedText>
                 </View>
               </View>
             </View>
           </View>
-        )}
+        ) : null}
       </ScrollView>
     </SafeAreaView>
   );

--- a/packages/frontend/app/(tabs)/profile/index.tsx
+++ b/packages/frontend/app/(tabs)/profile/index.tsx
@@ -147,7 +147,7 @@ export default function ProfileScreen() {
     if (!profile) return;
     const profileId = profile.id || profile._id;
     if (!profileId) {
-      toast.error(t('profile.invalidProfile', 'Invalid profile data'));
+      toast.error(t('profile.invalidProfile'));
       setPendingSwitch(null);
       return;
     }
@@ -155,7 +155,7 @@ export default function ProfileScreen() {
     try {
       await activateProfile(profileId);
       toast.success(
-        t('profile.switched', 'Switched to {{name}}', {
+        t('profile.switched', {
           name: getProfileDisplayName(profile),
         }),
       );
@@ -165,7 +165,7 @@ export default function ProfileScreen() {
       const message =
         error instanceof Error
           ? error.message
-          : t('profile.switchFailed', 'Failed to switch profile');
+          : t('profile.switchFailed');
       toast.error(message);
     } finally {
       setBusySwitch(false);
@@ -177,10 +177,10 @@ export default function ProfileScreen() {
     try {
       await logout();
       router.replace('/');
-      toast.success(t('settings.signOutSuccess', 'Signed out'));
+      toast.success(t('settings.signOutSuccess'));
     } catch (error: unknown) {
       logger.error('Failed to sign out:', error);
-      toast.error(t('settings.signOutFailed', 'Failed to sign out'));
+      toast.error(t('settings.signOutFailed'));
     } finally {
       setBusyLogout(false);
       setPendingLogout(false);
@@ -190,7 +190,7 @@ export default function ProfileScreen() {
   const header = (
     <Header
       options={{
-        title: t('profile.title', 'Profile'),
+        title: t('profile.title'),
       }}
     />
   );
@@ -215,9 +215,9 @@ export default function ProfileScreen() {
         {header}
         <View style={styles.centerWrap}>
           <ErrorState
-            title={t('profile.loadFailed', 'Failed to load profile')}
-            description={t('profile.loadFailedHint', 'Please try again later.')}
-            retryLabel={t('common.retry', 'Retry')}
+            title={t('profile.loadFailed')}
+            description={t('profile.loadFailedHint')}
+            retryLabel={t('common.retry')}
             onRetry={() => {
               primaryProfileQuery.refetch();
               profilesQuery.refetch();
@@ -297,14 +297,14 @@ export default function ProfileScreen() {
                 size="medium"
                 onPress={() => router.push('/profile/edit')}
               >
-                {t('profile.edit', 'Edit profile')}
+                {t('profile.actions.editProfile')}
               </Button>
               <Button
                 variant="ghost"
                 size="medium"
                 onPress={() => router.push('/profile/trust-score')}
               >
-                {t('profile.trustScoreCta', 'View trust score')}
+                {t('profile.trustScoreCta')}
               </Button>
             </View>
           </CardSurface>
@@ -312,16 +312,16 @@ export default function ProfileScreen() {
 
         <View style={styles.statsWrap}>
           <StatTile
-            label={t('profile.stats.saved', 'Saved')}
+            label={t('profile.stats.saved')}
             value={totalSaved}
             onPress={() => router.push('/saved')}
           />
           <StatTile
-            label={t('profile.stats.applications', 'Applications')}
+            label={t('profile.stats.applications')}
             value={totalApplications}
             description={
               approvedApplications > 0
-                ? t('profile.stats.applicationsApproved', '{{count}} approved', {
+                ? t('profile.stats.applicationsApproved', {
                     count: approvedApplications,
                   })
                 : undefined
@@ -329,47 +329,44 @@ export default function ProfileScreen() {
             onPress={() => router.push('/applications')}
           />
           <StatTile
-            label={t('profile.stats.stays', 'Stays')}
+            label={t('profile.stats.stays')}
             value={totalReservations}
             onPress={() => router.push('/stays')}
           />
         </View>
 
-        <SettingsListGroup title={t('profile.sections.activity', 'Activity')}>
+        <SettingsListGroup title={t('profile.sections.activity')}>
           <SettingsListItem
             icon={<RowIcon name="bookmark-outline" />}
-            title={t('saved.header', 'Saved')}
+            title={t('saved.header')}
             value={String(totalSaved)}
             onPress={() => router.push('/saved')}
           />
           <SettingsListItem
             icon={<RowIcon name="document-text-outline" />}
-            title={t('profile.applications', 'My applications')}
+            title={t('profile.applications')}
             value={String(totalApplications)}
             onPress={() => router.push('/applications')}
           />
           <SettingsListItem
             icon={<RowIcon name="bed-outline" />}
-            title={t('profile.stays', 'Stays')}
+            title={t('profile.stays')}
             value={String(totalReservations)}
             onPress={() => router.push('/stays')}
           />
           <SettingsListItem
             icon={<RowIcon name="swap-horizontal" />}
-            title={t('profile.exchanges', 'Exchanges')}
-            description={t(
-              'profile.exchangesDescription',
-              'Your home swaps and hosting requests.',
-            )}
+            title={t('profile.exchanges')}
+            description={t('profile.exchangesDescription')}
             onPress={() => router.push('/exchange/requests')}
           />
         </SettingsListGroup>
 
         <SettingsListGroup
-          title={t('profile.sections.profile', 'Profile')}
+          title={t('profile.sections.profile')}
           footer={
             activeProfile
-              ? t('profile.activeFooter', 'Active: {{name}}', {
+              ? t('profile.activeFooter', {
                   name: getProfileDisplayName(activeProfile),
                 })
               : undefined
@@ -386,7 +383,7 @@ export default function ProfileScreen() {
                 rightElement={
                   isActive ? (
                     <Badge
-                      content={t('profile.active', 'Active')}
+                      content={t('profile.active')}
                       variant="subtle"
                       color="success"
                       size="small"
@@ -401,40 +398,31 @@ export default function ProfileScreen() {
           })}
           <SettingsListItem
             icon={<RowIcon name="add-circle-outline" />}
-            title={t('profile.createNew', 'Create new profile')}
-            description={t(
-              'profile.createNewDescription',
-              'Add a business, agency, or cooperative profile.',
-            )}
+            title={t('profile.createNew')}
+            description={t('profile.createNewDescription')}
             onPress={() => router.push('/profile/create')}
           />
         </SettingsListGroup>
 
-        <SettingsListGroup title={t('agent.menu.section', 'Earn')}>
+        <SettingsListGroup title={t('agent.menu.section')}>
           <SettingsListItem
             icon={<RowIcon name="cash-outline" />}
-            title={t('agent.menu.title', 'Earn with Homiio')}
-            description={t(
-              'agent.menu.description',
-              'Bring homes to Homiio and earn when they rent or sell.',
-            )}
+            title={t('agent.menu.title')}
+            description={t('agent.menu.description')}
             onPress={() => router.push('/agent')}
           />
         </SettingsListGroup>
 
-        <SettingsListGroup title={t('profile.sections.account', 'Account')}>
+        <SettingsListGroup title={t('profile.sections.account')}>
           <SettingsListItem
             icon={<RowIcon name="star-outline" />}
-            title={t('profile.subscriptions', 'Subscriptions')}
-            description={t(
-              'profile.subscriptionsDescription',
-              'Manage Homiio Plus or buy one-time file analysis.',
-            )}
+            title={t('profile.subscriptions')}
+            description={t('profile.subscriptionsDescription')}
             onPress={() => router.push('/profile/subscriptions')}
           />
           <SettingsListItem
             icon={<RowIcon name="settings-outline" />}
-            title={t('settings.title', 'Settings')}
+            title={t('settings.title')}
             onPress={() => router.push('/settings')}
           />
         </SettingsListGroup>
@@ -442,7 +430,7 @@ export default function ProfileScreen() {
         <SettingsListGroup>
           <SettingsListItem
             icon={<RowIcon name="log-out" destructive />}
-            title={t('settings.signOut', 'Sign out')}
+            title={t('settings.signOut')}
             destructive
             onPress={() => setPendingLogout(true)}
           />
@@ -453,24 +441,24 @@ export default function ProfileScreen() {
 
       <ConfirmDialog
         visible={Boolean(pendingSwitch)}
-        title={t('profile.switchTitle', 'Switch profile?')}
+        title={t('profile.switchTitle')}
         message={
           pendingSwitch
-            ? t('profile.switchMessage', 'Activate {{name}}?', {
+            ? t('profile.switchMessage', {
                 name: getProfileDisplayName(pendingSwitch),
               })
             : ''
         }
-        confirmLabel={t('profile.switchConfirm', 'Switch')}
+        confirmLabel={t('profile.switchConfirm')}
         loading={busySwitch}
         onConfirm={handleSwitch}
         onCancel={() => setPendingSwitch(null)}
       />
       <ConfirmDialog
         visible={pendingLogout}
-        title={t('settings.signOut', 'Sign out')}
-        message={t('settings.signOutMessage', 'Are you sure you want to sign out?')}
-        confirmLabel={t('settings.signOut', 'Sign out')}
+        title={t('settings.signOut')}
+        message={t('settings.signOutMessage')}
+        confirmLabel={t('settings.signOut')}
         confirmDestructive
         loading={busyLogout}
         onConfirm={handleLogout}

--- a/packages/frontend/app/(tabs)/profile/subscriptions.tsx
+++ b/packages/frontend/app/(tabs)/profile/subscriptions.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { View, Text, TouchableOpacity, ScrollView, StyleSheet, Alert, RefreshControl } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { Ionicons as Icon } from '@expo/vector-icons';
@@ -8,11 +9,13 @@ import { useOxy } from '@oxyhq/services';
 import { useSubscriptionStore } from '@/store/subscriptionStore';
 import { api } from '@/utils/api';
 import { logger } from '@/utils/logger';
+import { getDateLocale } from '@/utils/dateLocale';
 
 const getErrorMessage = (error: unknown, fallback: string): string =>
     error instanceof Error ? error.message : fallback;
 
 export default function SubscriptionsScreen() {
+    const { t, i18n } = useTranslation();
     const router = useRouter();
     const { oxyServices, activeSessionId } = useOxy();
 
@@ -39,7 +42,7 @@ export default function SubscriptionsScreen() {
     // Show error alerts
     useEffect(() => {
         if (error) {
-            Alert.alert('Error', error);
+            Alert.alert(t('subscriptions.alertError'), error);
             resetError();
         }
     }, [error]);
@@ -58,7 +61,7 @@ export default function SubscriptionsScreen() {
 
     const handleStartCheckout = async (product: 'plus' | 'file' | 'founder') => {
         if (!oxyServices || !activeSessionId) {
-            Alert.alert('Error', 'Authentication required');
+            Alert.alert(t('subscriptions.alertError'), t('subscriptions.authRequired'));
             return;
         }
 
@@ -66,13 +69,13 @@ export default function SubscriptionsScreen() {
             await startCheckout(product, oxyServices, activeSessionId);
         } catch (error: unknown) {
             logger.error('Failed to start checkout:', error);
-            Alert.alert('Error', getErrorMessage(error, 'Failed to start checkout'));
+            Alert.alert(t('subscriptions.alertError'), getErrorMessage(error, t('subscriptions.checkoutFailed')));
         }
     };
 
     const handleManageSubscription = async () => {
         if (!oxyServices || !activeSessionId) {
-            Alert.alert('Error', 'Authentication required');
+            Alert.alert(t('subscriptions.alertError'), t('subscriptions.authRequired'));
             return;
         }
 
@@ -80,47 +83,47 @@ export default function SubscriptionsScreen() {
             await openCustomerPortal(oxyServices, activeSessionId);
         } catch (error: unknown) {
             logger.error('Failed to open subscription management:', error);
-            Alert.alert('Error', getErrorMessage(error, 'Failed to open subscription management'));
+            Alert.alert(t('subscriptions.alertError'), getErrorMessage(error, t('subscriptions.portalFailed')));
         }
     };
 
     const handleSyncSubscription = async () => {
         if (!oxyServices || !activeSessionId) {
-            Alert.alert('Error', 'Authentication required');
+            Alert.alert(t('subscriptions.alertError'), t('subscriptions.authRequired'));
             return;
         }
 
         try {
             await syncSubscription(oxyServices, activeSessionId);
-            Alert.alert('Success', 'Subscription status synced from Stripe');
+            Alert.alert(t('subscriptions.alertSuccess'), t('subscriptions.syncSuccess'));
         } catch (error: unknown) {
             logger.error('Failed to sync subscription:', error);
-            Alert.alert('Error', getErrorMessage(error, 'Failed to sync subscription'));
+            Alert.alert(t('subscriptions.alertError'), getErrorMessage(error, t('subscriptions.syncFailed')));
         }
     };
 
     const handleCancelSubscription = async (immediate: boolean) => {
         if (!oxyServices || !activeSessionId) {
-            Alert.alert('Error', 'Authentication required');
+            Alert.alert(t('subscriptions.alertError'), t('subscriptions.authRequired'));
             return;
         }
 
         if (immediate) {
             Alert.alert(
-                'Cancel Immediately',
-                'This will immediately cancel your subscription and you will lose access to Homiio+ features. Are you sure?',
+                t('subscriptions.page.cancelImmediateTitle'),
+                t('subscriptions.page.cancelImmediateBody'),
                 [
-                    { text: 'No', style: 'cancel' },
+                    { text: t('subscriptions.page.no'), style: 'cancel' },
                     {
-                        text: 'Yes, Cancel Now',
+                        text: t('subscriptions.page.yesCancelNow'),
                         style: 'destructive',
                         onPress: async () => {
                             try {
                                 await cancelSubscription(true, oxyServices, activeSessionId);
-                                Alert.alert('Success', 'Subscription canceled immediately');
+                                Alert.alert(t('subscriptions.alertSuccess'), t('subscriptions.cancelImmediateSuccess'));
                             } catch (error: unknown) {
                                 logger.error('Failed to cancel subscription immediately:', error);
-                                Alert.alert('Error', getErrorMessage(error, 'Failed to cancel subscription'));
+                                Alert.alert(t('subscriptions.alertError'), getErrorMessage(error, t('subscriptions.cancelFailed')));
                             }
                         }
                     }
@@ -129,17 +132,17 @@ export default function SubscriptionsScreen() {
         } else {
             try {
                 await cancelSubscription(false, oxyServices, activeSessionId);
-                Alert.alert('Success', 'Subscription will be canceled at the end of the current period');
+                Alert.alert(t('subscriptions.alertSuccess'), t('subscriptions.cancelEndOfPeriodSuccess'));
             } catch (error: unknown) {
                 logger.error('Failed to schedule subscription cancellation:', error);
-                Alert.alert('Error', getErrorMessage(error, 'Failed to cancel subscription'));
+                Alert.alert(t('subscriptions.alertError'), getErrorMessage(error, t('subscriptions.cancelFailed')));
             }
         }
     };
 
     const formatDate = (dateString?: string) => {
-        if (!dateString) return 'N/A';
-        return new Date(dateString).toLocaleDateString('en-US', {
+        if (!dateString) return t('subscriptions.page.notAvailable');
+        return new Date(dateString).toLocaleDateString(getDateLocale(i18n.language), {
             year: 'numeric',
             month: 'long',
             day: 'numeric'
@@ -159,10 +162,10 @@ export default function SubscriptionsScreen() {
                     <View style={styles.headerIcon}>
                         <Icon name="home" size={24} color={colors.primaryColor} />
                     </View>
-                    <Text style={styles.headerTitle}>Homiio+</Text>
-                    <Text style={styles.headerSubtitle}>Your ethical housing ally</Text>
+                    <Text style={styles.headerTitle}>{t('subscriptions.page.headerTitle')}</Text>
+                    <Text style={styles.headerSubtitle}>{t('subscriptions.page.headerSubtitle')}</Text>
                     <Text style={styles.introText}>
-                        Your subscription gives you access to Sindi, the legal assistant that scans your rental contracts and flags abusive clauses. No ads, no speculation, no data selling.
+                        {t('subscriptions.page.introText')}
                     </Text>
                 </View>
 
@@ -171,13 +174,13 @@ export default function SubscriptionsScreen() {
                     <View style={styles.cardHeader}>
                         <Icon name="document-text" size={24} color={colors.primaryColor} />
                         <View style={styles.cardTitleContainer}>
-                            <Text style={styles.cardTitle}>Pay per contract</Text>
-                            <Text style={styles.cardPrice}>5 € per contract review</Text>
+                            <Text style={styles.cardTitle}>{t('subscriptions.page.payPerContract.title')}</Text>
+                            <Text style={styles.cardPrice}>{t('subscriptions.page.payPerContract.price')}</Text>
                         </View>
                     </View>
 
                     <Text style={styles.cardDesc}>
-                        Perfect for one-time use.
+                        {t('subscriptions.page.payPerContract.description')}
                     </Text>
 
                     <TouchableOpacity
@@ -186,7 +189,7 @@ export default function SubscriptionsScreen() {
                         onPress={() => handleStartCheckout('file')}
                     >
                         <Text style={styles.secondaryBtnText}>
-                            {loadingStates.checkout ? 'Starting…' : 'Review Contract'}
+                            {loadingStates.checkout ? t('subscriptions.page.starting') : t('subscriptions.page.payPerContract.reviewButton')}
                         </Text>
                     </TouchableOpacity>
                 </View>
@@ -196,41 +199,41 @@ export default function SubscriptionsScreen() {
                     {plusActive && (
                         <View style={styles.activeBadge}>
                             <Icon name="checkmark-circle" size={16} color={colors.primaryForeground} />
-                            <Text style={styles.activeBadgeText}>Active subscription</Text>
+                            <Text style={styles.activeBadgeText}>{t('subscriptions.page.plus.activeBadge')}</Text>
                         </View>
                     )}
 
                     {plusCanceledAt && !plusActive && (
                         <View style={styles.canceledBadge}>
                             <Icon name="close-circle" size={16} color={colors.white} />
-                            <Text style={styles.canceledBadgeText}>Canceled on {formatDate(plusCanceledAt)}</Text>
+                            <Text style={styles.canceledBadgeText}>{t('subscriptions.page.plus.canceledBadge', { date: formatDate(plusCanceledAt) })}</Text>
                         </View>
                     )}
 
                     <View style={styles.cardHeader}>
                         <Icon name="star" size={24} color={colors.primaryColor} />
                         <View style={styles.cardTitleContainer}>
-                            <Text style={styles.cardTitle}>Homiio+ Subscription</Text>
-                            <Text style={styles.cardPrice}>9.99 €/month</Text>
+                            <Text style={styles.cardTitle}>{t('subscriptions.page.plus.title')}</Text>
+                            <Text style={styles.cardPrice}>{t('subscriptions.page.plus.price')}</Text>
                         </View>
                     </View>
 
                     <Text style={styles.cardDesc}>
-                        Includes up to 10 contracts per month free. From the 11th contract onwards: 2.50 € each.
+                        {t('subscriptions.page.plus.description')}
                     </Text>
 
                     <View style={styles.featuresList}>
                         <View style={styles.featureItem}>
                             <Icon name="checkmark-circle" size={16} color={colors.success} />
-                            <Text style={styles.featureText}>Unlimited contract history</Text>
+                            <Text style={styles.featureText}>{t('subscriptions.page.plus.featureHistory')}</Text>
                         </View>
                         <View style={styles.featureItem}>
                             <Icon name="checkmark-circle" size={16} color={colors.success} />
-                            <Text style={styles.featureText}>Legal alerts & notifications</Text>
+                            <Text style={styles.featureText}>{t('subscriptions.page.plus.featureAlerts')}</Text>
                         </View>
                         <View style={styles.featureItem}>
                             <Icon name="checkmark-circle" size={16} color={colors.success} />
-                            <Text style={styles.featureText}>Priority support</Text>
+                            <Text style={styles.featureText}>{t('subscriptions.page.plus.featureSupport')}</Text>
                         </View>
                     </View>
 
@@ -246,7 +249,13 @@ export default function SubscriptionsScreen() {
                         }}
                     >
                         <Text style={styles.primaryBtnText}>
-                            {plusActive ? 'Manage subscription' : plusCanceledAt ? 'Resubscribe' : loadingStates.checkout ? 'Starting…' : 'Subscribe now'}
+                            {plusActive
+                                ? t('subscriptions.page.plus.manage')
+                                : plusCanceledAt
+                                  ? t('subscriptions.page.plus.resubscribe')
+                                  : loadingStates.checkout
+                                    ? t('subscriptions.page.starting')
+                                    : t('subscriptions.page.plus.subscribeNow')}
                         </Text>
                     </TouchableOpacity>
                 </View>
@@ -256,13 +265,13 @@ export default function SubscriptionsScreen() {
                     <View style={styles.cardHeader}>
                         <Icon name="heart" size={24} color={colors.primaryColor} />
                         <View style={styles.cardTitleContainer}>
-                            <Text style={styles.cardTitle}>Founder supporter</Text>
-                            <Text style={styles.cardPrice}>Contribution from 10 €/month</Text>
+                            <Text style={styles.cardTitle}>{t('subscriptions.page.founder.title')}</Text>
+                            <Text style={styles.cardPrice}>{t('subscriptions.page.founder.price')}</Text>
                         </View>
                     </View>
 
                     <Text style={styles.cardDesc}>
-                        Support Homiio&apos;s independence. Get recognition in the app + early access to features.
+                        {t('subscriptions.page.founder.description')}
                     </Text>
 
                     <TouchableOpacity
@@ -271,7 +280,7 @@ export default function SubscriptionsScreen() {
                         onPress={() => handleStartCheckout('founder')}
                     >
                         <Text style={styles.secondaryBtnText}>
-                            {loadingStates.checkout ? 'Starting…' : 'Become a Supporter'}
+                            {loadingStates.checkout ? t('subscriptions.page.starting') : t('subscriptions.page.founder.becomeSupporter')}
                         </Text>
                     </TouchableOpacity>
                 </View>
@@ -279,7 +288,7 @@ export default function SubscriptionsScreen() {
                 {/* Footer */}
                 <View style={styles.footer}>
                     <Text style={styles.footerText}>
-                        Every euro keeps Homiio ethical, independent, and community-driven.
+                        {t('subscriptions.page.footer')}
                     </Text>
                 </View>
 
@@ -340,7 +349,7 @@ export default function SubscriptionsScreen() {
                                     }
                                 } catch (error: unknown) {
                                     logger.error('Failed to debug subscription:', error);
-                                    Alert.alert('Error', getErrorMessage(error, 'Failed to debug subscription'));
+                                    Alert.alert(t('subscriptions.alertError'), getErrorMessage(error, t('subscriptions.debugFailed')));
                                 }
                             }}
                         >
@@ -353,7 +362,7 @@ export default function SubscriptionsScreen() {
                 <View style={styles.navRow}>
                     <TouchableOpacity style={styles.linkBtn} onPress={() => router.back()}>
                         <Icon name="chevron-back" size={18} color={colors.text} />
-                        <Text style={styles.linkBtnText}>Back</Text>
+                        <Text style={styles.linkBtnText}>{t('subscriptions.page.back')}</Text>
                     </TouchableOpacity>
                 </View>
             </ScrollView>

--- a/packages/frontend/app/(tabs)/profile/trust-score.tsx
+++ b/packages/frontend/app/(tabs)/profile/trust-score.tsx
@@ -30,7 +30,7 @@ export default function TrustScorePage() {
       <Header
         options={{
           showBackButton: true,
-          title: t('Trust Score'),
+          title: t('profile.trustScorePage.title'),
           titlePosition: 'center',
         }}
       />
@@ -38,7 +38,7 @@ export default function TrustScorePage() {
         <View style={styles.heroWrap}>
           <CardSurface padding={spacing['2xl']}>
             <View style={styles.heroHeader}>
-              <H1 style={styles.heroTitle}>{t('Trust Score')}</H1>
+              <H1 style={styles.heroTitle}>{t('profile.trustScorePage.title')}</H1>
               <Button
                 variant="secondary"
                 size="medium"
@@ -51,15 +51,12 @@ export default function TrustScorePage() {
                   />
                 }
               >
-                {t('profile.edit', 'Edit profile')}
+                {t('profile.actions.editProfile')}
               </Button>
             </View>
 
             <BloomText style={styles.subtitle}>
-              {t(
-                'profile.trustScoreSubtitle',
-                'Build trust with landlords and roommates through verification and positive interactions.',
-              )}
+              {t('profile.trustScoreSubtitle')}
             </BloomText>
 
             <View style={styles.hint}>
@@ -69,10 +66,7 @@ export default function TrustScorePage() {
                 color={colors.primaryColor}
               />
               <BloomText style={styles.hintText}>
-                {t(
-                  'profile.trustScoreHint',
-                  'Complete your profile information to improve your trust score.',
-                )}
+                {t('profile.trustScoreHint')}
               </BloomText>
             </View>
           </CardSurface>

--- a/packages/frontend/app/(tabs)/saved/[folderId]/edit.tsx
+++ b/packages/frontend/app/(tabs)/saved/[folderId]/edit.tsx
@@ -57,23 +57,23 @@ export default function EditFolderScreen() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['savedFolders'] });
-      toast.success('Folder updated successfully');
+      toast.success(t('saved.toast.folderUpdated'));
       router.back();
     },
     onError: (error: unknown) => {
       logger.error('Failed to update folder:', error);
-      toast.error('Failed to update folder');
+      toast.error(t('saved.toast.folderUpdateFailed'));
     },
   });
 
   const handleSave = async () => {
     if (!folder) return;
     if (folder.isDefault) {
-      Alert.alert('Not allowed', 'Default folder cannot be renamed.');
+      Alert.alert(t('common.error'), t('saved.folder.alertDefaultFolderRename'));
       return;
     }
     if (!name.trim()) {
-      Alert.alert('Validation', 'Folder name is required');
+      Alert.alert(t('common.error'), t('saved.folder.alertFolderNameRequired'));
       return;
     }
 
@@ -97,24 +97,24 @@ export default function EditFolderScreen() {
     <View style={styles.container}>
       <Header
         options={{
-          title: `${emoji} ${folder.isDefault ? t('saved.defaultFolder', 'Default Folder') : t('saved.editFolder', 'Edit Folder')}`,
+          title: `${emoji} ${folder.isDefault ? t('saved.defaultFolder') : t('saved.editFolder')}`,
           showBackButton: true,
         }}
       />
       <View style={styles.form}>
-        <Text style={styles.label}>{t('common.emoji', 'Emoji')}</Text>
+        <Text style={styles.label}>{t('common.emoji')}</Text>
         <TextInput value={emoji} onChangeText={setEmoji} style={styles.input} maxLength={2} />
 
-        <Text style={styles.label}>{t('common.name', 'Name')}</Text>
+        <Text style={styles.label}>{t('common.name')}</Text>
         <TextInput
           value={name}
           onChangeText={setName}
           style={[styles.input, folder.isDefault && { opacity: 0.6 }]}
-          placeholder={t('saved.folderNamePlaceholder', 'Folder name')}
+          placeholder={t('saved.folderNamePlaceholder')}
           editable={!folder.isDefault}
         />
 
-        <Text style={styles.label}>{t('common.color', 'Color')}</Text>
+        <Text style={styles.label}>{t('common.color')}</Text>
         <View style={styles.colorGrid}>
           {FOLDER_COLORS.map((c) => {
             const isSelected = c === color;

--- a/packages/frontend/app/(tabs)/saved/[folderId]/index.tsx
+++ b/packages/frontend/app/(tabs)/saved/[folderId]/index.tsx
@@ -120,7 +120,7 @@ export default function SavedFolderScreen() {
       <View style={styles.root}>
         <Header
           options={{
-            title: t('saved.title', 'Folder'),
+            title: t('saved.title'),
             showBackButton: true,
           }}
         />
@@ -136,14 +136,14 @@ export default function SavedFolderScreen() {
       <View style={styles.root}>
         <Header
           options={{
-            title: t('saved.title', 'Folder'),
+            title: t('saved.title'),
             showBackButton: true,
           }}
         />
         <View style={styles.centerWrap}>
           <ErrorState
-            title={t('saved.loadFailed', "We couldn't load this folder")}
-            retryLabel={t('common.retry', 'Retry')}
+            title={t('saved.loadFailed')}
+            retryLabel={t('common.retry')}
             onRetry={handleRefresh}
           />
         </View>
@@ -156,18 +156,15 @@ export default function SavedFolderScreen() {
       <View style={styles.root}>
         <Header
           options={{
-            title: t('saved.title', 'Folder'),
+            title: t('saved.title'),
             showBackButton: true,
           }}
         />
         <View style={styles.centerWrap}>
           <EmptyState
             icon="folder-open-outline"
-            title={t('saved.noFolder', 'Folder not found')}
-            description={t(
-              'saved.noFolderDescription',
-              'This folder might have been removed.',
-            )}
+            title={t('saved.noFolder')}
+            description={t('saved.noFolderDescription')}
           />
         </View>
       </View>
@@ -196,7 +193,7 @@ export default function SavedFolderScreen() {
                     />
                   }
                 >
-                  {t('common.edit', 'Edit')}
+                  {t('common.edit')}
                 </Button>,
               ],
         }}
@@ -218,12 +215,9 @@ export default function SavedFolderScreen() {
           <View style={styles.emptyInner}>
             <EmptyState
               icon="folder-outline"
-              title={t('saved.noFolderItems', 'This folder is empty')}
-              description={t(
-                'saved.noFolderItemsDescription',
-                'Save properties to add them to this folder.',
-              )}
-              actionText={t('saved.exploreCta', 'Explore properties')}
+              title={t('saved.noFolderItems')}
+              description={t('saved.noFolderItemsDescription')}
+              actionText={t('saved.exploreCta')}
               actionIcon="search"
               onAction={() => router.push('/explore')}
             />

--- a/packages/frontend/app/(tabs)/saved/index.tsx
+++ b/packages/frontend/app/(tabs)/saved/index.tsx
@@ -166,7 +166,7 @@ export default function SavedPropertiesScreen() {
   const header = (
     <Header
       options={{
-        title: t('saved.header', 'Saved'),
+        title: t('saved.header'),
         titlePosition: 'left',
       }}
     />
@@ -179,12 +179,9 @@ export default function SavedPropertiesScreen() {
         <View style={styles.centerWrap}>
           <EmptyState
             icon="lock-closed"
-            title={t('profile.signInRequired', 'Sign in to view saved')}
-            description={t(
-              'profile.signInMessage',
-              'You need an account to save and revisit places.',
-            )}
-            actionText={t('common.signIn', 'Sign in')}
+            title={t('profile.signInRequired')}
+            description={t('profile.signInMessage')}
+            actionText={t('common.signIn')}
             actionIcon="log-in"
             onAction={() => showSignInModal()}
           />
@@ -209,26 +206,26 @@ export default function SavedPropertiesScreen() {
       <View style={styles.controls}>
         <SearchInput
           value={searchQuery}
-          label={t('saved.searchPlaceholder', 'Search saved properties')}
+          label={t('saved.searchPlaceholder')}
           onChangeText={setSearchQuery}
           onClearText={() => setSearchQuery('')}
         />
 
         <View style={styles.segmentedWrap}>
           <SegmentedControl<Tab>
-            label={t('saved.tabs.label', 'Saved view')}
+            label={t('saved.tabs.label')}
             type="tabs"
             value={tab}
             onChange={setTab}
           >
             <SegmentedControlItem value="folders">
               <SegmentedControlItemText>
-                {t('saved.tabs.folders', 'Folders')}
+                {t('saved.tabs.folders')}
               </SegmentedControlItemText>
             </SegmentedControlItem>
             <SegmentedControlItem value="recent">
               <SegmentedControlItemText>
-                {t('saved.tabs.recent', 'Recent')}
+                {t('saved.tabs.recent')}
               </SegmentedControlItemText>
             </SegmentedControlItem>
           </SegmentedControl>
@@ -262,13 +259,13 @@ export default function SavedPropertiesScreen() {
       ) : isError ? (
         <View style={styles.centerWrap}>
           <ErrorState
-            title={t('saved.loadFailed', "We couldn't load your saved items")}
+            title={t('saved.loadFailed')}
             description={
               savedQuery.error instanceof Error
                 ? savedQuery.error.message
-                : t('common.tryAgain', 'Please try again.')
+                : t('common.tryAgain')
             }
-            retryLabel={t('common.retry', 'Retry')}
+            retryLabel={t('common.retry')}
             onRetry={handleRefresh}
           />
         </View>
@@ -292,12 +289,9 @@ export default function SavedPropertiesScreen() {
             <View style={styles.emptyInner}>
               <EmptyState
                 icon="folder-open-outline"
-                title={t('saved.noFolders', 'No folders yet')}
-                description={t(
-                  'saved.noFoldersDescription',
-                  'Create folders to organise the places you like.',
-                )}
-                actionText={t('saved.createFolder', 'Create folder')}
+                title={t('saved.noFolders')}
+                description={t('saved.noFoldersDescription')}
+                actionText={t('saved.createFolder')}
                 actionIcon="add"
                 onAction={() => router.push('/saved')}
               />
@@ -323,21 +317,15 @@ export default function SavedPropertiesScreen() {
                 icon="bookmark-outline"
                 title={
                   searchQuery || recency !== 'all'
-                    ? t('saved.noResults', 'No matches')
-                    : t('saved.noProperties', 'No saved properties')
+                    ? t('saved.noResults')
+                    : t('saved.noProperties')
                 }
                 description={
                   searchQuery || recency !== 'all'
-                    ? t(
-                        'saved.adjustFilters',
-                        'Try a different filter or clear your search.',
-                      )
-                    : t(
-                        'saved.noPropertiesDescription',
-                        'Save properties to see them here.',
-                      )
+                    ? t('saved.adjustFilters')
+                    : t('saved.noPropertiesDescription')
                 }
-                actionText={t('saved.exploreCta', 'Explore properties')}
+                actionText={t('saved.exploreCta')}
                 actionIcon="search"
                 onAction={() => router.push('/explore')}
               />

--- a/packages/frontend/app/(tabs)/saved/notes.tsx
+++ b/packages/frontend/app/(tabs)/saved/notes.tsx
@@ -170,7 +170,7 @@ export default function NotesScreen() {
 
   return (
     <View style={styles.container}>
-      <Header options={{ title: t('saved.notes.title', 'Notes'), showBackButton: true }} />
+      <Header options={{ title: t('saved.notes.title'), showBackButton: true }} />
       <View style={styles.tabsContainer}>
         {([
           { key: 'all', label: 'All' },

--- a/packages/frontend/app/(tabs)/sindi/index.tsx
+++ b/packages/frontend/app/(tabs)/sindi/index.tsx
@@ -155,7 +155,7 @@ export default function Sindi() {
           icon="lock-closed"
           title={t('sindi.auth.required')}
           description={t('sindi.auth.message')}
-          actionText={t('Sign in')}
+          actionText={t('common.signIn')}
           actionIcon="log-in"
           onAction={() => showSignInModal()}
           iconColor={colors.primaryColor}

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -48,6 +48,7 @@ import { OXY_BASE_URL, OXY_CLIENT_ID } from '@/config';
 import { QueryClient, QueryClientProvider, onlineManager, focusManager } from '@tanstack/react-query';
 import NetInfo from '@react-native-community/netinfo';
 import { logger } from '@/utils/logger';
+import { getStoredLanguage } from '@/utils/languagePreference';
 
 i18nUse(initReactI18next);
 
@@ -297,6 +298,10 @@ export default function RootLayout() {
     let active = true;
     (async () => {
       try {
+        const storedLanguage = await getStoredLanguage();
+        if (storedLanguage) {
+          await i18n.changeLanguage(storedLanguage);
+        }
         if (Platform.OS !== 'web') {
           await setupNotifications();
           const hasPermission = await requestNotificationPermissions();

--- a/packages/frontend/app/addresses/[id].tsx
+++ b/packages/frontend/app/addresses/[id].tsx
@@ -25,6 +25,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Button } from '@oxyhq/bloom/button';
 import * as Skeleton from '@oxyhq/bloom/skeleton';
 import { H2, H3, Text as BloomText } from '@oxyhq/bloom/typography';
+import { useTranslation } from 'react-i18next';
 import { AddressDisplay } from '@/components/AddressDisplay';
 import { Header } from '@/components/Header';
 import { PropertyCard } from '@/components/PropertyCard';
@@ -110,12 +111,20 @@ interface ReviewData {
 type ReviewTab = 'overall' | 'apartments' | 'community' | 'area';
 type ContentTab = 'properties' | 'reviews';
 
-const REVIEW_TABS: { id: ReviewTab; label: string }[] = [
-  { id: 'overall', label: 'Overall' },
-  { id: 'apartments', label: 'Apartments' },
-  { id: 'community', label: 'Community' },
-  { id: 'area', label: 'Area' },
-];
+const REVIEW_TAB_IDS: ReviewTab[] = ['overall', 'apartments', 'community', 'area'];
+
+const reviewTabKey = (tab: ReviewTab): string => {
+  switch (tab) {
+    case 'overall':
+      return 'addresses.detail.tabOverall';
+    case 'apartments':
+      return 'addresses.detail.tabApartments';
+    case 'community':
+      return 'addresses.detail.tabCommunity';
+    case 'area':
+      return 'addresses.detail.tabArea';
+  }
+};
 
 const Stars: React.FC<{ rating: number }> = ({ rating }) => {
   const fullStars = Math.floor(rating);
@@ -323,22 +332,27 @@ const ContentTabSwitcher: React.FC<ContentTabSwitcherProps> = ({
   propertyCount,
   reviewCount,
   onChange,
-}) => (
-  <View style={styles.tabSwitcher}>
-    {[
-      { id: 'properties' as const, label: `Properties (${propertyCount})`, icon: 'home-outline' as IoniconName },
-      { id: 'reviews' as const, label: `Reviews (${reviewCount})`, icon: 'chatbubbles-outline' as IoniconName },
-    ].map((tab) => (
-      <ContentTabButton
-        key={tab.id}
-        label={tab.label}
-        icon={tab.icon}
-        active={selected === tab.id}
-        onPress={() => onChange(tab.id)}
-      />
-    ))}
-  </View>
-);
+}) => {
+  const { t } = useTranslation();
+  return (
+    <View style={styles.tabSwitcher}>
+      {(
+        [
+          { id: 'properties' as const, label: t('addresses.detail.tabProperties', { count: propertyCount }), icon: 'home-outline' as IoniconName },
+          { id: 'reviews' as const, label: t('addresses.detail.tabReviews', { count: reviewCount }), icon: 'chatbubbles-outline' as IoniconName },
+        ] as const
+      ).map((tab) => (
+        <ContentTabButton
+          key={tab.id}
+          label={tab.label}
+          icon={tab.icon}
+          active={selected === tab.id}
+          onPress={() => onChange(tab.id)}
+        />
+      ))}
+    </View>
+  );
+};
 
 interface ReviewTabSwitcherProps {
   selected: ReviewTab;
@@ -348,33 +362,37 @@ interface ReviewTabSwitcherProps {
 const ReviewTabSwitcher: React.FC<ReviewTabSwitcherProps> = ({
   selected,
   onChange,
-}) => (
-  <View style={styles.reviewTabBar}>
-    {REVIEW_TABS.map((tab) => {
-      const active = selected === tab.id;
-      return (
-        <Pressable
-          key={tab.id}
-          onPress={() => onChange(tab.id)}
-          style={[styles.reviewTab, active && styles.reviewTabActive]}
-          accessibilityRole="tab"
-          accessibilityState={{ selected: active }}
-        >
-          <BloomText
-            style={[
-              styles.reviewTabLabel,
-              active && styles.reviewTabLabelActive,
-            ]}
+}) => {
+  const { t } = useTranslation();
+  return (
+    <View style={styles.reviewTabBar}>
+      {REVIEW_TAB_IDS.map((tabId) => {
+        const active = selected === tabId;
+        return (
+          <Pressable
+            key={tabId}
+            onPress={() => onChange(tabId)}
+            style={[styles.reviewTab, active && styles.reviewTabActive]}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: active }}
           >
-            {tab.label}
-          </BloomText>
-        </Pressable>
-      );
-    })}
-  </View>
-);
+            <BloomText
+              style={[
+                styles.reviewTabLabel,
+                active && styles.reviewTabLabelActive,
+              ]}
+            >
+              {t(reviewTabKey(tabId))}
+            </BloomText>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+};
 
 export default function AddressDetailsPage() {
+  const { t } = useTranslation();
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const [refreshing, setRefreshing] = useState(false);
@@ -496,22 +514,22 @@ export default function AddressDetailsPage() {
   };
 
   const handleReviewHelpful = (_reviewId: string) => {
-    Alert.alert('Thank you', 'Your feedback has been recorded.');
+    Alert.alert(t('reviews.card.alertThankYouTitle'), t('reviews.card.alertThankYouBody'));
   };
 
   const handleReviewReport = (_reviewId: string) => {
     Alert.alert(
-      'Report Review',
-      'Are you sure you want to report this review for inappropriate content?',
+      t('reviews.card.alertReportTitle'),
+      t('reviews.card.alertReportBody'),
       [
-        { text: 'Cancel', style: 'cancel' },
+        { text: t('common.cancel'), style: 'cancel' },
         {
-          text: 'Report',
+          text: t('reviews.card.alertReportConfirm'),
           style: 'destructive',
           onPress: () => {
             Alert.alert(
-              'Reported',
-              'This review has been reported to our moderation team.',
+              t('reviews.card.alertReportedTitle'),
+              t('reviews.card.alertReportedBody'),
             );
           },
         },
@@ -521,18 +539,18 @@ export default function AddressDetailsPage() {
 
   const handleReplyToReview = (_reviewId: string) => {
     Alert.alert(
-      'Reply to Review',
-      'Reply functionality will allow landlords and property managers to respond to reviews.',
-      [{ text: 'OK' }],
+      t('reviews.card.alertReplyTitle'),
+      t('reviews.card.alertReplyBody'),
+      [{ text: t('common.confirm') }],
     );
   };
 
   const getAddressTitle = () => {
-    if (!address) return 'Address';
+    if (!address) return t('addresses.detail.title');
     const parts = [address.street, address.cityName, address.regionName].filter(Boolean);
     if (parts.length > 0) return parts.join(', ');
     if (address.location) return address.location;
-    return 'Address';
+    return t('addresses.detail.title');
   };
 
   const headerTitle = (() => {
@@ -561,14 +579,14 @@ export default function AddressDetailsPage() {
     return (
       <View style={styles.root}>
         <Header
-          options={{ title: 'Address', showBackButton: true }}
+          options={{ title: t('addresses.detail.title'), showBackButton: true }}
         />
         <ErrorState
           icon="search-outline"
-          title="Address not found"
-          description="We couldn't find any details for this address."
+          title={t('addresses.detail.notFound')}
+          description={t('addresses.detail.notFoundDescription')}
           onRetry={() => router.back()}
-          retryLabel="Go back"
+          retryLabel={t('common.goBack')}
         />
       </View>
     );
@@ -664,12 +682,12 @@ export default function AddressDetailsPage() {
 
           {contentTab === 'properties' ? (
             <View style={styles.sectionCard}>
-              <H3 style={styles.cardHeading}>Properties at this address</H3>
+              <H3 style={styles.cardHeading}>{t('addresses.detail.propertiesSection')}</H3>
               {properties.length === 0 ? (
                 <EmptyState
                   icon="home-outline"
-                  title="No properties yet"
-                  description="There are currently no listings at this address."
+                  title={t('addresses.detail.emptyPropertiesTitle')}
+                  description={t('addresses.detail.emptyPropertiesDescription')}
                 />
               ) : (
                 <View style={styles.propertiesList}>
@@ -691,8 +709,8 @@ export default function AddressDetailsPage() {
             <View style={styles.sectionCard}>
               <View style={styles.reviewsHeader}>
                 <View style={styles.headerText}>
-                  <SectionEyebrow>Reviews</SectionEyebrow>
-                  <H2 style={styles.cardHeading}>Stories from residents</H2>
+                  <SectionEyebrow>{t('addresses.detail.reviewsSection')}</SectionEyebrow>
+                  <H2 style={styles.cardHeading}>{t('addresses.detail.storiesTitle')}</H2>
                 </View>
                 <Button
                   variant="primary"
@@ -706,7 +724,7 @@ export default function AddressDetailsPage() {
                     />
                   }
                 >
-                  Write review
+                  {t('addresses.detail.writeReview')}
                 </Button>
               </View>
 
@@ -720,14 +738,10 @@ export default function AddressDetailsPage() {
                   icon="chatbubble-outline"
                   title={
                     activeTab === 'overall'
-                      ? 'No reviews yet'
-                      : `No ${activeTab} reviews yet`
+                      ? t('addresses.detail.emptyReviewsTitle')
+                      : t('addresses.detail.emptyReviewsTitle')
                   }
-                  description={
-                    activeTab === 'overall'
-                      ? 'Be the first to review this address and help others choose with confidence.'
-                      : `Be the first to review the ${activeTab} at this address.`
-                  }
+                  description={t('addresses.detail.emptyReviewsDescription')}
                 />
               ) : (
                 <View style={styles.reviewsList}>

--- a/packages/frontend/app/agent/index.tsx
+++ b/packages/frontend/app/agent/index.tsx
@@ -58,9 +58,9 @@ export default function AgentScreen() {
   // CTA copy + behaviour by state.
   const ctaLabel = useMemo(() => {
     if (!isAuthenticated || !isPartner) {
-      return t('agent.cta.start', 'Start earning');
+      return t('agent.cta.start');
     }
-    return t('agent.cta.share', 'Share your link');
+    return t('agent.cta.share');
   }, [isAuthenticated, isPartner, t]);
 
   const handleHeroCta = useCallback(async () => {
@@ -74,7 +74,7 @@ export default function AgentScreen() {
       joinMutation.mutate(undefined, {
         onError: () => {
           toast.error(
-            t('agent.join.error', 'Could not start earning right now. Please try again.'),
+            t('agent.join.error'),
           );
         },
       });
@@ -85,15 +85,15 @@ export default function AgentScreen() {
     if (link) {
       const outcome = await shareReferralLink({
         link,
-        message: t('agent.referral.shareMessage', 'List your home on Homiio: {{link}}', {
+        message: t('agent.referral.shareMessage', {
           link,
         }),
-        title: t('agent.referral.shareTitle', 'Earn with Homiio'),
+        title: t('agent.referral.shareTitle'),
       });
       if (outcome === 'copied') {
-        toast.success(t('agent.referral.copied', 'Link copied'));
+        toast.success(t('agent.referral.copied'));
       } else if (outcome === 'failed') {
-        toast.error(t('agent.referral.shareFailed', 'Could not share the link'));
+        toast.error(t('agent.referral.shareFailed'));
       }
     }
   }, [isAuthenticated, isPartner, link, joinMutation, t]);
@@ -112,15 +112,12 @@ export default function AgentScreen() {
             `marginTop`. */}
         <View className="gap-6 md:gap-8 pb-20">
           <AgentHero
-            title={t('agent.hero.title', 'Anyone can be a real estate agent.')}
-            subtitle={t(
-              'agent.hero.subtitle',
-              'Bring a home to Homiio. When it rents or sells, you earn.',
-            )}
+            title={t('agent.hero.title')}
+            subtitle={t('agent.hero.subtitle')}
             ctaLabel={ctaLabel}
             onPressCta={handleHeroCta}
             ctaLoading={joinMutation.isPending}
-            trustLine={t('agent.hero.trust', 'No license needed. Work from your phone.')}
+            trustLine={t('agent.hero.trust')}
           />
 
           <AgentHowItWorks />
@@ -146,10 +143,10 @@ export default function AgentScreen() {
           ) : null}
 
           <AgentCtaBanner
-            title={t('agent.banner.title', 'Start today. No license needed.')}
-            subtitle={t('agent.banner.subtitle', 'Turn the homes around you into income.')}
-            ctaLabel={t('agent.banner.cta', 'Become an agent')}
-            trustLine={t('agent.banner.trust', 'No license needed. Work from your phone.')}
+            title={t('agent.banner.title')}
+            subtitle={t('agent.banner.subtitle')}
+            ctaLabel={t('agent.banner.cta')}
+            trustLine={t('agent.banner.trust')}
             onPress={handleHeroCta}
           />
         </View>

--- a/packages/frontend/app/applications/[id].tsx
+++ b/packages/frontend/app/applications/[id].tsx
@@ -26,6 +26,8 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { format } from 'date-fns';
+import { useTranslation } from 'react-i18next';
+import i18next from 'i18next';
 import { toast } from '@/lib/sonner';
 import { Ionicons } from '@expo/vector-icons';
 
@@ -56,13 +58,6 @@ import { ErrorState } from '@/components/ui/ErrorState';
 import { radius, spacing, tracker } from '@/constants/styles';
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
-
-const formatEmployment = (status: string): string =>
-  status
-    .replace(/_/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase());
-
-const formatRelationship = formatEmployment;
 
 const formatCurrency = (amount: number): string => {
   try {
@@ -102,7 +97,7 @@ const openDocument = (url: string): void => {
     return;
   }
   Linking.openURL(url).catch(() => {
-    toast.error('Could not open the document.');
+    toast.error(i18next.t('applications.toast.openDocumentFailed'));
   });
 };
 
@@ -110,7 +105,10 @@ interface DocumentRowProps {
   document: TenantApplicationDocument;
 }
 
-const DocumentRow: React.FC<DocumentRowProps> = ({ document }) => (
+const DocumentRow: React.FC<DocumentRowProps> = ({ document }) => {
+  const { t } = useTranslation();
+
+  return (
   <Pressable
     onPress={() => openDocument(document.url)}
     style={styles.documentRow}
@@ -127,7 +125,7 @@ const DocumentRow: React.FC<DocumentRowProps> = ({ document }) => (
         {document.filename}
       </BloomText>
       <BloomText style={styles.documentType}>
-        {formatRelationship(document.type)}
+        {t(`applications.documentType.${document.type}`)}
       </BloomText>
     </View>
     <Ionicons
@@ -136,9 +134,11 @@ const DocumentRow: React.FC<DocumentRowProps> = ({ document }) => (
       color={colors.muted}
     />
   </Pressable>
-);
+  );
+};
 
 export default function ApplicationDetailScreen() {
+  const { t } = useTranslation();
   const router = useRouter();
   const params = useLocalSearchParams<{ id: string }>();
   const id = typeof params.id === 'string' ? params.id : params.id?.[0];
@@ -183,14 +183,16 @@ export default function ApplicationDetailScreen() {
         id,
         input: { status: TenantApplicationStatus.WITHDRAWN },
       });
-      toast.success('Application withdrawn');
+      toast.success(t('applications.toast.withdrawn'));
       setConfirmWithdraw(false);
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : 'Could not withdraw application';
+        error instanceof Error
+          ? error.message
+          : t('applications.toast.withdrawFailed');
       toast.error(message);
     }
-  }, [id, application, updateMutation]);
+  }, [id, application, updateMutation, t]);
 
   const handleCreateLease = useCallback(() => {
     if (!id) return;
@@ -313,7 +315,7 @@ export default function ApplicationDetailScreen() {
             />
             <DetailRow
               label="Employment"
-              value={formatEmployment(application.employmentStatus)}
+              value={t(`profile.edit.options.employmentStatus.${application.employmentStatus}`)}
             />
           </CardSurface>
 
@@ -330,7 +332,7 @@ export default function ApplicationDetailScreen() {
                     {reference.name}
                   </BloomText>
                   <BloomText style={styles.referenceMeta}>
-                    {formatRelationship(reference.relationship)} ·{' '}
+                    {t(`profile.edit.options.referenceRelationship.${reference.relationship}`)} ·{' '}
                     {reference.phone}
                   </BloomText>
                   <BloomText style={styles.referenceMeta}>

--- a/packages/frontend/app/applications/index.tsx
+++ b/packages/frontend/app/applications/index.tsx
@@ -13,6 +13,7 @@ import React, { useMemo, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
 import { isThisWeek, isToday } from 'date-fns';
 
 import { Chip } from '@oxyhq/bloom/chip';
@@ -36,14 +37,14 @@ type Filter = 'all' | 'active' | 'decided' | 'withdrawn';
 
 interface FilterOption {
   value: Filter;
-  label: string;
+  i18nKey: string;
 }
 
 const FILTERS: FilterOption[] = [
-  { value: 'all', label: 'All' },
-  { value: 'active', label: 'Active' },
-  { value: 'decided', label: 'Decided' },
-  { value: 'withdrawn', label: 'Withdrawn' },
+  { value: 'all', i18nKey: 'applications.list.filterAll' },
+  { value: 'active', i18nKey: 'applications.list.filterActive' },
+  { value: 'decided', i18nKey: 'applications.list.filterDecided' },
+  { value: 'withdrawn', i18nKey: 'applications.list.filterWithdrawn' },
 ];
 
 interface Buckets {
@@ -78,7 +79,7 @@ interface DateGroup {
  * Group a list of applications by submission recency so the screen reads
  * Today → This week → Earlier instead of a single dense column.
  */
-const groupByDate = (items: TenantApplication[]): DateGroup[] => {
+const groupByDate = (items: TenantApplication[], t: (key: string) => string): DateGroup[] => {
   const today: TenantApplication[] = [];
   const thisWeek: TenantApplication[] = [];
   const earlier: TenantApplication[] = [];
@@ -95,13 +96,14 @@ const groupByDate = (items: TenantApplication[]): DateGroup[] => {
   }
 
   return [
-    { label: 'Today', items: today },
-    { label: 'This week', items: thisWeek },
-    { label: 'Earlier', items: earlier },
+    { label: t('applications.list.today'), items: today },
+    { label: t('applications.list.thisWeek'), items: thisWeek },
+    { label: t('applications.list.earlier'), items: earlier },
   ].filter((group) => group.items.length > 0);
 };
 
 export default function MyApplicationsScreen() {
+  const { t } = useTranslation();
   const router = useRouter();
   const { isAuthenticated } = useOxy();
   const applicationsQuery = useMyApplications();
@@ -125,13 +127,13 @@ export default function MyApplicationsScreen() {
     }
   }, [filter, buckets]);
 
-  const dateGroups = useMemo(() => groupByDate(filtered), [filtered]);
+  const dateGroups = useMemo(() => groupByDate(filtered, t), [filtered, t]);
 
   const header = (
     <Header
       options={{
         showBackButton: true,
-        title: 'My applications',
+        title: t('applications.list.title'),
         titlePosition: 'center',
       }}
     />
@@ -145,9 +147,9 @@ export default function MyApplicationsScreen() {
           <View style={styles.centerWrap}>
             <EmptyState
               icon="document-text-outline"
-              title="Sign in to see your applications"
-              description="Track tenant applications you've sent to landlords."
-              actionText="Sign in"
+              title={t('applications.list.signInTitle')}
+              description={t('applications.list.signInDescription')}
+              actionText={t('applications.list.signIn')}
               actionIcon="log-in-outline"
               onAction={() => showSignInModal()}
             />
@@ -163,7 +165,7 @@ export default function MyApplicationsScreen() {
         {header}
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
           <View style={styles.content}>
-            <FilterRow value={filter} onChange={setFilter} />
+            <FilterRow value={filter} onChange={setFilter} t={t} />
             <ListSkeleton rows={5} rowHeight={120} />
           </View>
         </SafeAreaView>
@@ -178,11 +180,11 @@ export default function MyApplicationsScreen() {
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
           <View style={styles.centerWrap}>
             <ErrorState
-              title="Couldn't load your applications"
+              title={t('applications.list.loadError')}
               description={
-                applicationsQuery.error?.message ?? 'Please try again.'
+                applicationsQuery.error?.message ?? t('applications.list.tryAgain')
               }
-              retryLabel="Retry"
+              retryLabel={t('applications.list.retry')}
               onRetry={() => applicationsQuery.refetch()}
             />
           </View>
@@ -204,15 +206,15 @@ export default function MyApplicationsScreen() {
                 icon="document-text-outline"
                 title={
                   filter === 'all'
-                    ? 'No applications yet.'
-                    : 'Nothing in this view.'
+                    ? t('applications.list.emptyAllTitle')
+                    : t('applications.list.emptyFilteredTitle')
                 }
                 description={
                   filter === 'all'
-                    ? 'Browse listings and submit an application to a long-term rental.'
-                    : 'Try a different filter or submit a new application.'
+                    ? t('applications.list.emptyAllDescription')
+                    : t('applications.list.emptyFilteredDescription')
                 }
-                actionText={filter === 'all' ? 'Explore stays' : undefined}
+                actionText={filter === 'all' ? t('applications.list.exploreStays') : undefined}
                 actionIcon={filter === 'all' ? 'search-outline' : undefined}
                 onAction={
                   filter === 'all' ? () => router.push('/explore') : undefined
@@ -243,9 +245,10 @@ export default function MyApplicationsScreen() {
 interface FilterRowProps {
   value: Filter;
   onChange: (next: Filter) => void;
+  t: (key: string) => string;
 }
 
-const FilterRow: React.FC<FilterRowProps> = ({ value, onChange }) => (
+const FilterRow: React.FC<FilterRowProps> = ({ value, onChange, t }) => (
   <ScrollView
     horizontal
     showsHorizontalScrollIndicator={false}
@@ -260,7 +263,7 @@ const FilterRow: React.FC<FilterRowProps> = ({ value, onChange }) => (
         selected={value === option.value}
         onPress={() => onChange(option.value)}
       >
-        {option.label}
+        {t(option.i18nKey)}
       </Chip>
     ))}
   </ScrollView>

--- a/packages/frontend/app/contracts/[id].tsx
+++ b/packages/frontend/app/contracts/[id].tsx
@@ -16,7 +16,8 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Image, Linking, Platform, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { format } from 'date-fns';
+import { useTranslation } from 'react-i18next';
+import i18next from 'i18next';
 import * as ImagePicker from 'expo-image-picker';
 import { Ionicons } from '@expo/vector-icons';
 import { toast } from '@/lib/sonner';
@@ -41,6 +42,7 @@ import {
   useUploadLeaseDocument,
 } from '@/hooks/useLeaseQueries';
 import { getPropertyImageSource, getPropertyTitle } from '@/utils/propertyUtils';
+import { formatLocalized } from '@/utils/dateLocale';
 import { colors } from '@/styles/colors';
 import { radius, spacing, tracker } from '@/constants/styles';
 
@@ -50,13 +52,13 @@ const formatDate = (raw?: string): string => {
   if (!raw) return '—';
   const date = new Date(raw);
   if (Number.isNaN(date.getTime())) return raw;
-  return format(date, 'MMM d, yyyy');
+  return formatLocalized(date, 'MMM d, yyyy');
 };
 
 const formatMoney = (amount?: number, currency?: string): string => {
   if (amount === undefined || amount === null) return '—';
   try {
-    return new Intl.NumberFormat('en-US', {
+    return new Intl.NumberFormat(i18next.language, {
       style: 'currency',
       currency: currency || 'USD',
       maximumFractionDigits: 0,
@@ -66,12 +68,12 @@ const formatMoney = (amount?: number, currency?: string): string => {
   }
 };
 
-const openDocument = (url: string): void => {
+const openDocument = (url: string, t: (key: string) => string): void => {
   if (Platform.OS === 'web') {
     window.open(url, '_blank', 'noopener,noreferrer');
     return;
   }
-  Linking.openURL(url).catch(() => toast.error('Could not open the document.'));
+  Linking.openURL(url).catch(() => toast.error(t('contracts.detail.toastOpenDocumentFailed')));
 };
 
 interface DetailRowProps {
@@ -87,6 +89,7 @@ const DetailRow: React.FC<DetailRowProps> = ({ label, value }) => (
 );
 
 export default function ContractDetailScreen() {
+  const { t } = useTranslation();
   const router = useRouter();
   const params = useLocalSearchParams<{ id: string }>();
   const id = typeof params.id === 'string' ? params.id : params.id?.[0];
@@ -119,45 +122,45 @@ export default function ContractDetailScreen() {
     if (!id) return;
     try {
       await signMutation.mutateAsync({ signature: 'accepted-in-app', acceptTerms: true });
-      toast.success('Lease signed');
+      toast.success(t('contracts.detail.toastSigned'));
       setPendingAction(null);
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Could not sign the lease');
+      toast.error(error instanceof Error ? error.message : t('contracts.detail.toastSignFailed'));
       setPendingAction(null);
     }
-  }, [id, signMutation]);
+  }, [id, signMutation, t]);
 
   const handleTerminate = useCallback(async () => {
     if (!id) return;
     try {
       await terminateMutation.mutateAsync({});
-      toast.success('Lease terminated');
+      toast.success(t('contracts.detail.toastTerminated'));
       setPendingAction(null);
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Could not terminate the lease');
+      toast.error(error instanceof Error ? error.message : t('contracts.detail.toastTerminateFailed'));
       setPendingAction(null);
     }
-  }, [id, terminateMutation]);
+  }, [id, terminateMutation, t]);
 
   const handleDelete = useCallback(async () => {
     if (!id) return;
     try {
       await deleteMutation.mutateAsync(id);
-      toast.success('Draft deleted');
+      toast.success(t('contracts.detail.toastDeleted'));
       setPendingAction(null);
       router.back();
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Could not delete the draft');
+      toast.error(error instanceof Error ? error.message : t('contracts.detail.toastDeleteFailed'));
       setPendingAction(null);
     }
-  }, [id, deleteMutation, router]);
+  }, [id, deleteMutation, router, t]);
 
   const handleAddDocument = useCallback(async () => {
     if (!id) return;
     if (Platform.OS !== 'web') {
       const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
       if (permission.status !== 'granted') {
-        toast.error('Media library permission is required to attach a document.');
+        toast.error(t('contracts.detail.permissionRequired'));
         return;
       }
     }
@@ -173,15 +176,19 @@ export default function ContractDetailScreen() {
         name: asset.fileName ?? `lease-document-${Date.now()}.jpg`,
         type: 'other',
       });
-      toast.success('Document added');
+      toast.success(t('contracts.detail.toastDocumentAdded'));
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Could not add the document');
+      toast.error(error instanceof Error ? error.message : t('contracts.detail.toastDocumentFailed'));
     }
-  }, [id, uploadMutation]);
+  }, [id, uploadMutation, t]);
 
   const header = (
     <Header
-      options={{ showBackButton: true, title: 'Contract', titlePosition: 'center' }}
+      options={{
+        showBackButton: true,
+        title: t('contracts.detail.title'),
+        titlePosition: 'center',
+      }}
     />
   );
 
@@ -192,9 +199,9 @@ export default function ContractDetailScreen() {
         <View style={styles.centerWrap}>
           <ErrorState
             icon="warning-outline"
-            title="Invalid contract id"
-            description="The link is missing the contract reference."
-            retryLabel="Go back"
+            title={t('contracts.detail.invalidIdTitle')}
+            description={t('contracts.detail.invalidIdDescription')}
+            retryLabel={t('contracts.detail.goBack')}
             onRetry={() => router.back()}
           />
         </View>
@@ -219,9 +226,11 @@ export default function ContractDetailScreen() {
         {header}
         <View style={styles.centerWrap}>
           <ErrorState
-            title="Contract unavailable"
-            description={leaseQuery.error?.message ?? 'This contract could not be loaded.'}
-            retryLabel="Go back"
+            title={t('contracts.detail.unavailableTitle')}
+            description={
+              leaseQuery.error?.message ?? t('contracts.detail.unavailableDescription')
+            }
+            retryLabel={t('contracts.detail.goBack')}
             onRetry={() => router.back()}
           />
         </View>
@@ -230,7 +239,9 @@ export default function ContractDetailScreen() {
   }
 
   const property = lease.property ?? fetchedProperty;
-  const propertyTitle = property ? getPropertyTitle(property) : 'Property';
+  const propertyTitle = property
+    ? getPropertyTitle(property)
+    : t('contracts.detail.propertyFallback');
   const imageSource = property ? getPropertyImageSource(property) : null;
 
   const isParty = role === 'landlord' || role === 'tenant';
@@ -283,43 +294,54 @@ export default function ContractDetailScreen() {
           </CardSurface>
 
           <CardSurface>
-            <BloomText style={styles.sectionLabel}>Term</BloomText>
-            <DetailRow label="Start" value={formatDate(lease.leaseTerms?.startDate)} />
-            <DetailRow label="End" value={formatDate(lease.leaseTerms?.endDate)} />
+            <BloomText style={styles.sectionLabel}>{t('contracts.detail.term')}</BloomText>
+            <DetailRow label={t('contracts.detail.start')} value={formatDate(lease.leaseTerms?.startDate)} />
+            <DetailRow label={t('contracts.detail.end')} value={formatDate(lease.leaseTerms?.endDate)} />
           </CardSurface>
 
           <CardSurface>
-            <BloomText style={styles.sectionLabel}>Rent</BloomText>
+            <BloomText style={styles.sectionLabel}>{t('contracts.detail.rent')}</BloomText>
             <DetailRow
-              label="Monthly rent"
+              label={t('contracts.detail.monthlyRent')}
               value={formatMoney(lease.rentDetails?.monthlyRent, lease.rentDetails?.currency)}
             />
             {lease.rentDetails?.securityDeposit ? (
               <DetailRow
-                label="Security deposit"
+                label={t('contracts.detail.securityDeposit')}
                 value={formatMoney(lease.rentDetails.securityDeposit, lease.rentDetails.currency)}
               />
             ) : null}
             {lease.rentDetails?.dueDate ? (
-              <DetailRow label="Due day" value={`Day ${lease.rentDetails.dueDate} of the month`} />
+              <DetailRow
+                label={t('contracts.detail.dueDayLabel')}
+                value={t('contracts.detail.dueDay', { day: lease.rentDetails.dueDate })}
+              />
             ) : null}
           </CardSurface>
 
           <CardSurface>
-            <BloomText style={styles.sectionLabel}>Signatures</BloomText>
+            <BloomText style={styles.sectionLabel}>{t('contracts.detail.signatures')}</BloomText>
             <DetailRow
-              label="Landlord"
-              value={lease.signatures?.landlord?.signed ? 'Signed' : 'Pending'}
+              label={t('contracts.detail.landlord')}
+              value={
+                lease.signatures?.landlord?.signed
+                  ? t('contracts.detail.signed')
+                  : t('contracts.detail.signaturePending')
+              }
             />
             <DetailRow
-              label="Tenant"
-              value={lease.signatures?.tenant?.signed ? 'Signed' : 'Pending'}
+              label={t('contracts.detail.tenant')}
+              value={
+                lease.signatures?.tenant?.signed
+                  ? t('contracts.detail.signed')
+                  : t('contracts.detail.signaturePending')
+              }
             />
           </CardSurface>
 
           {payments.length > 0 ? (
             <CardSurface>
-              <BloomText style={styles.sectionLabel}>Payment schedule</BloomText>
+              <BloomText style={styles.sectionLabel}>{t('contracts.detail.payments')}</BloomText>
               {payments.map((payment) => (
                 <View key={payment.id} style={styles.paymentRow}>
                   <View style={styles.paymentMeta}>
@@ -354,7 +376,7 @@ export default function ContractDetailScreen() {
 
           <CardSurface>
             <View style={styles.docHeader}>
-              <BloomText style={styles.sectionLabel}>Documents</BloomText>
+              <BloomText style={styles.sectionLabel}>{t('contracts.detail.documents')}</BloomText>
               {isParty ? (
                 <Button
                   variant="secondary"
@@ -364,20 +386,20 @@ export default function ContractDetailScreen() {
                   loading={uploadMutation.isPending}
                   icon={<Ionicons name="add" size={16} color={colors.COLOR_BLACK} />}
                 >
-                  Add
+                  {t('contracts.detail.addShort')}
                 </Button>
               ) : null}
             </View>
             {documents.length === 0 ? (
-              <BloomText style={styles.emptyHint}>No documents attached.</BloomText>
+              <BloomText style={styles.emptyHint}>{t('contracts.detail.emptyDocuments')}</BloomText>
             ) : (
               documents.map((document) => (
                 <Pressable
                   key={document.id}
-                  onPress={() => openDocument(document.url)}
+                  onPress={() => openDocument(document.url, t)}
                   style={styles.documentRow}
                   accessibilityRole="link"
-                  accessibilityLabel={`Open document ${document.name}`}
+                  accessibilityLabel={t('contracts.detail.openDocument', { name: document.name })}
                 >
                   <Ionicons name="document-text-outline" size={20} color={colors.primaryDark} />
                   <View style={styles.documentMeta}>
@@ -385,7 +407,7 @@ export default function ContractDetailScreen() {
                       {document.name}
                     </BloomText>
                     <BloomText style={styles.documentType}>
-                      {document.type.replace(/_/g, ' ')}
+                      {t(`contracts.documentType.${document.type}`)}
                     </BloomText>
                   </View>
                   <Ionicons name="open-outline" size={18} color={colors.muted} />
@@ -404,7 +426,7 @@ export default function ContractDetailScreen() {
                   disabled={busy}
                   style={styles.actionButton}
                 >
-                  Sign lease
+                  {t('contracts.detail.signLease')}
                 </Button>
               ) : null}
               {canTerminate ? (
@@ -415,7 +437,7 @@ export default function ContractDetailScreen() {
                   disabled={busy}
                   style={styles.actionButton}
                 >
-                  Terminate
+                  {t('contracts.detail.terminate')}
                 </Button>
               ) : null}
               {canDelete ? (
@@ -426,7 +448,7 @@ export default function ContractDetailScreen() {
                   disabled={busy}
                   style={styles.actionButton}
                 >
-                  Delete draft
+                  {t('contracts.detail.deleteDraft')}
                 </Button>
               ) : null}
             </View>
@@ -435,18 +457,18 @@ export default function ContractDetailScreen() {
 
         <ConfirmDialog
           visible={pendingAction === 'sign'}
-          title="Sign this lease?"
-          message="By signing you agree to the lease terms. Once both parties sign, the lease becomes active."
-          confirmLabel="Sign"
+          title={t('contracts.detail.confirmSignTitle')}
+          message={t('contracts.detail.confirmSignExtended')}
+          confirmLabel={t('contracts.detail.confirmSignAction')}
           loading={signMutation.isPending}
           onConfirm={handleSign}
           onCancel={() => setPendingAction(null)}
         />
         <ConfirmDialog
           visible={pendingAction === 'terminate'}
-          title="Terminate lease?"
-          message="This records a termination notice and ends the lease. This cannot be undone."
-          confirmLabel="Terminate"
+          title={t('contracts.detail.confirmTerminateShortTitle')}
+          message={t('contracts.detail.confirmTerminateExtended')}
+          confirmLabel={t('contracts.detail.terminate')}
           confirmDestructive
           loading={terminateMutation.isPending}
           onConfirm={handleTerminate}
@@ -454,9 +476,9 @@ export default function ContractDetailScreen() {
         />
         <ConfirmDialog
           visible={pendingAction === 'delete'}
-          title="Delete draft?"
-          message="This permanently removes the draft lease."
-          confirmLabel="Delete"
+          title={t('contracts.detail.confirmDeleteTitle')}
+          message={t('contracts.detail.confirmDeleteExtended')}
+          confirmLabel={t('contracts.detail.confirmDeleteAction')}
           confirmDestructive
           loading={deleteMutation.isPending}
           onConfirm={handleDelete}

--- a/packages/frontend/app/contracts/index.tsx
+++ b/packages/frontend/app/contracts/index.tsx
@@ -65,12 +65,12 @@ const leasePropertyTitle = (property?: Lease['property']): string => {
 
 type FilterOption = 'all' | 'active' | 'pending_signatures' | 'expired' | 'draft';
 
-const FILTERS: { id: FilterOption; label: string }[] = [
-  { id: 'all', label: 'All' },
-  { id: 'active', label: 'Active' },
-  { id: 'pending_signatures', label: 'Pending' },
-  { id: 'expired', label: 'Expired' },
-  { id: 'draft', label: 'Drafts' },
+const FILTERS: { id: FilterOption; i18nKey: string }[] = [
+  { id: 'all', i18nKey: 'contracts.list.filterAll' },
+  { id: 'active', i18nKey: 'contracts.list.filterActive' },
+  { id: 'pending_signatures', i18nKey: 'contracts.list.filterPending' },
+  { id: 'expired', i18nKey: 'contracts.list.filterExpired' },
+  { id: 'draft', i18nKey: 'contracts.list.filterDrafts' },
 ];
 
 const ContractsSkeleton: React.FC = () => (
@@ -141,18 +141,16 @@ export default function ContractsScreen() {
       <View style={styles.root}>
         <Header
           options={{
-            title: t('Rental Contracts'),
+            title: t('contracts.list.title'),
             titlePosition: 'center',
           }}
         />
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
           <EmptyState
             icon="document-text-outline"
-            title={t('No rental contracts')}
-            description={t(
-              "You don't have any rental properties yet. Start by browsing available properties or listing your own.",
-            )}
-            actionText={t('Browse properties')}
+            title={t('contracts.list.noRentalPropertiesTitle')}
+            description={t('contracts.list.noRentalPropertiesDescription')}
+            actionText={t('contracts.list.browseProperties')}
             actionIcon="home"
             onAction={() => router.push('/')}
           />
@@ -165,20 +163,16 @@ export default function ContractsScreen() {
     <View style={styles.root}>
       <Header
         options={{
-          title: t('Rental Contracts'),
+          title: t('contracts.list.title'),
           titlePosition: 'center',
         }}
       />
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>
         <ScrollView contentContainerStyle={styles.content}>
           <View style={styles.titleBlock}>
-            <SectionEyebrow>Agreements</SectionEyebrow>
-            <H2 style={styles.title}>{t('Rental Contracts')}</H2>
-            <BloomText style={styles.subtitle}>
-              {t(
-                'Track every lease you sign or issue and pull up key terms in seconds.',
-              )}
-            </BloomText>
+            <SectionEyebrow>{t('contracts.list.eyebrow')}</SectionEyebrow>
+            <H2 style={styles.title}>{t('contracts.list.title')}</H2>
+            <BloomText style={styles.subtitle}>{t('contracts.list.subtitle')}</BloomText>
           </View>
 
           <ScrollView
@@ -196,7 +190,7 @@ export default function ContractsScreen() {
                   color={isActive ? 'primary' : 'default'}
                   selected={isActive}
                 >
-                  {t(entry.label)}
+                  {t(entry.i18nKey)}
                 </Chip>
               );
             })}
@@ -207,8 +201,8 @@ export default function ContractsScreen() {
           {leasesError ? (
             <ErrorState
               icon="cloud-offline-outline"
-              title={t("Couldn't load contracts")}
-              description={leasesError?.message || t('Please try again.')}
+              title={t('contracts.list.loadError')}
+              description={leasesError?.message || t('contracts.list.tryAgain')}
               onRetry={() => refetchLeases()}
             />
           ) : null}
@@ -217,13 +211,17 @@ export default function ContractsScreen() {
             <View style={styles.emptyWrap}>
               <EmptyState
                 icon="document-text-outline"
-                title={t('No contracts found')}
+                title={t('contracts.list.emptyTitle')}
                 description={
                   filter === 'all'
-                    ? t("You don't have any rental contracts yet")
-                    : t(`No ${filter.replace('_', ' ')} contracts to show`)
+                    ? t('contracts.list.emptyAllDescription')
+                    : t('contracts.list.emptyFilteredDescription', {
+                        filter: t(
+                          `statusBadge.${filter === 'pending_signatures' ? 'pendingSignatures' : filter}`,
+                        ),
+                      })
                 }
-                actionText={t('Create new contract')}
+                actionText={t('contracts.list.createNew')}
                 actionIcon="add"
                 onAction={handleAddNewContract}
               />
@@ -251,7 +249,7 @@ export default function ContractsScreen() {
             icon={<Ionicons name="add" size={20} color={colors.primaryForeground} />}
             style={styles.footerButton}
           >
-            {t('New contract')}
+            {t('contracts.list.newContract')}
           </Button>
         </View>
       </SafeAreaView>

--- a/packages/frontend/app/contracts/new.tsx
+++ b/packages/frontend/app/contracts/new.tsx
@@ -12,7 +12,7 @@ import React, { useCallback } from 'react';
 import { Image, ScrollView, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { format } from 'date-fns';
+import { useTranslation } from 'react-i18next';
 import { toast } from '@/lib/sonner';
 
 import { Button } from '@oxyhq/bloom/button';
@@ -28,15 +28,9 @@ import { useProperty } from '@/hooks';
 import { useApplicationById } from '@/hooks/useApplicationQueries';
 import { useCreateLeaseFromApplication } from '@/hooks/useLeaseQueries';
 import { getPropertyImageSource, getPropertyTitle } from '@/utils/propertyUtils';
+import { formatLocalized } from '@/utils/dateLocale';
 import { colors } from '@/styles/colors';
 import { radius, spacing, tracker } from '@/constants/styles';
-
-const formatDate = (raw?: string): string => {
-  if (!raw) return '—';
-  const date = new Date(raw);
-  if (Number.isNaN(date.getTime())) return raw;
-  return format(date, 'EEE, MMM d, yyyy');
-};
 
 interface DetailRowProps {
   label: string;
@@ -51,6 +45,7 @@ const DetailRow: React.FC<DetailRowProps> = ({ label, value }) => (
 );
 
 export default function NewContractScreen() {
+  const { t } = useTranslation();
   const router = useRouter();
   const params = useLocalSearchParams<{ application?: string }>();
   const applicationId =
@@ -61,21 +56,33 @@ export default function NewContractScreen() {
   const { property } = useProperty(application?.propertyId ?? '');
   const createLease = useCreateLeaseFromApplication();
 
+  const formatDate = useCallback((raw?: string): string => {
+    if (!raw) return '—';
+    const date = new Date(raw);
+    if (Number.isNaN(date.getTime())) return raw;
+    return formatLocalized(date, 'EEE, MMM d, yyyy');
+  }, []);
+
   const handleCreate = useCallback(async () => {
     if (!applicationId) return;
     try {
       const lease = await createLease.mutateAsync(applicationId);
-      toast.success('Draft lease created');
+      toast.success(t('contracts.new.toastCreated'));
       router.replace(`/contracts/${lease.id}`);
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Could not create the lease';
+      const message =
+        error instanceof Error ? error.message : t('contracts.new.toastCreateFailed');
       toast.error(message);
     }
-  }, [applicationId, createLease, router]);
+  }, [applicationId, createLease, router, t]);
 
   const header = (
     <Header
-      options={{ showBackButton: true, title: 'New contract', titlePosition: 'center' }}
+      options={{
+        showBackButton: true,
+        title: t('contracts.new.title'),
+        titlePosition: 'center',
+      }}
     />
   );
 
@@ -87,9 +94,9 @@ export default function NewContractScreen() {
           <View style={styles.centerWrap}>
             <EmptyState
               icon="document-text-outline"
-              title="Start from an application"
-              description="Leases are created from an approved tenant application. Open an approved application and choose “Create lease”."
-              actionText="View applications"
+              title={t('contracts.new.noApplicationTitle')}
+              description={t('contracts.new.noApplicationDescription')}
+              actionText={t('contracts.new.viewApplications')}
               actionIcon="albums-outline"
               onAction={() => router.replace('/applications')}
             />
@@ -116,11 +123,11 @@ export default function NewContractScreen() {
         {header}
         <View style={styles.centerWrap}>
           <ErrorState
-            title="Application unavailable"
+            title={t('contracts.new.applicationUnavailableTitle')}
             description={
-              applicationQuery.error?.message ?? 'This application could not be loaded.'
+              applicationQuery.error?.message ?? t('contracts.new.loadFailedDescription')
             }
-            retryLabel="Go back"
+            retryLabel={t('contracts.new.goBack')}
             onRetry={() => router.back()}
           />
         </View>
@@ -129,7 +136,9 @@ export default function NewContractScreen() {
   }
 
   const isApproved = application.status === TenantApplicationStatus.APPROVED;
-  const propertyTitle = property ? getPropertyTitle(property) : 'Property';
+  const propertyTitle = property
+    ? getPropertyTitle(property)
+    : t('contracts.new.propertyFallback');
   const imageSource = property ? getPropertyImageSource(property) : null;
 
   return (
@@ -147,22 +156,23 @@ export default function NewContractScreen() {
 
           <CardSurface>
             <H2 style={styles.title}>{propertyTitle}</H2>
-            <BloomText style={styles.subtitle}>
-              Create a draft lease from this application. You can edit the terms and
-              sign it on the next screen.
-            </BloomText>
+            <BloomText style={styles.subtitle}>{t('contracts.new.subtitle')}</BloomText>
           </CardSurface>
 
           <CardSurface>
-            <BloomText style={styles.sectionLabel}>Seeded terms</BloomText>
-            <DetailRow label="Move-in" value={formatDate(application.moveInDate)} />
-            <DetailRow label="Lease term" value={`${application.leaseTermMonths} months`} />
+            <BloomText style={styles.sectionLabel}>{t('contracts.new.seededTerms')}</BloomText>
+            <DetailRow
+              label={t('contracts.new.moveIn')}
+              value={formatDate(application.moveInDate)}
+            />
+            <DetailRow
+              label={t('contracts.new.leaseTerm')}
+              value={t('contracts.new.leaseTermMonths', { count: application.leaseTermMonths })}
+            />
           </CardSurface>
 
           {!isApproved ? (
-            <BloomText style={styles.warning}>
-              This application is not approved yet. Approve it first to create a lease.
-            </BloomText>
+            <BloomText style={styles.warning}>{t('contracts.new.notApprovedWarning')}</BloomText>
           ) : null}
         </ScrollView>
 
@@ -175,7 +185,7 @@ export default function NewContractScreen() {
             loading={createLease.isPending}
             style={styles.footerButton}
           >
-            Create draft lease
+            {t('contracts.new.createButton')}
           </Button>
         </View>
       </SafeAreaView>

--- a/packages/frontend/app/exchange/[id].tsx
+++ b/packages/frontend/app/exchange/[id].tsx
@@ -102,18 +102,18 @@ export default function ExchangeRequestDetailScreen() {
       try {
         await updateMutation.mutateAsync({ status });
         const toastKey: Record<string, string> = {
-          [ExchangeRequestStatus.CONFIRMED]: t('listing.exchange.toasts.confirmed', 'Exchange confirmed'),
-          [ExchangeRequestStatus.DECLINED]: t('listing.exchange.toasts.declined', 'Exchange declined'),
-          [ExchangeRequestStatus.CANCELLED]: t('listing.exchange.toasts.cancelled', 'Exchange cancelled'),
-          [ExchangeRequestStatus.COMPLETED]: t('listing.exchange.toasts.completed', 'Exchange completed'),
+          [ExchangeRequestStatus.CONFIRMED]: t('listing.exchange.toasts.confirmed'),
+          [ExchangeRequestStatus.DECLINED]: t('listing.exchange.toasts.declined'),
+          [ExchangeRequestStatus.CANCELLED]: t('listing.exchange.toasts.cancelled'),
+          [ExchangeRequestStatus.COMPLETED]: t('listing.exchange.toasts.completed'),
         };
-        toast.success(toastKey[status] ?? t('listing.exchange.toasts.updated', 'Exchange updated'));
+        toast.success(toastKey[status] ?? t('listing.exchange.toasts.updated'));
         setPendingAction(null);
       } catch (error) {
         const message =
           error instanceof Error
             ? error.message
-            : t('listing.exchange.errors.failed', 'Could not update request');
+            : t('listing.exchange.errors.failed');
         toast.error(message);
         setPendingAction(null);
       }
@@ -125,7 +125,7 @@ export default function ExchangeRequestDetailScreen() {
     <Header
       options={{
         showBackButton: true,
-        title: t('listing.exchange.detailTitle', 'Exchange'),
+        title: t('listing.exchange.detailTitle'),
         titlePosition: 'center',
       }}
     />
@@ -138,9 +138,9 @@ export default function ExchangeRequestDetailScreen() {
         <View style={styles.centerWrap}>
           <ErrorState
             icon="warning-outline"
-            title={t('listing.exchange.invalidId', 'Invalid exchange id')}
-            description={t('listing.exchange.invalidIdBody', 'The link is missing the exchange reference.')}
-            retryLabel={t('goBack', 'Go back')}
+            title={t('listing.exchange.invalidId')}
+            description={t('listing.exchange.invalidIdBody')}
+            retryLabel={t('goBack')}
             onRetry={() => router.back()}
           />
         </View>
@@ -165,9 +165,9 @@ export default function ExchangeRequestDetailScreen() {
         {header}
         <View style={styles.centerWrap}>
           <ErrorState
-            title={t('listing.exchange.unavailable', 'Exchange unavailable')}
-            description={requestQuery.error?.message ?? t('listing.exchange.unavailableBody', 'This exchange could not be loaded.')}
-            retryLabel={t('goBack', 'Go back')}
+            title={t('listing.exchange.unavailable')}
+            description={requestQuery.error?.message ?? t('listing.exchange.unavailableBody')}
+            retryLabel={t('goBack')}
             onRetry={() => router.back()}
           />
         </View>
@@ -175,12 +175,12 @@ export default function ExchangeRequestDetailScreen() {
     );
   }
 
-  const propertyTitle = property ? getPropertyTitle(property) : t('listing.exchange.cardFallback', 'Home');
+  const propertyTitle = property ? getPropertyTitle(property) : t('listing.exchange.cardFallback');
   const imageSource = property ? getPropertyImageSource(property) : null;
   const isSwap = request.mode === ExchangeMode.SWAP;
   const modeLabel = isSwap
-    ? t('listing.exchange.mode.swap', 'Home swap')
-    : t('listing.exchange.mode.host', 'Free hosting');
+    ? t('listing.exchange.mode.swap')
+    : t('listing.exchange.mode.host');
 
   // Whether the requested stay window has already ended (gates "complete"),
   // compared against the `now` snapshot captured above so render stays pure.
@@ -228,22 +228,22 @@ export default function ExchangeRequestDetailScreen() {
 
           <CardSurface>
             <BloomText style={styles.sectionLabel}>
-              {t('listing.exchange.detailsLabel', 'Exchange details')}
+              {t('listing.exchange.detailsLabel')}
             </BloomText>
-            <DetailRow label={t('listing.exchange.modeLabelShort', 'Type')} value={modeLabel} />
+            <DetailRow label={t('listing.exchange.modeLabelShort')} value={modeLabel} />
             <DetailRow
-              label={t('listing.exchange.requestedStay', 'Requested stay')}
+              label={t('listing.exchange.requestedStay')}
               value={formatWindow(request.requestedWindow)}
             />
             {isSwap && request.offeredWindow ? (
               <DetailRow
-                label={t('listing.exchange.offeredStay', 'Offered stay')}
+                label={t('listing.exchange.offeredStay')}
                 value={formatWindow(request.offeredWindow)}
               />
             ) : null}
             {isSwap && offeredProperty ? (
               <DetailRow
-                label={t('listing.exchange.offeredHome', 'Offered home')}
+                label={t('listing.exchange.offeredHome')}
                 value={getPropertyTitle(offeredProperty)}
               />
             ) : null}
@@ -252,7 +252,7 @@ export default function ExchangeRequestDetailScreen() {
           {request.message ? (
             <CardSurface>
               <BloomText style={styles.sectionLabel}>
-                {t('listing.exchange.messageHeading', 'Message')}
+                {t('listing.exchange.messageHeading')}
               </BloomText>
               <BloomText style={styles.messageText}>{request.message}</BloomText>
             </CardSurface>
@@ -269,7 +269,7 @@ export default function ExchangeRequestDetailScreen() {
                     disabled={updateMutation.isPending}
                     style={styles.actionButton}
                   >
-                    {t('listing.exchange.actions.approve', 'Approve')}
+                    {t('listing.exchange.actions.approve')}
                   </Button>
                   <Button
                     variant="secondary"
@@ -278,7 +278,7 @@ export default function ExchangeRequestDetailScreen() {
                     disabled={updateMutation.isPending}
                     style={styles.actionButton}
                   >
-                    {t('listing.exchange.actions.decline', 'Decline')}
+                    {t('listing.exchange.actions.decline')}
                   </Button>
                 </>
               ) : null}
@@ -290,7 +290,7 @@ export default function ExchangeRequestDetailScreen() {
                   disabled={updateMutation.isPending}
                   style={styles.actionButton}
                 >
-                  {t('listing.exchange.actions.complete', 'Mark completed')}
+                  {t('listing.exchange.actions.complete')}
                 </Button>
               ) : null}
               {showRequesterCancel ? (
@@ -301,7 +301,7 @@ export default function ExchangeRequestDetailScreen() {
                   disabled={updateMutation.isPending}
                   style={styles.actionButton}
                 >
-                  {t('listing.exchange.actions.cancel', 'Cancel request')}
+                  {t('listing.exchange.actions.cancel')}
                 </Button>
               ) : null}
             </View>
@@ -318,25 +318,25 @@ export default function ExchangeRequestDetailScreen() {
 
           {request.status === ExchangeRequestStatus.COMPLETED && alreadyReviewed ? (
             <BloomText style={styles.note}>
-              {t('listing.exchange.review.alreadyLeft', 'You’ve already reviewed this exchange.')}
+              {t('listing.exchange.review.alreadyLeft')}
             </BloomText>
           ) : null}
         </ScrollView>
 
         <ConfirmDialog
           visible={pendingAction === 'confirm'}
-          title={t('listing.exchange.confirm.approveTitle', 'Approve exchange?')}
-          message={t('listing.exchange.confirm.approveBody', 'The requester will be notified and the dates will be marked confirmed.')}
-          confirmLabel={t('listing.exchange.actions.approve', 'Approve')}
+          title={t('listing.exchange.confirm.approveTitle')}
+          message={t('listing.exchange.confirm.approveBody')}
+          confirmLabel={t('listing.exchange.actions.approve')}
           loading={updateMutation.isPending}
           onConfirm={() => handleAction(ExchangeRequestStatus.CONFIRMED)}
           onCancel={() => setPendingAction(null)}
         />
         <ConfirmDialog
           visible={pendingAction === 'decline'}
-          title={t('listing.exchange.confirm.declineTitle', 'Decline exchange?')}
-          message={t('listing.exchange.confirm.declineBody', 'The requester will be notified that this request was declined.')}
-          confirmLabel={t('listing.exchange.actions.decline', 'Decline')}
+          title={t('listing.exchange.confirm.declineTitle')}
+          message={t('listing.exchange.confirm.declineBody')}
+          confirmLabel={t('listing.exchange.actions.decline')}
           confirmDestructive
           loading={updateMutation.isPending}
           onConfirm={() => handleAction(ExchangeRequestStatus.DECLINED)}
@@ -344,9 +344,9 @@ export default function ExchangeRequestDetailScreen() {
         />
         <ConfirmDialog
           visible={pendingAction === 'cancel'}
-          title={t('listing.exchange.confirm.cancelTitle', 'Cancel request?')}
-          message={t('listing.exchange.confirm.cancelBody', 'This will withdraw your exchange request.')}
-          confirmLabel={t('listing.exchange.confirm.cancelConfirm', 'Yes, cancel')}
+          title={t('listing.exchange.confirm.cancelTitle')}
+          message={t('listing.exchange.confirm.cancelBody')}
+          confirmLabel={t('listing.exchange.confirm.cancelConfirm')}
           confirmDestructive
           loading={updateMutation.isPending}
           onConfirm={() => handleAction(ExchangeRequestStatus.CANCELLED)}
@@ -354,9 +354,9 @@ export default function ExchangeRequestDetailScreen() {
         />
         <ConfirmDialog
           visible={pendingAction === 'complete'}
-          title={t('listing.exchange.confirm.completeTitle', 'Mark as completed?')}
-          message={t('listing.exchange.confirm.completeBody', 'Confirm the stay happened. You’ll then be able to leave a review.')}
-          confirmLabel={t('listing.exchange.actions.complete', 'Mark completed')}
+          title={t('listing.exchange.confirm.completeTitle')}
+          message={t('listing.exchange.confirm.completeBody')}
+          confirmLabel={t('listing.exchange.actions.complete')}
           loading={updateMutation.isPending}
           onConfirm={() => handleAction(ExchangeRequestStatus.COMPLETED)}
           onCancel={() => setPendingAction(null)}

--- a/packages/frontend/app/exchange/requests.tsx
+++ b/packages/frontend/app/exchange/requests.tsx
@@ -36,13 +36,13 @@ import { radius, spacing } from '@/constants/styles';
 type RoleView = 'guest' | 'host';
 type StatusFilter = 'all' | ExchangeRequestStatus;
 
-const STATUS_FILTERS: { id: StatusFilter; i18nKey: string; fallback: string }[] = [
-  { id: 'all', i18nKey: 'common.all', fallback: 'All' },
-  { id: ExchangeRequestStatus.PENDING, i18nKey: 'listing.exchange.status.pending', fallback: 'Pending' },
-  { id: ExchangeRequestStatus.CONFIRMED, i18nKey: 'listing.exchange.status.confirmed', fallback: 'Confirmed' },
-  { id: ExchangeRequestStatus.COMPLETED, i18nKey: 'listing.exchange.status.completed', fallback: 'Completed' },
-  { id: ExchangeRequestStatus.DECLINED, i18nKey: 'listing.exchange.status.declined', fallback: 'Declined' },
-  { id: ExchangeRequestStatus.CANCELLED, i18nKey: 'listing.exchange.status.cancelled', fallback: 'Cancelled' },
+const STATUS_FILTERS: { id: StatusFilter; i18nKey: string }[] = [
+  { id: 'all', i18nKey: 'common.all' },
+  { id: ExchangeRequestStatus.PENDING, i18nKey: 'listing.exchange.status.pending' },
+  { id: ExchangeRequestStatus.CONFIRMED, i18nKey: 'listing.exchange.status.confirmed' },
+  { id: ExchangeRequestStatus.COMPLETED, i18nKey: 'listing.exchange.status.completed' },
+  { id: ExchangeRequestStatus.DECLINED, i18nKey: 'listing.exchange.status.declined' },
+  { id: ExchangeRequestStatus.CANCELLED, i18nKey: 'listing.exchange.status.cancelled' },
 ];
 
 /** Host inline approve/decline for a pending request. Owns its own mutation. */
@@ -59,14 +59,14 @@ const HostPendingActions: React.FC<{ request: ExchangeRequest }> = ({ request })
       await mutation.mutateAsync({ status });
       toast.success(
         status === ExchangeRequestStatus.CONFIRMED
-          ? t('listing.exchange.toasts.confirmed', 'Exchange confirmed')
-          : t('listing.exchange.toasts.declined', 'Exchange declined'),
+          ? t('listing.exchange.toasts.confirmed')
+          : t('listing.exchange.toasts.declined'),
       );
     } catch (error) {
       const message =
         error instanceof Error
           ? error.message
-          : t('listing.exchange.errors.failed', 'Could not update request');
+          : t('listing.exchange.errors.failed');
       toast.error(message);
     } finally {
       setBusy(null);
@@ -82,7 +82,7 @@ const HostPendingActions: React.FC<{ request: ExchangeRequest }> = ({ request })
         disabled={mutation.isPending}
         onPress={() => handle(ExchangeRequestStatus.CONFIRMED)}
       >
-        {t('listing.exchange.actions.approve', 'Approve')}
+        {t('listing.exchange.actions.approve')}
       </Button>
       <Button
         variant="secondary"
@@ -91,7 +91,7 @@ const HostPendingActions: React.FC<{ request: ExchangeRequest }> = ({ request })
         disabled={mutation.isPending}
         onPress={() => handle(ExchangeRequestStatus.DECLINED)}
       >
-        {t('listing.exchange.actions.decline', 'Decline')}
+        {t('listing.exchange.actions.decline')}
       </Button>
     </>
   );
@@ -123,7 +123,7 @@ export default function ExchangeRequestsScreen() {
     <Header
       options={{
         showBackButton: true,
-        title: t('listing.exchange.requestsTitle', 'Exchanges'),
+        title: t('listing.exchange.requestsTitle'),
         titlePosition: 'center',
       }}
     />
@@ -137,12 +137,9 @@ export default function ExchangeRequestsScreen() {
           <View style={styles.centerWrap}>
             <EmptyState
               icon="swap-horizontal"
-              title={t('listing.exchange.signInTitle', 'Sign in to see your exchanges')}
-              description={t(
-                'listing.exchange.signInBody',
-                'Your home swaps and hosting requests live here.',
-              )}
-              actionText={t('common.signIn', 'Sign in')}
+              title={t('listing.exchange.signInTitle')}
+              description={t('listing.exchange.signInBody')}
+              actionText={t('common.signIn')}
               actionIcon="log-in-outline"
               onAction={() => showSignInModal()}
             />
@@ -160,12 +157,12 @@ export default function ExchangeRequestsScreen() {
           {/* Role segmented toggle */}
           <View style={styles.segmented}>
             <SegmentButton
-              label={t('listing.exchange.asGuest', 'My requests')}
+              label={t('listing.exchange.asGuest')}
               active={role === 'guest'}
               onPress={() => setRole('guest')}
             />
             <SegmentButton
-              label={t('listing.exchange.asHost', 'For my homes')}
+              label={t('listing.exchange.asHost')}
               active={role === 'host'}
               onPress={() => setRole('host')}
             />
@@ -187,7 +184,7 @@ export default function ExchangeRequestsScreen() {
                   selected={active}
                   onPress={() => setStatusFilter(entry.id)}
                 >
-                  {t(entry.i18nKey, entry.fallback)}
+                  {t(entry.i18nKey)}
                 </Chip>
               );
             })}
@@ -198,9 +195,9 @@ export default function ExchangeRequestsScreen() {
           {query.isError ? (
             <ErrorState
               icon="cloud-offline-outline"
-              title={t('listing.exchange.loadErrorTitle', 'Couldn’t load exchanges')}
-              description={query.error?.message ?? t('common.tryAgain', 'Please try again.')}
-              retryLabel={t('common.retry', 'Retry')}
+              title={t('listing.exchange.loadErrorTitle')}
+              description={query.error?.message ?? t('common.tryAgain')}
+              retryLabel={t('common.retry')}
               onRetry={() => query.refetch()}
             />
           ) : null}
@@ -211,19 +208,13 @@ export default function ExchangeRequestsScreen() {
                 icon="swap-horizontal"
                 title={
                   role === 'guest'
-                    ? t('listing.exchange.emptyGuestTitle', 'No exchange requests yet')
-                    : t('listing.exchange.emptyHostTitle', 'No requests for your homes yet')
+                    ? t('listing.exchange.emptyGuestTitle')
+                    : t('listing.exchange.emptyHostTitle')
                 }
                 description={
                   role === 'guest'
-                    ? t(
-                        'listing.exchange.emptyGuestBody',
-                        'When you request a swap or hosting stay it shows up here.',
-                      )
-                    : t(
-                        'listing.exchange.emptyHostBody',
-                        'When someone proposes an exchange with your home it shows up here.',
-                      )
+                    ? t('listing.exchange.emptyGuestBody')
+                    : t('listing.exchange.emptyHostBody')
                 }
               />
             </View>

--- a/packages/frontend/app/horizon/index.tsx
+++ b/packages/frontend/app/horizon/index.tsx
@@ -18,31 +18,23 @@ export default function HorizonPage() {
   }[] = [
     {
       icon: 'home-outline',
-      title: t('Fair Housing'),
-      description: t(
-        'Access to affordable housing in 120+ cities worldwide with standardized ethical rental agreements',
-      ),
+      title: t('horizon.page.benefits.fairHousing.title'),
+      description: t('horizon.page.benefits.fairHousing.description'),
     },
     {
       icon: 'medkit-outline',
-      title: t('Healthcare Access'),
-      description: t(
-        'Universal healthcare coverage with partner clinics and telehealth services in every Horizon city',
-      ),
+      title: t('horizon.page.benefits.healthcare.title'),
+      description: t('horizon.page.benefits.healthcare.description'),
     },
     {
       icon: 'airplane-outline',
-      title: t('Travel Network'),
-      description: t(
-        'Discounted transportation and accommodation when traveling between Horizon locations',
-      ),
+      title: t('horizon.page.benefits.travel.title'),
+      description: t('horizon.page.benefits.travel.description'),
     },
     {
       icon: 'people-outline',
-      title: t('Community Support'),
-      description: t(
-        'Connect with local members for cultural integration, language exchange, and social activities',
-      ),
+      title: t('horizon.page.benefits.community.title'),
+      description: t('horizon.page.benefits.community.description'),
     },
   ];
 
@@ -51,7 +43,7 @@ export default function HorizonPage() {
       <Header
         options={{
           showBackButton: true,
-          title: t('Horizon Initiative'),
+          title: t('horizon.title'),
           titlePosition: 'center',
         }}
       />
@@ -61,31 +53,27 @@ export default function HorizonPage() {
         <View style={styles.heroSection}>
           <View style={styles.heroOverlay}>
             <Ionicons name="globe-outline" size={80} color={colors.ratingStar} style={styles.heroIcon} />
-            <Text style={styles.heroTitle}>{t('Global Housing Initiative')}</Text>
+            <Text style={styles.heroTitle}>{t('horizon.page.heroTitle')}</Text>
             <Text style={styles.heroSubtitle}>
-              {t('Creating a world of ethical housing, healthcare, and mobility')}
+              {t('horizon.page.heroSubtitle')}
             </Text>
           </View>
         </View>
 
         {/* About Section */}
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>{t('About Horizon')}</Text>
+          <Text style={styles.sectionTitle}>{t('horizon.page.aboutTitle')}</Text>
           <Text style={styles.sectionText}>
-            {t(
-              'Horizon is a global initiative designed to make housing more accessible, affordable, and ethical for everyone. By joining a network of properties across 120+ cities worldwide, members gain access to fair housing, healthcare benefits, and travel support.',
-            )}
+            {t('horizon.page.aboutBody1')}
           </Text>
           <Text style={styles.sectionText}>
-            {t(
-              'Our mission is to create sustainable living environments that foster community and wellbeing while reducing the environmental impact of housing.',
-            )}
+            {t('horizon.page.aboutBody2')}
           </Text>
         </View>
 
         {/* Benefits Section */}
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>{t('Member Benefits')}</Text>
+          <Text style={styles.sectionTitle}>{t('horizon.page.benefitsTitle')}</Text>
 
           {benefitItems.map((item, index) => (
             <View key={index} style={styles.benefitItem}>
@@ -102,18 +90,16 @@ export default function HorizonPage() {
 
         {/* How It Works */}
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>{t('How It Works')}</Text>
+          <Text style={styles.sectionTitle}>{t('horizon.page.howItWorksTitle')}</Text>
 
           <View style={styles.stepContainer}>
             <View style={styles.stepCircle}>
               <Text style={styles.stepNumber}>1</Text>
             </View>
             <View style={styles.stepContent}>
-              <Text style={styles.stepTitle}>{t('Apply for Membership')}</Text>
+              <Text style={styles.stepTitle}>{t('horizon.page.steps.apply.title')}</Text>
               <Text style={styles.stepDescription}>
-                {t(
-                  'Complete your profile and submit a membership application with your housing needs and preferences.',
-                )}
+                {t('horizon.page.steps.apply.description')}
               </Text>
             </View>
           </View>
@@ -123,11 +109,9 @@ export default function HorizonPage() {
               <Text style={styles.stepNumber}>2</Text>
             </View>
             <View style={styles.stepContent}>
-              <Text style={styles.stepTitle}>{t('Get Verified')}</Text>
+              <Text style={styles.stepTitle}>{t('horizon.page.steps.verify.title')}</Text>
               <Text style={styles.stepDescription}>
-                {t(
-                  'Our team reviews your application and verifies your identity and background information.',
-                )}
+                {t('horizon.page.steps.verify.description')}
               </Text>
             </View>
           </View>
@@ -137,11 +121,9 @@ export default function HorizonPage() {
               <Text style={styles.stepNumber}>3</Text>
             </View>
             <View style={styles.stepContent}>
-              <Text style={styles.stepTitle}>{t('Access the Network')}</Text>
+              <Text style={styles.stepTitle}>{t('horizon.page.steps.access.title')}</Text>
               <Text style={styles.stepDescription}>
-                {t(
-                  'Once approved, browse and book properties across our global network with priority access.',
-                )}
+                {t('horizon.page.steps.access.description')}
               </Text>
             </View>
           </View>
@@ -149,9 +131,9 @@ export default function HorizonPage() {
 
         {/* Join Now */}
         <View style={styles.joinSection}>
-          <Text style={styles.joinTitle}>{t('Ready to join Horizon?')}</Text>
+          <Text style={styles.joinTitle}>{t('horizon.page.joinTitle')}</Text>
           <Text style={styles.joinDescription}>
-            {t('Apply today and take the first step toward ethical, accessible housing worldwide.')}
+            {t('horizon.page.joinSubtitle')}
           </Text>
           <TouchableOpacity
             style={styles.joinButton}
@@ -159,13 +141,13 @@ export default function HorizonPage() {
               Linking.openURL('https://oxy.so/horizon').catch(() => undefined);
             }}
           >
-            <Text style={styles.joinButtonText}>{t('Apply for Membership')}</Text>
+            <Text style={styles.joinButtonText}>{t('horizon.page.steps.apply.title')}</Text>
           </TouchableOpacity>
         </View>
 
         {/* Testimonials */}
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>{t('Member Stories')}</Text>
+          <Text style={styles.sectionTitle}>{t('horizon.page.storiesTitle')}</Text>
 
           <View style={styles.testimonialCard}>
             <View style={styles.testimonialHeader}>
@@ -178,9 +160,7 @@ export default function HorizonPage() {
               </View>
             </View>
             <Text style={styles.testimonialText}>
-              {t(
-                'Horizon made my relocation so much easier. I found an ethical apartment in Berlin within a week and the healthcare coverage saved me when I needed emergency care.',
-              )}
+              {t('horizon.page.story1')}
             </Text>
           </View>
 
@@ -195,9 +175,7 @@ export default function HorizonPage() {
               </View>
             </View>
             <Text style={styles.testimonialText}>
-              {t(
-                'As a digital nomad, having access to quality housing in multiple cities has been life-changing. The community aspect is what makes Horizon truly special.',
-              )}
+              {t('horizon.page.story2')}
             </Text>
           </View>
         </View>

--- a/packages/frontend/app/host/calendar.tsx
+++ b/packages/frontend/app/host/calendar.tsx
@@ -30,6 +30,7 @@ import * as Skeleton from '@oxyhq/bloom/skeleton';
 import { TextFieldInput } from '@oxyhq/bloom/text-field';
 import { Text as BloomText, H2 } from '@oxyhq/bloom/typography';
 import { useOxy, showSignInModal } from '@oxyhq/services';
+import { useTranslation } from 'react-i18next';
 import {
   AvailabilityWindow,
   AvailabilityWindowStatus,
@@ -69,9 +70,8 @@ const INITIAL_BLOCK_STATE: BlockDialogState = {
   reason: '',
 };
 
-const HOST_CALENDAR_TITLE = 'Host calendar';
-
 export default function HostCalendarScreen() {
+  const { t } = useTranslation();
   const router = useRouter();
   const { oxyServices, activeSessionId } = useOxy();
   const isAuthed = Boolean(oxyServices && activeSessionId);
@@ -148,7 +148,7 @@ export default function HostCalendarScreen() {
     try {
       const property = await propertyService.getPropertyById(effectivePropertyId);
       if (!property) {
-        throw new Error('Property not found');
+        throw new Error(t('host.calendar.propertyNotFound'));
       }
       const next: AvailabilityWindow = {
         start: blockState.start.toISOString(),
@@ -165,10 +165,10 @@ export default function HostCalendarScreen() {
       queryClient.invalidateQueries({
         queryKey: reservationKeys.availability(effectivePropertyId),
       });
-      toast.success('Dates blocked');
+      toast.success(t('host.calendar.toastBlocked'));
       closeDialog();
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Block failed';
+      const message = error instanceof Error ? error.message : t('host.calendar.toastBlockFailed');
       toast.error(message);
     } finally {
       setSubmitting(false);
@@ -179,6 +179,7 @@ export default function HostCalendarScreen() {
     closeDialog,
     effectivePropertyId,
     queryClient,
+    t,
   ]);
 
   if (!isAuthed) {
@@ -187,7 +188,7 @@ export default function HostCalendarScreen() {
         <Header
           options={{
             showBackButton: true,
-            title: HOST_CALENDAR_TITLE,
+            title: t('host.calendar.title'),
             titlePosition: 'center',
           }}
         />
@@ -195,9 +196,9 @@ export default function HostCalendarScreen() {
           <View style={styles.emptyWrap}>
             <EmptyState
               icon="calendar-outline"
-              title="Sign in to manage your calendar"
-              description="Block dates and track bookings from one place."
-              actionText="Sign in"
+              title={t('host.calendar.signInTitle')}
+              description={t('host.calendar.signInDescription')}
+              actionText={t('host.calendar.signIn')}
               actionIcon="log-in-outline"
               onAction={() => showSignInModal()}
             />
@@ -213,7 +214,7 @@ export default function HostCalendarScreen() {
         <Header
           options={{
             showBackButton: true,
-            title: HOST_CALENDAR_TITLE,
+            title: t('host.calendar.title'),
             titlePosition: 'center',
           }}
         />
@@ -238,18 +239,18 @@ export default function HostCalendarScreen() {
         <Header
           options={{
             showBackButton: true,
-            title: HOST_CALENDAR_TITLE,
+            title: t('host.calendar.title'),
             titlePosition: 'center',
           }}
         />
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
           <ErrorState
             icon="cloud-offline-outline"
-            title="Couldn't load your properties"
+            title={t('host.calendar.loadPropertiesError')}
             description={
               typeof propertiesQuery.error === 'string'
                 ? propertiesQuery.error
-                : 'Please try again.'
+                : t('host.calendar.tryAgain')
             }
             onRetry={() => propertiesQuery.refetch()}
           />
@@ -264,7 +265,7 @@ export default function HostCalendarScreen() {
         <Header
           options={{
             showBackButton: true,
-            title: HOST_CALENDAR_TITLE,
+            title: t('host.calendar.title'),
             titlePosition: 'center',
           }}
         />
@@ -272,9 +273,9 @@ export default function HostCalendarScreen() {
           <View style={styles.emptyWrap}>
             <EmptyState
               icon="home-outline"
-              title="Add your first property"
-              description="List a place so guests can request dates here."
-              actionText="Create listing"
+              title={t('host.calendar.emptyTitle')}
+              description={t('host.calendar.emptyDescription')}
+              actionText={t('host.calendar.createListing')}
               actionIcon="add"
               onAction={() => router.push('/properties/create')}
             />
@@ -289,16 +290,16 @@ export default function HostCalendarScreen() {
       <Header
         options={{
           showBackButton: true,
-          title: HOST_CALENDAR_TITLE,
+          title: t('host.calendar.title'),
           titlePosition: 'center',
         }}
       />
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>
         <ScrollView contentContainerStyle={styles.content}>
           <View style={styles.pickerCard}>
-            <SectionEyebrow>Property</SectionEyebrow>
+            <SectionEyebrow>{t('host.calendar.property')}</SectionEyebrow>
             <Menu>
-              <MenuTrigger label="Choose property">
+              <MenuTrigger label={t('host.calendar.chooseProperty')}>
                 {({ props: triggerProps }) => (
                   <Button
                     onPress={triggerProps.onPress}
@@ -318,7 +319,7 @@ export default function HostCalendarScreen() {
                   >
                     {selectedProperty
                       ? getPropertyTitle(selectedProperty)
-                      : 'Choose property'}
+                      : t('host.calendar.chooseProperty')}
                   </Button>
                 )}
               </MenuTrigger>
@@ -355,10 +356,10 @@ export default function HostCalendarScreen() {
               </View>
 
               <View style={styles.legendRow}>
-                <LegendChip color={colors.successSubtle} dot={colors.success} label="Confirmed" />
-                <LegendChip color={colors.warningSubtle} dot={colors.warning} label="Pending" />
-                <LegendChip color={colors.blockedSubtle} dot={colors.danger} label="Blocked" />
-                <LegendChip color={colors.mutedSubtle} dot={colors.COLOR_BLACK_LIGHT_4} label="Available" />
+                <LegendChip color={colors.successSubtle} dot={colors.success} label={t('host.calendar.legendConfirmed')} />
+                <LegendChip color={colors.warningSubtle} dot={colors.warning} label={t('host.calendar.legendPending')} />
+                <LegendChip color={colors.blockedSubtle} dot={colors.danger} label={t('host.calendar.legendBlocked')} />
+                <LegendChip color={colors.mutedSubtle} dot={colors.COLOR_BLACK_LIGHT_4} label={t('host.calendar.legendAvailable')} />
               </View>
 
               <View style={styles.calendarCard}>
@@ -369,9 +370,9 @@ export default function HostCalendarScreen() {
                 ) : availabilityQuery.isError ? (
                   <ErrorState
                     icon="cloud-offline-outline"
-                    title="Couldn't load availability"
+                    title={t('host.calendar.availabilityError')}
                     description={
-                      availabilityQuery.error?.message ?? 'Please try again.'
+                      availabilityQuery.error?.message ?? t('host.calendar.tryAgain')
                     }
                     onRetry={() => availabilityQuery.refetch()}
                   />
@@ -392,28 +393,31 @@ export default function HostCalendarScreen() {
 
         <ConfirmDialog
           visible={blockState.visible}
-          title="Block these dates"
+          title={t('host.calendar.blockTitle')}
           message={
             blockState.start && blockState.end
-              ? `${format(blockState.start, 'EEE, MMM d')} → ${format(
-                  new Date(blockState.end.getTime() - 24 * 60 * 60 * 1000),
-                  'EEE, MMM d, yyyy',
-                )}`
-              : 'Choose how long these dates are unavailable.'
+              ? t('host.calendar.blockBodyRange', {
+                  start: format(blockState.start, 'EEE, MMM d'),
+                  end: format(
+                    new Date(blockState.end.getTime() - 24 * 60 * 60 * 1000),
+                    'EEE, MMM d, yyyy',
+                  ),
+                })
+              : t('host.calendar.blockBodySingle')
           }
-          confirmLabel="Block"
+          confirmLabel={t('host.calendar.blockConfirm')}
           loading={submitting}
           onConfirm={handleConfirmBlock}
           onCancel={closeDialog}
         >
           <TextFieldInput
-            label="Reason (optional)"
+            label={t('host.calendar.blockReasonLabel')}
             value={blockState.reason}
             onChangeText={(reason) =>
               setBlockState((state) => ({ ...state, reason }))
             }
             editable={!submitting}
-            placeholder="Maintenance, personal use, ..."
+            placeholder={t('host.calendar.blockReasonPlaceholder')}
           />
         </ConfirmDialog>
       </SafeAreaView>

--- a/packages/frontend/app/host/reservations.tsx
+++ b/packages/frontend/app/host/reservations.tsx
@@ -16,6 +16,7 @@ import { Chip } from '@oxyhq/bloom/chip';
 import * as Skeleton from '@oxyhq/bloom/skeleton';
 import { H2 } from '@oxyhq/bloom/typography';
 import { useOxy, showSignInModal } from '@oxyhq/services';
+import { useTranslation } from 'react-i18next';
 import {
   Reservation,
   ReservationStatus,
@@ -34,13 +35,13 @@ import { colors } from '@/styles/colors';
 
 type StatusFilter = 'all' | ReservationStatus;
 
-const FILTERS: { id: StatusFilter; label: string }[] = [
-  { id: 'all', label: 'All' },
-  { id: ReservationStatus.PENDING, label: 'Pending' },
-  { id: ReservationStatus.CONFIRMED, label: 'Confirmed' },
-  { id: ReservationStatus.DECLINED, label: 'Declined' },
-  { id: ReservationStatus.CANCELLED, label: 'Cancelled' },
-  { id: ReservationStatus.COMPLETED, label: 'Completed' },
+const FILTER_ENTRIES: { id: StatusFilter; labelKey: string }[] = [
+  { id: 'all', labelKey: 'host.reservations.filterAll' },
+  { id: ReservationStatus.PENDING, labelKey: 'host.reservations.filterPending' },
+  { id: ReservationStatus.CONFIRMED, labelKey: 'host.reservations.filterConfirmed' },
+  { id: ReservationStatus.DECLINED, labelKey: 'host.reservations.filterDeclined' },
+  { id: ReservationStatus.CANCELLED, labelKey: 'host.reservations.filterCancelled' },
+  { id: ReservationStatus.COMPLETED, labelKey: 'host.reservations.filterCompleted' },
 ];
 
 interface PendingActionsProps {
@@ -48,6 +49,7 @@ interface PendingActionsProps {
 }
 
 const PendingActions: React.FC<PendingActionsProps> = ({ reservation }) => {
+  const { t } = useTranslation();
   const router = useRouter();
   const mutation = useUpdateReservation(reservation.id);
   const [busyAction, setBusyAction] = useState<'confirm' | 'decline' | null>(
@@ -60,11 +62,11 @@ const PendingActions: React.FC<PendingActionsProps> = ({ reservation }) => {
       await mutation.mutateAsync({ status: target });
       toast.success(
         target === ReservationStatus.CONFIRMED
-          ? 'Reservation confirmed'
-          : 'Reservation declined',
+          ? t('host.reservations.toastConfirmed')
+          : t('host.reservations.toastDeclined'),
       );
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Update failed';
+      const message = error instanceof Error ? error.message : t('host.reservations.toastUpdateFailed');
       toast.error(message);
     } finally {
       setBusyAction(null);
@@ -82,7 +84,7 @@ const PendingActions: React.FC<PendingActionsProps> = ({ reservation }) => {
         disabled={mutation.isPending}
         onPress={() => handle(ReservationStatus.CONFIRMED)}
       >
-        Approve
+        {t('host.reservations.approve')}
       </Button>
       <Button
         variant="secondary"
@@ -91,14 +93,14 @@ const PendingActions: React.FC<PendingActionsProps> = ({ reservation }) => {
         disabled={mutation.isPending}
         onPress={() => handle(ReservationStatus.DECLINED)}
       >
-        Decline
+        {t('host.reservations.decline')}
       </Button>
       <Button
         variant="ghost"
         size="small"
         onPress={() => router.push(`/reservations/${reservation.id}`)}
       >
-        View
+        {t('host.reservations.view')}
       </Button>
     </>
   );
@@ -120,6 +122,7 @@ const ReservationListSkeleton: React.FC = () => (
 );
 
 export default function HostReservationsScreen() {
+  const { t } = useTranslation();
   const { oxyServices, activeSessionId } = useOxy();
   const isAuthed = Boolean(oxyServices && activeSessionId);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
@@ -138,13 +141,18 @@ export default function HostReservationsScreen() {
     [reservationsQuery.data?.items],
   );
 
+  const filters = FILTER_ENTRIES.map((entry) => ({
+    id: entry.id,
+    label: t(entry.labelKey),
+  }));
+
   if (!isAuthed) {
     return (
       <View style={styles.root}>
         <Header
           options={{
             showBackButton: true,
-            title: 'Reservations',
+            title: t('host.reservations.title'),
             titlePosition: 'center',
           }}
         />
@@ -152,9 +160,9 @@ export default function HostReservationsScreen() {
           <View style={styles.emptyWrap}>
             <EmptyState
               icon="mail-unread-outline"
-              title="Sign in to manage reservations"
-              description="Approve or decline guest requests from one place."
-              actionText="Sign in"
+              title={t('host.reservations.signInTitle')}
+              description={t('host.reservations.signInDescription')}
+              actionText={t('host.reservations.signIn')}
               actionIcon="log-in-outline"
               onAction={() => showSignInModal()}
             />
@@ -166,15 +174,15 @@ export default function HostReservationsScreen() {
 
   const activeLabel =
     statusFilter === 'all'
-      ? 'All reservations'
-      : FILTERS.find((entry) => entry.id === statusFilter)?.label ?? 'Reservations';
+      ? t('host.reservations.allReservations')
+      : filters.find((entry) => entry.id === statusFilter)?.label ?? t('host.reservations.title');
 
   return (
     <View style={styles.root}>
       <Header
         options={{
           showBackButton: true,
-          title: 'Reservations',
+          title: t('host.reservations.title'),
           titlePosition: 'center',
         }}
       />
@@ -185,7 +193,7 @@ export default function HostReservationsScreen() {
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={styles.filterRow}
           >
-            {FILTERS.map((entry) => {
+            {filters.map((entry) => {
               const isActive = statusFilter === entry.id;
               return (
                 <Chip
@@ -206,9 +214,9 @@ export default function HostReservationsScreen() {
           {reservationsQuery.isError ? (
             <ErrorState
               icon="cloud-offline-outline"
-              title="Couldn't load reservations"
+              title={t('host.reservations.loadError')}
               description={
-                reservationsQuery.error?.message ?? 'Please try again.'
+                reservationsQuery.error?.message ?? t('host.reservations.tryAgain')
               }
               onRetry={() => reservationsQuery.refetch()}
             />
@@ -220,8 +228,8 @@ export default function HostReservationsScreen() {
             <View style={styles.emptyWrap}>
               <EmptyState
                 icon="mail-outline"
-                title="No reservations yet"
-                description="When guests book your places, requests will show up here."
+                title={t('host.reservations.emptyTitle')}
+                description={t('host.reservations.emptyDescription')}
               />
             </View>
           ) : null}
@@ -229,7 +237,7 @@ export default function HostReservationsScreen() {
           {items.length > 0 ? (
             <View style={styles.listWrap}>
               <View style={styles.sectionHeader}>
-                <SectionEyebrow>Reservations</SectionEyebrow>
+                <SectionEyebrow>{t('host.reservations.title')}</SectionEyebrow>
                 <H2 style={styles.sectionTitle}>{activeLabel}</H2>
               </View>
               {items.map((reservation) => (

--- a/packages/frontend/app/landlord/applications/[id].tsx
+++ b/packages/frontend/app/landlord/applications/[id].tsx
@@ -21,6 +21,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
 import { format } from 'date-fns';
+import { useTranslation } from 'react-i18next';
+import i18next from 'i18next';
 import { toast } from '@/lib/sonner';
 import { Ionicons } from '@expo/vector-icons';
 import { Button } from '@oxyhq/bloom/button';
@@ -64,39 +66,31 @@ const REVIEW_TRANSITIONS: Record<ReviewAction, TenantApplicationStatus> = {
   reject: TenantApplicationStatus.REJECTED,
 };
 
-const REVIEW_LABELS: Record<ReviewAction, {
-  title: string;
-  message: string;
-  confirmLabel: string;
-  successToast: string;
-}> = {
+const getReviewLabels = (
+  t: (key: string) => string,
+): Record<
+  ReviewAction,
+  { title: string; message: string; confirmLabel: string; successToast: string }
+> => ({
   reviewing: {
-    title: 'Mark as reviewing?',
-    message:
-      'Lets the applicant know you have their application open. You can still approve or reject afterwards.',
-    confirmLabel: 'Mark as reviewing',
-    successToast: 'Application moved to reviewing',
+    title: t('applications.landlord.review.reviewing.title'),
+    message: t('applications.landlord.review.reviewing.message'),
+    confirmLabel: t('applications.landlord.review.reviewing.confirm'),
+    successToast: t('applications.landlord.review.reviewing.successToast'),
   },
   approve: {
-    title: 'Approve application?',
-    message:
-      'The applicant will be notified and can move forward to sign the lease.',
-    confirmLabel: 'Approve',
-    successToast: 'Application approved',
+    title: t('applications.landlord.review.approve.title'),
+    message: t('applications.landlord.review.approve.message'),
+    confirmLabel: t('applications.landlord.review.approve.confirm'),
+    successToast: t('applications.landlord.review.approve.successToast'),
   },
   reject: {
-    title: 'Reject application?',
-    message:
-      'The applicant will be notified. This cannot be undone — but they can submit a new application later.',
-    confirmLabel: 'Reject',
-    successToast: 'Application rejected',
+    title: t('applications.landlord.review.reject.title'),
+    message: t('applications.landlord.review.reject.message'),
+    confirmLabel: t('applications.landlord.review.reject.confirm'),
+    successToast: t('applications.landlord.review.reject.successToast'),
   },
-};
-
-const formatEmployment = (status: string): string =>
-  status.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-
-const formatRelationship = formatEmployment;
+});
 
 const formatCurrency = (amount: number): string => {
   try {
@@ -136,7 +130,7 @@ const openDocument = (url: string) => {
     return;
   }
   Linking.openURL(url).catch(() => {
-    toast.error('Could not open the document.');
+    toast.error(i18next.t('applications.landlord.toastOpenDocumentFailed'));
   });
 };
 
@@ -193,7 +187,10 @@ interface DocumentRowProps {
   document: TenantApplicationDocument;
 }
 
-const DocumentRow: React.FC<DocumentRowProps> = ({ document }) => (
+const DocumentRow: React.FC<DocumentRowProps> = ({ document }) => {
+  const { t } = useTranslation();
+
+  return (
   <Pressable
     onPress={() => openDocument(document.url)}
     style={styles.documentRow}
@@ -212,7 +209,7 @@ const DocumentRow: React.FC<DocumentRowProps> = ({ document }) => (
         {document.filename}
       </BloomText>
       <BloomText style={styles.documentType}>
-        {formatRelationship(document.type)}
+        {t(`applications.documentType.${document.type}`)}
       </BloomText>
     </View>
     <Ionicons
@@ -221,7 +218,8 @@ const DocumentRow: React.FC<DocumentRowProps> = ({ document }) => (
       color={colors.COLOR_BLACK_LIGHT_3}
     />
   </Pressable>
-);
+  );
+};
 
 interface DetailRowProps {
   label: string;
@@ -255,6 +253,7 @@ const DetailSkeleton: React.FC = () => (
 );
 
 export default function LandlordApplicationDetailScreen() {
+  const { t } = useTranslation();
   const router = useRouter();
   const params = useLocalSearchParams<{ id: string }>();
   const id = typeof params.id === 'string' ? params.id : params.id?.[0];
@@ -286,6 +285,7 @@ export default function LandlordApplicationDetailScreen() {
 
   const [pendingAction, setPendingAction] = useState<ReviewAction | null>(null);
   const [actionNotes, setActionNotes] = useState('');
+  const reviewLabels = useMemo(() => getReviewLabels(t), [t]);
 
   const handleOpen = useCallback((action: ReviewAction) => {
     setActionNotes('');
@@ -310,15 +310,15 @@ export default function LandlordApplicationDetailScreen() {
           notes: trimmedNotes ? trimmedNotes : undefined,
         },
       });
-      toast.success(REVIEW_LABELS[pendingAction].successToast);
+      toast.success(reviewLabels[pendingAction].successToast);
       setPendingAction(null);
       setActionNotes('');
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : 'Could not update application';
+        error instanceof Error ? error.message : t('applications.landlord.toastUpdateFailed');
       toast.error(message);
     }
-  }, [id, pendingAction, actionNotes, updateMutation]);
+  }, [id, pendingAction, actionNotes, updateMutation, reviewLabels, t]);
 
   if (!id) {
     return (
@@ -435,7 +435,7 @@ export default function LandlordApplicationDetailScreen() {
             <View style={styles.applicantHeaderText}>
               <H2 style={styles.applicantName}>{applicantName}</H2>
               <BloomText style={styles.subtitle}>
-                {formatEmployment(application.employmentStatus)} ·{' '}
+                {t(`profile.edit.options.employmentStatus.${application.employmentStatus}`)} ·{' '}
                 {formatCurrency(application.monthlyIncome)} / mo
               </BloomText>
             </View>
@@ -504,7 +504,7 @@ export default function LandlordApplicationDetailScreen() {
                       {reference.name}
                     </BloomText>
                     <BloomText style={styles.referenceMeta}>
-                      {formatRelationship(reference.relationship)} ·{' '}
+                      {t(`profile.edit.options.referenceRelationship.${reference.relationship}`)} ·{' '}
                       {reference.phone}
                     </BloomText>
                     <BloomText style={styles.referenceMeta}>
@@ -571,10 +571,10 @@ export default function LandlordApplicationDetailScreen() {
 
         <ConfirmDialog
           visible={pendingAction !== null}
-          title={pendingAction ? REVIEW_LABELS[pendingAction].title : ''}
-          message={pendingAction ? REVIEW_LABELS[pendingAction].message : ''}
+          title={pendingAction ? reviewLabels[pendingAction].title : ''}
+          message={pendingAction ? reviewLabels[pendingAction].message : ''}
           confirmLabel={
-            pendingAction ? REVIEW_LABELS[pendingAction].confirmLabel : ''
+            pendingAction ? reviewLabels[pendingAction].confirmLabel : ''
           }
           confirmDestructive={pendingAction === 'reject'}
           loading={updateMutation.isPending}

--- a/packages/frontend/app/properties/[id]/apply.tsx
+++ b/packages/frontend/app/properties/[id]/apply.tsx
@@ -51,27 +51,27 @@ const MAX_LEASE_MONTHS = 60;
 const LEASE_PRESET_MONTHS: number[] = [3, 6, 12, 18, 24];
 const MOVE_IN_MAX_OFFSET_DAYS = 180; // ~6 months
 
-const EMPLOYMENT_OPTIONS: { value: EmploymentStatus; labelKey: string; fallback: string }[] = [
-  { value: EmploymentStatus.EMPLOYED, labelKey: 'applications.employment.employed', fallback: 'Employed' },
-  { value: EmploymentStatus.SELF_EMPLOYED, labelKey: 'applications.employment.selfEmployed', fallback: 'Self-employed' },
-  { value: EmploymentStatus.STUDENT, labelKey: 'applications.employment.student', fallback: 'Student' },
-  { value: EmploymentStatus.RETIRED, labelKey: 'applications.employment.retired', fallback: 'Retired' },
-  { value: EmploymentStatus.UNEMPLOYED, labelKey: 'applications.employment.unemployed', fallback: 'Unemployed' },
-  { value: EmploymentStatus.OTHER, labelKey: 'applications.employment.other', fallback: 'Other' },
+const EMPLOYMENT_OPTIONS: { value: EmploymentStatus; labelKey: string }[] = [
+  { value: EmploymentStatus.EMPLOYED, labelKey: 'applications.employment.employed' },
+  { value: EmploymentStatus.SELF_EMPLOYED, labelKey: 'applications.employment.selfEmployed' },
+  { value: EmploymentStatus.STUDENT, labelKey: 'applications.employment.student' },
+  { value: EmploymentStatus.RETIRED, labelKey: 'applications.employment.retired' },
+  { value: EmploymentStatus.UNEMPLOYED, labelKey: 'applications.employment.unemployed' },
+  { value: EmploymentStatus.OTHER, labelKey: 'applications.employment.other' },
 ];
 
-const RELATIONSHIP_OPTIONS: { value: ReferenceRelationship; labelKey: string; fallback: string }[] = [
-  { value: ReferenceRelationship.LANDLORD, labelKey: 'applications.relationship.landlord', fallback: 'Previous landlord' },
-  { value: ReferenceRelationship.EMPLOYER, labelKey: 'applications.relationship.employer', fallback: 'Employer' },
-  { value: ReferenceRelationship.PERSONAL, labelKey: 'applications.relationship.personal', fallback: 'Personal' },
-  { value: ReferenceRelationship.OTHER, labelKey: 'applications.relationship.other', fallback: 'Other' },
+const RELATIONSHIP_OPTIONS: { value: ReferenceRelationship; labelKey: string }[] = [
+  { value: ReferenceRelationship.LANDLORD, labelKey: 'applications.relationship.landlord' },
+  { value: ReferenceRelationship.EMPLOYER, labelKey: 'applications.relationship.employer' },
+  { value: ReferenceRelationship.PERSONAL, labelKey: 'applications.relationship.personal' },
+  { value: ReferenceRelationship.OTHER, labelKey: 'applications.relationship.other' },
 ];
 
-const DOCUMENT_TYPE_OPTIONS: { value: TenantApplicationDocumentType; labelKey: string; fallback: string }[] = [
-  { value: TenantApplicationDocumentType.ID, labelKey: 'applications.docType.id', fallback: 'ID' },
-  { value: TenantApplicationDocumentType.INCOME, labelKey: 'applications.docType.income', fallback: 'Income proof' },
-  { value: TenantApplicationDocumentType.REFERENCE, labelKey: 'applications.docType.reference', fallback: 'Reference letter' },
-  { value: TenantApplicationDocumentType.OTHER, labelKey: 'applications.docType.other', fallback: 'Other' },
+const DOCUMENT_TYPE_OPTIONS: { value: TenantApplicationDocumentType; labelKey: string }[] = [
+  { value: TenantApplicationDocumentType.ID, labelKey: 'applications.docType.id' },
+  { value: TenantApplicationDocumentType.INCOME, labelKey: 'applications.docType.income' },
+  { value: TenantApplicationDocumentType.REFERENCE, labelKey: 'applications.docType.reference' },
+  { value: TenantApplicationDocumentType.OTHER, labelKey: 'applications.docType.other' },
 ];
 
 const IconComponent = Ionicons as unknown as React.ComponentType<{
@@ -258,10 +258,7 @@ export default function ApplyToRentScreen() {
       for (const asset of slice) {
         if (asset.size != null && asset.size > MAX_DOCUMENT_BYTES) {
           toast.error(
-            t(
-              'applications.documents.tooLarge',
-              { defaultValue: '{{name}} is over 10 MB and was skipped.', name: asset.name },
-            ),
+            t('applications.documents.tooLarge', { name: asset.name }),
           );
           continue;
         }
@@ -278,17 +275,14 @@ export default function ApplyToRentScreen() {
       }
       if (slice.length < assets.length) {
         toast.error(
-          t('applications.documents.limit', {
-            defaultValue: 'You can upload up to {{max}} documents per application.',
-            max: MAX_DOCUMENTS,
-          }),
+          t('applications.documents.limit', { max: MAX_DOCUMENTS }),
         );
       }
       if (next.length > 0) {
         setDocuments((prev) => [...prev, ...next]);
       }
     } catch {
-      toast.error(t('applications.documents.pickFailed', 'Could not pick documents'));
+      toast.error(t('applications.documents.pickFailed'));
     }
   };
 
@@ -297,21 +291,21 @@ export default function ApplyToRentScreen() {
       const response = err.response as { error?: { code?: string }; code?: string } | undefined;
       const code = response?.error?.code || response?.code;
       if (code === 'ALREADY_APPLIED') {
-        return t('applications.error.alreadyApplied', 'You already have an active application for this property.');
+        return t('applications.error.alreadyApplied');
       }
       if (code === 'EXTERNAL_PROPERTY') {
-        return t('applications.error.external', 'External listings cannot be applied to from Homiio.');
+        return t('applications.error.external');
       }
       if (code === 'NOT_APPLICABLE') {
-        return t('applications.error.notApplicable', 'This property does not accept long-term applications.');
+        return t('applications.error.notApplicable');
       }
       if (code === 'AUTHENTICATION_REQUIRED') {
-        return t('applications.error.auth', 'Please sign in to apply.');
+        return t('applications.error.auth');
       }
       return err.message;
     }
     if (err instanceof Error) return err.message;
-    return t('applications.error.generic', 'Something went wrong. Please try again.');
+    return t('applications.error.generic');
   };
 
   const handleSubmit = async () => {
@@ -321,12 +315,12 @@ export default function ApplyToRentScreen() {
     }
     if (!propertyId) return;
     if (!formIsValid) {
-      toast.error(t('applications.error.invalidForm', 'Please complete every required field.'));
+      toast.error(t('applications.error.invalidForm'));
       return;
     }
     const moveInIso = toIsoDate(moveInDate);
     if (!moveInIso || effectiveTermMonths == null || monthlyIncomeNumber == null) {
-      toast.error(t('applications.error.invalidForm', 'Please complete every required field.'));
+      toast.error(t('applications.error.invalidForm'));
       return;
     }
     const referencePayload: ApplicationReferenceInput[] = references.map((ref) => ({
@@ -353,7 +347,7 @@ export default function ApplyToRentScreen() {
         documents: documentPayload,
         notes: notes.trim() || undefined,
       });
-      toast.success(t('applications.success.submitted', 'Application submitted'));
+      toast.success(t('applications.success.submitted'));
       router.replace({ pathname: '/applications/[id]', params: { id: String(created.id) } });
     } catch (err) {
       toast.error(extractError(err));
@@ -365,7 +359,7 @@ export default function ApplyToRentScreen() {
       <Header
         options={{
           showBackButton: true,
-          title: t('applications.apply.title', 'Apply to rent'),
+          title: t('applications.apply.title'),
           titlePosition: 'center',
         }}
       />
@@ -383,14 +377,14 @@ export default function ApplyToRentScreen() {
                   {property.longTermRent.currency || ''}
                   {property.longTermRent.monthlyAmount}
                   {' / '}
-                  {t('common.month', 'month')}
+                  {t('common.month')}
                 </ThemedText>
               )}
             </View>
           )}
 
-          <Section title={t('applications.section.timing', 'Move-in & lease term')}>
-            <FieldLabel>{t('applications.field.moveInDate', 'Move-in date')}</FieldLabel>
+          <Section title={t('applications.section.timing')}>
+            <FieldLabel>{t('applications.field.moveInDate')}</FieldLabel>
             <TextInput
               style={styles.input}
               value={moveInDate}
@@ -403,10 +397,10 @@ export default function ApplyToRentScreen() {
               maxLength={10}
             />
             <ThemedText style={styles.helperText}>
-              {t('applications.field.moveInHelper', 'Within the next 6 months.')}
+              {t('applications.field.moveInHelper')}
             </ThemedText>
 
-            <FieldLabel>{t('applications.field.leaseTerm', 'Lease term')}</FieldLabel>
+            <FieldLabel>{t('applications.field.leaseTerm')}</FieldLabel>
             <View style={styles.chipRow}>
               {LEASE_PRESET_MONTHS.map((preset) => {
                 const isActive = !usingCustomTerm && leaseTermMonths === preset;
@@ -420,7 +414,7 @@ export default function ApplyToRentScreen() {
                     }}
                     style={styles.chip}
                   >
-                    {t('applications.field.leaseTermMonths', '{{count}} months', { count: preset })}
+                    {t('applications.field.leaseTermMonths', { count: preset })}
                   </Chip>
                 );
               })}
@@ -429,7 +423,7 @@ export default function ApplyToRentScreen() {
                 onPress={() => setUsingCustomTerm(true)}
                 style={styles.chip}
               >
-                {t('applications.field.leaseTermCustom', 'Other')}
+                {t('applications.field.leaseTermCustom')}
               </Chip>
             </View>
             {usingCustomTerm && (
@@ -437,7 +431,7 @@ export default function ApplyToRentScreen() {
                 style={styles.input}
                 value={leaseTermCustom}
                 onChangeText={(text) => setLeaseTermCustom(text.replace(/[^0-9]/g, ''))}
-                placeholder={t('applications.field.leaseTermCustomPlaceholder', 'Number of months')}
+                placeholder={t('applications.field.leaseTermCustomPlaceholder')}
                 placeholderTextColor={colors.COLOR_BLACK_LIGHT_3}
                 inputMode="numeric"
                 maxLength={2}
@@ -445,19 +439,19 @@ export default function ApplyToRentScreen() {
             )}
           </Section>
 
-          <Section title={t('applications.section.finances', 'Income & employment')}>
-            <FieldLabel>{t('applications.field.monthlyIncome', 'Gross monthly income')}</FieldLabel>
+          <Section title={t('applications.section.finances')}>
+            <FieldLabel>{t('applications.field.monthlyIncome')}</FieldLabel>
             <TextInput
               style={styles.input}
               value={monthlyIncome}
               onChangeText={setMonthlyIncome}
-              placeholder={t('applications.field.monthlyIncomePlaceholder', 'e.g. 2400')}
+              placeholder={t('applications.field.monthlyIncomePlaceholder')}
               placeholderTextColor={colors.COLOR_BLACK_LIGHT_3}
               inputMode="decimal"
               keyboardType="decimal-pad"
             />
 
-            <FieldLabel>{t('applications.field.employment', 'Employment status')}</FieldLabel>
+            <FieldLabel>{t('applications.field.employment')}</FieldLabel>
             <View style={styles.chipRow}>
               {EMPLOYMENT_OPTIONS.map((option) => (
                 <Chip
@@ -466,45 +460,42 @@ export default function ApplyToRentScreen() {
                   onPress={() => setEmploymentStatus(option.value)}
                   style={styles.chip}
                 >
-                  {t(option.labelKey, option.fallback)}
+                  {t(option.labelKey)}
                 </Chip>
               ))}
             </View>
           </Section>
 
           <Section
-            title={t('applications.section.references', 'References')}
-            description={t(
-              'applications.section.referencesHelp',
-              'Add 1 to 3 contacts the landlord can call to vouch for you.',
-            )}
+            title={t('applications.section.references')}
+            description={t('applications.section.referencesHelp')}
           >
             {references.map((reference, index) => (
               <View key={index} style={styles.referenceCard}>
                 <View style={styles.referenceHeader}>
                   <ThemedText style={styles.referenceTitle}>
-                    {t('applications.field.referenceIndex', 'Reference {{index}}', { index: index + 1 })}
+                    {t('applications.field.referenceIndex', { index: index + 1 })}
                   </ThemedText>
                   {references.length > 1 && (
                     <Pressable
                       onPress={() => handleRemoveReference(index)}
-                      accessibilityLabel={t('applications.field.removeReference', 'Remove reference')}
+                      accessibilityLabel={t('applications.field.removeReference')}
                       hitSlop={8}
                     >
                       <IconComponent name="close" size={18} color={colors.COLOR_BLACK_LIGHT_3} />
                     </Pressable>
                   )}
                 </View>
-                <FieldLabel>{t('applications.field.name', 'Full name')}</FieldLabel>
+                <FieldLabel>{t('applications.field.name')}</FieldLabel>
                 <TextInput
                   style={styles.input}
                   value={reference.name}
                   onChangeText={(value) => handleReferenceChange(index, { name: value })}
-                  placeholder={t('applications.field.namePlaceholder', 'Jane Doe')}
+                  placeholder={t('applications.field.namePlaceholder')}
                   placeholderTextColor={colors.COLOR_BLACK_LIGHT_3}
                   autoCapitalize="words"
                 />
-                <FieldLabel>{t('applications.field.relationship', 'Relationship')}</FieldLabel>
+                <FieldLabel>{t('applications.field.relationship')}</FieldLabel>
                 <View style={styles.chipRow}>
                   {RELATIONSHIP_OPTIONS.map((option) => (
                     <Chip
@@ -513,11 +504,11 @@ export default function ApplyToRentScreen() {
                       onPress={() => handleReferenceChange(index, { relationship: option.value })}
                       style={styles.chip}
                     >
-                      {t(option.labelKey, option.fallback)}
+                      {t(option.labelKey)}
                     </Chip>
                   ))}
                 </View>
-                <FieldLabel>{t('applications.field.phone', 'Phone number')}</FieldLabel>
+                <FieldLabel>{t('applications.field.phone')}</FieldLabel>
                 <TextInput
                   style={styles.input}
                   value={reference.phone}
@@ -527,7 +518,7 @@ export default function ApplyToRentScreen() {
                   inputMode="tel"
                   keyboardType="phone-pad"
                 />
-                <FieldLabel>{t('applications.field.email', 'Email')}</FieldLabel>
+                <FieldLabel>{t('applications.field.email')}</FieldLabel>
                 <TextInput
                   style={styles.input}
                   value={reference.email}
@@ -547,18 +538,15 @@ export default function ApplyToRentScreen() {
                 icon={<IconComponent name="add" size={16} color={colors.primaryDark} />}
                 style={styles.secondaryAction}
               >
-                {t('applications.field.addReference', 'Add another reference')}
+                {t('applications.field.addReference')}
               </Button>
             )}
           </Section>
 
           <Section
-            title={t('applications.section.documents', 'Documents (optional)')}
-            description={t(
-              'applications.section.documentsHelp',
-              'Upload up to {{max}} PDFs or images (10 MB each). Pick a category per file.',
-              { max: MAX_DOCUMENTS },
-            )}
+            title={t('applications.section.documents')}
+            description={t('applications.section.documentsHelp',
+              { max: MAX_DOCUMENTS },)}
           >
             <Button
               variant="secondary"
@@ -567,7 +555,7 @@ export default function ApplyToRentScreen() {
               icon={<IconComponent name="cloud-upload-outline" size={16} color={colors.primaryDark} />}
               style={styles.secondaryAction}
             >
-              {t('applications.field.pickDocuments', 'Add documents')}
+              {t('applications.field.pickDocuments')}
             </Button>
             {documents.map((doc) => (
               <View key={doc.id} style={styles.documentCard}>
@@ -582,7 +570,7 @@ export default function ApplyToRentScreen() {
                   </ThemedText>
                   <Pressable
                     onPress={() => handleRemoveDocument(doc.id)}
-                    accessibilityLabel={t('applications.field.removeDocument', 'Remove document')}
+                    accessibilityLabel={t('applications.field.removeDocument')}
                     hitSlop={8}
                   >
                     <IconComponent name="close" size={18} color={colors.COLOR_BLACK_LIGHT_3} />
@@ -601,7 +589,7 @@ export default function ApplyToRentScreen() {
                       onPress={() => handleDocumentTypeChange(doc.id, option.value)}
                       style={styles.chip}
                     >
-                      {t(option.labelKey, option.fallback)}
+                      {t(option.labelKey)}
                     </Chip>
                   ))}
                 </View>
@@ -609,15 +597,12 @@ export default function ApplyToRentScreen() {
             ))}
           </Section>
 
-          <Section title={t('applications.section.notes', 'Notes to landlord (optional)')}>
+          <Section title={t('applications.section.notes')}>
             <TextInput
               style={[styles.input, styles.notesInput]}
               value={notes}
               onChangeText={setNotes}
-              placeholder={t(
-                'applications.field.notesPlaceholder',
-                'Anything else the landlord should know about you?',
-              )}
+              placeholder={t('applications.field.notesPlaceholder')}
               placeholderTextColor={colors.COLOR_BLACK_LIGHT_3}
               multiline
               numberOfLines={4}
@@ -633,7 +618,7 @@ export default function ApplyToRentScreen() {
             size="large"
             style={styles.submitButton}
           >
-            {t('applications.actions.submit', 'Submit application')}
+            {t('applications.actions.submit')}
           </Button>
         </ScrollView>
       </SafeAreaView>

--- a/packages/frontend/app/properties/[id]/book-viewing.tsx
+++ b/packages/frontend/app/properties/[id]/book-viewing.tsx
@@ -93,7 +93,7 @@ export default function BookViewingPage() {
         if (code === 'TIME_CONFLICT') return t('viewings.error.timeConflict');
         if (code === 'TIME_IN_PAST') return t('viewings.error.timeInPast');
         if (code === 'AUTHENTICATION_REQUIRED') return t('viewings.error.authRequired');
-        if (code === 'EXTERNAL_PROPERTY') return t('viewings.error.externalProperty', 'Cannot book viewings for external properties');
+        if (code === 'EXTERNAL_PROPERTY') return t('viewings.error.externalProperty');
         if (msg) return msg;
         if (err.message) return err.message;
       } else if (err instanceof Error) {
@@ -263,7 +263,7 @@ export default function BookViewingPage() {
         <Header
           options={{
             showBackButton: true,
-            title: t('Loading...'),
+            title: t('app.loading'),
             titlePosition: 'center',
           }}
         />

--- a/packages/frontend/app/properties/[id]/index.tsx
+++ b/packages/frontend/app/properties/[id]/index.tsx
@@ -241,8 +241,8 @@ export default function PropertyDetailPage() {
     const summaries = resolveOfferingSummaries(apiProperty, browseMode);
     const alsoAvailable =
       summaries.length > 0
-        ? `${t('listing.offering.alsoAvailable', 'Also available')}: ${summaries
-            .map((summary) => t(summary.i18nKey, summary.fallback))
+        ? `${t('listing.offering.alsoAvailable')}: ${summaries
+            .map((summary) => t(summary.i18nKey))
             .join(' · ')}`
         : '';
 
@@ -334,15 +334,13 @@ export default function PropertyDetailPage() {
         }
       } catch {
         toast.error(
-          t('error.contact.openFailed', 'Could not open contact link') ||
-            'Could not open contact link',
+          t('error.contact.openFailed'),
         );
         return;
       }
       if (!apiProperty.sourceUrl) {
         toast.error(
-          t('error.source.noUrl', 'Source website URL not available') ||
-            'Source website URL not available',
+          t('error.source.noUrl'),
         );
         return;
       }
@@ -350,16 +348,14 @@ export default function PropertyDetailPage() {
         await Linking.openURL(apiProperty.sourceUrl);
       } catch {
         toast.error(
-          t('error.source.openFailed', 'Could not open the source website') ||
-            'Could not open the source website',
+          t('error.source.openFailed'),
         );
       }
       return;
     }
     if (!oxyServices || !activeSessionId) {
       toast.error(
-        t('error.auth.required', 'Please sign in to contact the owner') ||
-          'Please sign in to contact the owner',
+        t('error.auth.required'),
       );
       showSignInModal();
       return;
@@ -385,8 +381,7 @@ export default function PropertyDetailPage() {
           await Linking.openURL(`tel:${phone}`);
         } catch {
           toast.error(
-            t('error.contact.openFailed', 'Could not open contact link') ||
-              'Could not open contact link',
+            t('error.contact.openFailed'),
           );
         }
         return;
@@ -399,30 +394,26 @@ export default function PropertyDetailPage() {
           await Linking.openURL(waUrl);
         } catch {
           toast.error(
-            t('error.contact.openFailed', 'Could not open contact link') ||
-              'Could not open contact link',
+            t('error.contact.openFailed'),
           );
         }
         return;
       }
       toast.error(
-        t('error.contact.noPhone', 'No phone number available for this listing') ||
-          'No phone number available for this listing',
+        t('error.contact.noPhone'),
       );
       return;
     }
     if (!oxyServices || !activeSessionId) {
       toast.error(
-        t('error.auth.required', 'Please sign in to call the owner') ||
-          'Please sign in to call the owner',
+        t('error.auth.required'),
       );
       showSignInModal();
       return;
     }
     if (!landlordProfile) {
       toast.error(
-        t('error.profile.notFound', 'Owner profile not found') ||
-          'Owner profile not found',
+        t('error.profile.notFound'),
       );
       return;
     }
@@ -446,15 +437,13 @@ export default function PropertyDetailPage() {
     }
     if (!allowCalls) {
       toast.error(
-        t('error.call.notAllowed', 'Owner does not accept calls') ||
-          'Owner does not accept calls',
+        t('error.call.notAllowed'),
       );
       return;
     }
     if (!phoneNumber) {
       toast.error(
-        t('error.call.noPhone', 'No phone number available') ||
-          'No phone number available',
+        t('error.call.noPhone'),
       );
       return;
     }
@@ -462,8 +451,7 @@ export default function PropertyDetailPage() {
       await Linking.openURL(`tel:${phoneNumber}`);
     } catch {
       toast.error(
-        t('error.call.failed', 'Could not open phone dialer') ||
-          'Could not open phone dialer',
+        t('error.call.failed'),
       );
     }
   }, [oxyServices, activeSessionId, landlordProfile, t, apiProperty]);
@@ -483,8 +471,7 @@ export default function PropertyDetailPage() {
       await Linking.openURL(websiteUrl);
     } catch {
       toast.error(
-        t('error.publicHousing.openFailed', 'Could not open the housing website') ||
-          'Could not open the housing website',
+        t('error.publicHousing.openFailed'),
       );
     }
   }, [apiProperty?.address?.regionName, t]);
@@ -497,17 +484,17 @@ export default function PropertyDetailPage() {
     // The clipboard fallback copies the full details (not just the URL), matching
     // the share-sheet message.
     const outcome = await shareContent({
-      title: 'Share Property',
+      title: t('property.toast.shareTitle'),
       message: details,
       url: propertyUrl,
       copyText: details,
     });
     if (outcome === 'copied') {
-      toast.success('Property details copied to clipboard');
+      toast.success(t('property.toast.shareCopied'));
     } else if (outcome === 'failed') {
-      toast.error('Failed to share property');
+      toast.error(t('property.toast.shareFailed'));
     }
-  }, [property]);
+  }, [property, t]);
 
   const handleCtaPress = useCallback(() => {
     if (apiProperty?.housingType === 'public') {
@@ -567,21 +554,18 @@ export default function PropertyDetailPage() {
         <Header
           options={{
             showBackButton: true,
-            title: t('property.error', 'Error') || 'Error',
+            title: t('property.error'),
             titlePosition: 'center',
           }}
         />
         <SafeAreaView style={styles.errorBody} edges={['bottom']}>
           <ErrorState
             icon="home-outline"
-            title={t('property.notFound', 'Property not found') || 'Property not found'}
+            title={t('property.notFound')}
             description={
-              t(
-                'property.notFoundHelp',
-                'It may have been removed or the link is broken.',
-              ) || 'It may have been removed or the link is broken.'
+              t('property.notFoundHelp')
             }
-            retryLabel={t('goBack', 'Go back') || 'Go back'}
+            retryLabel={t('goBack')}
             onRetry={() => router.back()}
           />
         </SafeAreaView>
@@ -915,7 +899,7 @@ export default function PropertyDetailPage() {
                 landlordProfile={landlordProfile}
                 ownerProperties={ownerProperties}
                 onApplyPublic={handlePublicHousingApply}
-                t={(k, d) => t(k, d ?? '') || (d ?? k)}
+                t={(key) => t(key)}
               />
             </View>
           ) : null}
@@ -928,10 +912,7 @@ export default function PropertyDetailPage() {
           <View style={[styles.section, styles.divider]}>
             <FraudWarning
               text={
-                t(
-                  'Never pay or transfer funds outside the Homio platform',
-                  'Never pay or transfer funds outside the Homio platform',
-                ) || 'Never pay or transfer funds outside the Homio platform'
+                t('property.fraudWarning')
               }
             />
           </View>

--- a/packages/frontend/app/properties/[id]/report.tsx
+++ b/packages/frontend/app/properties/[id]/report.tsx
@@ -41,12 +41,12 @@ import { spacing } from '@/constants/styles';
 const MAX_DETAILS_LENGTH = 4000;
 const EMAIL_REGEX = /\S+@\S+\.\S+/;
 
-const REASON_OPTIONS: { value: ListingReportReason; labelKey: string; fallback: string }[] = [
-  { value: ListingReportReason.INACCURATE, labelKey: 'property.report.reason.inaccurate', fallback: 'Inaccurate information' },
-  { value: ListingReportReason.SCAM, labelKey: 'property.report.reason.scam', fallback: 'Suspected scam or fraud' },
-  { value: ListingReportReason.INAPPROPRIATE, labelKey: 'property.report.reason.inappropriate', fallback: 'Inappropriate content' },
-  { value: ListingReportReason.UNAVAILABLE, labelKey: 'property.report.reason.unavailable', fallback: 'Already rented or unavailable' },
-  { value: ListingReportReason.OTHER, labelKey: 'property.report.reason.other', fallback: 'Something else' },
+const REASON_OPTIONS: { value: ListingReportReason; labelKey: string }[] = [
+  { value: ListingReportReason.INACCURATE, labelKey: 'property.report.reason.inaccurate' },
+  { value: ListingReportReason.SCAM, labelKey: 'property.report.reason.scam' },
+  { value: ListingReportReason.INAPPROPRIATE, labelKey: 'property.report.reason.inappropriate' },
+  { value: ListingReportReason.UNAVAILABLE, labelKey: 'property.report.reason.unavailable' },
+  { value: ListingReportReason.OTHER, labelKey: 'property.report.reason.other' },
 ];
 
 /**
@@ -108,21 +108,21 @@ export default function ReportListingScreen() {
       const response = err.response as { error?: { code?: string }; code?: string } | undefined;
       const code = response?.error?.code || response?.code;
       if (code === 'INVALID_REASON') {
-        return t('property.report.error.invalidReason', 'Please choose a reason for your report.');
+        return t('property.report.error.invalidReason');
       }
       if (code === 'DETAILS_REQUIRED') {
-        return t('property.report.error.detailsRequired', 'Please add a few details about the problem.');
+        return t('property.report.error.detailsRequired');
       }
       if (code === 'AUTHENTICATION_REQUIRED') {
-        return t('property.report.error.auth', 'Please sign in to report a listing.');
+        return t('property.report.error.auth');
       }
       if (code === 'NOT_FOUND') {
-        return t('property.report.error.notFound', 'This listing no longer exists.');
+        return t('property.report.error.notFound');
       }
       return err.message;
     }
     if (err instanceof Error) return err.message;
-    return t('property.report.error.generic', 'Something went wrong. Please try again.');
+    return t('property.report.error.generic');
   };
 
   const handleSubmit = async () => {
@@ -131,7 +131,7 @@ export default function ReportListingScreen() {
       return;
     }
     if (!propertyId || !reason || !formIsValid) {
-      toast.error(t('property.report.error.invalidForm', 'Please choose a reason before submitting.'));
+      toast.error(t('property.report.error.invalidForm'));
       return;
     }
     const trimmedDetails = details.trim();
@@ -145,7 +145,7 @@ export default function ReportListingScreen() {
           contactEmail: trimmedEmail || undefined,
         },
       });
-      toast.success(t('property.report.success', 'Thanks — your report has been submitted.'));
+      toast.success(t('property.report.success'));
       router.back();
     } catch (err) {
       toast.error(extractError(err));
@@ -157,17 +157,14 @@ export default function ReportListingScreen() {
       <Header
         options={{
           showBackButton: true,
-          title: t('property.report.title', 'Report this listing'),
+          title: t('property.report.title'),
           titlePosition: 'center',
         }}
       />
       <SafeAreaView style={styles.scrollWrapper} edges={['bottom']}>
         <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
           <ThemedText style={styles.intro}>
-            {t(
-              'property.report.intro',
-              'Tell us what’s wrong with this listing. Reports are confidential and reviewed by our team — they are never shared with the host.',
-            )}
+            {t('property.report.intro')}
           </ThemedText>
 
           {property ? (
@@ -180,7 +177,7 @@ export default function ReportListingScreen() {
             </View>
           ) : null}
 
-          <Section title={t('property.report.section.reason', 'Why are you reporting this?')}>
+          <Section title={t('property.report.section.reason')}>
             <View style={styles.chipRow}>
               {REASON_OPTIONS.map((option) => (
                 <Chip
@@ -189,7 +186,7 @@ export default function ReportListingScreen() {
                   onPress={() => setReason(option.value)}
                   style={styles.chip}
                 >
-                  {t(option.labelKey, option.fallback)}
+                  {t(option.labelKey)}
                 </Chip>
               ))}
             </View>
@@ -198,22 +195,16 @@ export default function ReportListingScreen() {
           <Section
             title={
               detailsRequired
-                ? t('property.report.section.detailsRequired', 'Details')
-                : t('property.report.section.details', 'Details (optional)')
+                ? t('property.report.section.detailsRequired')
+                : t('property.report.section.details')
             }
-            description={t(
-              'property.report.section.detailsHelp',
-              'Add anything that helps us understand the problem.',
-            )}
+            description={t('property.report.section.detailsHelp')}
           >
             <TextInput
               style={[styles.input, styles.detailsInput]}
               value={details}
               onChangeText={setDetails}
-              placeholder={t(
-                'property.report.field.detailsPlaceholder',
-                'Describe what’s inaccurate, suspicious or inappropriate…',
-              )}
+              placeholder={t('property.report.field.detailsPlaceholder')}
               placeholderTextColor={colors.COLOR_BLACK_LIGHT_3}
               multiline
               numberOfLines={5}
@@ -223,11 +214,8 @@ export default function ReportListingScreen() {
           </Section>
 
           <Section
-            title={t('property.report.section.contact', 'Contact email (optional)')}
-            description={t(
-              'property.report.section.contactHelp',
-              'Share an email if you’re happy for us to follow up about this report.',
-            )}
+            title={t('property.report.section.contact')}
+            description={t('property.report.section.contactHelp')}
           >
             <TextInput
               style={styles.input}
@@ -249,10 +237,7 @@ export default function ReportListingScreen() {
               color={colors.COLOR_BLACK_LIGHT_3}
             />
             <ThemedText style={styles.noticeText}>
-              {t(
-                'property.report.notice',
-                'False or abusive reports may affect your account. Only report genuine problems.',
-              )}
+              {t('property.report.notice')}
             </ThemedText>
           </View>
 
@@ -264,7 +249,7 @@ export default function ReportListingScreen() {
             size="large"
             style={styles.submitButton}
           >
-            {t('property.report.actions.submit', 'Submit report')}
+            {t('property.report.actions.submit')}
           </Button>
         </ScrollView>
       </SafeAreaView>

--- a/packages/frontend/app/properties/city/[id].tsx
+++ b/packages/frontend/app/properties/city/[id].tsx
@@ -60,25 +60,25 @@ export default function CityPropertiesPage() {
   const filterSections: FilterSection[] = useMemo(() => [
     {
       id: 'verified',
-      title: t('Verified Properties'),
+      title: t('properties.city.verifiedProperties'),
       type: 'chips',
       options: [
-        { id: 'true', label: t('Verified Only'), value: 'true' }
+        { id: 'true', label: t('properties.city.verifiedOnly'), value: 'true' }
       ],
       value: filters.verified ? 'true' : undefined
     },
     {
       id: 'ecoFriendly',
-      title: t('Eco-Friendly'),
+      title: t('properties.city.ecoFriendly'),
       type: 'chips',
       options: [
-        { id: 'true', label: t('Eco-Friendly Only'), value: 'true' }
+        { id: 'true', label: t('properties.city.ecoFriendlyOnly'), value: 'true' }
       ],
       value: filters.ecoFriendly ? 'true' : undefined
     },
     {
       id: 'bedrooms',
-      title: t('Bedrooms'),
+      title: t('property.sections.bedrooms'),
       type: 'chips',
       options: [
         { id: '1', label: '1+', value: '1' },
@@ -90,7 +90,7 @@ export default function CityPropertiesPage() {
     },
     {
       id: 'bathrooms',
-      title: t('Bathrooms'),
+      title: t('property.sections.bathrooms'),
       type: 'chips',
       options: [
         { id: '1', label: '1+', value: '1' },
@@ -209,7 +209,7 @@ export default function CityPropertiesPage() {
           <Header
             options={{
               showBackButton: true,
-              title: t('Loading...'),
+              title: t('app.loading'),
               titlePosition: 'center',
             }}
           />
@@ -217,7 +217,7 @@ export default function CityPropertiesPage() {
         <View style={{ paddingTop: headerHeight, flex: 1 }}>
           <View style={styles.loadingContainer}>
             <ActivityIndicator size="large" color={colors.primaryColor} />
-            <Text style={styles.loadingText}>{t('Loading properties...')}</Text>
+            <Text style={styles.loadingText}>{t('properties.city.loadingProperties')}</Text>
           </View>
         </View>
       </View>
@@ -234,7 +234,7 @@ export default function CityPropertiesPage() {
           <Header
             options={{
               showBackButton: true,
-              title: t('Error'),
+              title: t('common.error'),
               titlePosition: 'center',
             }}
           />
@@ -242,8 +242,8 @@ export default function CityPropertiesPage() {
         <View style={{ paddingTop: headerHeight, flex: 1 }}>
           <EmptyState
             icon="alert-circle"
-            title={error || t('City not found')}
-            actionText={t('Go Back')}
+            title={error || t('properties.city.notFound')}
+            actionText={t('common.goBack')}
             actionIcon="arrow-back"
             onAction={() => router.back()}
           />
@@ -306,12 +306,12 @@ export default function CityPropertiesPage() {
         <View style={styles.statsSection}>
           <View style={styles.statCard}>
             <Text style={styles.statNumber}>{city.propertiesCount}</Text>
-            <Text style={styles.statLabel}>{t('Properties')}</Text>
+            <Text style={styles.statLabel}>{t('properties.city.properties')}</Text>
           </View>
           {typeof city.population === 'number' && city.population > 0 ? (
             <View style={styles.statCard}>
               <Text style={styles.statNumber}>{city.population.toLocaleString()}</Text>
-              <Text style={styles.statLabel}>{t('Population')}</Text>
+              <Text style={styles.statLabel}>{t('properties.city.population')}</Text>
             </View>
           ) : null}
         </View>
@@ -320,9 +320,9 @@ export default function CityPropertiesPage() {
         <View style={styles.propertiesSection}>
           <View style={styles.propertiesHeader}>
             <View>
-              <Text style={styles.sectionTitle}>{t('Available Properties')}</Text>
+              <Text style={styles.sectionTitle}>{t('properties.city.availableProperties')}</Text>
               <Text style={styles.propertiesSubtitle}>
-                {getFilteredAndSortedProperties().length} {t('properties found')}
+                {getFilteredAndSortedProperties().length} {t('properties.city.propertiesFound')}
               </Text>
             </View>
           </View>
@@ -344,12 +344,12 @@ export default function CityPropertiesPage() {
                   sections={[
                     {
                       id: 'sort',
-                      title: t('Sort By'),
+                      title: t('properties.city.sortBy'),
                       type: 'chips',
                       options: [
-                        { id: 'newest', label: t('Newest First'), value: 'newest' },
-                        { id: 'priceAsc', label: t('Price: Low to High'), value: 'priceAsc' },
-                        { id: 'priceDesc', label: t('Price: High to Low'), value: 'priceDesc' },
+                        { id: 'newest', label: t('properties.city.sortNewest'), value: 'newest' },
+                        { id: 'priceAsc', label: t('properties.city.sortPriceAsc'), value: 'priceAsc' },
+                        { id: 'priceDesc', label: t('properties.city.sortPriceDesc'), value: 'priceDesc' },
                       ],
                       value: filters.sortBy
                     }
@@ -375,9 +375,9 @@ export default function CityPropertiesPage() {
             ListEmptyComponent={
               <EmptyState
                 icon="home-outline"
-                title={t('No properties found')}
-                description={t('Try adjusting your filters or check back later')}
-                actionText={t('Clear Filters')}
+                title={t('properties.city.noPropertiesFound')}
+                description={t('properties.city.tryAdjustFilters')}
+                actionText={t('properties.city.clearFilters')}
                 actionIcon="refresh"
                 onAction={() => {
                   setFilters(prev => ({

--- a/packages/frontend/app/properties/drafts.tsx
+++ b/packages/frontend/app/properties/drafts.tsx
@@ -232,11 +232,11 @@ export default function PropertyDraftsScreen() {
     },
     onSuccess: (next) => {
       queryClient.setQueryData(DRAFTS_QUERY_KEY, next);
-      toast.success('Draft deleted successfully');
+      toast.success(t('property.drafts.toastDeleted'));
     },
     onError: (error: unknown) => {
       logger.error('Error deleting draft:', error);
-      toast.error('Failed to delete draft');
+      toast.error(t('property.drafts.toastDeleteFailed'));
     },
   });
 
@@ -247,7 +247,7 @@ export default function PropertyDraftsScreen() {
         router.push('/properties/create');
       } catch (error: unknown) {
         logger.error('Error setting current draft:', error);
-        toast.error('Failed to load draft');
+        toast.error(t('property.drafts.toastLoadFailed'));
       }
     },
     [router],
@@ -271,9 +271,9 @@ export default function PropertyDraftsScreen() {
       return (
         <EmptyState
           icon="folder-open-outline"
-          title="No drafts found"
-          description="You don't have any saved property drafts yet. Start creating a property to save drafts automatically."
-          actionText="Create new property"
+          title={t('property.drafts.emptyTitle')}
+          description={t('property.drafts.emptyDescription')}
+          actionText={t('property.drafts.createFirst')}
           actionIcon="add"
           onAction={() => router.push('/properties/create')}
         />
@@ -297,7 +297,7 @@ export default function PropertyDraftsScreen() {
           icon={<Ionicons name="add-circle" size={20} color={colors.primaryColor} />}
           style={styles.createNewButton}
         >
-          Create new property
+          {t('property.drafts.createFirst')}
         </Button>
       </View>
     );
@@ -306,7 +306,7 @@ export default function PropertyDraftsScreen() {
   return (
     <View style={styles.container}>
       <PropertyListHeader
-        title="Drafts"
+        title={t('property.drafts.title')}
         subtitle={drafts.length > 0 ? `${drafts.length} saved` : undefined}
       />
       <ScrollView
@@ -318,8 +318,8 @@ export default function PropertyDraftsScreen() {
       </ScrollView>
       <ConfirmDialog
         visible={deleteId !== null}
-        title="Delete draft"
-        message="Are you sure you want to delete this draft? This action cannot be undone."
+        title={t('property.drafts.deleteTitle')}
+        message={t('property.drafts.deleteMessage')}
         confirmLabel={t('common.delete')}
         cancelLabel={t('common.cancel')}
         confirmDestructive

--- a/packages/frontend/app/properties/index.tsx
+++ b/packages/frontend/app/properties/index.tsx
@@ -226,12 +226,12 @@ export default function PropertiesScreen() {
 
   const resultsHeading = useMemo(() => {
     if (isLoading) {
-      return t('properties.header.loading', 'Loading homes…') || 'Loading homes…';
+      return t('properties.header.loading');
     }
     if (total === 0) {
-      return t('properties.header.empty', 'No homes available') || 'No homes available';
+      return t('properties.header.empty');
     }
-    return t('search.header.count', `${total} homes`) || `${total} homes`;
+    return t('search.header.count', { count: total });
   }, [t, isLoading, total]);
 
   const body = (() => {
@@ -246,9 +246,9 @@ export default function PropertiesScreen() {
     if (isError) {
       return (
         <ErrorState
-          title={t('properties.error.title', 'Could not load homes') || 'Could not load homes'}
+          title={t('properties.error.title')}
           description={error?.message}
-          retryLabel={t('common.tryAgain', 'Try again') || 'Try again'}
+          retryLabel={t('common.tryAgain')}
           onRetry={() => void refetch()}
         />
       );
@@ -257,12 +257,11 @@ export default function PropertiesScreen() {
       return (
         <EmptyState
           icon="home-outline"
-          title={t('properties.empty.title', 'No homes available') || 'No homes available'}
+          title={t('properties.empty.title')}
           description={
-            t('properties.empty.description', 'Try relaxing your filters.') ||
-            'Try relaxing your filters.'
+            t('properties.empty.description')
           }
-          actionText={t('properties.empty.action', 'Clear filters') || 'Clear filters'}
+          actionText={t('properties.empty.action')}
           actionIcon="options-outline"
           onAction={handleFiltersPress}
         />
@@ -295,30 +294,30 @@ export default function PropertiesScreen() {
           contentContainerStyle={styles.topBarActions}
         >
           <SearchActionPill
-            label={t('search.actions.filters', 'Filters') || 'Filters'}
+            label={t('search.actions.filters')}
             icon="options-outline"
             active={activeFilterCount > 0}
             count={activeFilterCount}
             onPress={handleFiltersPress}
             accessibilityLabel={
               activeFilterCount > 0
-                ? `${t('search.actions.filters', 'Filters') || 'Filters'}, ${activeFilterCount}`
-                : t('search.actions.filters', 'Filters') || 'Filters'
+                ? `${t('search.actions.filters')}, ${activeFilterCount}`
+                : t('search.actions.filters')
             }
           />
           <SearchActionPill
-            label={sort.isDefault ? t('search.actions.sort', 'Sort') || 'Sort' : sort.label}
+            label={sort.isDefault ? t('search.actions.sort') : sort.label}
             icon="swap-vertical"
             active={!sort.isDefault}
             onPress={handleSortPress}
-            accessibilityLabel={`${t('search.actions.sort', 'Sort') || 'Sort'}: ${sort.label}`}
+            accessibilityLabel={`${t('search.actions.sort')}: ${sort.label}`}
           />
           <SearchActionPill
-            label={t('properties.actions.recent', 'Recently viewed') || 'Recently viewed'}
+            label={t('properties.actions.recent')}
             icon="time-outline"
             onPress={() => router.push('/properties/recently-viewed')}
             accessibilityLabel={
-              t('properties.actions.recent', 'Recently viewed') || 'Recently viewed'
+              t('properties.actions.recent')
             }
           />
         </ScrollView>
@@ -358,7 +357,7 @@ export default function PropertiesScreen() {
           variant="primary"
           style={styles.fabButton}
           icon={<Ionicons name="add" size={24} color={colors.primaryForeground} />}
-          accessibilityLabel={t('properties.actions.create', 'Add property') || 'Add property'}
+          accessibilityLabel={t('properties.actions.create')}
         />
       </View>
     </View>

--- a/packages/frontend/app/properties/my.tsx
+++ b/packages/frontend/app/properties/my.tsx
@@ -136,14 +136,14 @@ export default function MyPropertiesScreen() {
       await refetch();
       if (result.commission) {
         toast.success(
-          t('properties.my.transactCommission', 'Deal closed — commission recorded'),
+          t('properties.my.transactCommission'),
         );
       } else {
-        toast.success(t('properties.my.transactDone', 'Listing marked as closed'));
+        toast.success(t('properties.my.transactDone'));
       }
     } catch (transactError: unknown) {
       logger.error('Failed to mark property transacted:', transactError);
-      toast.error(t('properties.my.transactError', 'Could not close this listing'));
+      toast.error(t('properties.my.transactError'));
     } finally {
       setTransactTarget(null);
     }
@@ -178,8 +178,8 @@ export default function MyPropertiesScreen() {
               style={styles.ownerActionButton}
             >
               {closeStatus === PropertyStatus.SOLD
-                ? t('properties.my.markSold', 'Mark as sold')
-                : t('properties.my.markRented', 'Mark as rented')}
+                ? t('properties.my.markSold')
+                : t('properties.my.markRented')}
             </Button>
           ) : null}
           <View style={styles.ownerActions}>
@@ -290,18 +290,15 @@ export default function MyPropertiesScreen() {
         visible={transactTarget !== null}
         title={
           transactTarget?.status === PropertyStatus.SOLD
-            ? t('properties.my.markSoldTitle', 'Mark as sold?')
-            : t('properties.my.markRentedTitle', 'Mark as rented?')
+            ? t('properties.my.markSoldTitle')
+            : t('properties.my.markRentedTitle')
         }
-        message={t(
-          'properties.my.transactMessage',
-          'This closes "{{title}}" and removes it from active listings. This cannot be undone.',
-          { title: transactTarget?.title ?? '' },
-        )}
+        message={t('properties.my.transactMessage',
+          { title: transactTarget?.title ?? '' },)}
         confirmLabel={
           transactTarget?.status === PropertyStatus.SOLD
-            ? t('properties.my.markSold', 'Mark as sold')
-            : t('properties.my.markRented', 'Mark as rented')
+            ? t('properties.my.markSold')
+            : t('properties.my.markRented')
         }
         cancelLabel={t('common.cancel')}
         loading={markTransacted.isPending}

--- a/packages/frontend/app/properties/recently-viewed.tsx
+++ b/packages/frontend/app/properties/recently-viewed.tsx
@@ -109,7 +109,7 @@ export default function RecentlyViewedScreen() {
               onPress={handleClear}
               accessibilityLabel={t('home.recentlyViewed.retry')}
             >
-              {t('common.clear', 'Clear')}
+              {t('common.clear')}
             </Button>
           ) : undefined
         }

--- a/packages/frontend/app/properties/type/[type].tsx
+++ b/packages/frontend/app/properties/type/[type].tsx
@@ -297,19 +297,19 @@ export default function PropertyTypeScreen() {
           contentContainerStyle={styles.actions}
         >
           <SearchActionPill
-            label={t('search.actions.filters', 'Filters') || 'Filters'}
+            label={t('search.actions.filters')}
             icon="options-outline"
             active={activeFilterCount > 0}
             count={activeFilterCount}
             onPress={handleFiltersPress}
-            accessibilityLabel={t('search.actions.filters', 'Filters') || 'Filters'}
+            accessibilityLabel={t('search.actions.filters')}
           />
           <SearchActionPill
-            label={sort.isDefault ? t('search.actions.sort', 'Sort') || 'Sort' : sort.label}
+            label={sort.isDefault ? t('search.actions.sort') : sort.label}
             icon="swap-vertical"
             active={!sort.isDefault}
             onPress={handleSortPress}
-            accessibilityLabel={`${t('search.actions.sort', 'Sort') || 'Sort'}: ${sort.label}`}
+            accessibilityLabel={`${t('search.actions.sort')}: ${sort.label}`}
           />
         </ScrollView>
         {body}

--- a/packages/frontend/app/reservations/[id].tsx
+++ b/packages/frontend/app/reservations/[id].tsx
@@ -20,6 +20,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { format } from 'date-fns';
 import { toast } from '@/lib/sonner';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@oxyhq/bloom/button';
 import { Loading } from '@oxyhq/bloom/loading';
@@ -77,6 +78,7 @@ const canGuestCancelPreview = (reservation: Reservation): boolean => {
 };
 
 export default function ReservationDetailScreen() {
+  const { t } = useTranslation();
   const params = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const id = typeof params.id === 'string' ? params.id : params.id?.[0];
@@ -105,28 +107,28 @@ export default function ReservationDetailScreen() {
       if (!id) return;
       try {
         await updateMutation.mutateAsync({ status: target });
-        const verb =
+        const toastKey =
           target === ReservationStatus.CONFIRMED
-            ? 'confirmed'
+            ? 'reservations.detail.toastConfirmed'
             : target === ReservationStatus.DECLINED
-              ? 'declined'
-              : 'cancelled';
-        toast.success(`Reservation ${verb}`);
+              ? 'reservations.detail.toastDeclined'
+              : 'reservations.detail.toastCancelled';
+        toast.success(t(toastKey));
         setPendingAction(null);
       } catch (error) {
-        const message = error instanceof Error ? error.message : 'Update failed';
+        const message = error instanceof Error ? error.message : t('reservations.detail.toastUpdateFailed');
         toast.error(message);
         setPendingAction(null);
       }
     },
-    [id, updateMutation],
+    [id, updateMutation, t],
   );
 
   const header = (
     <Header
       options={{
         showBackButton: true,
-        title: 'Reservation',
+        title: t('reservations.detail.title'),
         titlePosition: 'center',
       }}
     />
@@ -139,9 +141,9 @@ export default function ReservationDetailScreen() {
         <View style={styles.centerWrap}>
           <ErrorState
             icon="warning-outline"
-            title="Invalid reservation id"
-            description="The link is missing the reservation reference."
-            retryLabel="Go back"
+            title={t('reservations.detail.invalidId')}
+            description={t('reservations.detail.invalidIdDescription')}
+            retryLabel={t('reservations.detail.goBack')}
             onRetry={() => router.back()}
           />
         </View>
@@ -166,11 +168,11 @@ export default function ReservationDetailScreen() {
         {header}
         <View style={styles.centerWrap}>
           <ErrorState
-            title="Reservation unavailable"
+            title={t('reservations.detail.unavailable')}
             description={
-              reservationQuery.error?.message ?? 'This reservation could not be loaded.'
+              reservationQuery.error?.message ?? t('reservations.detail.unavailableDescription')
             }
-            retryLabel="Go back"
+            retryLabel={t('reservations.detail.goBack')}
             onRetry={() => router.back()}
           />
         </View>
@@ -178,7 +180,7 @@ export default function ReservationDetailScreen() {
     );
   }
 
-  const propertyTitle = property ? getPropertyTitle(property) : 'Property';
+  const propertyTitle = property ? getPropertyTitle(property) : t('reservations.card.propertyFallback');
   const imageSource = property ? getPropertyImageSource(property) : null;
   const showGuestCancel =
     role === 'guest' &&
@@ -220,26 +222,28 @@ export default function ReservationDetailScreen() {
           </CardSurface>
 
           <CardSurface>
-            <BloomText style={styles.sectionLabel}>Trip details</BloomText>
+            <BloomText style={styles.sectionLabel}>{t('reservations.detail.tripDetails')}</BloomText>
             <DetailRow
-              label="Check-in"
+              label={t('reservations.detail.checkIn')}
               value={format(new Date(reservation.checkIn), 'EEE, MMM d, yyyy')}
             />
             <DetailRow
-              label="Check-out"
+              label={t('reservations.detail.checkOut')}
               value={format(new Date(reservation.checkOut), 'EEE, MMM d, yyyy')}
             />
             <DetailRow
-              label="Guests"
+              label={t('reservations.detail.guests')}
               value={`${reservation.guestCount} ${
-                reservation.guestCount === 1 ? 'guest' : 'guests'
+                reservation.guestCount === 1
+                  ? t('reservations.card.guest')
+                  : t('reservations.card.guests')
               }`}
             />
-            <DetailRow label="Nights" value={String(reservation.nights)} />
+            <DetailRow label={t('reservations.detail.nights')} value={String(reservation.nights)} />
           </CardSurface>
 
           <CardSurface>
-            <BloomText style={styles.sectionLabel}>Price</BloomText>
+            <BloomText style={styles.sectionLabel}>{t('reservations.detail.price')}</BloomText>
             <PriceBreakdown
               nights={reservation.nights}
               nightlyRate={reservation.nightlyRate}
@@ -271,7 +275,7 @@ export default function ReservationDetailScreen() {
                     disabled={updateMutation.isPending}
                     style={styles.actionButton}
                   >
-                    Approve
+                    {t('reservations.detail.approve')}
                   </Button>
                   <Button
                     variant="secondary"
@@ -280,7 +284,7 @@ export default function ReservationDetailScreen() {
                     disabled={updateMutation.isPending}
                     style={styles.actionButton}
                   >
-                    Decline
+                    {t('reservations.detail.decline')}
                   </Button>
                 </>
               ) : null}
@@ -292,7 +296,7 @@ export default function ReservationDetailScreen() {
                   disabled={updateMutation.isPending}
                   style={styles.actionButton}
                 >
-                  Cancel reservation
+                  {t('reservations.detail.cancelReservation')}
                 </Button>
               ) : null}
             </View>
@@ -302,18 +306,18 @@ export default function ReservationDetailScreen() {
           reservation.status === ReservationStatus.CONFIRMED &&
           !showGuestCancel ? (
             <BloomText style={styles.policyNote}>
-              Cancellation is no longer possible under the{' '}
-              {reservation.cancellationPolicy.replace('_', ' ')} policy. Contact your
-              host if you need to make changes.
+              {t('reservations.detail.cancelPolicyNote', {
+                policy: reservation.cancellationPolicy.replace('_', ' '),
+              })}
             </BloomText>
           ) : null}
         </ScrollView>
 
         <ConfirmDialog
           visible={pendingAction === 'cancel'}
-          title="Cancel reservation?"
-          message="This will release the dates back to the host and end the booking."
-          confirmLabel="Yes, cancel"
+          title={t('reservations.detail.confirmCancelTitle')}
+          message={t('reservations.detail.confirmCancelBody')}
+          confirmLabel={t('reservations.detail.confirmCancelAction')}
           confirmDestructive
           loading={updateMutation.isPending}
           onConfirm={() => handleAction(ReservationStatus.CANCELLED)}
@@ -321,18 +325,18 @@ export default function ReservationDetailScreen() {
         />
         <ConfirmDialog
           visible={pendingAction === 'confirm'}
-          title="Approve reservation?"
-          message="The guest will be notified and the dates will be marked confirmed on your calendar."
-          confirmLabel="Approve"
+          title={t('reservations.detail.confirmApproveTitle')}
+          message={t('reservations.detail.confirmApproveBody')}
+          confirmLabel={t('reservations.detail.approve')}
           loading={updateMutation.isPending}
           onConfirm={() => handleAction(ReservationStatus.CONFIRMED)}
           onCancel={() => setPendingAction(null)}
         />
         <ConfirmDialog
           visible={pendingAction === 'decline'}
-          title="Decline reservation?"
-          message="The guest will be notified that this request was declined."
-          confirmLabel="Decline"
+          title={t('reservations.detail.confirmDeclineTitle')}
+          message={t('reservations.detail.confirmDeclineBody')}
+          confirmLabel={t('reservations.detail.decline')}
           confirmDestructive
           loading={updateMutation.isPending}
           onConfirm={() => handleAction(ReservationStatus.DECLINED)}

--- a/packages/frontend/app/reviews/write.tsx
+++ b/packages/frontend/app/reviews/write.tsx
@@ -147,7 +147,7 @@ export default function WriteReviewPage() {
           mapRef.current.navigateToLocation([lng, lat], 15);
         }
       } catch {
-        if (!cancelled) setError('Failed to load address information');
+        if (!cancelled) setError(t('reviews.write.loadAddressFailed'));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -156,7 +156,7 @@ export default function WriteReviewPage() {
     return () => {
       cancelled = true;
     };
-  }, [addressId, oxyServices, activeSessionId]);
+  }, [addressId, oxyServices, activeSessionId, t]);
 
   const handleAddressSelect = useCallback(
     (address: AddressLookupResult, coordinates: [number, number]) => {
@@ -187,57 +187,57 @@ export default function WriteReviewPage() {
 
   const validateForm = (): boolean => {
     if (!formData.street.trim()) {
-      Alert.alert('Validation Error', 'Please provide a street address.');
+      Alert.alert(t('reviews.write.validationTitle'), t('reviews.write.streetRequired'));
       return false;
     }
     if (!formData.city.trim()) {
-      Alert.alert('Validation Error', 'Please provide a city.');
+      Alert.alert(t('reviews.write.validationTitle'), t('reviews.write.cityRequired'));
       return false;
     }
     if (!formData.postal_code.trim()) {
-      Alert.alert('Validation Error', 'Please provide a postal code.');
+      Alert.alert(t('reviews.write.validationTitle'), t('reviews.write.postalCodeRequired'));
       return false;
     }
     if (!formData.country.trim()) {
-      Alert.alert('Validation Error', 'Please provide a country.');
+      Alert.alert(t('reviews.write.validationTitle'), t('reviews.write.countryRequired'));
       return false;
     }
     if (!formData.opinion.trim()) {
       Alert.alert(
-        'Validation Error',
-        'Please provide your opinion about this address.',
+        t('reviews.write.validationTitle'),
+        t('reviews.write.opinionRequired'),
       );
       return false;
     }
     if (formData.opinion.trim().length < 10) {
       Alert.alert(
-        'Validation Error',
-        'Your opinion must be at least 10 characters long.',
+        t('reviews.write.validationTitle'),
+        t('reviews.write.opinionMinLength'),
       );
       return false;
     }
     if (!formData.price || parseFloat(formData.price) <= 0) {
-      Alert.alert('Validation Error', 'Please provide a valid price.');
+      Alert.alert(t('reviews.write.validationTitle'), t('reviews.write.priceRequired'));
       return false;
     }
     if (!formData.livedFrom || !formData.livedTo) {
       Alert.alert(
-        'Validation Error',
-        'Please provide both start and end dates.',
+        t('reviews.write.validationTitle'),
+        t('reviews.write.datesRequired'),
       );
       return false;
     }
     if (formData.recommendation === null) {
       Alert.alert(
-        'Validation Error',
-        'Please indicate whether you would recommend this address.',
+        t('reviews.write.validationTitle'),
+        t('reviews.write.recommendationRequired'),
       );
       return false;
     }
     if (formData.rating === 0) {
       Alert.alert(
-        'Validation Error',
-        'Please provide a rating from 1 to 5.',
+        t('reviews.write.validationTitle'),
+        t('reviews.write.ratingRequired'),
       );
       return false;
     }
@@ -289,14 +289,17 @@ export default function WriteReviewPage() {
         activeSessionId,
       );
       if (result.success) {
-        Alert.alert('Success', 'Your review has been submitted successfully!', [
-          { text: 'OK', onPress: () => router.back() },
+        Alert.alert(t('common.success'), t('reviews.write.submitSuccess'), [
+          { text: t('common.ok'), onPress: () => router.back() },
         ]);
       } else {
-        Alert.alert('Error', result.error || 'Failed to submit review');
+        Alert.alert(
+          t('common.error'),
+          result.error || t('reviews.write.submitFailed'),
+        );
       }
     } catch {
-      Alert.alert('Error', 'Failed to submit review. Please try again.');
+      Alert.alert(t('common.error'), t('reviews.write.submitFailedRetry'));
     } finally {
       setSubmitting(false);
     }
@@ -306,7 +309,7 @@ export default function WriteReviewPage() {
     return (
       <View style={styles.root}>
         <Header
-          options={{ title: t('Write review'), showBackButton: true }}
+          options={{ title: t('reviews.write.title'), showBackButton: true }}
         />
         <ScrollView>
           <WriteReviewSkeleton />
@@ -319,13 +322,13 @@ export default function WriteReviewPage() {
     return (
       <View style={styles.root}>
         <Header
-          options={{ title: t('Write review'), showBackButton: true }}
+          options={{ title: t('reviews.write.title'), showBackButton: true }}
         />
         <ErrorState
           icon="cloud-offline-outline"
-          title={t("Couldn't load address")}
+          title={t('reviews.write.loadAddressFailed')}
           description={error}
-          retryLabel={t('Go back')}
+          retryLabel={t('common.goBack')}
           onRetry={() => router.back()}
         />
       </View>
@@ -335,7 +338,7 @@ export default function WriteReviewPage() {
   return (
     <View style={styles.root}>
       <Header
-        options={{ title: t('Write review'), showBackButton: true }}
+        options={{ title: t('reviews.write.title'), showBackButton: true }}
       />
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>
         <ScrollView contentContainerStyle={styles.content}>

--- a/packages/frontend/app/roommates/[id].tsx
+++ b/packages/frontend/app/roommates/[id].tsx
@@ -1,11 +1,5 @@
 /**
  * Roommate profile detail — `/roommates/:id`.
- *
- * Shows a single roommate candidate's public profile (display name, bio,
- * verification, matching preferences) and lets the viewer send a roommate
- * request. Data comes from the authenticated profile-by-id read; the roommate
- * matching preferences and trust signals are derived through
- * `roommateService.getProfileDisplayInfo` (no invented values).
  */
 import React, { useState } from 'react';
 import { Alert, ScrollView, StyleSheet, View } from 'react-native';
@@ -16,6 +10,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Button } from '@oxyhq/bloom/button';
 import { Loading } from '@oxyhq/bloom/loading';
 import { H2, H3, Text as BloomText } from '@oxyhq/bloom/typography';
+import { useTranslation } from 'react-i18next';
 
 import { Header } from '@/components/Header';
 import { ErrorState } from '@/components/ui/ErrorState';
@@ -27,6 +22,7 @@ import { radius, spacing, withShadow } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
 export default function RoommateProfilePage() {
+  const { t } = useTranslation();
   const params = useLocalSearchParams<{ id: string }>();
   const profileId = String(params.id);
   const { sendRequest } = useRoommate();
@@ -47,10 +43,10 @@ export default function RoommateProfilePage() {
     try {
       const ok = await sendRequest(profileId);
       Alert.alert(
-        ok ? 'Request sent' : 'Could not send request',
+        ok ? t('roommates.profileDetail.requestSentTitle') : t('roommates.profileDetail.requestFailedTitle'),
         ok
-          ? 'Your roommate request was sent.'
-          : 'We could not send your request. Please try again.',
+          ? t('roommates.profileDetail.requestSentBody')
+          : t('roommates.profileDetail.requestFailedBody'),
       );
     } finally {
       setIsSending(false);
@@ -69,8 +65,8 @@ export default function RoommateProfilePage() {
     if (profileQuery.isError || !profile || !info) {
       return (
         <ErrorState
-          title="Couldn't load profile"
-          description="We couldn't load this roommate profile. Please try again."
+          title={t('roommates.profileDetail.loadError')}
+          description={t('roommates.profileDetail.loadErrorDescription')}
           onRetry={() => profileQuery.refetch()}
         />
       );
@@ -82,7 +78,7 @@ export default function RoommateProfilePage() {
           <View style={styles.avatar}>
             <Ionicons name="person" size={36} color={colors.COLOR_BLACK_LIGHT_4} />
           </View>
-          <SectionEyebrow>Roommate</SectionEyebrow>
+          <SectionEyebrow>{t('roommates.profileDetail.title')}</SectionEyebrow>
           <H2 style={styles.name}>{info.name}</H2>
           {info.occupation ? (
             <BloomText style={styles.subtitle}>{info.occupation}</BloomText>
@@ -97,37 +93,37 @@ export default function RoommateProfilePage() {
 
         {info.bio ? (
           <View style={styles.card}>
-            <H3 style={styles.cardTitle}>About</H3>
+            <H3 style={styles.cardTitle}>{t('roommates.profileDetail.about')}</H3>
             <BloomText style={styles.bodyText}>{info.bio}</BloomText>
           </View>
         ) : null}
 
         <View style={styles.card}>
-          <H3 style={styles.cardTitle}>Roommate preferences</H3>
+          <H3 style={styles.cardTitle}>{t('roommates.profileDetail.preferencesTitle')}</H3>
           <View style={styles.detailRow}>
-            <BloomText style={styles.detailLabel}>Budget</BloomText>
+            <BloomText style={styles.detailLabel}>{t('roommates.profileDetail.budget')}</BloomText>
             <BloomText style={styles.detailValue}>
               {info.budget.max > 0
                 ? `${info.budget.currency} ${info.budget.min}–${info.budget.max}/mo`
-                : 'Not specified'}
+                : t('roommates.profileDetail.notSpecified')}
             </BloomText>
           </View>
           <View style={styles.detailRow}>
-            <BloomText style={styles.detailLabel}>Move-in</BloomText>
+            <BloomText style={styles.detailLabel}>{t('roommates.profileDetail.moveIn')}</BloomText>
             <BloomText style={styles.detailValue}>{info.moveInDate}</BloomText>
           </View>
           <View style={styles.detailRow}>
-            <BloomText style={styles.detailLabel}>Lease length</BloomText>
+            <BloomText style={styles.detailLabel}>{t('roommates.profileDetail.leaseLength')}</BloomText>
             <BloomText style={styles.detailValue}>{info.duration}</BloomText>
           </View>
         </View>
 
         <View style={styles.card}>
-          <H3 style={styles.cardTitle}>Trust</H3>
+          <H3 style={styles.cardTitle}>{t('roommates.profileDetail.trust')}</H3>
           <View style={styles.badgeRow}>
-            <TrustBadge label="Verified" active={info.isVerified} />
-            <TrustBadge label="References" active={info.hasReferences} />
-            <TrustBadge label="Rental history" active={info.rentalHistory} />
+            <TrustBadge label={t('roommates.profileDetail.verified')} active={info.isVerified} />
+            <TrustBadge label={t('roommates.profileDetail.references')} active={info.hasReferences} />
+            <TrustBadge label={t('roommates.profileDetail.rentalHistory')} active={info.rentalHistory} />
           </View>
         </View>
 
@@ -138,7 +134,7 @@ export default function RoommateProfilePage() {
           disabled={isSending}
           style={styles.sendButton}
         >
-          {isSending ? 'Sending…' : 'Send roommate request'}
+          {isSending ? t('roommates.profileDetail.sending') : t('roommates.profileDetail.sendRequest')}
         </Button>
       </ScrollView>
     );
@@ -148,7 +144,7 @@ export default function RoommateProfilePage() {
     <View style={styles.root}>
       <Header
         options={{
-          title: 'Roommate',
+          title: t('roommates.profileDetail.title'),
           showBackButton: true,
           titlePosition: 'center',
         }}

--- a/packages/frontend/app/roommates/index.tsx
+++ b/packages/frontend/app/roommates/index.tsx
@@ -27,6 +27,7 @@ import { Button } from '@oxyhq/bloom/button';
 import { Loading } from '@oxyhq/bloom/loading';
 import { H1, Text as BloomText } from '@oxyhq/bloom/typography';
 import { useOxy } from '@oxyhq/services';
+import { useTranslation } from 'react-i18next';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ErrorState } from '@/components/ui/ErrorState';
 import { SectionEyebrow } from '@/components/ui/SectionEyebrow';
@@ -45,11 +46,11 @@ import { colors } from '@/styles/colors';
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 type Tab = 'discover' | 'requests' | 'relationships' | 'rooms';
 
-const TABS: { id: Tab; label: string; icon: IoniconName }[] = [
-  { id: 'discover', label: 'Discover', icon: 'search-outline' },
-  { id: 'requests', label: 'Requests', icon: 'mail-outline' },
-  { id: 'relationships', label: 'Matches', icon: 'people-circle-outline' },
-  { id: 'rooms', label: 'Rooms', icon: 'bed-outline' },
+const TAB_IDS: { id: Tab; icon: IoniconName; labelKey: string }[] = [
+  { id: 'discover', labelKey: 'roommates.tabs.discover', icon: 'search-outline' },
+  { id: 'requests', labelKey: 'roommates.tabs.requests', icon: 'mail-outline' },
+  { id: 'relationships', labelKey: 'roommates.tabs.matches', icon: 'people-circle-outline' },
+  { id: 'rooms', labelKey: 'roommates.tabs.rooms', icon: 'bed-outline' },
 ];
 
 const TabButton: React.FC<{
@@ -86,13 +87,14 @@ const TabButton: React.FC<{
 const TabBar: React.FC<{
   activeTab: Tab;
   onChange: (tab: Tab) => void;
-}> = ({ activeTab, onChange }) => (
+  tabs: { id: Tab; label: string; icon: IoniconName }[];
+}> = ({ activeTab, onChange, tabs }) => (
   <ScrollView
     horizontal
     showsHorizontalScrollIndicator={false}
     contentContainerStyle={styles.tabBarContent}
   >
-    {TABS.map((tab) => (
+    {tabs.map((tab) => (
       <TabButton
         key={tab.id}
         tab={tab}
@@ -104,6 +106,7 @@ const TabBar: React.FC<{
 );
 
 export default function RoommatesPage() {
+  const { t } = useTranslation();
   const router = useRouter();
   const queryClient = useQueryClient();
   const { oxyServices, activeSessionId } = useOxy();
@@ -207,6 +210,23 @@ export default function RoommatesPage() {
     }
   }, [activeTab, fetchProfiles, fetchRequests, fetchRelationships]);
 
+  const tabs = TAB_IDS.map((entry) => ({
+    id: entry.id,
+    icon: entry.icon,
+    label: t(entry.labelKey),
+  }));
+
+  const personalProfileEmpty = (
+    <EmptyState
+      icon="person-outline"
+      title={t('roommates.screen.personalProfileRequired')}
+      description={t('roommates.screen.personalProfileDescription')}
+      actionText={t('roommates.screen.switchToPersonal')}
+      actionIcon="person-circle"
+      onAction={() => router.push('/profile')}
+    />
+  );
+
   const handleToggleMatching = useCallback(async () => {
     if (!oxyServices || !activeSessionId) return;
     if (isToggling) return;
@@ -226,12 +246,14 @@ export default function RoommatesPage() {
         fetchProfiles();
       }
       Alert.alert(
-        'Success',
+        t('roommates.alert.successTitle'),
         result.message ||
-          `Roommate matching ${result.enabled ? 'enabled' : 'disabled'}`,
+          (result.enabled
+            ? t('roommates.screen.matchingEnabled')
+            : t('roommates.screen.matchingDisabled')),
       );
     } catch {
-      Alert.alert('Error', 'Failed to toggle roommate matching');
+      Alert.alert(t('roommates.alert.errorTitle'), t('roommates.alert.toggleFailed'));
     } finally {
       setIsToggling(false);
     }
@@ -242,6 +264,7 @@ export default function RoommatesPage() {
     hasRoommateMatching,
     queryClient,
     fetchProfiles,
+    t,
   ]);
 
   const handleViewProfile = (profileId: string) => {
@@ -281,16 +304,7 @@ export default function RoommatesPage() {
 
   const renderDiscoverTab = () => {
     if (!isPersonalProfile || !hasPersonalProfile) {
-      return (
-        <EmptyState
-          icon="person-outline"
-          title="Personal profile required"
-          description="Roommate matching is only available for personal profiles. Switch to your personal profile to use this feature."
-          actionText="Switch to personal profile"
-          actionIcon="person-circle"
-          onAction={() => router.push('/profile')}
-        />
-      );
+      return personalProfileEmpty;
     }
 
     if (isLoading) {
@@ -304,7 +318,7 @@ export default function RoommatesPage() {
     if (error && profiles.length === 0) {
       return (
         <ErrorState
-          title="Couldn't load roommates"
+          title={t('roommates.screen.loadError')}
           description={error}
           onRetry={fetchProfiles}
         />
@@ -315,9 +329,9 @@ export default function RoommatesPage() {
       return (
         <EmptyState
           icon="people-outline"
-          title="Enable roommate matching"
-          description="Turn on roommate matching to discover potential roommates based on your preferences."
-          actionText={isToggling ? 'Enabling…' : 'Enable matching'}
+          title={t('roommates.screen.enableMatchingTitle')}
+          description={t('roommates.screen.enableMatchingDescription')}
+          actionText={isToggling ? t('roommates.screen.enabling') : t('roommates.screen.enableMatching')}
           actionIcon="checkmark-circle"
           onAction={handleToggleMatching}
         />
@@ -328,9 +342,9 @@ export default function RoommatesPage() {
       return (
         <EmptyState
           icon="people-outline"
-          title="No roommates found"
-          description="We couldn't find anyone matching your preferences. Try adjusting your settings."
-          actionText="Update preferences"
+          title={t('roommates.screen.emptyDiscoverTitle')}
+          description={t('roommates.screen.emptyDiscoverDescription')}
+          actionText={t('roommates.screen.updatePreferences')}
           actionIcon="settings"
           onAction={() => router.push('/roommates/preferences')}
         />
@@ -358,16 +372,7 @@ export default function RoommatesPage() {
 
   const renderRequestsTab = () => {
     if (!isPersonalProfile || !hasPersonalProfile) {
-      return (
-        <EmptyState
-          icon="person-outline"
-          title="Personal profile required"
-          description="Roommate matching is only available for personal profiles. Switch to your personal profile to use this feature."
-          actionText="Switch to personal profile"
-          actionIcon="person-circle"
-          onAction={() => router.push('/profile')}
-        />
-      );
+      return personalProfileEmpty;
     }
 
     if (isLoading) {
@@ -381,7 +386,7 @@ export default function RoommatesPage() {
     if (error && requests.sent.length === 0 && requests.received.length === 0) {
       return (
         <ErrorState
-          title="Couldn't load requests"
+          title={t('roommates.screen.loadRequestsError')}
           description={error}
           onRetry={fetchRequests}
         />
@@ -392,9 +397,9 @@ export default function RoommatesPage() {
       return (
         <EmptyState
           icon="mail-outline"
-          title="No requests yet"
-          description="When you send or receive roommate requests, they'll appear here."
-          actionText="Discover roommates"
+          title={t('roommates.screen.emptyRequestsTitle')}
+          description={t('roommates.screen.emptyRequestsDescription')}
+          actionText={t('roommates.screen.discoverRoommates')}
           actionIcon="search"
           onAction={() => setActiveTab('discover')}
         />
@@ -432,16 +437,7 @@ export default function RoommatesPage() {
 
   const renderRelationshipsTab = () => {
     if (!isPersonalProfile || !hasPersonalProfile) {
-      return (
-        <EmptyState
-          icon="person-outline"
-          title="Personal profile required"
-          description="Roommate matching is only available for personal profiles. Switch to your personal profile to use this feature."
-          actionText="Switch to personal profile"
-          actionIcon="person-circle"
-          onAction={() => router.push('/profile')}
-        />
-      );
+      return personalProfileEmpty;
     }
 
     if (isLoading) {
@@ -455,7 +451,7 @@ export default function RoommatesPage() {
     if (error && relationships.length === 0) {
       return (
         <ErrorState
-          title="Couldn't load relationships"
+          title={t('roommates.screen.loadRelationshipsError')}
           description={error}
           onRetry={fetchRelationships}
         />
@@ -466,9 +462,9 @@ export default function RoommatesPage() {
       return (
         <EmptyState
           icon="people-circle-outline"
-          title="No active relationships"
-          description="When you accept roommate requests, your relationships will appear here."
-          actionText="Discover roommates"
+          title={t('roommates.screen.emptyRelationshipsTitle')}
+          description={t('roommates.screen.emptyRelationshipsDescription')}
+          actionText={t('roommates.screen.discoverRoommates')}
           actionIcon="search"
           onAction={() => setActiveTab('discover')}
         />
@@ -499,9 +495,9 @@ export default function RoommatesPage() {
       return (
         <EmptyState
           icon="person-outline"
-          title="Personal profile required"
-          description="Room search is only available for personal profiles. Switch to your personal profile to use this feature."
-          actionText="Switch to personal profile"
+          title={t('roommates.screen.personalProfileRequired')}
+          description={t('roommates.screen.roomSearchPersonalOnly')}
+          actionText={t('roommates.screen.switchToPersonal')}
           actionIcon="person-circle"
           onAction={() => router.push('/profile')}
         />
@@ -535,8 +531,8 @@ export default function RoommatesPage() {
       <SafeAreaView edges={['top']} style={styles.headerWrap}>
         <View style={styles.headerInner}>
           <View style={styles.titleBlock}>
-            <SectionEyebrow>Together</SectionEyebrow>
-            <H1 style={styles.title}>Roommates</H1>
+            <SectionEyebrow>{t('roommates.screen.eyebrow')}</SectionEyebrow>
+            <H1 style={styles.title}>{t('roommates.screen.title')}</H1>
           </View>
           <Button
             variant="secondary"
@@ -550,10 +546,10 @@ export default function RoommatesPage() {
               />
             }
           >
-            Preferences
+            {t('roommates.preferences')}
           </Button>
         </View>
-        <TabBar activeTab={activeTab} onChange={setActiveTab} />
+        <TabBar activeTab={activeTab} onChange={setActiveTab} tabs={tabs} />
       </SafeAreaView>
 
       <View style={styles.content}>{renderTabContent()}</View>

--- a/packages/frontend/app/roommates/preferences.tsx
+++ b/packages/frontend/app/roommates/preferences.tsx
@@ -14,6 +14,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Button } from '@oxyhq/bloom/button';
 import { Switch } from '@oxyhq/bloom/switch';
 import { H2, H3, Text as BloomText } from '@oxyhq/bloom/typography';
+import { useTranslation } from 'react-i18next';
 import { LeaseDuration } from '@homiio/shared-types';
 import { Header } from '@/components/Header';
 import { EmptyState } from '@/components/ui/EmptyState';
@@ -59,37 +60,37 @@ const DEFAULT_FORM: FormState = {
   schedule: 'flexible',
 };
 
-const GENDER_OPTIONS: { value: GenderPref; label: string }[] = [
-  { value: 'any', label: 'Any' },
-  { value: 'male', label: 'Male' },
-  { value: 'female', label: 'Female' },
+const GENDER_OPTIONS: { value: GenderPref; labelKey: string }[] = [
+  { value: 'any', labelKey: 'roommates.preferencesPage.options.gender.any' },
+  { value: 'male', labelKey: 'roommates.preferencesPage.options.gender.male' },
+  { value: 'female', labelKey: 'roommates.preferencesPage.options.gender.female' },
 ];
 
-const LIFESTYLE_OPTIONS: { value: LifestyleChoice; label: string }[] = [
-  { value: 'yes', label: 'Yes' },
-  { value: 'no', label: 'No' },
-  { value: 'prefer_not', label: 'No pref.' },
+const LIFESTYLE_OPTIONS: { value: LifestyleChoice; labelKey: string }[] = [
+  { value: 'yes', labelKey: 'roommates.preferencesPage.options.lifestyle.yes' },
+  { value: 'no', labelKey: 'roommates.preferencesPage.options.lifestyle.no' },
+  { value: 'prefer_not', labelKey: 'roommates.preferencesPage.options.lifestyle.prefer_not' },
 ];
 
-const CLEANLINESS_OPTIONS: { value: Cleanliness; label: string }[] = [
-  { value: 'very_clean', label: 'Very clean' },
-  { value: 'clean', label: 'Clean' },
-  { value: 'average', label: 'Average' },
-  { value: 'relaxed', label: 'Relaxed' },
+const CLEANLINESS_OPTIONS: { value: Cleanliness; labelKey: string }[] = [
+  { value: 'very_clean', labelKey: 'roommates.preferencesPage.options.cleanliness.very_clean' },
+  { value: 'clean', labelKey: 'roommates.preferencesPage.options.cleanliness.clean' },
+  { value: 'average', labelKey: 'roommates.preferencesPage.options.cleanliness.average' },
+  { value: 'relaxed', labelKey: 'roommates.preferencesPage.options.cleanliness.relaxed' },
 ];
 
-const SCHEDULE_OPTIONS: { value: Schedule; label: string }[] = [
-  { value: 'early_bird', label: 'Early bird' },
-  { value: 'night_owl', label: 'Night owl' },
-  { value: 'flexible', label: 'Flexible' },
+const SCHEDULE_OPTIONS: { value: Schedule; labelKey: string }[] = [
+  { value: 'early_bird', labelKey: 'roommates.preferencesPage.options.schedule.early_bird' },
+  { value: 'night_owl', labelKey: 'roommates.preferencesPage.options.schedule.night_owl' },
+  { value: 'flexible', labelKey: 'roommates.preferencesPage.options.schedule.flexible' },
 ];
 
-const LEASE_OPTIONS: { value: LeaseDuration; label: string }[] = [
-  { value: LeaseDuration.MONTHLY, label: 'Monthly' },
-  { value: LeaseDuration.THREE_MONTHS, label: '3 months' },
-  { value: LeaseDuration.SIX_MONTHS, label: '6 months' },
-  { value: LeaseDuration.YEARLY, label: 'Yearly' },
-  { value: LeaseDuration.FLEXIBLE, label: 'Flexible' },
+const LEASE_OPTIONS: { value: LeaseDuration; labelKey: string }[] = [
+  { value: LeaseDuration.MONTHLY, labelKey: 'roommates.preferencesPage.options.lease.monthly' },
+  { value: LeaseDuration.THREE_MONTHS, labelKey: 'roommates.preferencesPage.options.lease.3_months' },
+  { value: LeaseDuration.SIX_MONTHS, labelKey: 'roommates.preferencesPage.options.lease.6_months' },
+  { value: LeaseDuration.YEARLY, labelKey: 'roommates.preferencesPage.options.lease.yearly' },
+  { value: LeaseDuration.FLEXIBLE, labelKey: 'roommates.preferencesPage.options.lease.flexible' },
 ];
 
 function toNumber(value: string): number | undefined {
@@ -134,9 +135,10 @@ function ChipRow<T extends string>({
 }: {
   label: string;
   value: T;
-  options: { value: T; label: string }[];
+  options: { value: T; labelKey: string }[];
   onChange: (next: T) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <View style={styles.field}>
       <BloomText style={styles.fieldLabel}>{label}</BloomText>
@@ -144,7 +146,7 @@ function ChipRow<T extends string>({
         {options.map((option) => (
           <Chip
             key={option.value}
-            label={option.label}
+            label={t(option.labelKey)}
             selected={option.value === value}
             onPress={() => onChange(option.value)}
           />
@@ -190,6 +192,7 @@ function toPreferences(form: FormState): RoommateMatchingPreferences {
 }
 
 export default function RoommatePreferencesPage() {
+  const { t } = useTranslation();
   const router = useRouter();
   const queryClient = useQueryClient();
   const [roommateEnabled, setRoommateEnabled] = useState(false);
@@ -232,10 +235,10 @@ export default function RoommatePreferencesPage() {
       await useProfileStore.getState().fetchPrimaryProfile();
       await queryClient.invalidateQueries({ queryKey: ['roommates', 'preferences'] });
       await queryClient.invalidateQueries({ queryKey: ['roommates', 'status'] });
-      Alert.alert('Saved', 'Your roommate preferences were updated.');
+      Alert.alert(t('roommates.alert.successTitle'), t('roommates.alert.preferencesSaved'));
     },
     onError: () => {
-      Alert.alert('Error', 'Failed to save roommate preferences. Please try again.');
+      Alert.alert(t('roommates.alert.errorTitle'), t('roommates.alert.preferencesFailed'));
     },
   });
 
@@ -252,7 +255,7 @@ export default function RoommatePreferencesPage() {
       <View style={styles.root}>
         <Header
           options={{
-            title: 'Roommate preferences',
+            title: t('roommates.preferencesPage.title'),
             showBackButton: true,
             titlePosition: 'center',
           }}
@@ -261,9 +264,9 @@ export default function RoommatePreferencesPage() {
           <View style={styles.emptyWrap}>
             <EmptyState
               icon="person-outline"
-              title="Personal profile required"
-              description="Roommate preferences are only available for personal profiles. Please switch to your personal profile to manage your roommate settings."
-              actionText="Switch to personal profile"
+              title={t('roommates.preferencesPage.personalProfileRequired')}
+              description={t('roommates.preferencesPage.personalProfileDescription')}
+              actionText={t('roommates.preferencesPage.switchToPersonal')}
               actionIcon="person-circle"
               onAction={() => router.push('/profile')}
             />
@@ -277,7 +280,7 @@ export default function RoommatePreferencesPage() {
     <View style={styles.root}>
       <Header
         options={{
-          title: 'Roommate preferences',
+          title: t('roommates.preferencesPage.title'),
           showBackButton: true,
           titlePosition: 'center',
         }}
@@ -285,22 +288,19 @@ export default function RoommatePreferencesPage() {
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>
         <ScrollView contentContainerStyle={styles.content}>
           <View style={styles.titleBlock}>
-            <SectionEyebrow>Sharing a place</SectionEyebrow>
-            <H2 style={styles.title}>Roommate matching</H2>
-            <BloomText style={styles.subtitle}>
-              Let other Homiio users find you when their preferences and yours
-              line up.
-            </BloomText>
+            <SectionEyebrow>{t('roommates.preferencesPage.eyebrow')}</SectionEyebrow>
+            <H2 style={styles.title}>{t('roommates.preferences')}</H2>
+            <BloomText style={styles.subtitle}>{t('roommates.preferencesPage.subtitle')}</BloomText>
           </View>
 
           <View style={styles.card}>
             <View style={styles.toggleHeader}>
               <View style={styles.toggleHeaderText}>
                 <BloomText style={styles.toggleTitle}>
-                  Enable roommate matching
+                  {t('roommates.preferencesPage.enableTitle')}
                 </BloomText>
                 <BloomText style={styles.toggleDescription}>
-                  Allow other users to discover your profile for matching.
+                  {t('roommates.preferencesPage.enableDescription')}
                 </BloomText>
               </View>
               <Switch value={roommateEnabled} onValueChange={setRoommateEnabled} />
@@ -308,40 +308,40 @@ export default function RoommatePreferencesPage() {
           </View>
 
           <View style={styles.card}>
-            <H3 style={styles.cardTitle}>Budget & timeline</H3>
+            <H3 style={styles.cardTitle}>{t('roommates.preferencesPage.budgetTimeline')}</H3>
             <View style={styles.field}>
-              <BloomText style={styles.fieldLabel}>Monthly budget (€)</BloomText>
+              <BloomText style={styles.fieldLabel}>{t('roommates.preferencesPage.monthlyBudget')}</BloomText>
               <View style={styles.inlineInputs}>
                 <TextInput
                   style={styles.input}
                   keyboardType="numeric"
-                  placeholder="Min"
+                  placeholder={t('roommates.preferencesPage.min')}
                   placeholderTextColor={colors.muted}
                   value={form.budgetMin}
-                  onChangeText={(t) => updateField('budgetMin', t)}
+                  onChangeText={(text) => updateField('budgetMin', text)}
                 />
                 <TextInput
                   style={styles.input}
                   keyboardType="numeric"
-                  placeholder="Max"
+                  placeholder={t('roommates.preferencesPage.max')}
                   placeholderTextColor={colors.muted}
                   value={form.budgetMax}
-                  onChangeText={(t) => updateField('budgetMax', t)}
+                  onChangeText={(text) => updateField('budgetMax', text)}
                 />
               </View>
             </View>
             <View style={styles.field}>
-              <BloomText style={styles.fieldLabel}>Move-in date</BloomText>
+              <BloomText style={styles.fieldLabel}>{t('roommates.preferencesPage.moveInDate')}</BloomText>
               <TextInput
                 style={styles.input}
                 placeholder="YYYY-MM-DD"
                 placeholderTextColor={colors.muted}
                 value={form.moveInDate}
-                onChangeText={(t) => updateField('moveInDate', t)}
+                onChangeText={(text) => updateField('moveInDate', text)}
               />
             </View>
             <ChipRow
-              label="Lease length"
+              label={t('roommates.preferencesPage.leaseLength')}
               value={form.leaseDuration}
               options={LEASE_OPTIONS}
               onChange={(v) => updateField('leaseDuration', v)}
@@ -349,64 +349,64 @@ export default function RoommatePreferencesPage() {
           </View>
 
           <View style={styles.card}>
-            <H3 style={styles.cardTitle}>Roommate</H3>
+            <H3 style={styles.cardTitle}>{t('roommates.preferencesPage.roommateSection')}</H3>
             <ChipRow
-              label="Preferred gender"
+              label={t('roommates.preferencesPage.preferredGender')}
               value={form.gender}
               options={GENDER_OPTIONS}
               onChange={(v) => updateField('gender', v)}
             />
             <View style={styles.field}>
-              <BloomText style={styles.fieldLabel}>Age range</BloomText>
+              <BloomText style={styles.fieldLabel}>{t('roommates.preferencesPage.ageRange')}</BloomText>
               <View style={styles.inlineInputs}>
                 <TextInput
                   style={styles.input}
                   keyboardType="numeric"
-                  placeholder="Min"
+                  placeholder={t('roommates.preferencesPage.min')}
                   placeholderTextColor={colors.muted}
                   value={form.ageMin}
-                  onChangeText={(t) => updateField('ageMin', t)}
+                  onChangeText={(text) => updateField('ageMin', text)}
                 />
                 <TextInput
                   style={styles.input}
                   keyboardType="numeric"
-                  placeholder="Max"
+                  placeholder={t('roommates.preferencesPage.max')}
                   placeholderTextColor={colors.muted}
                   value={form.ageMax}
-                  onChangeText={(t) => updateField('ageMax', t)}
+                  onChangeText={(text) => updateField('ageMax', text)}
                 />
               </View>
             </View>
           </View>
 
           <View style={styles.card}>
-            <H3 style={styles.cardTitle}>Lifestyle</H3>
+            <H3 style={styles.cardTitle}>{t('roommates.preferencesPage.lifestyle')}</H3>
             <ChipRow
-              label="Smoking"
+              label={t('roommates.preferencesPage.smoking')}
               value={form.smoking}
               options={LIFESTYLE_OPTIONS}
               onChange={(v) => updateField('smoking', v)}
             />
             <ChipRow
-              label="Pets"
+              label={t('roommates.preferencesPage.pets')}
               value={form.pets}
               options={LIFESTYLE_OPTIONS}
               onChange={(v) => updateField('pets', v)}
             />
             <ChipRow
-              label="Partying"
+              label={t('roommates.preferencesPage.partying')}
               value={form.partying}
               options={LIFESTYLE_OPTIONS}
               onChange={(v) => updateField('partying', v)}
             />
             <ChipRow
-              label="Cleanliness"
+              label={t('roommates.preferencesPage.cleanliness')}
               value={form.cleanliness}
               options={CLEANLINESS_OPTIONS}
               onChange={(v) => updateField('cleanliness', v)}
             />
             <ChipRow
-              label="Schedule"
+              label={t('roommates.preferencesPage.schedule')}
               value={form.schedule}
               options={SCHEDULE_OPTIONS}
               onChange={(v) => updateField('schedule', v)}
@@ -420,7 +420,7 @@ export default function RoommatePreferencesPage() {
             disabled={saveMutation.isPending}
             style={styles.saveButton}
           >
-            {saveMutation.isPending ? 'Saving…' : 'Save preferences'}
+            {saveMutation.isPending ? t('roommates.preferencesPage.saving') : t('roommates.preferencesPage.save')}
           </Button>
         </ScrollView>
       </SafeAreaView>

--- a/packages/frontend/app/settings/currency.tsx
+++ b/packages/frontend/app/settings/currency.tsx
@@ -30,12 +30,12 @@ export default function CurrencySettingsScreen() {
     try {
       await changeCurrency(currencyCode);
       toast.success(
-        t('settings.currency.currencyChanged', 'Currency changed successfully'),
+        t('settings.currency.currencyChanged'),
       );
       router.back();
     } catch {
       toast.error(
-        t('settings.currency.errorChanging', 'Failed to change currency. Please try again.'),
+        t('settings.currency.errorChanging'),
       );
     }
   };
@@ -44,18 +44,15 @@ export default function CurrencySettingsScreen() {
     <View style={styles.root}>
       <Header
         options={{
-          title: t('settings.currency.title', 'Currency'),
+          title: t('settings.currency.title'),
           showBackButton: true,
           titlePosition: 'center',
         }}
       />
       <ScrollView contentContainerStyle={styles.scroll}>
         <SettingsListGroup
-          title={t('settings.currency.selectCurrency', 'Select your preferred currency')}
-          footer={t(
-            'settings.currency.description',
-            'This will be used to display prices throughout the app. Exchange rates are approximate.',
-          )}
+          title={t('settings.currency.selectCurrency')}
+          footer={t('settings.currency.description')}
         >
           {CURRENCIES.map((currency) => {
             const isActive = currentCurrency === currency.code;

--- a/packages/frontend/app/settings/index.tsx
+++ b/packages/frontend/app/settings/index.tsx
@@ -74,9 +74,9 @@ export default function SettingsScreen() {
       setDialogLoading(true);
       await logout();
       router.replace('/');
-      toast.success(t('settings.signOutSuccess', 'Signed out'));
+      toast.success(t('settings.signOutSuccess'));
     } catch {
-      toast.error(t('settings.signOutFailed', 'Failed to sign out'));
+      toast.error(t('settings.signOutFailed'));
     } finally {
       setDialogLoading(false);
       setPendingDialog(null);
@@ -89,7 +89,7 @@ export default function SettingsScreen() {
       // Implementation would clear app cache here.
       toast.success(t('settings.data.clearCacheSuccess'));
     } catch {
-      toast.error(t('common.error', 'Something went wrong'));
+      toast.error(t('common.error'));
     } finally {
       setDialogLoading(false);
       setPendingDialog(null);
@@ -101,7 +101,7 @@ export default function SettingsScreen() {
       setDialogLoading(true);
       toast.success(t('settings.data.exportDataSuccess'));
     } catch {
-      toast.error(t('common.error', 'Something went wrong'));
+      toast.error(t('common.error'));
     } finally {
       setDialogLoading(false);
       setPendingDialog(null);
@@ -126,11 +126,8 @@ export default function SettingsScreen() {
           />
           <SettingsListItem
             icon={<RowIcon name="folder" />}
-            title={t('settings.account.files', 'Files')}
-            description={t(
-              'settings.account.filesDescription',
-              'Manage uploaded documents',
-            )}
+            title={t('settings.account.files')}
+            description={t('settings.account.filesDescription')}
             onPress={() => showBottomSheet?.('FileManagement')}
           />
         </SettingsListGroup>
@@ -138,13 +135,13 @@ export default function SettingsScreen() {
         <SettingsListGroup title={t('settings.sections.preferences')}>
           <SettingsListItem
             icon={<RowIcon name="language" />}
-            title={t('Language')}
-            value={t('Select your preferred language')}
+            title={t('settings.language.title')}
+            value={t('settings.language.subtitle')}
             onPress={() => router.push('/settings/language')}
           />
           <SettingsListItem
             icon={<RowIcon name="cash" />}
-            title={t('settings.preferences.currency', 'Currency')}
+            title={t('settings.preferences.currency')}
             value={`${currentCurrencyInfo.symbol} ${currentCurrencyInfo.code}`}
             onPress={() => router.push('/settings/currency')}
           />
@@ -157,7 +154,7 @@ export default function SettingsScreen() {
           */}
         </SettingsListGroup>
 
-        <SettingsListGroup title={t('settings.sections.notifications', 'Notifications')}>
+        <SettingsListGroup title={t('settings.sections.notifications')}>
           <SettingsListItem
             icon={<RowIcon name="notifications" />}
             title={t('settings.preferences.notifications')}
@@ -168,11 +165,8 @@ export default function SettingsScreen() {
           />
           <SettingsListItem
             icon={<RowIcon name="options-outline" />}
-            title={t('settings.notifications.detail', 'Notification categories')}
-            description={t(
-              'settings.notifications.detailDesc',
-              'Choose which alerts you receive',
-            )}
+            title={t('settings.notifications.detail')}
+            description={t('settings.notifications.detailDesc')}
             onPress={() => router.push('/settings/notifications')}
           />
         </SettingsListGroup>

--- a/packages/frontend/app/settings/language.tsx
+++ b/packages/frontend/app/settings/language.tsx
@@ -16,11 +16,16 @@ import {
 
 import { Header } from '@/components/Header';
 import { EmptyState } from '@/components/ui/EmptyState';
+import {
+  SUPPORTED_LANGUAGE_CODES,
+  setStoredLanguage,
+  type SupportedLanguageCode,
+} from '@/utils/languagePreference';
 import { colors } from '@/styles/colors';
 import { spacing } from '@/constants/styles';
 
 interface LanguageOption {
-  code: string;
+  code: SupportedLanguageCode;
   label: string;
   description: string;
   flag: string;
@@ -30,15 +35,8 @@ const LANGUAGES: LanguageOption[] = [
   { code: 'en-US', label: 'English', description: 'English (United States)', flag: '🇺🇸' },
   { code: 'es-ES', label: 'Español', description: 'Español (España)', flag: '🇪🇸' },
   { code: 'ca-ES', label: 'Català', description: 'Català (Espanya)', flag: '🇪🇸' },
-  { code: 'fr-FR', label: 'Français', description: 'Français (France)', flag: '🇫🇷' },
-  { code: 'de-DE', label: 'Deutsch', description: 'Deutsch (Deutschland)', flag: '🇩🇪' },
   { code: 'it-IT', label: 'Italiano', description: 'Italiano (Italia)', flag: '🇮🇹' },
-  { code: 'pt-PT', label: 'Português', description: 'Português (Portugal)', flag: '🇵🇹' },
-  { code: 'zh-CN', label: '中文', description: 'Chinese (Simplified)', flag: '🇨🇳' },
-  { code: 'ja-JP', label: '日本語', description: 'Japanese (Japan)', flag: '🇯🇵' },
-  { code: 'ru-RU', label: 'Русский', description: 'Russian (Russia)', flag: '🇷🇺' },
-  { code: 'ar-AR', label: 'العربية', description: 'Arabic', flag: '🇸🇦' },
-];
+].filter((lang) => SUPPORTED_LANGUAGE_CODES.includes(lang.code));
 
 export default function LanguageSettingsScreen() {
   const { t, i18n } = useTranslation();
@@ -48,7 +46,7 @@ export default function LanguageSettingsScreen() {
     <View style={styles.root}>
       <Header
         options={{
-          title: t('Language'),
+          title: t('settings.language.title'),
           showBackButton: true,
           titlePosition: 'center',
         }}
@@ -57,16 +55,13 @@ export default function LanguageSettingsScreen() {
         {LANGUAGES.length === 0 ? (
           <EmptyState
             icon="language-outline"
-            title={t('No languages found')}
-            description={t('No language options are currently available')}
+            title={t('settings.language.emptyTitle')}
+            description={t('settings.language.emptyDescription')}
           />
         ) : (
           <SettingsListGroup
-            title={t('settings.language.choose', 'Choose a language')}
-            footer={t(
-              'settings.language.footer',
-              'Changing the language updates labels across the app immediately.',
-            )}
+            title={t('settings.language.choose')}
+            footer={t('settings.language.footer')}
           >
             {LANGUAGES.map((lang) => {
               const isActive = i18n.language === lang.code;
@@ -86,8 +81,8 @@ export default function LanguageSettingsScreen() {
                     ) : undefined
                   }
                   showChevron={!isActive}
-                  onPress={() => {
-                    i18n.changeLanguage(lang.code);
+                  onPress={async () => {
+                    await setStoredLanguage(lang.code);
                     router.back();
                   }}
                 />

--- a/packages/frontend/app/settings/notifications.tsx
+++ b/packages/frontend/app/settings/notifications.tsx
@@ -72,9 +72,9 @@ export default function NotificationSettingsScreen() {
       try {
         setIsUpdating(true);
         await updatePreferences({ [key]: value });
-        toast.success(t('notification.settings.updated', 'Settings updated'));
+        toast.success(t('notification.settings.updated'));
       } catch {
-        toast.error(t('notification.settings.error', 'Failed to update settings'));
+        toast.error(t('notification.settings.error'));
       } finally {
         setIsUpdating(false);
       }
@@ -87,16 +87,16 @@ export default function NotificationSettingsScreen() {
       const granted = await requestPermissions();
       if (granted) {
         toast.success(
-          t('notification.permissions.granted', 'Notification permissions granted'),
+          t('notification.permissions.granted'),
         );
       } else {
         toast.error(
-          t('notification.permissions.denied', 'Notification permissions denied'),
+          t('notification.permissions.denied'),
         );
       }
     } catch {
       toast.error(
-        t('notification.permissions.error', 'Failed to request permissions'),
+        t('notification.permissions.error'),
       );
     }
   }, [requestPermissions, t]);
@@ -106,11 +106,11 @@ export default function NotificationSettingsScreen() {
       setClearing(true);
       await clearAllNotifications();
       toast.success(
-        t('notification.clearAll.success', 'All notifications cleared'),
+        t('notification.clearAll.success'),
       );
     } catch {
       toast.error(
-        t('notification.clearAll.error', 'Failed to clear notifications'),
+        t('notification.clearAll.error'),
       );
     } finally {
       setClearing(false);
@@ -121,65 +121,44 @@ export default function NotificationSettingsScreen() {
   const categoryRows: PreferenceRow[] = [
     {
       key: 'property',
-      title: t('notification.settings.property.title', 'Property notifications'),
-      description: t(
-        'notification.settings.property.description',
-        'New properties, price changes, and viewing reminders',
-      ),
+      title: t('notification.settings.property.title'),
+      description: t('notification.settings.property.description'),
       icon: 'home-outline',
     },
     {
       key: 'message',
-      title: t('notification.settings.message.title', 'Message notifications'),
-      description: t(
-        'notification.settings.message.description',
-        'New messages from agents, landlords, and other users',
-      ),
+      title: t('notification.settings.message.title'),
+      description: t('notification.settings.message.description'),
       icon: 'chatbubble-outline',
     },
     {
       key: 'contract',
-      title: t('notification.settings.contract.title', 'Contract notifications'),
-      description: t(
-        'notification.settings.contract.description',
-        'Contract updates, signatures, and important deadlines',
-      ),
+      title: t('notification.settings.contract.title'),
+      description: t('notification.settings.contract.description'),
       icon: 'document-text-outline',
     },
     {
       key: 'payment',
-      title: t('notification.settings.payment.title', 'Payment notifications'),
-      description: t(
-        'notification.settings.payment.description',
-        'Payment confirmations, reminders, and receipts',
-      ),
+      title: t('notification.settings.payment.title'),
+      description: t('notification.settings.payment.description'),
       icon: 'card-outline',
     },
     {
       key: 'reminder',
-      title: t('notification.settings.reminder.title', 'Reminder notifications'),
-      description: t(
-        'notification.settings.reminder.description',
-        'Viewing reminders, application deadlines, and follow-ups',
-      ),
+      title: t('notification.settings.reminder.title'),
+      description: t('notification.settings.reminder.description'),
       icon: 'alarm-outline',
     },
     {
       key: 'system',
-      title: t('notification.settings.system.title', 'System notifications'),
-      description: t(
-        'notification.settings.system.description',
-        'App updates, maintenance, and important announcements',
-      ),
+      title: t('notification.settings.system.title'),
+      description: t('notification.settings.system.description'),
       icon: 'settings-outline',
     },
     {
       key: 'marketing',
-      title: t('notification.settings.marketing.title', 'Marketing notifications'),
-      description: t(
-        'notification.settings.marketing.description',
-        'Promotional offers, newsletters, and special deals',
-      ),
+      title: t('notification.settings.marketing.title'),
+      description: t('notification.settings.marketing.description'),
       icon: 'megaphone-outline',
     },
   ];
@@ -187,36 +166,27 @@ export default function NotificationSettingsScreen() {
   const behaviorRows: PreferenceRow[] = [
     {
       key: 'sound',
-      title: t('notification.settings.sound.title', 'Sound'),
-      description: t(
-        'notification.settings.sound.description',
-        'Play sound when notifications arrive',
-      ),
+      title: t('notification.settings.sound.title'),
+      description: t('notification.settings.sound.description'),
       icon: 'volume-high-outline',
     },
     {
       key: 'badge',
-      title: t('notification.settings.badge.title', 'Badge count'),
-      description: t(
-        'notification.settings.badge.description',
-        'Show unread count on the app icon',
-      ),
+      title: t('notification.settings.badge.title'),
+      description: t('notification.settings.badge.description'),
       icon: 'notifications-outline',
     },
     {
       key: 'push',
-      title: t('notification.settings.push.title', 'Push notifications'),
-      description: t(
-        'notification.settings.push.description',
-        'Receive notifications even when the app is closed',
-      ),
+      title: t('notification.settings.push.title'),
+      description: t('notification.settings.push.description'),
       icon: 'phone-portrait-outline',
     },
   ];
 
   const testActions: { label: string; icon: IoniconName; run: () => Promise<unknown> }[] = [
     {
-      label: t('notification.test.property', 'Test property'),
+      label: t('notification.test.property'),
       icon: 'home-outline',
       run: () =>
         createPropertyNotification(
@@ -227,7 +197,7 @@ export default function NotificationSettingsScreen() {
         ),
     },
     {
-      label: t('notification.test.message', 'Test message'),
+      label: t('notification.test.message'),
       icon: 'chatbubble-outline',
       run: () =>
         createMessageNotification(
@@ -238,7 +208,7 @@ export default function NotificationSettingsScreen() {
         ),
     },
     {
-      label: t('notification.test.reminder', 'Test reminder'),
+      label: t('notification.test.reminder'),
       icon: 'alarm-outline',
       run: () => {
         const tomorrow = new Date();
@@ -253,7 +223,7 @@ export default function NotificationSettingsScreen() {
       },
     },
     {
-      label: t('notification.test.repeating', 'Test repeating'),
+      label: t('notification.test.repeating'),
       icon: 'repeat-outline',
       run: () =>
         createRepeatingNotification(
@@ -270,11 +240,11 @@ export default function NotificationSettingsScreen() {
       try {
         await run();
         toast.success(
-          t('notification.test.success', 'Test notification sent'),
+          t('notification.test.success'),
         );
       } catch {
         toast.error(
-          t('notification.test.error', 'Failed to send test notification'),
+          t('notification.test.error'),
         );
       }
     },
@@ -285,7 +255,7 @@ export default function NotificationSettingsScreen() {
     <View style={styles.root}>
       <Header
         options={{
-          title: t('notification.settings.title', 'Notifications'),
+          title: t('notification.settings.title'),
           showBackButton: true,
           titlePosition: 'center',
         }}
@@ -302,25 +272,13 @@ export default function NotificationSettingsScreen() {
               <View style={styles.permissionTextWrap}>
                 <H3 style={styles.permissionTitle}>
                   {hasPermission
-                    ? t(
-                        'notification.permissions.enabled',
-                        'Notifications enabled',
-                      )
-                    : t(
-                        'notification.permissions.disabled',
-                        'Notifications disabled',
-                      )}
+                    ? t('notification.permissions.enabled.title')
+                    : t('notification.permissions.disabled.title')}
                 </H3>
                 <BloomText style={styles.permissionBody}>
                   {hasPermission
-                    ? t(
-                        'notification.permissions.enabled.description',
-                        'You will receive notifications for enabled categories.',
-                      )
-                    : t(
-                        'notification.permissions.disabled.description',
-                        'Enable notifications to receive updates about properties, messages and more.',
-                      )}
+                    ? t('notification.permissions.enabled.description')
+                    : t('notification.permissions.disabled.description')}
                 </BloomText>
               </View>
             </View>
@@ -331,10 +289,7 @@ export default function NotificationSettingsScreen() {
                   size="medium"
                   onPress={handleRequestPermissions}
                 >
-                  {t(
-                    'notification.permissions.enable',
-                    'Enable notifications',
-                  )}
+                  {t('notification.permissions.enable')}
                 </Button>
               </View>
             ) : null}
@@ -342,7 +297,7 @@ export default function NotificationSettingsScreen() {
         </View>
 
         <SettingsListGroup
-          title={t('notification.settings.categories', 'Notification categories')}
+          title={t('notification.settings.categories')}
         >
           {categoryRows.map((row) => (
             <SettingsListItem
@@ -364,7 +319,7 @@ export default function NotificationSettingsScreen() {
         </SettingsListGroup>
 
         <SettingsListGroup
-          title={t('notification.settings.behavior', 'Notification behavior')}
+          title={t('notification.settings.behavior')}
         >
           {behaviorRows.map((row) => (
             <SettingsListItem
@@ -387,11 +342,8 @@ export default function NotificationSettingsScreen() {
 
         {__DEV__ && hasPermission ? (
           <SettingsListGroup
-            title={t('notification.settings.test', 'Test notifications')}
-            footer={t(
-              'notification.settings.test.description',
-              'Send test notifications to verify your settings are working correctly.',
-            )}
+            title={t('notification.settings.test.title')}
+            footer={t('notification.settings.test.description')}
           >
             {testActions.map((action) => (
               <SettingsListItem
@@ -405,11 +357,11 @@ export default function NotificationSettingsScreen() {
         ) : null}
 
         <SettingsListGroup
-          title={t('notification.settings.manage', 'Manage notifications')}
+          title={t('notification.settings.manage')}
         >
           <SettingsListItem
             icon={<RowIcon name="trash-outline" destructive />}
-            title={t('notification.settings.clearAll', 'Clear all notifications')}
+            title={t('notification.settings.clearAll')}
             destructive
             onPress={() => setConfirmClear(true)}
           />
@@ -417,18 +369,12 @@ export default function NotificationSettingsScreen() {
 
         {Platform.OS === 'ios' ? (
           <SettingsListGroup
-            title={t('notification.settings.ios.title', 'iOS settings')}
-            footer={t(
-              'notification.settings.ios.description',
-              "For more granular control, manage notifications in Settings > Notifications > Homiio.",
-            )}
+            title={t('notification.settings.ios.title')}
+            footer={t('notification.settings.ios.description')}
           >
             <SettingsListItem
               icon={<RowIcon name="information-circle-outline" />}
-              title={t(
-                'notification.settings.ios.openSettings',
-                'Open system settings',
-              )}
+              title={t('notification.settings.ios.openSettings')}
               onPress={() => {
                 /* surfaced as guidance only */
               }}
@@ -439,18 +385,12 @@ export default function NotificationSettingsScreen() {
 
         {Platform.OS === 'android' ? (
           <SettingsListGroup
-            title={t('notification.settings.android.title', 'Android settings')}
-            footer={t(
-              'notification.settings.android.description',
-              "Manage notification channels in Settings > Apps > Homiio > Notifications.",
-            )}
+            title={t('notification.settings.android.title')}
+            footer={t('notification.settings.android.description')}
           >
             <SettingsListItem
               icon={<RowIcon name="information-circle-outline" />}
-              title={t(
-                'notification.settings.android.openSettings',
-                'Open system settings',
-              )}
+              title={t('notification.settings.android.openSettings')}
               onPress={() => {
                 /* surfaced as guidance only */
               }}
@@ -462,12 +402,9 @@ export default function NotificationSettingsScreen() {
 
       <ConfirmDialog
         visible={confirmClear}
-        title={t('notification.clearAll.title', 'Clear all notifications')}
-        message={t(
-          'notification.clearAll.message',
-          'This will clear all notifications and reset the badge count. This action cannot be undone.',
-        )}
-        confirmLabel={t('common.clear', 'Clear all')}
+        title={t('notification.clearAll.title')}
+        message={t('notification.clearAll.message')}
+        confirmLabel={t('common.clear')}
         confirmDestructive
         loading={clearing}
         onConfirm={handleClearAll}

--- a/packages/frontend/app/settings/sindi.tsx
+++ b/packages/frontend/app/settings/sindi.tsx
@@ -45,7 +45,7 @@ export default function SindiSettingsScreen() {
 
   const handleResetDefaults = useCallback((): void => {
     setShowTips(true);
-    toast.success(t('sindi.settings.resetDone', 'Sindi preferences reset.'));
+    toast.success(t('sindi.settings.resetDone'));
     setPendingDialog(null);
   }, [t]);
 
@@ -53,7 +53,7 @@ export default function SindiSettingsScreen() {
     <View style={styles.root}>
       <Header
         options={{
-          title: t('sindi.settings.title', 'Sindi preferences'),
+          title: t('sindi.settings.title'),
           showBackButton: true,
           titlePosition: 'center',
           leftComponents: [
@@ -65,29 +65,23 @@ export default function SindiSettingsScreen() {
       />
       <ScrollView contentContainerStyle={styles.scroll}>
         <SettingsListGroup
-          title={t('sindi.settings.behavior', 'Behavior')}
-          footer={t(
-            'sindi.settings.behaviorFooter',
-            'Tune how Sindi behaves while you browse properties.',
-          )}
+          title={t('sindi.settings.behavior')}
+          footer={t('sindi.settings.behaviorFooter')}
         >
           <SettingsListItem
             icon={<RowIcon name="information-circle-outline" />}
-            title={t('sindi.settings.tips', 'Show tips & hints')}
-            description={t(
-              'sindi.settings.tipsDescription',
-              'Surface inline guidance while you chat.',
-            )}
+            title={t('sindi.settings.tips')}
+            description={t('sindi.settings.tipsDescription')}
             rightElement={
               <Switch value={showTips} onValueChange={setShowTips} />
             }
           />
         </SettingsListGroup>
 
-        <SettingsListGroup title={t('sindi.settings.actions', 'Actions')}>
+        <SettingsListGroup title={t('sindi.settings.actions')}>
           <SettingsListItem
             icon={<RowIcon name="refresh-outline" />}
-            title={t('sindi.settings.reset', 'Reset Sindi to defaults')}
+            title={t('sindi.settings.reset')}
             onPress={() => setPendingDialog('reset')}
           />
         </SettingsListGroup>
@@ -95,12 +89,9 @@ export default function SindiSettingsScreen() {
 
       <ConfirmDialog
         visible={pendingDialog === 'reset'}
-        title={t('sindi.settings.resetTitle', 'Reset Sindi?')}
-        message={t(
-          'sindi.settings.resetMessage',
-          'This will reset all Sindi preferences to their defaults.',
-        )}
-        confirmLabel={t('common.reset', 'Reset')}
+        title={t('sindi.settings.resetTitle')}
+        message={t('sindi.settings.resetMessage')}
+        confirmLabel={t('common.reset')}
         confirmDestructive
         onConfirm={handleResetDefaults}
         onCancel={() => setPendingDialog(null)}

--- a/packages/frontend/app/stays/index.tsx
+++ b/packages/frontend/app/stays/index.tsx
@@ -11,6 +11,7 @@ import React, { useMemo, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
 
 import { Chip } from '@oxyhq/bloom/chip';
 import { Text as BloomText } from '@oxyhq/bloom/typography';
@@ -33,14 +34,14 @@ type Filter = 'all' | 'upcoming' | 'past' | 'cancelled';
 
 interface FilterOption {
   value: Filter;
-  label: string;
+  i18nKey: string;
 }
 
 const FILTERS: FilterOption[] = [
-  { value: 'all', label: 'All' },
-  { value: 'upcoming', label: 'Upcoming' },
-  { value: 'past', label: 'Past' },
-  { value: 'cancelled', label: 'Cancelled' },
+  { value: 'all', i18nKey: 'stays.list.filterAll' },
+  { value: 'upcoming', i18nKey: 'stays.list.filterUpcoming' },
+  { value: 'past', i18nKey: 'stays.list.filterPast' },
+  { value: 'cancelled', i18nKey: 'stays.list.filterCancelled' },
 ];
 
 interface Buckets {
@@ -80,6 +81,7 @@ const bucketReservations = (items: Reservation[]): Buckets => {
 };
 
 export default function StaysScreen() {
+  const { t } = useTranslation();
   const router = useRouter();
   const { oxyServices, activeSessionId } = useOxy();
   const isAuthed = Boolean(oxyServices && activeSessionId);
@@ -97,31 +99,31 @@ export default function StaysScreen() {
   const filteredGroups = useMemo<{ label: string; items: Reservation[] }[]>(() => {
     if (filter === 'all') {
       return [
-        { label: 'Upcoming', items: buckets.upcoming },
-        { label: 'Past', items: buckets.past },
-        { label: 'Cancelled', items: buckets.cancelled },
+        { label: t('stays.list.groupUpcoming'), items: buckets.upcoming },
+        { label: t('stays.list.groupPast'), items: buckets.past },
+        { label: t('stays.list.groupCancelled'), items: buckets.cancelled },
       ].filter((group) => group.items.length > 0);
     }
     if (filter === 'upcoming') {
       return buckets.upcoming.length > 0
-        ? [{ label: 'Upcoming', items: buckets.upcoming }]
+        ? [{ label: t('stays.list.groupUpcoming'), items: buckets.upcoming }]
         : [];
     }
     if (filter === 'past') {
       return buckets.past.length > 0
-        ? [{ label: 'Past', items: buckets.past }]
+        ? [{ label: t('stays.list.groupPast'), items: buckets.past }]
         : [];
     }
     return buckets.cancelled.length > 0
-      ? [{ label: 'Cancelled', items: buckets.cancelled }]
+      ? [{ label: t('stays.list.groupCancelled'), items: buckets.cancelled }]
       : [];
-  }, [filter, buckets]);
+  }, [filter, buckets, t]);
 
   const header = (
     <Header
       options={{
         showBackButton: true,
-        title: 'Stays',
+        title: t('stays.list.title'),
         titlePosition: 'center',
       }}
     />
@@ -135,9 +137,9 @@ export default function StaysScreen() {
           <View style={styles.centerWrap}>
             <EmptyState
               icon="bed-outline"
-              title="Sign in to see your stays"
-              description="Bookings across hosts and dates live here."
-              actionText="Sign in"
+              title={t('stays.list.signInTitle')}
+              description={t('stays.list.signInDescription')}
+              actionText={t('stays.list.signIn')}
               actionIcon="log-in-outline"
               onAction={() => showSignInModal()}
             />
@@ -153,7 +155,7 @@ export default function StaysScreen() {
         {header}
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
           <View style={styles.content}>
-            <FilterRow value={filter} onChange={setFilter} />
+            <FilterRow value={filter} onChange={setFilter} t={t} />
             <ListSkeleton rows={4} rowHeight={140} />
           </View>
         </SafeAreaView>
@@ -168,9 +170,9 @@ export default function StaysScreen() {
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
           <View style={styles.centerWrap}>
             <ErrorState
-              title="Couldn't load your stays"
-              description={reservationsQuery.error?.message ?? 'Please try again.'}
-              retryLabel="Retry"
+              title={t('stays.list.loadError')}
+              description={reservationsQuery.error?.message ?? t('stays.list.tryAgain')}
+              retryLabel={t('applications.list.retry')}
               onRetry={() => reservationsQuery.refetch()}
             />
           </View>
@@ -190,13 +192,17 @@ export default function StaysScreen() {
             <View style={styles.emptyWrap}>
               <EmptyState
                 icon="bed-outline"
-                title={filter === 'all' ? 'No stays yet' : 'Nothing in this view.'}
+                title={
+                  filter === 'all'
+                    ? t('stays.list.emptyAllTitle')
+                    : t('stays.list.emptyFilteredTitle')
+                }
                 description={
                   filter === 'all'
-                    ? 'Once you book a place it will show up here.'
-                    : 'Try a different filter or explore new stays.'
+                    ? t('stays.list.emptyAllDescription')
+                    : t('stays.list.emptyFilteredDescription')
                 }
-                actionText={filter === 'all' ? 'Explore stays' : 'Explore stays'}
+                actionText={t('stays.list.exploreStays')}
                 actionIcon="search-outline"
                 onAction={() => router.push('/explore?offering=short_term_rent')}
               />
@@ -225,9 +231,10 @@ export default function StaysScreen() {
 interface FilterRowProps {
   value: Filter;
   onChange: (next: Filter) => void;
+  t: (key: string) => string;
 }
 
-const FilterRow: React.FC<FilterRowProps> = ({ value, onChange }) => (
+const FilterRow: React.FC<FilterRowProps> = ({ value, onChange, t }) => (
   <ScrollView
     horizontal
     showsHorizontalScrollIndicator={false}
@@ -242,7 +249,7 @@ const FilterRow: React.FC<FilterRowProps> = ({ value, onChange }) => (
         selected={value === option.value}
         onPress={() => onChange(option.value)}
       >
-        {option.label}
+        {t(option.i18nKey)}
       </Chip>
     ))}
   </ScrollView>

--- a/packages/frontend/app/tips/[slug].tsx
+++ b/packages/frontend/app/tips/[slug].tsx
@@ -162,9 +162,9 @@ export default function TipArticleScreen() {
         <Header options={{ title: t('tips.article'), showBackButton: true }} />
         <ErrorState
           icon="document-text-outline"
-          title={t('tips.unavailable', 'Article unavailable')}
-          description={t('tips.missingSlug', 'This tip could not be loaded.')}
-          retryLabel={t('common.goBack', 'Go back')}
+          title={t('tips.unavailable')}
+          description={t('tips.missingSlug')}
+          retryLabel={t('common.goBack')}
           onRetry={() => router.back()}
         />
       </View>
@@ -186,9 +186,9 @@ export default function TipArticleScreen() {
         <Header options={{ title: t('tips.article'), showBackButton: true }} />
         <ErrorState
           icon="document-text-outline"
-          title={t('tips.unavailable', 'Article unavailable')}
-          description={tipQuery.error?.message ?? t('tips.loadFailed', 'This tip could not be loaded.')}
-          retryLabel={t('common.goBack', 'Go back')}
+          title={t('tips.unavailable')}
+          description={tipQuery.error?.message ?? t('tips.loadFailed')}
+          retryLabel={t('common.goBack')}
           onRetry={() => router.back()}
         />
       </View>
@@ -249,7 +249,7 @@ export default function TipArticleScreen() {
         {relatedTips.length >= 2 ? (
           <View style={styles.relatedSection}>
             <H2 style={styles.relatedHeading}>
-              {t('tips.related', 'Related tips')}
+              {t('tips.related')}
             </H2>
             <View style={styles.relatedGrid}>
               {relatedTips.map((related) => (

--- a/packages/frontend/app/tips/index.tsx
+++ b/packages/frontend/app/tips/index.tsx
@@ -143,13 +143,10 @@ export default function TipsScreen() {
       />
       <ScrollView contentContainerStyle={styles.content}>
         <View style={styles.titleBlock}>
-          <SectionEyebrow>{t('home.tips.eyebrow', 'Renting smarter')}</SectionEyebrow>
-          <H2 style={styles.title}>{t('home.tips.title', 'Rental tips')}</H2>
+          <SectionEyebrow>{t('home.tips.eyebrow')}</SectionEyebrow>
+          <H2 style={styles.title}>{t('home.tips.title')}</H2>
           <BloomText style={styles.subtitle}>
-            {t(
-              'home.tips.subtitle',
-              'Practical guides from local tenants, legal experts, and the Homiio editorial team.',
-            )}
+            {t('home.tips.subtitle')}
           </BloomText>
         </View>
 
@@ -165,7 +162,7 @@ export default function TipsScreen() {
               color={activeTag === undefined ? 'primary' : 'default'}
               selected={activeTag === undefined}
             >
-              {t('tips.all', 'All')}
+              {t('tips.all')}
             </Chip>
             {allTags.map((tag) => {
               const isActive = activeTag === tag;
@@ -189,18 +186,15 @@ export default function TipsScreen() {
         ) : tipsQuery.isError ? (
           <ErrorState
             icon="cloud-offline-outline"
-            title={t('tips.loadError', "Couldn't load tips")}
-            description={tipsQuery.error?.message ?? t('tips.tryAgain', 'Please try again.')}
+            title={t('tips.loadError')}
+            description={tipsQuery.error?.message ?? t('tips.tryAgain')}
             onRetry={() => tipsQuery.refetch()}
           />
         ) : tips.length === 0 ? (
           <ErrorState
             icon="newspaper-outline"
-            title={t('tips.emptyTitle', 'No tips yet')}
-            description={t(
-              'tips.emptyDescription',
-              'Check back soon for new rental guides and advice.',
-            )}
+            title={t('tips.emptyTitle')}
+            description={t('tips.emptyDescription')}
           />
         ) : (
           <View style={styles.magazine}>

--- a/packages/frontend/app/viewings/index.tsx
+++ b/packages/frontend/app/viewings/index.tsx
@@ -245,7 +245,7 @@ export default function ViewingsPage() {
         <Header
           options={{
             showBackButton: true,
-            title: t('viewings.title') || 'Viewings',
+            title: t('viewings.title'),
             titlePosition: 'center',
           }}
         />
@@ -270,7 +270,7 @@ export default function ViewingsPage() {
       <Header
         options={{
           showBackButton: true,
-          title: t('viewings.title') || 'Viewings',
+          title: t('viewings.title'),
           titlePosition: 'center',
         }}
       />

--- a/packages/frontend/components/AddressDisplay.tsx
+++ b/packages/frontend/components/AddressDisplay.tsx
@@ -47,10 +47,10 @@ export function AddressDisplay({
   const handleCopyAddress = async () => {
     try {
       await Clipboard.setStringAsync(formattedAddress);
-      toast.success(t('Address copied to clipboard'));
+      toast.success(t('addresses.display.copySuccess'));
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     } catch (error) {
-      toast.error(t('Failed to copy address'));
+      toast.error(t('addresses.display.copyFailed'));
     }
   };
 
@@ -70,7 +70,7 @@ export function AddressDisplay({
       }
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     } catch (error) {
-      toast.error(t('Failed to open maps'));
+      toast.error(t('addresses.display.mapsFailed'));
     }
   };
 
@@ -126,7 +126,7 @@ export function AddressDisplay({
         {showMap && address.coordinates && (
           <View style={styles.mapPlaceholder}>
             <Ionicons name="map" size={24} color={colors.COLOR_BLACK_LIGHT_5} />
-            <ThemedText style={styles.mapPlaceholderText}>{t('Map view available')}</ThemedText>
+            <ThemedText style={styles.mapPlaceholderText}>{t('address.display.mapPlaceholder')}</ThemedText>
           </View>
         )}
       </View>
@@ -153,12 +153,12 @@ export function AddressDisplay({
         <View style={styles.detailedActions}>
           <TouchableOpacity style={styles.detailedActionButton} onPress={handleCopyAddress}>
             <Ionicons name="copy-outline" size={16} color={colors.primaryColor} />
-            <ThemedText style={styles.actionButtonText}>{t('Copy')}</ThemedText>
+            <ThemedText style={styles.actionButtonText}>{t('address.display.copy')}</ThemedText>
           </TouchableOpacity>
 
           <TouchableOpacity style={styles.detailedActionButton} onPress={handleOpenInMaps}>
             <Ionicons name="map-outline" size={16} color={colors.primaryColor} />
-            <ThemedText style={styles.actionButtonText}>{t('Open in Maps')}</ThemedText>
+            <ThemedText style={styles.actionButtonText}>{t('address.display.openInMaps')}</ThemedText>
           </TouchableOpacity>
         </View>
       )}

--- a/packages/frontend/components/AmenitiesSelector.tsx
+++ b/packages/frontend/components/AmenitiesSelector.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, TouchableOpacity, StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { ThemedText } from '@/components/ThemedText';
 import { colors } from '@/styles/colors';
@@ -25,6 +26,8 @@ export function AmenitiesSelector({
   style,
   propertyType,
 }: AmenitiesSelectorProps) {
+  const { t } = useTranslation();
+
   // Get amenities based on property type, fallback to all amenities if no type specified
   const availableAmenities = propertyType
     ? getAmenitiesByPropertyType(propertyType)
@@ -54,7 +57,7 @@ export function AmenitiesSelector({
                 <ThemedText
                   style={[styles.pickerOptionText, isSelected && styles.pickerOptionTextSelected]}
                 >
-                  {amenity.name}
+                  {amenity.nameKey ? t(amenity.nameKey) : amenity.name}
                 </ThemedText>
               </View>
             </TouchableOpacity>

--- a/packages/frontend/components/ApplicationCard.tsx
+++ b/packages/frontend/components/ApplicationCard.tsx
@@ -7,7 +7,7 @@
 import React, { useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
-import { format } from 'date-fns';
+import { useTranslation } from 'react-i18next';
 import { Text as BloomText } from '@oxyhq/bloom/typography';
 import { Avatar } from '@oxyhq/bloom/avatar';
 import { TenantApplication } from '@homiio/shared-types';
@@ -17,6 +17,7 @@ import { ThumbnailImage } from '@/components/ui/ThumbnailImage';
 import { useProperty } from '@/hooks';
 import { getPropertyImageSource, getPropertyTitle } from '@/utils/propertyUtils';
 import { formatCurrency } from '@/utils/currency';
+import { formatLocalized } from '@/utils/dateLocale';
 import { colors } from '@/styles/colors';
 import { spacing } from '@/constants/styles';
 
@@ -38,11 +39,6 @@ export interface ApplicationCardProps {
 
 const APPLICATION_INCOME_CURRENCY = 'EUR';
 
-const formatEmployment = (status: string): string =>
-  status
-    .replace(/_/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase());
-
 export const ApplicationCard: React.FC<ApplicationCardProps> = ({
   application,
   href,
@@ -50,13 +46,14 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({
   applicantName,
   applicantAvatarFileId,
 }) => {
+  const { t } = useTranslation();
   const router = useRouter();
   const { property } = useProperty(application.propertyId);
 
   const propertyTitle = useMemo(() => {
-    if (!property) return 'Property';
+    if (!property) return t('applications.card.propertyFallback');
     return getPropertyTitle(property);
-  }, [property]);
+  }, [property, t]);
 
   const imageSource = useMemo(() => {
     if (!property) return null;
@@ -64,8 +61,17 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({
   }, [property]);
 
   const submittedLabel = useMemo(
-    () => format(new Date(application.submittedAt), 'MMM d, yyyy'),
+    () => formatLocalized(new Date(application.submittedAt), 'MMM d, yyyy'),
     [application.submittedAt],
+  );
+
+  const moveInLabel = useMemo(
+    () =>
+      formatLocalized(
+        new Date(application.moveInDate),
+        variant === 'landlord' ? 'MMM d' : 'MMM d, yyyy',
+      ),
+    [application.moveInDate, variant],
   );
 
   const handlePress = () => {
@@ -76,11 +82,11 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({
     <ThumbnailCard
       thumbnail={<ThumbnailImage source={imageSource} />}
       onPress={handlePress}
-      accessibilityLabel={`Application ${application.id}`}
+      accessibilityLabel={t('applications.card.accessibility', { id: application.id })}
     >
       <View style={styles.headerRow}>
         <BloomText style={styles.title} numberOfLines={1}>
-          {variant === 'landlord' ? applicantName ?? 'Applicant' : propertyTitle}
+          {variant === 'landlord' ? applicantName ?? t('applications.card.applicantFallback') : propertyTitle}
         </BloomText>
         <ApplicationStatusBadge status={application.status} />
       </View>
@@ -98,19 +104,20 @@ export const ApplicationCard: React.FC<ApplicationCardProps> = ({
             </BloomText>
           </View>
           <BloomText style={styles.meta} numberOfLines={1}>
-            {formatCurrency(application.monthlyIncome, APPLICATION_INCOME_CURRENCY)} / month ·{' '}
-            {formatEmployment(application.employmentStatus)} · Move-in{' '}
-            {format(new Date(application.moveInDate), 'MMM d')}
+            {formatCurrency(application.monthlyIncome, APPLICATION_INCOME_CURRENCY)}
+            {t('applications.card.perMonth')} ·{' '}
+            {t(`profile.edit.options.employmentStatus.${application.employmentStatus}`)} ·{' '}
+            {t('applications.card.moveIn')} {moveInLabel}
           </BloomText>
         </>
       ) : (
         <>
           <BloomText style={styles.subtitle} numberOfLines={1}>
-            {application.leaseTermMonths}-month lease · Move-in{' '}
-            {format(new Date(application.moveInDate), 'MMM d, yyyy')}
+            {t('applications.card.monthLease', { count: application.leaseTermMonths })} ·{' '}
+            {t('applications.card.moveIn')} {moveInLabel}
           </BloomText>
           <BloomText style={styles.meta} numberOfLines={1}>
-            Submitted {submittedLabel}
+            {t('applications.card.submitted', { date: submittedLabel })}
           </BloomText>
         </>
       )}

--- a/packages/frontend/components/ApplicationStatusBadge.tsx
+++ b/packages/frontend/components/ApplicationStatusBadge.tsx
@@ -2,11 +2,11 @@ import { TenantApplicationStatus } from '@homiio/shared-types';
 import { createStatusBadge, type StatusBadgeEntry } from '@/components/ui/createStatusBadge';
 
 const STATUS_MAP: Record<TenantApplicationStatus, StatusBadgeEntry> = {
-  [TenantApplicationStatus.SUBMITTED]: { label: 'Submitted', color: 'info' },
-  [TenantApplicationStatus.REVIEWING]: { label: 'Reviewing', color: 'warning' },
-  [TenantApplicationStatus.APPROVED]: { label: 'Approved', color: 'success' },
-  [TenantApplicationStatus.REJECTED]: { label: 'Rejected', color: 'error' },
-  [TenantApplicationStatus.WITHDRAWN]: { label: 'Withdrawn', color: 'default' },
+  [TenantApplicationStatus.SUBMITTED]: { i18nKey: 'statusBadge.application.submitted', label: 'Submitted', color: 'info' },
+  [TenantApplicationStatus.REVIEWING]: { i18nKey: 'statusBadge.application.reviewing', label: 'Reviewing', color: 'warning' },
+  [TenantApplicationStatus.APPROVED]: { i18nKey: 'statusBadge.application.approved', label: 'Approved', color: 'success' },
+  [TenantApplicationStatus.REJECTED]: { i18nKey: 'statusBadge.application.rejected', label: 'Rejected', color: 'error' },
+  [TenantApplicationStatus.WITHDRAWN]: { i18nKey: 'statusBadge.application.withdrawn', label: 'Withdrawn', color: 'default' },
 };
 
 export const ApplicationStatusBadge = createStatusBadge(STATUS_MAP);

--- a/packages/frontend/components/BookingWidget.tsx
+++ b/packages/frontend/components/BookingWidget.tsx
@@ -3,6 +3,7 @@ import { Modal, Platform, Pressable, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { format } from 'date-fns';
+import { useTranslation } from 'react-i18next';
 import { toast } from '@/lib/sonner';
 import { Button } from '@oxyhq/bloom/button';
 import { Text as BloomText, H3 } from '@oxyhq/bloom/typography';
@@ -62,6 +63,7 @@ const isVacationCapable = (property: Property): boolean => {
 };
 
 export const BookingWidget: React.FC<BookingWidgetProps> = ({ property }) => {
+  const { t } = useTranslation();
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { oxyServices, activeSessionId } = useOxy();
@@ -110,15 +112,25 @@ export const BookingWidget: React.FC<BookingWidgetProps> = ({ property }) => {
       return;
     }
     if (!range || nights === 0) {
-      toast.error('Pick check-in and check-out dates first');
+      toast.error(t('booking.toast.pickDates'));
       return;
     }
     if (minStay && nights < minStay) {
-      toast.error(`Minimum stay is ${minStay} ${minStay === 1 ? 'night' : 'nights'}`);
+      toast.error(
+        t('booking.toast.minStay', {
+          count: minStay,
+          unit: t(minStay === 1 ? 'booking.toast.night' : 'booking.toast.nights'),
+        }),
+      );
       return;
     }
     if (maxStay && nights > maxStay) {
-      toast.error(`Maximum stay is ${maxStay} ${maxStay === 1 ? 'night' : 'nights'}`);
+      toast.error(
+        t('booking.toast.maxStay', {
+          count: maxStay,
+          unit: t(maxStay === 1 ? 'booking.toast.night' : 'booking.toast.nights'),
+        }),
+      );
       return;
     }
     try {
@@ -131,7 +143,7 @@ export const BookingWidget: React.FC<BookingWidgetProps> = ({ property }) => {
       router.push(`/reservations/${reservation.id}`);
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : 'Booking failed';
+        error instanceof Error ? error.message : t('booking.toast.failed');
       toast.error(message);
     }
   }, [
@@ -145,6 +157,7 @@ export const BookingWidget: React.FC<BookingWidgetProps> = ({ property }) => {
     propertyId,
     range,
     router,
+    t,
   ]);
 
   if (!isVacationCapable(property)) return null;
@@ -172,7 +185,7 @@ export const BookingWidget: React.FC<BookingWidgetProps> = ({ property }) => {
           style={styles.triggerCell}
           onPress={handleOpenCalendar}
           accessibilityRole="button"
-          accessibilityLabel="Select dates"
+          accessibilityLabel={t('booking.accessibility.selectDates')}
         >
           <BloomText style={styles.triggerLabel}>Dates</BloomText>
           <BloomText style={styles.triggerValue} numberOfLines={1}>
@@ -184,7 +197,7 @@ export const BookingWidget: React.FC<BookingWidgetProps> = ({ property }) => {
           style={styles.triggerCell}
           onPress={handleOpenGuests}
           accessibilityRole="button"
-          accessibilityLabel="Select guests"
+          accessibilityLabel={t('booking.accessibility.selectGuests')}
         >
           <BloomText style={styles.triggerLabel}>Guests</BloomText>
           <BloomText style={styles.triggerValue} numberOfLines={1}>
@@ -248,7 +261,7 @@ export const BookingWidget: React.FC<BookingWidgetProps> = ({ property }) => {
                 variant="icon"
                 size="small"
                 onPress={closeSheet}
-                accessibilityLabel="Close"
+                accessibilityLabel={t('booking.accessibility.close')}
               >
                 {'×'}
               </Button>

--- a/packages/frontend/components/ContractCard.tsx
+++ b/packages/frontend/components/ContractCard.tsx
@@ -14,6 +14,7 @@
  */
 import React, { useMemo, useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { Button } from '@oxyhq/bloom/button';
 import { Text as BloomText, H3 } from '@oxyhq/bloom/typography';
@@ -22,6 +23,7 @@ import { radius, spacing } from '@/constants/styles';
 import { CardSurface } from './ui/CardSurface';
 import { CardActionsFooter } from './ui/CardActionsFooter';
 import { StatusBadge, type StatusType } from './ui/StatusBadge';
+import { formatLocalized } from '@/utils/dateLocale';
 
 export type ContractStatus =
   | 'draft'
@@ -52,11 +54,7 @@ interface ContractCardProps {
 const formatDate = (raw: string): string => {
   const date = new Date(raw);
   if (Number.isNaN(date.getTime())) return raw;
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
+  return formatLocalized(date, 'MMM d, yyyy');
 };
 
 export const ContractCard: React.FC<ContractCardProps> = ({
@@ -73,6 +71,7 @@ export const ContractCard: React.FC<ContractCardProps> = ({
   onSharePress,
   onDownloadPress,
 }) => {
+  const { t } = useTranslation();
   const [pressed, setPressed] = useState(false);
 
   const formattedRent = useMemo(
@@ -91,7 +90,7 @@ export const ContractCard: React.FC<ContractCardProps> = ({
         </View>
         <View style={styles.rentBlock}>
           <BloomText style={styles.rentAmount}>{formattedRent}</BloomText>
-          <BloomText style={styles.rentPeriod}> / month</BloomText>
+          <BloomText style={styles.rentPeriod}>{t('contracts.card.perMonth')}</BloomText>
         </View>
       </View>
 
@@ -108,11 +107,11 @@ export const ContractCard: React.FC<ContractCardProps> = ({
 
       <View style={styles.datesContainer}>
         <View style={styles.dateRow}>
-          <BloomText style={styles.dateLabel}>Start</BloomText>
+          <BloomText style={styles.dateLabel}>{t('contracts.card.start')}</BloomText>
           <BloomText style={styles.dateValue}>{formatDate(startDate)}</BloomText>
         </View>
         <View style={styles.dateRow}>
-          <BloomText style={styles.dateLabel}>End</BloomText>
+          <BloomText style={styles.dateLabel}>{t('contracts.card.end')}</BloomText>
           <BloomText style={styles.dateValue}>{formatDate(endDate)}</BloomText>
         </View>
       </View>
@@ -124,7 +123,7 @@ export const ContractCard: React.FC<ContractCardProps> = ({
             size={16}
             color={colors.COLOR_BLACK_LIGHT_2}
           />
-          <BloomText style={styles.partyLabel}>Landlord</BloomText>
+          <BloomText style={styles.partyLabel}>{t('contracts.card.landlord')}</BloomText>
           <BloomText style={styles.partyName} numberOfLines={1}>
             {landlordName}
           </BloomText>
@@ -135,7 +134,7 @@ export const ContractCard: React.FC<ContractCardProps> = ({
             size={16}
             color={colors.COLOR_BLACK_LIGHT_2}
           />
-          <BloomText style={styles.partyLabel}>Tenant</BloomText>
+          <BloomText style={styles.partyLabel}>{t('contracts.card.tenant')}</BloomText>
           <BloomText style={styles.partyName} numberOfLines={1}>
             {tenantName}
           </BloomText>
@@ -153,7 +152,7 @@ export const ContractCard: React.FC<ContractCardProps> = ({
           onPressOut={() => setPressed(false)}
           style={[styles.bodyPressable, pressed && styles.containerPressed]}
           accessibilityRole="button"
-          accessibilityLabel={`Contract ${title}`}
+          accessibilityLabel={t('contracts.card.accessibility', { title })}
         >
           {body}
         </Pressable>
@@ -176,7 +175,7 @@ export const ContractCard: React.FC<ContractCardProps> = ({
                 />
               }
             >
-              Share
+              {t('contracts.card.share')}
             </Button>
           ) : null}
           {onDownloadPress ? (
@@ -192,7 +191,7 @@ export const ContractCard: React.FC<ContractCardProps> = ({
                 />
               }
             >
-              Download
+              {t('contracts.card.download')}
             </Button>
           ) : null}
         </CardActionsFooter>

--- a/packages/frontend/components/HomeCategoryStrip.tsx
+++ b/packages/frontend/components/HomeCategoryStrip.tsx
@@ -42,29 +42,28 @@ import { tracker } from '@/constants/styles';
 interface CategoryDef {
   id: HomeCategory;
   labelKey: string;
-  fallback: string;
 }
 
 const LONG_TERM_CATEGORIES: CategoryDef[] = [
-  { id: 'studios', labelKey: 'home.category.studios', fallback: 'Studios' },
-  { id: 'apartments', labelKey: 'home.category.apartments', fallback: 'Apartments' },
-  { id: 'houses', labelKey: 'home.category.houses', fallback: 'Houses' },
-  { id: 'rooms', labelKey: 'home.category.rooms', fallback: 'Rooms' },
-  { id: 'coliving', labelKey: 'home.category.coliving', fallback: 'Co-living' },
-  { id: 'luxury', labelKey: 'home.category.luxury', fallback: 'Luxury' },
-  { id: 'new_listings', labelKey: 'home.category.newListings', fallback: 'New listings' },
-  { id: 'near_you', labelKey: 'home.category.nearYou', fallback: 'Near you' },
+  { id: 'studios', labelKey: 'home.category.studios' },
+  { id: 'apartments', labelKey: 'home.category.apartments' },
+  { id: 'houses', labelKey: 'home.category.houses' },
+  { id: 'rooms', labelKey: 'home.category.rooms' },
+  { id: 'coliving', labelKey: 'home.category.coliving' },
+  { id: 'luxury', labelKey: 'home.category.luxury' },
+  { id: 'new_listings', labelKey: 'home.category.newListings' },
+  { id: 'near_you', labelKey: 'home.category.nearYou' },
 ];
 
 const VACATION_CATEGORIES: CategoryDef[] = [
-  { id: 'beachfront', labelKey: 'home.category.beachfront', fallback: 'Beachfront' },
-  { id: 'cabins', labelKey: 'home.category.cabins', fallback: 'Cabins' },
-  { id: 'pools', labelKey: 'home.category.pools', fallback: 'Pools' },
-  { id: 'mountain', labelKey: 'home.category.mountain', fallback: 'Mountain' },
-  { id: 'city_breaks', labelKey: 'home.category.cityBreaks', fallback: 'City breaks' },
-  { id: 'countryside', labelKey: 'home.category.countryside', fallback: 'Countryside' },
-  { id: 'instant_book', labelKey: 'home.category.instantBook', fallback: 'Instant book' },
-  { id: 'pet_friendly', labelKey: 'home.category.petFriendly', fallback: 'Pet friendly' },
+  { id: 'beachfront', labelKey: 'home.category.beachfront' },
+  { id: 'cabins', labelKey: 'home.category.cabins' },
+  { id: 'pools', labelKey: 'home.category.pools' },
+  { id: 'mountain', labelKey: 'home.category.mountain' },
+  { id: 'city_breaks', labelKey: 'home.category.cityBreaks' },
+  { id: 'countryside', labelKey: 'home.category.countryside' },
+  { id: 'instant_book', labelKey: 'home.category.instantBook' },
+  { id: 'pet_friendly', labelKey: 'home.category.petFriendly' },
 ];
 
 /** Edge length of the isometric tile — compact so more categories fit on screen. */
@@ -211,7 +210,7 @@ export const HomeCategoryStrip: React.FC<HomeCategoryStripProps> = ({
           <CategoryItem
             key={item.id}
             active={category === item.id}
-            label={t(item.labelKey, item.fallback)}
+            label={t(item.labelKey)}
             image={resolveCategoryImage(item.id)}
             onPress={() => handlePress(item.id)}
           />

--- a/packages/frontend/components/ImageUpload.tsx
+++ b/packages/frontend/components/ImageUpload.tsx
@@ -9,20 +9,19 @@ import {
   ActivityIndicator,
   Platform,
 } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
 import { colors } from '@/styles/colors';
 import { ThemedText } from '@/components/ThemedText';
 import { imageUploadService, UploadedImage } from '@/services/imageUploadService';
 
-
-
 interface ImageUploadProps {
-    images: UploadedImage[];
-    onImagesChange: (images: UploadedImage[]) => void;
-    maxImages?: number;
-    folder?: string;
-    disabled?: boolean;
+  images: UploadedImage[];
+  onImagesChange: (images: UploadedImage[]) => void;
+  maxImages?: number;
+  folder?: string;
+  disabled?: boolean;
 }
 
 export function ImageUpload({
@@ -32,414 +31,386 @@ export function ImageUpload({
   folder = 'properties',
   disabled = false,
 }: ImageUploadProps) {
+  const { t } = useTranslation();
   const [uploading, setUploading] = useState(false);
-  const [uploadProgress, setUploadProgress] = useState<Record<string, number>>({});
 
-    const requestPermissions = async () => {
-        if (Platform.OS !== 'web') {
-            const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
-            if (status !== 'granted') {
-                Alert.alert(
-                    'Permission Required',
-                    'Sorry, we need camera roll permissions to upload images.',
-                    [{ text: 'OK' }]
-                );
-                return false;
-            }
-        }
-        return true;
-    };
-
-    const pickImages = async () => {
-        if (disabled || uploading) return;
-
-        const hasPermission = await requestPermissions();
-        if (!hasPermission) return;
-
-        if (images.length >= maxImages) {
-            Alert.alert(
-                'Maximum Images Reached',
-                `You can upload a maximum of ${maxImages} images.`,
-                [{ text: 'OK' }]
-            );
-            return;
-        }
-
-        try {
-            const result = await ImagePicker.launchImageLibraryAsync({
-                mediaTypes: ImagePicker.MediaTypeOptions.Images,
-                allowsMultipleSelection: true,
-                quality: 0.8,
-                aspect: [4, 3],
-                allowsEditing: false,
-            });
-
-            if (!result.canceled && result.assets) {
-                const selectedImages = result.assets.slice(0, maxImages - images.length);
-                await uploadImages(selectedImages);
-            }
-        } catch (error) {
-            console.error('Error picking images:', error);
-            Alert.alert('Error', 'Failed to select images. Please try again.');
-        }
-    };
-
-    const takePhoto = async () => {
-        if (disabled || uploading) return;
-
-        const hasPermission = await requestPermissions();
-        if (!hasPermission) return;
-
-        if (images.length >= maxImages) {
-            Alert.alert(
-                'Maximum Images Reached',
-                `You can upload a maximum of ${maxImages} images.`,
-                [{ text: 'OK' }]
-            );
-            return;
-        }
-
-        try {
-            const result = await ImagePicker.launchCameraAsync({
-                mediaTypes: ImagePicker.MediaTypeOptions.Images,
-                quality: 0.8,
-                aspect: [4, 3],
-                allowsEditing: false,
-            });
-
-            if (!result.canceled && result.assets) {
-                await uploadImages(result.assets);
-            }
-        } catch (error) {
-            console.error('Error taking photo:', error);
-            Alert.alert('Error', 'Failed to take photo. Please try again.');
-        }
-    };
-
-    const uploadImages = async (selectedImages: ImagePicker.ImagePickerAsset[]) => {
-        setUploading(true);
-        const newImages: UploadedImage[] = [];
-
-        try {
-            // Upload images using the service
-            const response = await imageUploadService.uploadMultipleImages(
-                selectedImages.map((img) => img.uri),
-                folder,
-            );
-
-            // Map the upload response into UploadedImage records and flag the
-            // first image as primary when the gallery is currently empty.
-            const processedImages: UploadedImage[] = response.data.images.map((image, index) => ({
-                imageId: image.imageId,
-                urls: {
-                    small: image.urls.small ?? image.urls.original ?? '',
-                    medium: image.urls.medium ?? image.urls.original ?? '',
-                    large: image.urls.large ?? image.urls.original ?? '',
-                    original: image.urls.original ?? '',
-                },
-                keys: image.keys,
-                metadata: image.metadata,
-                isPrimary: images.length === 0 && index === 0,
-            }));
-
-            // Add new images to existing ones
-            const updatedImages = [...images, ...processedImages];
-            onImagesChange(updatedImages);
-
-        } catch (error) {
-            console.error('Error uploading images:', error);
-            Alert.alert('Upload Error', 'Failed to upload some images. Please try again.');
-        } finally {
-            setUploading(false);
-            setUploadProgress({});
-        }
-    };
-
-    const deleteImage = async (imageId: string) => {
+  const requestPermissions = async () => {
+    if (Platform.OS !== 'web') {
+      const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (status !== 'granted') {
         Alert.alert(
-            'Delete Image',
-            'Are you sure you want to delete this image?',
-            [
-                { text: 'Cancel', style: 'cancel' },
-                {
-                    text: 'Delete',
-                    style: 'destructive',
-                    onPress: async () => {
-                        try {
-                            const imageToDelete = images.find(img => img.imageId === imageId);
-                            if (!imageToDelete) return;
-
-                            // Delete from backend using service
-                            await imageUploadService.deleteImage(imageToDelete.keys.original);
-
-                            // Remove from local state
-                            const updatedImages = images.filter(img => img.imageId !== imageId);
-
-                            // If deleted image was primary, make first remaining image primary
-                            if (imageToDelete.isPrimary && updatedImages.length > 0) {
-                                updatedImages[0].isPrimary = true;
-                            }
-
-                            onImagesChange(updatedImages);
-                        } catch (error) {
-                            console.error('Error deleting image:', error);
-                            Alert.alert('Error', 'Failed to delete image. Please try again.');
-                        }
-                    },
-                },
-            ]
+          t('imageUpload.permissionTitle'),
+          t('imageUpload.permissionMessage'),
+          [{ text: t('common.ok') }],
         );
-    };
+        return false;
+      }
+    }
+    return true;
+  };
 
-    const setPrimaryImage = (imageId: string) => {
-        const updatedImages = images.map(img => ({
-            ...img,
-            isPrimary: img.imageId === imageId,
-        }));
-        onImagesChange(updatedImages);
-    };
+  const pickImages = async () => {
+    if (disabled || uploading) return;
 
-    const formatFileSize = (bytes: number): string => {
-        return imageUploadService.formatFileSize(bytes);
-    };
+    const hasPermission = await requestPermissions();
+    if (!hasPermission) return;
 
-    return (
-        <View style={styles.container}>
-            {/* Upload Buttons */}
-            <View style={styles.uploadButtonsContainer}>
-                <TouchableOpacity
-                    style={[styles.uploadButton, disabled && styles.uploadButtonDisabled]}
-                    onPress={pickImages}
-                    disabled={disabled || uploading}
-                >
-                    <Ionicons name="images-outline" size={24} color={colors.primaryLight} />
-                    <ThemedText style={styles.uploadButtonText}>Choose Photos</ThemedText>
-                </TouchableOpacity>
+    if (images.length >= maxImages) {
+      Alert.alert(
+        t('imageUpload.maxImagesTitle'),
+        t('imageUpload.maxImagesMessage', { max: maxImages }),
+        [{ text: t('common.ok') }],
+      );
+      return;
+    }
 
-                <TouchableOpacity
-                    style={[styles.uploadButton, disabled && styles.uploadButtonDisabled]}
-                    onPress={takePhoto}
-                    disabled={disabled || uploading}
-                >
-                    <Ionicons name="camera-outline" size={24} color={colors.primaryLight} />
-                    <ThemedText style={styles.uploadButtonText}>Take Photo</ThemedText>
-                </TouchableOpacity>
-            </View>
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        allowsMultipleSelection: true,
+        quality: 0.8,
+        aspect: [4, 3],
+        allowsEditing: false,
+      });
 
-            {/* Upload Progress */}
-            {uploading && (
-                <View style={styles.uploadProgressContainer}>
-                    <ActivityIndicator size="small" color={colors.primaryColor} />
-                    <ThemedText style={styles.uploadProgressText}>Uploading images...</ThemedText>
-                </View>
-            )}
+      if (!result.canceled && result.assets) {
+        const selectedImages = result.assets.slice(0, maxImages - images.length);
+        await uploadImages(selectedImages);
+      }
+    } catch (error) {
+      console.error('Error picking images:', error);
+      Alert.alert(t('common.error'), t('imageUpload.selectFailed'));
+    }
+  };
 
-            {/* Image Count */}
-            <View style={styles.imageCountContainer}>
-                <ThemedText style={styles.imageCountText}>
-                    {images.length} of {maxImages} images uploaded
-                </ThemedText>
-            </View>
+  const takePhoto = async () => {
+    if (disabled || uploading) return;
 
-            {/* Image Grid */}
-            <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.imageScrollView}>
-                <View style={styles.imageGrid}>
-                    {images.map((image, index) => (
-                        <View key={image.imageId} style={styles.imageContainer}>
-                            <Image source={{ uri: image.urls.small }} style={styles.image} />
+    const hasPermission = await requestPermissions();
+    if (!hasPermission) return;
 
-                            {/* Primary Badge */}
-                            {image.isPrimary && (
-                                <View style={styles.primaryBadge}>
-                                    <ThemedText style={styles.primaryBadgeText}>Primary</ThemedText>
-                                </View>
-                            )}
+    if (images.length >= maxImages) {
+      Alert.alert(
+        t('imageUpload.maxImagesTitle'),
+        t('imageUpload.maxImagesMessage', { max: maxImages }),
+        [{ text: t('common.ok') }],
+      );
+      return;
+    }
 
-                            {/* Image Actions */}
-                            <View style={styles.imageActions}>
-                                {!image.isPrimary && (
-                                    <TouchableOpacity
-                                        style={styles.actionButton}
-                                        onPress={() => setPrimaryImage(image.imageId)}
-                                    >
-                                        <Ionicons name="star-outline" size={16} color={colors.white} />
-                                    </TouchableOpacity>
-                                )}
+    try {
+      const result = await ImagePicker.launchCameraAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        quality: 0.8,
+        aspect: [4, 3],
+        allowsEditing: false,
+      });
 
-                                <TouchableOpacity
-                                    style={[styles.actionButton, styles.deleteButton]}
-                                    onPress={() => deleteImage(image.imageId)}
-                                >
-                                    <Ionicons name="trash-outline" size={16} color={colors.white} />
-                                </TouchableOpacity>
-                            </View>
+      if (!result.canceled && result.assets) {
+        await uploadImages(result.assets);
+      }
+    } catch (error) {
+      console.error('Error taking photo:', error);
+      Alert.alert(t('common.error'), t('imageUpload.photoFailed'));
+    }
+  };
 
-                            {/* Image Info */}
-                            <View style={styles.imageInfo}>
-                                <ThemedText style={styles.imageInfoText}>
-                                    {formatFileSize(image.metadata.originalSize)}
-                                </ThemedText>
-                            </View>
-                        </View>
-                    ))}
+  const uploadImages = async (selectedImages: ImagePicker.ImagePickerAsset[]) => {
+    setUploading(true);
 
-                    {/* Add More Button */}
-                    {images.length < maxImages && !uploading && (
-                        <TouchableOpacity
-                            style={[styles.imageContainer, styles.addMoreButton]}
-                            onPress={pickImages}
-                            disabled={disabled}
-                        >
-                            <Ionicons name="add" size={32} color={colors.COLOR_BLACK_LIGHT_4} />
-                            <ThemedText style={styles.addMoreText}>Add More</ThemedText>
-                        </TouchableOpacity>
-                    )}
-                </View>
-            </ScrollView>
+    try {
+      const response = await imageUploadService.uploadMultipleImages(
+        selectedImages.map((img) => img.uri),
+        folder,
+      );
 
-            {/* Helper Text */}
-            <ThemedText style={styles.helperText}>
-                Upload high-quality images of your property. Include photos of all rooms, exterior, and any special features.
-                {images.length === 0 && ' The first image will be set as the primary image.'}
-            </ThemedText>
-        </View>
+      const processedImages: UploadedImage[] = response.data.images.map((image, index) => ({
+        imageId: image.imageId,
+        urls: {
+          small: image.urls.small ?? image.urls.original ?? '',
+          medium: image.urls.medium ?? image.urls.original ?? '',
+          large: image.urls.large ?? image.urls.original ?? '',
+          original: image.urls.original ?? '',
+        },
+        keys: image.keys,
+        metadata: image.metadata,
+        isPrimary: images.length === 0 && index === 0,
+      }));
+
+      onImagesChange([...images, ...processedImages]);
+    } catch (error) {
+      console.error('Error uploading images:', error);
+      Alert.alert(t('common.error'), t('imageUpload.uploadFailed'));
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const deleteImage = async (imageId: string) => {
+    Alert.alert(t('imageUpload.deleteTitle'), t('imageUpload.deleteMessage'), [
+      { text: t('common.cancel'), style: 'cancel' },
+      {
+        text: t('common.delete'),
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            const imageToDelete = images.find((img) => img.imageId === imageId);
+            if (!imageToDelete) return;
+
+            await imageUploadService.deleteImage(imageToDelete.keys.original);
+
+            const updatedImages = images.filter((img) => img.imageId !== imageId);
+            if (imageToDelete.isPrimary && updatedImages.length > 0) {
+              updatedImages[0].isPrimary = true;
+            }
+
+            onImagesChange(updatedImages);
+          } catch (error) {
+            console.error('Error deleting image:', error);
+            Alert.alert(t('common.error'), t('imageUpload.deleteFailed'));
+          }
+        },
+      },
+    ]);
+  };
+
+  const setPrimaryImage = (imageId: string) => {
+    onImagesChange(
+      images.map((img) => ({
+        ...img,
+        isPrimary: img.imageId === imageId,
+      })),
     );
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.uploadButtonsContainer}>
+        <TouchableOpacity
+          style={[styles.uploadButton, disabled && styles.uploadButtonDisabled]}
+          onPress={pickImages}
+          disabled={disabled || uploading}
+        >
+          <Ionicons name="images-outline" size={24} color={colors.primaryLight} />
+          <ThemedText style={styles.uploadButtonText}>{t('imageUpload.choosePhotos')}</ThemedText>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.uploadButton, disabled && styles.uploadButtonDisabled]}
+          onPress={takePhoto}
+          disabled={disabled || uploading}
+        >
+          <Ionicons name="camera-outline" size={24} color={colors.primaryLight} />
+          <ThemedText style={styles.uploadButtonText}>{t('imageUpload.takePhoto')}</ThemedText>
+        </TouchableOpacity>
+      </View>
+
+      {uploading ? (
+        <View style={styles.uploadProgressContainer}>
+          <ActivityIndicator size="small" color={colors.primaryColor} />
+          <ThemedText style={styles.uploadProgressText}>{t('imageUpload.uploading')}</ThemedText>
+        </View>
+      ) : null}
+
+      <View style={styles.imageCountContainer}>
+        <ThemedText style={styles.imageCountText}>
+          {t('imageUpload.imageCount', { current: images.length, max: maxImages })}
+        </ThemedText>
+      </View>
+
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.imageScrollView}>
+        <View style={styles.imageGrid}>
+          {images.map((image) => (
+            <View key={image.imageId} style={styles.imageContainer}>
+              <Image source={{ uri: image.urls.small }} style={styles.image} />
+
+              {image.isPrimary ? (
+                <View style={styles.primaryBadge}>
+                  <ThemedText style={styles.primaryBadgeText}>{t('imageUpload.primary')}</ThemedText>
+                </View>
+              ) : null}
+
+              <View style={styles.imageActions}>
+                {!image.isPrimary ? (
+                  <TouchableOpacity
+                    style={styles.actionButton}
+                    onPress={() => setPrimaryImage(image.imageId)}
+                  >
+                    <Ionicons name="star-outline" size={16} color={colors.white} />
+                  </TouchableOpacity>
+                ) : null}
+
+                <TouchableOpacity
+                  style={[styles.actionButton, styles.deleteButton]}
+                  onPress={() => deleteImage(image.imageId)}
+                >
+                  <Ionicons name="trash-outline" size={16} color={colors.white} />
+                </TouchableOpacity>
+              </View>
+
+              <View style={styles.imageInfo}>
+                <ThemedText style={styles.imageInfoText}>
+                  {imageUploadService.formatFileSize(image.metadata.originalSize)}
+                </ThemedText>
+              </View>
+            </View>
+          ))}
+
+          {images.length < maxImages && !uploading ? (
+            <TouchableOpacity
+              style={[styles.imageContainer, styles.addMoreButton]}
+              onPress={pickImages}
+              disabled={disabled}
+            >
+              <Ionicons name="add" size={32} color={colors.COLOR_BLACK_LIGHT_4} />
+              <ThemedText style={styles.addMoreText}>{t('imageUpload.addMore')}</ThemedText>
+            </TouchableOpacity>
+          ) : null}
+        </View>
+      </ScrollView>
+
+      <ThemedText style={styles.helperText}>
+        {t('imageUpload.helperText')}
+        {images.length === 0 ? t('imageUpload.helperPrimaryNote') : ''}
+      </ThemedText>
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
-    container: {
-        marginBottom: 20,
-    },
-    uploadButtonsContainer: {
-        flexDirection: 'row',
-        gap: 12,
-        marginBottom: 16,
-    },
-    uploadButton: {
-        flex: 1,
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'center',
-        paddingVertical: 12,
-        paddingHorizontal: 16,
-        backgroundColor: colors.COLOR_BLACK_LIGHT_9,
-        borderWidth: 1,
-        borderColor: colors.COLOR_BLACK_LIGHT_6,
-        borderRadius: 8,
-        gap: 8,
-    },
-    uploadButtonDisabled: {
-        opacity: 0.5,
-    },
-    uploadButtonText: {
-        fontSize: 14,
-        color: colors.primaryDark,
-        fontWeight: '500',
-    },
-    uploadProgressContainer: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'center',
-        paddingVertical: 12,
-        backgroundColor: colors.COLOR_BLACK_LIGHT_9,
-        borderRadius: 8,
-        marginBottom: 16,
-        gap: 8,
-    },
-    uploadProgressText: {
-        fontSize: 14,
-        color: colors.COLOR_BLACK_LIGHT_3,
-    },
-    imageCountContainer: {
-        marginBottom: 12,
-    },
-    imageCountText: {
-        fontSize: 14,
-        color: colors.COLOR_BLACK_LIGHT_3,
-    },
-    imageScrollView: {
-        marginBottom: 16,
-    },
-    imageGrid: {
-        flexDirection: 'row',
-        gap: 12,
-        paddingHorizontal: 4,
-    },
-    imageContainer: {
-        position: 'relative',
-        width: 120,
-        height: 120,
-        borderRadius: 8,
-        overflow: 'hidden',
-        backgroundColor: colors.COLOR_BLACK_LIGHT_9,
-    },
-    image: {
-        width: '100%',
-        height: '100%',
-    },
-    primaryBadge: {
-        position: 'absolute',
-        top: 8,
-        left: 8,
-        backgroundColor: colors.primaryColor,
-        paddingHorizontal: 6,
-        paddingVertical: 2,
-        borderRadius: 4,
-    },
-    primaryBadgeText: {
-        fontSize: 10,
-        color: colors.primaryForeground,
-        fontWeight: 'bold',
-    },
-    imageActions: {
-        position: 'absolute',
-        top: 8,
-        right: 8,
-        flexDirection: 'row',
-        gap: 4,
-    },
-    actionButton: {
-        width: 24,
-        height: 24,
-        borderRadius: 12,
-        backgroundColor: 'rgba(0, 0, 0, 0.6)',
-        alignItems: 'center',
-        justifyContent: 'center',
-    },
-    deleteButton: {
-        backgroundColor: 'rgba(255, 59, 48, 0.8)',
-    },
-    imageInfo: {
-        position: 'absolute',
-        bottom: 8,
-        left: 8,
-        right: 8,
-    },
-    imageInfoText: {
-        fontSize: 10,
-        color: colors.white,
-        textAlign: 'center',
-        backgroundColor: 'rgba(0, 0, 0, 0.6)',
-        paddingHorizontal: 4,
-        paddingVertical: 2,
-        borderRadius: 2,
-    },
-    addMoreButton: {
-        borderWidth: 2,
-        borderColor: colors.COLOR_BLACK_LIGHT_6,
-        borderStyle: 'dashed',
-        backgroundColor: 'transparent',
-        alignItems: 'center',
-        justifyContent: 'center',
-    },
-    addMoreText: {
-        fontSize: 12,
-        color: colors.COLOR_BLACK_LIGHT_4,
-        marginTop: 4,
-    },
-    helperText: {
-        fontSize: 12,
-        color: colors.COLOR_BLACK_LIGHT_4,
-        lineHeight: 16,
-    },
+  container: {
+    marginBottom: 20,
+  },
+  uploadButtonsContainer: {
+    flexDirection: 'row',
+    gap: 12,
+    marginBottom: 16,
+  },
+  uploadButton: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: colors.COLOR_BLACK_LIGHT_9,
+    borderWidth: 1,
+    borderColor: colors.COLOR_BLACK_LIGHT_6,
+    borderRadius: 8,
+    gap: 8,
+  },
+  uploadButtonDisabled: {
+    opacity: 0.5,
+  },
+  uploadButtonText: {
+    fontSize: 14,
+    color: colors.primaryDark,
+    fontWeight: '500',
+  },
+  uploadProgressContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    backgroundColor: colors.COLOR_BLACK_LIGHT_9,
+    borderRadius: 8,
+    marginBottom: 16,
+    gap: 8,
+  },
+  uploadProgressText: {
+    fontSize: 14,
+    color: colors.COLOR_BLACK_LIGHT_3,
+  },
+  imageCountContainer: {
+    marginBottom: 12,
+  },
+  imageCountText: {
+    fontSize: 14,
+    color: colors.COLOR_BLACK_LIGHT_3,
+  },
+  imageScrollView: {
+    marginBottom: 16,
+  },
+  imageGrid: {
+    flexDirection: 'row',
+    gap: 12,
+    paddingHorizontal: 4,
+  },
+  imageContainer: {
+    position: 'relative',
+    width: 120,
+    height: 120,
+    borderRadius: 8,
+    overflow: 'hidden',
+    backgroundColor: colors.COLOR_BLACK_LIGHT_9,
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  primaryBadge: {
+    position: 'absolute',
+    top: 8,
+    left: 8,
+    backgroundColor: colors.primaryColor,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  primaryBadgeText: {
+    fontSize: 10,
+    color: colors.primaryForeground,
+    fontWeight: 'bold',
+  },
+  imageActions: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    flexDirection: 'row',
+    gap: 4,
+  },
+  actionButton: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  deleteButton: {
+    backgroundColor: 'rgba(255, 59, 48, 0.8)',
+  },
+  imageInfo: {
+    position: 'absolute',
+    bottom: 8,
+    left: 8,
+    right: 8,
+  },
+  imageInfoText: {
+    fontSize: 10,
+    color: colors.white,
+    textAlign: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    paddingHorizontal: 4,
+    paddingVertical: 2,
+    borderRadius: 2,
+  },
+  addMoreButton: {
+    borderWidth: 2,
+    borderColor: colors.COLOR_BLACK_LIGHT_6,
+    borderStyle: 'dashed',
+    backgroundColor: 'transparent',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  addMoreText: {
+    fontSize: 12,
+    color: colors.COLOR_BLACK_LIGHT_4,
+    marginTop: 4,
+  },
+  helperText: {
+    fontSize: 12,
+    color: colors.COLOR_BLACK_LIGHT_4,
+    lineHeight: 16,
+  },
 });

--- a/packages/frontend/components/NotFoundScreen.tsx
+++ b/packages/frontend/components/NotFoundScreen.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '@/styles/colors';
 
 export default function NotFoundScreen() {
   const router = useRouter();
+  const { t } = useTranslation();
 
   return (
     <View style={styles.container}>
       <Ionicons name="alert-circle-outline" size={80} color={colors.primaryColor} />
-      <Text style={styles.title}>Page Not Found</Text>
-      <Text style={styles.message}>The page you are looking for does not exist.</Text>
+      <Text style={styles.title}>{t('notFound.title')}</Text>
+      <Text style={styles.message}>{t('notFound.message')}</Text>
       <TouchableOpacity style={styles.button} onPress={() => router.back()}>
-        <Text style={styles.buttonText}>Go Back</Text>
+        <Text style={styles.buttonText}>{t('notFound.goBack')}</Text>
       </TouchableOpacity>
     </View>
   );

--- a/packages/frontend/components/PropertyCard.tsx
+++ b/packages/frontend/components/PropertyCard.tsx
@@ -249,7 +249,7 @@ export function PropertyCard({
   const primaryOffering = resolvePrimaryOffering(
     property,
     browseMode,
-    t('listing.exchange.free', 'Free'),
+    t('listing.exchange.free'),
   );
 
   // The OTHER offerings this multi-offering listing carries (excluding the one
@@ -282,15 +282,15 @@ export function PropertyCard({
   // long-term → "month", short-term → "night"; sale/exchange have none.
   const priceUnitSuffix = propertyData.priceUnit
     ? propertyData.priceUnit === PriceUnit.NIGHT
-      ? t('listing.offering.perNightUnit', 'night')
-      : t('listing.offering.perMonthUnit', 'month')
+      ? t('listing.offering.perNightUnit')
+      : t('listing.offering.perMonthUnit')
     : '';
 
   // "Also available: By night · For sale" — joins the other offerings' labels.
   const alsoAvailableLabel =
     otherOfferings.length > 0
-      ? `${t('listing.offering.alsoAvailable', 'Also available')}: ${otherOfferings
-          .map((summary) => t(summary.i18nKey, summary.fallback))
+      ? `${t('listing.offering.alsoAvailable')}: ${otherOfferings
+          .map((summary) => t(summary.i18nKey))
           .join(' · ')}`
       : '';
 
@@ -302,10 +302,7 @@ export function PropertyCard({
   const typeMeta: { icon: IoniconName; label: string } | null = propertyData.type
     ? {
         icon: propertyData.type === 'house' ? 'home-outline' : 'business-outline',
-        label: t(
-          `properties.titles.types.${propertyData.type}`,
-          propertyData.type.charAt(0).toUpperCase() + propertyData.type.slice(1),
-        ),
+        label: t(`properties.titles.types.${propertyData.type}`),
       }
     : null;
 
@@ -396,7 +393,7 @@ export function PropertyCard({
             <MediaChip
               icon="flash"
               accent={colors.primarySubtleForeground}
-              label={t('listing.badge.instantBook', 'Instant book')}
+              label={t('listing.badge.instantBook')}
             />
           ) : null}
 

--- a/packages/frontend/components/ReservationCard.tsx
+++ b/packages/frontend/components/ReservationCard.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
 import { Text as BloomText } from '@oxyhq/bloom/typography';
 import { Reservation } from '@homiio/shared-types';
 import { ReservationStatusBadge } from '@/components/ReservationStatusBadge';
@@ -26,13 +27,14 @@ export const ReservationCard: React.FC<ReservationCardProps> = ({
   variant = 'guest',
   actions,
 }) => {
+  const { t } = useTranslation();
   const router = useRouter();
   const { property } = useProperty(reservation.propertyId);
 
   const title = useMemo(() => {
-    if (!property) return 'Property';
+    if (!property) return t('reservations.card.propertyFallback');
     return getPropertyTitle(property);
-  }, [property]);
+  }, [property, t]);
 
   const imageSource = useMemo(() => {
     if (!property) return null;
@@ -43,13 +45,20 @@ export const ReservationCard: React.FC<ReservationCardProps> = ({
     router.push(`/reservations/${reservation.id}`);
   };
 
-  const guestLabel = reservation.guestCount === 1 ? 'guest' : 'guests';
+  const guestLabel =
+    reservation.guestCount === 1
+      ? t('reservations.card.guest')
+      : t('reservations.card.guests');
+  const nightLabel =
+    reservation.nights === 1
+      ? t('reservations.card.night')
+      : t('reservations.card.nights');
 
   return (
     <ThumbnailCard
       thumbnail={<ThumbnailImage source={imageSource} />}
       onPress={handlePress}
-      accessibilityLabel={`Reservation ${reservation.id}`}
+      accessibilityLabel={t('reservations.card.accessibility', { id: reservation.id })}
       actions={actions}
     >
       <View style={styles.headerRow}>
@@ -62,9 +71,8 @@ export const ReservationCard: React.FC<ReservationCardProps> = ({
         {formatDateRange(reservation.checkIn, reservation.checkOut)}
       </BloomText>
       <BloomText style={styles.meta} numberOfLines={1}>
-        {reservation.nights} {reservation.nights === 1 ? 'night' : 'nights'} ·{' '}
-        {reservation.guestCount} {guestLabel}
-        {variant === 'host' ? ' (guest)' : ''} ·{' '}
+        {reservation.nights} {nightLabel} · {reservation.guestCount} {guestLabel}
+        {variant === 'host' ? ` ${t('reservations.card.hostGuestSuffix')}` : ''} ·{' '}
         {formatCurrency(reservation.total, reservation.currency)}
       </BloomText>
     </ThumbnailCard>

--- a/packages/frontend/components/ReservationStatusBadge.tsx
+++ b/packages/frontend/components/ReservationStatusBadge.tsx
@@ -2,11 +2,11 @@ import { ReservationStatus } from '@homiio/shared-types';
 import { createStatusBadge, type StatusBadgeEntry } from '@/components/ui/createStatusBadge';
 
 const STATUS_MAP: Record<ReservationStatus, StatusBadgeEntry> = {
-  [ReservationStatus.PENDING]: { label: 'Pending', color: 'warning' },
-  [ReservationStatus.CONFIRMED]: { label: 'Confirmed', color: 'success' },
-  [ReservationStatus.DECLINED]: { label: 'Declined', color: 'error' },
-  [ReservationStatus.CANCELLED]: { label: 'Cancelled', color: 'default' },
-  [ReservationStatus.COMPLETED]: { label: 'Completed', color: 'info' },
+  [ReservationStatus.PENDING]: { i18nKey: 'statusBadge.reservation.pending', label: 'Pending', color: 'warning' },
+  [ReservationStatus.CONFIRMED]: { i18nKey: 'statusBadge.reservation.confirmed', label: 'Confirmed', color: 'success' },
+  [ReservationStatus.DECLINED]: { i18nKey: 'statusBadge.reservation.declined', label: 'Declined', color: 'error' },
+  [ReservationStatus.CANCELLED]: { i18nKey: 'statusBadge.reservation.cancelled', label: 'Cancelled', color: 'default' },
+  [ReservationStatus.COMPLETED]: { i18nKey: 'statusBadge.reservation.completed', label: 'Completed', color: 'info' },
 };
 
 export const ReservationStatusBadge = createStatusBadge(STATUS_MAP);

--- a/packages/frontend/components/ReviewCard.tsx
+++ b/packages/frontend/components/ReviewCard.tsx
@@ -10,10 +10,12 @@ import {
     TouchableOpacity,
     Alert,
 } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { ThemedText } from './ThemedText';
 import { colors } from '@/styles/colors';
 import { radius, spacing, withShadow } from '@/constants/styles';
+import { formatLocalized } from '@/utils/dateLocale';
 
 export interface ReviewData {
     _id: string;
@@ -97,6 +99,8 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
     variant = 'default',
     showActions = true
 }) => {
+    const { t } = useTranslation();
+
     const renderStars = (rating: number) => {
         const fullStars = Math.floor(rating);
         const halfStar = rating % 1 >= 0.5;
@@ -119,7 +123,10 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
         if (onHelpful) {
             onHelpful(review._id);
         } else {
-            Alert.alert('Thank you', 'Your feedback has been recorded.');
+            Alert.alert(
+                t('reviews.card.alertThankYouTitle'),
+                t('reviews.card.alertThankYouBody'),
+            );
         }
     };
 
@@ -128,15 +135,18 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
             onReport(review._id);
         } else {
             Alert.alert(
-                'Report Review',
-                'Are you sure you want to report this review for inappropriate content?',
+                t('reviews.card.alertReportTitle'),
+                t('reviews.card.alertReportBody'),
                 [
-                    { text: 'Cancel', style: 'cancel' },
+                    { text: t('common.cancel'), style: 'cancel' },
                     {
-                        text: 'Report',
+                        text: t('reviews.card.alertReportConfirm'),
                         style: 'destructive',
                         onPress: () => {
-                            Alert.alert('Reported', 'This review has been reported to our moderation team.');
+                            Alert.alert(
+                                t('reviews.card.alertReportedTitle'),
+                                t('reviews.card.alertReportedBody'),
+                            );
                         }
                     }
                 ]
@@ -149,13 +159,14 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
             onReply(review._id);
         } else {
             Alert.alert(
-                'Reply to Review',
-                'Reply functionality will allow landlords and property managers to respond to reviews.',
-                [{ text: 'OK' }]
+                t('reviews.card.alertReplyTitle'),
+                t('reviews.card.alertReplyBody'),
+                [{ text: t('common.ok') }]
             );
         }
     };
 
+    const evidenceCount = review.evidenceCount || 1;
     const isCompact = variant === 'compact';
 
     return (
@@ -168,45 +179,50 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
                     <View style={styles.reviewerDetails}>
                         <View style={styles.reviewerNameRow}>
                             <ThemedText style={styles.reviewerName}>
-                                {review.isAnonymous ? 'Anonymous' : 'Verified Resident'}
+                                {review.isAnonymous
+                                    ? t('reviews.card.anonymous')
+                                    : t('reviews.card.verifiedResident')}
                             </ThemedText>
 
-                            {/* Verification and Trust Indicators */}
                             <View style={styles.trustIndicators}>
                                 {review.verified && (
                                     <View style={styles.verifiedBadge}>
                                         <Ionicons name="checkmark-circle" size={14} color={colors.primaryColor} />
-                                        <ThemedText style={styles.verifiedText}>Verified</ThemedText>
+                                        <ThemedText style={styles.verifiedText}>
+                                            {t('reviews.card.verified')}
+                                        </ThemedText>
                                     </View>
                                 )}
 
-                                {/* Confidence Score */}
                                 {!isCompact && (
                                     <View style={[styles.confidenceBadge, {
                                         backgroundColor: (review.confidenceScore || 0) >= 80 ? colors.success :
                                             (review.confidenceScore || 0) >= 60 ? colors.warning : colors.danger
                                     }]}>
                                         <ThemedText style={styles.confidenceText}>
-                                            {review.confidenceScore || 0}% confident
+                                            {t('reviews.card.confident', { score: review.confidenceScore || 0 })}
                                         </ThemedText>
                                     </View>
                                 )}
 
-                                {/* Evidence Indicator */}
                                 {review.evidenceAttached && (
                                     <View style={styles.evidenceBadge}>
                                         <Ionicons name="document-attach" size={12} color={colors.COLOR_BLACK_LIGHT_3} />
                                         <ThemedText style={styles.evidenceText}>
-                                            {review.evidenceCount || 1} proof{(review.evidenceCount || 1) > 1 ? 's' : ''}
+                                            {evidenceCount}{' '}
+                                            {evidenceCount > 1
+                                                ? t('reviews.card.proofs')
+                                                : t('reviews.card.proof')}
                                         </ThemedText>
                                     </View>
                                 )}
 
-                                {/* Karma Score */}
                                 {!isCompact && (review.karmaScore || 0) > 0 && (
                                     <View style={styles.karmaBadge}>
                                         <Ionicons name="trending-up" size={12} color={colors.info} />
-                                        <ThemedText style={styles.karmaText}>{review.karmaScore || 0} karma</ThemedText>
+                                        <ThemedText style={styles.karmaText}>
+                                            {t('reviews.card.karma', { score: review.karmaScore || 0 })}
+                                        </ThemedText>
                                     </View>
                                 )}
                             </View>
@@ -214,19 +230,21 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
 
                         <View style={styles.reviewMetaRow}>
                             <ThemedText style={styles.reviewDate}>
-                                {new Date(review.createdAt).toLocaleDateString()}
+                                {formatLocalized(new Date(review.createdAt), 'PP')}
                             </ThemedText>
                             <ThemedText style={styles.livedDuration}>
-                                Lived {review.livedForMonths} months
+                                {t('reviews.card.livedMonths', { count: review.livedForMonths })}
                             </ThemedText>
-                            {review.price && (
+                            {review.price ? (
                                 <ThemedText style={styles.price}>
-                                    {review.price} {review.currency}/month
+                                    {t('reviews.card.perMonth', {
+                                        price: review.price,
+                                        currency: review.currency,
+                                    })}
                                 </ThemedText>
-                            )}
+                            ) : null}
                         </View>
 
-                        {/* Flagged Issues Tags */}
                         {!isCompact && review.flaggedIssues && review.flaggedIssues.length > 0 && (
                             <View style={styles.issueTagsContainer}>
                                 {review.flaggedIssues.slice(0, 3).map((issue, index) => (
@@ -236,7 +254,11 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
                                 ))}
                                 {review.flaggedIssues.length > 3 && (
                                     <View style={styles.issueTag}>
-                                        <ThemedText style={styles.issueTagText}>+{review.flaggedIssues.length - 3} more</ThemedText>
+                                        <ThemedText style={styles.issueTagText}>
+                                            {t('reviews.card.moreIssues', {
+                                                count: review.flaggedIssues.length - 3,
+                                            })}
+                                        </ThemedText>
                                     </View>
                                 )}
                             </View>
@@ -252,21 +274,20 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
 
             {!isCompact && review.positiveComment && (
                 <View style={styles.commentSection}>
-                    <ThemedText style={styles.commentLabel}>Positive:</ThemedText>
+                    <ThemedText style={styles.commentLabel}>{t('reviews.card.positive')}</ThemedText>
                     <ThemedText style={styles.commentText}>{review.positiveComment}</ThemedText>
                 </View>
             )}
 
             {!isCompact && review.negativeComment && (
                 <View style={styles.commentSection}>
-                    <ThemedText style={styles.commentLabel}>Negative:</ThemedText>
+                    <ThemedText style={styles.commentLabel}>{t('reviews.card.negative')}</ThemedText>
                     <ThemedText style={styles.commentText}>{review.negativeComment}</ThemedText>
                 </View>
             )}
 
             {showActions && (
                 <View style={styles.reviewFooter}>
-                    {/* Community Moderation Section */}
                     <View style={styles.moderationSection}>
                         <TouchableOpacity
                             style={[styles.helpfulButton, {
@@ -283,7 +304,7 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
                             <ThemedText style={[styles.helpfulText, {
                                 color: (review.helpfulVotes || 0) > 0 ? colors.success : colors.COLOR_BLACK_LIGHT_4
                             }]}>
-                                Helpful ({review.helpfulVotes || 0})
+                                {t('reviews.card.helpful', { count: review.helpfulVotes || 0 })}
                             </ThemedText>
                         </TouchableOpacity>
 
@@ -295,10 +316,11 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
                             onPress={handleReport}
                         >
                             <Ionicons name="flag" size={18} color={colors.error} />
-                            <ThemedText style={[styles.helpfulText, { color: colors.error }]}>Report</ThemedText>
+                            <ThemedText style={[styles.helpfulText, { color: colors.error }]}>
+                                {t('reviews.card.report')}
+                            </ThemedText>
                         </TouchableOpacity>
 
-                        {/* Right of Reply Button */}
                         {review.replyAllowed && (
                             <TouchableOpacity
                                 style={[styles.helpfulButton, {
@@ -308,22 +330,26 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
                                 onPress={handleReply}
                             >
                                 <Ionicons name="chatbubble" size={18} color={colors.primaryColor} />
-                                <ThemedText style={[styles.helpfulText, { color: colors.primaryColor }]}>Reply</ThemedText>
+                                <ThemedText style={[styles.helpfulText, { color: colors.primaryColor }]}>
+                                    {t('reviews.card.reply')}
+                                </ThemedText>
                             </TouchableOpacity>
                         )}
                     </View>
 
-                    {/* Recommendation and Trust Info */}
                     <View style={styles.recommendationSection}>
                         <ThemedText style={styles.recommendationText}>
-                            {review.recommendation ? '✓ Recommends' : '✗ Does not recommend'}
+                            {review.recommendation
+                                ? t('reviews.card.recommends')
+                                : t('reviews.card.doesNotRecommend')}
                         </ThemedText>
 
-                        {/* Moderation Status Indicator */}
                         {review.moderationStatus === 'flagged' && (
                             <View style={styles.flaggedIndicator}>
                                 <Ionicons name="warning" size={12} color={colors.warning} />
-                                <ThemedText style={styles.flaggedText}>Under Review</ThemedText>
+                                <ThemedText style={styles.flaggedText}>
+                                    {t('reviews.card.underReview')}
+                                </ThemedText>
                             </View>
                         )}
                     </View>

--- a/packages/frontend/components/RoommateMatch.tsx
+++ b/packages/frontend/components/RoommateMatch.tsx
@@ -7,6 +7,7 @@ import {
   Alert,
   TextInput,
 } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '@/styles/colors';
 import { shadowToken } from '@/styles/shadows';
@@ -25,6 +26,7 @@ export const RoommateMatch: React.FC<RoommateMatchProps> = ({
   onSendRequest,
   onViewProfile,
 }) => {
+  const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
   const [showMessageInput, setShowMessageInput] = useState(false);
   const [message, setMessage] = useState('');
@@ -41,16 +43,16 @@ export const RoommateMatch: React.FC<RoommateMatchProps> = ({
       if (success) {
         setShowMessageInput(false);
         setMessage('');
-        Alert.alert('Success', 'Roommate request sent successfully!');
+        Alert.alert(t('roommates.alert.successTitle'), t('roommates.alert.requestSent'));
       }
-    } catch (error) {
-      Alert.alert('Error', 'Failed to send roommate request');
+    } catch {
+      Alert.alert(t('roommates.alert.errorTitle'), t('roommates.alert.requestFailed'));
     } finally {
       setIsLoading(false);
     }
   };
 
-  const getDisplayName = () => profile.displayName?.trim() || 'Roommate';
+  const getDisplayName = () => profile.displayName?.trim() || t('roommates.match.fallbackName');
 
   const getMatchScoreColor = (score: number) => {
     if (score >= 80) return colors.success; // Green for success
@@ -59,9 +61,9 @@ export const RoommateMatch: React.FC<RoommateMatchProps> = ({
   };
 
   const getMatchScoreText = (score: number) => {
-    if (score >= 80) return 'Excellent Match';
-    if (score >= 60) return 'Good Match';
-    return 'Fair Match';
+    if (score >= 80) return t('roommates.match.excellent');
+    if (score >= 60) return t('roommates.match.good');
+    return t('roommates.match.fair');
   };
 
   return (
@@ -101,7 +103,7 @@ export const RoommateMatch: React.FC<RoommateMatchProps> = ({
       {/* Preferences */}
       {profile.personalProfile?.settings?.roommate?.preferences && (
         <View style={styles.preferencesSection}>
-          <Text style={styles.sectionTitle}>Preferences</Text>
+          <Text style={styles.sectionTitle}>{t('roommates.match.preferences')}</Text>
           <View style={styles.preferencesGrid}>
             <View style={styles.preferenceItem}>
               <Ionicons name="cash-outline" size={16} color={colors.COLOR_BLACK_LIGHT_5} />
@@ -112,13 +114,13 @@ export const RoommateMatch: React.FC<RoommateMatchProps> = ({
             <View style={styles.preferenceItem}>
               <Ionicons name="calendar-outline" size={16} color={colors.COLOR_BLACK_LIGHT_5} />
               <Text style={styles.preferenceText}>
-                {profile.personalProfile.settings.roommate.preferences.moveInDate || 'Flexible'}
+                {profile.personalProfile.settings.roommate.preferences.moveInDate || t('roommates.match.flexible')}
               </Text>
             </View>
             <View style={styles.preferenceItem}>
               <Ionicons name="home-outline" size={16} color={colors.COLOR_BLACK_LIGHT_5} />
               <Text style={styles.preferenceText}>
-                {profile.personalProfile.settings.roommate.preferences.leaseDuration || 'Flexible'}
+                {profile.personalProfile.settings.roommate.preferences.leaseDuration || t('roommates.match.flexible')}
               </Text>
             </View>
           </View>
@@ -128,12 +130,12 @@ export const RoommateMatch: React.FC<RoommateMatchProps> = ({
       {/* Message input */}
       {showMessageInput && (
         <View style={styles.messageSection}>
-          <Text style={styles.messageLabel}>Add a message (optional):</Text>
+          <Text style={styles.messageLabel}>{t('roommates.match.messageLabel')}</Text>
           <TextInput
             style={styles.messageInput}
             value={message}
             onChangeText={setMessage}
-            placeholder="Hi! I think we'd be great roommates..."
+            placeholder={t('roommates.match.messagePlaceholder')}
             multiline
             maxLength={500}
           />
@@ -147,12 +149,12 @@ export const RoommateMatch: React.FC<RoommateMatchProps> = ({
           onPress={() => onViewProfile(profile.id)}
         >
           <Ionicons name="eye-outline" size={20} color={colors.primaryDark} />
-          <Text style={styles.viewProfileText}>View Profile</Text>
+          <Text style={styles.viewProfileText}>{t('roommates.match.viewProfile')}</Text>
         </TouchableOpacity>
 
         <ActionButton
           icon={showMessageInput ? 'send' : 'person-add'}
-          text={showMessageInput ? 'Send Request' : 'Send Request'}
+          text={t('roommates.match.sendRequest')}
           onPress={handleSendRequest}
           variant="primary"
           loading={isLoading}

--- a/packages/frontend/components/RoommateRelationship.tsx
+++ b/packages/frontend/components/RoommateRelationship.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '@/styles/colors';
 import { shadowToken } from '@/styles/shadows';
 import type { RoommateRelationship, RoommateProfile } from '@/hooks/useRoommate';
 import { ActionButton } from '@/components/ui/ActionButton';
-
+import { getDateLocale } from '@/utils/dateLocale';
 
 interface RoommateRelationshipProps {
   relationship: RoommateRelationship;
@@ -18,26 +19,27 @@ export const RoommateRelationshipComponent: React.FC<RoommateRelationshipProps> 
   onEndRelationship,
   onViewProfile,
 }) => {
+  const { t, i18n } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
 
   const handleEndRelationship = async () => {
     Alert.alert(
-      'End Relationship',
-      'Are you sure you want to end this roommate relationship? This action cannot be undone.',
+      t('roommates.relationship.confirmEndTitle'),
+      t('roommates.relationship.confirmEndBody'),
       [
-        { text: 'Cancel', style: 'cancel' },
+        { text: t('common.cancel'), style: 'cancel' },
         {
-          text: 'End Relationship',
+          text: t('roommates.relationship.confirmEndAction'),
           style: 'destructive',
           onPress: async () => {
             setIsLoading(true);
             try {
               const success = await onEndRelationship(relationship.id);
               if (success) {
-                Alert.alert('Success', 'Roommate relationship ended');
+                Alert.alert(t('roommates.alert.successTitle'), t('roommates.alert.relationshipEnded'));
               }
-            } catch (error) {
-              Alert.alert('Error', 'Failed to end roommate relationship');
+            } catch {
+              Alert.alert(t('roommates.alert.errorTitle'), t('roommates.alert.relationshipEndFailed'));
             } finally {
               setIsLoading(false);
             }
@@ -48,7 +50,7 @@ export const RoommateRelationshipComponent: React.FC<RoommateRelationshipProps> 
   };
 
   const getDisplayName = (profile: RoommateProfile) =>
-    profile.displayName?.trim() || 'Roommate';
+    profile.displayName?.trim() || t('roommates.screen.fallbackName');
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -66,19 +68,19 @@ export const RoommateRelationshipComponent: React.FC<RoommateRelationshipProps> 
   const getStatusText = (status: string) => {
     switch (status) {
       case 'active':
-        return 'Active';
+        return t('roommates.relationship.statusActive');
       case 'inactive':
-        return 'Inactive';
+        return t('roommates.relationship.statusInactive');
       case 'ended':
-        return 'Ended';
+        return t('roommates.relationship.statusEnded');
       default:
-        return 'Unknown';
+        return t('roommates.relationship.statusUnknown');
     }
   };
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
-    return date.toLocaleDateString();
+    return date.toLocaleDateString(getDateLocale(i18n.language));
   };
 
   const getDuration = () => {
@@ -88,24 +90,31 @@ export const RoommateRelationshipComponent: React.FC<RoommateRelationshipProps> 
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 
     if (diffDays < 30) {
-      return `${diffDays} days`;
-    } else if (diffDays < 365) {
-      const months = Math.floor(diffDays / 30);
-      return `${months} month${months > 1 ? 's' : ''}`;
-    } else {
-      const years = Math.floor(diffDays / 365);
-      return `${years} year${years > 1 ? 's' : ''}`;
+      return t('roommates.relationship.durationDays', { count: diffDays });
     }
+    if (diffDays < 365) {
+      const months = Math.floor(diffDays / 30);
+      return months > 1
+        ? t('roommates.relationship.durationMonths', { count: months })
+        : t('roommates.relationship.durationMonth', { count: months });
+    }
+    const years = Math.floor(diffDays / 365);
+    return years > 1
+      ? t('roommates.relationship.durationYears', { count: years })
+      : t('roommates.relationship.durationYear', { count: years });
   };
 
   return (
     <View style={styles.container}>
-      {/* Header with relationship info */}
       <View style={styles.header}>
         <View style={styles.relationshipInfo}>
-          <Text style={styles.relationshipTitle}>Roommate Relationship</Text>
-          <Text style={styles.duration}>Duration: {getDuration()}</Text>
-          <Text style={styles.startDate}>Started: {formatDate(relationship.startDate)}</Text>
+          <Text style={styles.relationshipTitle}>{t('roommates.relationship.title')}</Text>
+          <Text style={styles.duration}>
+            {t('roommates.relationship.duration', { duration: getDuration() })}
+          </Text>
+          <Text style={styles.startDate}>
+            {t('roommates.relationship.started', { date: formatDate(relationship.startDate) })}
+          </Text>
         </View>
 
         <View
@@ -115,22 +124,21 @@ export const RoommateRelationshipComponent: React.FC<RoommateRelationshipProps> 
         </View>
       </View>
 
-      {/* Match score */}
       <View style={styles.matchScoreSection}>
-        <Text style={styles.matchScoreText}>{relationship.matchScore}% Match</Text>
-        <Text style={styles.matchScoreLabel}>Compatibility Score</Text>
+        <Text style={styles.matchScoreText}>
+          {t('roommates.relationship.percentMatch', { score: relationship.matchScore })}
+        </Text>
+        <Text style={styles.matchScoreLabel}>{t('roommates.compatibility')}</Text>
       </View>
 
-      {/* Roommate profiles */}
       <View style={styles.profilesSection}>
-        <Text style={styles.sectionTitle}>Roommates</Text>
+        <Text style={styles.sectionTitle}>{t('roommates.relationship.roommatesSection')}</Text>
 
         <View style={styles.profileRow}>
           <TouchableOpacity
             style={styles.profileContainer}
             onPress={() => onViewProfile(relationship.profile1.id)}
           >
-            {/* Avatar placeholder since avatar is not in PersonalProfile type */}
             <View style={styles.avatarPlaceholder}>
               <Ionicons name="person" size={20} color={colors.COLOR_BLACK_LIGHT_5} />
             </View>
@@ -145,7 +153,6 @@ export const RoommateRelationshipComponent: React.FC<RoommateRelationshipProps> 
             style={styles.profileContainer}
             onPress={() => onViewProfile(relationship.profile2.id)}
           >
-            {/* Avatar placeholder since avatar is not in PersonalProfile type */}
             <View style={styles.avatarPlaceholder}>
               <Ionicons name="person" size={20} color={colors.COLOR_BLACK_LIGHT_5} />
             </View>
@@ -154,12 +161,11 @@ export const RoommateRelationshipComponent: React.FC<RoommateRelationshipProps> 
         </View>
       </View>
 
-      {/* Actions */}
       {relationship.status === 'active' && (
         <View style={styles.actions}>
           <ActionButton
             icon="close-circle"
-            text="End Relationship"
+            text={t('roommates.relationship.endRelationship')}
             onPress={handleEndRelationship}
             variant="secondary"
             loading={isLoading}
@@ -170,7 +176,9 @@ export const RoommateRelationshipComponent: React.FC<RoommateRelationshipProps> 
 
       {relationship.status === 'ended' && relationship.endDate && (
         <View style={styles.endedInfo}>
-          <Text style={styles.endedText}>Ended on {formatDate(relationship.endDate)}</Text>
+          <Text style={styles.endedText}>
+            {t('roommates.relationship.endedOn', { date: formatDate(relationship.endDate) })}
+          </Text>
         </View>
       )}
     </View>
@@ -253,12 +261,6 @@ const styles = StyleSheet.create({
   profileContainer: {
     alignItems: 'center',
     flex: 1,
-  },
-  profileAvatar: {
-    width: 50,
-    height: 50,
-    borderRadius: 25,
-    marginBottom: 8,
   },
   avatarPlaceholder: {
     width: 50,

--- a/packages/frontend/components/RoommateRequest.tsx
+++ b/packages/frontend/components/RoommateRequest.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, StyleSheet, TouchableOpacity, Alert, TextInput } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '@/styles/colors';
 import { shadowToken } from '@/styles/shadows';
@@ -23,6 +24,7 @@ export const RoommateRequestComponent: React.FC<RoommateRequestProps> = ({
   onDecline,
   onViewProfile,
 }) => {
+  const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
   const [showResponseInput, setShowResponseInput] = useState(false);
   const [responseMessage, setResponseMessage] = useState('');
@@ -41,10 +43,10 @@ export const RoommateRequestComponent: React.FC<RoommateRequestProps> = ({
       if (success) {
         setShowResponseInput(false);
         setResponseMessage('');
-        Alert.alert('Success', 'Roommate request accepted!');
+        Alert.alert(t('roommates.alert.successTitle'), t('roommates.alert.accepted'));
       }
-    } catch (error) {
-      Alert.alert('Error', 'Failed to accept roommate request');
+    } catch {
+      Alert.alert(t('roommates.alert.errorTitle'), t('roommates.alert.acceptFailed'));
     } finally {
       setIsLoading(false);
     }
@@ -64,17 +66,17 @@ export const RoommateRequestComponent: React.FC<RoommateRequestProps> = ({
       if (success) {
         setShowResponseInput(false);
         setResponseMessage('');
-        Alert.alert('Success', 'Roommate request declined');
+        Alert.alert(t('roommates.alert.successTitle'), t('roommates.alert.declined'));
       }
-    } catch (error) {
-      Alert.alert('Error', 'Failed to decline roommate request');
+    } catch {
+      Alert.alert(t('roommates.alert.errorTitle'), t('roommates.alert.declineFailed'));
     } finally {
       setIsLoading(false);
     }
   };
 
   const getDisplayName = (profile: RoommateProfile) =>
-    profile.displayName?.trim() || 'Roommate';
+    profile.displayName?.trim() || t('roommates.screen.fallbackName');
 
   const getStatusColor = (status: string) => {
     switch (status) {

--- a/packages/frontend/components/SaveSearchBottomSheet.tsx
+++ b/packages/frontend/components/SaveSearchBottomSheet.tsx
@@ -47,17 +47,17 @@ export const SaveSearchBottomSheet: React.FC<SaveSearchBottomSheetProps> = ({
     return (
         <View style={styles.container}>
             <View style={styles.header}>
-                <Text style={styles.title}>{t('Save this search')}</Text>
+                <Text style={styles.title}>{t('search.save.title')}</Text>
                 <TouchableOpacity onPress={onClose} style={styles.closeBtn}>
                     <Ionicons name="close" size={22} color={colors.COLOR_BLACK_LIGHT_4} />
                 </TouchableOpacity>
             </View>
 
             <View style={styles.inputGroup}>
-                <Text style={styles.inputLabel}>{t('Name')}</Text>
+                <Text style={styles.inputLabel}>{t('common.name')}</Text>
                 <TextInput
                     style={styles.input}
-                    placeholder={t('Give your search a name')}
+                    placeholder={t('search.save.namePlaceholder')}
                     value={name}
                     onChangeText={setName}
                     maxLength={60}
@@ -65,7 +65,7 @@ export const SaveSearchBottomSheet: React.FC<SaveSearchBottomSheetProps> = ({
             </View>
 
             <View style={styles.row}>
-                <Text style={styles.toggleLabel}>{t('Enable notifications')}</Text>
+                <Text style={styles.toggleLabel}>{t('search.save.enableNotifications')}</Text>
                 <Switch
                     value={notificationsEnabled}
                     onValueChange={setNotificationsEnabled}
@@ -83,7 +83,7 @@ export const SaveSearchBottomSheet: React.FC<SaveSearchBottomSheetProps> = ({
                     disabled={!name.trim() || !query.trim() || submitting}
                     onPress={handleSave}
                 >
-                    <Text style={styles.saveText}>{submitting ? t('Saving...') : t('common.save')}</Text>
+                    <Text style={styles.saveText}>{submitting ? t('common.saving') : t('common.save')}</Text>
                 </TouchableOpacity>
             </View>
         </View>

--- a/packages/frontend/components/SaveToFolderBottomSheet.tsx
+++ b/packages/frontend/components/SaveToFolderBottomSheet.tsx
@@ -54,7 +54,7 @@ export function SaveToFolderBottomSheet({
   onClose,
   onSave,
 }: SaveToFolderBottomSheetProps) {
-  const { t: _t } = useTranslation();
+  const { t } = useTranslation();
   const { folders, isLoading, loadFolders } = useSavedPropertiesContext();
   const queryClient = useQueryClient();
 
@@ -71,11 +71,11 @@ export function SaveToFolderBottomSheet({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['savedProperties'] });
       queryClient.invalidateQueries({ queryKey: ['savedFolders'] });
-      toast.success('Property saved to folder');
+      toast.success(t('saved.toast.propertySavedToFolder'));
     },
     onError: (error: Error) => {
       console.error('Failed to save to folder:', error);
-      toast.error('Failed to save to folder');
+      toast.error(t('saved.toast.saveToFolderFailed'));
     },
   });
 
@@ -85,11 +85,11 @@ export function SaveToFolderBottomSheet({
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['savedFolders'] });
-      toast.success('Folder created successfully');
+      toast.success(t('saved.toast.folderCreated'));
     },
     onError: (error: Error) => {
       console.error('Failed to create folder:', error);
-      toast.error('Failed to create folder');
+      toast.error(t('saved.toast.folderCreateFailed'));
     },
   });
 
@@ -112,7 +112,7 @@ export function SaveToFolderBottomSheet({
 
   const handleCreateFolder = useCallback(async () => {
     if (!newFolderName.trim()) {
-      Alert.alert('Error', 'Please enter a folder name');
+      Alert.alert(t('common.error'), t('saved.folder.alertFolderNameRequired'));
       return;
     }
 
@@ -145,7 +145,7 @@ export function SaveToFolderBottomSheet({
       <View style={styles.folderInfo}>
         <ThemedText style={styles.folderName}>{folder.name}</ThemedText>
         <ThemedText style={styles.folderCount}>
-          {folder.propertyCount} {folder.propertyCount === 1 ? 'property' : 'properties'}
+          {t('saved.folder.propertyCount', { count: folder.propertyCount })}
         </ThemedText>
       </View>
       <Ionicons name="chevron-forward" size={20} color={colors.COLOR_BLACK_LIGHT_4} />
@@ -154,17 +154,17 @@ export function SaveToFolderBottomSheet({
 
   const renderCreateFolderForm = () => (
     <View style={styles.createFolderForm}>
-      <ThemedText style={styles.sectionTitle}>Create New Folder</ThemedText>
+      <ThemedText style={styles.sectionTitle}>{t('saved.folder.createNew')}</ThemedText>
 
       <TextInput
         style={styles.input}
-        placeholder="Folder name"
+        placeholder={t('saved.folder.folderNamePlaceholder')}
         value={newFolderName}
         onChangeText={setNewFolderName}
         maxLength={100}
       />
 
-      <ThemedText style={styles.sectionTitle}>Choose Color</ThemedText>
+      <ThemedText style={styles.sectionTitle}>{t('saved.folder.chooseColor')}</ThemedText>
       <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.colorPicker}>
         {FOLDER_COLORS.map((color) => (
           <TouchableOpacity
@@ -181,7 +181,7 @@ export function SaveToFolderBottomSheet({
         ))}
       </ScrollView>
 
-      <ThemedText style={styles.sectionTitle}>Choose Emoji</ThemedText>
+      <ThemedText style={styles.sectionTitle}>{t('saved.folder.chooseEmoji')}</ThemedText>
       <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.iconPicker}>
         {FOLDER_EMOJIS.map((emoji) => (
           <TouchableOpacity
@@ -198,14 +198,14 @@ export function SaveToFolderBottomSheet({
 
       <View style={styles.createFolderActions}>
         <TouchableOpacity onPress={() => setShowCreateFolder(false)} style={styles.cancelButton}>
-          <ThemedText style={styles.cancelButtonText}>Cancel</ThemedText>
+          <ThemedText style={styles.cancelButtonText}>{t('common.cancel')}</ThemedText>
         </TouchableOpacity>
         <Button
           onPress={handleCreateFolder}
           disabled={createFolderMutation.isPending || !newFolderName.trim()}
           style={styles.createButton}
         >
-          {createFolderMutation.isPending ? 'Creating...' : 'Create & Save'}
+          {createFolderMutation.isPending ? t('saved.folder.creating') : t('saved.folder.createAndSave')}
         </Button>
       </View>
     </View>
@@ -214,7 +214,7 @@ export function SaveToFolderBottomSheet({
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <ThemedText style={styles.title}>Save to Folder</ThemedText>
+        <ThemedText style={styles.title}>{t('saved.folder.title')}</ThemedText>
         <TouchableOpacity onPress={onClose} style={styles.closeButton}>
           <Ionicons name="close" size={24} color={colors.COLOR_BLACK_LIGHT_4} />
         </TouchableOpacity>
@@ -257,7 +257,7 @@ export function SaveToFolderBottomSheet({
               disabled={isLoading}
             >
               <Ionicons name="add-circle-outline" size={24} color={colors.primaryColor} />
-              <ThemedText style={styles.createFolderText}>Create New Folder</ThemedText>
+              <ThemedText style={styles.createFolderText}>{t('saved.folder.createNew')}</ThemedText>
             </TouchableOpacity>
           </>
         )}

--- a/packages/frontend/components/SearchBar.tsx
+++ b/packages/frontend/components/SearchBar.tsx
@@ -44,8 +44,6 @@ type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 interface SegmentDef {
   id: string;
   labelKey: string;
-  fallbackLabel: string;
-  valueFallback: string;
   icon: IoniconName;
 }
 
@@ -53,22 +51,16 @@ const LONG_TERM_SEGMENTS: SegmentDef[] = [
   {
     id: 'where',
     labelKey: 'searchBar.long.where',
-    fallbackLabel: 'Where',
-    valueFallback: 'Any city',
     icon: 'location-outline',
   },
   {
     id: 'moveIn',
     labelKey: 'searchBar.long.moveIn',
-    fallbackLabel: 'Move-in',
-    valueFallback: 'Add date',
     icon: 'calendar-outline',
   },
   {
     id: 'propertyType',
     labelKey: 'searchBar.long.propertyType',
-    fallbackLabel: 'Property type',
-    valueFallback: 'Any type',
     icon: 'home-outline',
   },
 ];
@@ -77,22 +69,16 @@ const VACATION_SEGMENTS: SegmentDef[] = [
   {
     id: 'where',
     labelKey: 'searchBar.vacation.where',
-    fallbackLabel: 'Where',
-    valueFallback: 'Any destination',
     icon: 'location-outline',
   },
   {
     id: 'when',
     labelKey: 'searchBar.vacation.when',
-    fallbackLabel: 'When',
-    valueFallback: 'Add dates',
     icon: 'calendar-outline',
   },
   {
     id: 'who',
     labelKey: 'searchBar.vacation.who',
-    fallbackLabel: 'Who',
-    valueFallback: 'Add guests',
     icon: 'people-outline',
   },
 ];
@@ -216,24 +202,21 @@ export const SearchBar: React.FC<SearchBarProps> = ({
     <View style={styles.root}>
       <View style={[styles.modeWrapper, isWeb ? styles.modeWrapperWeb : null]}>
         <SegmentedControl<RentalMode>
-          label={t('searchBar.mode.label', 'Rental mode')}
+          label={t('searchBar.mode.label')}
           type="tabs"
           size="small"
           value={mode}
           onChange={handleModeChange}
-          accessibilityHint={t(
-            'searchBar.mode.hint',
-            'Switch between long-term rentals and vacation stays',
-          )}
+          accessibilityHint={t('searchBar.mode.hint')}
         >
           <SegmentedControlItem value="long_term">
             <SegmentedControlItemText>
-              {t('searchBar.mode.longTerm', 'Long-term')}
+              {t('searchBar.mode.longTerm')}
             </SegmentedControlItemText>
           </SegmentedControlItem>
           <SegmentedControlItem value="vacation">
             <SegmentedControlItemText>
-              {t('searchBar.mode.vacation', 'Vacation')}
+              {t('searchBar.mode.vacation')}
             </SegmentedControlItemText>
           </SegmentedControlItem>
         </SegmentedControl>
@@ -245,12 +228,12 @@ export const SearchBar: React.FC<SearchBarProps> = ({
             <React.Fragment key={segment.id}>
               {index > 0 ? <View style={styles.pillDivider} /> : null}
               <PillSegment
-                label={t(segment.labelKey, segment.fallbackLabel) || segment.fallbackLabel}
-                value={t(`${segment.labelKey}.value`, segment.valueFallback) || segment.valueFallback}
+                label={t(segment.labelKey)}
+                value={t(`${segment.labelKey}.value`)}
                 isFirst={index === 0}
                 isLast={false}
                 onPress={openFilters}
-                accessibilityLabel={t(segment.labelKey, segment.fallbackLabel) || segment.fallbackLabel}
+                accessibilityLabel={t(segment.labelKey)}
               />
             </React.Fragment>
           ))}
@@ -259,7 +242,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
               style={styles.searchButton}
               onPress={submitSearch}
               accessibilityRole="button"
-              accessibilityLabel={t('searchBar.search', 'Search') || 'Search'}
+              accessibilityLabel={t('searchBar.search')}
             >
               <Ionicons name="search" size={20} color={colors.primaryForeground} />
             </Pressable>

--- a/packages/frontend/components/SearchFiltersBottomSheet.tsx
+++ b/packages/frontend/components/SearchFiltersBottomSheet.tsx
@@ -43,18 +43,18 @@ interface SearchFiltersBottomSheetProps {
 }
 
 const PROPERTY_TYPES_LONG_TERM = [
-    { id: 'apartment', label: 'Apartments' },
-    { id: 'house', label: 'Houses' },
-    { id: 'room', label: 'Rooms' },
-    { id: 'studio', label: 'Studios' },
-];
+    { id: 'apartment', labelKey: 'search.types.apartments' },
+    { id: 'house', labelKey: 'search.types.houses' },
+    { id: 'room', labelKey: 'search.types.rooms' },
+    { id: 'studio', labelKey: 'search.types.studios' },
+] as const;
 
 const PROPERTY_TYPES_VACATION = [
-    { id: 'apartment', label: 'Apartments' },
-    { id: 'house', label: 'Whole houses' },
-    { id: 'room', label: 'Private rooms' },
-    { id: 'studio', label: 'Studios' },
-];
+    { id: 'apartment', labelKey: 'search.types.apartments' },
+    { id: 'house', labelKey: 'search.filters.propertyTypeVacation.wholeHouses' },
+    { id: 'room', labelKey: 'search.filters.propertyTypeVacation.privateRooms' },
+    { id: 'studio', labelKey: 'search.types.studios' },
+] as const;
 
 const AMENITIES = [
     'wifi',
@@ -70,19 +70,33 @@ const AMENITIES = [
     'washing_machine',
 ];
 
+const AMENITY_I18N_KEYS: Record<string, string> = {
+    wifi: 'search.filters.amenity.wifi',
+    parking: 'search.filters.amenity.parking',
+    gym: 'search.filters.amenity.gym',
+    pool: 'search.filters.amenity.pool',
+    balcony: 'search.filters.amenity.balcony',
+    garden: 'search.filters.amenity.garden',
+    elevator: 'search.filters.amenity.elevator',
+    air_conditioning: 'search.filters.amenity.airConditioning',
+    heating: 'search.filters.amenity.heating',
+    dishwasher: 'search.filters.amenity.dishwasher',
+    washing_machine: 'search.filters.amenity.washingMachine',
+};
+
 const LEASE_DURATIONS = [
-    { id: '3_months', label: '3 months' },
-    { id: '6_months', label: '6 months' },
-    { id: '12_months', label: '12 months' },
-    { id: 'flexible', label: 'Flexible' },
-];
+    { id: '3_months', labelKey: 'search.filters.leaseDuration.3Months' },
+    { id: '6_months', labelKey: 'search.filters.leaseDuration.6Months' },
+    { id: '12_months', labelKey: 'search.filters.leaseDuration.12Months' },
+    { id: 'flexible', labelKey: 'search.filters.leaseDuration.flexible' },
+] as const;
 
 const CANCELLATION_POLICIES = [
-    { id: CancellationPolicy.FLEXIBLE, label: 'Flexible' },
-    { id: CancellationPolicy.MODERATE, label: 'Moderate' },
-    { id: CancellationPolicy.STRICT, label: 'Strict' },
-    { id: CancellationPolicy.SUPER_STRICT, label: 'Super strict' },
-];
+    { id: CancellationPolicy.FLEXIBLE, labelKey: 'search.filters.cancellation.flexible' },
+    { id: CancellationPolicy.MODERATE, labelKey: 'search.filters.cancellation.moderate' },
+    { id: CancellationPolicy.STRICT, labelKey: 'search.filters.cancellation.strict' },
+    { id: CancellationPolicy.SUPER_STRICT, labelKey: 'search.filters.cancellation.superStrict' },
+] as const;
 
 export function SearchFiltersBottomSheet({
     filters,
@@ -98,18 +112,18 @@ export function SearchFiltersBottomSheet({
         const sections: FilterSection[] = [
             {
                 id: 'type',
-                title: t('Property Type'),
+                title: t('search.filters.propertyType'),
                 type: 'chips',
                 options: propertyTypes.map((type) => ({
                     id: type.id,
-                    label: t(type.label),
+                    label: t(type.labelKey),
                     value: type.id,
                 })),
                 value: filters.type,
             },
             {
                 id: 'price',
-                title: mode === 'vacation' ? t('Nightly price') : t('Monthly price'),
+                title: mode === 'vacation' ? t('search.filters.nightlyPrice') : t('search.filters.monthlyPrice'),
                 type: 'range',
                 min: 0,
                 max: mode === 'vacation' ? 1000 : 10000,
@@ -120,7 +134,7 @@ export function SearchFiltersBottomSheet({
             },
             {
                 id: 'bedrooms',
-                title: t('Bedrooms'),
+                title: t('property.sections.bedrooms'),
                 type: 'chips',
                 options: [
                     { id: '1', label: '1', value: '1' },
@@ -133,7 +147,7 @@ export function SearchFiltersBottomSheet({
             },
             {
                 id: 'bathrooms',
-                title: t('Bathrooms'),
+                title: t('property.sections.bathrooms'),
                 type: 'chips',
                 options: [
                     { id: '1', label: '1', value: '1' },
@@ -149,37 +163,37 @@ export function SearchFiltersBottomSheet({
             sections.push(
                 {
                     id: 'checkIn',
-                    title: t('Check-in'),
+                    title: t('search.filters.checkIn'),
                     type: 'date',
                     value: filters.checkIn || '',
-                    placeholder: t('Add date'),
+                    placeholder: t('search.filters.addDate'),
                 },
                 {
                     id: 'checkOut',
-                    title: t('Check-out'),
+                    title: t('search.filters.checkOut'),
                     type: 'date',
                     value: filters.checkOut || '',
-                    placeholder: t('Add date'),
+                    placeholder: t('search.filters.addDate'),
                 },
                 {
                     id: 'guests',
-                    title: t('Guests'),
+                    title: t('search.filters.guests'),
                     type: 'counter',
                     value: typeof filters.guests === 'number' ? filters.guests : 0,
                 },
                 {
                     id: 'instantBook',
-                    title: t('Instant book'),
+                    title: t('search.filters.instantBook'),
                     type: 'toggle',
                     value: Boolean(filters.instantBook),
                 },
                 {
                     id: 'cancellationPolicy',
-                    title: t('Cancellation policy'),
+                    title: t('search.filters.cancellationPolicy'),
                     type: 'chips',
                     options: CANCELLATION_POLICIES.map((policy) => ({
                         id: policy.id,
-                        label: t(policy.label),
+                        label: t(policy.labelKey),
                         value: policy.id,
                     })),
                     value: filters.cancellationPolicy,
@@ -189,25 +203,25 @@ export function SearchFiltersBottomSheet({
             sections.push(
                 {
                     id: 'moveIn',
-                    title: t('Move-in date'),
+                    title: t('search.filters.moveInDate'),
                     type: 'date',
                     value: filters.moveIn || '',
-                    placeholder: t('Add date'),
+                    placeholder: t('search.filters.addDate'),
                 },
                 {
                     id: 'leaseDuration',
-                    title: t('Lease duration'),
+                    title: t('search.filters.leaseDuration'),
                     type: 'chips',
                     options: LEASE_DURATIONS.map((duration) => ({
                         id: duration.id,
-                        label: t(duration.label),
+                        label: t(duration.labelKey),
                         value: duration.id,
                     })),
                     value: filters.leaseDuration,
                 },
                 {
                     id: 'maxDeposit',
-                    title: t('Max deposit'),
+                    title: t('search.filters.maxDeposit'),
                     type: 'range',
                     min: 0,
                     max: 10000,
@@ -215,7 +229,7 @@ export function SearchFiltersBottomSheet({
                 },
                 {
                     id: 'furnished',
-                    title: t('Furnished'),
+                    title: t('property.sections.furnished'),
                     type: 'toggle',
                     value: Boolean(filters.furnished),
                 },
@@ -224,11 +238,11 @@ export function SearchFiltersBottomSheet({
 
         sections.push({
             id: 'amenities',
-            title: t('Amenities'),
+            title: t('search.filters.amenities'),
             type: 'chips',
             options: AMENITIES.map((amenity) => ({
                 id: amenity,
-                label: t(amenity.replace('_', ' ')),
+                label: t(AMENITY_I18N_KEYS[amenity]),
                 value: amenity,
             })),
             value: filters.amenities,

--- a/packages/frontend/components/SideBar/ModeToggle.tsx
+++ b/packages/frontend/components/SideBar/ModeToggle.tsx
@@ -26,15 +26,14 @@ interface ModeRow {
   mode: BrowseMode;
   icon: LucideIcon;
   labelKey: string;
-  labelFallback: string;
   shortcut: string;
 }
 
 const MODE_ROWS: readonly ModeRow[] = [
-  { mode: 'long_term', icon: Home, labelKey: 'sidebar.mode.longTerm', labelFallback: 'Long-term', shortcut: '1' },
-  { mode: 'vacation', icon: CalendarDays, labelKey: 'sidebar.mode.vacation', labelFallback: 'Vacation', shortcut: '2' },
-  { mode: 'buy', icon: Tag, labelKey: 'sidebar.mode.buy', labelFallback: 'Buy', shortcut: '3' },
-  { mode: 'exchange', icon: Repeat, labelKey: 'sidebar.mode.exchange', labelFallback: 'Exchange', shortcut: '4' },
+  { mode: 'long_term', icon: Home, labelKey: 'sidebar.mode.longTerm', shortcut: '1' },
+  { mode: 'vacation', icon: CalendarDays, labelKey: 'sidebar.mode.vacation', shortcut: '2' },
+  { mode: 'buy', icon: Tag, labelKey: 'sidebar.mode.buy', shortcut: '3' },
+  { mode: 'exchange', icon: Repeat, labelKey: 'sidebar.mode.exchange', shortcut: '4' },
 ] as const;
 
 interface ModeRowButtonProps {
@@ -56,7 +55,7 @@ const ModeRowButton = React.memo(function ModeRowButton({
 }: ModeRowButtonProps) {
   const { t } = useTranslation();
   const Icon = row.icon;
-  const label = t(row.labelKey, { defaultValue: row.labelFallback });
+  const label = t(row.labelKey);
   const color = active ? colors.primaryDark : colors.primaryDark_2;
   const handlePress = React.useCallback(() => onSelect(row.mode), [onSelect, row.mode]);
 

--- a/packages/frontend/components/SideBar/RecentPropertyItem.tsx
+++ b/packages/frontend/components/SideBar/RecentPropertyItem.tsx
@@ -141,9 +141,7 @@ export const RecentPropertyItem = React.memo(function RecentPropertyItem({
               <View className="flex-row items-center gap-2 py-1 px-2">
                 <Trash2 size={14} color={colors.busy} />
                 <Text style={{ fontSize: 13, color: colors.busy }}>
-                  {t('sidebar.recent.remove', {
-                    defaultValue: 'Remove from recent',
-                  })}
+                  {t('sidebar.recent.remove')}
                 </Text>
               </View>
             </MenuOption>

--- a/packages/frontend/components/SideBar/index.tsx
+++ b/packages/frontend/components/SideBar/index.tsx
@@ -279,9 +279,7 @@ export function SideBar() {
           key: 'applications',
           icon: FileText,
           iconActive: FileText,
-          label: t('sidebar.navigation.applications', {
-            defaultValue: 'My applications',
-          }),
+          label: t('sidebar.navigation.applications'),
           route: '/applications',
         });
       } else {
@@ -289,7 +287,7 @@ export function SideBar() {
           key: 'stays',
           icon: BedDouble,
           iconActive: BedDouble,
-          label: t('sidebar.navigation.stays', { defaultValue: 'Stays' }),
+          label: t('sidebar.navigation.stays'),
           route: '/stays',
         });
       }
@@ -307,7 +305,7 @@ export function SideBar() {
       key: 'tips',
       icon: Lightbulb,
       iconActive: Lightbulb,
-      label: t('sidebar.navigation.tips', { defaultValue: 'Tips' }),
+      label: t('sidebar.navigation.tips'),
       route: '/tips',
     });
 
@@ -326,9 +324,7 @@ export function SideBar() {
         key: 'host-calendar',
         icon: CalendarClock,
         iconActive: CalendarClock,
-        label: t('sidebar.navigation.hostCalendar', {
-          defaultValue: 'Host calendar',
-        }),
+        label: t('sidebar.navigation.hostCalendar'),
         route: '/host/calendar',
       });
     }
@@ -437,11 +433,9 @@ export function SideBar() {
   const dateGroups = React.useMemo(
     () =>
       groupByDate(recentEntries, {
-        today: t('sidebar.recent.today', { defaultValue: 'Today' }),
-        yesterday: t('sidebar.recent.yesterday', {
-          defaultValue: 'Yesterday',
-        }),
-        earlier: t('sidebar.recent.earlier', { defaultValue: 'Earlier' }),
+        today: t('sidebar.recent.today'),
+        yesterday: t('sidebar.recent.yesterday'),
+        earlier: t('sidebar.recent.earlier'),
       }),
     [recentEntries, t],
   );
@@ -596,9 +590,7 @@ export function SideBar() {
           <Pressable
             onPress={toggleSidebarCollapsed}
             accessibilityRole="button"
-            accessibilityLabel={t('sidebar.expand', {
-              defaultValue: 'Expand sidebar',
-            })}
+            accessibilityLabel={t('sidebar.expand')}
             className="h-10 w-10 rounded-xl items-center justify-center hover:bg-muted active:bg-muted/80"
           >
             <ChevronsRight size={18} color={colors.primaryDark_2} />
@@ -626,9 +618,7 @@ export function SideBar() {
             <Pressable
               onPress={closeMobileDrawer}
               accessibilityRole="button"
-              accessibilityLabel={t('sidebar.close', {
-                defaultValue: 'Close menu',
-              })}
+              accessibilityLabel={t('sidebar.close')}
               className="h-10 w-10 rounded-xl items-center justify-center hover:bg-muted active:bg-muted/80"
             >
               <X size={20} color={colors.primaryDark_2} />
@@ -639,9 +629,7 @@ export function SideBar() {
             <Pressable
               onPress={toggleSidebarCollapsed}
               accessibilityRole="button"
-              accessibilityLabel={t('sidebar.collapse', {
-                defaultValue: 'Collapse sidebar',
-              })}
+              accessibilityLabel={t('sidebar.collapse')}
               className="h-10 w-10 rounded-xl items-center justify-center hover:bg-muted active:bg-muted/80"
             >
               <ChevronsLeft size={18} color={colors.primaryDark_2} />
@@ -682,18 +670,14 @@ export function SideBar() {
   const middle = (
     <>
       <SectionHeader
-        label={t('sidebar.savedProperties.title', {
-          defaultValue: 'Saved folders',
-        })}
+        label={t('sidebar.savedProperties.title')}
         isOpen={savedFoldersOpen}
         onToggle={toggleSavedFolders}
         action={
           <Pressable
             onPress={handleSaved}
             accessibilityRole="button"
-            accessibilityLabel={t('sidebar.savedProperties.viewAll', {
-              defaultValue: 'View all',
-            })}
+            accessibilityLabel={t('sidebar.savedProperties.viewAll')}
             className="h-6 w-6 items-center justify-center rounded-md hover:bg-muted"
           >
             <ChevronRight size={14} color={colors.primaryDark_2} />
@@ -708,9 +692,7 @@ export function SideBar() {
                 style={{ fontSize: 12, color: colors.primaryDark_2 }}
                 numberOfLines={2}
               >
-                {t('sidebar.savedProperties.empty', {
-                  defaultValue: 'No saved folders yet',
-                })}
+                {t('sidebar.savedProperties.empty')}
               </Text>
             </View>
           ) : (
@@ -730,7 +712,7 @@ export function SideBar() {
       )}
 
       <SectionHeader
-        label={t('sidebar.recent.title', { defaultValue: 'Recently viewed' })}
+        label={t('sidebar.recent.title')}
         isOpen={recentPropertiesOpen}
         onToggle={toggleRecentProperties}
       />
@@ -742,9 +724,7 @@ export function SideBar() {
                 style={{ fontSize: 12, color: colors.primaryDark_2 }}
                 numberOfLines={2}
               >
-                {t('sidebar.recent.empty', {
-                  defaultValue: 'Properties you view will appear here',
-                })}
+                {t('sidebar.recent.empty')}
               </Text>
             </View>
           ) : (
@@ -788,9 +768,7 @@ export function SideBar() {
                 textDecorationLine: 'underline',
               }}
             >
-              {t('sidebar.menu.privacy', {
-                defaultValue: 'Privacy policy',
-              })}
+              {t('sidebar.menu.privacy')}
             </Text>
           </Pressable>
           <Text style={{ fontSize: 10, color: colors.primaryDark_2 }}>·</Text>
@@ -802,9 +780,7 @@ export function SideBar() {
                 textDecorationLine: 'underline',
               }}
             >
-              {t('sidebar.menu.terms', {
-                defaultValue: 'Terms of service',
-              })}
+              {t('sidebar.menu.terms')}
             </Text>
           </Pressable>
         </View>
@@ -850,9 +826,7 @@ export function SideBar() {
                 entering={FadeIn.duration(MOBILE_DRAWER_DURATION)}
                 exiting={FadeOut.duration(MOBILE_DRAWER_DURATION)}
                 accessibilityRole="button"
-                accessibilityLabel={t('sidebar.close', {
-                  defaultValue: 'Close menu',
-                })}
+                accessibilityLabel={t('sidebar.close')}
                 onPress={closeMobileDrawer}
                 style={[
                   StyleSheet.absoluteFill,

--- a/packages/frontend/components/TrustScore.tsx
+++ b/packages/frontend/components/TrustScore.tsx
@@ -1,14 +1,32 @@
 import React, { useMemo, useCallback } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { colors } from '@/styles/colors';
 import { useProfile } from '@/hooks/useProfile';
+
+const TRUST_FACTOR_TYPES = new Set([
+  'verification',
+  'reviews',
+  'payment_history',
+  'communication',
+  'rental_history',
+]);
 
 type TrustFactor = {
   type: string;
   value: number;
   maxValue: number;
-  label: string;
 };
+
+type TrustLevelKey = 'excellent' | 'good' | 'average' | 'fair' | 'needsImprovement';
+
+function trustLevelKey(score: number): TrustLevelKey {
+  if (score >= 90) return 'excellent';
+  if (score >= 70) return 'good';
+  if (score >= 50) return 'average';
+  if (score >= 30) return 'fair';
+  return 'needsImprovement';
+}
 
 type TrustScoreProps = {
   score: number; // 0-100 score
@@ -27,25 +45,24 @@ export function TrustScore({
   showDetails = false,
   onRecalculate,
 }: TrustScoreProps) {
-  const { updateProfile, isLoading } = useProfile();
+  const { t } = useTranslation();
+  const { isLoading } = useProfile();
 
-  // Memoize expensive calculations
-  const { color, trustLevel, sizeStyle } = useMemo(() => {
-    // Calculate the appropriate color based on the score
-    const getColor = (score: number) => {
-      if (score >= 90) return colors.success; // Excellent
-      if (score >= 70) return colors.success; // Good
-      if (score >= 50) return colors.warning; // Average
-      if (score >= 30) return colors.warning; // Below Average
-      return colors.danger; // Poor
-    };
+  const factorLabel = useCallback(
+    (factorType: string) =>
+      TRUST_FACTOR_TYPES.has(factorType)
+        ? t(`trust.manager.factors.${factorType}.label`)
+        : factorType,
+    [t],
+  );
 
-    const getTrustLevel = (score: number) => {
-      if (score >= 90) return 'Excellent';
-      if (score >= 70) return 'Good';
-      if (score >= 50) return 'Average';
-      if (score >= 30) return 'Fair';
-      return 'Needs Improvement';
+  const { color, levelKey, sizeStyle } = useMemo(() => {
+    const getColor = (value: number) => {
+      if (value >= 90) return colors.success;
+      if (value >= 70) return colors.success;
+      if (value >= 50) return colors.warning;
+      if (value >= 30) return colors.warning;
+      return colors.danger;
     };
 
     const sizeStyles = {
@@ -71,12 +88,11 @@ export function TrustScore({
 
     return {
       color: getColor(score),
-      trustLevel: getTrustLevel(score),
+      levelKey: trustLevelKey(score),
       sizeStyle: sizeStyles[size],
     };
   }, [score, size]);
 
-  // Memoize factor color calculation
   const getFactorColor = useCallback((value: number, maxValue: number) => {
     const percentage = (value / maxValue) * 100;
     if (percentage >= 80) return colors.success;
@@ -86,23 +102,19 @@ export function TrustScore({
     return colors.danger;
   }, []);
 
-  // Memoize recalculate handler
   const handleRecalculate = useCallback(async () => {
     try {
-      // For now, we'll trigger a refetch of profiles which will recalculate trust scores
-      // In the future, we can add a specific recalculate action to Redux
       onRecalculate?.();
     } catch (error) {
       console.error('Failed to recalculate trust score:', error);
     }
   }, [onRecalculate]);
 
-  // Memoize factor items to prevent unnecessary re-renders
   const factorItems = useMemo(() => {
     return factors.map((factor, index) => (
       <View key={`${factor.type}-${index}`} style={styles.factorItem}>
         <View style={styles.factorHeader}>
-          <Text style={styles.factorLabel}>{factor.label}</Text>
+          <Text style={styles.factorLabel}>{factorLabel(factor.type)}</Text>
           <Text style={styles.factorScore}>
             {factor.value}/{factor.maxValue}
           </Text>
@@ -120,7 +132,7 @@ export function TrustScore({
         </View>
       </View>
     ));
-  }, [factors, getFactorColor]);
+  }, [factors, factorLabel, getFactorColor]);
 
   return (
     <View style={styles.wrapper}>
@@ -133,7 +145,7 @@ export function TrustScore({
         {showLabel && (
           <View style={styles.labelContainer}>
             <Text style={[styles.label, { fontSize: sizeStyle.labelSize, color }]}>
-              {trustLevel}
+              {t(`trust.score.levels.${levelKey}`)}
             </Text>
           </View>
         )}
@@ -142,14 +154,14 @@ export function TrustScore({
       {showDetails && factors.length > 0 && (
         <View style={styles.detailsContainer}>
           <View style={styles.detailsHeader}>
-            <Text style={styles.detailsTitle}>Trust Score Breakdown</Text>
+            <Text style={styles.detailsTitle}>{t('trust.score.breakdown')}</Text>
             <TouchableOpacity
               style={styles.recalculateButton}
               onPress={handleRecalculate}
               disabled={isLoading}
             >
               <Text style={styles.recalculateButtonText}>
-                {isLoading ? 'Recalculating...' : 'Recalculate'}
+                {isLoading ? t('trust.score.recalculating') : t('trust.score.recalculate')}
               </Text>
             </TouchableOpacity>
           </View>

--- a/packages/frontend/components/TrustScoreCompact.tsx
+++ b/packages/frontend/components/TrustScoreCompact.tsx
@@ -1,6 +1,17 @@
 import React, { useMemo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { colors } from '@/styles/colors';
+
+type TrustLevelKey = 'excellent' | 'good' | 'average' | 'fair' | 'needsImprovement';
+
+function trustLevelKey(score: number): TrustLevelKey {
+  if (score >= 90) return 'excellent';
+  if (score >= 70) return 'good';
+  if (score >= 50) return 'average';
+  if (score >= 30) return 'fair';
+  return 'needsImprovement';
+}
 
 type TrustScoreCompactProps = {
   score: number;
@@ -15,22 +26,15 @@ export function TrustScoreCompact({
   showLabel = true,
   showPercentage = false,
 }: TrustScoreCompactProps) {
-  // Memoize expensive calculations
-  const { color, trustLevel, sizeStyle } = useMemo(() => {
-    const getColor = (score: number) => {
-      if (score >= 90) return colors.success;
-      if (score >= 70) return colors.success;
-      if (score >= 50) return colors.warning;
-      if (score >= 30) return colors.warning;
-      return colors.danger;
-    };
+  const { t } = useTranslation();
 
-    const getTrustLevel = (score: number) => {
-      if (score >= 90) return 'Excellent';
-      if (score >= 70) return 'Good';
-      if (score >= 50) return 'Average';
-      if (score >= 30) return 'Fair';
-      return 'Needs Improvement';
+  const { color, levelKey, sizeStyle } = useMemo(() => {
+    const getColor = (value: number) => {
+      if (value >= 90) return colors.success;
+      if (value >= 70) return colors.success;
+      if (value >= 50) return colors.warning;
+      if (value >= 30) return colors.warning;
+      return colors.danger;
     };
 
     const sizeStyles = {
@@ -56,7 +60,7 @@ export function TrustScoreCompact({
 
     return {
       color: getColor(score),
-      trustLevel: getTrustLevel(score),
+      levelKey: trustLevelKey(score),
       sizeStyle: sizeStyles[size],
     };
   }, [score, size]);
@@ -71,7 +75,9 @@ export function TrustScoreCompact({
         </View>
       </View>
       {showLabel && (
-        <Text style={[styles.label, { fontSize: sizeStyle.labelSize, color }]}>{trustLevel}</Text>
+        <Text style={[styles.label, { fontSize: sizeStyle.labelSize, color }]}>
+          {t(`trust.score.levels.${levelKey}`)}
+        </Text>
       )}
     </View>
   );

--- a/packages/frontend/components/TrustScoreManager.tsx
+++ b/packages/frontend/components/TrustScoreManager.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, ScrollView } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { colors } from '@/styles/colors';
 import { shadowToken } from '@/styles/shadows';
 import { useTrustScore } from '@/hooks/useTrustScore';
@@ -8,7 +9,30 @@ import { TrustScore } from './TrustScore';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 
+const TRUST_FACTOR_TYPES = [
+  'verification',
+  'reviews',
+  'payment_history',
+  'communication',
+  'rental_history',
+] as const;
+
+type TrustFactorType = (typeof TRUST_FACTOR_TYPES)[number];
+
+function isTrustFactorType(value: string): value is TrustFactorType {
+  return (TRUST_FACTOR_TYPES as readonly string[]).includes(value);
+}
+
+const PROFILE_SECTIONS: Record<TrustFactorType, string> = {
+  verification: 'personal',
+  reviews: 'references',
+  payment_history: 'rental-history',
+  communication: 'personal',
+  rental_history: 'rental-history',
+};
+
 export function TrustScoreManager() {
+  const { t } = useTranslation();
   const { data: activeProfile } = useActiveProfile();
   const currentProfileId = activeProfile?.id || activeProfile?._id;
   const router = useRouter();
@@ -21,7 +45,6 @@ export function TrustScoreManager() {
     fetchTrustScoreData,
   } = useTrustScore(currentProfileId);
 
-  // Set the profile ID and fetch trust score when active profile changes
   useEffect(() => {
     if (currentProfileId) {
       setCurrentProfileId(currentProfileId);
@@ -29,10 +52,58 @@ export function TrustScoreManager() {
     }
   }, [currentProfileId, setCurrentProfileId, fetchTrustScoreData]);
 
+  const factorLabel = (factorType: string) =>
+    isTrustFactorType(factorType)
+      ? t(`trust.manager.factors.${factorType}.label`)
+      : factorType;
+
+  const factorDescription = (factorType: string) =>
+    isTrustFactorType(factorType)
+      ? t(`trust.manager.factors.${factorType}.description`)
+      : t('trust.manager.factors.default.description');
+
+  const factorActionText = (factorType: string) =>
+    isTrustFactorType(factorType)
+      ? t(`trust.manager.factors.${factorType}.action`)
+      : t('trust.manager.factors.default.action');
+
+  const getProfileSection = (factorType: string) =>
+    isTrustFactorType(factorType) ? PROFILE_SECTIONS[factorType] : 'personal';
+
+  const handleEditProfile = (section?: string) => {
+    if (section) {
+      router.push(`/profile/edit?section=${section}`);
+    } else {
+      router.push('/profile/edit');
+    }
+  };
+
+  const showFactorDetails = (factorType: string) => {
+    const factor = trustScoreData?.factors.find((f) => f.type === factorType);
+    if (!factor) return;
+
+    const section = getProfileSection(factorType);
+    Alert.alert(
+      factorLabel(factorType),
+      t('trust.manager.factorAlertBody', {
+        description: factorDescription(factorType),
+        score: factor.value,
+        action: factorActionText(factorType),
+      }),
+      [
+        { text: t('trust.manager.cancel'), style: 'cancel' },
+        {
+          text: t('trust.manager.editProfile'),
+          onPress: () => handleEditProfile(section),
+        },
+      ],
+    );
+  };
+
   if (isLoading) {
     return (
       <View style={styles.container}>
-        <Text style={styles.loadingText}>Loading trust score...</Text>
+        <Text style={styles.loadingText}>{t('trust.manager.loading')}</Text>
       </View>
     );
   }
@@ -40,7 +111,7 @@ export function TrustScoreManager() {
   if (error) {
     return (
       <View style={styles.container}>
-        <Text style={styles.errorText}>Error loading trust score</Text>
+        <Text style={styles.errorText}>{t('trust.manager.error')}</Text>
       </View>
     );
   }
@@ -48,116 +119,39 @@ export function TrustScoreManager() {
   if (!trustScoreData || trustScoreData.type !== 'personal') {
     return (
       <View style={styles.container}>
-        <Text style={styles.errorText}>No personal trust score data found</Text>
+        <Text style={styles.errorText}>{t('trust.manager.noData')}</Text>
       </View>
     );
   }
 
   const factors = trustScoreData.factors;
 
-  const getFactorLabel = (factorType: string) => {
-    const labels: Record<string, string> = {
-      verification: 'Identity Verification',
-      reviews: 'User Reviews',
-      payment_history: 'Payment History',
-      communication: 'Communication',
-      rental_history: 'Rental History',
-    };
-    return (
-      labels[factorType] || factorType.replace('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase())
-    );
-  };
-
-  const getFactorDescription = (factorType: string) => {
-    const descriptions: Record<string, string> = {
-      verification: 'Complete identity verification to build trust',
-      reviews: 'Get positive reviews from landlords and roommates',
-      payment_history: 'Maintain a good payment history',
-      communication: 'Respond promptly to messages and requests',
-      rental_history: 'Build a positive rental history',
-    };
-    return descriptions[factorType] || 'Improve this factor to increase your trust score';
-  };
-
-  const getFactorActionText = (factorType: string) => {
-    const actions: Record<string, string> = {
-      verification: 'Add personal information and income details',
-      reviews: 'Add references from previous landlords',
-      payment_history: 'Add rental history with payment records',
-      communication: 'Complete your profile bio and contact info',
-      rental_history: 'Add your previous rental addresses',
-    };
-    return actions[factorType] || 'Complete your profile to improve this factor';
-  };
-
-  const handleEditProfile = (section?: string) => {
-    if (section) {
-      // Navigate to specific section if provided
-      router.push(`/profile/edit?section=${section}`);
-    } else {
-      router.push('/profile/edit');
-    }
-  };
-
-  const getProfileSection = (factorType: string) => {
-    const sections: Record<string, string> = {
-      verification: 'personal',
-      reviews: 'references',
-      payment_history: 'rental-history',
-      communication: 'personal',
-      rental_history: 'rental-history',
-    };
-    return sections[factorType] || 'personal';
-  };
-
-  const showFactorDetails = (factorType: string) => {
-    const factor = factors.find((f) => f.type === factorType);
-    if (!factor) return;
-
-    const section = getProfileSection(factorType);
-    const actionText = getFactorActionText(factorType);
-
-    Alert.alert(
-      getFactorLabel(factorType),
-      `${getFactorDescription(factorType)}\n\nCurrent Score: ${factor.value}/100\n\nTo improve: ${actionText}`,
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Edit Profile',
-          onPress: () => handleEditProfile(section),
-        },
-      ],
-    );
-  };
-
   return (
     <ScrollView style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.title}>Trust Score</Text>
-        <Text style={styles.subtitle}>Build trust with landlords and roommates</Text>
+        <Text style={styles.title}>{t('trust.manager.title')}</Text>
+        <Text style={styles.subtitle}>{t('trust.manager.subtitle')}</Text>
       </View>
 
       <View style={styles.scoreSection}>
         <TrustScore score={trustScoreData.score} size="large" showLabel={true} />
         <Text style={styles.scoreDescription}>
-          Your overall trust score is {trustScoreData.score}/100
+          {t('trust.manager.scoreDescription', { score: trustScoreData.score })}
         </Text>
       </View>
 
       <View style={styles.factorsSection}>
-        <Text style={styles.sectionTitle}>Trust Factors</Text>
-        <Text style={styles.sectionSubtitle}>
-          Improve these factors to increase your trust score
-        </Text>
+        <Text style={styles.sectionTitle}>{t('trust.manager.factorsTitle')}</Text>
+        <Text style={styles.sectionSubtitle}>{t('trust.manager.factorsSubtitle')}</Text>
 
-        {factors.map((factor, index) => (
+        {factors.map((factor) => (
           <TouchableOpacity
-            key={index}
+            key={factor.type}
             style={styles.factorCard}
             onPress={() => showFactorDetails(factor.type)}
           >
             <View style={styles.factorHeader}>
-              <Text style={styles.factorTitle}>{getFactorLabel(factor.type)}</Text>
+              <Text style={styles.factorTitle}>{factorLabel(factor.type)}</Text>
               <Text style={styles.factorScore}>{factor.value}/100</Text>
             </View>
 
@@ -178,33 +172,33 @@ export function TrustScoreManager() {
               />
             </View>
 
-            <Text style={styles.factorDescription}>{getFactorDescription(factor.type)}</Text>
+            <Text style={styles.factorDescription}>{factorDescription(factor.type)}</Text>
           </TouchableOpacity>
         ))}
       </View>
 
       <View style={styles.tipsSection}>
-        <Text style={styles.sectionTitle}>Quick Actions to Improve Score</Text>
+        <Text style={styles.sectionTitle}>{t('trust.manager.quickActionsTitle')}</Text>
 
         <TouchableOpacity style={styles.actionCard} onPress={() => handleEditProfile('personal')}>
           <View style={styles.actionCardHeader}>
             <Ionicons name="person-outline" size={24} color={colors.primaryColor} />
-            <Text style={styles.actionCardTitle}>Complete Personal Info</Text>
+            <Text style={styles.actionCardTitle}>{t('trust.manager.actions.personalInfo.title')}</Text>
             <Ionicons name="chevron-forward" size={20} color={colors.COLOR_BLACK_LIGHT_5} />
           </View>
           <Text style={styles.actionCardText}>
-            Add your occupation, income, and employment details to build trust.
+            {t('trust.manager.actions.personalInfo.description')}
           </Text>
         </TouchableOpacity>
 
         <TouchableOpacity style={styles.actionCard} onPress={() => handleEditProfile('references')}>
           <View style={styles.actionCardHeader}>
             <Ionicons name="people-outline" size={24} color={colors.primaryColor} />
-            <Text style={styles.actionCardTitle}>Add References</Text>
+            <Text style={styles.actionCardTitle}>{t('trust.manager.actions.references.title')}</Text>
             <Ionicons name="chevron-forward" size={20} color={colors.COLOR_BLACK_LIGHT_5} />
           </View>
           <Text style={styles.actionCardText}>
-            Include references from previous landlords and employers.
+            {t('trust.manager.actions.references.description')}
           </Text>
         </TouchableOpacity>
 
@@ -214,17 +208,17 @@ export function TrustScoreManager() {
         >
           <View style={styles.actionCardHeader}>
             <Ionicons name="home-outline" size={24} color={colors.primaryColor} />
-            <Text style={styles.actionCardTitle}>Add Rental History</Text>
+            <Text style={styles.actionCardTitle}>{t('trust.manager.actions.rentalHistory.title')}</Text>
             <Ionicons name="chevron-forward" size={20} color={colors.COLOR_BLACK_LIGHT_5} />
           </View>
           <Text style={styles.actionCardText}>
-            Document your rental history to show your reliability as a tenant.
+            {t('trust.manager.actions.rentalHistory.description')}
           </Text>
         </TouchableOpacity>
 
         <TouchableOpacity style={styles.primaryActionButton} onPress={() => handleEditProfile()}>
           <Ionicons name="create-outline" size={20} color={colors.primaryLight} />
-          <Text style={styles.primaryActionButtonText}>Complete Profile</Text>
+          <Text style={styles.primaryActionButtonText}>{t('trust.manager.completeProfile')}</Text>
         </TouchableOpacity>
       </View>
     </ScrollView>
@@ -362,25 +356,6 @@ const styles = StyleSheet.create({
     color: colors.primaryLight,
     fontSize: 16,
     fontWeight: 'bold',
-  },
-  tipCard: {
-    backgroundColor: colors.primaryLight_1,
-    padding: 16,
-    borderRadius: 8,
-    marginBottom: 12,
-    borderLeftWidth: 4,
-    borderLeftColor: colors.primaryColor,
-  },
-  tipTitle: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: colors.COLOR_BLACK,
-    marginBottom: 4,
-  },
-  tipText: {
-    fontSize: 14,
-    color: colors.COLOR_BLACK_LIGHT_5,
-    lineHeight: 20,
   },
   loadingText: {
     fontSize: 16,

--- a/packages/frontend/components/agent/AgentHowItWorks.tsx
+++ b/packages/frontend/components/agent/AgentHowItWorks.tsx
@@ -97,7 +97,7 @@ export const AgentHowItWorks: React.FC = () => {
     <View style={{ paddingHorizontal: horizontalPadding }}>
       <View style={styles.header}>
         <H1 style={[styles.title, { textAlign: isWide ? 'center' : 'left' }]}>
-          {t('agent.how.title', 'How it works')}
+          {t('agent.how.title')}
         </H1>
       </View>
       <View

--- a/packages/frontend/components/agent/EarningsCalculator.tsx
+++ b/packages/frontend/components/agent/EarningsCalculator.tsx
@@ -140,23 +140,23 @@ export const EarningsCalculator: React.FC = () => {
   // slider-drag frame.
   const offeringLabels = useMemo<Record<CommissionOffering, string>>(
     () => ({
-      rent: t('agent.calculator.offerings.rent', 'Rent'),
-      sale: t('agent.calculator.offerings.sale', 'Sale'),
-      exchange: t('agent.calculator.offerings.exchange', 'Exchange'),
+      rent: t('agent.calculator.offerings.rent'),
+      sale: t('agent.calculator.offerings.sale'),
+      exchange: t('agent.calculator.offerings.exchange'),
     }),
     [t],
   );
 
-  const title = t('agent.calculator.title', 'See what you could earn');
-  const inputLabel = t('agent.calculator.monthlyRent', 'Monthly rent');
-  const perMonth = t('agent.calculator.perMonth', 'mo');
+  const title = t('agent.calculator.title');
+  const inputLabel = t('agent.calculator.monthlyRent');
+  const perMonth = t('agent.calculator.perMonth');
 
   // Sale/exchange are flat rewards, so we show a short note instead of a
   // misleading slider that would imply the payout scales with the deal value.
   const flatNote =
     offering === 'sale'
-      ? t('agent.calculator.flatNoteSale', 'Flat reward per closed sale')
-      : t('agent.calculator.flatNoteExchange', 'Flat reward per exchange');
+      ? t('agent.calculator.flatNoteSale')
+      : t('agent.calculator.flatNoteExchange');
 
   return (
     <View style={{ paddingHorizontal: horizontalPadding }}>
@@ -186,11 +186,11 @@ export const EarningsCalculator: React.FC = () => {
 
         <View style={styles.resultBlock}>
           <BloomText style={styles.resultLabel}>
-            {t('agent.calculator.result', 'You earn')}
+            {t('agent.calculator.result')}
           </BloomText>
           <H1 style={styles.resultAmount}>{formatCurrency(payout, currency, WHOLE_CURRENCY)}</H1>
           <BloomText style={styles.resultCaption}>
-            {t('agent.calculator.caption', 'Paid when the deal closes — no license needed.')}
+            {t('agent.calculator.caption')}
           </BloomText>
         </View>
       </View>

--- a/packages/frontend/components/agent/PartnerDashboard.tsx
+++ b/packages/frontend/components/agent/PartnerDashboard.tsx
@@ -160,13 +160,13 @@ export const PartnerDashboard: React.FC<PartnerDashboardProps> = ({
     return (points - currentTier.minPoints) / pointsBetweenTiers;
   }, [nextTier, currentTier, points]);
 
-  const tierName = (key: RewardTierKey): string => t(`agent.rewards.tiers.${key}`, key);
+  const tierName = (key: RewardTierKey): string => t(`agent.rewards.tiers.${key}`);
 
   const offeringLabel = (offering: CommissionOffering): string =>
-    t(`agent.calculator.offerings.${offering}`, offering);
+    t(`agent.calculator.offerings.${offering}`);
 
   const statusLabel = (status: CommissionStatus): string =>
-    t(`agent.dashboard.status.${status}`, status);
+    t(`agent.dashboard.status.${status}`);
 
   const statusColor = (status: CommissionStatus): string => {
     switch (status) {
@@ -187,22 +187,22 @@ export const PartnerDashboard: React.FC<PartnerDashboardProps> = ({
   const summaryCells: ReadonlyArray<{ key: string; label: string; value: string }> = [
     {
       key: 'referrals',
-      label: t('agent.dashboard.referrals', 'Referrals'),
+      label: t('agent.dashboard.referrals'),
       value: String(stats.referredCount),
     },
     {
       key: 'listings',
-      label: t('agent.dashboard.listings', 'Listings'),
+      label: t('agent.dashboard.listings'),
       value: String(stats.activeListings),
     },
     {
       key: 'pending',
-      label: t('agent.dashboard.pending', 'Pending'),
+      label: t('agent.dashboard.pending'),
       value: formatCurrency(stats.pendingEarnings, stats.currency, WHOLE_CURRENCY),
     },
     {
       key: 'earned',
-      label: t('agent.dashboard.earned', 'Earned'),
+      label: t('agent.dashboard.earned'),
       value: formatCurrency(stats.paidEarnings, stats.currency, WHOLE_CURRENCY),
     },
   ];
@@ -213,7 +213,7 @@ export const PartnerDashboard: React.FC<PartnerDashboardProps> = ({
   return (
     <View style={{ paddingHorizontal: horizontalPadding }}>
       <View style={styles.panel}>
-        <H1 style={styles.heading}>{t('agent.dashboard.title', 'Your dashboard')}</H1>
+        <H1 style={styles.heading}>{t('agent.dashboard.title')}</H1>
 
         {/* Stat grid */}
         <View style={styles.statGrid}>
@@ -233,7 +233,7 @@ export const PartnerDashboard: React.FC<PartnerDashboardProps> = ({
               <BloomText style={styles.tierName}>{tierName(currentTier.key)}</BloomText>
             </View>
             <BloomText style={styles.pointsValue}>
-              {t('agent.dashboard.pointsValue', '{{count}} pts', { count: points })}
+              {t('agent.dashboard.pointsValue', { count: points })}
             </BloomText>
           </View>
           <ProgressBar
@@ -245,24 +245,21 @@ export const PartnerDashboard: React.FC<PartnerDashboardProps> = ({
           />
           <BloomText style={styles.progressCaption}>
             {nextTier
-              ? t('agent.dashboard.toNext', '{{points}} pts to {{tier}}', {
+              ? t('agent.dashboard.toNext', {
                   points: Math.max(nextTier.minPoints - points, 0),
                   tier: tierName(nextTier.key),
                 })
-              : t('agent.dashboard.maxTier', "You've reached the top tier.")}
+              : t('agent.dashboard.maxTier')}
           </BloomText>
         </View>
 
         {/* Recent referrals */}
         <ListSection
-          title={t('agent.dashboard.recentReferrals', 'Your referrals')}
+          title={t('agent.dashboard.recentReferrals')}
           loading={referralsLoading}
           isEmpty={recentReferrals.length === 0}
-          loadingText={t('common.loading', 'Loading…')}
-          emptyText={t(
-            'agent.dashboard.noReferrals',
-            'No referred listings yet — share your link to get started.',
-          )}
+          loadingText={t('common.loading')}
+          emptyText={t('agent.dashboard.noReferrals')}
         >
           {recentReferrals.map((property) => (
             <View key={String(property._id ?? property.id)} style={styles.row}>
@@ -280,14 +277,11 @@ export const PartnerDashboard: React.FC<PartnerDashboardProps> = ({
 
         {/* Recent commissions (ledger) */}
         <ListSection
-          title={t('agent.dashboard.recentEarnings', 'Recent earnings')}
+          title={t('agent.dashboard.recentEarnings')}
           loading={earningsLoading}
           isEmpty={recentCommissions.length === 0}
-          loadingText={t('common.loading', 'Loading…')}
-          emptyText={t(
-            'agent.dashboard.noEarnings',
-            "No earnings yet — you'll see payouts here when a referred deal closes.",
-          )}
+          loadingText={t('common.loading')}
+          emptyText={t('agent.dashboard.noEarnings')}
         >
           {recentCommissions.map((commission) => {
             const tint = statusColor(commission.status);

--- a/packages/frontend/components/agent/ReferralLinkCard.tsx
+++ b/packages/frontend/components/agent/ReferralLinkCard.tsx
@@ -45,24 +45,24 @@ export const ReferralLinkCard: React.FC<ReferralLinkCardProps> = ({ link }) => {
     try {
       await Clipboard.setStringAsync(link);
       setCopied(true);
-      toast.success(t('agent.referral.copied', 'Link copied'));
+      toast.success(t('agent.referral.copied'));
     } catch {
-      toast.error(t('agent.referral.copyFailed', 'Could not copy the link'));
+      toast.error(t('agent.referral.copyFailed'));
     }
   }, [link, t]);
 
   const handleShare = useCallback(async () => {
     const outcome = await shareReferralLink({
       link,
-      message: t('agent.referral.shareMessage', 'List your home on Homiio: {{link}}', {
+      message: t('agent.referral.shareMessage', {
         link,
       }),
-      title: t('agent.referral.shareTitle', 'Earn with Homiio'),
+      title: t('agent.referral.shareTitle'),
     });
     if (outcome === 'copied') {
-      toast.success(t('agent.referral.copied', 'Link copied'));
+      toast.success(t('agent.referral.copied'));
     } else if (outcome === 'failed') {
-      toast.error(t('agent.referral.shareFailed', 'Could not share the link'));
+      toast.error(t('agent.referral.shareFailed'));
     }
   }, [link, t]);
 
@@ -70,7 +70,7 @@ export const ReferralLinkCard: React.FC<ReferralLinkCardProps> = ({ link }) => {
     <View style={{ paddingHorizontal: horizontalPadding }}>
       <View style={styles.card}>
         <BloomText style={styles.label}>
-          {t('agent.referral.title', 'Your referral link')}
+          {t('agent.referral.title')}
         </BloomText>
 
         <View style={styles.linkRow}>
@@ -92,8 +92,8 @@ export const ReferralLinkCard: React.FC<ReferralLinkCardProps> = ({ link }) => {
             style={styles.action}
           >
             {copied
-              ? t('agent.referral.copiedShort', 'Copied')
-              : t('agent.referral.copy', 'Copy')}
+              ? t('agent.referral.copiedShort')
+              : t('agent.referral.copy')}
           </Button>
           <Button
             variant="secondary"
@@ -101,7 +101,7 @@ export const ReferralLinkCard: React.FC<ReferralLinkCardProps> = ({ link }) => {
             onPress={handleShare}
             style={styles.action}
           >
-            {t('agent.referral.share', 'Share your link')}
+            {t('agent.referral.share')}
           </Button>
         </View>
       </View>

--- a/packages/frontend/components/agent/RewardsTeaser.tsx
+++ b/packages/frontend/components/agent/RewardsTeaser.tsx
@@ -117,17 +117,16 @@ export const RewardsTeaser: React.FC<RewardsTeaserProps> = ({ points }) => {
 
   const cardWidth = isWide ? 260 : 220;
 
-  const tierName = (key: RewardTierKey): string =>
-    t(`agent.rewards.tiers.${key}`, key);
+  const tierName = (key: RewardTierKey): string => t(`agent.rewards.tiers.${key}`);
 
   return (
     <View>
       <View style={[styles.header, { paddingHorizontal: horizontalPadding }]}>
         <H1 style={styles.title}>
-          {t('agent.rewards.title', 'Level up, get rewarded')}
+          {t('agent.rewards.title')}
         </H1>
         <BloomText style={styles.subtitle}>
-          {t('agent.rewards.subtitle', 'The more you bring in, the more you unlock.')}
+          {t('agent.rewards.subtitle')}
         </BloomText>
       </View>
 
@@ -143,12 +142,8 @@ export const RewardsTeaser: React.FC<RewardsTeaserProps> = ({ points }) => {
               key={tier.key}
               tier={tier}
               name={tierName(tier.key)}
-              pointsLabel={t('agent.rewards.pointsLabel', '{{count}} pts', {
-                count: tier.minPoints,
-              })}
-              perks={tier.perkKeys.map((perkKey) =>
-                t(`agent.rewards.perks.${perkKey}`, perkKey),
-              )}
+              pointsLabel={t('agent.rewards.pointsLabel', { count: tier.minPoints })}
+              perks={tier.perkKeys.map((perkKey) => t(`agent.rewards.perks.${perkKey}`))}
               reached={reached}
               isCurrent={currentTierKey === tier.key}
               width={cardWidth}

--- a/packages/frontend/components/exchange/ExchangeRequestBottomSheet.tsx
+++ b/packages/frontend/components/exchange/ExchangeRequestBottomSheet.tsx
@@ -140,19 +140,19 @@ export const ExchangeRequestBottomSheet: React.FC<ExchangeRequestBottomSheetProp
     }
     if (!requestedWindow) {
       toast.error(
-        t('listing.exchange.errors.pickDates', 'Pick the dates you want to stay'),
+        t('listing.exchange.errors.pickDates'),
       );
       return;
     }
     if (isSwap && !offeredPropertyId) {
       toast.error(
-        t('listing.exchange.errors.pickProperty', 'Choose the home you’re offering'),
+        t('listing.exchange.errors.pickProperty'),
       );
       return;
     }
     if (isSwap && !offeredWindow) {
       toast.error(
-        t('listing.exchange.errors.pickOfferedDates', 'Pick the dates you’re offering'),
+        t('listing.exchange.errors.pickOfferedDates'),
       );
       return;
     }
@@ -176,14 +176,14 @@ export const ExchangeRequestBottomSheet: React.FC<ExchangeRequestBottomSheetProp
 
     try {
       const request = await createMutation.mutateAsync(payload);
-      toast.success(t('listing.exchange.requestSent', 'Exchange request sent'));
+      toast.success(t('listing.exchange.requestSent'));
       onClose();
       router.push(`/exchange/${request.id}`);
     } catch (error) {
       const messageText =
         error instanceof Error
           ? error.message
-          : t('listing.exchange.errors.failed', 'Could not send request');
+          : t('listing.exchange.errors.failed');
       toast.error(messageText);
     }
   }, [
@@ -220,13 +220,13 @@ export const ExchangeRequestBottomSheet: React.FC<ExchangeRequestBottomSheetProp
         >
           <View style={styles.header}>
             <H3 style={styles.title}>
-              {t('listing.exchange.requestTitle', 'Request exchange')}
+              {t('listing.exchange.requestTitle')}
             </H3>
             <Button
               variant="icon"
               size="small"
               onPress={onClose}
-              accessibilityLabel={t('common.close', 'Close')}
+              accessibilityLabel={t('common.close')}
             >
               {'×'}
             </Button>
@@ -241,19 +241,19 @@ export const ExchangeRequestBottomSheet: React.FC<ExchangeRequestBottomSheetProp
             {allowsBoth ? (
               <View style={styles.field}>
                 <BloomText style={styles.label}>
-                  {t('listing.exchange.requestModeLabel', 'What are you proposing?')}
+                  {t('listing.exchange.requestModeLabel')}
                 </BloomText>
                 <View style={styles.modeRow}>
                   <ModeChip
                     active={mode === ExchangeMode.SWAP}
                     icon="swap-horizontal"
-                    label={t('listing.exchange.mode.swap', 'Home swap')}
+                    label={t('listing.exchange.mode.swap')}
                     onPress={() => setMode(ExchangeMode.SWAP)}
                   />
                   <ModeChip
                     active={mode === ExchangeMode.HOST}
                     icon="bed-outline"
-                    label={t('listing.exchange.mode.host', 'Free hosting')}
+                    label={t('listing.exchange.mode.host')}
                     onPress={() => setMode(ExchangeMode.HOST)}
                   />
                 </View>
@@ -263,16 +263,13 @@ export const ExchangeRequestBottomSheet: React.FC<ExchangeRequestBottomSheetProp
             {/* Requested window */}
             <View style={styles.field}>
               <BloomText style={styles.label}>
-                {t('listing.exchange.requestedWindow', 'Dates you want to stay')}
+                {t('listing.exchange.requestedWindow')}
               </BloomText>
               <Pressable
                 style={styles.dateTrigger}
                 onPress={() => setCalendarTarget('requested')}
                 accessibilityRole="button"
-                accessibilityLabel={t(
-                  'listing.exchange.requestedWindow',
-                  'Dates you want to stay',
-                )}
+                accessibilityLabel={t('listing.exchange.requestedWindow')}
               >
                 <Ionicons
                   name="calendar-outline"
@@ -288,7 +285,7 @@ export const ExchangeRequestBottomSheet: React.FC<ExchangeRequestBottomSheetProp
                 >
                   {requestedWindow
                     ? formatRange(requestedWindow)
-                    : t('listing.exchange.addDates', 'Add dates')}
+                    : t('listing.exchange.addDates')}
                 </BloomText>
               </Pressable>
             </View>
@@ -298,7 +295,7 @@ export const ExchangeRequestBottomSheet: React.FC<ExchangeRequestBottomSheetProp
               <>
                 <View style={styles.field}>
                   <BloomText style={styles.label}>
-                    {t('listing.exchange.offeredProperty', 'Home you’re offering')}
+                    {t('listing.exchange.offeredProperty')}
                   </BloomText>
                   {myExchangeProperties.length > 0 ? (
                     <View style={styles.propertyList}>
@@ -334,26 +331,20 @@ export const ExchangeRequestBottomSheet: React.FC<ExchangeRequestBottomSheetProp
                     </View>
                   ) : (
                     <BloomText style={styles.helperText}>
-                      {t(
-                        'listing.exchange.noExchangeProperties',
-                        'You have no exchange-enabled homes yet. List one to propose a swap.',
-                      )}
+                      {t('listing.exchange.noExchangeProperties')}
                     </BloomText>
                   )}
                 </View>
 
                 <View style={styles.field}>
                   <BloomText style={styles.label}>
-                    {t('listing.exchange.offeredWindow', 'Dates you’re offering')}
+                    {t('listing.exchange.offeredWindow')}
                   </BloomText>
                   <Pressable
                     style={styles.dateTrigger}
                     onPress={() => setCalendarTarget('offered')}
                     accessibilityRole="button"
-                    accessibilityLabel={t(
-                      'listing.exchange.offeredWindow',
-                      'Dates you’re offering',
-                    )}
+                    accessibilityLabel={t('listing.exchange.offeredWindow')}
                   >
                     <Ionicons
                       name="calendar-outline"
@@ -369,7 +360,7 @@ export const ExchangeRequestBottomSheet: React.FC<ExchangeRequestBottomSheetProp
                     >
                       {offeredWindow
                         ? formatRange(offeredWindow)
-                        : t('listing.exchange.addDates', 'Add dates')}
+                        : t('listing.exchange.addDates')}
                     </BloomText>
                   </Pressable>
                 </View>
@@ -379,16 +370,13 @@ export const ExchangeRequestBottomSheet: React.FC<ExchangeRequestBottomSheetProp
             {/* Message */}
             <View style={styles.field}>
               <BloomText style={styles.label}>
-                {t('listing.exchange.messageLabel', 'Message to the host')}
+                {t('listing.exchange.messageLabel')}
               </BloomText>
               <TextInput
                 style={styles.messageInput}
                 value={message}
                 onChangeText={setMessage}
-                placeholder={t(
-                  'listing.exchange.messagePlaceholder',
-                  'Introduce yourself and your trip.',
-                )}
+                placeholder={t('listing.exchange.messagePlaceholder')}
                 placeholderTextColor={colors.COLOR_BLACK_LIGHT_4}
                 multiline
                 textAlignVertical="top"
@@ -405,7 +393,7 @@ export const ExchangeRequestBottomSheet: React.FC<ExchangeRequestBottomSheetProp
             disabled={createMutation.isPending}
             style={styles.submit}
           >
-            {t('listing.exchange.sendRequest', 'Send request')}
+            {t('listing.exchange.sendRequest')}
           </Button>
         </View>
       </View>
@@ -429,14 +417,14 @@ export const ExchangeRequestBottomSheet: React.FC<ExchangeRequestBottomSheetProp
             <View style={styles.header}>
               <H3 style={styles.title}>
                 {calendarTarget === 'offered'
-                  ? t('listing.exchange.offeredWindow', 'Dates you’re offering')
-                  : t('listing.exchange.requestedWindow', 'Dates you want to stay')}
+                  ? t('listing.exchange.offeredWindow')
+                  : t('listing.exchange.requestedWindow')}
               </H3>
               <Button
                 variant="icon"
                 size="small"
                 onPress={() => setCalendarTarget(null)}
-                accessibilityLabel={t('common.close', 'Close')}
+                accessibilityLabel={t('common.close')}
               >
                 {'×'}
               </Button>

--- a/packages/frontend/components/exchange/ExchangeRequestCard.tsx
+++ b/packages/frontend/components/exchange/ExchangeRequestCard.tsx
@@ -34,7 +34,7 @@ export const ExchangeRequestCard: React.FC<ExchangeRequestCardProps> = ({
   const { property } = useProperty(request.propertyId);
 
   const title = useMemo(
-    () => (property ? getPropertyTitle(property) : t('listing.exchange.cardFallback', 'Home')),
+    () => (property ? getPropertyTitle(property) : t('listing.exchange.cardFallback')),
     [property, t],
   );
   const imageSource = useMemo(
@@ -44,8 +44,8 @@ export const ExchangeRequestCard: React.FC<ExchangeRequestCardProps> = ({
 
   const modeLabel =
     request.mode === ExchangeMode.SWAP
-      ? t('listing.exchange.mode.swap', 'Home swap')
-      : t('listing.exchange.mode.host', 'Free hosting');
+      ? t('listing.exchange.mode.swap')
+      : t('listing.exchange.mode.host');
 
   return (
     <ThumbnailCard

--- a/packages/frontend/components/exchange/ExchangeReviewForm.tsx
+++ b/packages/frontend/components/exchange/ExchangeReviewForm.tsx
@@ -37,7 +37,7 @@ const StarPicker: React.FC<{ value: number; onChange: (next: number) => void }> 
             key={rating}
             onPress={() => onChange(rating)}
             accessibilityRole="button"
-            accessibilityLabel={t('listing.exchange.review.starLabel', '{{count}} stars', {
+            accessibilityLabel={t('listing.exchange.review.starLabel', {
               count: rating,
             })}
             hitSlop={6}
@@ -70,7 +70,7 @@ export const ExchangeReviewForm: React.FC<ExchangeReviewFormProps> = ({
 
   const handleSubmit = useCallback(async () => {
     if (rating < 1) {
-      toast.error(t('listing.exchange.review.pickRating', 'Pick a star rating first'));
+      toast.error(t('listing.exchange.review.pickRating'));
       return;
     }
     try {
@@ -78,13 +78,13 @@ export const ExchangeReviewForm: React.FC<ExchangeReviewFormProps> = ({
         rating,
         comment: comment.trim() || undefined,
       });
-      toast.success(t('listing.exchange.review.thanks', 'Thanks for your review'));
+      toast.success(t('listing.exchange.review.thanks'));
       onSubmitted();
     } catch (error) {
       const message =
         error instanceof Error
           ? error.message
-          : t('listing.exchange.review.failed', 'Could not submit review');
+          : t('listing.exchange.review.failed');
       toast.error(message);
     }
   }, [rating, comment, mutation, onSubmitted, t]);
@@ -92,23 +92,17 @@ export const ExchangeReviewForm: React.FC<ExchangeReviewFormProps> = ({
   return (
     <View style={styles.container}>
       <BloomText style={styles.title}>
-        {t('listing.exchange.review.title', 'Leave a review')}
+        {t('listing.exchange.review.title')}
       </BloomText>
       <BloomText style={styles.subtitle}>
-        {t(
-          'listing.exchange.review.subtitle',
-          'Rate your exchange — your feedback builds trust for everyone.',
-        )}
+        {t('listing.exchange.review.subtitle')}
       </BloomText>
       <StarPicker value={rating} onChange={setRating} />
       <TextInput
         style={styles.input}
         value={comment}
         onChangeText={setComment}
-        placeholder={t(
-          'listing.exchange.review.placeholder',
-          'Share how the stay went (optional).',
-        )}
+        placeholder={t('listing.exchange.review.placeholder')}
         placeholderTextColor={colors.COLOR_BLACK_LIGHT_4}
         multiline
         textAlignVertical="top"
@@ -122,7 +116,7 @@ export const ExchangeReviewForm: React.FC<ExchangeReviewFormProps> = ({
         disabled={mutation.isPending}
         style={styles.submit}
       >
-        {t('listing.exchange.review.submit', 'Submit review')}
+        {t('listing.exchange.review.submit')}
       </Button>
     </View>
   );

--- a/packages/frontend/components/exchange/ProfileExchangeReviews.tsx
+++ b/packages/frontend/components/exchange/ProfileExchangeReviews.tsx
@@ -45,7 +45,7 @@ const ReviewItem: React.FC<{ review: ExchangeReview }> = ({ review }) => {
         </View>
         <View style={styles.reviewHeaderText}>
           <BloomText style={styles.author}>
-            {t('listing.exchange.review.guestAuthor', 'Exchange guest')}
+            {t('listing.exchange.review.guestAuthor')}
           </BloomText>
           {date ? <BloomText style={styles.reviewDate}>{date}</BloomText> : null}
         </View>
@@ -76,12 +76,12 @@ export const ProfileExchangeReviews: React.FC<Props> = ({ profileId }) => {
     <View style={styles.container}>
       <View style={styles.summary}>
         <BloomText style={styles.heading}>
-          {t('listing.exchange.review.profileHeading', 'Exchange reviews')}
+          {t('listing.exchange.review.profileHeading')}
         </BloomText>
         <View style={styles.summaryRow}>
           <Stars rating={average} size={16} />
           <BloomText style={styles.summaryText}>
-            {t('listing.exchange.review.summary', '{{average}} · {{count}} reviews', {
+            {t('listing.exchange.review.summary', {
               average: average.toFixed(RATING_FRACTION_DIGITS),
               count: reviewCount,
             })}

--- a/packages/frontend/components/profile/edit/AgencyProfileSections.tsx
+++ b/packages/frontend/components/profile/edit/AgencyProfileSections.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, TextInput, TouchableOpacity } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import type { AgencyProfile } from '@/services/profileService';
 import { profileEditStyles as styles } from './styles';
 import type {
@@ -32,9 +33,6 @@ const AGENCY_SPECIALTIES = [
 
 const PROFILE_VISIBILITIES = ['public', 'private', 'contacts_only'] as const;
 
-const titleizeUnderscore = (value: string) =>
-  value.replace('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase());
-
 interface AgencyProfileSectionsProps {
   activeSection: string;
   agencyInfo: AgencyInfoForm;
@@ -56,14 +54,16 @@ export function AgencyProfileSections({
   toggleSpecialty,
   toggleVerification,
 }: AgencyProfileSectionsProps) {
+  const { t } = useTranslation();
+
   switch (activeSection) {
     case 'business':
       return (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Agency Information</Text>
+          <Text style={styles.sectionTitle}>{t('profile.edit.sections.agencyInformation')}</Text>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Business Type *</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.businessType')}</Text>
             <View style={styles.checkboxGroup}>
               {AGENCY_BUSINESS_TYPES.map((type) => (
                 <TouchableOpacity
@@ -82,7 +82,7 @@ export function AgencyProfileSections({
                       agencyInfo.businessType === type && styles.checkboxTextSelected,
                     ]}
                   >
-                    {titleizeUnderscore(type)}
+                    {t(`profile.edit.options.agencyBusinessType.${type}`)}
                   </Text>
                 </TouchableOpacity>
               ))}
@@ -90,22 +90,22 @@ export function AgencyProfileSections({
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Legal Company Name *</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.legalCompanyName')}</Text>
             <TextInput
               style={styles.input}
               value={agencyInfo.legalCompanyName}
               onChangeText={(text) => updateAgencyInfo({ legalCompanyName: text })}
-              placeholder="Enter your legal company name"
+              placeholder={t('profile.edit.placeholders.legalCompanyName')}
             />
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Description</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.description')}</Text>
             <TextInput
               style={[styles.input, styles.textArea]}
               value={agencyInfo.description}
               onChangeText={(text) => updateAgencyInfo({ description: text })}
-              placeholder="Describe your business..."
+              placeholder={t('profile.edit.placeholders.description')}
               multiline
               numberOfLines={4}
             />
@@ -113,7 +113,7 @@ export function AgencyProfileSections({
 
           <View style={styles.row}>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>License Number</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.licenseNumber')}</Text>
               <TextInput
                 style={styles.input}
                 value={agencyInfo.businessDetails.licenseNumber}
@@ -122,11 +122,11 @@ export function AgencyProfileSections({
                     businessDetails: { ...agencyInfo.businessDetails, licenseNumber: text },
                   })
                 }
-                placeholder="Enter license number"
+                placeholder={t('profile.edit.placeholders.licenseNumber')}
               />
             </View>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>Tax ID</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.taxId')}</Text>
               <TextInput
                 style={styles.input}
                 value={agencyInfo.businessDetails.taxId}
@@ -135,14 +135,14 @@ export function AgencyProfileSections({
                     businessDetails: { ...agencyInfo.businessDetails, taxId: text },
                   })
                 }
-                placeholder="Enter tax ID"
+                placeholder={t('profile.edit.placeholders.taxId')}
               />
             </View>
           </View>
 
           <View style={styles.row}>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>Year Established</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.yearEstablished')}</Text>
               <TextInput
                 style={styles.input}
                 value={agencyInfo.businessDetails.yearEstablished}
@@ -151,12 +151,12 @@ export function AgencyProfileSections({
                     businessDetails: { ...agencyInfo.businessDetails, yearEstablished: text },
                   })
                 }
-                placeholder="e.g., 2020"
+                placeholder={t('profile.edit.placeholders.yearEstablished')}
                 keyboardType="numeric"
               />
             </View>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>Number of Employees</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.employeeCount')}</Text>
               <View style={styles.pickerContainer}>
                 {AGENCY_EMPLOYEE_COUNTS.map((count) => (
                   <TouchableOpacity
@@ -191,7 +191,7 @@ export function AgencyProfileSections({
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Specialties</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.specialties')}</Text>
             <View style={styles.checkboxGroup}>
               {AGENCY_SPECIALTIES.map((specialty) => (
                 <TouchableOpacity
@@ -210,7 +210,7 @@ export function AgencyProfileSections({
                         styles.checkboxTextSelected,
                     ]}
                   >
-                    {titleizeUnderscore(specialty)}
+                    {t(`profile.edit.options.agencySpecialty.${specialty}`)}
                   </Text>
                 </TouchableOpacity>
               ))}
@@ -222,13 +222,13 @@ export function AgencyProfileSections({
     case 'verification':
       return (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Agency Verification</Text>
+          <Text style={styles.sectionTitle}>{t('profile.edit.sections.agencyVerification')}</Text>
           <Text style={styles.sectionSubtitle}>
-            Complete these verifications to build trust with clients
+            {t('profile.edit.subtitles.agencyVerification')}
           </Text>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Verification Status</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.verificationStatus')}</Text>
 
             <TouchableOpacity
               style={[
@@ -238,9 +238,11 @@ export function AgencyProfileSections({
               onPress={() => toggleVerification('businessLicense')}
             >
               <View style={styles.verificationItemContent}>
-                <Text style={styles.verificationItemTitle}>Business License</Text>
+                <Text style={styles.verificationItemTitle}>
+                  {t('profile.edit.verification.businessLicenseTitle')}
+                </Text>
                 <Text style={styles.verificationItemDescription}>
-                  Upload your business license for verification
+                  {t('profile.edit.verification.businessLicenseDescription')}
                 </Text>
               </View>
               <View
@@ -263,9 +265,11 @@ export function AgencyProfileSections({
               onPress={() => toggleVerification('insurance')}
             >
               <View style={styles.verificationItemContent}>
-                <Text style={styles.verificationItemTitle}>Insurance</Text>
+                <Text style={styles.verificationItemTitle}>
+                  {t('profile.edit.verification.insuranceTitle')}
+                </Text>
                 <Text style={styles.verificationItemDescription}>
-                  Provide proof of business insurance
+                  {t('profile.edit.verification.insuranceDescription')}
                 </Text>
               </View>
               <View
@@ -288,9 +292,11 @@ export function AgencyProfileSections({
               onPress={() => toggleVerification('bonding')}
             >
               <View style={styles.verificationItemContent}>
-                <Text style={styles.verificationItemTitle}>Bonding</Text>
+                <Text style={styles.verificationItemTitle}>
+                  {t('profile.edit.verification.bondingTitle')}
+                </Text>
                 <Text style={styles.verificationItemDescription}>
-                  Provide surety bond information
+                  {t('profile.edit.verification.bondingDescription')}
                 </Text>
               </View>
               <View
@@ -313,9 +319,11 @@ export function AgencyProfileSections({
               onPress={() => toggleVerification('backgroundCheck')}
             >
               <View style={styles.verificationItemContent}>
-                <Text style={styles.verificationItemTitle}>Background Check</Text>
+                <Text style={styles.verificationItemTitle}>
+                  {t('profile.edit.verification.backgroundCheckTitle')}
+                </Text>
                 <Text style={styles.verificationItemDescription}>
-                  Complete background check for all team members
+                  {t('profile.edit.verification.backgroundCheckDescription')}
                 </Text>
               </View>
               <View
@@ -336,27 +344,31 @@ export function AgencyProfileSections({
     case 'team':
       return (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Team Management</Text>
-          <Text style={styles.sectionSubtitle}>Manage your team members and their roles</Text>
+          <Text style={styles.sectionTitle}>{t('profile.edit.sections.teamManagement')}</Text>
+          <Text style={styles.sectionSubtitle}>{t('profile.edit.team.subtitle')}</Text>
 
           {members && members.length > 0 ? (
             members.map((member, index) => (
               <View key={index} style={styles.teamMemberItem}>
                 <View style={styles.teamMemberInfo}>
-                  <Text style={styles.teamMemberName}>Member {index + 1}</Text>
+                  <Text style={styles.teamMemberName}>
+                    {t('profile.edit.team.memberLabel', { index: index + 1 })}
+                  </Text>
                   <Text style={styles.teamMemberRole}>{member.role}</Text>
                   <Text style={styles.teamMemberDate}>
-                    Added: {new Date(member.addedAt).toLocaleDateString()}
+                    {t('profile.edit.team.addedLabel', {
+                      date: new Date(member.addedAt).toLocaleDateString(),
+                    })}
                   </Text>
                 </View>
               </View>
             ))
           ) : (
-            <Text style={styles.emptyStateText}>No team members added yet.</Text>
+            <Text style={styles.emptyStateText}>{t('profile.edit.team.emptyText')}</Text>
           )}
 
           <TouchableOpacity style={styles.addButton}>
-            <Text style={styles.addButtonText}>+ Add Team Member</Text>
+            <Text style={styles.addButtonText}>{t('profile.edit.team.addMember')}</Text>
           </TouchableOpacity>
         </View>
       );
@@ -364,11 +376,11 @@ export function AgencyProfileSections({
     case 'settings':
       return (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Business Settings</Text>
-          <Text style={styles.sectionSubtitle}>Configure your business profile settings</Text>
+          <Text style={styles.sectionTitle}>{t('profile.edit.sections.businessSettings')}</Text>
+          <Text style={styles.sectionSubtitle}>{t('profile.edit.subtitles.businessSettings')}</Text>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Profile Visibility</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.profileVisibility')}</Text>
             <View style={styles.pickerContainer}>
               {PROFILE_VISIBILITIES.map((visibility) => (
                 <TouchableOpacity
@@ -394,7 +406,7 @@ export function AgencyProfileSections({
                         styles.pickerOptionTextSelected,
                     ]}
                   >
-                    {visibility.replace('_', ' ').toUpperCase()}
+                    {t(`profile.edit.options.profileVisibility.${visibility}`)}
                   </Text>
                 </TouchableOpacity>
               ))}
@@ -402,7 +414,7 @@ export function AgencyProfileSections({
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Notifications</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.notifications')}</Text>
             <View style={styles.checkboxGroup}>
               <TouchableOpacity
                 style={[styles.checkbox, settings.notifications.email && styles.checkboxSelected]}
@@ -421,7 +433,7 @@ export function AgencyProfileSections({
                     settings.notifications.email && styles.checkboxTextSelected,
                   ]}
                 >
-                  Email Notifications
+                  {t('profile.edit.toggles.emailNotifications')}
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
@@ -441,7 +453,7 @@ export function AgencyProfileSections({
                     settings.notifications.push && styles.checkboxTextSelected,
                   ]}
                 >
-                  Push Notifications
+                  {t('profile.edit.toggles.pushNotifications')}
                 </Text>
               </TouchableOpacity>
             </View>

--- a/packages/frontend/components/profile/edit/BusinessProfileSections.tsx
+++ b/packages/frontend/components/profile/edit/BusinessProfileSections.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, TextInput, TouchableOpacity } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { profileEditStyles as styles } from './styles';
 import type {
   BusinessBusinessTypeValue,
@@ -24,9 +25,6 @@ const BUSINESS_EMPLOYEE_COUNTS = ['1-5', '6-10', '11-25', '26+'] as const;
 
 const PROFILE_VISIBILITIES = ['public', 'private', 'contacts_only'] as const;
 
-const titleizeUnderscore = (value: string) =>
-  value.replace('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase());
-
 interface BusinessProfileSectionsProps {
   activeSection: string;
   businessInfo: BusinessInfoForm;
@@ -42,14 +40,16 @@ export function BusinessProfileSections({
   updateBusinessInfo,
   updateSettings,
 }: BusinessProfileSectionsProps) {
+  const { t } = useTranslation();
+
   switch (activeSection) {
     case 'business':
       return (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Business Information</Text>
+          <Text style={styles.sectionTitle}>{t('profile.edit.sections.businessInformation')}</Text>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Business Type *</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.businessType')}</Text>
             <View style={styles.checkboxGroup}>
               {BUSINESS_TYPES.map((type) => (
                 <TouchableOpacity
@@ -68,7 +68,7 @@ export function BusinessProfileSections({
                       businessInfo.businessType === type && styles.checkboxTextSelected,
                     ]}
                   >
-                    {titleizeUnderscore(type)}
+                    {t(`profile.edit.options.businessType.${type}`)}
                   </Text>
                 </TouchableOpacity>
               ))}
@@ -76,22 +76,22 @@ export function BusinessProfileSections({
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Legal Company Name *</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.legalCompanyName')}</Text>
             <TextInput
               style={styles.input}
               value={businessInfo.legalCompanyName}
               onChangeText={(text) => updateBusinessInfo({ legalCompanyName: text })}
-              placeholder="Enter your legal company name"
+              placeholder={t('profile.edit.placeholders.legalCompanyName')}
             />
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Description</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.description')}</Text>
             <TextInput
               style={[styles.input, styles.textArea]}
               value={businessInfo.description}
               onChangeText={(text) => updateBusinessInfo({ description: text })}
-              placeholder="Describe your business..."
+              placeholder={t('profile.edit.placeholders.description')}
               multiline
               numberOfLines={4}
             />
@@ -99,7 +99,7 @@ export function BusinessProfileSections({
 
           <View style={styles.row}>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>License Number</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.licenseNumber')}</Text>
               <TextInput
                 style={styles.input}
                 value={businessInfo.businessDetails.licenseNumber}
@@ -108,11 +108,11 @@ export function BusinessProfileSections({
                     businessDetails: { ...businessInfo.businessDetails, licenseNumber: text },
                   })
                 }
-                placeholder="Enter license number"
+                placeholder={t('profile.edit.placeholders.licenseNumber')}
               />
             </View>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>Tax ID</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.taxId')}</Text>
               <TextInput
                 style={styles.input}
                 value={businessInfo.businessDetails.taxId}
@@ -121,14 +121,14 @@ export function BusinessProfileSections({
                     businessDetails: { ...businessInfo.businessDetails, taxId: text },
                   })
                 }
-                placeholder="Enter tax ID"
+                placeholder={t('profile.edit.placeholders.taxId')}
               />
             </View>
           </View>
 
           <View style={styles.row}>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>Year Established</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.yearEstablished')}</Text>
               <TextInput
                 style={styles.input}
                 value={businessInfo.businessDetails.yearEstablished}
@@ -137,12 +137,12 @@ export function BusinessProfileSections({
                     businessDetails: { ...businessInfo.businessDetails, yearEstablished: text },
                   })
                 }
-                placeholder="e.g., 2020"
+                placeholder={t('profile.edit.placeholders.yearEstablished')}
                 keyboardType="numeric"
               />
             </View>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>Number of Employees</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.employeeCount')}</Text>
               <View style={styles.pickerContainer}>
                 {BUSINESS_EMPLOYEE_COUNTS.map((count) => (
                   <TouchableOpacity
@@ -177,7 +177,7 @@ export function BusinessProfileSections({
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Industry</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.industry')}</Text>
             <TextInput
               style={styles.input}
               value={businessInfo.businessDetails.industry}
@@ -186,7 +186,7 @@ export function BusinessProfileSections({
                   businessDetails: { ...businessInfo.businessDetails, industry: text },
                 })
               }
-              placeholder="Enter industry"
+              placeholder={t('profile.edit.placeholders.industry')}
             />
           </View>
         </View>
@@ -195,13 +195,11 @@ export function BusinessProfileSections({
     case 'verification':
       return (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Business Verification</Text>
-          <Text style={styles.sectionSubtitle}>
-            Complete these verifications to build trust with clients
-          </Text>
+          <Text style={styles.sectionTitle}>{t('profile.edit.sections.businessVerification')}</Text>
+          <Text style={styles.sectionSubtitle}>{t('profile.edit.subtitles.businessVerification')}</Text>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Verification Status</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.verificationStatus')}</Text>
 
             <TouchableOpacity
               style={[
@@ -218,9 +216,11 @@ export function BusinessProfileSections({
               }
             >
               <View style={styles.verificationItemContent}>
-                <Text style={styles.verificationItemTitle}>Business License</Text>
+                <Text style={styles.verificationItemTitle}>
+                  {t('profile.edit.verification.businessLicenseTitle')}
+                </Text>
                 <Text style={styles.verificationItemDescription}>
-                  Upload your business license for verification
+                  {t('profile.edit.verification.businessLicenseDescription')}
                 </Text>
               </View>
               <View
@@ -250,9 +250,11 @@ export function BusinessProfileSections({
               }
             >
               <View style={styles.verificationItemContent}>
-                <Text style={styles.verificationItemTitle}>Insurance</Text>
+                <Text style={styles.verificationItemTitle}>
+                  {t('profile.edit.verification.insuranceTitle')}
+                </Text>
                 <Text style={styles.verificationItemDescription}>
-                  Provide proof of business insurance
+                  {t('profile.edit.verification.insuranceDescription')}
                 </Text>
               </View>
               <View
@@ -282,9 +284,11 @@ export function BusinessProfileSections({
               }
             >
               <View style={styles.verificationItemContent}>
-                <Text style={styles.verificationItemTitle}>Background Check</Text>
+                <Text style={styles.verificationItemTitle}>
+                  {t('profile.edit.verification.backgroundCheckTitle')}
+                </Text>
                 <Text style={styles.verificationItemDescription}>
-                  Complete background check for all team members
+                  {t('profile.edit.verification.backgroundCheckDescription')}
                 </Text>
               </View>
               <View
@@ -305,11 +309,11 @@ export function BusinessProfileSections({
     case 'settings':
       return (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Business Settings</Text>
-          <Text style={styles.sectionSubtitle}>Configure your business profile settings</Text>
+          <Text style={styles.sectionTitle}>{t('profile.edit.sections.businessSettings')}</Text>
+          <Text style={styles.sectionSubtitle}>{t('profile.edit.subtitles.businessSettings')}</Text>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Profile Visibility</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.profileVisibility')}</Text>
             <View style={styles.pickerContainer}>
               {PROFILE_VISIBILITIES.map((visibility) => (
                 <TouchableOpacity
@@ -335,7 +339,7 @@ export function BusinessProfileSections({
                         styles.pickerOptionTextSelected,
                     ]}
                   >
-                    {visibility.replace('_', ' ').toUpperCase()}
+                    {t(`profile.edit.options.profileVisibility.${visibility}`)}
                   </Text>
                 </TouchableOpacity>
               ))}
@@ -343,7 +347,7 @@ export function BusinessProfileSections({
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Notifications</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.notifications')}</Text>
             <View style={styles.checkboxGroup}>
               <TouchableOpacity
                 style={[styles.checkbox, settings.notifications.email && styles.checkboxSelected]}
@@ -362,7 +366,7 @@ export function BusinessProfileSections({
                     settings.notifications.email && styles.checkboxTextSelected,
                   ]}
                 >
-                  Email Notifications
+                  {t('profile.edit.toggles.emailNotifications')}
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
@@ -382,7 +386,7 @@ export function BusinessProfileSections({
                     settings.notifications.push && styles.checkboxTextSelected,
                   ]}
                 >
-                  Push Notifications
+                  {t('profile.edit.toggles.pushNotifications')}
                 </Text>
               </TouchableOpacity>
             </View>

--- a/packages/frontend/components/profile/edit/CooperativeProfileSections.tsx
+++ b/packages/frontend/components/profile/edit/CooperativeProfileSections.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, TextInput, TouchableOpacity } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { profileEditStyles as styles } from './styles';
 import type { CooperativeInfoForm, ProfileVisibilityValue, SettingsForm } from './types';
 
@@ -20,29 +21,31 @@ export function CooperativeProfileSections({
   updateCooperativeInfo,
   updateSettings,
 }: CooperativeProfileSectionsProps) {
+  const { t } = useTranslation();
+
   switch (activeSection) {
     case 'cooperative':
       return (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Cooperative Information</Text>
+          <Text style={styles.sectionTitle}>{t('profile.edit.sections.cooperativeInformation')}</Text>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Legal Name *</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.legalName')}</Text>
             <TextInput
               style={styles.input}
               value={cooperativeInfo.legalName}
               onChangeText={(text) => updateCooperativeInfo({ legalName: text })}
-              placeholder="Enter cooperative legal name"
+              placeholder={t('profile.edit.placeholders.cooperativeLegalName')}
             />
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Description</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.description')}</Text>
             <TextInput
               style={[styles.input, styles.textArea]}
               value={cooperativeInfo.description}
               onChangeText={(text) => updateCooperativeInfo({ description: text })}
-              placeholder="Describe your cooperative..."
+              placeholder={t('profile.edit.placeholders.cooperativeDescription')}
               multiline
               numberOfLines={4}
             />
@@ -53,11 +56,11 @@ export function CooperativeProfileSections({
     case 'settings':
       return (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Cooperative Settings</Text>
-          <Text style={styles.sectionSubtitle}>Configure your cooperative profile settings</Text>
+          <Text style={styles.sectionTitle}>{t('profile.edit.sections.cooperativeSettings')}</Text>
+          <Text style={styles.sectionSubtitle}>{t('profile.edit.subtitles.cooperativeSettings')}</Text>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Profile Visibility</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.profileVisibility')}</Text>
             <View style={styles.pickerContainer}>
               {PROFILE_VISIBILITIES.map((visibility) => (
                 <TouchableOpacity
@@ -83,7 +86,7 @@ export function CooperativeProfileSections({
                         styles.pickerOptionTextSelected,
                     ]}
                   >
-                    {visibility.replace('_', ' ').toUpperCase()}
+                    {t(`profile.edit.options.profileVisibility.${visibility}`)}
                   </Text>
                 </TouchableOpacity>
               ))}
@@ -91,7 +94,7 @@ export function CooperativeProfileSections({
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Notifications</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.notifications')}</Text>
             <View style={styles.checkboxGroup}>
               <TouchableOpacity
                 style={[styles.checkbox, settings.notifications.email && styles.checkboxSelected]}
@@ -110,7 +113,7 @@ export function CooperativeProfileSections({
                     settings.notifications.email && styles.checkboxTextSelected,
                   ]}
                 >
-                  Email Notifications
+                  {t('profile.edit.toggles.emailNotifications')}
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
@@ -130,7 +133,7 @@ export function CooperativeProfileSections({
                     settings.notifications.push && styles.checkboxTextSelected,
                   ]}
                 >
-                  Push Notifications
+                  {t('profile.edit.toggles.pushNotifications')}
                 </Text>
               </TouchableOpacity>
             </View>

--- a/packages/frontend/components/profile/edit/PersonalProfileSections.tsx
+++ b/packages/frontend/components/profile/edit/PersonalProfileSections.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, TextInput, TouchableOpacity } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { TrustScore } from '@/components/TrustScore';
 import { profileEditStyles as styles } from './styles';
 import type {
@@ -51,9 +52,6 @@ const REASONS_FOR_LEAVING = [
   'other',
 ] as const;
 
-const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
-const titleizeUnderscore = (value: string) => value.replace('_', ' ').toUpperCase();
-
 interface PersonalProfileSectionsProps {
   activeSection: string;
   personalInfo: PersonalInfoForm;
@@ -95,19 +93,21 @@ export function PersonalProfileSections({
   updateRentalHistory,
   removeRentalHistory,
 }: PersonalProfileSectionsProps) {
+  const { t } = useTranslation();
+
   switch (activeSection) {
     case 'personal':
       return (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Personal Information</Text>
+          <Text style={styles.sectionTitle}>{t('profile.edit.sections.personalInformation')}</Text>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Bio</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.bio')}</Text>
             <TextInput
               style={[styles.input, styles.textArea]}
               value={personalInfo.bio}
               onChangeText={(text) => updatePersonalInfo({ bio: text })}
-              placeholder="Tell us about yourself..."
+              placeholder={t('profile.edit.placeholders.bio')}
               multiline
               numberOfLines={4}
             />
@@ -115,38 +115,38 @@ export function PersonalProfileSections({
 
           <View style={styles.row}>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>Occupation</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.occupation')}</Text>
               <TextInput
                 style={styles.input}
                 value={personalInfo.occupation}
                 onChangeText={(text) => updatePersonalInfo({ occupation: text })}
-                placeholder="e.g., Software Engineer"
+                placeholder={t('profile.edit.placeholders.occupation')}
               />
             </View>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>Employer</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.employer')}</Text>
               <TextInput
                 style={styles.input}
                 value={personalInfo.employer}
                 onChangeText={(text) => updatePersonalInfo({ employer: text })}
-                placeholder="e.g., Tech Corp"
+                placeholder={t('profile.edit.placeholders.employer')}
               />
             </View>
           </View>
 
           <View style={styles.row}>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>Annual Income ($)</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.annualIncome')}</Text>
               <TextInput
                 style={styles.input}
                 value={personalInfo.annualIncome}
                 onChangeText={(text) => updatePersonalInfo({ annualIncome: text })}
-                placeholder="e.g., 75000"
+                placeholder={t('profile.edit.placeholders.annualIncome')}
                 keyboardType="numeric"
               />
             </View>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>Employment Status</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.employmentStatus')}</Text>
               <View style={styles.pickerContainer}>
                 {EMPLOYMENT_STATUSES.map((status) => (
                   <TouchableOpacity
@@ -164,7 +164,7 @@ export function PersonalProfileSections({
                           styles.pickerOptionTextSelected,
                       ]}
                     >
-                      {titleizeUnderscore(status)}
+                      {t(`profile.edit.options.employmentStatus.${status}`)}
                     </Text>
                   </TouchableOpacity>
                 ))}
@@ -174,16 +174,16 @@ export function PersonalProfileSections({
 
           <View style={styles.row}>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>Move-in Date</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.moveInDate')}</Text>
               <TextInput
                 style={styles.input}
                 value={personalInfo.moveInDate}
                 onChangeText={(text) => updatePersonalInfo({ moveInDate: text })}
-                placeholder="YYYY-MM-DD"
+                placeholder={t('profile.edit.placeholders.moveInDate')}
               />
             </View>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>Lease Duration</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.leaseDuration')}</Text>
               <View style={styles.pickerContainer}>
                 {LEASE_DURATIONS.map((duration) => (
                   <TouchableOpacity
@@ -201,7 +201,7 @@ export function PersonalProfileSections({
                           styles.pickerOptionTextSelected,
                       ]}
                     >
-                      {titleizeUnderscore(duration)}
+                      {t(`profile.edit.options.leaseDuration.${duration}`)}
                     </Text>
                   </TouchableOpacity>
                 ))}
@@ -214,21 +214,21 @@ export function PersonalProfileSections({
     case 'preferences':
       return (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Property Preferences</Text>
+          <Text style={styles.sectionTitle}>{t('profile.edit.sections.propertyPreferences')}</Text>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Maximum Rent ($)</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.maxRent')}</Text>
             <TextInput
               style={styles.input}
               value={preferences.maxRent}
               onChangeText={(text) => updatePreferences({ maxRent: text })}
-              placeholder="Enter maximum rent"
+              placeholder={t('profile.edit.placeholders.maxRent')}
               keyboardType="numeric"
             />
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Rent Period</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.rentPeriod')}</Text>
             <View style={styles.pickerContainer}>
               {PRICE_UNITS.map((unit) => (
                 <TouchableOpacity
@@ -245,7 +245,7 @@ export function PersonalProfileSections({
                       preferences.priceUnit === unit && styles.pickerOptionTextSelected,
                     ]}
                   >
-                    {capitalize(unit)}
+                    {t(`profile.edit.options.priceUnit.${unit}`)}
                   </Text>
                 </TouchableOpacity>
               ))}
@@ -254,7 +254,7 @@ export function PersonalProfileSections({
 
           <View style={styles.row}>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>Min Bedrooms</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.minBedrooms')}</Text>
               <TextInput
                 style={styles.input}
                 value={preferences.minBedrooms}
@@ -264,7 +264,7 @@ export function PersonalProfileSections({
               />
             </View>
             <View style={[styles.inputGroup, styles.halfWidth]}>
-              <Text style={styles.label}>Min Bathrooms</Text>
+              <Text style={styles.label}>{t('profile.edit.labels.minBathrooms')}</Text>
               <TextInput
                 style={styles.input}
                 value={preferences.minBathrooms}
@@ -276,7 +276,7 @@ export function PersonalProfileSections({
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Property Types</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.propertyTypes')}</Text>
             <View style={styles.checkboxGroup}>
               {PROPERTY_TYPES.map((type) => (
                 <TouchableOpacity
@@ -293,7 +293,7 @@ export function PersonalProfileSections({
                       preferences.propertyTypes.includes(type) && styles.checkboxTextSelected,
                     ]}
                   >
-                    {capitalize(type)}
+                    {t(`profile.edit.options.propertyType.${type}`)}
                   </Text>
                 </TouchableOpacity>
               ))}
@@ -301,7 +301,7 @@ export function PersonalProfileSections({
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Preferred Amenities</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.preferredAmenities')}</Text>
             <View style={styles.checkboxGroup}>
               {AMENITIES.map((amenity) => (
                 <TouchableOpacity
@@ -319,7 +319,7 @@ export function PersonalProfileSections({
                         styles.checkboxTextSelected,
                     ]}
                   >
-                    {capitalize(amenity)}
+                    {t(`profile.edit.options.amenity.${amenity}`)}
                   </Text>
                 </TouchableOpacity>
               ))}
@@ -327,7 +327,7 @@ export function PersonalProfileSections({
           </View>
 
           <View style={styles.inputGroup}>
-            <Text style={styles.label}>Additional Preferences</Text>
+            <Text style={styles.label}>{t('profile.edit.labels.additionalPreferences')}</Text>
             <View style={styles.switchGroup}>
               <TouchableOpacity
                 style={[styles.switch, preferences.petFriendly && styles.switchActive]}
@@ -336,7 +336,7 @@ export function PersonalProfileSections({
                 <Text
                   style={[styles.switchText, preferences.petFriendly && styles.switchTextActive]}
                 >
-                  Pet Friendly
+                  {t('profile.edit.toggles.petFriendly')}
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
@@ -346,7 +346,7 @@ export function PersonalProfileSections({
                 <Text
                   style={[styles.switchText, preferences.smokingAllowed && styles.switchTextActive]}
                 >
-                  Smoking Allowed
+                  {t('profile.edit.toggles.smokingAllowed')}
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
@@ -354,7 +354,7 @@ export function PersonalProfileSections({
                 onPress={() => updatePreferences({ furnished: !preferences.furnished })}
               >
                 <Text style={[styles.switchText, preferences.furnished && styles.switchTextActive]}>
-                  Furnished
+                  {t('profile.edit.toggles.furnished')}
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
@@ -367,7 +367,7 @@ export function PersonalProfileSections({
                     preferences.parkingRequired && styles.switchTextActive,
                   ]}
                 >
-                  Parking Required
+                  {t('profile.edit.toggles.parkingRequired')}
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
@@ -377,7 +377,7 @@ export function PersonalProfileSections({
                 <Text
                   style={[styles.switchText, preferences.accessibility && styles.switchTextActive]}
                 >
-                  Accessibility Features
+                  {t('profile.edit.toggles.accessibilityFeatures')}
                 </Text>
               </TouchableOpacity>
             </View>
@@ -389,33 +389,35 @@ export function PersonalProfileSections({
       return (
         <View style={styles.section}>
           <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>References</Text>
+            <Text style={styles.sectionTitle}>{t('profile.edit.sections.references')}</Text>
             <TouchableOpacity style={styles.addButton} onPress={addReference}>
-              <Text style={styles.addButtonText}>+ Add Reference</Text>
+              <Text style={styles.addButtonText}>{t('profile.edit.actions.addReference')}</Text>
             </TouchableOpacity>
           </View>
 
           {references.map((reference, index) => (
             <View key={index} style={styles.referenceCard}>
               <View style={styles.cardHeader}>
-                <Text style={styles.cardTitle}>Reference {index + 1}</Text>
+                <Text style={styles.cardTitle}>
+                  {t('profile.edit.actions.referenceLabel', { index: index + 1 })}
+                </Text>
                 <TouchableOpacity onPress={() => removeReference(index)}>
-                  <Text style={styles.removeButton}>Remove</Text>
+                  <Text style={styles.removeButton}>{t('profile.edit.actions.remove')}</Text>
                 </TouchableOpacity>
               </View>
 
               <View style={styles.inputGroup}>
-                <Text style={styles.label}>Name</Text>
+                <Text style={styles.label}>{t('profile.edit.labels.name')}</Text>
                 <TextInput
                   style={styles.input}
                   value={reference.name}
                   onChangeText={(text) => updateReference(index, { name: text })}
-                  placeholder="Full name"
+                  placeholder={t('profile.edit.placeholders.fullName')}
                 />
               </View>
 
               <View style={styles.inputGroup}>
-                <Text style={styles.label}>Relationship</Text>
+                <Text style={styles.label}>{t('profile.edit.labels.relationship')}</Text>
                 <View style={styles.pickerContainer}>
                   {REFERENCE_RELATIONSHIPS.map((rel) => (
                     <TouchableOpacity
@@ -436,7 +438,7 @@ export function PersonalProfileSections({
                           reference.relationship === rel && styles.pickerOptionTextSelected,
                         ]}
                       >
-                        {capitalize(rel)}
+                        {t(`profile.edit.options.referenceRelationship.${rel}`)}
                       </Text>
                     </TouchableOpacity>
                   ))}
@@ -445,22 +447,22 @@ export function PersonalProfileSections({
 
               <View style={styles.row}>
                 <View style={[styles.inputGroup, styles.halfWidth]}>
-                  <Text style={styles.label}>Phone</Text>
+                  <Text style={styles.label}>{t('profile.edit.labels.phone')}</Text>
                   <TextInput
                     style={styles.input}
                     value={reference.phone}
                     onChangeText={(text) => updateReference(index, { phone: text })}
-                    placeholder="Phone number"
+                    placeholder={t('profile.edit.placeholders.phoneNumber')}
                     keyboardType="phone-pad"
                   />
                 </View>
                 <View style={[styles.inputGroup, styles.halfWidth]}>
-                  <Text style={styles.label}>Email</Text>
+                  <Text style={styles.label}>{t('profile.edit.labels.email')}</Text>
                   <TextInput
                     style={styles.input}
                     value={reference.email}
                     onChangeText={(text) => updateReference(index, { email: text })}
-                    placeholder="Email address"
+                    placeholder={t('profile.edit.placeholders.emailAddress')}
                     keyboardType="email-address"
                   />
                 </View>
@@ -474,65 +476,67 @@ export function PersonalProfileSections({
       return (
         <View style={styles.section}>
           <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>Rental History</Text>
+            <Text style={styles.sectionTitle}>{t('profile.edit.sections.rentalHistory')}</Text>
             <TouchableOpacity style={styles.addButton} onPress={addRentalHistory}>
-              <Text style={styles.addButtonText}>+ Add History</Text>
+              <Text style={styles.addButtonText}>{t('profile.edit.actions.addHistory')}</Text>
             </TouchableOpacity>
           </View>
 
           {rentalHistory.map((history, index) => (
             <View key={index} style={styles.referenceCard}>
               <View style={styles.cardHeader}>
-                <Text style={styles.cardTitle}>Rental {index + 1}</Text>
+                <Text style={styles.cardTitle}>
+                  {t('profile.edit.actions.rentalLabel', { index: index + 1 })}
+                </Text>
                 <TouchableOpacity onPress={() => removeRentalHistory(index)}>
-                  <Text style={styles.removeButton}>Remove</Text>
+                  <Text style={styles.removeButton}>{t('profile.edit.actions.remove')}</Text>
                 </TouchableOpacity>
               </View>
 
               <View style={styles.inputGroup}>
-                <Text style={styles.label}>Address</Text>
+                <Text style={styles.label}>{t('profile.edit.labels.address')}</Text>
                 <TextInput
                   style={styles.input}
                   value={history.address}
                   onChangeText={(text) => updateRentalHistory(index, { address: text })}
-                  placeholder="Full address"
+                  placeholder={t('profile.edit.placeholders.fullAddress')}
                 />
               </View>
 
               <View style={styles.row}>
                 <View style={[styles.inputGroup, styles.halfWidth]}>
-                  <Text style={styles.label}>Start Date</Text>
+                  <Text style={styles.label}>{t('profile.edit.labels.startDate')}</Text>
                   <TextInput
                     style={styles.input}
                     value={history.startDate}
                     onChangeText={(text) => updateRentalHistory(index, { startDate: text })}
-                    placeholder="YYYY-MM-DD"
+                    placeholder={t('profile.edit.placeholders.moveInDate')}
                   />
                 </View>
                 <View style={[styles.inputGroup, styles.halfWidth]}>
-                  <Text style={styles.label}>End Date</Text>
+                  <Text style={styles.label}>{t('profile.edit.labels.endDate')}</Text>
                   <TextInput
                     style={styles.input}
                     value={history.endDate}
                     onChangeText={(text) => updateRentalHistory(index, { endDate: text })}
-                    placeholder="YYYY-MM-DD (optional)"
+                    placeholder={t('profile.edit.placeholders.endDateOptional')}
                   />
                 </View>
               </View>
 
               <View style={styles.row}>
                 <View style={[styles.inputGroup, styles.halfWidth]}>
-                  <Text style={styles.label}>Monthly Rent ($)</Text>
+                  <Text style={styles.label}>{t('profile.edit.labels.monthlyRent')}</Text>
                   <TextInput
                     style={styles.input}
                     value={history.monthlyRent}
                     onChangeText={(text) => updateRentalHistory(index, { monthlyRent: text })}
-                    placeholder="e.g., 1500"
+                    placeholder={t('profile.edit.placeholders.monthlyRent')}
                     keyboardType="numeric"
                   />
                 </View>
                 <View style={[styles.inputGroup, styles.halfWidth]}>
-                  <Text style={styles.label}>Reason for Leaving</Text>
+                  <Text style={styles.label}>{t('profile.edit.labels.reasonForLeaving')}</Text>
                   <View style={styles.pickerContainer}>
                     {REASONS_FOR_LEAVING.map((reason) => (
                       <TouchableOpacity
@@ -554,7 +558,7 @@ export function PersonalProfileSections({
                               styles.pickerOptionTextSelected,
                           ]}
                         >
-                          {titleizeUnderscore(reason)}
+                          {t(`profile.edit.options.reasonForLeaving.${reason}`)}
                         </Text>
                       </TouchableOpacity>
                     ))}
@@ -563,7 +567,7 @@ export function PersonalProfileSections({
               </View>
 
               <View style={styles.inputGroup}>
-                <Text style={styles.label}>Landlord Contact</Text>
+                <Text style={styles.label}>{t('profile.edit.labels.landlordContact')}</Text>
                 <View style={styles.row}>
                   <View style={[styles.inputGroup, styles.halfWidth]}>
                     <TextInput
@@ -574,7 +578,7 @@ export function PersonalProfileSections({
                           landlordContact: { ...history.landlordContact, name: text },
                         })
                       }
-                      placeholder="Landlord name"
+                      placeholder={t('profile.edit.placeholders.landlordName')}
                     />
                   </View>
                   <View style={[styles.inputGroup, styles.halfWidth]}>
@@ -586,7 +590,7 @@ export function PersonalProfileSections({
                           landlordContact: { ...history.landlordContact, phone: text },
                         })
                       }
-                      placeholder="Phone"
+                      placeholder={t('profile.edit.placeholders.phone')}
                       keyboardType="phone-pad"
                     />
                   </View>
@@ -599,7 +603,7 @@ export function PersonalProfileSections({
                       landlordContact: { ...history.landlordContact, email: text },
                     })
                   }
-                  placeholder="Email"
+                  placeholder={t('profile.edit.placeholders.email')}
                   keyboardType="email-address"
                 />
               </View>
@@ -611,7 +615,7 @@ export function PersonalProfileSections({
     case 'trust-score':
       return (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Trust Score</Text>
+          <Text style={styles.sectionTitle}>{t('profile.edit.sections.trustScore')}</Text>
           <TrustScore
             score={trustScoreData.score}
             size="large"
@@ -624,10 +628,10 @@ export function PersonalProfileSections({
     case 'settings':
       return (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Settings</Text>
+          <Text style={styles.sectionTitle}>{t('profile.edit.sections.settings')}</Text>
 
           <View style={styles.subsection}>
-            <Text style={styles.subsectionTitle}>Notifications</Text>
+            <Text style={styles.subsectionTitle}>{t('profile.edit.labels.notifications')}</Text>
             <View style={styles.switchGroup}>
               <TouchableOpacity
                 style={[styles.switch, settings.notifications.email && styles.switchActive]}
@@ -646,7 +650,7 @@ export function PersonalProfileSections({
                     settings.notifications.email && styles.switchTextActive,
                   ]}
                 >
-                  Email Notifications
+                  {t('profile.edit.toggles.emailNotifications')}
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
@@ -666,14 +670,14 @@ export function PersonalProfileSections({
                     settings.notifications.push && styles.switchTextActive,
                   ]}
                 >
-                  Push Notifications
+                  {t('profile.edit.toggles.pushNotifications')}
                 </Text>
               </TouchableOpacity>
             </View>
           </View>
 
           <View style={styles.subsection}>
-            <Text style={styles.subsectionTitle}>Privacy</Text>
+            <Text style={styles.subsectionTitle}>{t('profile.edit.labels.privacy')}</Text>
             <View style={styles.switchGroup}>
               <TouchableOpacity
                 style={[styles.switch, settings.privacy.showContactInfo && styles.switchActive]}
@@ -692,7 +696,7 @@ export function PersonalProfileSections({
                     settings.privacy.showContactInfo && styles.switchTextActive,
                   ]}
                 >
-                  Show Contact Info
+                  {t('profile.edit.toggles.showContactInfo')}
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
@@ -709,7 +713,7 @@ export function PersonalProfileSections({
                     settings.privacy.showIncome && styles.switchTextActive,
                   ]}
                 >
-                  Show Income
+                  {t('profile.edit.toggles.showIncome')}
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
@@ -729,7 +733,7 @@ export function PersonalProfileSections({
                     settings.privacy.showRentalHistory && styles.switchTextActive,
                   ]}
                 >
-                  Show Rental History
+                  {t('profile.edit.toggles.showRentalHistory')}
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
@@ -749,7 +753,7 @@ export function PersonalProfileSections({
                     settings.privacy.showReferences && styles.switchTextActive,
                   ]}
                 >
-                  Show References
+                  {t('profile.edit.toggles.showReferences')}
                 </Text>
               </TouchableOpacity>
             </View>

--- a/packages/frontend/components/property/AmenitiesGrid.tsx
+++ b/packages/frontend/components/property/AmenitiesGrid.tsx
@@ -60,11 +60,8 @@ function useAmenityLabel(): (entry: ResolvedAmenity) => string {
   const { t } = useTranslation();
   return useCallback(
     ({ id, amenity }: ResolvedAmenity): string => {
-      if (amenity?.nameKey) {
-        const translated = t(amenity.nameKey, amenity.name);
-        return translated || amenity.name || id;
-      }
-      return amenity?.name ?? id;
+      if (!amenity?.nameKey) return id;
+      return t(amenity.nameKey);
     },
     [t],
   );
@@ -113,14 +110,10 @@ const AmenitiesSheet: React.FC<AmenitiesSheetProps> = ({ ids, maxScrollHeight })
   const resolveGroupTitle = useCallback(
     (group: AmenityGroup): string => {
       if (group.categoryId === UNCATEGORIZED_AMENITY_ID || !group.category) {
-        return t('amenities.categories.other', 'More');
+        return t('amenities.categories.other');
       }
-      const { nameKey, name } = group.category;
-      if (nameKey) {
-        const translated = t(nameKey, name);
-        return translated || name;
-      }
-      return name;
+      const { nameKey } = group.category;
+      return nameKey ? t(nameKey) : group.categoryId;
     },
     [t],
   );
@@ -128,7 +121,7 @@ const AmenitiesSheet: React.FC<AmenitiesSheetProps> = ({ ids, maxScrollHeight })
   return (
     <View style={styles.sheet}>
       <View style={styles.sheetHeader}>
-        <SectionHeader title={t('property.amenities.title', 'What this place offers')} />
+        <SectionHeader title={t('property.amenities.title')} />
       </View>
       <ScrollView
         style={[styles.sheetScroll, { maxHeight: maxScrollHeight }]}
@@ -191,7 +184,7 @@ export const AmenitiesGrid: React.FC<AmenitiesGridProps> = ({
   const showAllLabel = t('property.amenities.showAll', { count: ids.length });
 
   return (
-    <Section title={t('property.amenities.title', 'What this place offers')}>
+    <Section title={t('property.amenities.title')}>
       <DetailIconGrid>
         {previewEntries.map((entry, idx) => (
           <DetailIconCell key={`${entry.id}-${idx}`}>

--- a/packages/frontend/components/property/ApplyToRentCTA.tsx
+++ b/packages/frontend/components/property/ApplyToRentCTA.tsx
@@ -107,13 +107,10 @@ export const ApplyToRentCTA: React.FC<ApplyToRentCTAProps> = ({ property }) => {
     return (
       <View style={styles.content}>
         <BloomText style={styles.title}>
-          {t('applications.detail.alreadySubmitted', 'Application submitted')}
+          {t('applications.detail.alreadySubmitted')}
         </BloomText>
         <BloomText style={styles.subtitle}>
-          {t(
-            'applications.detail.alreadySubmittedBody',
-            'You already have an application in review for this property.',
-          )}
+          {t('applications.detail.alreadySubmittedBody')}
         </BloomText>
         <Button
           variant="primary"
@@ -121,7 +118,7 @@ export const ApplyToRentCTA: React.FC<ApplyToRentCTAProps> = ({ property }) => {
           onPress={handleViewStatus}
           style={styles.button}
         >
-          {t('applications.detail.viewStatus', 'View status')}
+          {t('applications.detail.viewStatus')}
         </Button>
       </View>
     );
@@ -129,18 +126,15 @@ export const ApplyToRentCTA: React.FC<ApplyToRentCTAProps> = ({ property }) => {
 
   const moveInLabel = moveInDate
     ? format(moveInDate, 'MMM d, yyyy')
-    : t('applications.cta.addMoveIn', 'Add move-in date');
+    : t('applications.cta.addMoveIn');
 
   return (
     <View style={styles.content}>
       <BloomText style={styles.title}>
-        {t('applications.cta.title', 'Interested in this place?')}
+        {t('applications.cta.title')}
       </BloomText>
       <BloomText style={styles.subtitle}>
-        {t(
-          'applications.cta.subtitle',
-          'Submit a quick application with your move-in date, income and references — the landlord reviews and replies inside Homiio.',
-        )}
+        {t('applications.cta.subtitle')}
       </BloomText>
 
       {priceLabel ? (
@@ -159,11 +153,11 @@ export const ApplyToRentCTA: React.FC<ApplyToRentCTAProps> = ({ property }) => {
       <Pressable
         onPress={openCalendar}
         accessibilityRole="button"
-        accessibilityLabel={t('applications.field.moveInDate', 'Move-in date')}
+        accessibilityLabel={t('applications.field.moveInDate')}
         style={styles.moveInField}
       >
         <BloomText style={styles.moveInLabel}>
-          {t('applications.field.moveInDate', 'Move-in date')}
+          {t('applications.field.moveInDate')}
         </BloomText>
         <View style={styles.moveInValueRow}>
           <BloomText
@@ -186,7 +180,7 @@ export const ApplyToRentCTA: React.FC<ApplyToRentCTAProps> = ({ property }) => {
         onPress={handleApply}
         style={styles.button}
       >
-        {t('applications.cta.apply', 'Apply to rent')}
+        {t('applications.cta.apply')}
       </Button>
 
       <Modal
@@ -204,13 +198,13 @@ export const ApplyToRentCTA: React.FC<ApplyToRentCTAProps> = ({ property }) => {
           >
             <View style={styles.modalHeader}>
               <H3 style={styles.modalTitle}>
-                {t('applications.field.moveInDate', 'Move-in date')}
+                {t('applications.field.moveInDate')}
               </H3>
               <Button
                 variant="icon"
                 size="small"
                 onPress={closeCalendar}
-                accessibilityLabel={t('common.close', 'Close')}
+                accessibilityLabel={t('common.close')}
               >
                 {'×'}
               </Button>

--- a/packages/frontend/components/property/AvailabilitySection.tsx
+++ b/packages/frontend/components/property/AvailabilitySection.tsx
@@ -16,16 +16,16 @@ export const AvailabilitySection: React.FC<Props> = ({ property }) => {
     if (!availableFrom && !leaseTerm) return null;
     const dateStr = availableFrom ? new Date(availableFrom).toLocaleDateString() : undefined;
     return (
-        <Section title={t('Availability')} bodyStyle={styles.body}>
+        <Section title={t('property.sections.availability')} bodyStyle={styles.body}>
             {dateStr && (
                 <View style={styles.row}>
-                    <BloomText style={styles.label}>{t('Available From')}</BloomText>
+                    <BloomText style={styles.label}>{t('property.sections.availableFrom')}</BloomText>
                     <BloomText style={styles.value}>{dateStr}</BloomText>
                 </View>
             )}
             {leaseTerm && (
                 <View style={styles.row}>
-                    <BloomText style={styles.label}>{t('Lease Term')}</BloomText>
+                    <BloomText style={styles.label}>{t('property.sections.leaseTerm')}</BloomText>
                     <BloomText style={styles.value}>{leaseTerm}</BloomText>
                 </View>
             )}

--- a/packages/frontend/components/property/BasicInfoSection.tsx
+++ b/packages/frontend/components/property/BasicInfoSection.tsx
@@ -52,8 +52,8 @@ export const BasicInfoSection: React.FC<Props> = ({
   const description = property?.description;
 
   const rentLabel = isVacation
-    ? t('Nightly Rent', 'Nightly Rent') || 'Nightly Rent'
-    : t('Monthly Rent', 'Monthly Rent') || 'Monthly Rent';
+    ? t('property.sections.nightlyRent')
+    : t('property.sections.monthlyRent');
 
   return (
     <View style={styles.container}>
@@ -75,7 +75,7 @@ export const BasicInfoSection: React.FC<Props> = ({
               color={colors.COLOR_BLACK_LIGHT_3}
             />
             <BloomText style={styles.sourceBadgeText}>
-              {`${t('Sourced from', 'Sourced from') || 'Sourced from'} ${property.source.charAt(0).toUpperCase()}${property.source.slice(1)}`}
+              {`${t('property.sections.sourcedFrom')} ${property.source.charAt(0).toUpperCase()}${property.source.slice(1)}`}
             </BloomText>
           </View>
         </View>
@@ -84,8 +84,7 @@ export const BasicInfoSection: React.FC<Props> = ({
       {description && description.trim() !== '' ? (
         <View style={styles.descriptionBlock}>
           <BloomText style={styles.aboutTitle}>
-            {t('property.about.title', 'About this property') ||
-              'About this property'}
+            {t('property.about.title')}
           </BloomText>
           <TruncatedDescription text={description} />
         </View>
@@ -97,18 +96,17 @@ export const BasicInfoSection: React.FC<Props> = ({
             <Ionicons name="calendar" size={20} color={colors.primaryColor} />
           </View>
           <BloomText style={styles.viewingBannerText}>
-            {t('viewings.banner.hasViewing', 'You have a viewing scheduled') ||
-              'You have a viewing scheduled'}
+            {t('viewings.banner.hasViewing')}
           </BloomText>
           <Button
             onPress={onViewingsPress}
             variant="primary"
             size="small"
             accessibilityLabel={
-              t('viewings.banner.viewDetails', 'View details') || 'View details'
+              t('viewings.banner.viewDetails')
             }
           >
-            {t('viewings.banner.viewDetails', 'View details') || 'View details'}
+            {t('viewings.banner.viewDetails')}
           </Button>
         </View>
       ) : null}

--- a/packages/frontend/components/property/BookingCard.tsx
+++ b/packages/frontend/components/property/BookingCard.tsx
@@ -105,7 +105,6 @@ export const BookingCard: React.FC<BookingCardProps> = ({
               </BloomText>
               <BloomText style={styles.ratingCount}>
                 {t('property.reviews.countWithNumber', {
-                  defaultValue: '({{count}} reviews)',
                   count: ratingSummary.totalReviews,
                 })}
               </BloomText>
@@ -119,11 +118,11 @@ export const BookingCard: React.FC<BookingCardProps> = ({
                 color={colors.COLOR_BLACK_LIGHT_3}
               />
               <BloomText style={styles.hostName} numberOfLines={1}>
-                {t('property.host.hostedBy', 'Hosted by')} {hostName}
+                {t('property.host.hostedBy')} {hostName}
               </BloomText>
               {hostIsSuper ? (
                 <Badge
-                  content={t('property.host.superHost', 'Super host')}
+                  content={t('property.host.superHost')}
                   variant="solid"
                   color="success"
                   size="small"
@@ -148,7 +147,7 @@ export const BookingCard: React.FC<BookingCardProps> = ({
       >
         <Ionicons name="flag-outline" size={16} color={colors.COLOR_BLACK_LIGHT_3} />
         <BloomText style={styles.reportLabel}>
-          {t('property.report', 'Report this listing')}
+          {t('property.report')}
         </BloomText>
       </Pressable>
     </View>

--- a/packages/frontend/components/property/CommunityNoteCard.tsx
+++ b/packages/frontend/components/property/CommunityNoteCard.tsx
@@ -191,7 +191,7 @@ export const CommunityNoteCard: React.FC<CommunityNoteCardProps> = ({
       t('property.communityNotes.reportTitle'),
       t('property.communityNotes.reportBody'),
       [
-        { text: t('common.cancel', 'Cancel') || 'Cancel', style: 'cancel' },
+        { text: t('common.cancel'), style: 'cancel' },
         {
           text: t('property.communityNotes.reportConfirm'),
           style: 'destructive',

--- a/packages/frontend/components/property/CommunityNotesSection.tsx
+++ b/packages/frontend/components/property/CommunityNotesSection.tsx
@@ -316,7 +316,7 @@ export const CommunityNotesSection: React.FC<CommunityNotesSectionProps> = ({
             icon="chatbubbles-outline"
             title={t('property.communityNotes.errorTitle')}
             description={error}
-            retryLabel={t('common.tryAgain', 'Try again') || 'Try again'}
+            retryLabel={t('common.tryAgain')}
             onRetry={() => {
               refetch();
             }}

--- a/packages/frontend/components/property/ExchangeSection.tsx
+++ b/packages/frontend/components/property/ExchangeSection.tsx
@@ -34,27 +34,18 @@ const ICON_SIZE = 18;
 const MAX_WINDOWS_SHOWN = 4;
 
 /** Exchange-mode → headline + helper copy. */
-const MODE_COPY: Record<
-  ExchangeMode,
-  { titleKey: string; titleFallback: string; helpKey: string; helpFallback: string }
-> = {
+const MODE_COPY: Record<ExchangeMode, { titleKey: string; helpKey: string }> = {
   [ExchangeMode.SWAP]: {
     titleKey: 'listing.exchange.mode.swap',
-    titleFallback: 'Home swap',
     helpKey: 'listing.exchange.mode.swapHelp',
-    helpFallback: 'Each party stays in the other’s home.',
   },
   [ExchangeMode.HOST]: {
     titleKey: 'listing.exchange.mode.host',
-    titleFallback: 'Free hosting',
     helpKey: 'listing.exchange.mode.hostHelp',
-    helpFallback: 'Welcome a guest with no stay in return.',
   },
   [ExchangeMode.BOTH]: {
     titleKey: 'listing.exchange.mode.both',
-    titleFallback: 'Either',
     helpKey: 'listing.exchange.mode.bothHelp',
-    helpFallback: 'Open to a swap or to hosting a guest.',
   },
 };
 
@@ -94,16 +85,16 @@ export const ExchangeSection: React.FC<Props> = ({ exchange, onRequestExchange }
   const stayLabel = useMemo(() => {
     const { minStay, maxStay } = exchange;
     if (minStay && maxStay) {
-      return t('listing.exchange.stayRange', '{{min}}–{{max}} nights', {
+      return t('listing.exchange.stayRange', {
         min: minStay,
         max: maxStay,
       });
     }
     if (minStay) {
-      return t('listing.exchange.minStay', 'Min {{count}} nights', { count: minStay });
+      return t('listing.exchange.minStay', { count: minStay });
     }
     if (maxStay) {
-      return t('listing.exchange.maxStay', 'Max {{count}} nights', { count: maxStay });
+      return t('listing.exchange.maxStay', { count: maxStay });
     }
     return undefined;
   }, [exchange, t]);
@@ -111,7 +102,7 @@ export const ExchangeSection: React.FC<Props> = ({ exchange, onRequestExchange }
   const languages = exchange.languages?.filter(Boolean) ?? [];
 
   return (
-    <Section title={t('listing.exchange.sectionTitle', 'Home exchange')}>
+    <Section title={t('listing.exchange.sectionTitle')}>
       {/* Mode */}
       <View style={styles.modeRow}>
         <View style={styles.modeBadge}>
@@ -119,10 +110,10 @@ export const ExchangeSection: React.FC<Props> = ({ exchange, onRequestExchange }
         </View>
         <View style={styles.modeText}>
           <BloomText style={styles.modeTitle}>
-            {t(mode.titleKey, mode.titleFallback)}
+            {t(mode.titleKey)}
           </BloomText>
           <BloomText style={styles.modeHelp}>
-            {t(mode.helpKey, mode.helpFallback)}
+            {t(mode.helpKey)}
           </BloomText>
         </View>
       </View>
@@ -141,7 +132,7 @@ export const ExchangeSection: React.FC<Props> = ({ exchange, onRequestExchange }
           <Divider />
           <View style={styles.block}>
             <BloomText style={styles.blockLabel}>
-              {t('listing.exchange.availabilityTitle', 'Availability')}
+              {t('listing.exchange.availabilityTitle')}
             </BloomText>
             {windows.map((window) => (
               <View key={`${window.start}_${window.end}`} style={styles.windowRow}>
@@ -157,7 +148,7 @@ export const ExchangeSection: React.FC<Props> = ({ exchange, onRequestExchange }
             ))}
             {extraWindows > 0 ? (
               <BloomText style={styles.moreWindows}>
-                {t('listing.exchange.moreWindows', '+{{count}} more', {
+                {t('listing.exchange.moreWindows', {
                   count: extraWindows,
                 })}
               </BloomText>
@@ -173,7 +164,7 @@ export const ExchangeSection: React.FC<Props> = ({ exchange, onRequestExchange }
         {languages.length > 0 ? (
           <FactRow
             icon="chatbubbles-outline"
-            label={t('listing.exchange.languagesValue', 'Speaks {{languages}}', {
+            label={t('listing.exchange.languagesValue', {
               languages: languages.join(', '),
             })}
           />
@@ -181,15 +172,15 @@ export const ExchangeSection: React.FC<Props> = ({ exchange, onRequestExchange }
         {exchange.mealsIncluded ? (
           <FactRow
             icon="restaurant-outline"
-            label={t('listing.exchange.mealsIncludedFact', 'Meals included')}
+            label={t('listing.exchange.mealsIncludedFact')}
           />
         ) : null}
         <FactRow
           icon={exchange.requiresReciprocity ? 'repeat-outline' : 'gift-outline'}
           label={
             exchange.requiresReciprocity
-              ? t('listing.exchange.reciprocityRequired', 'Return stay expected')
-              : t('listing.exchange.reciprocityOptional', 'No return stay required')
+              ? t('listing.exchange.reciprocityRequired')
+              : t('listing.exchange.reciprocityOptional')
           }
         />
       </View>
@@ -200,7 +191,7 @@ export const ExchangeSection: React.FC<Props> = ({ exchange, onRequestExchange }
         onPress={onRequestExchange}
         style={styles.cta}
       >
-        {t('listing.exchange.requestCta', 'Request exchange')}
+        {t('listing.exchange.requestCta')}
       </Button>
     </Section>
   );

--- a/packages/frontend/components/property/ExternalContactSection.tsx
+++ b/packages/frontend/components/property/ExternalContactSection.tsx
@@ -105,8 +105,7 @@ export const ExternalContactSection: React.FC<Props> = ({ property }) => {
   return (
     <View style={styles.container}>
       <BloomText style={styles.title}>
-        {t('property.external.contactTitle', 'Contact on listing') ||
-          'Contact on listing'}
+        {t('property.external.contactTitle')}
       </BloomText>
       {displayName ? (
         <BloomText style={styles.subtitle}>{displayName}</BloomText>

--- a/packages/frontend/components/property/HostStatsCard.tsx
+++ b/packages/frontend/components/property/HostStatsCard.tsx
@@ -120,13 +120,10 @@ export const HostStatsCard: React.FC<HostStatsCardProps> = ({
           <H3 style={styles.name}>
             {state
               ? `${state} Housing Authority`
-              : t('property.host.publicAuthority', 'Public Housing Authority')}
+              : t('property.host.publicAuthority')}
           </H3>
           <BloomText style={styles.subtitle}>
-            {t(
-              'property.host.publicSubtitle',
-              'Government-managed affordable housing',
-            )}
+            {t('property.host.publicSubtitle')}
           </BloomText>
           <View style={styles.badgeRow}>
             <Badge content="GOV" variant="solid" color="info" size="small" />
@@ -143,7 +140,7 @@ export const HostStatsCard: React.FC<HostStatsCardProps> = ({
       onPressOut={() => setPressed(false)}
       onPress={handleOpenProfile}
       accessibilityRole="button"
-      accessibilityLabel={t('property.host.openProfile', 'Open host profile') || 'Open host profile'}
+      accessibilityLabel={t('property.host.openProfile')}
     >
       <Avatar
         source={avatarSource}
@@ -154,24 +151,21 @@ export const HostStatsCard: React.FC<HostStatsCardProps> = ({
       />
       <View style={styles.body}>
         <H3 style={styles.name}>
-          {t('property.host.hostedBy', 'Hosted by')} {displayName}
+          {t('property.host.hostedBy')} {displayName}
         </H3>
         {hostingSince ? (
           <BloomText style={styles.subtitle}>
-            {t('property.host.hostingSince', 'Hosting since')} {hostingSince}
+            {t('property.host.hostingSince')} {hostingSince}
           </BloomText>
         ) : null}
         <BloomText style={styles.responseRate}>
           <Ionicons name="time-outline" size={13} color={colors.COLOR_BLACK_LIGHT_3} />{' '}
-          {t(
-            'property.host.responseRate',
-            'Typically responds within an hour',
-          )}
+          {t('property.host.responseRate')}
         </BloomText>
         {isVerified ? (
           <View style={styles.badgeRow}>
             <Badge
-              content={t('property.host.verified', 'Verified') || 'Verified'}
+              content={t('property.host.verified')}
               variant="solid"
               color="success"
               size="small"

--- a/packages/frontend/components/property/HouseRules.tsx
+++ b/packages/frontend/components/property/HouseRules.tsx
@@ -15,24 +15,24 @@ export const HouseRules: React.FC<Props> = ({ property }) => {
     const smokingAllowed = property?.rules?.smokingAllowed;
     const partiesAllowed = property?.rules?.partiesAllowed;
     if (petsAllowed === undefined && smokingAllowed === undefined && partiesAllowed === undefined) return null;
-    const yesNo = (v?: boolean) => v === undefined ? '-' : v ? t('Yes') : t('No');
+    const yesNo = (v?: boolean) => v === undefined ? '-' : v ? t('propertyCreate.amenities.yes') : t('propertyCreate.amenities.no');
     return (
-        <Section title={t('House Rules')} bodyStyle={styles.body}>
+        <Section title={t('propertyCreate.amenities.houseRules')} bodyStyle={styles.body}>
             {petsAllowed !== undefined && (
                 <View style={styles.row}>
-                    <BloomText style={styles.label}>{t('Pets Allowed')}</BloomText>
+                    <BloomText style={styles.label}>{t('propertyCreate.amenities.petsAllowed')}</BloomText>
                     <BloomText style={styles.value}>{yesNo(petsAllowed)}</BloomText>
                 </View>
             )}
             {smokingAllowed !== undefined && (
                 <View style={styles.row}>
-                    <BloomText style={styles.label}>{t('Smoking Allowed')}</BloomText>
+                    <BloomText style={styles.label}>{t('propertyCreate.amenities.smokingAllowed')}</BloomText>
                     <BloomText style={styles.value}>{yesNo(smokingAllowed)}</BloomText>
                 </View>
             )}
             {partiesAllowed !== undefined && (
                 <View style={styles.row}>
-                    <BloomText style={styles.label}>{t('Parties Allowed')}</BloomText>
+                    <BloomText style={styles.label}>{t('propertyCreate.amenities.partiesAllowed')}</BloomText>
                     <BloomText style={styles.value}>{yesNo(partiesAllowed)}</BloomText>
                 </View>
             )}

--- a/packages/frontend/components/property/LandlordSection.tsx
+++ b/packages/frontend/components/property/LandlordSection.tsx
@@ -19,7 +19,7 @@ interface LandlordSectionProps {
     landlordProfile: Profile | null;
     ownerProperties: Property[];
     onApplyPublic: () => void;
-    t: (k: string, d?: string) => string | undefined;
+    t: (k: string) => string;
 }
 
 export const LandlordSection: React.FC<LandlordSectionProps> = ({
@@ -114,7 +114,7 @@ export const LandlordSection: React.FC<LandlordSectionProps> = ({
     return (
         <Section
             fullBleed
-            title={isPublicHousing ? t('Housing Authority') || 'Housing Authority' : t('Landlord') || 'Landlord'}
+            title={isPublicHousing ? t('listing.cta.housingAuthority') : t('listing.cta.landlord')}
         >
             {isPublicHousing ? (
                 <View style={[styles.contentContainer, styles.gutter]}>
@@ -136,7 +136,7 @@ export const LandlordSection: React.FC<LandlordSectionProps> = ({
                     </View>
                     <ActionButton
                         icon="globe"
-                        text={t('Apply on State Website') || 'Apply on State Website'}
+                        text={t('listing.cta.applyOnStateWebsite')}
                         onPress={onApplyPublic}
                         variant="primary"
                         size="medium"
@@ -170,7 +170,7 @@ export const LandlordSection: React.FC<LandlordSectionProps> = ({
                     {landlordProfile && ownerProperties.length > 0 && (
                         <View style={styles.propertiesSection}>
                             <HomeCarouselSection
-                                title={t('More properties by this owner') || 'More properties by this owner'}
+                                title={t('listing.cta.moreByOwner')}
                                 items={ownerProperties}
                                 loading={false}
                                 renderItem={(prop) => (

--- a/packages/frontend/components/property/LocationDisplay.tsx
+++ b/packages/frontend/components/property/LocationDisplay.tsx
@@ -58,7 +58,7 @@ export const LocationDisplay: React.FC<LocationDisplayProps> = ({ property }) =>
 
   return (
     <View>
-      <SectionHeader title={t('property.location.title', "Where you'll be")} />
+      <SectionHeader title={t('property.location.title')} />
       <View style={styles.body}>
         {neighborhoodSummary ? (
           <BloomText style={styles.summary}>{neighborhoodSummary}</BloomText>

--- a/packages/frontend/components/property/LocationSection.tsx
+++ b/packages/frontend/components/property/LocationSection.tsx
@@ -29,14 +29,14 @@ export const LocationSection: React.FC<Props> = ({ property }) => {
         coordinates[1] >= -90 && coordinates[1] <= 90;     // Valid latitude
     const proximity = property?.proximity || {};
     const amenities: string[] = [];
-    if (proximity.proximityToTransport) amenities.push(t('Public Transport'));
-    if (proximity.proximityToSchools) amenities.push(t('Schools'));
-    if (proximity.proximityToShopping) amenities.push(t('Shopping'));
+    if (proximity.proximityToTransport) amenities.push(t('property.sections.publicTransport'));
+    if (proximity.proximityToSchools) amenities.push(t('property.sections.schools'));
+    if (proximity.proximityToShopping) amenities.push(t('property.sections.shopping'));
 
     if (!hasAddress && !hasMap) return null;
     return (
         <View style={styles.container}>
-            <ThemedText style={styles.sectionTitle}>{t('Location')}</ThemedText>
+            <ThemedText style={styles.sectionTitle}>{t('property.sections.location')}</ThemedText>
             {hasAddress && (
                 <View style={styles.card}>
                     {address.street && <ThemedText style={styles.item}>{address.street}</ThemedText>}
@@ -57,7 +57,7 @@ export const LocationSection: React.FC<Props> = ({ property }) => {
             )}
             {amenities.length > 0 && (
                 <View style={styles.amenitiesCard}>
-                    <ThemedText style={styles.amenitiesTitle}>{t('Nearby Amenities')}</ThemedText>
+                    <ThemedText style={styles.amenitiesTitle}>{t('property.sections.nearbyAmenities')}</ThemedText>
                     {amenities.map(a => (
                         <ThemedText key={a} style={styles.amenityItem}>• {a}</ThemedText>
                     ))}

--- a/packages/frontend/components/property/MortgageCalculatorSection.tsx
+++ b/packages/frontend/components/property/MortgageCalculatorSection.tsx
@@ -116,8 +116,8 @@ export const MortgageCalculatorSection: React.FC<Props> = ({ salePrice, currency
 
   return (
     <Section
-      title={t('listing.mortgage.title', 'Mortgage calculator')}
-      subtitle={t('listing.mortgage.subtitle', 'An estimate — not a mortgage offer.')}
+      title={t('listing.mortgage.title')}
+      subtitle={t('listing.mortgage.subtitle')}
     >
       {/* Monthly payment headline */}
       <View style={styles.headline}>
@@ -128,7 +128,7 @@ export const MortgageCalculatorSection: React.FC<Props> = ({ salePrice, currency
           style={styles.monthly}
         />
         <BloomText style={styles.monthlyUnit}>
-          {` / ${t('listing.mortgage.perMonth', 'mo')}`}
+          {` / ${t('listing.mortgage.perMonth')}`}
         </BloomText>
       </View>
 
@@ -136,7 +136,7 @@ export const MortgageCalculatorSection: React.FC<Props> = ({ salePrice, currency
       <View style={styles.control}>
         <View style={styles.controlHeader}>
           <BloomText style={styles.controlLabel}>
-            {t('listing.mortgage.downPayment', 'Down payment')}
+            {t('listing.mortgage.downPayment')}
           </BloomText>
           <BloomText style={styles.controlValue}>
             {downPaymentPercentLabel}
@@ -156,7 +156,7 @@ export const MortgageCalculatorSection: React.FC<Props> = ({ salePrice, currency
           step={DOWN_PAYMENT_DRAG_STEP}
           keyboardStep={DOWN_PAYMENT_KEYBOARD_STEP}
           onChange={setDownPaymentFraction}
-          accessibilityLabel={t('listing.mortgage.downPayment', 'Down payment')}
+          accessibilityLabel={t('listing.mortgage.downPayment')}
           accessibilityNow={fractionToPercent}
           accessibilityMin={fractionToPercent(MIN_DOWN_PAYMENT_FRACTION)}
           accessibilityMax={fractionToPercent(MAX_DOWN_PAYMENT_FRACTION)}
@@ -167,7 +167,7 @@ export const MortgageCalculatorSection: React.FC<Props> = ({ salePrice, currency
       <View style={styles.control}>
         <View style={styles.controlHeader}>
           <BloomText style={styles.controlLabel}>
-            {t('listing.mortgage.interestRate', 'Interest rate')}
+            {t('listing.mortgage.interestRate')}
           </BloomText>
         </View>
         <View style={styles.rateInputRow}>
@@ -177,7 +177,7 @@ export const MortgageCalculatorSection: React.FC<Props> = ({ salePrice, currency
             onChangeText={setAnnualRateText}
             keyboardType="decimal-pad"
             placeholder="0"
-            accessibilityLabel={t('listing.mortgage.interestRate', 'Interest rate')}
+            accessibilityLabel={t('listing.mortgage.interestRate')}
           />
           <BloomText style={styles.ratePercent}>%</BloomText>
         </View>
@@ -187,11 +187,11 @@ export const MortgageCalculatorSection: React.FC<Props> = ({ salePrice, currency
       <View style={styles.control}>
         <View style={styles.controlHeader}>
           <BloomText style={styles.controlLabel}>
-            {t('listing.mortgage.term', 'Term')}
+            {t('listing.mortgage.term')}
           </BloomText>
         </View>
         <SegmentedControl
-          label={t('listing.mortgage.term', 'Term')}
+          label={t('listing.mortgage.term')}
           type="radio"
           value={String(termYears)}
           onChange={handleSetTerm}
@@ -199,7 +199,7 @@ export const MortgageCalculatorSection: React.FC<Props> = ({ salePrice, currency
           {DEFAULT_MORTGAGE_CONFIG.termOptions.map((option) => (
             <SegmentedControlItem key={option} value={String(option)}>
               <SegmentedControlItemText>
-                {t('listing.mortgage.years', '{{count}} yr', { count: option })}
+                {t('listing.mortgage.years', { count: option })}
               </SegmentedControlItemText>
             </SegmentedControlItem>
           ))}
@@ -218,13 +218,13 @@ export const MortgageCalculatorSection: React.FC<Props> = ({ salePrice, currency
           <View style={styles.legendItem}>
             <View style={[styles.legendDot, { backgroundColor: colors.primaryColor }]} />
             <BloomText style={styles.legendLabel}>
-              {`${t('listing.mortgage.principal', 'Principal')} · ${principalPercent}%`}
+              {`${t('listing.mortgage.principal')} · ${principalPercent}%`}
             </BloomText>
           </View>
           <View style={styles.legendItem}>
             <View style={[styles.legendDot, { backgroundColor: colors.warning }]} />
             <BloomText style={styles.legendLabel}>
-              {`${t('listing.mortgage.interest', 'Interest')} · ${interestPercent}%`}
+              {`${t('listing.mortgage.interest')} · ${interestPercent}%`}
             </BloomText>
           </View>
         </View>
@@ -234,7 +234,7 @@ export const MortgageCalculatorSection: React.FC<Props> = ({ salePrice, currency
       <View style={styles.totals}>
         <View style={styles.totalRow}>
           <BloomText style={styles.totalLabel}>
-            {t('listing.mortgage.loanAmount', 'Loan amount')}
+            {t('listing.mortgage.loanAmount')}
           </BloomText>
           <CurrencyFormatter
             amount={Math.round(result.loanAmount)}
@@ -245,7 +245,7 @@ export const MortgageCalculatorSection: React.FC<Props> = ({ salePrice, currency
         </View>
         <View style={styles.totalRow}>
           <BloomText style={styles.totalLabel}>
-            {t('listing.mortgage.totalInterest', 'Total interest')}
+            {t('listing.mortgage.totalInterest')}
           </BloomText>
           <CurrencyFormatter
             amount={Math.round(result.totalInterest)}
@@ -256,7 +256,7 @@ export const MortgageCalculatorSection: React.FC<Props> = ({ salePrice, currency
         </View>
         <View style={[styles.totalRow, styles.totalRowEmphasis]}>
           <BloomText style={styles.totalLabelStrong}>
-            {t('listing.mortgage.totalPaid', 'Total paid')}
+            {t('listing.mortgage.totalPaid')}
           </BloomText>
           <CurrencyFormatter
             amount={Math.round(result.totalPaid)}

--- a/packages/frontend/components/property/NeighborhoodInfo.tsx
+++ b/packages/frontend/components/property/NeighborhoodInfo.tsx
@@ -30,27 +30,27 @@ export const NeighborhoodInfo: React.FC<Props> = ({ property }) => {
   const currencyCode = currency ?? 'EUR';
 
   return (
-    <Section title={t('Neighborhood')}>
+    <Section title={t('property.neighborhood.title')}>
       <BloomText style={styles.name}>
         {city ? `${name}, ${city}` : name}
       </BloomText>
       <View style={styles.metricsRow}>
         <BloomText style={styles.metric}>
-          {t('{{count}} listings', { count: listingCount })}
+          {t('property.neighborhood.listingCount', { count: listingCount })}
         </BloomText>
         {averageRent !== null ? (
           <BloomText style={styles.metric}>
-            {t('Avg. {{amount}}/mo', { amount: formatCurrency(averageRent, currencyCode) })}
+            {t('property.neighborhood.avgAmountPerMonth', { amount: formatCurrency(averageRent, currencyCode) })}
           </BloomText>
         ) : null}
       </View>
       {vsCity ? (
         <BloomText style={styles.vsCity}>
           {vsCity.percentDiff === 0
-            ? t('On par with the city average')
-            : t('{{pct}}% {{dir}} than the city average', {
+            ? t('property.neighborhood.onParWithCity')
+            : t('property.neighborhood.pctVsCity', {
                 pct: Math.abs(vsCity.percentDiff),
-                dir: vsCity.percentDiff < 0 ? t('cheaper') : t('pricier'),
+                dir: vsCity.percentDiff < 0 ? t('property.neighborhood.cheaper') : t('property.neighborhood.pricier'),
               })}
         </BloomText>
       ) : null}

--- a/packages/frontend/components/property/OfferingBadge.tsx
+++ b/packages/frontend/components/property/OfferingBadge.tsx
@@ -31,7 +31,6 @@ interface OfferingMeta {
   accent: string;
   icon: IoniconName;
   i18nKey: string;
-  fallback: string;
 }
 
 const OFFERING_META: Partial<Record<OfferingType, OfferingMeta>> = {
@@ -39,19 +38,16 @@ const OFFERING_META: Partial<Record<OfferingType, OfferingMeta>> = {
     accent: colors.primarySubtleForeground,
     icon: 'moon',
     i18nKey: 'listing.badge.byNight',
-    fallback: 'By night',
   },
   [OfferingType.SALE]: {
     accent: colors.saleAccent,
     icon: 'pricetag',
     i18nKey: 'listing.badge.forSale',
-    fallback: 'For sale',
   },
   [OfferingType.EXCHANGE]: {
     accent: colors.exchangeAccent,
     icon: 'swap-horizontal',
     i18nKey: 'listing.badge.exchange',
-    fallback: 'Exchange',
   },
 };
 
@@ -65,7 +61,7 @@ export const OfferingBadge: React.FC<OfferingBadgeProps> = ({ offering, size = '
     <MediaChip
       icon={meta.icon}
       accent={meta.accent}
-      label={t(meta.i18nKey, meta.fallback)}
+      label={t(meta.i18nKey)}
       size={size}
     />
   );

--- a/packages/frontend/components/property/PhotoGallery.tsx
+++ b/packages/frontend/components/property/PhotoGallery.tsx
@@ -33,9 +33,9 @@ export const PhotoGallery: React.FC<PhotoGalleryProps> = ({ images, onOpen, t })
         <>
             <View style={styles.photoGalleryContainer}>
                 <View style={styles.galleryHeader}>
-                    <BloomText style={styles.sectionTitle}>{t('Photo Gallery')}</BloomText>
+                    <BloomText style={styles.sectionTitle}>{t('property.sections.photoGallery')}</BloomText>
                     <TouchableOpacity style={styles.viewAllButton} onPress={() => handleImagePress(0)}>
-                        <BloomText style={styles.viewAllButtonText}>{t('View All')}</BloomText>
+                        <BloomText style={styles.viewAllButtonText}>{t('property.sections.viewAll')}</BloomText>
                         <Ionicons name="chevron-forward" size={16} color={colors.primaryColor} />
                     </TouchableOpacity>
                 </View>

--- a/packages/frontend/components/property/PricingDetails.tsx
+++ b/packages/frontend/components/property/PricingDetails.tsx
@@ -54,8 +54,8 @@ export const PricingDetails: React.FC<Props> = ({ property, mode }) => {
   const rentAmount = isVacation ? shortTerm?.nightlyRate : longTerm?.monthlyAmount;
   const currency = (isVacation ? shortTerm?.currency : longTerm?.currency) ?? 'EUR';
   const rentUnit = isVacation
-    ? t('listing.offering.perNightUnit', 'night')
-    : t('listing.offering.perMonthUnit', 'month');
+    ? t('listing.offering.perNightUnit')
+    : t('listing.offering.perMonthUnit');
   const deposit = isVacation ? shortTerm?.deposit : longTerm?.deposit;
   const utilitiesValue = isVacation ? undefined : longTerm?.utilities;
   const utilitiesIncluded =
@@ -72,12 +72,12 @@ export const PricingDetails: React.FC<Props> = ({ property, mode }) => {
   // ----- Pricing & Costs rows -----
   const rows: MoneyRow[] = [];
   if (rentAmount !== undefined) {
-    rows.push({ key: 'rent', label: t('Rent', 'Rent') || 'Rent', amount: rentAmount });
+    rows.push({ key: 'rent', label: t('property.sections.rent'), amount: rentAmount });
   }
   if (deposit !== undefined) {
     rows.push({
       key: 'deposit',
-      label: t('Deposit', 'Deposit') || 'Deposit',
+      label: t('property.sections.deposit'),
       amount: deposit,
     });
   }
@@ -149,7 +149,7 @@ export const PricingDetails: React.FC<Props> = ({ property, mode }) => {
     : t('property.moveInCost.total');
 
   return (
-    <Section title={t('Pricing & Costs', 'Pricing & Costs')}>
+    <Section title={t('property.sections.pricingAndCosts')}>
       {rows.map((row, idx) => (
         <React.Fragment key={row.key}>
           <View style={styles.row}>
@@ -175,12 +175,12 @@ export const PricingDetails: React.FC<Props> = ({ property, mode }) => {
           <Divider />
           <View style={styles.row}>
             <BloomText style={styles.label}>
-              {t('Utilities Included', 'Utilities Included') || 'Utilities Included'}
+              {t('property.sections.utilitiesIncluded')}
             </BloomText>
             <BloomText style={styles.value}>
               {utilitiesIncluded
-                ? t('Yes', 'Yes') || 'Yes'
-                : t('No', 'No') || 'No'}
+                ? t('propertyCreate.amenities.yes')
+                : t('propertyCreate.amenities.no')}
             </BloomText>
           </View>
         </>

--- a/packages/frontend/components/property/PropertyActionBar.tsx
+++ b/packages/frontend/components/property/PropertyActionBar.tsx
@@ -60,7 +60,7 @@ export const PropertyActionBar: React.FC<Props> = ({
             <>
                 <ActionButton
                     icon="swap-horizontal"
-                    text={t('listing.exchange.requestCta', 'Request exchange')}
+                    text={t('listing.exchange.requestCta')}
                     onPress={onRequestExchange}
                     variant="primary"
                     size="large"
@@ -88,7 +88,7 @@ export const PropertyActionBar: React.FC<Props> = ({
             <>
                 <ActionButton
                     icon="calendar-outline"
-                    text={t('listing.sale.requestViewing', 'Request viewing')}
+                    text={t('listing.sale.requestViewing')}
                     onPress={onRequestViewing}
                     variant="primary"
                     size="large"
@@ -112,7 +112,7 @@ export const PropertyActionBar: React.FC<Props> = ({
                 {isPublic ? (
                     <ActionButton
                         icon="globe"
-                        text={t('Apply on State Website')}
+                        text={t('listing.cta.applyOnStateWebsite')}
                         onPress={onApplyPublic}
                         variant="primary"
                         size="large"
@@ -122,7 +122,7 @@ export const PropertyActionBar: React.FC<Props> = ({
                     <>
                         <ActionButton
                             icon="open-outline"
-                            text={t('View on Source Website')}
+                            text={t('listing.cta.viewOnSourceWebsite')}
                             onPress={onContact}
                             variant="primary"
                             size="large"
@@ -131,7 +131,7 @@ export const PropertyActionBar: React.FC<Props> = ({
                         {canCall ? (
                             <ActionButton
                                 icon="call-outline"
-                                text={t('Call Now')}
+                                text={t('listing.cta.callNow')}
                                 onPress={onCall}
                                 variant="secondary"
                                 size="large"
@@ -157,7 +157,7 @@ export const PropertyActionBar: React.FC<Props> = ({
                         {canCall && landlordProfile && (
                             <ActionButton
                                 icon="call-outline"
-                                text={t('Call Now')}
+                                text={t('listing.cta.callNow')}
                                 onPress={onCall}
                                 variant="secondary"
                                 size="large"

--- a/packages/frontend/components/property/PropertyDetailsCard.tsx
+++ b/packages/frontend/components/property/PropertyDetailsCard.tsx
@@ -16,27 +16,27 @@ export const PropertyDetailsCard: React.FC<Props> = ({ property }) => {
     const yearBuilt = property?.yearBuilt;
     const parkingSpaces = property?.parkingSpaces;
     return (
-        <Section title={t('Property Details') || 'Property Details'}>
+        <Section title={t('property.sections.details')}>
             <View style={styles.grid}>
                 <View style={styles.item}>
-                    <BloomText style={styles.label}>{t('Property Type') || 'Property Type'}</BloomText>
-                    <BloomText style={styles.value}>{type ? type.charAt(0).toUpperCase() + type.slice(1) : t('Not specified') || 'Not specified'}</BloomText>
+                    <BloomText style={styles.label}>{t('property.sections.propertyType')}</BloomText>
+                    <BloomText style={styles.value}>{type ? type.charAt(0).toUpperCase() + type.slice(1) : t('property.sections.notSpecified')}</BloomText>
                 </View>
                 {floor !== undefined && (
                     <View style={styles.item}>
-                        <BloomText style={styles.label}>{t('Floor') || 'Floor'}</BloomText>
+                        <BloomText style={styles.label}>{t('property.sections.floor')}</BloomText>
                         <BloomText style={styles.value}>{floor}</BloomText>
                     </View>
                 )}
                 {yearBuilt && (
                     <View style={styles.item}>
-                        <BloomText style={styles.label}>{t('Year Built') || 'Year Built'}</BloomText>
+                        <BloomText style={styles.label}>{t('property.sections.yearBuilt')}</BloomText>
                         <BloomText style={styles.value}>{yearBuilt}</BloomText>
                     </View>
                 )}
                 {parkingSpaces !== undefined && (
                     <View style={styles.item}>
-                        <BloomText style={styles.label}>{t('Parking Spaces') || 'Parking Spaces'}</BloomText>
+                        <BloomText style={styles.label}>{t('property.sections.parkingSpaces')}</BloomText>
                         <BloomText style={styles.value}>{parkingSpaces}</BloomText>
                     </View>
                 )}

--- a/packages/frontend/components/property/PropertyFeatures.tsx
+++ b/packages/frontend/components/property/PropertyFeatures.tsx
@@ -80,22 +80,22 @@ export const PropertyFeatures: React.FC<Props> = ({ property }) => {
         if (furnishedStatus !== undefined) {
             const label =
                 furnishedStatus === 'furnished'
-                    ? t('Furnished')
+                    ? t('property.sections.furnished')
                     : furnishedStatus === 'partially_furnished'
-                        ? t('Partially Furnished')
-                        : t('Unfurnished');
+                        ? t('property.sections.partiallyFurnished')
+                        : t('property.sections.unfurnished');
             next.push({ key: 'furnished', label, imageId: 'furnished', icon: 'cube' });
         }
         if (hasBalcony === true) {
-            next.push({ key: 'balcony', label: t('Balcony'), imageId: 'balcony', icon: 'home' });
+            next.push({ key: 'balcony', label: t('property.sections.balcony'), imageId: 'balcony', icon: 'home' });
         }
         if (hasGarden === true) {
-            next.push({ key: 'garden', label: t('Garden'), icon: 'leaf' });
+            next.push({ key: 'garden', label: t('property.sections.garden'), icon: 'leaf' });
         }
         if (hasElevator === true) {
             next.push({
                 key: 'elevator',
-                label: t('Elevator'),
+                label: t('property.sections.elevator'),
                 imageId: 'elevator',
                 icon: 'arrow-up-circle',
             });
@@ -107,7 +107,7 @@ export const PropertyFeatures: React.FC<Props> = ({ property }) => {
     if (rows.length === 0) return null;
 
     return (
-        <Section title={t('Property Features')}>
+        <Section title={t('property.sections.features')}>
             <DetailIconGrid>
                 {rows.map(({ key, ...data }) => (
                     <DetailIconCell key={key}>

--- a/packages/frontend/components/property/PropertyOverview.tsx
+++ b/packages/frontend/components/property/PropertyOverview.tsx
@@ -41,21 +41,21 @@ export const PropertyOverview: React.FC<Props> = ({ property }) => {
 
   const rows: Row[] = [
     {
-      label: t('Bedrooms', 'Bedrooms') || 'Bedrooms',
+      label: t('property.sections.bedrooms'),
       value: property?.bedrooms !== undefined ? String(property.bedrooms) : '-',
     },
     {
-      label: t('Bathrooms', 'Bathrooms') || 'Bathrooms',
+      label: t('property.sections.bathrooms'),
       value: property?.bathrooms !== undefined ? String(property.bathrooms) : '-',
     },
     {
-      label: t('Size', 'Size') || 'Size',
+      label: t('property.sections.size'),
       value: size !== undefined ? `${size}m²` : '-',
     },
     ...(property?.floor !== undefined
       ? [
           {
-            label: t('Floor', 'Floor') || 'Floor',
+            label: t('property.sections.floor'),
             value: String(property.floor),
           },
         ]
@@ -63,7 +63,7 @@ export const PropertyOverview: React.FC<Props> = ({ property }) => {
   ];
 
   return (
-    <Section title={t('Property Overview', 'Property Overview')}>
+    <Section title={t('property.sections.overview')}>
       {rows.map((row, idx) => (
         <React.Fragment key={row.label}>
           <View style={styles.row}>

--- a/packages/frontend/components/property/ReviewsSection.tsx
+++ b/packages/frontend/components/property/ReviewsSection.tsx
@@ -88,7 +88,7 @@ const RatingHeader: React.FC<RatingHeaderProps> = ({ stats }) => {
         <H1 style={styles.ratingNumber}>{stats.averageRating.toFixed(1)}</H1>
         <BloomText style={styles.ratingMeta}>
           · {stats.totalReviews}{' '}
-          {t('property.reviews.count', 'reviews') || 'reviews'}
+          {t('property.reviews.count')}
         </BloomText>
       </View>
       <View style={styles.statsRow}>
@@ -97,13 +97,13 @@ const RatingHeader: React.FC<RatingHeaderProps> = ({ stats }) => {
             {Math.round(stats.recommendationPercentage)}%
           </BloomText>
           <BloomText style={styles.statLabel}>
-            {t('property.reviews.recommend', 'Recommend') || 'Recommend'}
+            {t('property.reviews.recommend')}
           </BloomText>
         </View>
         <View style={styles.statItem}>
           <BloomText style={styles.statValue}>{stats.verifiedCount}</BloomText>
           <BloomText style={styles.statLabel}>
-            {t('property.reviews.verified', 'Verified') || 'Verified'}
+            {t('property.reviews.verified')}
           </BloomText>
         </View>
         <View style={styles.statItem}>
@@ -111,7 +111,7 @@ const RatingHeader: React.FC<RatingHeaderProps> = ({ stats }) => {
             {stats.withEvidenceCount}
           </BloomText>
           <BloomText style={styles.statLabel}>
-            {t('property.reviews.evidence', 'With evidence') || 'With evidence'}
+            {t('property.reviews.evidence')}
           </BloomText>
         </View>
       </View>
@@ -166,14 +166,10 @@ export const ReviewsSection: React.FC<ReviewsSectionProps> = ({
 
   return (
     <View>
-      <SectionHeader title={t('property.reviews.title', 'Reviews') || 'Reviews'} />
+      <SectionHeader title={t('property.reviews.title')} />
       <View style={styles.body}>
       <BloomText style={styles.disclaimer}>
-        {t(
-          'property.reviews.disclaimer',
-          'Community-verified reviews about the building. Experiences may vary by unit.',
-        ) ||
-          'Community-verified reviews about the building. Experiences may vary by unit.'}
+        {t('property.reviews.disclaimer')}
       </BloomText>
 
       {loading ? (
@@ -208,11 +204,10 @@ export const ReviewsSection: React.FC<ReviewsSectionProps> = ({
         <ErrorState
           icon="chatbubbles-outline"
           title={
-            t('property.reviews.errorTitle', 'Could not load reviews') ||
-            'Could not load reviews'
+            t('property.reviews.errorTitle')
           }
           description={error}
-          retryLabel={t('common.tryAgain', 'Try again') || 'Try again'}
+          retryLabel={t('common.tryAgain')}
           onRetry={() => {
             refetch();
           }}
@@ -223,18 +218,13 @@ export const ReviewsSection: React.FC<ReviewsSectionProps> = ({
         <EmptyState
           icon="chatbubbles-outline"
           title={
-            t('property.reviews.emptyTitle', 'No reviews yet') ||
-            'No reviews yet'
+            t('property.reviews.emptyTitle')
           }
           description={
-            t(
-              'property.reviews.emptyDescription',
-              'Be the first to share what it was like to live here.',
-            ) || 'Be the first to share what it was like to live here.'
+            t('property.reviews.emptyDescription')
           }
           actionText={
-            t('property.reviews.writeAction', 'Write a review') ||
-            'Write a review'
+            t('property.reviews.writeAction')
           }
           actionIcon="create-outline"
           onAction={handleWriteReview}
@@ -287,12 +277,10 @@ export const ReviewsSection: React.FC<ReviewsSectionProps> = ({
               }
               iconPosition="left"
               accessibilityLabel={
-                t('property.reviews.writeAction', 'Write a review') ||
-                'Write a review'
+                t('property.reviews.writeAction')
               }
             >
-              {t('property.reviews.writeAction', 'Write a review') ||
-                'Write a review'}
+              {t('property.reviews.writeAction')}
             </Button>
           </View>
         </>

--- a/packages/frontend/components/property/SaleDetailsSection.tsx
+++ b/packages/frontend/components/property/SaleDetailsSection.tsx
@@ -30,11 +30,11 @@ const PERCENT_MAX_FRACTION_DIGITS = 1;
 /** Chain-status → i18n key + fallback. */
 const CHAIN_STATUS_LABEL: Record<
   NonNullable<PropertySale['chainStatus']>,
-  { key: string; fallback: string }
+  { key: string }
 > = {
-  no_chain: { key: 'listing.sale.chainStatus.noChain', fallback: 'No chain' },
-  chain: { key: 'listing.sale.chainStatus.chain', fallback: 'In a chain' },
-  unknown: { key: 'listing.sale.chainStatus.unknown', fallback: 'Unknown' },
+  no_chain: { key: 'listing.sale.chainStatus.noChain' },
+  chain: { key: 'listing.sale.chainStatus.chain' },
+  unknown: { key: 'listing.sale.chainStatus.unknown' },
 };
 
 export const SaleDetailsSection: React.FC<Props> = ({ sale }) => {
@@ -43,7 +43,7 @@ export const SaleDetailsSection: React.FC<Props> = ({ sale }) => {
   const chain = sale.chainStatus ? CHAIN_STATUS_LABEL[sale.chainStatus] : undefined;
 
   return (
-    <Section title={t('listing.sale.sectionTitle', 'For sale')}>
+    <Section title={t('listing.sale.sectionTitle')}>
       <View style={styles.headline}>
         <CurrencyFormatter
           amount={sale.price}
@@ -55,7 +55,7 @@ export const SaleDetailsSection: React.FC<Props> = ({ sale }) => {
           <View style={styles.reducedChip}>
             <Ionicons name="trending-down" size={14} color={colors.success} />
             <BloomText style={styles.reducedText}>
-              {t('listing.sale.priceReduced', 'Price reduced')}
+              {t('listing.sale.priceReduced')}
             </BloomText>
           </View>
         ) : null}
@@ -66,7 +66,7 @@ export const SaleDetailsSection: React.FC<Props> = ({ sale }) => {
           <Divider />
           <View style={styles.row}>
             <BloomText style={styles.label}>
-              {t('listing.sale.pricePerSqm', 'Price per m²')}
+              {t('listing.sale.pricePerSqm')}
             </BloomText>
             <BloomText style={styles.value}>
               <CurrencyFormatter
@@ -85,7 +85,7 @@ export const SaleDetailsSection: React.FC<Props> = ({ sale }) => {
           <Divider />
           <View style={styles.row}>
             <BloomText style={styles.label}>
-              {t('listing.sale.estimatedYield', 'Estimated yield')}
+              {t('listing.sale.estimatedYield')}
             </BloomText>
             <BloomText style={styles.value}>
               {`${sale.estimatedYield.toLocaleString(undefined, {
@@ -101,9 +101,9 @@ export const SaleDetailsSection: React.FC<Props> = ({ sale }) => {
           <Divider />
           <View style={styles.row}>
             <BloomText style={styles.label}>
-              {t('listing.sale.chainStatus.label', 'Chain status')}
+              {t('listing.sale.chainStatus.label')}
             </BloomText>
-            <BloomText style={styles.value}>{t(chain.key, chain.fallback)}</BloomText>
+            <BloomText style={styles.value}>{t(chain.key)}</BloomText>
           </View>
         </>
       ) : null}

--- a/packages/frontend/components/property/SleepArrangement.tsx
+++ b/packages/frontend/components/property/SleepArrangement.tsx
@@ -49,11 +49,11 @@ export const SleepArrangement: React.FC<SleepArrangementProps> = ({ property }) 
       id: idx + 1,
       title:
         idx === 0
-          ? t('property.sleep.mainBedroom', 'Main bedroom') ?? 'Main bedroom'
+          ? t('property.sleep.mainBedroom') ?? 'Main bedroom'
           : (t('property.sleep.bedroomN', { n: idx + 1 }) as string) ||
             `Bedroom ${idx + 1}`,
       description:
-        (t('property.sleep.oneBed', '1 bed') as string) || '1 bed',
+        (t('property.sleep.oneBed') as string) || '1 bed',
     }));
   }, [property.bedrooms, t]);
 
@@ -61,7 +61,7 @@ export const SleepArrangement: React.FC<SleepArrangementProps> = ({ property }) 
 
   return (
     <View>
-      <SectionHeader title={t('property.sleep.title', "Where you'll sleep")} />
+      <SectionHeader title={t('property.sleep.title')} />
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}

--- a/packages/frontend/components/property/StickyPropertyHeader.tsx
+++ b/packages/frontend/components/property/StickyPropertyHeader.tsx
@@ -80,8 +80,8 @@ export const StickyPropertyHeader: React.FC<StickyPropertyHeaderProps> = ({
       : styles.barNative;
 
   const ctaLabel = rentalMode === 'vacation'
-    ? t('property.cta.reserve', 'Reserve') || 'Reserve'
-    : t('property.cta.apply', 'Apply') || 'Apply';
+    ? t('property.cta.reserve')
+    : t('property.cta.apply');
 
   return (
     <View style={[styles.bar, containerStyle, { paddingTop: insets.top }]}>
@@ -92,7 +92,7 @@ export const StickyPropertyHeader: React.FC<StickyPropertyHeaderProps> = ({
           onPressOut={() => setBackPressed(false)}
           style={[styles.iconButton, backPressed && styles.iconButtonPressed]}
           accessibilityRole="button"
-          accessibilityLabel={t('goBack', 'Go back') || 'Go back'}
+          accessibilityLabel={t('goBack')}
         >
           <Ionicons name="arrow-back" size={22} color={colors.COLOR_BLACK} />
         </Pressable>
@@ -111,7 +111,7 @@ export const StickyPropertyHeader: React.FC<StickyPropertyHeaderProps> = ({
             onPressOut={() => setSharePressed(false)}
             style={[styles.iconButton, sharePressed && styles.iconButtonPressed]}
             accessibilityRole="button"
-            accessibilityLabel={t('common.share', 'Share') || 'Share'}
+            accessibilityLabel={t('common.share')}
           >
             <Ionicons name="share-outline" size={20} color={colors.COLOR_BLACK} />
           </Pressable>

--- a/packages/frontend/components/property/create/AmenitiesStep.tsx
+++ b/packages/frontend/components/property/create/AmenitiesStep.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, TextInput, TouchableOpacity } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '@/styles/colors';
 import { ThemedText } from '@/components/ThemedText';
@@ -9,15 +10,13 @@ import type { AmenitiesStepProps } from './types';
 
 interface RuleToggleProps {
   label: string;
+  yesLabel: string;
+  noLabel: string;
   value: boolean | undefined;
   onToggle: () => void;
 }
 
-/**
- * A single yes/no house-rule toggle. Markup matches the previous inline toggles
- * exactly (icon, colour, and label behaviour).
- */
-function RuleToggle({ label, value, onToggle }: RuleToggleProps) {
+function RuleToggle({ label, yesLabel, noLabel, value, onToggle }: RuleToggleProps) {
   return (
     <View style={styles.toggleContainer}>
       <ThemedText style={styles.label}>{label}</ThemedText>
@@ -30,27 +29,24 @@ function RuleToggle({ label, value, onToggle }: RuleToggleProps) {
           size={24}
           color={value ? colors.primaryColor : colors.COLOR_BLACK_LIGHT_4}
         />
-        <ThemedText style={styles.toggleText}>{value ? 'Yes' : 'No'}</ThemedText>
+        <ThemedText style={styles.toggleText}>{value ? yesLabel : noLabel}</ThemedText>
       </TouchableOpacity>
     </View>
   );
 }
 
-/**
- * "Amenities" wizard step: amenities selector plus the combined house-rules
- * toggles and the conditional max-guests field.
- */
 export function AmenitiesStep({
   formData,
   validationErrors,
   updateFormField,
   onAmenityToggle,
 }: AmenitiesStepProps) {
+  const { t } = useTranslation();
   const { amenities, rules, basicInfo } = formData;
 
   return (
     <View>
-      <ThemedText type="subtitle">Amenities & Rules</ThemedText>
+      <ThemedText type="subtitle">{t('propertyCreate.amenities.rulesTitle')}</ThemedText>
 
       <AmenitiesSelector
         selectedAmenities={amenities.selectedAmenities || []}
@@ -61,43 +57,51 @@ export function AmenitiesStep({
 
       <View>
         <ThemedText type="subtitle" style={styles.rulesSectionTitle}>
-          House Rules
+          {t('propertyCreate.amenities.houseRules')}
         </ThemedText>
 
         <RuleToggle
-          label="Pets Allowed"
+          label={t('propertyCreate.amenities.petsAllowed')}
+          yesLabel={t('propertyCreate.amenities.yes')}
+          noLabel={t('propertyCreate.amenities.no')}
           value={rules?.petsAllowed}
           onToggle={() => updateFormField('rules', 'petsAllowed', !rules?.petsAllowed)}
         />
 
         <RuleToggle
-          label="Smoking Allowed"
+          label={t('propertyCreate.amenities.smokingAllowed')}
+          yesLabel={t('propertyCreate.amenities.yes')}
+          noLabel={t('propertyCreate.amenities.no')}
           value={rules?.smokingAllowed}
           onToggle={() => updateFormField('rules', 'smokingAllowed', !rules?.smokingAllowed)}
         />
 
         <RuleToggle
-          label="Parties Allowed"
+          label={t('propertyCreate.amenities.partiesAllowed')}
+          yesLabel={t('propertyCreate.amenities.yes')}
+          noLabel={t('propertyCreate.amenities.no')}
           value={rules?.partiesAllowed}
           onToggle={() => updateFormField('rules', 'partiesAllowed', !rules?.partiesAllowed)}
         />
 
         <RuleToggle
-          label="Guests Allowed"
+          label={t('propertyCreate.amenities.guestsAllowed')}
+          yesLabel={t('propertyCreate.amenities.yes')}
+          noLabel={t('propertyCreate.amenities.no')}
           value={rules?.guestsAllowed}
           onToggle={() => updateFormField('rules', 'guestsAllowed', !rules?.guestsAllowed)}
         />
 
         {rules?.guestsAllowed && (
           <View style={styles.formGroup}>
-            <ThemedText style={styles.label}>Maximum Number of Guests</ThemedText>
+            <ThemedText style={styles.label}>{t('propertyCreate.amenities.maxGuests')}</ThemedText>
             <TextInput
               style={[styles.input, validationErrors.maxGuests && styles.inputError]}
               value={rules.maxGuests?.toString() || ''}
               onChangeText={(text) =>
                 updateFormField('rules', 'maxGuests', parseInt(text, 10) || undefined)
               }
-              placeholder="e.g., 2"
+              placeholder={t('propertyCreate.amenities.maxGuestsPlaceholder')}
               keyboardType="numeric"
             />
             {validationErrors.maxGuests && (

--- a/packages/frontend/components/property/create/ExchangeSettingsStep.tsx
+++ b/packages/frontend/components/property/create/ExchangeSettingsStep.tsx
@@ -142,19 +142,16 @@ export function ExchangeSettingsStep({ formData, setFormData }: PropertyStepProp
   return (
     <View>
       <ThemedText type="subtitle">
-        {t('listing.exchange.stepTitle', 'Exchange settings')}
+        {t('listing.exchange.stepTitle')}
       </ThemedText>
       <ThemedText style={styles.addressInstructions}>
-        {t(
-          'listing.exchange.stepHelp',
-          'Tell guests how your home swap or hosting works.',
-        )}
+        {t('listing.exchange.stepHelp')}
       </ThemedText>
 
       {/* Mode */}
       <View style={styles.formGroup}>
         <ThemedText style={styles.label}>
-          {t('listing.exchange.modeLabel', 'How do you want to exchange?')}
+          {t('listing.exchange.modeLabel')}
         </ThemedText>
         <View style={exchangeStyles.modeList}>
           {EXCHANGE_MODE_OPTIONS.map((option) => {
@@ -169,7 +166,7 @@ export function ExchangeSettingsStep({ formData, setFormData }: PropertyStepProp
                 onPress={() => handleSelectMode(option.value)}
                 accessibilityRole="radio"
                 accessibilityState={{ selected }}
-                accessibilityLabel={t(option.i18nKey, option.fallback)}
+                accessibilityLabel={t(option.i18nKey)}
               >
                 <Ionicons
                   name={selected ? 'radio-button-on' : 'radio-button-off'}
@@ -183,10 +180,10 @@ export function ExchangeSettingsStep({ formData, setFormData }: PropertyStepProp
                       selected && exchangeStyles.modeTitleSelected,
                     ]}
                   >
-                    {t(option.i18nKey, option.fallback)}
+                    {t(option.i18nKey)}
                   </ThemedText>
                   <ThemedText style={exchangeStyles.modeDescription}>
-                    {t(option.descriptionKey, option.descriptionFallback)}
+                    {t(option.descriptionKey)}
                   </ThemedText>
                 </View>
               </TouchableOpacity>
@@ -198,7 +195,7 @@ export function ExchangeSettingsStep({ formData, setFormData }: PropertyStepProp
       {/* Availability windows */}
       <View style={styles.formGroup}>
         <ThemedText style={styles.label}>
-          {t('listing.exchange.availabilityLabel', 'When are you available?')}
+          {t('listing.exchange.availabilityLabel')}
         </ThemedText>
         {windows.length > 0 ? (
           <View style={exchangeStyles.windowList}>
@@ -217,10 +214,7 @@ export function ExchangeSettingsStep({ formData, setFormData }: PropertyStepProp
                   <Pressable
                     onPress={() => handleRemoveWindow(key)}
                     accessibilityRole="button"
-                    accessibilityLabel={t(
-                      'listing.exchange.removeWindow',
-                      'Remove window',
-                    )}
+                    accessibilityLabel={t('listing.exchange.removeWindow')}
                     hitSlop={8}
                   >
                     <Ionicons
@@ -235,21 +229,18 @@ export function ExchangeSettingsStep({ formData, setFormData }: PropertyStepProp
           </View>
         ) : (
           <ThemedText style={exchangeStyles.emptyWindows}>
-            {t(
-              'listing.exchange.noWindows',
-              'No windows yet. Add the dates your home is free.',
-            )}
+            {t('listing.exchange.noWindows')}
           </ThemedText>
         )}
         <TouchableOpacity
           style={exchangeStyles.addWindowButton}
           onPress={() => setCalendarOpen(true)}
           accessibilityRole="button"
-          accessibilityLabel={t('listing.exchange.addWindow', 'Add availability')}
+          accessibilityLabel={t('listing.exchange.addWindow')}
         >
           <Ionicons name="add" size={ICON_SIZE} color={colors.primaryColor} />
           <ThemedText style={exchangeStyles.addWindowText}>
-            {t('listing.exchange.addWindow', 'Add availability')}
+            {t('listing.exchange.addWindow')}
           </ThemedText>
         </TouchableOpacity>
       </View>
@@ -257,16 +248,13 @@ export function ExchangeSettingsStep({ formData, setFormData }: PropertyStepProp
       {/* Welcome note */}
       <View style={styles.formGroup}>
         <ThemedText style={styles.label}>
-          {t('listing.exchange.welcomeNote', 'Welcome note')}
+          {t('listing.exchange.welcomeNote')}
         </ThemedText>
         <TextInput
           style={styles.textArea}
           value={offering.exchangeWelcomeNote ?? ''}
           onChangeText={handleWelcomeNote}
-          placeholder={t(
-            'listing.exchange.welcomeNotePlaceholder',
-            'Share what makes staying in your home special.',
-          )}
+          placeholder={t('listing.exchange.welcomeNotePlaceholder')}
           placeholderTextColor={colors.COLOR_BLACK_LIGHT_4}
           multiline
           textAlignVertical="top"
@@ -276,7 +264,7 @@ export function ExchangeSettingsStep({ formData, setFormData }: PropertyStepProp
       {/* Languages */}
       <View style={styles.formGroup}>
         <ThemedText style={styles.label}>
-          {t('listing.exchange.languages', 'Languages you speak')}
+          {t('listing.exchange.languages')}
         </ThemedText>
         <View style={styles.optionRow}>
           {EXCHANGE_LANGUAGE_OPTIONS.map((language) => {
@@ -309,7 +297,7 @@ export function ExchangeSettingsStep({ formData, setFormData }: PropertyStepProp
       {/* Meals included */}
       <View style={styles.toggleContainer}>
         <ThemedText style={styles.label}>
-          {t('listing.exchange.mealsIncluded', 'Meals included')}
+          {t('listing.exchange.mealsIncluded')}
         </ThemedText>
         <TouchableOpacity
           style={[
@@ -331,8 +319,8 @@ export function ExchangeSettingsStep({ formData, setFormData }: PropertyStepProp
           />
           <ThemedText style={styles.toggleText}>
             {offering.exchangeMealsIncluded
-              ? t('common.yes', 'Yes')
-              : t('common.no', 'No')}
+              ? t('common.yes')
+              : t('common.no')}
           </ThemedText>
         </TouchableOpacity>
       </View>
@@ -341,13 +329,10 @@ export function ExchangeSettingsStep({ formData, setFormData }: PropertyStepProp
       <View style={styles.toggleContainer}>
         <View style={exchangeStyles.reciprocityLabelWrap}>
           <ThemedText style={styles.label}>
-            {t('listing.exchange.requiresReciprocity', 'Requires a return stay')}
+            {t('listing.exchange.requiresReciprocity')}
           </ThemedText>
           <ThemedText style={exchangeStyles.reciprocityHelp}>
-            {t(
-              'listing.exchange.requiresReciprocityHelp',
-              'On means a true swap; off allows one-way hosting.',
-            )}
+            {t('listing.exchange.requiresReciprocityHelp')}
           </ThemedText>
         </View>
         <TouchableOpacity
@@ -374,8 +359,8 @@ export function ExchangeSettingsStep({ formData, setFormData }: PropertyStepProp
           />
           <ThemedText style={styles.toggleText}>
             {offering.exchangeRequiresReciprocity
-              ? t('common.yes', 'Yes')
-              : t('common.no', 'No')}
+              ? t('common.yes')
+              : t('common.no')}
           </ThemedText>
         </TouchableOpacity>
       </View>
@@ -397,13 +382,13 @@ export function ExchangeSettingsStep({ formData, setFormData }: PropertyStepProp
           >
             <View style={exchangeStyles.modalHeader}>
               <H3 style={exchangeStyles.modalTitle}>
-                {t('listing.exchange.addWindow', 'Add availability')}
+                {t('listing.exchange.addWindow')}
               </H3>
               <Button
                 variant="icon"
                 size="small"
                 onPress={() => setCalendarOpen(false)}
-                accessibilityLabel={t('common.close', 'Close')}
+                accessibilityLabel={t('common.close')}
               >
                 {'×'}
               </Button>

--- a/packages/frontend/components/property/create/LocationStep.tsx
+++ b/packages/frontend/components/property/create/LocationStep.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import { View, TextInput, TouchableOpacity } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '@/styles/colors';
 import { ThemedText } from '@/components/ThemedText';
@@ -26,21 +27,17 @@ export function LocationStep({
   onFloorChange,
   onShowFloorToggle,
 }: LocationStepProps) {
+  const { t } = useTranslation();
   const bottomSheet = useContext(BottomSheetContext);
   const { location } = formData;
 
   return (
     <View>
-      <ThemedText type="subtitle">Location</ThemedText>
+      <ThemedText type="subtitle">{t('propertyCreate.location.title')}</ThemedText>
 
       <View style={styles.formGroup}>
         <ThemedText style={styles.addressInstructions}>
-          📍 Address Details: Fill in the complete address information. Our system uses a
-          hierarchical structure:
-          {'\n'}• STREET level: Street name only
-          {'\n'}• BUILDING level: Street + number + building details
-          {'\n'}• UNIT level: Building + floor + unit/apartment details
-          {'\n'}Reviews and listings are organized by these levels for better organization.
+          {t('propertyCreate.location.instructions')}
         </ThemedText>
       </View>
 
@@ -64,7 +61,7 @@ export function LocationStep({
       </View>
 
       <View style={styles.formGroup}>
-        <ThemedText style={styles.label}>Country or Region</ThemedText>
+        <ThemedText style={styles.label}>{t('propertyCreate.location.country')}</ThemedText>
         <TouchableOpacity
           style={[styles.input, styles.inputCentered]}
           onPress={() =>
@@ -73,7 +70,7 @@ export function LocationStep({
                 options={[...COUNTRY_OPTIONS]}
                 selected={location.country || ''}
                 onSelect={(value) => updateFormField('location', 'country', value)}
-                title="Country or Region"
+                title={t('propertyCreate.location.countryPickerTitle')}
                 onClose={() => {}}
               />,
             )
@@ -82,18 +79,18 @@ export function LocationStep({
           <ThemedText
             style={location.country ? styles.pickerValueSelected : styles.pickerValuePlaceholder}
           >
-            {location.country || 'Select country or region'}
+            {location.country || t('propertyCreate.location.selectCountry')}
           </ThemedText>
         </TouchableOpacity>
       </View>
 
       <View style={styles.formGroup}>
-        <ThemedText style={styles.label}>Address</ThemedText>
+        <ThemedText style={styles.label}>{t('propertyCreate.location.street')}</ThemedText>
         <TextInput
           style={[styles.input, validationErrors.address && styles.inputError]}
           value={location.address}
           onChangeText={(text) => updateFormField('location', 'address', text)}
-          placeholder="Street name"
+          placeholder={t('propertyCreate.location.streetPlaceholder')}
         />
         {validationErrors.address && (
           <ThemedText style={styles.errorText}>{validationErrors.address}</ThemedText>
@@ -101,56 +98,56 @@ export function LocationStep({
       </View>
 
       <View style={styles.formGroup}>
-        <ThemedText style={styles.label}>Unit/Apartment Number (optional)</ThemedText>
+        <ThemedText style={styles.label}>{t('propertyCreate.location.unitOptional')}</ThemedText>
         <TextInput
           style={styles.input}
           value={location.unit || ''}
           onChangeText={(text) => updateFormField('location', 'unit', text)}
-          placeholder="Apartment, suite, etc. (optional)"
+          placeholder={t('propertyCreate.location.unitPlaceholder')}
         />
       </View>
 
       {/* Additional Canonical Address Fields */}
       <View style={styles.formRow}>
         <View style={[styles.formGroup, styles.formGroupLeft]}>
-          <ThemedText style={styles.label}>Building Name (optional)</ThemedText>
+          <ThemedText style={styles.label}>{t('propertyCreate.location.buildingNameOptional')}</ThemedText>
           <TextInput
             style={styles.input}
             value={location.building_name || ''}
             onChangeText={(text) => updateFormField('location', 'building_name', text)}
-            placeholder="e.g., Torre Barcelona"
+            placeholder={t('propertyCreate.location.buildingNamePlaceholder')}
           />
         </View>
 
         <View style={[styles.formGroup, styles.formGroupRight]}>
-          <ThemedText style={styles.label}>Block (optional)</ThemedText>
+          <ThemedText style={styles.label}>{t('propertyCreate.location.blockOptional')}</ThemedText>
           <TextInput
             style={styles.input}
             value={location.block || ''}
             onChangeText={(text) => updateFormField('location', 'block', text)}
-            placeholder="e.g., Block A"
+            placeholder={t('propertyCreate.location.blockPlaceholder')}
           />
         </View>
       </View>
 
       <View style={styles.formRow}>
         <View style={[styles.formGroup, styles.formGroupLeft]}>
-          <ThemedText style={styles.label}>Entrance/Door (optional)</ThemedText>
+          <ThemedText style={styles.label}>{t('propertyCreate.location.entranceOptional')}</ThemedText>
           <TextInput
             style={styles.input}
             value={location.entrance || ''}
             onChangeText={(text) => updateFormField('location', 'entrance', text)}
-            placeholder="e.g., Door 1, Entrance B"
+            placeholder={t('propertyCreate.location.entrancePlaceholder')}
           />
         </View>
 
         <View style={[styles.formGroup, styles.formGroupRight]}>
-          <ThemedText style={styles.label}>Sub-unit (optional)</ThemedText>
+          <ThemedText style={styles.label}>{t('propertyCreate.location.subunitOptional')}</ThemedText>
           <TextInput
             style={styles.input}
             value={location.subunit || ''}
             onChangeText={(text) => updateFormField('location', 'subunit', text)}
-            placeholder="e.g., Room A"
+            placeholder={t('propertyCreate.location.subunitPlaceholder')}
           />
         </View>
       </View>
@@ -158,7 +155,7 @@ export function LocationStep({
       <View style={styles.formRow}>
         <View style={[styles.formGroup, styles.formGroupLeft]}>
           <View style={styles.labelContainer}>
-            <ThemedText style={styles.label}>Street Number</ThemedText>
+            <ThemedText style={styles.label}>{t('propertyCreate.location.number')}</ThemedText>
             <Ionicons
               name="information-circle-outline"
               size={16}
@@ -171,7 +168,7 @@ export function LocationStep({
                 style={[styles.detailInput, validationErrors.number && styles.inputError]}
                 value={location.number || ''}
                 onChangeText={(text) => updateFormField('location', 'number', text)}
-                placeholder="Enter number"
+                placeholder={t('propertyCreate.location.numberPlaceholder')}
                 keyboardType="numeric"
               />
             </View>
@@ -185,7 +182,7 @@ export function LocationStep({
 
         <View style={[styles.formGroup, styles.formGroupRight]}>
           <View style={styles.labelContainer}>
-            <ThemedText style={styles.label}>Floor</ThemedText>
+            <ThemedText style={styles.label}>{t('propertyCreate.location.floor')}</ThemedText>
             <Ionicons
               name="information-circle-outline"
               size={16}
@@ -198,7 +195,7 @@ export function LocationStep({
                 style={[styles.detailInput, validationErrors.floor && styles.inputError]}
                 value={location.floor?.toString() || ''}
                 onChangeText={onFloorChange}
-                placeholder="Enter floor"
+                placeholder={t('propertyCreate.location.floorPlaceholder')}
                 keyboardType="numeric"
               />
               <TouchableOpacity
@@ -216,7 +213,7 @@ export function LocationStep({
                     location.showFloor && styles.privacyToggleTextActive,
                   ]}
                 >
-                  {location.showFloor ? 'Public' : 'Private'}
+                  {location.showFloor ? t('propertyCreate.location.floorPublic') : t('propertyCreate.location.floorPrivate')}
                 </ThemedText>
               </TouchableOpacity>
             </View>
@@ -226,7 +223,7 @@ export function LocationStep({
               )}
               {location.floor && !location.showFloor && (
                 <ThemedText style={styles.privacyMessage}>
-                  ℹ️ Will be shown as approximate for privacy
+                  {t('propertyCreate.location.floorPrivacyHint')}
                 </ThemedText>
               )}
             </View>
@@ -235,55 +232,55 @@ export function LocationStep({
       </View>
 
       <View style={styles.formGroup}>
-        <ThemedText style={styles.label}>Neighborhood (optional)</ThemedText>
+        <ThemedText style={styles.label}>{t('propertyCreate.location.neighborhoodOptional')}</ThemedText>
         <TextInput
           style={styles.input}
           value={location.neighborhood || ''}
           onChangeText={(text) => updateFormField('location', 'neighborhood', text)}
-          placeholder="e.g., Gràcia, Sant Andreu, Eixample"
+          placeholder={t('propertyCreate.location.neighborhoodPlaceholder')}
         />
       </View>
 
       <View style={styles.formGroup}>
-        <ThemedText style={styles.label}>District (optional)</ThemedText>
+        <ThemedText style={styles.label}>{t('propertyCreate.location.districtOptional')}</ThemedText>
         <TextInput
           style={styles.input}
           value={location.district || ''}
           onChangeText={(text) => updateFormField('location', 'district', text)}
-          placeholder="e.g., Administrative district"
+          placeholder={t('propertyCreate.location.districtPlaceholder')}
         />
       </View>
 
       <View style={styles.formRow}>
         <View style={[styles.formGroup, styles.formGroupLeft]}>
-          <ThemedText style={styles.label}>PO Box (optional)</ThemedText>
+          <ThemedText style={styles.label}>{t('propertyCreate.location.poBoxOptional')}</ThemedText>
           <TextInput
             style={styles.input}
             value={location.po_box || ''}
             onChangeText={(text) => updateFormField('location', 'po_box', text)}
-            placeholder="e.g., PO Box 123"
+            placeholder={t('propertyCreate.location.poBoxPlaceholder')}
           />
         </View>
 
         <View style={[styles.formGroup, styles.formGroupRight]}>
-          <ThemedText style={styles.label}>Reference (optional)</ThemedText>
+          <ThemedText style={styles.label}>{t('propertyCreate.location.referenceOptional')}</ThemedText>
           <TextInput
             style={styles.input}
             value={location.reference || ''}
             onChangeText={(text) => updateFormField('location', 'reference', text)}
-            placeholder="e.g., Near Metro Station"
+            placeholder={t('propertyCreate.location.referencePlaceholder')}
           />
         </View>
       </View>
 
       <View style={styles.formRow}>
         <View style={[styles.formGroup, styles.formGroupLeft]}>
-          <ThemedText style={styles.label}>City/District</ThemedText>
+          <ThemedText style={styles.label}>{t('propertyCreate.location.cityDistrict')}</ThemedText>
           <TextInput
             style={[styles.input, validationErrors.city && styles.inputError]}
             value={location.city}
             onChangeText={(text) => updateFormField('location', 'city', text)}
-            placeholder="City or district"
+            placeholder={t('propertyCreate.location.cityDistrictPlaceholder')}
           />
           {validationErrors.city && (
             <ThemedText style={styles.errorText}>{validationErrors.city}</ThemedText>
@@ -291,7 +288,7 @@ export function LocationStep({
         </View>
 
         <View style={[styles.formGroup, styles.formGroupRight]}>
-          <ThemedText style={styles.label}>State/Province/Region</ThemedText>
+          <ThemedText style={styles.label}>{t('propertyCreate.location.state')}</ThemedText>
           <TouchableOpacity
             style={[styles.input, styles.inputCentered]}
             onPress={() =>
@@ -300,7 +297,7 @@ export function LocationStep({
                   options={[...STATE_OPTIONS]}
                   selected={location.state || ''}
                   onSelect={(value) => updateFormField('location', 'state', value)}
-                  title="State/Province/Region"
+                  title={t('propertyCreate.location.statePickerTitle')}
                   onClose={() => {}}
                 />,
               )
@@ -309,7 +306,7 @@ export function LocationStep({
             <ThemedText
               style={location.state ? styles.pickerValueSelected : styles.pickerValuePlaceholder}
             >
-              {location.state || 'Select state/province/region'}
+              {location.state || t('propertyCreate.location.selectState')}
             </ThemedText>
           </TouchableOpacity>
           {validationErrors.state && (
@@ -319,12 +316,12 @@ export function LocationStep({
       </View>
 
       <View style={styles.formGroup}>
-        <ThemedText style={styles.label}>ZIP/Postal Code</ThemedText>
+        <ThemedText style={styles.label}>{t('propertyCreate.location.zipPostalCode')}</ThemedText>
         <TextInput
           style={[styles.input, validationErrors.postal_code && styles.inputError]}
           value={location.postal_code}
           onChangeText={(text) => updateFormField('location', 'postal_code', text)}
-          placeholder="ZIP or postal code"
+          placeholder={t('propertyCreate.location.zipPlaceholder')}
           keyboardType="numeric"
         />
         {validationErrors.postal_code && (
@@ -334,22 +331,22 @@ export function LocationStep({
 
       <View style={styles.formRow}>
         <View style={[styles.formGroup, styles.formGroupLeft]}>
-          <ThemedText style={styles.label}>Available From</ThemedText>
+          <ThemedText style={styles.label}>{t('propertyCreate.location.availableFrom')}</ThemedText>
           <TextInput
             style={styles.input}
             value={location.availableFrom}
             onChangeText={(text) => updateFormField('location', 'availableFrom', text)}
-            placeholder="Available from date"
+            placeholder={t('propertyCreate.location.availableFromPlaceholder')}
           />
         </View>
 
         <View style={[styles.formGroup, styles.formGroupRight]}>
-          <ThemedText style={styles.label}>Lease Term</ThemedText>
+          <ThemedText style={styles.label}>{t('propertyCreate.location.leaseTerm')}</ThemedText>
           <TextInput
             style={styles.input}
             value={location.leaseTerm}
             onChangeText={(text) => updateFormField('location', 'leaseTerm', text)}
-            placeholder="Lease term"
+            placeholder={t('propertyCreate.location.leaseTermPlaceholder')}
           />
         </View>
       </View>

--- a/packages/frontend/components/property/create/LongTermPricingStep.tsx
+++ b/packages/frontend/components/property/create/LongTermPricingStep.tsx
@@ -36,12 +36,12 @@ export function LongTermPricingStep({
   return (
     <View>
       <ThemedText type="subtitle">
-        {t('listing.offering.longTermStepTitle', 'Monthly rent')}
+        {t('listing.offering.longTermStepTitle')}
       </ThemedText>
 
       <View style={styles.formGroup}>
         <ThemedText style={styles.label}>
-          {t('listing.pricing.monthlyRent', 'Monthly Rent')}
+          {t('listing.pricing.monthlyRent')}
         </ThemedText>
         <TextInput
           style={[styles.input, validationErrors.monthlyRent && styles.inputError]}
@@ -64,7 +64,7 @@ export function LongTermPricingStep({
 
       <View style={styles.formGroup}>
         <ThemedText style={styles.label}>
-          {t('listing.pricing.securityDeposit', 'Security Deposit')}
+          {t('listing.pricing.securityDeposit')}
         </ThemedText>
         <TextInput
           style={styles.input}
@@ -77,7 +77,7 @@ export function LongTermPricingStep({
 
       <View style={styles.formGroup}>
         <ThemedText style={styles.label}>
-          {t('listing.pricing.applicationFee', 'Application Fee')}
+          {t('listing.pricing.applicationFee')}
         </ThemedText>
         <TextInput
           style={styles.input}
@@ -90,7 +90,7 @@ export function LongTermPricingStep({
 
       <View style={styles.formGroup}>
         <ThemedText style={styles.label}>
-          {t('listing.pricing.lateFee', 'Late Fee')}
+          {t('listing.pricing.lateFee')}
         </ThemedText>
         <TextInput
           style={styles.input}

--- a/packages/frontend/components/property/create/NightlyPricingStep.tsx
+++ b/packages/frontend/components/property/create/NightlyPricingStep.tsx
@@ -53,12 +53,12 @@ export function NightlyPricingStep({
   return (
     <View>
       <ThemedText type="subtitle">
-        {t('listing.offering.nightlyStepTitle', 'Nightly rate')}
+        {t('listing.offering.nightlyStepTitle')}
       </ThemedText>
 
       <View style={styles.formGroup}>
         <ThemedText style={styles.label}>
-          {t('listing.nightly.nightlyRate', 'Nightly rate')}
+          {t('listing.nightly.nightlyRate')}
         </ThemedText>
         <TextInput
           style={[styles.input, validationErrors.nightlyRate && styles.inputError]}
@@ -75,7 +75,7 @@ export function NightlyPricingStep({
       <View style={styles.formRow}>
         <View style={[styles.formGroup, styles.formGroupLeft]}>
           <ThemedText style={styles.label}>
-            {t('listing.nightly.cleaningFee', 'Cleaning fee')}
+            {t('listing.nightly.cleaningFee')}
           </ThemedText>
           <TextInput
             style={styles.input}
@@ -87,7 +87,7 @@ export function NightlyPricingStep({
         </View>
         <View style={[styles.formGroup, styles.formGroupRight]}>
           <ThemedText style={styles.label}>
-            {t('listing.nightly.serviceFee', 'Service fee')}
+            {t('listing.nightly.serviceFee')}
           </ThemedText>
           <TextInput
             style={styles.input}
@@ -101,7 +101,7 @@ export function NightlyPricingStep({
 
       <View style={styles.formGroup}>
         <ThemedText style={styles.label}>
-          {t('listing.nightly.taxesPercent', 'Taxes (%)')}
+          {t('listing.nightly.taxesPercent')}
         </ThemedText>
         <TextInput
           style={[styles.input, validationErrors.taxesPercent && styles.inputError]}
@@ -118,7 +118,7 @@ export function NightlyPricingStep({
       <View style={styles.formRow}>
         <View style={[styles.formGroup, styles.formGroupLeft]}>
           <ThemedText style={styles.label}>
-            {t('listing.nightly.minNights', 'Min nights')}
+            {t('listing.nightly.minNights')}
           </ThemedText>
           <TextInput
             style={[styles.input, validationErrors.minNights && styles.inputError]}
@@ -130,14 +130,14 @@ export function NightlyPricingStep({
         </View>
         <View style={[styles.formGroup, styles.formGroupRight]}>
           <ThemedText style={styles.label}>
-            {t('listing.nightly.maxNights', 'Max nights')}
+            {t('listing.nightly.maxNights')}
           </ThemedText>
           <TextInput
             style={styles.input}
             value={pricing.maxNights !== undefined ? pricing.maxNights.toString() : ''}
             onChangeText={handleNights('maxNights')}
             keyboardType="number-pad"
-            placeholder={t('listing.nightly.noMax', 'No max')}
+            placeholder={t('listing.nightly.noMax')}
           />
         </View>
       </View>
@@ -147,7 +147,7 @@ export function NightlyPricingStep({
 
       <View style={styles.toggleContainer}>
         <ThemedText style={styles.label}>
-          {t('listing.nightly.instantBook', 'Instant book')}
+          {t('listing.nightly.instantBook')}
         </ThemedText>
         <TouchableOpacity
           style={[styles.toggleButton, pricing.instantBook ? styles.toggleButtonActive : null]}
@@ -161,7 +161,7 @@ export function NightlyPricingStep({
             color={pricing.instantBook ? colors.primaryColor : colors.COLOR_BLACK_LIGHT_4}
           />
           <ThemedText style={styles.toggleText}>
-            {pricing.instantBook ? t('common.yes', 'Yes') : t('common.no', 'No')}
+            {pricing.instantBook ? t('common.yes') : t('common.no')}
           </ThemedText>
         </TouchableOpacity>
       </View>
@@ -171,7 +171,7 @@ export function NightlyPricingStep({
       {pricing.nightlyRate > 0 ? (
         <View style={nightlyPricingStyles.previewWrap}>
           <ThemedText style={styles.label}>
-            {t('listing.nightly.previewTitle', 'Example {{count}}-night total', {
+            {t('listing.nightly.previewTitle', {
               count: PREVIEW_NIGHTS,
             })}
           </ThemedText>

--- a/packages/frontend/components/property/create/OfferingSelector.tsx
+++ b/packages/frontend/components/property/create/OfferingSelector.tsx
@@ -46,13 +46,10 @@ export function OfferingSelector({ formData, setFormData }: PropertyStepProps) {
   return (
     <View>
       <ThemedText type="subtitle">
-        {t('listing.offering.stepTitle', 'How are you offering this?')}
+        {t('listing.offering.stepTitle')}
       </ThemedText>
       <ThemedText style={styles.addressInstructions}>
-        {t(
-          'listing.offering.stepHelp',
-          'Choose one or more. You can rent and sell the same place.',
-        )}
+        {t('listing.offering.stepHelp')}
       </ThemedText>
 
       <View style={offeringSelectorStyles.list}>
@@ -68,7 +65,7 @@ export function OfferingSelector({ formData, setFormData }: PropertyStepProps) {
               onPress={() => toggleOffering(option.value)}
               accessibilityRole="checkbox"
               accessibilityState={{ checked: selected }}
-              accessibilityLabel={t(option.i18nKey, option.fallback)}
+              accessibilityLabel={t(option.i18nKey)}
             >
               <View style={offeringSelectorStyles.rowIcon}>
                 <Ionicons
@@ -84,10 +81,10 @@ export function OfferingSelector({ formData, setFormData }: PropertyStepProps) {
                     selected && offeringSelectorStyles.rowTitleSelected,
                   ]}
                 >
-                  {t(option.i18nKey, option.fallback)}
+                  {t(option.i18nKey)}
                 </ThemedText>
                 <ThemedText style={offeringSelectorStyles.rowDescription}>
-                  {t(option.descriptionKey, option.descriptionFallback)}
+                  {t(option.descriptionKey)}
                 </ThemedText>
               </View>
               <Ionicons
@@ -102,7 +99,7 @@ export function OfferingSelector({ formData, setFormData }: PropertyStepProps) {
 
       <View style={styles.formGroup}>
         <ThemedText style={styles.label}>
-          {t('listing.offering.currency', 'Currency')}
+          {t('listing.offering.currency')}
         </ThemedText>
         <View style={styles.optionRow}>
           {CURRENCY_OPTIONS.map((option) => (

--- a/packages/frontend/components/property/create/SaleDetailsStep.tsx
+++ b/packages/frontend/components/property/create/SaleDetailsStep.tsx
@@ -53,13 +53,13 @@ export function SaleDetailsStep({
   return (
     <View>
       <ThemedText type="subtitle">
-        {t('listing.sale.stepTitle', 'Sale details')}
+        {t('listing.sale.stepTitle')}
       </ThemedText>
 
       <View style={styles.formRow}>
         <View style={[styles.formGroup, styles.formGroupLeft]}>
           <ThemedText style={styles.label}>
-            {t('listing.sale.askingPrice', 'Asking price')}
+            {t('listing.sale.askingPrice')}
           </ThemedText>
           <TextInput
             style={[styles.input, validationErrors.salePrice && styles.inputError]}
@@ -74,7 +74,7 @@ export function SaleDetailsStep({
         </View>
 
         <View style={[styles.formGroup, styles.formGroupRight]}>
-          <ThemedText style={styles.label}>{t('listing.sale.currency', 'Currency')}</ThemedText>
+          <ThemedText style={styles.label}>{t('listing.sale.currency')}</ThemedText>
           <View style={styles.optionRow}>
             {CURRENCY_OPTIONS.map((option) => (
               <TouchableOpacity
@@ -101,7 +101,7 @@ export function SaleDetailsStep({
 
       <View style={styles.formGroup}>
         <ThemedText style={styles.label}>
-          {t('listing.sale.chainStatus.label', 'Chain status')}
+          {t('listing.sale.chainStatus.label')}
         </ThemedText>
         <View style={styles.optionRow}>
           {CHAIN_STATUS_OPTIONS.map((option) => (
@@ -119,7 +119,7 @@ export function SaleDetailsStep({
                   offering.chainStatus === option.value && styles.propertyTypeTextSelected,
                 ]}
               >
-                {t(option.i18nKey, option.fallback)}
+                {t(option.i18nKey)}
               </ThemedText>
             </TouchableOpacity>
           ))}
@@ -128,7 +128,7 @@ export function SaleDetailsStep({
 
       <View style={styles.toggleContainer}>
         <ThemedText style={styles.label}>
-          {t('listing.sale.priceReduced', 'Price reduced')}
+          {t('listing.sale.priceReduced')}
         </ThemedText>
         <TouchableOpacity
           style={[
@@ -148,8 +148,8 @@ export function SaleDetailsStep({
           />
           <ThemedText style={styles.toggleText}>
             {offering.isPriceReduced
-              ? t('common.yes', 'Yes')
-              : t('common.no', 'No')}
+              ? t('common.yes')
+              : t('common.no')}
           </ThemedText>
         </TouchableOpacity>
       </View>

--- a/packages/frontend/components/property/create/constants.ts
+++ b/packages/frontend/components/property/create/constants.ts
@@ -370,9 +370,7 @@ export const CURRENCY_OPTIONS: readonly CurrencyOption[] = [
 export interface OfferingOption {
   value: OfferingType;
   i18nKey: string;
-  fallback: string;
   descriptionKey: string;
-  descriptionFallback: string;
   icon: string;
 }
 
@@ -380,33 +378,25 @@ export const PRICING_OFFERING_OPTIONS: readonly OfferingOption[] = [
   {
     value: OfferingType.LONG_TERM_RENT,
     i18nKey: 'listing.offering.longTerm',
-    fallback: 'Rent monthly',
     descriptionKey: 'listing.offering.longTermHelp',
-    descriptionFallback: 'Traditional long-term lease, priced per month.',
     icon: 'home-outline',
   },
   {
     value: OfferingType.SHORT_TERM_RENT,
     i18nKey: 'listing.offering.nightly',
-    fallback: 'Rent by night',
     descriptionKey: 'listing.offering.nightlyHelp',
-    descriptionFallback: 'Vacation / short stays, priced per night.',
     icon: 'moon-outline',
   },
   {
     value: OfferingType.SALE,
     i18nKey: 'listing.offering.sell',
-    fallback: 'Sell',
     descriptionKey: 'listing.offering.sellHelp',
-    descriptionFallback: 'List the property for sale.',
     icon: 'pricetag-outline',
   },
   {
     value: OfferingType.EXCHANGE,
     i18nKey: 'listing.offering.exchange',
-    fallback: 'Exchange',
     descriptionKey: 'listing.offering.exchangeHelp',
-    descriptionFallback: 'Home swap or free hosting.',
     icon: 'swap-horizontal-outline',
   },
 ];
@@ -418,13 +408,12 @@ export const PRICING_OFFERING_OPTIONS: readonly OfferingOption[] = [
 export interface ChainStatusOption {
   value: NonNullable<import('@homiio/shared-types').PropertySale['chainStatus']>;
   i18nKey: string;
-  fallback: string;
 }
 
 export const CHAIN_STATUS_OPTIONS: readonly ChainStatusOption[] = [
-  { value: 'no_chain', i18nKey: 'listing.sale.chainStatus.noChain', fallback: 'No chain' },
-  { value: 'chain', i18nKey: 'listing.sale.chainStatus.chain', fallback: 'In a chain' },
-  { value: 'unknown', i18nKey: 'listing.sale.chainStatus.unknown', fallback: 'Unknown' },
+  { value: 'no_chain', i18nKey: 'listing.sale.chainStatus.noChain' },
+  { value: 'chain', i18nKey: 'listing.sale.chainStatus.chain' },
+  { value: 'unknown', i18nKey: 'listing.sale.chainStatus.unknown' },
 ];
 
 /**
@@ -435,32 +424,24 @@ export const CHAIN_STATUS_OPTIONS: readonly ChainStatusOption[] = [
 export interface ExchangeModeOption {
   value: ExchangeMode;
   i18nKey: string;
-  fallback: string;
   descriptionKey: string;
-  descriptionFallback: string;
 }
 
 export const EXCHANGE_MODE_OPTIONS: readonly ExchangeModeOption[] = [
   {
     value: ExchangeMode.SWAP,
     i18nKey: 'listing.exchange.mode.swap',
-    fallback: 'Home swap',
     descriptionKey: 'listing.exchange.mode.swapHelp',
-    descriptionFallback: 'Each party stays in the other’s home.',
   },
   {
     value: ExchangeMode.HOST,
     i18nKey: 'listing.exchange.mode.host',
-    fallback: 'Free hosting',
     descriptionKey: 'listing.exchange.mode.hostHelp',
-    descriptionFallback: 'Welcome a guest with no stay in return.',
   },
   {
     value: ExchangeMode.BOTH,
     i18nKey: 'listing.exchange.mode.both',
-    fallback: 'Either',
     descriptionKey: 'listing.exchange.mode.bothHelp',
-    descriptionFallback: 'Open to a swap or to hosting a guest.',
   },
 ];
 

--- a/packages/frontend/components/search/SearchPanel.tsx
+++ b/packages/frontend/components/search/SearchPanel.tsx
@@ -68,12 +68,12 @@ const BROWSE_MODE_ORDER: readonly BrowseMode[] = [
   'exchange',
 ];
 
-/** i18n key + fallback label for each browse mode in the panel toggle. */
-const BROWSE_MODE_LABELS: Record<BrowseMode, { key: string; fallback: string }> = {
-  long_term: { key: 'search.mode.longTerm', fallback: 'Long-term' },
-  vacation: { key: 'search.mode.vacation', fallback: 'Vacation' },
-  buy: { key: 'search.mode.buy', fallback: 'Buy' },
-  exchange: { key: 'search.mode.exchange', fallback: 'Exchange' },
+/** i18n key for each browse mode in the panel toggle. */
+const BROWSE_MODE_LABELS: Record<BrowseMode, string> = {
+  long_term: 'search.mode.longTerm',
+  vacation: 'search.mode.vacation',
+  buy: 'search.mode.buy',
+  exchange: 'search.mode.exchange',
 };
 
 /** Ordered steps per rental mode. Long-term never includes `dates`. */
@@ -85,11 +85,11 @@ const VACATION_STEPS: readonly SearchStep[] = ['where', 'type', 'dates', 'price'
  * single tapped step (mirrors the collapsed pill's column labels). The narrow
  * sheet keeps its own generic "Search" title and per-step content headings.
  */
-const STEP_TITLE: Record<SearchStep, { key: string; fallback: string }> = {
-  where: { key: 'searchBar.long.where', fallback: 'Where' },
-  type: { key: 'searchBar.long.propertyType', fallback: 'Property type' },
-  dates: { key: 'searchBar.vacation.when', fallback: 'When' },
-  price: { key: 'search.step.price.title', fallback: 'Price range' },
+const STEP_TITLE: Record<SearchStep, string> = {
+  where: 'searchBar.long.where',
+  type: 'searchBar.long.propertyType',
+  dates: 'searchBar.vacation.when',
+  price: 'search.step.price.title',
 };
 
 /**
@@ -345,7 +345,7 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({
       <Pressable
         onPress={onClose}
         accessibilityRole="button"
-        accessibilityLabel={t('common.close', 'Close') || 'Close'}
+        accessibilityLabel={t('common.close')}
         hitSlop={spacing.sm}
         style={styles.headerClose}
       >
@@ -353,7 +353,7 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({
       </Pressable>
       <View style={styles.modeToggle}>
         <SegmentedControl<BrowseMode>
-          label={t('search.mode.label', 'Browse mode') || 'Browse mode'}
+          label={t('search.mode.label')}
           type="tabs"
           size="small"
           value={draftBrowseMode}
@@ -362,8 +362,7 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({
           {BROWSE_MODE_ORDER.map((browseMode) => (
             <SegmentedControlItem key={browseMode} value={browseMode}>
               <SegmentedControlItemText>
-                {t(BROWSE_MODE_LABELS[browseMode].key, BROWSE_MODE_LABELS[browseMode].fallback) ||
-                  BROWSE_MODE_LABELS[browseMode].fallback}
+                {t(BROWSE_MODE_LABELS[browseMode])}
               </SegmentedControlItemText>
             </SegmentedControlItem>
           ))}
@@ -386,9 +385,9 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({
         variant="text"
         size="small"
         onPress={handleClear}
-        accessibilityLabel={t('search.actions.clearAll', 'Clear all') || 'Clear all'}
+        accessibilityLabel={t('search.actions.clearAll')}
       >
-        {t('search.actions.clearAll', 'Clear all') || 'Clear all'}
+        {t('search.actions.clearAll')}
       </Button>
       <View style={styles.footerActions}>
         {stepIndex > 0 ? (
@@ -396,9 +395,9 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({
             variant="secondary"
             size="medium"
             onPress={handleBack}
-            accessibilityLabel={t('common.back', 'Back') || 'Back'}
+            accessibilityLabel={t('common.back')}
           >
-            {t('common.back', 'Back') || 'Back'}
+            {t('common.back')}
           </Button>
         ) : null}
         {isLastStep ? (
@@ -408,18 +407,18 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({
             onPress={handleSubmit}
             icon={<Ionicons name="search" size={16} color={colors.primaryForeground} />}
             iconPosition="left"
-            accessibilityLabel={t('search.actions.search', 'Search') || 'Search'}
+            accessibilityLabel={t('search.actions.search')}
           >
-            {t('search.actions.search', 'Search') || 'Search'}
+            {t('search.actions.search')}
           </Button>
         ) : (
           <Button
             variant="primary"
             size="medium"
             onPress={handleNext}
-            accessibilityLabel={t('common.next', 'Next') || 'Next'}
+            accessibilityLabel={t('common.next')}
           >
-            {t('common.next', 'Next') || 'Next'}
+            {t('common.next')}
           </Button>
         )}
       </View>
@@ -434,8 +433,7 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({
   // the collapsed pill updates) and closes. No browse-mode toggle and no
   // Back/Next chrome: the pill's circular Search button runs the search.
   if (isWide) {
-    const stepTitle =
-      t(STEP_TITLE[step].key, STEP_TITLE[step].fallback) || STEP_TITLE[step].fallback;
+    const stepTitle = t(STEP_TITLE[step]);
     return (
       <Dialog
         placement="center"
@@ -451,9 +449,9 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({
             variant="primary"
             size="medium"
             onPress={handleApply}
-            accessibilityLabel={t('common.done', 'Done') || 'Done'}
+            accessibilityLabel={t('common.done')}
           >
-            {t('common.done', 'Done') || 'Done'}
+            {t('common.done')}
           </Button>
         </View>
       </Dialog>
@@ -467,13 +465,13 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({
         <Pressable
           style={styles.backdrop}
           accessibilityRole="button"
-          accessibilityLabel={t('common.close', 'Close') || 'Close'}
+          accessibilityLabel={t('common.close')}
           onPress={onClose}
         />
         <View style={styles.modalSheet}>
           <View style={styles.sheetHandleWrap}>
             <H3 style={styles.sheetTitle}>
-              {t('search.panel.title', 'Search') || 'Search'}
+              {t('search.panel.title')}
             </H3>
           </View>
           <View style={[styles.panel, styles.panelFull, cardShadow.lg]}>

--- a/packages/frontend/components/search/SearchResultsView.tsx
+++ b/packages/frontend/components/search/SearchResultsView.tsx
@@ -251,10 +251,10 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
       location: {
         label:
           query.location?.label ||
-          (t('search.summary.mapArea', 'Map area') || 'Map area'),
+          (t('search.summary.mapArea')),
         shortLabel:
           query.location?.shortLabel ||
-          (t('search.summary.mapArea', 'Map area') || 'Map area'),
+          (t('search.summary.mapArea')),
         center,
         bounds: pendingBounds,
       },
@@ -384,15 +384,12 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
 
   const resultsHeading = useMemo(() => {
     if (isLoading) {
-      return t('search.header.loading', 'Searching homes...') || 'Searching homes...';
+      return t('search.header.loading');
     }
     if (total === 0) {
-      return t('search.header.noResults', 'No homes match this search') ||
-        'No homes match this search';
+      return t('search.header.noResults');
     }
-    return (
-      t('search.header.count', `${total} homes`) || `${total} homes`
-    );
+    return t('search.header.count', { count: total });
   }, [t, isLoading, total]);
 
   // --- shared sub-renders ---
@@ -413,8 +410,8 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
             isSaved={isSearchSaved}
             saveAccessibilityLabel={
               isSearchSaved
-                ? t('search.actions.saved', 'Saved') || 'Saved'
-                : t('search.actions.save', 'Save') || 'Save'
+                ? t('search.actions.saved')
+                : t('search.actions.save')
             }
           />
         </View>
@@ -429,27 +426,27 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
           contentContainerStyle={styles.topBarActions}
         >
           <SearchActionPill
-            label={t('search.actions.filters', 'Filters') || 'Filters'}
+            label={t('search.actions.filters')}
             icon="options-outline"
             active={activeFilterCount > 0}
             count={activeFilterCount}
             onPress={handleFiltersPress}
             accessibilityLabel={
               activeFilterCount > 0
-                ? `${t('search.actions.filters', 'Filters') || 'Filters'}, ${activeFilterCount}`
-                : t('search.actions.filters', 'Filters') || 'Filters'
+                ? `${t('search.actions.filters')}, ${activeFilterCount}`
+                : t('search.actions.filters')
             }
           />
           <SearchActionPill
             label={
               sort.isDefault
-                ? t('search.actions.sort', 'Sort') || 'Sort'
+                ? t('search.actions.sort')
                 : sort.label
             }
             icon="swap-vertical"
             active={!sort.isDefault}
             onPress={handleSortPress}
-            accessibilityLabel={`${t('search.actions.sort', 'Sort') || 'Sort'}: ${sort.label}`}
+            accessibilityLabel={`${t('search.actions.sort')}: ${sort.label}`}
           />
         </ScrollView>
       </View>
@@ -473,9 +470,9 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
     if (isError) {
       return (
         <ErrorState
-          title={t('search.error.title', 'Could not load homes') || 'Could not load homes'}
+          title={t('search.error.title')}
           description={error?.message}
-          retryLabel={t('common.tryAgain', 'Try again') || 'Try again'}
+          retryLabel={t('common.tryAgain')}
           onRetry={() => void refetch()}
         />
       );
@@ -485,14 +482,12 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
         <EmptyState
           icon="home-outline"
           title={
-            t('search.empty.title', 'No homes match this search') ||
-            'No homes match this search'
+            t('search.empty.title')
           }
           description={
-            t('search.empty.description', 'Try widening your area or relaxing your filters.') ||
-            'Try widening your area or relaxing your filters.'
+            t('search.empty.description')
           }
-          actionText={t('search.empty.action', 'Edit search') || 'Edit search'}
+          actionText={t('search.empty.action')}
           actionIcon="search"
           onAction={onEditSearch}
         />
@@ -559,10 +554,10 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
               icon={<Ionicons name="refresh" size={16} color={colors.primaryForeground} />}
               iconPosition="left"
               accessibilityLabel={
-                t('search.actions.searchArea', 'Search this area') || 'Search this area'
+                t('search.actions.searchArea')
               }
             >
-              {t('search.actions.searchArea', 'Search this area') || 'Search this area'}
+              {t('search.actions.searchArea')}
             </Button>
           </View>
         </View>
@@ -617,8 +612,8 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
         onPress={() => setShowMobileMap((prev) => !prev)}
         label={
           showMobileMap
-            ? t('search.fab.list', 'List') || 'List'
-            : t('search.fab.map', 'Map') || 'Map'
+            ? t('search.fab.list')
+            : t('search.fab.map')
         }
         icon={showMobileMap ? 'list' : 'map'}
         // Lift the floating toggle above the home indicator (the FAB's default

--- a/packages/frontend/components/search/SearchSummaryBar.tsx
+++ b/packages/frontend/components/search/SearchSummaryBar.tsx
@@ -39,22 +39,22 @@ import { colors } from '@/styles/colors';
 import { cardShadow, hairline, radius, spacing, tracker } from '@/constants/styles';
 import type { SearchQuery, SearchStep } from './types';
 
-/** Human label for a single property type. */
-const TYPE_LABELS: Record<PropertyType, string> = {
-  [PropertyType.APARTMENT]: 'Apartment',
-  [PropertyType.HOUSE]: 'House',
-  [PropertyType.ROOM]: 'Room',
-  [PropertyType.STUDIO]: 'Studio',
-  [PropertyType.COUCHSURFING]: 'Couchsurfing',
-  [PropertyType.ROOMMATES]: 'Roommates',
-  [PropertyType.COLIVING]: 'Coliving',
-  [PropertyType.HOSTEL]: 'Hostel',
-  [PropertyType.GUESTHOUSE]: 'Guesthouse',
-  [PropertyType.CAMPSITE]: 'Campsite',
-  [PropertyType.BOAT]: 'Boat',
-  [PropertyType.TREEHOUSE]: 'Treehouse',
-  [PropertyType.YURT]: 'Yurt',
-  [PropertyType.OTHER]: 'Other',
+/** i18n key for a single property type label. */
+const TYPE_I18N_KEYS: Record<PropertyType, string> = {
+  [PropertyType.APARTMENT]: 'properties.titles.types.apartment',
+  [PropertyType.HOUSE]: 'properties.titles.types.house',
+  [PropertyType.ROOM]: 'properties.titles.types.room',
+  [PropertyType.STUDIO]: 'properties.titles.types.studio',
+  [PropertyType.COUCHSURFING]: 'search.propertyType.couchsurfing',
+  [PropertyType.ROOMMATES]: 'search.propertyType.roommates',
+  [PropertyType.COLIVING]: 'search.propertyType.coliving',
+  [PropertyType.HOSTEL]: 'search.propertyType.hostel',
+  [PropertyType.GUESTHOUSE]: 'search.propertyType.guesthouse',
+  [PropertyType.CAMPSITE]: 'search.propertyType.campsite',
+  [PropertyType.BOAT]: 'search.propertyType.boat',
+  [PropertyType.TREEHOUSE]: 'search.propertyType.treehouse',
+  [PropertyType.YURT]: 'search.propertyType.yurt',
+  [PropertyType.OTHER]: 'search.propertyType.other',
 };
 
 /**
@@ -269,23 +269,19 @@ export const SearchSummaryBar: React.FC<SearchSummaryBarProps> = ({
   const whereLabel = useMemo(
     () =>
       query.location?.shortLabel ||
-      (t('search.summary.anywhere', 'Anywhere') || 'Anywhere'),
+      (t('search.summary.anywhere')),
     [query.location?.shortLabel, t],
   );
 
   // Shared "Property type" label, reused by both layouts.
   const typeLabel = useMemo(() => {
     if (query.propertyTypes.length === 0) {
-      return t('search.summary.anyType', 'Any type') || 'Any type';
+      return t('search.summary.anyType');
     }
     if (query.propertyTypes.length === 1) {
-      const label = TYPE_LABELS[query.propertyTypes[0]];
-      return t(label, label) || label;
+      return t(TYPE_I18N_KEYS[query.propertyTypes[0]]);
     }
-    return (
-      t('search.summary.typeCount', `${query.propertyTypes.length} types`) ||
-      `${query.propertyTypes.length} types`
-    );
+    return t('search.summary.typeCount', { count: query.propertyTypes.length });
   }, [query.propertyTypes, t]);
 
   // Dates label for the wide pill's middle column.
@@ -296,9 +292,9 @@ export const SearchSummaryBar: React.FC<SearchSummaryBarProps> = ({
         : query.dates.start;
     }
     if (isVacation) {
-      return t('search.summary.anyTime', 'Any time') || 'Any time';
+      return t('search.summary.anyTime');
     }
-    return t('search.summary.addDates', 'Add dates') || 'Add dates';
+    return t('search.summary.addDates');
   }, [query.dates, isVacation, t]);
 
   // Single-line summary segments (compact mode, results top bar).
@@ -315,7 +311,7 @@ export const SearchSummaryBar: React.FC<SearchSummaryBarProps> = ({
     } else if (query.priceMin !== undefined) {
       price = `≥ €${query.priceMin}`;
     } else {
-      price = t('search.summary.anyPrice', 'Any price') || 'Any price';
+      price = t('search.summary.anyPrice');
     }
 
     return { where: whereLabel, type: typeLabel, price };
@@ -336,12 +332,12 @@ export const SearchSummaryBar: React.FC<SearchSummaryBarProps> = ({
     // three columns flex down and leave room for the full-size button.
     const isNarrow = !isWide;
     const whereColLabel =
-      t('searchBar.long.where', 'Where') || 'Where';
+      t('searchBar.long.where');
     const middleColLabel = isVacation
-      ? t('searchBar.vacation.when', 'When') || 'When'
-      : t('searchBar.long.moveIn', 'Move-in') || 'Move-in';
+      ? t('searchBar.vacation.when')
+      : t('searchBar.long.moveIn');
     const typeColLabel =
-      t('searchBar.long.propertyType', 'Property type') || 'Property type';
+      t('searchBar.long.propertyType');
 
     return (
       <View style={[styles.pill3col, cardShadow.md]}>
@@ -374,7 +370,7 @@ export const SearchSummaryBar: React.FC<SearchSummaryBarProps> = ({
           onPressIn={() => setSearchPressed(true)}
           onPressOut={() => setSearchPressed(false)}
           accessibilityRole="button"
-          accessibilityLabel={t('searchBar.search', 'Search') || 'Search'}
+          accessibilityLabel={t('searchBar.search')}
           style={[styles.searchButton, searchPressed && styles.searchButtonPressed]}
         >
           <Ionicons name="search" size={SEARCH_ICON_SIZE} color={colors.primaryForeground} />
@@ -398,7 +394,7 @@ export const SearchSummaryBar: React.FC<SearchSummaryBarProps> = ({
         onPressOut={() => setSummaryPressed(false)}
         accessibilityRole="button"
         accessibilityLabel={
-          t('search.summary.edit', 'Edit search') || 'Edit search'
+          t('search.summary.edit')
         }
         style={[styles.summaryTap, summaryPressed && styles.summaryTapPressed]}
       >
@@ -428,7 +424,7 @@ export const SearchSummaryBar: React.FC<SearchSummaryBarProps> = ({
             onPress={handleSavePress}
             accessibilityLabel={
               saveAccessibilityLabel ||
-              (t('search.actions.save', 'Save') || 'Save')
+              (t('search.actions.save'))
             }
           />
         </>

--- a/packages/frontend/components/search/SortControl.tsx
+++ b/packages/frontend/components/search/SortControl.tsx
@@ -22,7 +22,6 @@ import type { SearchSortBy, SearchSortOrder } from './types';
 interface SortOption {
   key: string;
   labelKey: string;
-  fallback: string;
   sortBy: SearchSortBy;
   sortOrder: SearchSortOrder;
 }
@@ -31,28 +30,24 @@ const SORT_OPTIONS: readonly SortOption[] = [
   {
     key: 'relevance',
     labelKey: 'search.sort.recommended',
-    fallback: 'Recommended',
     sortBy: 'relevance',
     sortOrder: 'desc',
   },
   {
     key: 'price_asc',
     labelKey: 'search.sort.priceAsc',
-    fallback: 'Price: Low to high',
     sortBy: 'price',
     sortOrder: 'asc',
   },
   {
     key: 'price_desc',
     labelKey: 'search.sort.priceDesc',
-    fallback: 'Price: High to low',
     sortBy: 'price',
     sortOrder: 'desc',
   },
   {
     key: 'newest',
     labelKey: 'search.sort.newest',
-    fallback: 'Newest first',
     sortBy: 'createdAt',
     sortOrder: 'desc',
   },
@@ -76,11 +71,11 @@ export const DEFAULT_SORT_OPTION = SORT_OPTIONS[0];
 export function resolveSortLabel(
   sortBy: SearchSortBy,
   sortOrder: SearchSortOrder,
-  t: (key: string, fallback: string) => string,
+  t: (key: string) => string,
 ): { label: string; isDefault: boolean } {
   const option = matchOption(sortBy, sortOrder);
   return {
-    label: t(option.labelKey, option.fallback) || option.fallback,
+    label: t(option.labelKey),
     isDefault: option.key === DEFAULT_SORT_OPTION.key,
   };
 }
@@ -143,10 +138,10 @@ export const SortControl: React.FC<SortControlProps> = ({
 
   return (
     <View style={styles.container}>
-      <H3 style={styles.title}>{t('search.sort.title', 'Sort by')}</H3>
+      <H3 style={styles.title}>{t('search.sort.title')}</H3>
       {SORT_OPTIONS.map((option) => {
         const isSelected = option.key === activeKey;
-        const label = t(option.labelKey, option.fallback) || option.fallback;
+        const label = t(option.labelKey);
         return (
           <SortRow
             key={option.key}

--- a/packages/frontend/components/search/steps/DatesStep.tsx
+++ b/packages/frontend/components/search/steps/DatesStep.tsx
@@ -118,14 +118,14 @@ export const DatesStep: React.FC<DatesStepProps> = ({ value, onChange, compact =
     <View style={styles.container}>
       {compact ? null : (
         <BloomText style={styles.heading}>
-          {t('search.step.dates.title', 'When?') || 'When?'}
+          {t('search.step.dates.title')}
         </BloomText>
       )}
 
       <View style={styles.weekdays}>
         {WEEKDAY_KEYS.map((key) => (
           <BloomText key={key} style={styles.weekday}>
-            {t(`search.step.dates.weekday.${key}`, key) || key}
+            {t(`search.step.dates.weekday.${key}`)}
           </BloomText>
         ))}
       </View>

--- a/packages/frontend/components/search/steps/PriceStep.tsx
+++ b/packages/frontend/components/search/steps/PriceStep.tsx
@@ -106,8 +106,8 @@ export const PriceStep: React.FC<PriceStepProps> = ({
   );
 
   const unitLabel = isVacation
-    ? t('search.step.price.perNight', 'per night') || 'per night'
-    : t('search.step.price.perMonth', 'per month') || 'per month';
+    ? t('search.step.price.perNight')
+    : t('search.step.price.perMonth');
 
   return (
     <View style={compact ? styles.containerCompact : styles.container}>
@@ -117,7 +117,7 @@ export const PriceStep: React.FC<PriceStepProps> = ({
         <BloomText style={styles.unitStandalone}>{`(${unitLabel})`}</BloomText>
       ) : (
         <BloomText style={styles.heading}>
-          {t('search.step.price.title', 'Price range') || 'Price range'}{' '}
+          {t('search.step.price.title')}{' '}
           <BloomText style={styles.unit}>({unitLabel})</BloomText>
         </BloomText>
       )}
@@ -145,7 +145,7 @@ export const PriceStep: React.FC<PriceStepProps> = ({
       <View style={styles.inputs}>
         <View style={styles.inputGroup}>
           <BloomText style={styles.inputLabel}>
-            {t('search.step.price.min', 'Minimum') || 'Minimum'}
+            {t('search.step.price.min')}
           </BloomText>
           <TextInput
             style={styles.input}
@@ -155,13 +155,13 @@ export const PriceStep: React.FC<PriceStepProps> = ({
             inputMode="numeric"
             placeholder={`${currencySymbol}0`}
             placeholderTextColor={colors.COLOR_BLACK_LIGHT_5}
-            accessibilityLabel={t('search.step.price.min', 'Minimum') || 'Minimum'}
+            accessibilityLabel={t('search.step.price.min')}
           />
         </View>
         <View style={styles.separator} />
         <View style={styles.inputGroup}>
           <BloomText style={styles.inputLabel}>
-            {t('search.step.price.max', 'Maximum') || 'Maximum'}
+            {t('search.step.price.max')}
           </BloomText>
           <TextInput
             style={styles.input}
@@ -169,9 +169,9 @@ export const PriceStep: React.FC<PriceStepProps> = ({
             onChangeText={handleMaxChange}
             keyboardType="number-pad"
             inputMode="numeric"
-            placeholder={t('search.step.price.any', 'Any') || 'Any'}
+            placeholder={t('search.step.price.any')}
             placeholderTextColor={colors.COLOR_BLACK_LIGHT_5}
-            accessibilityLabel={t('search.step.price.max', 'Maximum') || 'Maximum'}
+            accessibilityLabel={t('search.step.price.max')}
           />
         </View>
       </View>

--- a/packages/frontend/components/search/steps/TypeStep.tsx
+++ b/packages/frontend/components/search/steps/TypeStep.tsx
@@ -19,15 +19,15 @@ import { spacing } from '@/constants/styles';
 /** A selectable property type with its long-term and short-term labels. */
 interface TypeOption {
   type: PropertyType;
-  longTerm: string;
-  vacation: string;
+  longTermKey: string;
+  vacationKey: string;
 }
 
 const TYPE_OPTIONS: readonly TypeOption[] = [
-  { type: PropertyType.APARTMENT, longTerm: 'Apartments', vacation: 'Apartments' },
-  { type: PropertyType.HOUSE, longTerm: 'Houses', vacation: 'Whole houses' },
-  { type: PropertyType.ROOM, longTerm: 'Rooms', vacation: 'Private rooms' },
-  { type: PropertyType.STUDIO, longTerm: 'Studios', vacation: 'Studios' },
+  { type: PropertyType.APARTMENT, longTermKey: 'search.types.apartments', vacationKey: 'search.types.apartments' },
+  { type: PropertyType.HOUSE, longTermKey: 'search.types.houses', vacationKey: 'search.filters.propertyTypeVacation.wholeHouses' },
+  { type: PropertyType.ROOM, longTermKey: 'search.types.rooms', vacationKey: 'search.filters.propertyTypeVacation.privateRooms' },
+  { type: PropertyType.STUDIO, longTermKey: 'search.types.studios', vacationKey: 'search.types.studios' },
 ] as const;
 
 interface TypeStepProps {
@@ -56,12 +56,12 @@ export const TypeStep: React.FC<TypeStepProps> = ({
     <View style={compact ? styles.containerCompact : styles.container}>
       {compact ? null : (
         <BloomText style={styles.heading}>
-          {t('search.step.type.title', 'What type of place?') || 'What type of place?'}
+          {t('search.step.type.title')}
         </BloomText>
       )}
       <View style={styles.chips}>
         {TYPE_OPTIONS.map((option) => {
-          const label = isVacation ? option.vacation : option.longTerm;
+          const labelKey = isVacation ? option.vacationKey : option.longTermKey;
           const isSelected = selected.includes(option.type);
           return (
             <Chip
@@ -71,9 +71,9 @@ export const TypeStep: React.FC<TypeStepProps> = ({
               size="large"
               selected={isSelected}
               onPress={() => onToggle(option.type)}
-              accessibilityLabel={t(label, label) || label}
+              accessibilityLabel={t(labelKey)}
             >
-              {t(label, label) || label}
+              {t(labelKey)}
             </Chip>
           );
         })}

--- a/packages/frontend/components/search/steps/WhereStep.tsx
+++ b/packages/frontend/components/search/steps/WhereStep.tsx
@@ -167,8 +167,7 @@ export const WhereStep: React.FC<WhereStepProps> = ({
         onClearText={handleClear}
         autoFocus
         label={
-          t('search.input.placeholder', 'Search cities, neighborhoods, or addresses') ||
-          'Search cities, neighborhoods, or addresses'
+          t('search.input.placeholder')
         }
       />
 
@@ -176,7 +175,7 @@ export const WhereStep: React.FC<WhereStepProps> = ({
         recentSearches.length > 0 ? (
           <View style={styles.list}>
             <BloomText style={styles.sectionLabel}>
-              {t('search.recent.title', 'Recent searches') || 'Recent searches'}
+              {t('search.recent.title')}
             </BloomText>
             {recentSearches.map((recent) => (
               <SuggestionRow
@@ -194,8 +193,7 @@ export const WhereStep: React.FC<WhereStepProps> = ({
         <View style={styles.list}>
           {loading && resolvedSuggestions.length === 0 ? (
             <BloomText style={styles.statusText}>
-              {t('search.header.geocoding', 'Looking up location...') ||
-                'Looking up location...'}
+              {t('search.header.geocoding')}
             </BloomText>
           ) : null}
           {resolvedSuggestions.map((location) => (

--- a/packages/frontend/components/sindi/SindiPanel.tsx
+++ b/packages/frontend/components/sindi/SindiPanel.tsx
@@ -308,9 +308,7 @@ export function SindiPanel() {
             <Pressable
               onPress={handleBackToList}
               accessibilityRole="button"
-              accessibilityLabel={t('sindi.panel.conversations', {
-                defaultValue: 'Conversations',
-              })}
+              accessibilityLabel={t('sindi.panel.conversations')}
               style={styles.headerIconButton}
             >
               <Ionicons name="chevron-back" size={20} color={colors.primaryDark} />
@@ -322,10 +320,10 @@ export function SindiPanel() {
           )}
           <View style={styles.headerTitleWrap}>
             <BloomText style={styles.headerTitle} numberOfLines={1}>
-              {t('sindi.panel.title', { defaultValue: t('sindi.title') })}
+              {t('sindi.panel.title')}
             </BloomText>
             <BloomText style={styles.headerSubtitle} numberOfLines={1}>
-              {t('sindi.panel.subtitle', { defaultValue: t('sindi.subtitle') })}
+              {t('sindi.panel.subtitle')}
             </BloomText>
           </View>
         </View>
@@ -333,9 +331,7 @@ export function SindiPanel() {
           <Pressable
             onPress={handleNewChat}
             accessibilityRole="button"
-            accessibilityLabel={t('sindi.panel.newChat', {
-              defaultValue: 'New chat',
-            })}
+            accessibilityLabel={t('sindi.panel.newChat')}
             style={styles.headerIconButton}
           >
             <Ionicons name="create-outline" size={20} color={colors.primaryDark} />
@@ -343,7 +339,7 @@ export function SindiPanel() {
           <Pressable
             onPress={closeSindiPanel}
             accessibilityRole="button"
-            accessibilityLabel={t('sindi.panel.close', { defaultValue: 'Close' })}
+            accessibilityLabel={t('sindi.panel.close')}
             style={styles.headerIconButton}
           >
             <Ionicons name="close" size={20} color={colors.primaryDark} />
@@ -357,7 +353,7 @@ export function SindiPanel() {
           icon="lock-closed"
           title={t('sindi.auth.required')}
           description={t('sindi.auth.message')}
-          actionText={t('Sign in')}
+          actionText={t('common.signIn')}
           actionIcon="log-in"
           onAction={() => showSignInModal()}
           iconColor={colors.primaryColor}
@@ -387,34 +383,28 @@ export function SindiPanel() {
               <SindiIcon size={40} color={colors.primaryColor} />
             </View>
             <BloomText style={styles.introTitle}>
-              {t('sindi.panel.title', { defaultValue: t('sindi.title') })}
+              {t('sindi.panel.title')}
             </BloomText>
             <BloomText style={styles.introBody}>
-              {t('sindi.panel.intro', {
-                defaultValue: t('sindi.subtitle'),
-              })}
+              {t('sindi.panel.intro')}
             </BloomText>
           </View>
 
           <Pressable
             onPress={handleNewChat}
             accessibilityRole="button"
-            accessibilityLabel={t('sindi.panel.startNew', {
-              defaultValue: 'Start new conversation',
-            })}
+            accessibilityLabel={t('sindi.panel.startNew')}
             style={styles.startButton}
           >
             <Ionicons name="add" size={18} color={colors.primaryForeground} />
             <BloomText style={styles.startButtonLabel}>
-              {t('sindi.panel.startNew', {
-                defaultValue: 'Start new conversation',
-              })}
+              {t('sindi.panel.startNew')}
             </BloomText>
           </Pressable>
 
           <View style={styles.historyBlock}>
             <H3 style={styles.historyTitle}>
-              {t('sindi.panel.conversations', { defaultValue: 'Conversations' })}
+              {t('sindi.panel.conversations')}
             </H3>
             {loading ? (
               <PanelSkeleton />
@@ -426,9 +416,7 @@ export function SindiPanel() {
                   color={colors.muted}
                 />
                 <BloomText style={styles.emptyHistoryText}>
-                  {t('sindi.panel.empty', {
-                    defaultValue: 'Start a new conversation to get help.',
-                  })}
+                  {t('sindi.panel.empty')}
                 </BloomText>
               </View>
             ) : (
@@ -486,7 +474,7 @@ export function SindiPanel() {
           entering={FadeIn.duration(SCRIM_FADE_DURATION)}
           exiting={FadeOut.duration(SCRIM_FADE_DURATION)}
           accessibilityRole="button"
-          accessibilityLabel={t('sindi.panel.close', { defaultValue: 'Close' })}
+          accessibilityLabel={t('sindi.panel.close')}
           onPress={closeSindiPanel}
           style={[
             StyleSheet.absoluteFill,

--- a/packages/frontend/components/ui/SectionEyebrow.tsx
+++ b/packages/frontend/components/ui/SectionEyebrow.tsx
@@ -7,8 +7,8 @@
  * Centered on mobile (handled by parent), left-aligned by default.
  *
  * Usage:
- *   <SectionEyebrow>{t('home.recommended.eyebrow', 'For you')}</SectionEyebrow>
- *   <H1>{t('home.recommended.title', 'Recommended homes')}</H1>
+ *   <SectionEyebrow>{t('home.recommended.eyebrow')}</SectionEyebrow>
+ *   <H1>{t('home.recommended.title')}</H1>
  */
 import React from 'react';
 import { StyleSheet, type StyleProp, type TextStyle } from 'react-native';

--- a/packages/frontend/components/ui/StatusBadge.tsx
+++ b/packages/frontend/components/ui/StatusBadge.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, ViewStyle } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { Badge, type BadgeColor, type BadgeSize } from '@oxyhq/bloom/badge';
 import { colors } from '@/styles/colors';
@@ -7,7 +8,6 @@ import { colors } from '@/styles/colors';
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 
 export type StatusType =
-  // Contract statuses
   | 'draft'
   | 'pending'
   | 'pending_signatures'
@@ -15,17 +15,14 @@ export type StatusType =
   | 'expired'
   | 'terminated'
   | 'cancelled'
-  // Payment statuses
   | 'processing'
   | 'completed'
   | 'failed'
   | 'refunded'
-  // General statuses
   | 'success'
   | 'warning'
   | 'error'
   | 'info'
-  // Custom statuses
   | 'investigating'
   | 'resolved'
   | 'online'
@@ -46,55 +43,73 @@ interface StatusInfo {
   icon: IoniconName;
   color: string;
   badgeColor: BadgeColor;
-  label: string;
+  i18nKey: string;
 }
+
+const STATUS_I18N: Record<StatusType, string> = {
+  draft: 'statusBadge.draft',
+  pending: 'statusBadge.pending',
+  pending_signatures: 'statusBadge.pendingSignatures',
+  active: 'statusBadge.active',
+  expired: 'statusBadge.expired',
+  terminated: 'statusBadge.terminated',
+  cancelled: 'statusBadge.cancelled',
+  processing: 'statusBadge.processing',
+  completed: 'statusBadge.completed',
+  failed: 'statusBadge.failed',
+  refunded: 'statusBadge.refunded',
+  success: 'statusBadge.success',
+  warning: 'statusBadge.warning',
+  error: 'statusBadge.error',
+  info: 'statusBadge.info',
+  investigating: 'statusBadge.investigating',
+  resolved: 'statusBadge.resolved',
+  online: 'statusBadge.online',
+  offline: 'statusBadge.offline',
+};
 
 function getStatusInfo(status: StatusType): StatusInfo {
   switch (status) {
-    // Contract statuses
     case 'draft':
-      return { icon: 'document-outline', color: colors.COLOR_BLACK_LIGHT_3, badgeColor: 'default', label: 'Draft' };
+      return { icon: 'document-outline', color: colors.COLOR_BLACK_LIGHT_3, badgeColor: 'default', i18nKey: STATUS_I18N.draft };
     case 'pending':
-      return { icon: 'hourglass-outline', color: colors.warning, badgeColor: 'warning', label: 'Pending' };
+      return { icon: 'hourglass-outline', color: colors.warning, badgeColor: 'warning', i18nKey: STATUS_I18N.pending };
     case 'pending_signatures':
-      return { icon: 'create-outline', color: colors.warning, badgeColor: 'warning', label: 'Pending signatures' };
+      return { icon: 'create-outline', color: colors.warning, badgeColor: 'warning', i18nKey: STATUS_I18N.pending_signatures };
     case 'active':
-      return { icon: 'checkmark-circle', color: colors.success, badgeColor: 'success', label: 'Active' };
+      return { icon: 'checkmark-circle', color: colors.success, badgeColor: 'success', i18nKey: STATUS_I18N.active };
     case 'expired':
-      return { icon: 'calendar-outline', color: colors.textTertiary, badgeColor: 'default', label: 'Expired' };
+      return { icon: 'calendar-outline', color: colors.textTertiary, badgeColor: 'default', i18nKey: STATUS_I18N.expired };
     case 'terminated':
-      return { icon: 'close-circle-outline', color: colors.danger, badgeColor: 'error', label: 'Terminated' };
+      return { icon: 'close-circle-outline', color: colors.danger, badgeColor: 'error', i18nKey: STATUS_I18N.terminated };
     case 'cancelled':
-      return { icon: 'close-circle-outline', color: colors.textTertiary, badgeColor: 'default', label: 'Cancelled' };
-    // Payment statuses
+      return { icon: 'close-circle-outline', color: colors.textTertiary, badgeColor: 'default', i18nKey: STATUS_I18N.cancelled };
     case 'processing':
-      return { icon: 'reload-outline', color: colors.info, badgeColor: 'info', label: 'Processing' };
+      return { icon: 'reload-outline', color: colors.info, badgeColor: 'info', i18nKey: STATUS_I18N.processing };
     case 'completed':
-      return { icon: 'checkmark-circle', color: colors.success, badgeColor: 'success', label: 'Completed' };
+      return { icon: 'checkmark-circle', color: colors.success, badgeColor: 'success', i18nKey: STATUS_I18N.completed };
     case 'failed':
-      return { icon: 'close-circle-outline', color: colors.danger, badgeColor: 'error', label: 'Failed' };
+      return { icon: 'close-circle-outline', color: colors.danger, badgeColor: 'error', i18nKey: STATUS_I18N.failed };
     case 'refunded':
-      return { icon: 'refresh-circle-outline', color: colors.textTertiary, badgeColor: 'default', label: 'Refunded' };
-    // General statuses
+      return { icon: 'refresh-circle-outline', color: colors.textTertiary, badgeColor: 'default', i18nKey: STATUS_I18N.refunded };
     case 'success':
-      return { icon: 'checkmark-circle', color: colors.success, badgeColor: 'success', label: 'Success' };
+      return { icon: 'checkmark-circle', color: colors.success, badgeColor: 'success', i18nKey: STATUS_I18N.success };
     case 'warning':
-      return { icon: 'warning', color: colors.warning, badgeColor: 'warning', label: 'Warning' };
+      return { icon: 'warning', color: colors.warning, badgeColor: 'warning', i18nKey: STATUS_I18N.warning };
     case 'error':
-      return { icon: 'close-circle-outline', color: colors.danger, badgeColor: 'error', label: 'Error' };
+      return { icon: 'close-circle-outline', color: colors.danger, badgeColor: 'error', i18nKey: STATUS_I18N.error };
     case 'info':
-      return { icon: 'information-circle-outline', color: colors.info, badgeColor: 'info', label: 'Info' };
-    // Custom statuses
+      return { icon: 'information-circle-outline', color: colors.info, badgeColor: 'info', i18nKey: STATUS_I18N.info };
     case 'investigating':
-      return { icon: 'search-outline', color: colors.warning, badgeColor: 'warning', label: 'Investigating' };
+      return { icon: 'search-outline', color: colors.warning, badgeColor: 'warning', i18nKey: STATUS_I18N.investigating };
     case 'resolved':
-      return { icon: 'checkmark-circle', color: colors.success, badgeColor: 'success', label: 'Resolved' };
+      return { icon: 'checkmark-circle', color: colors.success, badgeColor: 'success', i18nKey: STATUS_I18N.resolved };
     case 'online':
-      return { icon: 'radio-button-on', color: colors.success, badgeColor: 'success', label: 'Online' };
+      return { icon: 'radio-button-on', color: colors.success, badgeColor: 'success', i18nKey: STATUS_I18N.online };
     case 'offline':
-      return { icon: 'radio-button-off', color: colors.textTertiary, badgeColor: 'default', label: 'Offline' };
+      return { icon: 'radio-button-off', color: colors.textTertiary, badgeColor: 'default', i18nKey: STATUS_I18N.offline };
     default:
-      return { icon: 'help-circle-outline', color: colors.COLOR_BLACK_LIGHT_3, badgeColor: 'default', label: 'Unknown' };
+      return { icon: 'help-circle-outline', color: colors.COLOR_BLACK_LIGHT_3, badgeColor: 'default', i18nKey: 'statusBadge.unknown' };
   }
 }
 
@@ -120,13 +135,12 @@ export function StatusBadge({
   customIcon,
   customText,
 }: StatusBadgeProps) {
+  const { t } = useTranslation();
   const statusInfo = getStatusInfo(status);
   const finalColor = customColor || statusInfo.color;
   const finalIcon = (customIcon as IoniconName | undefined) || statusInfo.icon;
-  const finalText = customText || statusInfo.label;
+  const finalText = customText ?? t(statusInfo.i18nKey);
 
-  // When icon + text is desired with a custom override color, render a custom row
-  // so we can keep the original Homiio look (solid bg + white icon + white text).
   if (showIcon && showText) {
     const iconSize = ICON_SIZE_MAP[size];
     const padding = size === 'small' ? 2 : size === 'large' ? 6 : 4;
@@ -144,7 +158,6 @@ export function StatusBadge({
     );
   }
 
-  // Otherwise delegate to Bloom Badge.
   return (
     <Badge
       content={showText ? finalText : undefined}

--- a/packages/frontend/components/ui/TruncatedDescription.tsx
+++ b/packages/frontend/components/ui/TruncatedDescription.tsx
@@ -63,13 +63,13 @@ export const TruncatedDescription: React.FC<TruncatedDescriptionProps> = ({
             size="small"
             accessibilityLabel={
               expanded
-                ? t('property.description.showLess', 'Show less') || 'Show less'
-                : t('property.description.showMore', 'Show more') || 'Show more'
+                ? t('property.description.showLess')
+                : t('property.description.showMore')
             }
           >
             {expanded
-              ? t('property.description.showLess', 'Show less') || 'Show less'
-              : t('property.description.showMore', 'Show more') || 'Show more'}
+              ? t('property.description.showLess')
+              : t('property.description.showMore')}
           </Button>
         </View>
       ) : null}

--- a/packages/frontend/components/ui/createStatusBadge.tsx
+++ b/packages/frontend/components/ui/createStatusBadge.tsx
@@ -8,10 +8,9 @@
  * rendering rule so each domain only declares its map.
  *
  * Each entry carries a Bloom `color` and a `label`. When an entry also supplies
- * an `i18nKey`, the badge renders `t(i18nKey, label)` (label as the fallback);
- * otherwise it renders the literal `label`. The returned component always calls
- * `useTranslation`, so an i18n map and a static map share one code path without
- * the caller opting in.
+ * an `i18nKey`, the badge renders `t(i18nKey)`; otherwise it renders the literal
+ * `label`. The returned component always calls `useTranslation`, so an i18n map
+ * and a static map share one code path without the caller opting in.
  */
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -21,9 +20,9 @@ import { Badge, type BadgeColor } from '@oxyhq/bloom/badge';
 export interface StatusBadgeEntry {
   /** Bloom semantic color for the badge. */
   color: BadgeColor;
-  /** Display label, or the i18n fallback when `i18nKey` is set. */
+  /** Display label when no `i18nKey` is set. */
   label: string;
-  /** When present, the label is resolved as `t(i18nKey, label)`. */
+  /** When present, the label is resolved as `t(i18nKey)`. */
   i18nKey?: string;
 }
 
@@ -43,7 +42,7 @@ export function createStatusBadge<T extends string>(
   const StatusBadge: React.FC<StatusBadgeProps<T>> = ({ status }) => {
     const { t } = useTranslation();
     const entry = map[status];
-    const content = entry.i18nKey ? t(entry.i18nKey, entry.label) : entry.label;
+    const content = entry.i18nKey ? t(entry.i18nKey) : entry.label;
     return <Badge content={content} variant="subtle" color={entry.color} size="small" />;
   };
   return StatusBadge;

--- a/packages/frontend/components/widgets/EcoCertificationWidget.tsx
+++ b/packages/frontend/components/widgets/EcoCertificationWidget.tsx
@@ -9,15 +9,12 @@ export function EcoCertificationWidget() {
 
   return (
     <BaseWidget
-      title={t('home.eco.title', 'Eco-Certified Properties')}
+      title={t('home.eco.title')}
       icon={<Ionicons name="leaf" size={22} color="green" />}
     >
       <View style={styles.ecoCertContent}>
         <Text style={styles.ecoText}>
-          {t(
-            'home.eco.description',
-            'Find sustainable properties that meet eco-friendly standards',
-          )}
+          {t('home.eco.description')}
         </Text>
       </View>
     </BaseWidget>

--- a/packages/frontend/components/widgets/FeaturedPropertiesWidget.tsx
+++ b/packages/frontend/components/widgets/FeaturedPropertiesWidget.tsx
@@ -54,7 +54,7 @@ export function FeaturedPropertiesWidget() {
         {loading ? (
           <View style={styles.loadingContainer}>
             <Loading iconSize={16} showText={false} />
-            <ThemedText style={styles.loadingText}>{t('state.loading')}</ThemedText>
+            <ThemedText style={styles.loadingText}>{t('common.loading')}</ThemedText>
           </View>
         ) : (
           <FeaturedProperties properties={featured} />

--- a/packages/frontend/components/widgets/HorizonInitiativeWidget.tsx
+++ b/packages/frontend/components/widgets/HorizonInitiativeWidget.tsx
@@ -13,14 +13,11 @@ export function HorizonInitiativeWidget() {
 
   return (
     <BaseWidget
-      title={t('horizon.title', 'Horizon Initiative')}
+      title={t('horizon.title')}
       icon={<Ionicons name="star" size={22} color={colors.ratingStar} />}
     >
       <ThemedText style={styles.membershipText}>
-        {t(
-          'horizon.description',
-          'Horizon is a global initiative offering fair housing, healthcare, and travel support. Integrated with Homiio, it ensures affordable living within a connected, sustainable network.',
-        )}
+        {t('horizon.description')}
       </ThemedText>
       <Button
         style={styles.joinButton}
@@ -29,7 +26,7 @@ export function HorizonInitiativeWidget() {
           Linking.openURL('https://oxy.so/horizon').catch(() => undefined);
         }}
       >
-        {t('home.horizon.learnMore', 'Learn More')}
+        {t('home.horizon.learnMore')}
       </Button>
     </BaseWidget>
   );

--- a/packages/frontend/components/widgets/NeighborhoodRatingWidget.tsx
+++ b/packages/frontend/components/widgets/NeighborhoodRatingWidget.tsx
@@ -46,7 +46,7 @@ export function NeighborhoodRatingWidget({
 
   return (
     <BaseWidget
-      title={t('Neighborhood')}
+      title={t('property.neighborhood.title')}
       icon={<Ionicons name="location" size={22} color={colors.primaryColor} />}
     >
       <View style={styles.container}>
@@ -58,12 +58,12 @@ export function NeighborhoodRatingWidget({
         <View style={styles.metricsRow}>
           <View style={styles.metric}>
             <Text style={styles.metricValue}>{listingCount}</Text>
-            <Text style={styles.metricLabel}>{t('Listings')}</Text>
+            <Text style={styles.metricLabel}>{t('property.neighborhood.listings')}</Text>
           </View>
           {averageRent !== null ? (
             <View style={styles.metric}>
               <Text style={styles.metricValue}>{formatCurrency(averageRent, currencyCode)}</Text>
-              <Text style={styles.metricLabel}>{t('Avg. rent / mo')}</Text>
+              <Text style={styles.metricLabel}>{t('property.neighborhood.avgRentPerMonth')}</Text>
             </View>
           ) : null}
         </View>
@@ -77,10 +77,10 @@ export function NeighborhoodRatingWidget({
             />
             <Text style={styles.vsCityText}>
               {vsCity.percentDiff === 0
-                ? t('On par with the city average')
-                : t('{{pct}}% {{dir}} than the city average', {
+                ? t('property.neighborhood.onParWithCity')
+                : t('property.neighborhood.pctVsCity', {
                     pct: Math.abs(vsCity.percentDiff),
-                    dir: vsCity.percentDiff < 0 ? t('cheaper') : t('pricier'),
+                    dir: vsCity.percentDiff < 0 ? t('property.neighborhood.cheaper') : t('property.neighborhood.pricier'),
                   })}
             </Text>
           </View>

--- a/packages/frontend/components/widgets/TrustScoreWidget.tsx
+++ b/packages/frontend/components/widgets/TrustScoreWidget.tsx
@@ -11,6 +11,17 @@ import { useActiveProfile } from '@/hooks/useProfileQueries';
 import { ThemedText } from '../ThemedText';
 import { BaseWidget } from './BaseWidget';
 
+const TRUST_FACTOR_TYPES = new Set([
+  'verification',
+  'reviews',
+  'payment_history',
+  'communication',
+  'rental_history',
+]);
+
+const trustFactorLabel = (type: string, t: (key: string) => string): string =>
+  TRUST_FACTOR_TYPES.has(type) ? t(`trust.manager.factors.${type}.label`) : type;
+
 export const TrustScoreWidget = React.memo(function TrustScoreWidget() {
   const { t } = useTranslation();
   const { isAuthenticated } = useOxy();
@@ -63,8 +74,8 @@ export const TrustScoreWidget = React.memo(function TrustScoreWidget() {
       <Loading iconSize={16} showText={false} />
       <ThemedText style={styles.loadingText}>
         {profileType === 'agency'
-          ? t('trust.loadingVerification', 'Loading verification status...')
-          : t('trust.loadingScore', 'Loading trust score...')}
+          ? t('trust.loadingVerification')
+          : t('trust.loadingScore')}
       </ThemedText>
     </View>
   ), [profileType, t]);
@@ -74,12 +85,12 @@ export const TrustScoreWidget = React.memo(function TrustScoreWidget() {
     <View style={styles.errorContainer}>
       <ThemedText style={styles.errorText}>
         {profileType === 'agency'
-          ? t('trust.errorVerification', 'Unable to load verification status')
-          : t('trust.errorScore', 'Unable to load trust score')}
+          ? t('trust.errorVerification')
+          : t('trust.errorScore')}
       </ThemedText>
       <TouchableOpacity style={[styles.retryButton]} onPress={handlePress}>
         <ThemedText style={styles.retryButtonText}>
-          {t('trust.viewDetails', 'View Details')}
+          {t('trust.viewDetails')}
         </ThemedText>
       </TouchableOpacity>
     </View>
@@ -90,14 +101,14 @@ export const TrustScoreWidget = React.memo(function TrustScoreWidget() {
     <View style={styles.noProfileContainer}>
       <Text style={styles.noProfileText}>
         {profileType === 'agency'
-          ? t('trust.noVerification', 'No verification data')
-          : t('trust.noScore', 'No trust score data')}
+          ? t('trust.noVerification')
+          : t('trust.noScore')}
       </Text>
       <TouchableOpacity
         style={[styles.setupButton, { backgroundColor: colors.primaryColor }]}
         onPress={handlePress}
       >
-        <Text style={styles.setupButtonText}>{t('trust.viewDetails', 'View Details')}</Text>
+        <Text style={styles.setupButtonText}>{t('trust.viewDetails')}</Text>
       </TouchableOpacity>
     </View>
   ), [profileType, t, handlePress]);
@@ -115,18 +126,20 @@ export const TrustScoreWidget = React.memo(function TrustScoreWidget() {
               {Math.round(trustScoreData.score)}%
             </ThemedText>
             <ThemedText style={styles.verificationLabel}>
-              {t('trust.verified', 'Verified')}
+              {t('trust.verified')}
             </ThemedText>
           </View>
         </View>
         <View style={styles.rightCol}>
-          <ThemedText style={styles.rowTitle}>{trustScoreData.level}</ThemedText>
+          <ThemedText style={styles.rowTitle}>
+            {t(`trust.score.levels.${trustScoreData.levelKey}`)}
+          </ThemedText>
           <TouchableOpacity
             style={[styles.ctaButton, { backgroundColor: scoreColor }]}
             onPress={handlePress}
           >
             <ThemedText style={styles.ctaButtonText}>
-              {t('trust.completeVerification', 'Complete Verification')}
+              {t('trust.completeVerification')}
             </ThemedText>
           </TouchableOpacity>
         </View>
@@ -146,13 +159,13 @@ export const TrustScoreWidget = React.memo(function TrustScoreWidget() {
         </View>
         <View style={styles.rightCol}>
           <ThemedText style={styles.rowTitle}>
-            {t('trust.yourScoreIs', 'Your trust score is')} {trustScoreData.level}
+            {t('trust.yourScoreIs')} {t(`trust.score.levels.${trustScoreData.levelKey}`)}
           </ThemedText>
           <View style={styles.factorsRow}>
             {trustScoreData.factors.slice(0, 3).map((factor, index) => (
               <View key={index} style={styles.factorChip}>
                 <ThemedText style={styles.factorChipText}>
-                  {factor.type.replace('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase())}
+                  {trustFactorLabel(factor.type, t)}
                 </ThemedText>
                 <View style={styles.chipProgress}>
                   <View style={[styles.chipProgressFill, { width: `${factor.value}%`, backgroundColor: scoreColor }]} />
@@ -165,7 +178,7 @@ export const TrustScoreWidget = React.memo(function TrustScoreWidget() {
             onPress={handlePress}
           >
             <ThemedText style={styles.ctaButtonText}>
-              {t('trust.improveScore', 'Improve Score')}
+              {t('trust.improveScore')}
             </ThemedText>
           </TouchableOpacity>
         </View>

--- a/packages/frontend/constants/amenities.tsx
+++ b/packages/frontend/constants/amenities.tsx
@@ -67,6 +67,7 @@ export const AMENITY_CATEGORIES: AmenityCategory[] = [
   {
     id: 'kitchen',
     name: 'Kitchen & dining',
+    nameKey: 'amenities.kitchen',
     nameKey: 'amenities.categories.kitchen',
     icon: 'restaurant',
     color: '#ea580c',
@@ -210,6 +211,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'wheelchair_accessible',
     name: 'Wheelchair Accessible',
+    nameKey: 'amenities.wheelchairAccessible',
     icon: 'accessibility',
     category: 'accessibility',
     description: 'Full ADA compliance with ramps, wide doorways, and accessible bathrooms',
@@ -221,6 +223,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'elevator',
     name: 'Elevator Access',
+    nameKey: 'amenities.elevator',
     icon: 'arrow-up',
     category: 'accessibility',
     description: 'Building elevator for multi-floor access',
@@ -232,6 +235,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'grab_bars',
     name: 'Safety Grab Bars',
+    nameKey: 'amenities.grabBars',
     icon: 'hand-right',
     category: 'accessibility',
     description: 'Bathroom safety grab bars and support rails',
@@ -243,6 +247,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'wide_doorways',
     name: 'Wide Doorways',
+    nameKey: 'amenities.wideDoorways',
     icon: 'resize',
     category: 'accessibility',
     description: 'Extra-wide doorways for accessibility',
@@ -254,6 +259,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'ramp_access',
     name: 'Ramp Access',
+    nameKey: 'amenities.rampAccess',
     icon: 'trending-up',
     category: 'accessibility',
     description: 'Wheelchair ramp access to building',
@@ -267,6 +273,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'solar_panels',
     name: 'Solar Energy System',
+    nameKey: 'amenities.solarPanels',
     icon: 'sunny',
     category: 'eco',
     description: 'Renewable energy reducing environmental impact',
@@ -277,6 +284,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'energy_efficient',
     name: 'Energy Star Appliances',
+    nameKey: 'amenities.energyEfficient',
     icon: 'leaf',
     category: 'eco',
     description: 'ENERGY STAR certified appliances for efficiency',
@@ -287,6 +295,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'recycling_program',
     name: 'Comprehensive Recycling',
+    nameKey: 'amenities.recyclingProgram',
     icon: 'refresh',
     category: 'eco',
     description: 'Full recycling and composting programs',
@@ -297,6 +306,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'green_roof',
     name: 'Living Roof System',
+    nameKey: 'amenities.greenRoof',
     icon: 'leaf',
     category: 'eco',
     description: 'Green roof with plants for insulation and air quality',
@@ -307,6 +317,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'rainwater_collection',
     name: 'Rainwater Harvesting',
+    nameKey: 'amenities.rainwaterCollection',
     icon: 'water',
     category: 'eco',
     description: 'Rainwater collection system for sustainability',
@@ -319,6 +330,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'air_conditioning',
     name: 'Air Conditioning',
+    nameKey: 'amenities.airConditioning',
     icon: 'snow',
     category: 'comfort',
     description: 'Cooling system for health and safety in hot weather',
@@ -329,6 +341,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'insulation',
     name: 'Proper Insulation',
+    nameKey: 'amenities.insulation',
     icon: 'shield',
     category: 'comfort',
     description: 'Well-insulated for energy efficiency and comfort',
@@ -339,6 +352,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'ceiling_fans',
     name: 'Ceiling Fans',
+    nameKey: 'amenities.ceilingFans',
     icon: 'refresh',
     category: 'comfort',
     description: 'Energy-efficient ceiling fans for air circulation',
@@ -362,6 +376,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'refrigerator',
     name: 'Full-Size Refrigerator',
+    nameKey: 'amenities.refrigerator',
     icon: 'snow',
     category: 'kitchen',
     description: 'Essential food storage appliance',
@@ -373,6 +388,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'stove',
     name: 'Cooking Range',
+    nameKey: 'amenities.stove',
     icon: 'flame',
     category: 'kitchen',
     description: 'Gas or electric cooking range for food preparation',
@@ -384,6 +400,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'oven',
     name: 'Oven',
+    nameKey: 'amenities.oven',
     icon: 'flame',
     category: 'kitchen',
     description: 'Built-in oven for cooking and baking',
@@ -395,6 +412,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'microwave',
     name: 'Microwave',
+    nameKey: 'amenities.microwave',
     icon: 'radio',
     category: 'kitchen',
     description: 'Energy-efficient microwave for quick food preparation',
@@ -405,6 +423,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'dishwasher',
     name: 'Dishwasher',
+    nameKey: 'amenities.dishwasher',
     icon: 'water',
     category: 'kitchen',
     description: 'Energy-efficient dishwasher',
@@ -417,6 +436,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'washing_machine',
     name: 'In-Unit Washer',
+    nameKey: 'amenities.washingMachine',
     icon: 'shirt',
     category: 'essential',
     description: 'Private washing machine in unit',
@@ -427,6 +447,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'dryer',
     name: 'In-Unit Dryer',
+    nameKey: 'amenities.dryer',
     icon: 'shirt',
     category: 'essential',
     description: 'Private clothes dryer in unit',
@@ -437,6 +458,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'laundry_room',
     name: 'Shared Laundry Facility',
+    nameKey: 'amenities.laundryRoom',
     icon: 'business',
     category: 'essential',
     description: 'Clean, well-maintained shared laundry room',
@@ -450,6 +472,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'bike_storage',
     name: 'Secure Bike Storage',
+    nameKey: 'amenities.bikeStorage',
     icon: 'bicycle',
     category: 'transportation',
     description: 'Safe bicycle storage facility',
@@ -460,6 +483,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'parking_space',
     name: 'Parking Space',
+    nameKey: 'amenities.parkingSpace',
     icon: 'car',
     category: 'transportation',
     description: 'Assigned parking spot',
@@ -470,6 +494,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'ev_charging',
     name: 'Electric Vehicle Charging',
+    nameKey: 'amenities.evCharging',
     icon: 'battery-charging',
     category: 'transportation',
     description: 'Electric vehicle charging station access',
@@ -480,6 +505,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'public_transit_access',
     name: 'Public Transit Access',
+    nameKey: 'amenities.publicTransitAccess',
     icon: 'bus',
     category: 'transportation',
     description: 'Close proximity to public transportation',
@@ -492,6 +518,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'fire_safety',
     name: 'Fire Safety System',
+    nameKey: 'amenities.fireSafety',
     icon: 'flame',
     category: 'security',
     description: 'Sprinklers, alarms, and emergency systems',
@@ -503,6 +530,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'secure_entry',
     name: 'Controlled Access',
+    nameKey: 'amenities.secureEntry',
     icon: 'key',
     category: 'security',
     description: 'Secure building entry with access control',
@@ -513,6 +541,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'security_cameras',
     name: 'Security Cameras',
+    nameKey: 'amenities.securityCameras',
     icon: 'videocam',
     category: 'security',
     description: 'CCTV surveillance in common areas (with privacy protections)',
@@ -523,6 +552,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'intercom',
     name: 'Intercom System',
+    nameKey: 'amenities.intercom',
     icon: 'chatbubble',
     category: 'security',
     description: 'Building intercom for visitor communication',
@@ -535,6 +565,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'storage_unit',
     name: 'Storage Space',
+    nameKey: 'amenities.storageUnit',
     icon: 'cube',
     category: 'storage',
     description: 'Additional storage space',
@@ -545,6 +576,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'walk_in_closet',
     name: 'Walk-in Closet',
+    nameKey: 'amenities.walkInCloset',
     icon: 'shirt',
     category: 'storage',
     description: 'Large walk-in closet space',
@@ -555,6 +587,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'pantry',
     name: 'Kitchen Pantry',
+    nameKey: 'amenities.pantry',
     icon: 'library',
     category: 'storage',
     description: 'Kitchen pantry for food storage',
@@ -567,6 +600,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'community_room',
     name: 'Community Room',
+    nameKey: 'amenities.communityRoom',
     icon: 'people',
     category: 'community',
     description: 'Shared community space for residents',
@@ -577,6 +611,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'gym',
     name: 'Fitness Center',
+    nameKey: 'amenities.gym',
     icon: 'fitness',
     category: 'wellness',
     description: 'On-site fitness facility',
@@ -597,6 +632,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'garden_space',
     name: 'Community Garden',
+    nameKey: 'amenities.gardenSpace',
     icon: 'flower',
     category: 'community',
     description: 'Shared gardening space for residents',
@@ -609,6 +645,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'fiber_internet',
     name: 'Fiber Internet',
+    nameKey: 'amenities.fiberInternet',
     icon: 'wifi',
     category: 'technology',
     description: 'Ultra-high-speed fiber internet connection',
@@ -620,6 +657,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'cable_tv',
     name: 'Cable TV Ready',
+    nameKey: 'amenities.cableTv',
     icon: 'tv',
     category: 'technology',
     description: 'Pre-wired for cable television service',
@@ -632,6 +670,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'balcony',
     name: 'Private Balcony',
+    nameKey: 'amenities.balcony',
     icon: 'leaf',
     category: 'outdoor',
     description: 'Private outdoor balcony space',
@@ -642,6 +681,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'garden_access',
     name: 'Garden Access',
+    nameKey: 'amenities.gardenAccess',
     icon: 'flower',
     category: 'outdoor',
     description: 'Access to shared garden space',
@@ -652,6 +692,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'natural_light',
     name: 'Abundant Natural Light',
+    nameKey: 'amenities.naturalLight',
     icon: 'sunny',
     category: 'outdoor',
     description: 'Large windows and good natural light',
@@ -664,6 +705,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'pet_friendly',
     name: 'Pet-Friendly Policy',
+    nameKey: 'amenities.petFriendly',
     icon: 'paw',
     category: 'community',
     description: 'Welcomes pets with reasonable policies',
@@ -675,6 +717,7 @@ export const AMENITIES: Amenity[] = [
   {
     id: 'dog_park',
     name: 'Pet Exercise Area',
+    nameKey: 'amenities.dogPark',
     icon: 'paw',
     category: 'outdoor',
     description: 'Dedicated pet exercise and socialization area',

--- a/packages/frontend/context/SavedPropertiesContext.tsx
+++ b/packages/frontend/context/SavedPropertiesContext.tsx
@@ -7,6 +7,7 @@ import React, {
   ReactNode,
 } from 'react';
 import { toast } from '@/lib/sonner';
+import i18next from 'i18next';
 import { useOxy } from '@oxyhq/services';
 import savedPropertyFolderService, {
   SavedPropertyFolder,
@@ -135,7 +136,7 @@ export const SavedPropertiesProvider: React.FC<SavedPropertiesProviderProps> = (
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Failed to load folders';
       setError(message);
-      toast.error('Failed to load folders');
+      toast.error(i18next.t('saved.toast.loadFoldersFailed'));
     }
   }, [isAuthenticated, queryClient]);
 
@@ -159,12 +160,12 @@ export const SavedPropertiesProvider: React.FC<SavedPropertiesProviderProps> = (
         queryClient.setQueryData<SavedPropertyFoldersResponse>(SAVED_FOLDERS_KEY, (prev) => ({
           folders: [...(prev?.folders ?? []), newFolder],
         }));
-        toast.success('Folder created successfully');
+        toast.success(i18next.t('saved.toast.folderCreated'));
         return newFolder;
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : 'Failed to create folder';
         setError(message);
-        toast.error('Failed to create folder');
+        toast.error(i18next.t('saved.toast.folderCreateFailed'));
         throw error;
       }
     },
@@ -188,12 +189,12 @@ export const SavedPropertiesProvider: React.FC<SavedPropertiesProviderProps> = (
             folder._id === folderId ? updatedFolder : folder,
           ),
         }));
-        toast.success('Folder updated successfully');
+        toast.success(i18next.t('saved.toast.folderUpdated'));
         return updatedFolder;
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : 'Failed to update folder';
         setError(message);
-        toast.error('Failed to update folder');
+        toast.error(i18next.t('saved.toast.folderUpdateFailed'));
         throw error;
       }
     },
@@ -209,11 +210,11 @@ export const SavedPropertiesProvider: React.FC<SavedPropertiesProviderProps> = (
         queryClient.setQueryData<SavedPropertyFoldersResponse>(SAVED_FOLDERS_KEY, (prev) => ({
           folders: (prev?.folders ?? []).filter((folder) => folder._id !== folderId),
         }));
-        toast.success('Folder deleted successfully');
+        toast.success(i18next.t('saved.toast.folderDeleted'));
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : 'Failed to delete folder';
         setError(message);
-        toast.error('Failed to delete folder');
+        toast.error(i18next.t('saved.toast.folderDeleteFailed'));
         throw error;
       }
     },
@@ -266,7 +267,7 @@ export const SavedPropertiesProvider: React.FC<SavedPropertiesProviderProps> = (
           newSet.delete(propertyId);
           return newSet;
         });
-        toast.success('Property saved successfully');
+        toast.success(i18next.t('saved.toast.propertySaved'));
         // Refresh folders to update counts immediately.
         await queryClient.invalidateQueries({ queryKey: SAVED_FOLDERS_KEY });
       } catch (error: unknown) {
@@ -282,7 +283,7 @@ export const SavedPropertiesProvider: React.FC<SavedPropertiesProviderProps> = (
 
         const message = error instanceof Error ? error.message : 'Failed to save property';
         setError(message);
-        toast.error('Failed to save property');
+        toast.error(i18next.t('saved.toast.propertySaveFailed'));
         throw error;
       }
     },
@@ -316,7 +317,7 @@ export const SavedPropertiesProvider: React.FC<SavedPropertiesProviderProps> = (
           newSet.delete(propertyId);
           return newSet;
         });
-        toast.success('Property removed from saved');
+        toast.success(i18next.t('saved.toast.propertyRemoved'));
 
         // Update folder counts locally.
         if (removed?.folderId) {
@@ -353,7 +354,7 @@ export const SavedPropertiesProvider: React.FC<SavedPropertiesProviderProps> = (
         });
 
         setError(message);
-        toast.error('Failed to unsave property');
+        toast.error(i18next.t('saved.toast.propertyUnsaveFailed'));
         throw error;
       }
     },

--- a/packages/frontend/hooks/profile/useProfileEditForm.ts
+++ b/packages/frontend/hooks/profile/useProfileEditForm.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Alert } from 'react-native';
+import i18next from 'i18next';
 import type { Profile, UpdateProfileData } from '@/services/profileService';
 import { usePrimaryProfileQuery, useUpdateProfileMutation } from '@/hooks/query/useProfiles';
 import { logger } from '@/utils/logger';
@@ -307,7 +308,6 @@ interface TrustFactorView {
   type: string;
   value: number;
   maxValue: number;
-  label: string;
 }
 
 /** Max value per trust-score factor (kept from the original screen). */
@@ -393,7 +393,6 @@ export function useProfileEditForm(): UseProfileEditFormResult {
           type: factor.type,
           value: factor.value,
           maxValue: TRUST_FACTOR_MAX_VALUE,
-          label: factor.type.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase()),
         })) || [],
     };
   }, [activeProfile?.personalProfile?.trustScore]);
@@ -543,7 +542,7 @@ export function useProfileEditForm(): UseProfileEditFormResult {
 
   const handleSave = useCallback(async () => {
     if (!activeProfile) {
-      Alert.alert('Error', 'No profile found to update.');
+      Alert.alert(i18next.t('common.error'), i18next.t('profile.edit.noProfile'));
       return;
     }
 
@@ -568,7 +567,7 @@ export function useProfileEditForm(): UseProfileEditFormResult {
 
     if (!validation.success) {
       const message = validation.error.issues[0]?.message || 'Please review the form and try again.';
-      Alert.alert('Error', message);
+      Alert.alert(i18next.t('common.error'), message);
       return;
     }
 
@@ -604,11 +603,11 @@ export function useProfileEditForm(): UseProfileEditFormResult {
       await updateProfile({ profileId, data: updateData });
 
       setHasUnsavedChanges(false);
-      Alert.alert('Success', 'Profile updated successfully!');
+      Alert.alert(i18next.t('common.success'), i18next.t('profile.edit.updateSuccess'));
     } catch (error) {
       logger.error('Error saving profile', error);
       const message = error instanceof Error ? error.message : 'Failed to update profile.';
-      Alert.alert('Error', message);
+      Alert.alert(i18next.t('common.error'), message);
     } finally {
       setIsSaving(false);
     }

--- a/packages/frontend/hooks/useCreatePropertyWizard.ts
+++ b/packages/frontend/hooks/useCreatePropertyWizard.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useRouter } from 'expo-router';
 import { useMutation } from '@tanstack/react-query';
 import { toast } from '@/lib/sonner';
+import i18next from 'i18next';
 import {
   UtilitiesIncluded,
   PropertyStatus,
@@ -274,7 +275,7 @@ export function useCreatePropertyWizard(id: string | undefined) {
       }
       if (isEditMode) {
         logger.info('Property update result', property);
-        toast.success('Property updated successfully');
+        toast.success(i18next.t('property.toast.updateSuccess'));
         if (redirectId) {
           router.push(`/properties/${redirectId}`);
         } else {
@@ -283,7 +284,7 @@ export function useCreatePropertyWizard(id: string | undefined) {
         return;
       }
       logger.info('Property creation result', property);
-      toast.success('Property created successfully');
+      toast.success(i18next.t('property.toast.createSuccess'));
       // The captured referral code has now been consumed by this listing —
       // clear it so a later, un-referred listing isn't mis-attributed.
       useReferralStore.getState().clearReferralCode();
@@ -295,7 +296,9 @@ export function useCreatePropertyWizard(id: string | undefined) {
     },
     onError: (error) => {
       const message =
-        error.message || (isEditMode ? 'Failed to update property' : 'Failed to create property');
+        error instanceof Error
+          ? error.message
+          : i18next.t(isEditMode ? 'property.toast.updateFailed' : 'property.toast.createFailed');
       setError(message);
       toast.error(message);
     },

--- a/packages/frontend/hooks/useProfile.ts
+++ b/packages/frontend/hooks/useProfile.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import i18next from 'i18next';
 import { useProfileStore } from '@/store/profileStore';
 import { Profile, CreateProfileData } from '@/services/profileService';
 import { useOxy } from '@oxyhq/services';
@@ -26,7 +27,7 @@ export const useProfile = () => {
       setAllProfiles(allProfiles || []);
     } catch (error: any) {
       setError(error.message || 'Failed to load profiles');
-      toast.error('Failed to load profiles');
+      toast.error(i18next.t('profile.toast.loadFailed'));
     } finally {
       setLoading(false);
     }
@@ -47,11 +48,11 @@ export const useProfile = () => {
           setPrimaryProfile(newProfile);
         }
 
-        toast.success('Profile created successfully');
+        toast.success(i18next.t('profile.toast.createSuccess'));
         return newProfile;
       } catch (error: any) {
         setError(error.message || 'Failed to create profile');
-        toast.error('Failed to create profile');
+        toast.error(i18next.t('profile.toast.createFailed'));
         throw error;
       } finally {
         setLoading(false);
@@ -86,11 +87,11 @@ export const useProfile = () => {
           setPrimaryProfile(updatedProfile);
         }
 
-        toast.success('Profile updated successfully');
+        toast.success(i18next.t('profile.toast.updateSuccess'));
         return updatedProfile;
       } catch (error: any) {
         setError(error.message || 'Failed to update profile');
-        toast.error('Failed to update profile');
+        toast.error(i18next.t('profile.toast.updateFailed'));
         throw error;
       } finally {
         setLoading(false);
@@ -125,10 +126,10 @@ export const useProfile = () => {
           setPrimaryProfile(null);
         }
 
-        toast.success('Profile deleted successfully');
+        toast.success(i18next.t('profile.toast.deleteSuccess'));
       } catch (error: any) {
         setError(error.message || 'Failed to delete profile');
-        toast.error('Failed to delete profile');
+        toast.error(i18next.t('profile.toast.deleteFailed'));
         throw error;
       } finally {
         setLoading(false);
@@ -165,11 +166,11 @@ export const useProfile = () => {
         setAllProfiles(updatedProfiles);
         setPrimaryProfile(activatedProfile);
 
-        toast.success('Profile activated successfully');
+        toast.success(i18next.t('profile.toast.activateSuccess'));
         return activatedProfile;
       } catch (error: any) {
         setError(error.message || 'Failed to activate profile');
-        toast.error('Failed to activate profile');
+        toast.error(i18next.t('profile.toast.activateFailed'));
         throw error;
       } finally {
         setLoading(false);

--- a/packages/frontend/hooks/useProfileQueries.ts
+++ b/packages/frontend/hooks/useProfileQueries.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect } from 'react';
+import i18next from 'i18next';
 import { useProfileStore } from '@/store/profileStore';
 import { useOxy } from '@oxyhq/services';
 import { toast } from '@/lib/sonner';
@@ -45,10 +46,11 @@ export const useProfileRedux = () => {
           .getState()
           .updateProfile(profileId, profileData);
 
-        toast.success('Profile updated successfully');
+        toast.success(i18next.t('profile.toast.updateSuccess'));
         return updatedProfile;
-      } catch (error: any) {
-        toast.error(error.message || 'Failed to update profile');
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : i18next.t('profile.toast.updateFailed');
+        toast.error(message);
         throw error;
       }
     },
@@ -66,10 +68,11 @@ export const useProfileRedux = () => {
         .getState()
         .createProfile({ profileType: ProfileType.PERSONAL });
 
-      toast.success('Profile created successfully');
+      toast.success(i18next.t('profile.toast.createSuccess'));
       return profile;
-    } catch (error: any) {
-      toast.error(error.message || 'Failed to create profile');
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : i18next.t('profile.toast.createFailed');
+      toast.error(message);
       throw error;
     }
   }, [oxyServices, activeSessionId]);

--- a/packages/frontend/hooks/usePropertyQueries.ts
+++ b/packages/frontend/hooks/usePropertyQueries.ts
@@ -7,6 +7,7 @@ import {
   PropertyNearbyServices,
 } from '@homiio/shared-types';
 import { toast } from '@/lib/sonner';
+import i18next from 'i18next';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 /** Area-scale lookups (price insights, nearby services) are comparatively
@@ -230,10 +231,11 @@ export const useCreateProperty = () => {
         // Use the propertyService instead of propertyApi
         const response = await propertyService.createProperty(data);
 
-        toast.success('Property created successfully');
+        toast.success(i18next.t('property.toast.createSuccess'));
         return response;
       } catch (error: any) {
-        const errorMessage = error.message || 'Failed to create property';
+        const errorMessage =
+          error instanceof Error ? error.message : i18next.t('property.toast.createFailed');
         setError(errorMessage);
         toast.error(errorMessage);
         throw error;
@@ -267,10 +269,11 @@ export const useUpdateProperty = () => {
           data,
         );
 
-        toast.success('Property updated successfully');
+        toast.success(i18next.t('property.toast.updateSuccess'));
         return response;
       } catch (error: any) {
-        const errorMessage = error.message || 'Failed to update property';
+        const errorMessage =
+          error instanceof Error ? error.message : i18next.t('property.toast.updateFailed');
         setError(errorMessage);
         toast.error(errorMessage);
         throw error;
@@ -301,9 +304,10 @@ export const useDeleteProperty = () => {
         // Use propertyService instead of propertyApi
         await propertyService.deleteProperty(id);
 
-        toast.success('Property deleted successfully');
+        toast.success(i18next.t('property.toast.deleteSuccess'));
       } catch (error: any) {
-        const errorMessage = error.message || 'Failed to delete property';
+        const errorMessage =
+          error instanceof Error ? error.message : i18next.t('property.toast.deleteFailed');
         setError(errorMessage);
         toast.error(errorMessage);
         throw error;

--- a/packages/frontend/hooks/useRecentlyViewedQueries.ts
+++ b/packages/frontend/hooks/useRecentlyViewedQueries.ts
@@ -4,6 +4,7 @@ import { recentlyViewedService } from '@/services/recentlyViewedService';
 import { useRecentlyViewedStore } from '@/store/recentlyViewedStore';
 import { RecentlyViewedType, Property } from '@homiio/shared-types';
 import { toast } from '@/lib/sonner';
+import i18next from 'i18next';
 
 /**
  * Hook for fetching recently viewed properties
@@ -86,7 +87,7 @@ export const useTrackPropertyView = () => {
     },
     // No optimistic updates - let the main hook handle all cache updates
     onError: (err, propertyId) => {
-      toast.error('Failed to track property view');
+      toast.error(i18next.t('recentlyViewed.trackFailed'));
     },
     // No onSettled callback to avoid interfering with local cache updates
   });
@@ -120,10 +121,10 @@ export const useClearRecentlyViewed = () => {
       
       // Invalidate queries
       await queryClient.invalidateQueries({ queryKey: ['recentlyViewed', 'properties'] });
-      toast.success('Recently viewed properties cleared');
+      toast.success(i18next.t('recentlyViewed.clearSuccess'));
     },
-    onError: (error: any) => {
-      toast.error('Failed to clear recently viewed properties');
+    onError: () => {
+      toast.error(i18next.t('recentlyViewed.clearFailed'));
     },
   });
 };

--- a/packages/frontend/hooks/useSindiConversation.ts
+++ b/packages/frontend/hooks/useSindiConversation.ts
@@ -13,6 +13,7 @@ import { api } from '@/utils/api';
 import { getData, storeData } from '@/utils/storage';
 import { logger } from '@/utils/logger';
 import { API_URL } from '@/config';
+import i18next from 'i18next';
 
 /** Key under which we record that the file-upsell sheet has been shown once. */
 const FILE_UPSELL_KEY = 'sindi:fileUpsellShown';
@@ -382,8 +383,9 @@ export function useSindiConversation({
       setAttachedFile(null);
     } catch (e) {
       logger.error('File upload failed:', e);
-      const messageText = e instanceof Error ? e.message : 'Could not analyze the file.';
-      Alert.alert('Upload failed', messageText);
+      const messageText =
+        e instanceof Error ? e.message : i18next.t('sindi.errors.uploadAnalyzeFailed');
+      Alert.alert(i18next.t('sindi.errors.uploadFailedTitle'), messageText);
     } finally {
       setIsUploading(false);
     }

--- a/packages/frontend/hooks/useTrustScore.ts
+++ b/packages/frontend/hooks/useTrustScore.ts
@@ -3,6 +3,32 @@ import { useTrustScoreStore } from '@/store/trustScoreStore';
 import profileService from '@/services/profileService';
 import { colors } from '@/styles/colors';
 
+type TrustLevelKey = 'excellent' | 'good' | 'average' | 'fair' | 'needsImprovement';
+
+function trustLevelKey(score: number): TrustLevelKey {
+  if (score >= 90) return 'excellent';
+  if (score >= 70) return 'good';
+  if (score >= 50) return 'average';
+  if (score >= 30) return 'fair';
+  return 'needsImprovement';
+}
+
+type TrustScoreFactor = {
+  id: string;
+  type: string;
+  score: number;
+  weight: number;
+};
+
+function mapTrustFactors(factors: Array<{ type: string; value: number }>): TrustScoreFactor[] {
+  return factors.map((factor, index) => ({
+    id: `${factor.type}-${index}`,
+    type: factor.type,
+    score: factor.value,
+    weight: 1,
+  }));
+}
+
 export const useTrustScore = (profileId?: string) => {
   const {
     score,
@@ -15,16 +41,13 @@ export const useTrustScore = (profileId?: string) => {
     setHistory,
     setLoading,
     setError,
-    clearError,
   } = useTrustScoreStore();
 
-  // Local state for current profile ID
   const [currentProfileId, setCurrentProfileId] = useState<string | undefined>(profileId);
   const [profileType, setProfileType] = useState<
     'personal' | 'agency' | 'business' | 'cooperative'
   >('personal');
 
-  // Fetch trust score for a specific profile
   const fetchTrustScoreData = useCallback(
     async (targetProfileId?: string) => {
       const profileToFetch = targetProfileId || currentProfileId || profileId;
@@ -40,54 +63,30 @@ export const useTrustScore = (profileId?: string) => {
         setLoading(true);
         setError(null);
 
-        const profile = await profileService.getProfileById(
-          profileToFetch,
-        );
+        const profile = await profileService.getProfileById(profileToFetch);
 
-        // Update store with response data
         if (profile && profile.personalProfile?.trustScore) {
           const trustScore = profile.personalProfile.trustScore;
           setScore(trustScore.score || 0);
-
-          // Transform factors to match the store interface
-          const transformedFactors = (trustScore.factors || []).map((factor, index) => ({
-            id: `${factor.type}-${index}`,
-            name: factor.type.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase()),
-            score: factor.value,
-            weight: 1,
-            description: `Trust factor: ${factor.type}`,
-          }));
-
-          setFactors(transformedFactors);
-          setHistory([]); // History not available in current structure
-
-          // Set profile type
+          setFactors(mapTrustFactors(trustScore.factors || []));
+          setHistory([]);
           setProfileType(profile.profileType);
         } else {
-          // No trust score data available
           setScore(0);
           setFactors([]);
           setHistory([]);
           setProfileType(profile?.profileType || 'personal');
         }
-      } catch (error: any) {
-        setError(error.message || 'Failed to fetch trust score');
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : 'Failed to fetch trust score';
+        setError(message);
       } finally {
         setLoading(false);
       }
     },
-    [
-      currentProfileId,
-      profileId,
-      setLoading,
-      setError,
-      setScore,
-      setFactors,
-      setHistory,
-    ],
+    [currentProfileId, profileId, setLoading, setError, setScore, setFactors, setHistory],
   );
 
-  // Update trust score for a specific profile
   const updateTrustScoreData = useCallback(
     async (factor: string, value: number, targetProfileId?: string) => {
       const profileToUpdate = targetProfileId || currentProfileId || profileId;
@@ -103,47 +102,24 @@ export const useTrustScore = (profileId?: string) => {
         setLoading(true);
         setError(null);
 
-        const profile = await profileService.updateTrustScore(
-          profileToUpdate,
-          factor,
-          value
-        );
+        const profile = await profileService.updateTrustScore(profileToUpdate, factor, value);
 
-        // Update store with response data
         if (profile && profile.personalProfile?.trustScore) {
           const trustScore = profile.personalProfile.trustScore;
           setScore(trustScore.score || 0);
-
-          // Transform factors to match the store interface
-          const transformedFactors = (trustScore.factors || []).map((factor, index) => ({
-            id: `${factor.type}-${index}`,
-            name: factor.type.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase()),
-            score: factor.value,
-            weight: 1,
-            description: `Trust factor: ${factor.type}`,
-          }));
-
-          setFactors(transformedFactors);
-          setHistory([]); // History not available in current structure
+          setFactors(mapTrustFactors(trustScore.factors || []));
+          setHistory([]);
         }
-      } catch (error: any) {
-        setError(error.message || 'Failed to update trust score');
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : 'Failed to update trust score';
+        setError(message);
       } finally {
         setLoading(false);
       }
     },
-    [
-      currentProfileId,
-      profileId,
-      setLoading,
-      setError,
-      setScore,
-      setFactors,
-      setHistory,
-    ],
+    [currentProfileId, profileId, setLoading, setError, setScore, setFactors, setHistory],
   );
 
-  // Recalculate trust score for a specific profile
   const recalculateTrustScoreData = useCallback(
     async (targetProfileId?: string) => {
       const profileToRecalculate = targetProfileId || currentProfileId || profileId;
@@ -161,41 +137,23 @@ export const useTrustScore = (profileId?: string) => {
 
         const response = await profileService.recalculatePrimaryTrustScore();
 
-        // Update store with response data
         if (response && response.profile && response.profile.personalProfile?.trustScore) {
           const trustScore = response.profile.personalProfile.trustScore;
           setScore(trustScore.score || 0);
-
-          // Transform factors to match the store interface
-          const transformedFactors = (trustScore.factors || []).map((factor, index) => ({
-            id: `${factor.type}-${index}`,
-            name: factor.type.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase()),
-            score: factor.value,
-            weight: 1,
-            description: `Trust factor: ${factor.type}`,
-          }));
-
-          setFactors(transformedFactors);
-          setHistory([]); // History not available in current structure
+          setFactors(mapTrustFactors(trustScore.factors || []));
+          setHistory([]);
         }
-      } catch (error: any) {
-        setError(error.message || 'Failed to recalculate trust score');
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error ? error.message : 'Failed to recalculate trust score';
+        setError(message);
       } finally {
         setLoading(false);
       }
     },
-    [
-      currentProfileId,
-      profileId,
-      setLoading,
-      setError,
-      setScore,
-      setFactors,
-      setHistory,
-    ],
+    [currentProfileId, profileId, setLoading, setError, setScore, setFactors, setHistory],
   );
 
-  // Clear trust score data
   const clearTrustScoreData = useCallback(() => {
     setScore(0);
     setFactors([]);
@@ -203,23 +161,20 @@ export const useTrustScore = (profileId?: string) => {
     setError(null);
   }, [setScore, setFactors, setHistory, setError]);
 
-  // Create trust score data object for components
   const trustScoreData = {
     score,
     factors: factors.map((factor) => ({
-      type: factor.name.toLowerCase().replace(/\s+/g, '_'),
+      type: factor.type,
       value: factor.score,
       maxValue: 100,
-      label: factor.name,
     })),
     history,
     type: profileType,
     color: score >= 80 ? colors.success : score >= 60 ? colors.warning : colors.danger,
-    level: score >= 80 ? 'Excellent' : score >= 60 ? 'Good' : score >= 40 ? 'Fair' : 'Poor',
+    levelKey: trustLevelKey(score),
   };
 
   return {
-    // State
     trustScoreData,
     score,
     factors,
@@ -228,8 +183,6 @@ export const useTrustScore = (profileId?: string) => {
     error,
     profileType,
     currentProfileId,
-
-    // Actions
     setCurrentProfileId,
     fetchTrustScoreData,
     updateTrustScoreData,

--- a/packages/frontend/locales/ca-ES.json
+++ b/packages/frontend/locales/ca-ES.json
@@ -14,128 +14,96 @@
       "transportation": "Aparcament i transport",
       "community": "Espais comuns",
       "other": "Més"
-    }
+    },
+    "airConditioning": "Aire condicionat",
+    "airPurifier": "Sistema de purificació d'aire",
+    "balcony": "Balcó privat",
+    "bbqArea": "Zona de barbacoa",
+    "bikeStorage": "Emmagatzematge segur per a bicicletes",
+    "builtInShelving": "Prestatgeries encastades",
+    "cableTv": "Preparat per a TV per cable",
+    "ceilingFans": "Ventiladors de sostre",
+    "coatCloset": "Armari d'entrada",
+    "communityRoom": "Sala comunitària",
+    "conferenceRoom": "Sala de reunions",
+    "coworkingSpace": "Espai de coworking",
+    "daycare": "Llar d'infants a la finca",
+    "dimmerSwitches": "Interruptors reguladors",
+    "dishwasher": "Rentavaixelles",
+    "dogPark": "Zona d'exercici per a mascotes",
+    "doubleVanity": "Doble lavabo",
+    "dryer": "Assecadora a la vivenda",
+    "electricity": "Electricitat inclosa",
+    "elevator": "Accés amb ascensor",
+    "energyEfficient": "Electrodomèstics eficients",
+    "evCharging": "Càrrega per a vehicle elèctric",
+    "familyRoom": "Sala d'activitats familiar",
+    "fiberInternet": "Internet de fibra",
+    "firePit": "Zona amb foguera",
+    "fireSafety": "Sistema de seguretat contra incendis",
+    "garbageDisposal": "Triturador de brossa",
+    "gardenAccess": "Accés al jardí",
+    "gardenSpace": "Hort comunitari",
+    "grabBars": "Barres d'apoi",
+    "graniteCounters": "Taulells de granit",
+    "greenRoof": "Terrat verd",
+    "gym": "Gimnàs",
+    "hardwoodFloors": "Sòl de fusta",
+    "heatedFloors": "Sòl radiant",
+    "heating": "Calefacció adequada",
+    "homeOffice": "Espai d'oficina a casa",
+    "hotTub": "Banyera d'hidromassatge",
+    "humidifier": "Humidificador central",
+    "iceMaker": "Màquina de gel",
+    "insulation": "Aïllament adequat",
+    "intercom": "Porter automàtic",
+    "jettedTub": "Banyera d'hidromassatge",
+    "kitchen": "Cuina",
+    "laundryRoom": "Bugaderia compartida",
+    "ledLighting": "Il·luminació LED",
+    "linenCloset": "Armari de roba blanca",
+    "mailRoom": "Sala de paquets i correu",
+    "microwave": "Microones",
+    "mobilityAssistance": "Accessibilitat i mobilitat",
+    "naturalLight": "Llum natural abundant",
+    "oven": "Forn",
+    "pantry": "Despensa",
+    "parkingSpace": "Plaça d'aparcament",
+    "pendantLighting": "Il·luminació de disseny",
+    "petFriendly": "S'admeten mascotes",
+    "printingStation": "Centre d'impressió i còpies",
+    "publicTransitAccess": "Accés al transport públic",
+    "rainwaterCollection": "Recollida d'aigua de pluja",
+    "rampAccess": "Accés amb rampa",
+    "recyclingProgram": "Programa de reciclatge integral",
+    "refrigerator": "Nevera de mida completa",
+    "rooftopDeck": "Terrassa a la coberta",
+    "secureEntry": "Accés controlat",
+    "securityCameras": "Càmeres de seguretat",
+    "seniorServices": "Serveis de suport per a gent gran",
+    "smartDoorbell": "Timbre amb vídeo",
+    "smartHome": "Llar intel·ligent",
+    "solarPanels": "Energia solar",
+    "stainlessAppliances": "Electrodomèstics d'acer inoxidable",
+    "storageUnit": "Espai d'emmagatzematge",
+    "stove": "Cuina",
+    "studyRoom": "Espai d'estudi tranquil",
+    "swimmingPool": "Piscina",
+    "teenRoom": "Sala d'activitats per a adolescents",
+    "tileFloors": "Sòl de rajoles",
+    "trashPickup": "Recollida de residus",
+    "usbOutlets": "Endolls USB",
+    "walkInCloset": "Vestidor",
+    "walkInShower": "Dutxa a ras de terra",
+    "washingMachine": "Rentadora a la vivenda",
+    "water": "Aigua i clavegueram inclosos",
+    "waterFilter": "Sistema de filtratge d'aigua",
+    "wheelchairAccessible": "Accessible amb cadira de rodes",
+    "wholeHouseFan": "Ventilador de tota la casa",
+    "wideDoorways": "Portes amples",
+    "wifi": "Internet d'alta velocitat",
+    "wineFridge": "Nevera per a vins"
   },
-  "Home": "Inici",
-  "Search": "Cercar",
-  "Notifications": "Notificacions",
-  "Messages": "Missatges",
-  "New Post": "Nova Publicació",
-  "What's happening?": "Què està passant?",
-  "Post": "Publicar",
-  "Save": "Guardar",
-  "Settings": "Configuració",
-  "Language": "Idioma",
-  "Primary Color": "Color Principal",
-  "Apply Settings": "Aplicar Configuració",
-  "Welcome to Homiio! 👋": "Benvingut a Homiio! 👋",
-  "Thanks for trying out our app. Start exploring now!": "Gràcies per provar la nostra aplicació. Comença a explorar ara!",
-  "This screen doesn't exist.": "Aquesta pantalla no existeix.",
-  "Go to home screen!": "Vés a la pantalla d'inici!",
-  "Hey, how are you?": "Hola, com estàs?",
-  "Let's catch up soon!": "Posem-nos al dia aviat!",
-  "liked your Post": "ha donat m'agrada a la teva publicació",
-  "reposted your Post": "ha republicat la teva publicació",
-  "This is a sample post": "Aquesta és una publicació d'exemple",
-  "Another example post": "Una altra publicació d'exemple",
-  "Customize your view": "Personalitza la teva vista",
-  "These settings affect all the Mention accounts on this device.": "Aquesta configuració afecta tots els comptes de Homiio en aquest dispositiu.",
-  "Account": "Compte",
-  "Manage your account settings": "Gestiona la configuració del teu compte",
-  "Notification preferences": "Preferències de notificacions",
-  "Privacy and security settings": "Configuració de privacitat i seguretat",
-  "Appearance": "Aparença",
-  "Theme, font size, colors": "Tema, mida de lletra, colors",
-  "Help & Support": "Ajuda i Suport",
-  "Get help and support": "Obtenir ajuda i suport",
-  "About": "Sobre",
-  "About this app": "Sobre aquesta aplicació",
-  "Battery": "Bateria",
-  "Loading...": "Carregant...",
-  "Trends for you": "Tendències per a tu",
-  "Show more": "Mostrar més",
-  "posts": "publicacions",
-  "File Manager": "Gestor d'Arxius",
-  "Filter files by name": "Filtrar arxius per nom",
-  "Filter files by date (MM/DD/YYYY)": "Filtrar arxius per data (DD/MM/AAAA)",
-  "Filter files by type (e.g., image, video)": "Filtrar arxius per tipus (p. ex., imatge, vídeo)",
-  "Who to follow": "A qui seguir",
-  "Search...": "Cercar...",
-  "No results found for": "No s'han trobat resultats per",
-  "Follow": "Seguir",
-  "Following": "Seguint",
-  "Explore": "Explorar",
-  "Chat": "Xat",
-  "Bookmarks": "Marcadors",
-  "Feeds": "Feeds",
-  "Lists": "Llistes",
-  "Videos": "Vídeos",
-  "Sign Up": "Registrar-se",
-  "Sign In": "Iniciar Sessió",
-  "Join the conversation": "Uneix-te a la conversa",
-  "error.socket.not_connected": "No connectat al servidor de xat",
-  "error.message.send_timeout": "Temps d'espera per enviar missatge. Torna-ho a provar.",
-  "error.message.edit_timeout": "Temps d'espera per editar. Torna-ho a provar.",
-  "error.message.delete_timeout": "Temps d'espera per eliminar. Torna-ho a provar.",
-  "error.signup.missing_fields": "Si us plau, omple tots els camps",
-  "error.signup.failed": "Error en el registre:",
-  "error.boundary.title": "Alguna cosa ha anat malament",
-  "error.boundary.message": "Un problema inesperat ha interromput el que estaves fent. Pots tornar-ho a provar o enviar-nos un informe ràpid perquè ho investiguem.",
-  "error.boundary.retry": "Torna-ho a provar",
-  "error.boundary.reportIssue": "Informar del problema",
-  "error.boundary.errorId": "ID d'error",
-  "error.boundary.copyIdHint": "Toca per copiar l'ID",
-  "error.boundary.copiedToClipboard": "Copiat al porta-retalls",
-  "error.boundary.showDetails": "Mostrar detalls tècnics",
-  "error.boundary.hideDetails": "Amagar detalls tècnics",
-  "error.boundary.technicalDetails": "Detalls tècnics",
-  "error.boundary.maxRetriesTitle": "Segueix sense funcionar",
-  "error.boundary.maxRetriesMessage": "Has assolit el límit de reintents. Si us plau, informa del problema perquè ho puguem revisar.",
-  "error.boundary.forceRetry": "Forçar reintent",
-  "error.boundary.reportCopiedTitle": "Informe copiat",
-  "error.boundary.reportCopiedMessage": "L'informe d'error s'ha copiat al porta-retalls.",
-  "error.boundary.reportFailedTitle": "No s'ha pogut copiar",
-  "error.boundary.reportFailedMessage": "No hem pogut copiar l'informe al porta-retalls. Torna-ho a provar.",
-  "error.boundary.errorMessage": "Missatge d'error",
-  "error.boundary.errorType": "Tipus d'error",
-  "error.boundary.stackTrace": "Traça de pila",
-  "error.boundary.componentStack": "Pila de components",
-  "error.boundary.deviceInformation": "Informació del dispositiu",
-  "error.file_selection": "Error processant els arxius seleccionats. Si us plau, torna-ho a provar.",
-  "error.login_required": "Si us plau, inicia sessió per gestionar arxius",
-  "error.load_notifications": "Error carregant notificacions",
-  "error.fetch_trends": "Error carregant tendències",
-  "error.signup.password_mismatch": "Les contrasenyes no coincideixen",
-  "error.validation.token_expired": "El token ha caducat",
-  "error.validation.token_invalid": "El format del token no és vàlid",
-  "error.validation.token_signature": "La signatura del token no és vàlida",
-  "error.auth.invalid_token": "Token d'autenticació invàlid",
-  "error.chat.forward_failed": "No s'ha pogut reenviar el missatge",
-  "error.chat.delete_failed": "No s'ha pogut eliminar el missatge",
-  "error.chat.send_failed": "Error enviant missatge",
-  "error.chat.load_failed": "Error carregant missatges",
-  "error.data.fetch_failed": "Error obtenint dades: {{message}}",
-  "error.users.fetch_failed": "Error obtenint usuaris: {{message}}",
-  "inbox.title": "Bústia",
-  "notification.welcome.title": "Benvingut a Homiio! 👋",
-  "notification.welcome.body": "Gràcies per provar la nostra aplicació. Comença a explorar ara!",
-  "success.signup": "Registre exitós",
-  "action.retry": "Tornar a provar",
-  "status.loading": "Carregant...",
-  "state.loading": "Carregant...",
-  "state.no_results": "Sense resultats",
-  "state.empty_state": "Res a mostrar",
-  "state.not_connected": "No connectat",
-  "state.session_expired": "Sessió caducada",
-  "state.no_session": "Si us plau, inicia sessió",
-  "state.retrying": "Tornant a provar...",
-  "state.uploading": "Pujant...",
-  "state.downloading": "Descarregant...",
-  "state.processing": "Processant...",
-  "state.please_wait": "Si us plau, espera...",
-  "file.size_mb": "MB",
-  "profile.edit": "Editar perfil",
-  "profile.chat": "Xat",
   "home": {
     "hero": {
       "title": "Troba la teva llar ètica",
@@ -200,7 +168,8 @@
       "errorDescription": "Si us plau, torna-ho a provar.",
       "retry": "Tornar a provar",
       "results": "Resultats",
-      "filtered": "filtrades"
+      "filtered": "filtrades",
+      "continue": "Continue browsing"
     },
     "saved": {
       "header": "Desats",
@@ -238,7 +207,32 @@
       "noFolderItemsDescription": "Desa propietats en aquesta carpeta per veure-les aquí"
     },
     "tips": {
-      "article": "Article"
+      "article": "Article",
+      "title": "Rental Tips & Guides",
+      "categories": {
+        "search": "Search",
+        "safety": "Safety",
+        "legal": "Legal",
+        "inspection": "Inspection"
+      },
+      "firstTimeRenting": {
+        "title": "First Time Renting? Here's Your Complete Guide",
+        "description": "Everything you need to know about finding, viewing, and securing your first rental property."
+      },
+      "avoidScams": {
+        "title": "How to Avoid Rental Scams: Red Flags to Watch For",
+        "description": "Learn to identify common rental scams and protect yourself from fraud when searching for a new home."
+      },
+      "rentalAgreement": {
+        "title": "Understanding Your Rental Agreement: Key Terms Explained",
+        "description": "Break down complex legal terms and understand what you're signing before committing to a rental."
+      },
+      "propertyInspection": {
+        "title": "Property Inspection Checklist: What to Look For",
+        "description": "A comprehensive guide to inspecting potential rental properties and identifying potential issues."
+      },
+      "subtitle": "Practical guides from local tenants, legal experts, and the Homiio editorial team.",
+      "eyebrow": "Renting smarter"
     },
     "faq": {
       "title": "Preguntes Freqüents",
@@ -262,6 +256,46 @@
     "cityShowcase": {
       "title": "Explora {{place}}",
       "defaultPlace": "Espanya"
+    },
+    "insights": {
+      "title": "Platform Insights"
+    },
+    "noProfilesTitle": "No Saved Profiles",
+    "noProfilesDescription": "Follow profiles to see them here",
+    "recommended": {
+      "title": "Recommended homes",
+      "eyebrow": "For you"
+    },
+    "hostCta": {
+      "cta": "Become a host",
+      "subtitle": "Reach verified renters across Spain — free to list, fair fees, real human support.",
+      "title": "List your space, find a great tenant"
+    },
+    "footerStrip": {
+      "support": "Real support, real people",
+      "fair": "Fair agreements",
+      "verified": "Verified listings"
+    },
+    "nearby": {
+      "title": "Homes in {{city}}"
+    },
+    "category": {
+      "studios": "Estudis",
+      "apartments": "Apartaments",
+      "houses": "Cases",
+      "rooms": "Habitacions",
+      "coliving": "Co-living",
+      "luxury": "Luxury",
+      "newListings": "Nous anuncis",
+      "nearYou": "A prop teu",
+      "beachfront": "Davant del mar",
+      "cabins": "Cabanes",
+      "pools": "Piscines",
+      "mountain": "Muntanya",
+      "cityBreaks": "Escapades urbanes",
+      "countryside": "Camp",
+      "instantBook": "Reserva instantània",
+      "petFriendly": "Admet mascotes"
     }
   },
   "agent": {
@@ -367,6 +401,9 @@
       "subtitle": "Converteix les llars que t'envolten en ingressos.",
       "cta": "Fes-te agent",
       "trust": "Sense llicència. Treballa des del mòbil."
+    },
+    "join": {
+      "error": "Could not start earning right now. Please try again."
     }
   },
   "search": {
@@ -386,20 +423,57 @@
     "enableNotifications": "Habilitar Notificacions",
     "notificationsDescription": "Rep notificacions quan noves propietats coincideixin amb aquesta cerca",
     "withFilters": "Amb filtres",
-    "error": "Error",
+    "error": {
+      "title": "Could not load homes"
+    },
     "enterSearchQuery": "Si us plau introdueix una consulta de cerca primer",
     "deleteSearch": "Eliminar Cerca",
     "deleteSearchConfirm": "Estàs segur que vols eliminar la cerca \"{{name}}\"?",
     "viewAllSaved": "Veure Totes Guardades",
     "more": "més",
-    "Eco-friendly": "Ecològic",
-    "Co-living": "Convivència",
-    "Furnished": "Amoblat",
-    "Pets Allowed": "Mascotes Permeses",
-    "Verified": "Verificat",
-    "Search with": "Cercar amb",
     "filters": {
-      "listingType": "Tipus d'anunci"
+      "listingType": "Tipus d'anunci",
+      "propertyType": "Tipus de propietat",
+      "nightlyPrice": "Preu per nit",
+      "monthlyPrice": "Preu mensual",
+      "checkIn": "Entrada",
+      "checkOut": "Sortida",
+      "addDate": "Afegir data",
+      "guests": "Hostes",
+      "instantBook": "Reserva instantània",
+      "cancellationPolicy": "Política de cancel·lació",
+      "moveInDate": "Data d'entrada",
+      "leaseDuration": {
+        "3Months": "3 mesos",
+        "6Months": "6 mesos",
+        "12Months": "12 mesos",
+        "flexible": "Flexible"
+      },
+      "maxDeposit": "Dipòsit màxim",
+      "amenities": "Comoditats",
+      "amenity": {
+        "wifi": "Wi-Fi",
+        "parking": "Aparcament",
+        "gym": "Gimnàs",
+        "pool": "Piscina",
+        "balcony": "Balcó",
+        "garden": "Jardí",
+        "elevator": "Ascensor",
+        "airConditioning": "Aire condicionat",
+        "heating": "Calefacció",
+        "dishwasher": "Rentaplats",
+        "washingMachine": "Rentadora"
+      },
+      "propertyTypeVacation": {
+        "wholeHouses": "Cases senceres",
+        "privateRooms": "Habitacions privades"
+      },
+      "cancellation": {
+        "flexible": "Flexible",
+        "moderate": "Moderada",
+        "strict": "Estricta",
+        "superStrict": "Molt estricta"
+      }
     },
     "mode": {
       "label": "Mode de cerca",
@@ -408,7 +482,6 @@
       "buy": "Comprar",
       "exchange": "Intercanvi"
     },
-    "Advanced Filters": "Filtres Avançats",
     "types": {
       "apartments": "Apartaments",
       "houses": "Cases",
@@ -430,7 +503,16 @@
       "rooms": "Habitacions",
       "studios": "Estudis",
       "coliving": "Convivència",
-      "publicHousing": "Habitatge Públic"
+      "publicHousing": "Habitatge Públic",
+      "couchsurfing": "Couchsurfing",
+      "roommates": "Roommates",
+      "hostel": "Hostel",
+      "guesthouse": "Guesthouse",
+      "campsite": "Campsite",
+      "boat": "Boat",
+      "treehouse": "Treehouse",
+      "yurt": "Yurt",
+      "other": "Other"
     },
     "areas": {
       "downtown": "Centre",
@@ -515,7 +597,97 @@
       }
     },
     "editSearch": "Edita la cerca",
-    "searchQueryPlaceholder": "Introdueix la teva consulta de cerca"
+    "searchQueryPlaceholder": "Introdueix la teva consulta de cerca",
+    "placeholder": {
+      "suggestion1": "Find your dream apartment in Barcelona...",
+      "suggestion2": "Looking for a pet-friendly home?",
+      "suggestion3": "Discover eco-friendly properties...",
+      "suggestion4": "Search for furnished studios near you..."
+    },
+    "disableNotifications": "Disable notifications",
+    "duplicateName": "A search with this name already exists",
+    "duplicateExact": "You already saved this exact search",
+    "tryDifferentName": "Please choose a different name",
+    "actions": {
+      "save": "Save",
+      "search": "Search",
+      "clearAll": "Clear all",
+      "searchArea": "Search this area",
+      "sort": "Sort",
+      "filters": "Filters",
+      "saved": "Saved"
+    },
+    "summary": {
+      "edit": "Edit search",
+      "anyPrice": "Any price",
+      "addDates": "Add dates",
+      "anyTime": "Any time",
+      "anyType": "Any type",
+      "anywhere": "Anywhere",
+      "mapArea": "Map area",
+      "typeCount": "{{count}} types"
+    },
+    "step": {
+      "dates": {
+        "title": "When?",
+        "weekday": {
+          "Mo": "Dl",
+          "Tu": "Dt",
+          "We": "Dc",
+          "Th": "Dj",
+          "Fr": "Dv",
+          "Sa": "Ds",
+          "Su": "Dg"
+        }
+      },
+      "type": {
+        "title": "What type of place?"
+      },
+      "price": {
+        "max": "Maximum",
+        "any": "Any",
+        "min": "Minimum",
+        "title": "Price range",
+        "perMonth": "per month",
+        "perNight": "per night"
+      }
+    },
+    "header": {
+      "geocoding": "Looking up location...",
+      "noResults": "No homes match this search",
+      "loading": "Searching homes...",
+      "count": "{{count}} homes"
+    },
+    "recent": {
+      "title": "Recent searches"
+    },
+    "input": {
+      "placeholder": "Search cities, neighborhoods, or addresses"
+    },
+    "panel": {
+      "title": "Search"
+    },
+    "fab": {
+      "map": "Map",
+      "list": "List"
+    },
+    "empty": {
+      "action": "Edit search",
+      "description": "Try widening your area or relaxing your filters.",
+      "title": "No homes match this search"
+    },
+    "sort": {
+      "title": "Ordenar per",
+      "recommended": "Recomanat",
+      "priceAsc": "Preu: de menor a major",
+      "priceDesc": "Preu: de major a menor",
+      "newest": "Més recents"
+    },
+    "save": {
+      "title": "Save this search",
+      "namePlaceholder": "Give your search a name",
+      "enableNotifications": "Enable notifications"
+    }
   },
   "profile": {
     "title": "Perfil",
@@ -544,12 +716,19 @@
       "properties": "Les Meves Propietats",
       "contracts": "Els Meus Contractes",
       "trustScore": "Puntuació de Confiança",
-      "settings": "Configuració"
+      "settings": "Configuració",
+      "account": "Account",
+      "profile": "Profile",
+      "activity": "Activity"
     },
     "stats": {
       "propertiesCount": "Propietats",
       "contractsCount": "Contractes",
-      "trustScore": "Puntuació de Confiança"
+      "trustScore": "Puntuació de Confiança",
+      "stays": "Stays",
+      "applications": "Applications",
+      "saved": "Saved",
+      "applicationsApproved": "{{count}} aprovades"
     },
     "actions": {
       "manageProperties": "Gestionar Propietats",
@@ -566,7 +745,323 @@
       "deleteFailed": "Error eliminant perfil"
     },
     "exchanges": "Intercanvis",
-    "exchangesDescription": "Els teus intercanvis de casa i sol·licituds d’allotjament."
+    "exchangesDescription": "Els teus intercanvis de casa i sol·licituds d’allotjament.",
+    "edit": {
+      "noProfile": "No s'ha trobat cap perfil per actualitzar.",
+      "updateSuccess": "Perfil actualitzat correctament!",
+      "updateFailed": "No s'ha pogut actualitzar el perfil",
+      "sections": {
+        "agencyInformation": "Agency Information",
+        "agencyVerification": "Agency Verification",
+        "teamManagement": "Team Management",
+        "businessSettings": "Business Settings",
+        "businessInformation": "Informació del negoci",
+        "businessVerification": "Business Verification",
+        "cooperativeInformation": "Informació de la cooperativa",
+        "cooperativeSettings": "Cooperative Settings",
+        "personalInformation": "Informació personal",
+        "propertyPreferences": "Property Preferences",
+        "references": "References",
+        "rentalHistory": "Rental History",
+        "trustScore": "Trust Score",
+        "settings": "Settings"
+      },
+      "labels": {
+        "businessType": "Business Type *",
+        "legalCompanyName": "Legal Company Name *",
+        "description": "Description",
+        "licenseNumber": "License Number",
+        "taxId": "Tax ID",
+        "yearEstablished": "Year Established",
+        "employeeCount": "Number of Employees",
+        "specialties": "Specialties",
+        "verificationStatus": "Verification Status",
+        "profileVisibility": "Profile Visibility",
+        "notifications": "Notifications",
+        "emailNotifications": "Email Notifications",
+        "pushNotifications": "Push Notifications",
+        "legalName": "Legal Name *",
+        "industry": "Industry",
+        "bio": "Biografia",
+        "occupation": "Occupation",
+        "employer": "Employer",
+        "annualIncome": "Annual Income ($)",
+        "employmentStatus": "Employment Status",
+        "moveInDate": "Move-in Date",
+        "leaseDuration": "Lease Duration",
+        "maxRent": "Maximum Rent ($)",
+        "rentPeriod": "Rent Period",
+        "minBedrooms": "Min Bedrooms",
+        "minBathrooms": "Min Bathrooms",
+        "propertyTypes": "Property Types",
+        "preferredAmenities": "Preferred Amenities",
+        "additionalPreferences": "Additional Preferences",
+        "name": "Name",
+        "relationship": "Relationship",
+        "phone": "Phone",
+        "email": "Email",
+        "address": "Address",
+        "startDate": "Start Date",
+        "endDate": "End Date",
+        "monthlyRent": "Monthly Rent ($)",
+        "reasonForLeaving": "Reason for Leaving",
+        "landlordContact": "Landlord Contact",
+        "privacy": "Privacy"
+      },
+      "subtitles": {
+        "agencyVerification": "Complete these verifications to build trust with clients",
+        "businessVerification": "Complete these verifications to build trust with clients",
+        "businessSettings": "Configure your business profile settings",
+        "cooperativeSettings": "Configure your cooperative profile settings"
+      },
+      "placeholders": {
+        "legalCompanyName": "Enter your legal company name",
+        "description": "Describe your business...",
+        "licenseNumber": "Enter license number",
+        "taxId": "Enter tax ID",
+        "yearEstablished": "e.g., 2020",
+        "industry": "Enter industry",
+        "cooperativeLegalName": "Enter cooperative legal name",
+        "cooperativeDescription": "Describe your cooperative...",
+        "bio": "Explica'ns sobre tu...",
+        "occupation": "p. ex., Enginyer de programari",
+        "employer": "p. ex., Tech Corp",
+        "annualIncome": "p. ex., 75000",
+        "moveInDate": "AAAA-MM-DD",
+        "maxRent": "Introdueix el lloguer màxim",
+        "fullName": "Nom complet",
+        "phoneNumber": "Número de telèfon",
+        "emailAddress": "Correu electrònic",
+        "fullAddress": "Adreça completa",
+        "landlordName": "Nom del propietari",
+        "phone": "Telèfon",
+        "email": "Correu",
+        "endDateOptional": "AAAA-MM-DD (opcional)",
+        "monthlyRent": "p. ex., 1500"
+      },
+      "options": {
+        "agencyBusinessType": {
+          "real_estate_agency": "Agència immobiliària",
+          "property_management": "Gestió de propietats",
+          "brokerage": "Corretatge",
+          "developer": "Promotora",
+          "other": "Altre"
+        },
+        "agencySpecialty": {
+          "residential": "Residencial",
+          "commercial": "Comercial",
+          "luxury": "Luxury",
+          "student_housing": "Habitatge estudiantil",
+          "senior_housing": "Habitatge senior",
+          "vacation_rentals": "Lloguer vacacional"
+        },
+        "businessType": {
+          "small_business": "Petita empresa",
+          "startup": "Startup",
+          "freelancer": "Autònom",
+          "consultant": "Consultor",
+          "other": "Altre"
+        },
+        "employmentStatus": {
+          "employed": "Empleat",
+          "self_employed": "Autònom",
+          "student": "Estudiant",
+          "retired": "Jubilat",
+          "unemployed": "Aturat",
+          "other": "Altre"
+        },
+        "leaseDuration": {
+          "monthly": "Mensual",
+          "3_months": "3 mesos",
+          "6_months": "6 mesos",
+          "yearly": "Anual",
+          "flexible": "Flexible"
+        },
+        "priceUnit": {
+          "day": "Dia",
+          "night": "Nit",
+          "week": "Setmana",
+          "month": "Mes",
+          "year": "Any"
+        },
+        "propertyType": {
+          "apartment": "Apartament",
+          "house": "Casa",
+          "room": "Habitació",
+          "studio": "Estudi"
+        },
+        "amenity": {
+          "parking": "Aparcament",
+          "gym": "Gimnàs",
+          "pool": "Piscina",
+          "washer": "Rentadora",
+          "dishwasher": "Rentaplats",
+          "balcony": "Balcó",
+          "elevator": "Ascensor",
+          "ac": "Aire condicionat",
+          "heating": "Calefacció",
+          "internet": "Internet"
+        },
+        "referenceRelationship": {
+          "landlord": "Propietari",
+          "employer": "Empresa",
+          "personal": "Personal",
+          "other": "Altre"
+        },
+        "reasonForLeaving": {
+          "lease_ended": "Fi de contracte",
+          "bought_home": "Va comprar habitatge",
+          "job_relocation": "Trasllat laboral",
+          "family_reasons": "Motius familiars",
+          "upgrade": "Millora",
+          "other": "Altre"
+        },
+        "profileVisibility": {
+          "public": "Públic",
+          "private": "Privat",
+          "contacts_only": "Només contactes"
+        }
+      },
+      "verification": {
+        "businessLicenseTitle": "Llicència comercial",
+        "businessLicenseDescription": "Puja la teva llicència comercial per a verificació",
+        "insuranceTitle": "Assegurança",
+        "insuranceDescription": "Aporta prova de l'assegurança comercial",
+        "bondingTitle": "Fiador",
+        "bondingDescription": "Aporta informació de la fiança",
+        "backgroundCheckTitle": "Verificació d'antecedents",
+        "backgroundCheckDescription": "Completa la verificació d'antecedents de tot l'equip"
+      },
+      "toggles": {
+        "emailNotifications": "Notificacions per correu",
+        "pushNotifications": "Notificacions push",
+        "petFriendly": "Admet mascotes",
+        "smokingAllowed": "Fumar permès",
+        "furnished": "Moblat",
+        "parkingRequired": "Aparcament obligatori",
+        "accessibilityFeatures": "Accessibilitat",
+        "showContactInfo": "Mostrar dades de contacte",
+        "showIncome": "Mostrar ingressos",
+        "showRentalHistory": "Mostrar historial de lloguer",
+        "showReferences": "Mostrar referències"
+      },
+      "team": {
+        "subtitle": "Gestiona els membres de l'equip i els seus rols",
+        "memberLabel": "Membre {{index}}",
+        "addedLabel": "Afegit: {{date}}",
+        "emptyText": "Encara no hi ha membres a l'equip.",
+        "addMember": "+ Afegir membre de l'equip"
+      },
+      "actions": {
+        "addReference": "+ Afegir referència",
+        "addHistory": "+ Afegir historial",
+        "remove": "Eliminar",
+        "referenceLabel": "Referència {{index}}",
+        "rentalLabel": "Lloguer {{index}}"
+      }
+    },
+    "create": {
+      "selectType": "Selecciona un tipus de perfil.",
+      "selectBusinessType": "Selecciona un tipus de negoci.",
+      "cooperativeLegalNameRequired": "Introdueix el nom legal de la cooperativa.",
+      "createdSuccess": "{{type}} creat correctament!",
+      "headerTitle": "Create Profile",
+      "createButton": "Create",
+      "chooseType": "Choose Business Profile Type",
+      "types": {
+        "agency": {
+          "title": "Agency Profile",
+          "description": "For real estate agencies and property management"
+        },
+        "business": {
+          "title": "Business Profile",
+          "description": "For small businesses and freelancers"
+        },
+        "cooperative": {
+          "title": "Cooperative Profile",
+          "description": "For housing or member-owned cooperatives"
+        }
+      },
+      "sections": {
+        "agencyInfo": "Agency Information",
+        "businessInfo": "Business Information",
+        "cooperativeInfo": "Cooperative Information",
+        "whatsNext": "What's Next?",
+        "profileSetup": "Profile Setup"
+      },
+      "whatsNext": {
+        "description": "After creating your {{type}} profile, you can customize preferences, add verification documents, and build your trust score."
+      },
+      "placeholders": {
+        "agencyDescription": "Describe your agency...",
+        "businessDescription": "Describe your business...",
+        "licenseOptional": "Enter license number (if applicable)",
+        "cooperativeLegalName": "Cooperative Legal Name",
+        "cooperativeDescription": "Describe the cooperative"
+      },
+      "options": {
+        "agencySpecialty": {
+          "residential": "Residential",
+          "commercial": "Commercial",
+          "investment": "Investment",
+          "rental": "Rental",
+          "new_construction": "New Construction"
+        },
+        "businessSpecialty": {
+          "consulting": "Consulting",
+          "technology": "Technology",
+          "design": "Design",
+          "marketing": "Marketing",
+          "finance": "Finance",
+          "healthcare": "Healthcare",
+          "education": "Education",
+          "retail": "Retail",
+          "services": "Services"
+        }
+      }
+    },
+    "toast": {
+      "loadFailed": "No s'han pogut carregar els perfils",
+      "createSuccess": "Perfil creat correctament",
+      "createFailed": "No s'ha pogut crear el perfil",
+      "updateSuccess": "Perfil actualitzat correctament",
+      "updateFailed": "No s'ha pogut actualitzar el perfil",
+      "deleteSuccess": "Perfil eliminat correctament",
+      "deleteFailed": "No s'ha pogut eliminar el perfil",
+      "activateSuccess": "Perfil activat correctament",
+      "activateFailed": "No s'ha pogut activar el perfil"
+    },
+    "trustScoreHint": "Complete your profile information to improve your trust score.",
+    "trustScoreSubtitle": "Build trust with landlords and roommates through verification and positive interactions.",
+    "established": "Established",
+    "serviceAreas": "Service areas",
+    "specialties": "Specialties",
+    "about": "About",
+    "preferences": "Preferences",
+    "budget": "Budget",
+    "employer": "Employer",
+    "occupation": "Occupation",
+    "listings": "Listings",
+    "switchConfirm": "Switch",
+    "switchMessage": "Activate {{name}}?",
+    "switchTitle": "Switch profile?",
+    "subscriptionsDescription": "Manage Homiio Plus or buy one-time file analysis.",
+    "subscriptions": "Subscriptions",
+    "createNewDescription": "Add a business, agency, or cooperative profile.",
+    "createNew": "Create new profile",
+    "active": "Active",
+    "activeFooter": "Active: {{name}}",
+    "stays": "Stays",
+    "applications": "My applications",
+    "trustScoreCta": "View trust score",
+    "loadFailedHint": "Please try again later.",
+    "loadFailed": "Failed to load profile",
+    "switchFailed": "Failed to switch profile",
+    "switched": "Switched to {{name}}",
+    "invalidProfile": "Invalid profile data",
+    "trustScorePage": {
+      "title": "Trust Score"
+    }
   },
   "trust": {
     "loadingVerification": "Carregant estat de verificació...",
@@ -579,7 +1074,79 @@
     "verified": "Verificat",
     "completeVerification": "Completar verificació",
     "yourScoreIs": "La teva puntuació de confiança és",
-    "improveScore": "Millorar puntuació"
+    "improveScore": "Millorar puntuació",
+    "manager": {
+      "loading": "Carregant puntuació de confiança...",
+      "error": "Error en carregar la puntuació de confiança",
+      "noData": "No s'han trobat dades de puntuació personal",
+      "title": "Puntuació de confiança",
+      "subtitle": "Genera confiança amb propietaris i companys de pis",
+      "scoreDescription": "La teva puntuació global és {{score}}/100",
+      "factorsTitle": "Factors de confiança",
+      "factorsSubtitle": "Millora aquests factors per augmentar la puntuació",
+      "quickActionsTitle": "Accions ràpides per millorar",
+      "completeProfile": "Completar perfil",
+      "cancel": "Cancel·lar",
+      "editProfile": "Editar perfil",
+      "factorAlertBody": "{{description}}\n\nPuntuació actual: {{score}}/100\n\nPer millorar: {{action}}",
+      "factors": {
+        "verification": {
+          "label": "Verificació d'identitat",
+          "description": "Completa la verificació d'identitat per generar confiança",
+          "action": "Afegeix informació personal i dades d'ingressos"
+        },
+        "reviews": {
+          "label": "Ressenyes d'usuaris",
+          "description": "Obtén ressenyes positives de propietaris i companys",
+          "action": "Afegeix referències de propietaris anteriors"
+        },
+        "payment_history": {
+          "label": "Historial de pagaments",
+          "description": "Mantén un bon historial de pagaments",
+          "action": "Afegeix historial de lloguer amb registres de pagament"
+        },
+        "communication": {
+          "label": "Comunicació",
+          "description": "Respon amb promptitud a missatges i sol·licituds",
+          "action": "Completa la biografia i la informació de contacte"
+        },
+        "rental_history": {
+          "label": "Historial de lloguer",
+          "description": "Construeix un historial de lloguer positiu",
+          "action": "Afegeix les teves adreces de lloguer anteriors"
+        },
+        "default": {
+          "description": "Millora aquest factor per augmentar la puntuació",
+          "action": "Completa el teu perfil per millorar aquest factor"
+        }
+      },
+      "actions": {
+        "personalInfo": {
+          "title": "Completar informació personal",
+          "description": "Afegeix la teva ocupació, ingressos i dades laborals per generar confiança."
+        },
+        "references": {
+          "title": "Afegir referències",
+          "description": "Inclou referències de propietaris i empresaris anteriors."
+        },
+        "rentalHistory": {
+          "title": "Afegir historial de lloguer",
+          "description": "Documenta el teu historial de lloguer per demostrar fiabilitat."
+        }
+      }
+    },
+    "score": {
+      "levels": {
+        "excellent": "Excel·lent",
+        "good": "Bo",
+        "average": "Mitjà",
+        "fair": "Regular",
+        "needsImprovement": "Cal millorar"
+      },
+      "breakdown": "Desglossament de la puntuació de confiança",
+      "recalculate": "Recalcular",
+      "recalculating": "Recalculant…"
+    }
   },
   "notifications": {
     "title": "Notificacions",
@@ -620,9 +1187,6 @@
     "share": "Compartir",
     "contact": "Contactar",
     "bookViewing": "Reservar Visita",
-    "Housing Authority": "Autoritat d'Habitatge",
-    "Apply on State Website": "Aplicar al Lloc Web de l'Estat",
-    "Contact Housing Authority": "Contactar Autoritat d'Habitatge",
     "my": {
       "title": "Les Meves Propietats",
       "edit": "Editar",
@@ -634,7 +1198,15 @@
       "emptyDescription": "Encara no has creat cap propietat. Comença afegint la teva primera llista de propietat.",
       "createFirst": "Crear La Teva Primera Propietat",
       "errorTitle": "Error Carregant Propietats",
-      "errorDescription": "Hi ha hagut un error carregant les teves propietats. Si us plau, torna-ho a provar."
+      "errorDescription": "Hi ha hagut un error carregant les teves propietats. Si us plau, torna-ho a provar.",
+      "markRented": "Mark as rented",
+      "markSold": "Mark as sold",
+      "transactMessage": "This closes \"{{title}}\" and removes it from active listings. This cannot be undone.",
+      "markRentedTitle": "Mark as rented?",
+      "markSoldTitle": "Mark as sold?",
+      "transactError": "Could not close this listing",
+      "transactDone": "Listing marked as closed",
+      "transactCommission": "Deal closed — commission recorded"
     },
     "details": {
       "price": "Preu",
@@ -660,6 +1232,61 @@
         "duplex": "Dúplex",
         "penthouse": "Àtic"
       }
+    },
+    "type": {
+      "title": "{{type}}",
+      "subtitle": "{{count}} {{type}} available",
+      "empty": "No {{type}} available at the moment",
+      "filters": {
+        "title": "Filters",
+        "price": "Price Range",
+        "bedrooms": "Bedrooms",
+        "bathrooms": "Bathrooms",
+        "amenities": "Amenities",
+        "sort": {
+          "title": "Sort By",
+          "newest": "Newest First",
+          "priceAsc": "Price: Low to High",
+          "priceDesc": "Price: High to Low"
+        },
+        "apply": "Apply Filters",
+        "clear": "Clear All"
+      }
+    },
+    "actions": {
+      "create": "Add property",
+      "recent": "Recently viewed"
+    },
+    "empty": {
+      "action": "Clear filters",
+      "description": "Try relaxing your filters.",
+      "title": "No homes available"
+    },
+    "error": {
+      "title": "Could not load homes"
+    },
+    "header": {
+      "empty": "No homes available",
+      "loading": "Loading homes…"
+    },
+    "city": {
+      "verifiedProperties": "Verified Properties",
+      "verifiedOnly": "Verified Only",
+      "ecoFriendly": "Eco-Friendly",
+      "ecoFriendlyOnly": "Eco-Friendly Only",
+      "loadingProperties": "Loading properties...",
+      "notFound": "City not found",
+      "properties": "Properties",
+      "population": "Population",
+      "availableProperties": "Available Properties",
+      "propertiesFound": "properties found",
+      "sortBy": "Sort By",
+      "sortNewest": "Newest First",
+      "sortPriceAsc": "Price: Low to High",
+      "sortPriceDesc": "Price: High to Low",
+      "noPropertiesFound": "No properties found",
+      "tryAdjustFilters": "Try adjusting your filters or check back later",
+      "clearFilters": "Clear Filters"
     }
   },
   "property": {
@@ -786,7 +1413,176 @@
       "listedDaysAgo_other": "Publicat fa {{count}} dies",
       "saved_one": "{{count}} desat",
       "saved_other": "{{count}} desats"
-    }
+    },
+    "loading": "Loading property details...",
+    "error": "Error",
+    "notFound": "Property not found",
+    "bed": "Bed",
+    "bath": "Bath",
+    "pricingReviewNeeded": "Pricing Review Needed",
+    "bedrooms": "Number of Bedrooms",
+    "bathrooms": "Number of Bathrooms",
+    "customNumber": {
+      "title": "Enter Custom Number",
+      "placeholder": "Enter number",
+      "confirm": "Confirm",
+      "cancel": "Cancel"
+    },
+    "suggestedRent": "Suggested: ${{amount}}/month",
+    "maxEthicalRent": "Max Ethical: ${{amount}}/month",
+    "ethicalPricingWarning": "Your price exceeds the ethical maximum. Consider lowering it to make housing more accessible.",
+    "warningBullet": "• {{warning}}",
+    "ethicalPricing": "Ethical Pricing",
+    "toast": {
+      "createSuccess": "Propietat creada correctament",
+      "updateSuccess": "Propietat actualitzada correctament",
+      "deleteSuccess": "Propietat eliminada correctament",
+      "createFailed": "No s'ha pogut crear la propietat",
+      "updateFailed": "No s'ha pogut actualitzar la propietat",
+      "deleteFailed": "No s'ha pogut eliminar la propietat",
+      "shareCopied": "Detalls de la propietat copiats al porta-retalls",
+      "shareFailed": "No s'ha pogut compartir la propietat",
+      "shareTitle": "Share Property"
+    },
+    "drafts": {
+      "title": "Esborranys",
+      "emptyTitle": "No hi ha esborranys",
+      "emptyDescription": "Encara no tens esborranys guardats. Comença a crear una propietat per desar-los automàticament.",
+      "createFirst": "Crear nova propietat",
+      "deleteTitle": "Eliminar esborrany",
+      "deleteMessage": "Segur que vols eliminar aquest esborrany? Aquesta acció no es pot desfer.",
+      "toastDeleted": "Esborrany eliminat correctament",
+      "toastDeleteFailed": "No s'ha pogut eliminar l'esborrany",
+      "toastLoadFailed": "No s'ha pogut carregar l'esborrany"
+    },
+    "description": {
+      "showMore": "Show more",
+      "showLess": "Show less"
+    },
+    "external": {
+      "contactTitle": "Contact on listing"
+    },
+    "location": {
+      "title": "Where you'll be"
+    },
+    "cta": {
+      "apply": "Apply",
+      "reserve": "Reserve"
+    },
+    "host": {
+      "verified": "Verified",
+      "responseRate": "Typically responds within an hour",
+      "hostingSince": "Hosting since",
+      "hostedBy": "Hosted by",
+      "openProfile": "Open host profile",
+      "publicSubtitle": "Government-managed affordable housing",
+      "publicAuthority": "Public Housing Authority",
+      "superHost": "Super host"
+    },
+    "report": {
+      "actions": {
+        "submit": "Enviar denúncia"
+      },
+      "notice": "Les denúncies falses o abusives poden afectar el teu compte. Denuncia només problemes reals.",
+      "section": {
+        "contactHelp": "Comparteix un correu si vols que et contactem sobre aquesta denúncia.",
+        "contact": "Correu de contacte (opcional)",
+        "detailsHelp": "Afegeix qualsevol detall que ens ajudi a entendre el problema.",
+        "details": "Detalls (opcional)",
+        "detailsRequired": "Detalls",
+        "reason": "Per què denuncies aquest anunci?"
+      },
+      "field": {
+        "detailsPlaceholder": "Descriu què és inexacte, sospitós o inadequat…"
+      },
+      "intro": "Explica'ns què falla en aquest anunci. Les denúncies són confidencials i les revisa el nostre equip — mai es comparteixen amb l'amfitrió.",
+      "title": "Denunciar aquest anunci",
+      "success": "Gràcies — la teva denúncia s'ha enviat.",
+      "error": {
+        "invalidForm": "Tria un motiu abans d'enviar.",
+        "generic": "Alguna cosa ha anat malament. Torna-ho a provar.",
+        "notFound": "Aquest anunci ja no existeix.",
+        "auth": "Inicia sessió per denunciar un anunci.",
+        "detailsRequired": "Afegeix alguns detalls sobre el problema.",
+        "invalidReason": "Tria un motiu per a la teva denúncia."
+      },
+      "reason": {
+        "inaccurate": "Informació inexacta",
+        "scam": "Possible estafa o frau",
+        "inappropriate": "Contingut inadequat",
+        "unavailable": "Ja llogat o no disponible",
+        "other": "Un altre motiu"
+      }
+    },
+    "about": {
+      "title": "About this property"
+    },
+    "sleep": {
+      "title": "Where you'll sleep",
+      "oneBed": "1 bed",
+      "mainBedroom": "Main bedroom"
+    },
+    "reviews": {
+      "writeAction": "Write a review",
+      "emptyDescription": "Be the first to share what it was like to live here.",
+      "emptyTitle": "No reviews yet",
+      "errorTitle": "Could not load reviews",
+      "disclaimer": "Community-verified reviews about the building. Experiences may vary by unit.",
+      "title": "Reviews",
+      "evidence": "With evidence",
+      "verified": "Verified",
+      "recommend": "Recommend",
+      "count": "reviews",
+      "countWithNumber": "({{count}} ressenyes)"
+    },
+    "notFoundHelp": "It may have been removed or the link is broken.",
+    "sections": {
+      "photoGallery": "Galeria de fotos",
+      "viewAll": "Veure-ho tot",
+      "features": "Característiques",
+      "furnished": "Moblat",
+      "partiallyFurnished": "Parcialment moblat",
+      "unfurnished": "Sense moblar",
+      "balcony": "Balcó",
+      "garden": "Jardí",
+      "elevator": "Ascensor",
+      "overview": "Resum",
+      "bedrooms": "Dormitoris",
+      "bathrooms": "Banys",
+      "size": "Mida",
+      "floor": "Planta",
+      "details": "Detalls",
+      "notSpecified": "No especificat",
+      "yearBuilt": "Any de construcció",
+      "parkingSpaces": "Places d'aparcament",
+      "pricingAndCosts": "Preu i costos",
+      "rent": "Lloguer",
+      "deposit": "Dipòsit",
+      "utilitiesIncluded": "Serveis inclosos",
+      "nightlyRent": "Lloguer per nit",
+      "monthlyRent": "Lloguer mensual",
+      "sourcedFrom": "Font",
+      "availability": "Disponibilitat",
+      "availableFrom": "Disponible des de",
+      "leaseTerm": "Durada del contracte",
+      "location": "Ubicació",
+      "nearbyAmenities": "Serveis propers",
+      "publicTransport": "Transport públic",
+      "schools": "Escoles",
+      "shopping": "Comerços"
+    },
+    "neighborhood": {
+      "title": "Neighborhood",
+      "listings": "Listings",
+      "avgRentPerMonth": "Avg. rent / mo",
+      "onParWithCity": "On par with the city average",
+      "listingCount": "{{count}} listings",
+      "avgAmountPerMonth": "Avg. {{amount}}/mo",
+      "pctVsCity": "{{pct}}% {{dir}} than the city average",
+      "cheaper": "cheaper",
+      "pricier": "pricier"
+    },
+    "fraudWarning": "Never pay or transfer funds outside the Homio platform"
   },
   "viewings": {
     "title": "Visites",
@@ -806,7 +1602,8 @@
       "timeInPast": "L'hora programada ha de ser en el futur.",
       "authRequired": "Si us plau, inicieu sessió per sol·licitar una visita.",
       "notFound": "Sol·licitud de visita no trobada.",
-      "cannotCancel": "No es pot cancel·lar aquesta sol·licitud de visita."
+      "cannotCancel": "No es pot cancel·lar aquesta sol·licitud de visita.",
+      "externalProperty": "Cannot book viewings for external properties"
     },
     "selectDate": "Selecciona data",
     "availableTimeSlots": "Franges horàries disponibles",
@@ -829,6 +1626,10 @@
     },
     "cancel": {
       "confirmMessage": "Esteu segur que voleu cancel·lar aquesta sol·licitud de visita?"
+    },
+    "banner": {
+      "viewDetails": "View details",
+      "hasViewing": "You have a viewing scheduled"
     }
   },
   "payments": {
@@ -864,6 +1665,116 @@
       "download": "Descarregar",
       "sign": "Signar",
       "renew": "Renovar"
+    },
+    "list": {
+      "title": "Contractes de lloguer",
+      "eyebrow": "Acords",
+      "subtitle": "Fes seguiment de cada contracte que signis o emetis i consulta els termes clau a l'instant.",
+      "filterAll": "Tots",
+      "filterActive": "Actius",
+      "filterPending": "Pendents",
+      "filterExpired": "Vençuts",
+      "filterDrafts": "Esborranys",
+      "noRentalPropertiesTitle": "Sense contractes de lloguer",
+      "noRentalPropertiesDescription": "Encara no tens propietats de lloguer. Comença explorant propietats disponibles o publicant la teva.",
+      "browseProperties": "Explorar propietats",
+      "loadError": "No s'han pogut carregar els contractes",
+      "tryAgain": "Torna-ho a provar.",
+      "emptyTitle": "No s'han trobat contractes",
+      "emptyAllDescription": "Encara no tens contractes de lloguer",
+      "emptyFilteredDescription": "No hi ha contractes {{filter}} per mostrar",
+      "newContract": "Nou contracte",
+      "createNew": "Crear nou contracte"
+    },
+    "card": {
+      "start": "Inici",
+      "end": "Fi",
+      "landlord": "Arrendador",
+      "tenant": "Inquilí",
+      "perMonth": "/ mes",
+      "share": "Compartir",
+      "download": "Descarregar",
+      "accessibility": "Contracte {{title}}"
+    },
+    "detail": {
+      "title": "Contracte",
+      "invalidIdTitle": "ID de contracte no vàlid",
+      "invalidIdDescription": "L'enllaç no inclou la referència del contracte.",
+      "unavailableTitle": "Contracte no disponible",
+      "unavailableDescription": "No s'ha pogut carregar aquest contracte.",
+      "term": "Termini",
+      "rent": "Lloguer",
+      "start": "Inici",
+      "end": "Fi",
+      "monthlyRent": "Lloguer mensual",
+      "securityDeposit": "Dipòsit de garantia",
+      "signatures": "Signatures",
+      "landlord": "Arrendador",
+      "tenant": "Inquilí",
+      "payments": "Calendari de pagaments",
+      "documents": "Documents",
+      "addDocument": "Afegir document",
+      "sign": "Signar contracte",
+      "terminate": "Rescindir contracte",
+      "deleteDraft": "Eliminar esborrany",
+      "confirmSignTitle": "Signar aquest contracte?",
+      "confirmSignBody": "La teva signatura confirma que acceptes els termes del contracte.",
+      "confirmTerminateTitle": "Rescindir aquest contracte?",
+      "confirmTerminateBody": "Això finalitza el contracte per a totes les parts.",
+      "confirmDeleteTitle": "Eliminar aquest esborrany?",
+      "confirmDeleteBody": "Aquest esborrany s'eliminarà permanentment.",
+      "toastSigned": "Contracte signat",
+      "toastSignFailed": "No s'ha pogut signar el contracte",
+      "toastTerminated": "Contracte rescindit",
+      "toastTerminateFailed": "No s'ha pogut rescindir el contracte",
+      "toastDeleted": "Esborrany eliminat",
+      "toastDeleteFailed": "No s'ha pogut eliminar l'esborrany",
+      "toastDocumentAdded": "Document afegit",
+      "toastDocumentFailed": "No s'ha pogut afegir el document",
+      "toastOpenDocumentFailed": "No s'ha pogut obrir el document.",
+      "permissionRequired": "Es requereix permís de la biblioteca multimèdia per adjuntar un document.",
+      "propertyFallback": "Propietat",
+      "goBack": "Go back",
+      "dueDay": "Day {{day}} of the month",
+      "signed": "Signed",
+      "signaturePending": "Pending",
+      "emptyDocuments": "No documents attached.",
+      "addShort": "Add",
+      "signLease": "Sign lease",
+      "confirmSignExtended": "By signing you agree to the lease terms. Once both parties sign, the lease becomes active.",
+      "confirmSignAction": "Sign",
+      "confirmTerminateShortTitle": "Terminate lease?",
+      "confirmTerminateExtended": "This records a termination notice and ends the lease. This cannot be undone.",
+      "confirmDeleteExtended": "This permanently removes the draft lease.",
+      "confirmDeleteAction": "Delete",
+      "openDocument": "Open document {{name}}",
+      "dueDayLabel": "Due day"
+    },
+    "new": {
+      "title": "Nou contracte",
+      "noApplicationTitle": "Comença des d'una sol·licitud",
+      "noApplicationDescription": "Els contractes es creen des d'una sol·licitud de llogater aprovada. Obre una sol·licitud aprovada i tria \"Crear contracte\".",
+      "viewApplications": "Veure sol·licituds",
+      "applicationUnavailableTitle": "Sol·licitud no disponible",
+      "loadFailedDescription": "No s'ha pogut carregar aquesta sol·licitud.",
+      "goBack": "Tornar",
+      "subtitle": "Crea un esborrany de contracte des d'aquesta sol·licitud. Pots editar els termes i signar-lo a la pantalla següent.",
+      "seededTerms": "Termes inicials",
+      "moveIn": "Entrada",
+      "leaseTerm": "Durada del contracte",
+      "leaseTermMonths": "{{count}} mesos",
+      "notApprovedWarning": "Aquesta sol·licitud encara no està aprovada. Aprova-la primer per crear un contracte.",
+      "createButton": "Crear esborrany de contracte",
+      "toastCreated": "Esborrany de contracte creat",
+      "toastCreateFailed": "No s'ha pogut crear el contracte",
+      "propertyFallback": "Propietat"
+    },
+    "documentType": {
+      "lease_agreement": "Contracte de lloguer",
+      "addendum": "Annex",
+      "inspection_report": "Informe d'inspecció",
+      "insurance": "Assegurança",
+      "other": "Altre"
     }
   },
   "roommates": {
@@ -877,6 +1788,185 @@
       "message": "Missatge",
       "connect": "Connectar",
       "viewProfile": "Veure Perfil"
+    },
+    "tabs": {
+      "discover": "Descobrir",
+      "requests": "Sol·licituds",
+      "matches": "Coincidències",
+      "rooms": "Habitacions"
+    },
+    "alert": {
+      "requestSent": "Sol·licitud de company de pis enviada correctament!",
+      "requestFailed": "No s'ha pogut enviar la sol·licitud de company de pis",
+      "accepted": "Sol·licitud de company de pis acceptada!",
+      "acceptFailed": "No s'ha pogut acceptar la sol·licitud de company de pis",
+      "declined": "Sol·licitud de company de pis rebutjada",
+      "declineFailed": "No s'ha pogut rebutjar la sol·licitud de company de pis",
+      "relationshipEnded": "Relació de companys de pis finalitzada",
+      "relationshipEndFailed": "No s'ha pogut finalitzar la relació de companys de pis",
+      "toggleFailed": "No s'ha pogut canviar la cerca de companys de pis",
+      "preferencesSaved": "Les teves preferències de company de pis s'han actualitzat.",
+      "preferencesFailed": "No s'han pogut desar les preferències de company de pis. Torna-ho a provar.",
+      "successTitle": "Èxit",
+      "errorTitle": "Error"
+    },
+    "screen": {
+      "title": "Company de pis",
+      "signInTitle": "Sign in to find roommates",
+      "signInDescription": "Discover compatible roommates and manage your requests.",
+      "signIn": "Sign in",
+      "loadError": "Couldn't load roommates",
+      "tryAgain": "Please try again.",
+      "emptyDiscoverTitle": "No matches yet",
+      "emptyDiscoverDescription": "Complete your roommate profile to start discovering matches.",
+      "emptyRequestsTitle": "No requests",
+      "emptyRequestsDescription": "Incoming and outgoing roommate requests will appear here.",
+      "emptyRelationshipsTitle": "No matches yet",
+      "emptyRelationshipsDescription": "Accepted roommate requests become matches here.",
+      "emptyRoomsTitle": "No rooms listed",
+      "emptyRoomsDescription": "Room listings from your network will appear here.",
+      "enableMatching": "Enable roommate matching",
+      "editPreferences": "Edit preferences",
+      "fallbackName": "Company",
+      "eyebrow": "Junts",
+      "loadRequestsError": "Couldn't load requests",
+      "loadRelationshipsError": "Couldn't load relationships",
+      "personalProfileRequired": "Perfil personal requerit",
+      "personalProfileDescription": "La cerca de company només està disponible per a perfils personals. Canvia al teu perfil personal per usar aquesta funció.",
+      "roomSearchPersonalOnly": "Room search is only available for personal profiles. Switch to your personal profile to use this feature.",
+      "switchToPersonal": "Canviar a perfil personal",
+      "enableMatchingTitle": "Activar cerca de company",
+      "enableMatchingDescription": "Turn on roommate matching to discover potential roommates based on your preferences.",
+      "enabling": "Enabling…",
+      "discoverRoommates": "Descobrir companys",
+      "updatePreferences": "Update preferences",
+      "matchingEnabled": "Roommate matching enabled",
+      "matchingDisabled": "Roommate matching disabled"
+    },
+    "request": {
+      "accept": "Accept",
+      "decline": "Decline",
+      "viewProfile": "View profile",
+      "sent": "Sent",
+      "received": "Received",
+      "pending": "Pending",
+      "accepted": "Accepted",
+      "declined": "Declined",
+      "responsePlaceholder": "Add an optional message..."
+    },
+    "relationship": {
+      "endRelationship": "End relationship",
+      "confirmEndTitle": "End roommate relationship?",
+      "confirmEndBody": "You will no longer appear as roommates.",
+      "message": "Message",
+      "title": "Roommate Relationship",
+      "duration": "Duration: {{duration}}",
+      "started": "Started: {{date}}",
+      "endedOn": "Ended on {{date}}",
+      "statusActive": "Active",
+      "statusInactive": "Inactive",
+      "statusEnded": "Ended",
+      "statusUnknown": "Unknown",
+      "durationDays": "{{count}} days",
+      "durationMonth": "{{count}} month",
+      "durationMonths": "{{count}} months",
+      "durationYear": "{{count}} year",
+      "durationYears": "{{count}} years",
+      "percentMatch": "{{score}}% Match",
+      "roommatesSection": "Roommates",
+      "confirmEndAction": "End Relationship"
+    },
+    "match": {
+      "compatibility": "{{score}}% match",
+      "viewProfile": "View profile",
+      "connect": "Connect",
+      "excellent": "Excellent Match",
+      "good": "Good Match",
+      "fair": "Fair Match",
+      "preferences": "Preferences",
+      "flexible": "Flexible",
+      "messageLabel": "Add a message (optional):",
+      "messagePlaceholder": "Hi! I think we'd be great roommates...",
+      "sendRequest": "Send Request",
+      "fallbackName": "Roommate"
+    },
+    "profileDetail": {
+      "title": "Company",
+      "loadError": "Couldn't load profile",
+      "loadErrorDescription": "We couldn't load this roommate profile. Please try again.",
+      "about": "About",
+      "preferencesTitle": "Roommate preferences",
+      "budget": "Budget",
+      "moveIn": "Move-in",
+      "leaseLength": "Lease length",
+      "notSpecified": "Not specified",
+      "trust": "Trust",
+      "verified": "Verified",
+      "references": "References",
+      "rentalHistory": "Rental history",
+      "sending": "Sending…",
+      "sendRequest": "Enviar sol·licitud de company",
+      "requestSentTitle": "Request sent",
+      "requestSentBody": "Your roommate request was sent.",
+      "requestFailedTitle": "Could not send request",
+      "requestFailedBody": "We could not send your request. Please try again."
+    },
+    "preferencesPage": {
+      "title": "Preferències de company",
+      "eyebrow": "Sharing a place",
+      "subtitle": "Let other Homiio users find you when their preferences and yours line up.",
+      "enableTitle": "Enable roommate matching",
+      "enableDescription": "Allow other users to discover your profile for matching.",
+      "budgetTimeline": "Budget & timeline",
+      "monthlyBudget": "Monthly budget (€)",
+      "min": "Min",
+      "max": "Max",
+      "moveInDate": "Move-in date",
+      "leaseLength": "Lease length",
+      "roommateSection": "Roommate",
+      "preferredGender": "Preferred gender",
+      "ageRange": "Age range",
+      "lifestyle": "Lifestyle",
+      "smoking": "Smoking",
+      "pets": "Pets",
+      "partying": "Partying",
+      "cleanliness": "Cleanliness",
+      "schedule": "Schedule",
+      "saving": "Saving…",
+      "save": "Desar preferències",
+      "personalProfileRequired": "Personal profile required",
+      "personalProfileDescription": "Roommate preferences are only available for personal profiles. Please switch to your personal profile to manage your roommate settings.",
+      "switchToPersonal": "Switch to personal profile",
+      "options": {
+        "gender": {
+          "any": "Any",
+          "male": "Male",
+          "female": "Female"
+        },
+        "lifestyle": {
+          "yes": "Yes",
+          "no": "No",
+          "prefer_not": "No pref."
+        },
+        "cleanliness": {
+          "very_clean": "Very clean",
+          "clean": "Clean",
+          "average": "Average",
+          "relaxed": "Relaxed"
+        },
+        "schedule": {
+          "early_bird": "Early bird",
+          "night_owl": "Night owl",
+          "flexible": "Flexible"
+        },
+        "lease": {
+          "monthly": "Monthly",
+          "3_months": "3 months",
+          "6_months": "6 months",
+          "yearly": "Yearly",
+          "flexible": "Flexible"
+        }
+      }
     }
   },
   "safety": {
@@ -894,11 +1984,57 @@
     }
   },
   "horizon": {
-    "title": "Iniciativa Horizon",
+    "title": "Horizon Initiative",
     "description": "Iniciativa global per a habitatge just, assistència sanitària i suport de viatge",
     "benefits": "Beneficis",
     "join": "Uneix-te a Horizon",
-    "learnMore": "Saber Més"
+    "learnMore": "Saber Més",
+    "page": {
+      "benefits": {
+        "fairHousing": {
+          "title": "Habitatge just",
+          "description": "Accés a habitatge assequible en més de 120 ciutats amb contractes ètics estandarditzats"
+        },
+        "healthcare": {
+          "title": "Accés a la salut",
+          "description": "Cobertura sanitària universal amb clíniques associades i telemedicina a cada ciutat Horizon"
+        },
+        "travel": {
+          "title": "Xarxa de viatges",
+          "description": "Transport i allotjament amb descompte en viatjar entre ubicacions Horizon"
+        },
+        "community": {
+          "title": "Suport comunitari",
+          "description": "Connecta amb membres locals per a integració cultural, intercanvi d'idiomes i activitats socials"
+        }
+      },
+      "heroTitle": "Iniciativa global d'habitatge",
+      "heroSubtitle": "Creant un món d'habitatge, salut i mobilitat ètiques",
+      "aboutTitle": "Sobre Horizon",
+      "aboutBody1": "Horizon és una iniciativa global dissenyada per fer l'habitatge més accessible, assequible i ètic per a tothom. En unir-te a una xarxa de propietats en més de 120 ciutats, els membres accedeixen a habitatge just, beneficis sanitaris i suport de viatge.",
+      "aboutBody2": "La nostra missió és crear entorns de vida sostenibles que fomentin la comunitat i el benestar, reduint l'impacte ambiental de l'habitatge.",
+      "benefitsTitle": "Beneficis per a membres",
+      "howItWorksTitle": "Com funciona",
+      "steps": {
+        "apply": {
+          "title": "Sol·licitar membresia",
+          "description": "Completa el teu perfil i envia una sol·licitud amb les teves necessitats i preferències d'habitatge."
+        },
+        "verify": {
+          "title": "Verificació",
+          "description": "El nostre equip revisa la sol·licitud i verifica la identitat i la informació de fons."
+        },
+        "access": {
+          "title": "Accedeix a la xarxa",
+          "description": "Un cop aprovat, explora i reserva propietats a la xarxa global amb accés prioritari."
+        }
+      },
+      "joinTitle": "Preparat per unir-te a Horizon?",
+      "joinSubtitle": "Sol·licita-ho avui i fes el primer pas cap a un habitatge ètic i accessible arreu del món.",
+      "storiesTitle": "Històries de membres",
+      "story1": "Horizon em va facilitar molt la meva mudança. Vaig trobar un pis ètic a Berlín en una setmana i la cobertura sanitària em va ajudar quan vaig necessitar atenció urgent.",
+      "story2": "Com a nòmada digital, tenir accés a habitatge de qualitat en diverses ciutats ha canviat la meva vida. L'aspecte comunitari és el que fa especial Horizon."
+    }
   },
   "settings": {
     "title": "Configuració",
@@ -911,7 +2047,8 @@
       "supportFeedback": "Suport i Comentaris",
       "preferences": "Preferències de l'App",
       "quickActions": "Accions Ràpides",
-      "data": "Gestió de Dades"
+      "data": "Gestió de Dades",
+      "notifications": "Notifications"
     },
     "aboutHomiio": {
       "appName": "Homiio",
@@ -967,8 +2104,27 @@
       "title": "Moneda",
       "selectCurrency": "Selecciona la teva moneda preferida",
       "description": "Això s'utilitzarà per mostrar preus a tota l'aplicació",
-      "currencyChanged": "Moneda canviada amb èxit"
-    }
+      "currencyChanged": "Moneda canviada amb èxit",
+      "errorChanging": "Failed to change currency. Please try again."
+    },
+    "language": {
+      "title": "Language",
+      "choose": "Tria un idioma",
+      "footer": "Canviar l'idioma actualitza les etiquetes de l'app a l'instant.",
+      "emptyTitle": "No s'han trobat idiomes",
+      "emptyDescription": "No hi ha opcions d'idioma disponibles",
+      "subtitle": "Select your preferred language"
+    },
+    "notifications": {
+      "detailDesc": "Choose which alerts you receive",
+      "detail": "Notification categories"
+    },
+    "account": {
+      "filesDescription": "Manage uploaded documents",
+      "files": "Files"
+    },
+    "signOutFailed": "Failed to sign out",
+    "signOutSuccess": "Signed out"
   },
   "common": {
     "cancel": "Cancel·lar",
@@ -983,7 +2139,7 @@
     "loading": "Carregant...",
     "retry": "Tornar a provar",
     "save": "Guardar",
-    "saving": "Guardant...",
+    "saving": "Saving...",
     "delete": "Eliminar",
     "edit": "Editar",
     "close": "Tancar",
@@ -1014,14 +2170,7 @@
     "view": "Veure",
     "details": "Detalls",
     "more": "Més",
-    "Sign in to save searches": "Inicia sessió per guardar cerques",
-    "Go to Search": "Anar a Cercar",
-    "No saved searches yet": "Encara no hi ha cerques guardades",
-    "Create New Search": "Crear Nova Cerca",
-    "View All": "Veure Tot",
-    "Sign in to create property alerts": "Inicia sessió per crear alertes de propietats",
     "Creating...": "Creant...",
-    "Create Alert": "Crear Alerta",
     "less": "Menys",
     "all": "Tot",
     "none": "Cap",
@@ -1029,9 +2178,14 @@
     "noData": "No hi ha dades disponibles",
     "noResults": "No s'han trobat resultats",
     "tryAgain": "Provar de nou",
-    "goBack": "Tornar",
+    "goBack": "Go Back",
     "goHome": "Anar a l'inici",
-    "signIn": "Inicia sessió"
+    "signIn": "Inicia sessió",
+    "name": "Name",
+    "emoji": "Emoji",
+    "color": "Color",
+    "month": "month",
+    "reset": "Reset"
   },
   "sindi": {
     "name": "Sindi",
@@ -1153,7 +2307,9 @@
     },
     "errors": {
       "connection": "Error de Connexió",
-      "connectionMessage": "Si us plau, verifiqueu la vostra connexió i intenteu-ho de nou."
+      "connectionMessage": "Si us plau, verifiqueu la vostra connexió i intenteu-ho de nou.",
+      "uploadFailedTitle": "Error en pujar",
+      "uploadAnalyzeFailed": "No s'ha pogut analitzar el fitxer."
     },
     "shared": {
       "loading": "Carregant Conversació Compartida",
@@ -1195,6 +2351,18 @@
         "title": "Inicieu la Vostra Conversació",
         "subtitle": "Pregunteu a Sindi sobre drets de llogaters, cerca d'habitatge, o qualsevol pregunta relacionada amb habitatge. Estic aquí per ajudar-vos a lluitar per la justícia habitacional."
       }
+    },
+    "settings": {
+      "resetMessage": "This will reset all Sindi preferences to their defaults.",
+      "resetTitle": "Reset Sindi?",
+      "reset": "Reset Sindi to defaults",
+      "actions": "Actions",
+      "tipsDescription": "Surface inline guidance while you chat.",
+      "tips": "Show tips & hints",
+      "behaviorFooter": "Tune how Sindi behaves while you browse properties.",
+      "behavior": "Behavior",
+      "title": "Sindi preferences",
+      "resetDone": "Sindi preferences reset."
     }
   },
   "sidebar": {
@@ -1215,7 +2383,8 @@
       "tips": "Consells",
       "hostCalendar": "Calendari d'amfitrió",
       "hostReservations": "Reserves d'amfitrió",
-      "landlordApplications": "Safata de sol·licituds"
+      "landlordApplications": "Safata de sol·licituds",
+      "insights": "Insights"
     },
     "actions": {
       "addProperty": "Afegir Propietat",
@@ -1291,7 +2460,94 @@
       "newest": "Més Recents Primer",
       "oldest": "Més Antics Primer",
       "alphabetical": "Alfabètic"
-    }
+    },
+    "tabs": {
+      "all": "All",
+      "recent": "Recent",
+      "noted": "With Notes",
+      "quickSaves": "Quick Saves",
+      "folders": "Folders",
+      "profiles": "Profiles",
+      "searches": "Saved Searches",
+      "label": "Saved view"
+    },
+    "view": {
+      "list": "List",
+      "grid": "Grid"
+    },
+    "searchPlaceholder": "Search your saved items...",
+    "profilesLabel": "profiles",
+    "adjustFilters": "Try adjusting your search or filter criteria",
+    "sort": {
+      "recent": "Recently Saved",
+      "price-low": "Price: Low to High",
+      "price-high": "Price: High to Low",
+      "title": "Property Name",
+      "notes": "Most Notes"
+    },
+    "editFolder": "Edit Folder",
+    "defaultFolder": "Default Folder",
+    "folderNamePlaceholder": "Folder name",
+    "noFolder": "Folder not found",
+    "noFolderDescription": "This folder may have been removed",
+    "noFolderItems": "No properties in this folder",
+    "noFolderItemsDescription": "Save properties to this folder to see them here",
+    "toast": {
+      "loadFoldersFailed": "Failed to load folders",
+      "folderCreated": "Folder created successfully",
+      "folderCreateFailed": "Failed to create folder",
+      "folderUpdated": "Folder updated successfully",
+      "folderUpdateFailed": "Failed to update folder",
+      "folderDeleted": "Folder deleted successfully",
+      "folderDeleteFailed": "Failed to delete folder",
+      "propertySaved": "Propietat desada correctament",
+      "propertySaveFailed": "Failed to save property",
+      "propertyRemoved": "Property removed from saved",
+      "propertyUnsaveFailed": "Failed to unsave property",
+      "propertySavedToFolder": "Propietat guardada a la carpeta",
+      "saveToFolderFailed": "No s'ha pogut guardar a la carpeta"
+    },
+    "folder": {
+      "title": "Guardar a carpeta",
+      "createNew": "Crear carpeta nova",
+      "folderNamePlaceholder": "Nom de la carpeta",
+      "chooseColor": "Triar color",
+      "chooseEmoji": "Triar emoji",
+      "creating": "Creant...",
+      "createAndSave": "Crear i guardar",
+      "propertyCount_one": "{{count}} propietat",
+      "propertyCount_other": "{{count}} propietats",
+      "alertFolderNameRequired": "Introdueix un nom per a la carpeta",
+      "alertDefaultFolderRename": "La carpeta predeterminada no es pot reanomenar."
+    },
+    "exploreCta": "Explore properties",
+    "loadFailed": "We couldn't load this folder",
+    "noPropertiesDescription": "Save properties to see them here.",
+    "noProperties": "No saved properties",
+    "noResults": "No matches",
+    "createFolder": "Create folder",
+    "noFoldersDescription": "Create folders to organise the places you like.",
+    "noFolders": "No folders yet"
+  },
+  "imageUpload": {
+    "permissionTitle": "Permís necessari",
+    "permissionMessage": "Necessitem permís per accedir a la galeria i pujar imatges.",
+    "maxImagesTitle": "Màxim d'imatges assolit",
+    "maxImagesMessage": "Pots pujar un màxim de {{max}} imatges.",
+    "selectFailed": "No s'han pogut seleccionar les imatges. Torna-ho a provar.",
+    "photoFailed": "No s'ha pogut fer la foto. Torna-ho a provar.",
+    "uploadFailed": "No s'han pogut pujar algunes imatges. Torna-ho a provar.",
+    "deleteTitle": "Eliminar imatge",
+    "deleteMessage": "Segur que vols eliminar aquesta imatge?",
+    "deleteFailed": "No s'ha pogut eliminar la imatge. Torna-ho a provar.",
+    "choosePhotos": "Choose Photos",
+    "takePhoto": "Take Photo",
+    "uploading": "Uploading images...",
+    "imageCount": "{{current}} of {{max}} images uploaded",
+    "primary": "Primary",
+    "addMore": "Add More",
+    "helperText": "Upload high-quality images of your property. Include photos of all rooms, exterior, and any special features.",
+    "helperPrimaryNote": " The first image will be set as the primary image."
   },
   "listing": {
     "exchange": {
@@ -1418,7 +2674,7 @@
       "forSale": "En venda",
       "exchange": "Intercanvi",
       "verified": "Verificat",
-      "eco": "Eco",
+      "eco": "Ecològic",
       "instantBook": "Reserva immediata"
     },
     "offering": {
@@ -1491,7 +2747,876 @@
       "loanAmount": "Import del préstec",
       "totalInterest": "Interessos totals",
       "totalPaid": "Total pagat"
+    },
+    "cta": {
+      "housingAuthority": "Habitatge públic",
+      "landlord": "Propietari",
+      "applyOnStateWebsite": "Sol·licitar al web oficial",
+      "viewOnSourceWebsite": "Veure al portal d'origen",
+      "callNow": "Trucar ara",
+      "moreByOwner": "Més propietats d'aquest propietari"
     }
   },
-  "goBack": "Tornar"
+  "goBack": "Tornar",
+  "app": {
+    "welcome": {
+      "title": "Welcome to Homiio! 👋",
+      "subtitle": "Thanks for trying out our app. Start exploring now!"
+    },
+    "errors": {
+      "screenNotExist": "This screen doesn't exist.",
+      "goHome": "Go to home screen!",
+      "noResults": "No results found for"
+    },
+    "loading": "Loading...",
+    "battery": "Battery"
+  },
+  "tips": {
+    "article": "Article",
+    "all": "All",
+    "loadError": "Couldn't load tips",
+    "tryAgain": "Please try again.",
+    "emptyTitle": "No tips yet",
+    "emptyDescription": "Check back soon for new rental guides and advice.",
+    "unavailable": "Article unavailable",
+    "missingSlug": "This tip could not be loaded.",
+    "loadFailed": "This tip could not be loaded.",
+    "related": "Related tips"
+  },
+  "donations": {
+    "widget": {
+      "title": "Support Our Mission",
+      "description": "Help us build the future of ethical housing. Your support makes a difference.",
+      "button": "Donate to Homiio"
+    },
+    "page": {
+      "title": "Donate to Homiio",
+      "subtitle": "Support the future of ethical housing",
+      "description": "Your contribution helps us build a transparent, fair, and ethical housing platform that benefits everyone in the rental ecosystem.",
+      "chooseContribution": "Choose Your Contribution",
+      "frequency": {
+        "label": "Donation frequency",
+        "monthly": "Monthly",
+        "oneTime": "One-time",
+        "perMonth": "/mo"
+      },
+      "error": {
+        "title": "Something went wrong",
+        "generic": "Unable to process your donation. Please try again later."
+      },
+      "tiers": {
+        "supporter": {
+          "title": "One-time donation",
+          "subtitle": "Help with a small contribution",
+          "button": "Donate Now"
+        },
+        "monthly": {
+          "title": "Monthly supporter",
+          "subtitle": "Become a regular supporter",
+          "button": "Start Supporting"
+        },
+        "founder": {
+          "title": "Founder supporter",
+          "subtitle": "Join our founding supporters",
+          "button": "Become a Founder"
+        }
+      },
+      "impact": {
+        "title": "What Your Support Enables",
+        "areas": {
+          "development": {
+            "title": "Platform Development",
+            "description": "Continuous improvement of our housing platform"
+          },
+          "safety": {
+            "title": "Trust & Safety",
+            "description": "Enhanced verification and fraud prevention"
+          },
+          "legal": {
+            "title": "Legal Integration",
+            "description": "Sindi legal support and transparent contracts"
+          },
+          "innovation": {
+            "title": "Innovation",
+            "description": "FairCoin payments and energy monitoring"
+          },
+          "community": {
+            "title": "Community Building",
+            "description": "Growing the ethical housing movement"
+          }
+        }
+      },
+      "mission": {
+        "title": "Why Support Homiio?",
+        "description": "We're building more than just a rental platform—we're creating a complete ecosystem for ethical housing. Your support helps us:",
+        "goals": [
+          "Fight against rental abuse and hidden fees",
+          "Create transparent processes for tenants and landlords",
+          "Integrate innovative payment methods like FairCoin",
+          "Provide legal support through our Sindi integration",
+          "Build sustainable, community-driven solutions"
+        ]
+      }
+    }
+  },
+  "notFound": {
+    "title": "Pàgina no trobada",
+    "message": "La pàgina que busques no existeix.",
+    "goBack": "Tornar"
+  },
+  "statusBadge": {
+    "draft": "Esborrany",
+    "pending": "Pendent",
+    "pendingSignatures": "Signatures pendents",
+    "active": "Actiu",
+    "expired": "Vençut",
+    "terminated": "Rescindit",
+    "cancelled": "Cancel·lat",
+    "processing": "Processant",
+    "completed": "Completat",
+    "failed": "Fallit",
+    "refunded": "Reemborsat",
+    "success": "Èxit",
+    "warning": "Advertència",
+    "error": "Error",
+    "info": "Informació",
+    "investigating": "En investigació",
+    "resolved": "Resolt",
+    "online": "En línia",
+    "offline": "Sense connexió",
+    "unknown": "Desconegut",
+    "application": {
+      "submitted": "Enviada",
+      "reviewing": "En revisió",
+      "approved": "Aprovada",
+      "rejected": "Rebutjada",
+      "withdrawn": "Retirada"
+    },
+    "reservation": {
+      "pending": "Pendent",
+      "confirmed": "Confirmada",
+      "declined": "Rebutjada",
+      "cancelled": "Cancel·lada",
+      "completed": "Completada"
+    }
+  },
+  "applications": {
+    "list": {
+      "title": "Les meves sol·licituds",
+      "filterAll": "Totes",
+      "filterActive": "Actives",
+      "filterDecided": "Decidides",
+      "filterWithdrawn": "Retirades",
+      "signInTitle": "Inicia sessió per veure les teves sol·licituds",
+      "signInDescription": "Fes seguiment de les sol·licituds d'inquilí que has enviat a arrendadors.",
+      "signIn": "Iniciar sessió",
+      "loadError": "No s'han pogut carregar les teves sol·licituds",
+      "tryAgain": "Torna-ho a provar.",
+      "retry": "Reintentar",
+      "emptyAllTitle": "Encara no hi ha sol·licituds.",
+      "emptyFilteredTitle": "Res en aquesta vista.",
+      "emptyAllDescription": "Explora anuncis i envia una sol·licitud per a un lloguer a llarg termini.",
+      "emptyFilteredDescription": "Prova un altre filtre o envia una nova sol·licitud.",
+      "exploreStays": "Explorar allotjaments",
+      "today": "Avui",
+      "thisWeek": "Aquesta setmana",
+      "earlier": "Anteriors"
+    },
+    "card": {
+      "propertyFallback": "Propietat",
+      "applicantFallback": "Sol·licitant",
+      "monthLease": "Contracte de {{count}} mesos",
+      "moveIn": "Entrada",
+      "submitted": "Enviada el {{date}}",
+      "perMonth": "/ mes",
+      "accessibility": "Sol·licitud {{id}}"
+    },
+    "toast": {
+      "openDocumentFailed": "No s'ha pogut obrir el document.",
+      "withdrawn": "Sol·licitud retirada",
+      "withdrawFailed": "No s'ha pogut retirar la sol·licitud"
+    },
+    "documentType": {
+      "id": "Identificació",
+      "income": "Ingressos",
+      "reference": "Referència",
+      "other": "Altre"
+    },
+    "landlord": {
+      "toastOpenDocumentFailed": "No s'ha pogut obrir el document.",
+      "review": {
+        "reviewing": {
+          "title": "Marcar com a en revisió?",
+          "message": "El sol·licitant sabrà que tens la seva sol·licitud oberta. Podràs aprovar o rebutjar després.",
+          "confirm": "Marcar com a en revisió",
+          "successToast": "Sol·licitud marcada com a en revisió"
+        },
+        "approve": {
+          "title": "Aprovar sol·licitud?",
+          "message": "Es notificarà al sol·licitant i podrà avançar per signar el contracte.",
+          "confirm": "Aprovar",
+          "successToast": "Sol·licitud aprovada"
+        },
+        "reject": {
+          "title": "Rebutjar sol·licitud?",
+          "message": "Es notificarà al sol·licitant. No es pot desfer, però pot enviar una nova sol·licitud més endavant.",
+          "confirm": "Rebutjar",
+          "successToast": "Sol·licitud rebutjada"
+        }
+      },
+      "toastUpdateFailed": "No s'ha pogut actualitzar la sol·licitud"
+    },
+    "field": {
+      "moveInDate": "Move-in date",
+      "notesPlaceholder": "Anything else the landlord should know about you?",
+      "removeDocument": "Remove document",
+      "pickDocuments": "Add documents",
+      "addReference": "Add another reference",
+      "email": "Email",
+      "phone": "Phone number",
+      "relationship": "Relationship",
+      "namePlaceholder": "Jane Doe",
+      "name": "Full name",
+      "removeReference": "Remove reference",
+      "referenceIndex": "Reference {{index}}",
+      "employment": "Employment status",
+      "monthlyIncomePlaceholder": "e.g. 2400",
+      "monthlyIncome": "Gross monthly income",
+      "leaseTermCustomPlaceholder": "Number of months",
+      "leaseTermCustom": "Other",
+      "leaseTerm": "Lease term",
+      "moveInHelper": "Within the next 6 months.",
+      "leaseTermMonths": "{{count}} months"
+    },
+    "cta": {
+      "apply": "Apply to rent",
+      "subtitle": "Submit a quick application with your move-in date, income and references — the landlord reviews and replies inside Homiio.",
+      "title": "Interested in this place?",
+      "addMoveIn": "Add move-in date"
+    },
+    "detail": {
+      "viewStatus": "View status",
+      "alreadySubmittedBody": "You already have an application in review for this property.",
+      "alreadySubmitted": "Application submitted"
+    },
+    "actions": {
+      "submit": "Submit application"
+    },
+    "section": {
+      "notes": "Notes to landlord (optional)",
+      "documentsHelp": "Upload up to {{max}} PDFs or images (10 MB each). Pick a category per file.",
+      "documents": "Documents (optional)",
+      "referencesHelp": "Add 1 to 3 contacts the landlord can call to vouch for you.",
+      "references": "References",
+      "finances": "Income & employment",
+      "timing": "Move-in & lease term"
+    },
+    "apply": {
+      "title": "Apply to rent"
+    },
+    "success": {
+      "submitted": "Application submitted"
+    },
+    "error": {
+      "invalidForm": "Please complete every required field.",
+      "generic": "Something went wrong. Please try again.",
+      "auth": "Please sign in to apply.",
+      "notApplicable": "This property does not accept long-term applications.",
+      "external": "External listings cannot be applied to from Homiio.",
+      "alreadyApplied": "You already have an active application for this property."
+    },
+    "documents": {
+      "pickFailed": "Could not pick documents",
+      "tooLarge": "{{name}} supera els 10 MB i s'ha omès.",
+      "limit": "Pots pujar fins a {{max}} documents per sol·licitud."
+    },
+    "employment": {
+      "employed": "Employed",
+      "selfEmployed": "Self-employed",
+      "student": "Student",
+      "retired": "Retired",
+      "unemployed": "Unemployed",
+      "other": "Other"
+    },
+    "relationship": {
+      "landlord": "Previous landlord",
+      "employer": "Employer",
+      "personal": "Personal",
+      "other": "Other"
+    },
+    "docType": {
+      "id": "ID",
+      "income": "Income proof",
+      "reference": "Reference letter",
+      "other": "Other"
+    }
+  },
+  "reservations": {
+    "card": {
+      "propertyFallback": "Propietat",
+      "night": "nit",
+      "nights": "nits",
+      "guest": "hoste",
+      "guests": "hostes",
+      "hostGuestSuffix": "(hoste)",
+      "accessibility": "Reserva {{id}}"
+    },
+    "detail": {
+      "title": "Reserva",
+      "invalidId": "ID de reserva no vàlid",
+      "invalidIdDescription": "L'enllaç no inclou la referència de la reserva.",
+      "unavailable": "Reserva no disponible",
+      "unavailableDescription": "No s'ha pogut carregar aquesta reserva.",
+      "goBack": "Tornar",
+      "tripDetails": "Detalls del viatge",
+      "checkIn": "Entrada",
+      "checkOut": "Sortida",
+      "guests": "Hostes",
+      "nights": "Nits",
+      "price": "Preu",
+      "approve": "Aprovar",
+      "decline": "Rebutjar",
+      "cancelReservation": "Cancel reservation",
+      "cancelPolicyNote": "Cancellation is no longer possible under the {{policy}} policy. Contact your host if you need to make changes.",
+      "confirmCancelTitle": "Cancel reservation?",
+      "confirmCancelBody": "This will release the dates back to the host and end the booking.",
+      "confirmCancelAction": "Yes, cancel",
+      "confirmApproveTitle": "Approve reservation?",
+      "confirmApproveBody": "The guest will be notified and the dates will be marked confirmed on your calendar.",
+      "confirmDeclineTitle": "Decline reservation?",
+      "confirmDeclineBody": "The guest will be notified that this request was declined.",
+      "toastConfirmed": "Reservation confirmed",
+      "toastDeclined": "Reservation declined",
+      "toastCancelled": "Reservation cancelled",
+      "toastUpdateFailed": "Update failed"
+    }
+  },
+  "reviews": {
+    "card": {
+      "anonymous": "Anònim",
+      "verifiedResident": "Resident verificat",
+      "verified": "Verificat",
+      "confident": "{{score}}% de confiança",
+      "proof": "prova",
+      "proofs": "proves",
+      "karma": "{{score}} karma",
+      "livedMonths": "Va viure {{count}} mesos",
+      "perMonth": "{{price}} {{currency}}/mes",
+      "moreIssues": "+{{count}} més",
+      "positive": "Positiu:",
+      "negative": "Negatiu:",
+      "helpful": "Útil ({{count}})",
+      "report": "Reportar",
+      "reply": "Respondre",
+      "recommends": "✓ Recomana",
+      "doesNotRecommend": "✗ No recomana",
+      "underReview": "En revisió",
+      "alertThankYouTitle": "Gràcies",
+      "alertThankYouBody": "El teu comentari s'ha registrat.",
+      "alertReportTitle": "Reportar ressenya",
+      "alertReportBody": "Segur que vols reportar aquesta ressenya per contingut inapropiat?",
+      "alertReportConfirm": "Reportar",
+      "alertReportedTitle": "Reportada",
+      "alertReportedBody": "Aquesta ressenya s'ha reportat al nostre equip de moderació.",
+      "alertReplyTitle": "Respondre a la ressenya",
+      "alertReplyBody": "La funció de resposta permetrà a arrendadors i administradors de propietats respondre a les ressenyes."
+    },
+    "write": {
+      "validationTitle": "Error de validació",
+      "streetRequired": "Introdueix un carrer.",
+      "cityRequired": "Introdueix una ciutat.",
+      "postalCodeRequired": "Introdueix un codi postal.",
+      "countryRequired": "Introdueix un país.",
+      "opinionRequired": "Comparteix la teva opinió sobre aquesta adreça.",
+      "opinionMinLength": "La teva opinió ha de tenir almenys 10 caràcters.",
+      "priceRequired": "Introdueix un preu vàlid.",
+      "datesRequired": "Introdueix les dates d'inici i fi.",
+      "recommendationRequired": "Indica si recomanaries aquesta adreça.",
+      "ratingRequired": "Assigna una valoració de l'1 al 5.",
+      "submitSuccess": "La teva ressenya s'ha enviat correctament!",
+      "submitFailed": "No s'ha pogut enviar la ressenya",
+      "submitFailedRetry": "No s'ha pogut enviar la ressenya. Torna-ho a provar.",
+      "loadAddressFailed": "Couldn't load address",
+      "title": "Write review"
+    }
+  },
+  "subscriptions": {
+    "title": "Subscripcions",
+    "alertError": "Error",
+    "alertSuccess": "Èxit",
+    "authRequired": "Autenticació requerida",
+    "checkoutFailed": "No s'ha pogut iniciar el pagament",
+    "portalFailed": "No s'ha pogut obrir la gestió de subscripcions",
+    "syncSuccess": "Estat de subscripció sincronitzat des de Stripe",
+    "syncFailed": "No s'ha pogut sincronitzar la subscripció",
+    "cancelImmediateSuccess": "Subscripció cancel·lada immediatament",
+    "cancelFailed": "No s'ha pogut cancel·lar la subscripció",
+    "cancelEndOfPeriodSuccess": "La subscripció es cancel·larà al final del període actual",
+    "debugFailed": "No s'ha pogut depurar la subscripció",
+    "plusActive": "Homiio Plus active",
+    "plusInactive": "Upgrade to Homiio Plus",
+    "manage": "Manage subscription",
+    "sync": "Sync from Stripe",
+    "cancel": "Cancel subscription",
+    "cancelImmediate": "Cancel immediately",
+    "cancelEndOfPeriod": "Cancel at period end",
+    "fileCredits": "{{count}} file credits",
+    "since": "Member since {{date}}",
+    "canceledOn": "Canceled on {{date}}",
+    "lastPayment": "Last payment {{date}}",
+    "products": {
+      "plus": "Homiio Plus",
+      "plusDescription": "Priority support and premium features",
+      "file": "File credits",
+      "fileDescription": "Extra document storage credits",
+      "founder": "Founder",
+      "founderDescription": "Support Homiio and unlock founder perks"
+    },
+    "subscribe": "Subscribe",
+    "buyCredits": "Buy credits",
+    "becomeFounder": "Become a founder",
+    "page": {
+      "headerTitle": "Homiio+",
+      "headerSubtitle": "El teu aliat d'habitatge ètic",
+      "introText": "Your subscription gives you access to Sindi, the legal assistant that scans your rental contracts and flags abusive clauses. No ads, no speculation, no data selling.",
+      "payPerContract": {
+        "title": "Pay per contract",
+        "price": "5 € per contract review",
+        "description": "Perfect for one-time use.",
+        "reviewButton": "Review Contract"
+      },
+      "plus": {
+        "title": "Homiio+ Subscription",
+        "price": "9.99 €/month",
+        "description": "Includes up to 10 contracts per month free. From the 11th contract onwards: 2.50 € each.",
+        "activeBadge": "Active subscription",
+        "canceledBadge": "Canceled on {{date}}",
+        "featureHistory": "Unlimited contract history",
+        "featureAlerts": "Legal alerts & notifications",
+        "featureSupport": "Priority support",
+        "manage": "Manage subscription",
+        "resubscribe": "Resubscribe",
+        "subscribeNow": "Subscribe now"
+      },
+      "founder": {
+        "title": "Founder supporter",
+        "price": "Contribution from 10 €/month",
+        "description": "Support Homiio's independence. Get recognition in the app + early access to features.",
+        "becomeSupporter": "Become a Supporter"
+      },
+      "footer": "Every euro keeps Homiio ethical, independent, and community-driven.",
+      "starting": "Starting…",
+      "back": "Tornar",
+      "notAvailable": "N/A",
+      "cancelImmediateTitle": "Cancel Immediately",
+      "cancelImmediateBody": "This will immediately cancel your subscription and you will lose access to Homiio+ features. Are you sure?",
+      "no": "No",
+      "yesCancelNow": "Yes, Cancel Now"
+    }
+  },
+  "recentlyViewed": {
+    "trackFailed": "No s'ha pogut registrar la visita a la propietat",
+    "clearSuccess": "Propietats vistes recentment esborrades",
+    "clearFailed": "No s'han pogut esborrar les propietats vistes recentment"
+  },
+  "host": {
+    "calendar": {
+      "title": "Calendari d'amfitrió",
+      "signInTitle": "Inicia sessió per gestionar el calendari",
+      "signInDescription": "Bloqueja dates i fes seguiment de reserves des d'un sol lloc.",
+      "signIn": "Iniciar sessió",
+      "loadPropertiesError": "No s'han pogut carregar les teves propietats",
+      "tryAgain": "Torna-ho a provar.",
+      "emptyTitle": "Afegeix la teva primera propietat",
+      "emptyDescription": "Publica un allotjament perquè els hostes puguin sol·licitar dates aquí.",
+      "createListing": "Crear anunci",
+      "chooseProperty": "Triar propietat",
+      "legendConfirmed": "Confirmada",
+      "legendPending": "Pendent",
+      "legendBlocked": "Bloquejada",
+      "legendAvailable": "Disponible",
+      "availabilityError": "No s'ha pogut carregar la disponibilitat",
+      "blockTitle": "Bloquejar aquestes dates",
+      "blockBodyRange": "Block from {{start}} to {{end}}.",
+      "blockBodySingle": "Choose how long these dates are unavailable.",
+      "blockConfirm": "Bloquejar",
+      "blockReasonLabel": "Reason (optional)",
+      "blockReasonPlaceholder": "Maintenance, personal use, ...",
+      "toastBlocked": "Dates bloquejades",
+      "toastBlockFailed": "No s'ha pogut bloquejar",
+      "propertyNotFound": "Propietat no trobada",
+      "property": "Propietat"
+    },
+    "reservations": {
+      "title": "Reserves",
+      "allReservations": "All reservations",
+      "signInTitle": "Sign in to manage reservations",
+      "signInDescription": "Approve or decline guest requests from one place.",
+      "signIn": "Sign in",
+      "filterAll": "All",
+      "loadError": "Couldn't load reservations",
+      "tryAgain": "Please try again.",
+      "emptyTitle": "No reservations yet",
+      "emptyDescription": "Guest requests will appear here once someone books.",
+      "toastConfirmed": "Reservation confirmed",
+      "toastDeclined": "Reservation declined",
+      "toastUpdateFailed": "Update failed",
+      "confirm": "Confirm",
+      "decline": "Decline",
+      "approve": "Aprovar",
+      "view": "Veure",
+      "filterPending": "Pending",
+      "filterConfirmed": "Confirmed",
+      "filterDeclined": "Declined",
+      "filterCancelled": "Cancelled",
+      "filterCompleted": "Completed"
+    }
+  },
+  "stays": {
+    "list": {
+      "title": "Estades",
+      "filterAll": "Totes",
+      "filterUpcoming": "Properes",
+      "filterPast": "Passades",
+      "filterCancelled": "Cancel·lades",
+      "groupUpcoming": "Upcoming",
+      "groupPast": "Past",
+      "groupCancelled": "Cancelled",
+      "signInTitle": "Sign in to see your stays",
+      "signInDescription": "Track short-term bookings you've made.",
+      "signIn": "Sign in",
+      "loadError": "Couldn't load stays",
+      "tryAgain": "Please try again.",
+      "emptyAllTitle": "No stays yet",
+      "emptyFilteredTitle": "Nothing in this view.",
+      "emptyAllDescription": "Once you book a place it will show up here.",
+      "emptyFilteredDescription": "Try a different filter or explore new stays.",
+      "exploreStays": "Explorar estades"
+    }
+  },
+  "addresses": {
+    "detail": {
+      "title": "Address",
+      "loadError": "No s'ha pogut carregar aquesta adreça",
+      "tryAgain": "Torna-ho a provar.",
+      "propertiesSection": "Propietats",
+      "reviewsSection": "Ressenyes",
+      "emptyPropertiesTitle": "Encara no hi ha propietats aquí",
+      "emptyPropertiesDescription": "Els anuncis en aquesta adreça apareixeran aquí.",
+      "emptyReviewsTitle": "Encara no hi ha ressenyes",
+      "emptyReviewsDescription": "Sigues el primer a compartir la teva experiència en aquesta adreça.",
+      "writeReview": "Escriure una ressenya",
+      "switchLevel": "Canviar nivell",
+      "buildingLevel": "Edifici",
+      "unitLevel": "Unitat",
+      "notFound": "Adreça no trobada",
+      "notFoundDescription": "We couldn't find any details for this address.",
+      "storiesTitle": "Històries de residents",
+      "tabOverall": "General",
+      "tabApartments": "Apartaments",
+      "tabCommunity": "Comunitat",
+      "tabArea": "Zona",
+      "tabProperties": "Propietats ({{count}})",
+      "tabReviews": "Ressenyes ({{count}})"
+    },
+    "display": {
+      "copySuccess": "Adreça copiada al porta-retalls",
+      "copyFailed": "No s'ha pogut copiar l'adreça",
+      "mapsFailed": "No s'ha pogut obrir mapes"
+    }
+  },
+  "propertyCreate": {
+    "location": {
+      "title": "Location",
+      "instructions": "📍 Address Details: Fill in the complete address information. Our system uses a hierarchical structure:\n• STREET level: Street name only\n• BUILDING level: Street + number + building details\n• UNIT level: Building + floor + unit/apartment details\nReviews and listings are organized by these levels for better organization.",
+      "country": "Country or Region",
+      "countryPickerTitle": "Country or Region",
+      "state": "State / Province / Region",
+      "statePickerTitle": "State / Province / Region",
+      "city": "City",
+      "street": "Street",
+      "number": "Number",
+      "postalCode": "Postal code",
+      "floor": "Floor",
+      "unit": "Unit / Apartment",
+      "showFloor": "Show floor field",
+      "hideFloor": "Hide floor field",
+      "selectCountry": "Select country or region",
+      "streetPlaceholder": "Street name",
+      "unitOptional": "Unit/Apartment Number (optional)",
+      "unitPlaceholder": "Apartment, suite, etc. (optional)",
+      "buildingNameOptional": "Nom de l'edifici (opcional)",
+      "buildingNamePlaceholder": "p. ex., Torre Barcelona",
+      "blockOptional": "Bloc (opcional)",
+      "blockPlaceholder": "p. ex., Bloc A",
+      "entranceOptional": "Entrada/Porta (opcional)",
+      "entrancePlaceholder": "p. ex., Porta 1, Entrada B",
+      "subunitOptional": "Subunitat (opcional)",
+      "subunitPlaceholder": "p. ex., Habitació A",
+      "numberPlaceholder": "Introdueix el número",
+      "floorPlaceholder": "Introdueix la planta",
+      "floorPublic": "Públic",
+      "floorPrivate": "Privat",
+      "floorPrivacyHint": "ℹ️ Es mostrarà de forma aproximada per privacitat",
+      "neighborhoodOptional": "Barri (opcional)",
+      "neighborhoodPlaceholder": "p. ex., Gràcia, Sant Andreu, Eixample",
+      "districtOptional": "Districte (opcional)",
+      "districtPlaceholder": "p. ex., Districte administratiu",
+      "poBoxOptional": "Apartat de correus (opcional)",
+      "poBoxPlaceholder": "p. ex., Apartat 123",
+      "referenceOptional": "Referència (opcional)",
+      "referencePlaceholder": "p. ex., A prop del metro",
+      "cityDistrict": "Ciutat/Districte",
+      "cityDistrictPlaceholder": "Ciutat o districte",
+      "selectState": "Selecciona província/regió",
+      "zipPostalCode": "Codi postal",
+      "zipPlaceholder": "Codi postal",
+      "availableFrom": "Disponible des de",
+      "availableFromPlaceholder": "Data de disponibilitat",
+      "leaseTerm": "Durada del contracte",
+      "leaseTermPlaceholder": "Durada del contracte"
+    },
+    "amenities": {
+      "title": "Amenities",
+      "subtitle": "Select the amenities available at this property.",
+      "rulesTitle": "Serveis i normes",
+      "houseRules": "House Rules",
+      "petsAllowed": "Pets Allowed",
+      "smokingAllowed": "Smoking Allowed",
+      "partiesAllowed": "Parties Allowed",
+      "guestsAllowed": "Guests Allowed",
+      "maxGuests": "Maximum Number of Guests",
+      "maxGuestsPlaceholder": "e.g., 2",
+      "yes": "Yes",
+      "no": "No"
+    }
+  },
+  "booking": {
+    "toast": {
+      "pickDates": "Selecciona primer les dates d'entrada i sortida",
+      "minStay": "Estada mínima de {{count}} {{unit}}",
+      "maxStay": "Estada màxima de {{count}} {{unit}}",
+      "night": "nit",
+      "nights": "nits",
+      "failed": "Error en la reserva"
+    },
+    "accessibility": {
+      "selectDates": "Select dates",
+      "selectGuests": "Select guests",
+      "close": "Close"
+    }
+  },
+  "searchBar": {
+    "search": "Cerca",
+    "long": {
+      "propertyType": "Tipus de propietat",
+      "moveIn": "Data d'entrada",
+      "where": "On",
+      "where.value": "Qualsevol ciutat",
+      "moveIn.value": "Afegir data",
+      "propertyType.value": "Qualsevol tipus"
+    },
+    "vacation": {
+      "where": "On",
+      "when": "Quan",
+      "who": "Qui",
+      "where.value": "Qualsevol destinació",
+      "when.value": "Afegir dates",
+      "who.value": "Afegir hostes"
+    },
+    "mode": {
+      "vacation": "Vacances",
+      "longTerm": "Llarg termini",
+      "hint": "Canvia entre lloguers a llarg termini i estades vacacionals",
+      "label": "Mode de lloguer"
+    }
+  },
+  "error": {
+    "publicHousing": {
+      "openFailed": "No s'ha pogut obrir el lloc web d'habitatge"
+    },
+    "call": {
+      "failed": "No s'ha pogut obrir el marcador telefònic",
+      "noPhone": "No hi ha número de telèfon disponible",
+      "notAllowed": "El propietari no accepta trucades"
+    },
+    "profile": {
+      "notFound": "Perfil del propietari no trobat"
+    },
+    "auth": {
+      "required": "Inicia sessió per trucar al propietari"
+    },
+    "contact": {
+      "noPhone": "No hi ha telèfon disponible per a aquest anunci",
+      "openFailed": "No s'ha pogut obrir l'enllaç de contacte"
+    },
+    "source": {
+      "openFailed": "No s'ha pogut obrir el lloc web d'origen",
+      "noUrl": "URL del lloc d'origen no disponible"
+    },
+    "boundary": {
+      "title": "Alguna cosa ha anat malament",
+      "message": "Un problema inesperat ha interromput el que estaves fent. Pots tornar-ho a provar o enviar-nos un informe ràpid perquè ho investiguem.",
+      "retry": "Torna-ho a provar",
+      "reportIssue": "Informar del problema",
+      "errorId": "ID d'error",
+      "copyIdHint": "Toca per copiar l'ID",
+      "copiedToClipboard": "Copiat al porta-retalls",
+      "showDetails": "Mostrar detalls tècnics",
+      "hideDetails": "Amagar detalls tècnics",
+      "technicalDetails": "Detalls tècnics",
+      "maxRetriesTitle": "Segueix sense funcionar",
+      "maxRetriesMessage": "Has assolit el límit de reintents. Si us plau, informa del problema perquè ho puguem revisar.",
+      "forceRetry": "Forçar reintent",
+      "reportCopiedTitle": "Informe copiat",
+      "reportCopiedMessage": "L'informe d'error s'ha copiat al porta-retalls.",
+      "reportFailedTitle": "No s'ha pogut copiar",
+      "reportFailedMessage": "No hem pogut copiar l'informe al porta-retalls. Torna-ho a provar.",
+      "errorMessage": "Missatge d'error",
+      "errorType": "Tipus d'error",
+      "stackTrace": "Traça de pila",
+      "componentStack": "Pila de components",
+      "deviceInformation": "Informació del dispositiu"
+    },
+    "loadNotifications": "Error carregant notificacions"
+  },
+  "notification": {
+    "settings": {
+      "android": {
+        "openSettings": "Obrir configuració del sistema",
+        "title": "Android Settings",
+        "description": "You can manage notification channels and advanced settings in your device's Settings app under Apps > Homiio > Notifications."
+      },
+      "ios": {
+        "openSettings": "Obrir configuració del sistema",
+        "title": "iOS Settings",
+        "description": "For more granular control, you can also manage notification settings in your device's Settings app under Notifications > Homiio."
+      },
+      "test": {
+        "title": "Test Notifications",
+        "description": "Envia notificacions de prova per verificar que la teva configuració funciona correctament."
+      },
+      "property": {
+        "title": "Property Notifications",
+        "description": "New properties, price changes, and viewing reminders"
+      },
+      "message": {
+        "title": "Message Notifications",
+        "description": "New messages from agents, landlords, and other users"
+      },
+      "contract": {
+        "title": "Contract Notifications",
+        "description": "Contract updates, signatures, and important deadlines"
+      },
+      "payment": {
+        "title": "Payment Notifications",
+        "description": "Payment confirmations, reminders, and receipts"
+      },
+      "reminder": {
+        "title": "Reminder Notifications",
+        "description": "Viewing reminders, application deadlines, and follow-ups"
+      },
+      "system": {
+        "title": "System Notifications",
+        "description": "App updates, maintenance, and important announcements"
+      },
+      "marketing": {
+        "title": "Marketing Notifications",
+        "description": "Promotional offers, newsletters, and special deals"
+      },
+      "sound": {
+        "title": "Sound",
+        "description": "Play sound when notifications arrive"
+      },
+      "badge": {
+        "title": "Badge Count",
+        "description": "Show unread count on app icon"
+      },
+      "push": {
+        "title": "Push Notifications",
+        "description": "Receive notifications even when app is closed"
+      },
+      "title": "Notification Settings",
+      "categories": "Notification Categories",
+      "behavior": "Notification Behavior",
+      "manage": "Manage Notifications",
+      "clearAll": "Clear All Notifications",
+      "updated": "Settings updated",
+      "error": "Failed to update settings"
+    },
+    "test": {
+      "success": "Notificació de prova enviada",
+      "property": "Test Property",
+      "message": "Test Message",
+      "reminder": "Test Reminder",
+      "repeating": "Test Repeating",
+      "error": "Failed to send test notification"
+    },
+    "empty": {
+      "filteredTitle": "Sense coincidències",
+      "title": "No notifications",
+      "message": "You're all caught up! New notifications will appear here.",
+      "filtered": "No notifications match your current filter"
+    },
+    "filter": {
+      "label": "Filtrar notificacions",
+      "all": "All",
+      "unread": "Unread"
+    },
+    "scheduled": {
+      "label": "Notificació programada",
+      "title": "Scheduled Notifications",
+      "clearAll": "Clear All"
+    },
+    "markAllRead": {
+      "action": "Marcar-ho tot com a llegit",
+      "success": "All notifications marked as read",
+      "error": "Failed to mark all as read"
+    },
+    "permissions": {
+      "enabled": {
+        "title": "Notifications Enabled",
+        "description": "Rebràs notificacions de les categories activades."
+      },
+      "disabled": {
+        "title": "Notifications Disabled",
+        "description": "Activa les notificacions per rebre novetats sobre propietats, missatges i més."
+      },
+      "title": "Enable Notifications",
+      "message": "Get notified about new properties, messages, and important updates.",
+      "enable": "Enable Notifications",
+      "granted": "Notification permissions granted",
+      "denied": "Notification permissions denied",
+      "error": "Failed to request permissions"
+    },
+    "welcome": {
+      "title": "Benvingut a Homiio! 👋",
+      "body": "Gràcies per provar la nostra aplicació. Comença a explorar ara!"
+    },
+    "search": {
+      "placeholder": "Search notifications..."
+    },
+    "delete": {
+      "title": "Delete Notification",
+      "message": "Are you sure you want to delete this notification?",
+      "success": "Notification deleted",
+      "error": "Failed to delete notification"
+    },
+    "clearAll": {
+      "title": "Clear All Notifications",
+      "message": "This will clear all notifications and reset the badge count. This action cannot be undone.",
+      "success": "All notifications cleared",
+      "error": "Failed to clear notifications"
+    }
+  },
+  "address": {
+    "display": {
+      "mapPlaceholder": "Map view available",
+      "copy": "Copy",
+      "openInMaps": "Open in Maps"
+    }
+  },
+  "inbox": {
+    "title": "Bústia"
+  }
 }

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -1,37 +1,4 @@
 {
-  "navigation": {
-    "home": "Home",
-    "search": "Search",
-    "notifications": "Notifications",
-    "messages": "Messages",
-    "settings": "Settings",
-    "explore": "Explore",
-    "chat": "Chat",
-    "bookmarks": "Bookmarks",
-    "feeds": "Feeds",
-    "lists": "Lists",
-    "videos": "Videos"
-  },
-  "actions": {
-    "save": "Save",
-    "post": "Post",
-    "follow": "Follow",
-    "following": "Following",
-    "signUp": "Sign Up",
-    "signIn": "Sign In",
-    "showMore": "Show more",
-    "applySettings": "Apply Settings"
-  },
-  "content": {
-    "newPost": "New Post",
-    "whatsHappening": "What's happening?",
-    "posts": "posts",
-    "samplePost": "This is a sample post",
-    "anotherPost": "Another example post",
-    "likedPost": "liked your Post",
-    "repostedPost": "reposted your Post",
-    "joinConversation": "Join the conversation"
-  },
   "app": {
     "welcome": {
       "title": "Welcome to Homiio! 👋",
@@ -60,145 +27,96 @@
       "transportation": "Parking & transport",
       "community": "Community spaces",
       "other": "More"
-    }
+    },
+    "airConditioning": "Air Conditioning",
+    "airPurifier": "Air Purification System",
+    "balcony": "Private Balcony",
+    "bbqArea": "BBQ/Grilling Area",
+    "bikeStorage": "Secure Bike Storage",
+    "builtInShelving": "Built-in Shelving",
+    "cableTv": "Cable TV Ready",
+    "ceilingFans": "Ceiling Fans",
+    "coatCloset": "Entry Coat Closet",
+    "communityRoom": "Community Room",
+    "conferenceRoom": "Conference Room",
+    "coworkingSpace": "Shared Workspace",
+    "daycare": "On-site Childcare",
+    "dimmerSwitches": "Dimmer Switches",
+    "dishwasher": "Dishwasher",
+    "dogPark": "Pet Exercise Area",
+    "doubleVanity": "Double Vanity",
+    "dryer": "In-Unit Dryer",
+    "electricity": "Electricity Included",
+    "elevator": "Elevator Access",
+    "energyEfficient": "Energy Star Appliances",
+    "evCharging": "Electric Vehicle Charging",
+    "familyRoom": "Family Activity Room",
+    "fiberInternet": "Fiber Internet",
+    "firePit": "Fire Pit Area",
+    "fireSafety": "Fire Safety System",
+    "garbageDisposal": "Garbage Disposal",
+    "gardenAccess": "Garden Access",
+    "gardenSpace": "Community Garden",
+    "grabBars": "Safety Grab Bars",
+    "graniteCounters": "Granite Countertops",
+    "greenRoof": "Living Roof System",
+    "gym": "Fitness Center",
+    "hardwoodFloors": "Hardwood Flooring",
+    "heatedFloors": "Heated Floors",
+    "heating": "Adequate Heating",
+    "homeOffice": "Home Office Space",
+    "hotTub": "Hot Tub/Spa",
+    "humidifier": "Whole-House Humidifier",
+    "iceMaker": "Ice Maker",
+    "insulation": "Proper Insulation",
+    "intercom": "Intercom System",
+    "jettedTub": "Jetted Tub",
+    "kitchen": "Kitchen",
+    "laundryRoom": "Shared Laundry Facility",
+    "ledLighting": "LED Lighting",
+    "linenCloset": "Linen Closet",
+    "mailRoom": "Package & Mail Room",
+    "microwave": "Microwave",
+    "mobilityAssistance": "Mobility Assistance Features",
+    "naturalLight": "Abundant Natural Light",
+    "oven": "Oven",
+    "pantry": "Kitchen Pantry",
+    "parkingSpace": "Parking Space",
+    "pendantLighting": "Designer Lighting",
+    "petFriendly": "Pet-Friendly Policy",
+    "printingStation": "Printing & Copy Center",
+    "publicTransitAccess": "Public Transit Access",
+    "rainwaterCollection": "Rainwater Harvesting",
+    "rampAccess": "Ramp Access",
+    "recyclingProgram": "Comprehensive Recycling",
+    "refrigerator": "Full-Size Refrigerator",
+    "rooftopDeck": "Rooftop Deck",
+    "secureEntry": "Controlled Access",
+    "securityCameras": "Security Cameras",
+    "seniorServices": "Senior Support Services",
+    "smartDoorbell": "Video Doorbell",
+    "smartHome": "Smart Home Features",
+    "solarPanels": "Solar Energy System",
+    "stainlessAppliances": "Stainless Steel Appliances",
+    "storageUnit": "Storage Space",
+    "stove": "Cooking Range",
+    "studyRoom": "Quiet Study Space",
+    "swimmingPool": "Swimming Pool",
+    "teenRoom": "Teen Activity Room",
+    "tileFloors": "Tile Flooring",
+    "trashPickup": "Waste Collection",
+    "usbOutlets": "USB Charging Outlets",
+    "walkInCloset": "Walk-in Closet",
+    "walkInShower": "Walk-in Shower",
+    "washingMachine": "In-Unit Washer",
+    "water": "Water & Sewer Included",
+    "waterFilter": "Water Filtration System",
+    "wheelchairAccessible": "Wheelchair Accessible",
+    "wholeHouseFan": "Whole House Fan",
+    "wideDoorways": "Wide Doorways",
+    "wifi": "High-Speed Internet",
+    "wineFridge": "Wine Refrigerator"
   },
-  "error.socket.not_connected": "Not connected to chat server",
-  "error.message.send_timeout": "Message send timeout. Please try again.",
-  "error.message.edit_timeout": "Edit timeout. Please try again.",
-  "error.message.delete_timeout": "Delete timeout. Please try again.",
-  "error.signup.missing_fields": "Please fill in all fields",
-  "error.signup.failed": "Signup failed:",
-  "error.boundary.title": "Something went wrong",
-  "error.boundary.message": "An unexpected issue interrupted what you were doing. You can try again, or send us a quick report so we can investigate.",
-  "error.boundary.retry": "Try again",
-  "error.boundary.reportIssue": "Report issue",
-  "error.boundary.errorId": "Error ID",
-  "error.boundary.copyIdHint": "Tap to copy ID",
-  "error.boundary.copiedToClipboard": "Copied to clipboard",
-  "error.boundary.showDetails": "Show technical details",
-  "error.boundary.hideDetails": "Hide technical details",
-  "error.boundary.technicalDetails": "Technical details",
-  "error.boundary.maxRetriesTitle": "Still not working",
-  "error.boundary.maxRetriesMessage": "You've reached the retry limit. Please report the issue so we can take a look.",
-  "error.boundary.forceRetry": "Force retry",
-  "error.boundary.reportCopiedTitle": "Report copied",
-  "error.boundary.reportCopiedMessage": "The error report has been copied to your clipboard.",
-  "error.boundary.reportFailedTitle": "Couldn't copy",
-  "error.boundary.reportFailedMessage": "We couldn't copy the report to your clipboard. Please try again.",
-  "error.boundary.errorMessage": "Error message",
-  "error.boundary.errorType": "Error type",
-  "error.boundary.stackTrace": "Stack trace",
-  "error.boundary.componentStack": "Component stack",
-  "error.boundary.deviceInformation": "Device information",
-  "error.file_selection": "Error processing selected files. Please try again.",
-  "error.login_required": "Please login to manage files",
-  "error.load_notifications": "Error loading notifications",
-  "error.fetch_trends": "Error loading trends",
-  "error.signup.password_mismatch": "Passwords do not match",
-  "error.validation.token_expired": "Token has expired",
-  "error.validation.token_invalid": "Token format is invalid",
-  "error.validation.token_signature": "Token signature is invalid",
-  "error.auth.invalid_token": "Invalid authentication token",
-  "error.chat.forward_failed": "Could not forward message",
-  "error.chat.delete_failed": "Could not delete message",
-  "error.chat.send_failed": "Failed to send message",
-  "error.chat.load_failed": "Failed to load messages",
-  "error.data.fetch_failed": "Error fetching data: {{message}}",
-  "error.users.fetch_failed": "Error fetching users: {{message}}",
-  "inbox.title": "Inbox",
-  "notification.welcome.title": "Welcome to Homiio! 👋",
-  "notification.welcome.body": "Thanks for trying out our app. Start exploring now!",
-  "notification.search.placeholder": "Search notifications...",
-  "notification.filter.all": "All",
-  "notification.filter.unread": "Unread",
-  "notification.filter.property": "Property",
-  "notification.filter.message": "Message",
-  "notification.filter.system": "System",
-  "notification.empty.title": "No notifications",
-  "notification.empty.message": "You're all caught up! New notifications will appear here.",
-  "notification.empty.filtered": "No notifications match your current filter",
-  "notification.delete.title": "Delete Notification",
-  "notification.delete.message": "Are you sure you want to delete this notification?",
-  "notification.delete.success": "Notification deleted",
-  "notification.delete.error": "Failed to delete notification",
-  "notification.markAllRead.success": "All notifications marked as read",
-  "notification.markAllRead.error": "Failed to mark all as read",
-  "notification.permissions.title": "Enable Notifications",
-  "notification.permissions.message": "Get notified about new properties, messages, and important updates.",
-  "notification.permissions.enable": "Enable Notifications",
-  "notification.permissions.granted": "Notification permissions granted",
-  "notification.permissions.denied": "Notification permissions denied",
-  "notification.permissions.error": "Failed to request permissions",
-  "notification.permissions.enabled": "Notifications Enabled",
-  "notification.permissions.disabled": "Notifications Disabled",
-  "notification.permissions.enabled.description": "You will receive notifications for enabled categories.",
-  "notification.permissions.disabled.description": "Enable notifications to receive updates about properties, messages, and more.",
-  "notification.scheduled.title": "Scheduled Notifications",
-  "notification.scheduled.clearAll": "Clear All",
-  "notification.settings.title": "Notification Settings",
-  "notification.settings.permissions": "Permissions",
-  "notification.settings.categories": "Notification Categories",
-  "notification.settings.behavior": "Notification Behavior",
-  "notification.settings.test": "Test Notifications",
-  "notification.settings.test.description": "Send test notifications to verify your settings are working correctly.",
-  "notification.settings.manage": "Manage Notifications",
-  "notification.settings.clearAll": "Clear All Notifications",
-  "notification.settings.updated": "Settings updated",
-  "notification.settings.error": "Failed to update settings",
-  "notification.settings.property.title": "Property Notifications",
-  "notification.settings.property.description": "New properties, price changes, and viewing reminders",
-  "notification.settings.message.title": "Message Notifications",
-  "notification.settings.message.description": "New messages from agents, landlords, and other users",
-  "notification.settings.contract.title": "Contract Notifications",
-  "notification.settings.contract.description": "Contract updates, signatures, and important deadlines",
-  "notification.settings.payment.title": "Payment Notifications",
-  "notification.settings.payment.description": "Payment confirmations, reminders, and receipts",
-  "notification.settings.reminder.title": "Reminder Notifications",
-  "notification.settings.reminder.description": "Viewing reminders, application deadlines, and follow-ups",
-  "notification.settings.system.title": "System Notifications",
-  "notification.settings.system.description": "App updates, maintenance, and important announcements",
-  "notification.settings.marketing.title": "Marketing Notifications",
-  "notification.settings.marketing.description": "Promotional offers, newsletters, and special deals",
-  "notification.settings.sound.title": "Sound",
-  "notification.settings.sound.description": "Play sound when notifications arrive",
-  "notification.settings.badge.title": "Badge Count",
-  "notification.settings.badge.description": "Show unread count on app icon",
-  "notification.settings.push.title": "Push Notifications",
-  "notification.settings.push.description": "Receive notifications even when app is closed",
-  "notification.test.property": "Test Property",
-  "notification.test.message": "Test Message",
-  "notification.test.reminder": "Test Reminder",
-  "notification.test.repeating": "Test Repeating",
-  "notification.test.property.success": "Property notification sent",
-  "notification.test.message.success": "Message notification sent",
-  "notification.test.reminder.success": "Reminder notification scheduled",
-  "notification.test.repeating.success": "Repeating notification scheduled",
-  "notification.test.error": "Failed to send test notification",
-  "notification.clearAll.title": "Clear All Notifications",
-  "notification.clearAll.message": "This will clear all notifications and reset the badge count. This action cannot be undone.",
-  "notification.clearAll.success": "All notifications cleared",
-  "notification.clearAll.error": "Failed to clear notifications",
-  "notification.settings.ios.title": "iOS Settings",
-  "notification.settings.ios.description": "For more granular control, you can also manage notification settings in your device's Settings app under Notifications > Homiio.",
-  "notification.settings.android.title": "Android Settings",
-  "notification.settings.android.description": "You can manage notification channels and advanced settings in your device's Settings app under Apps > Homiio > Notifications.",
-  "success.signup": "Registration successful",
-  "action.retry": "Retry",
-  "status.loading": "Loading...",
-  "state.loading": "Loading...",
-  "state.no_results": "No results",
-  "state.empty_state": "Nothing to show",
-  "state.not_connected": "Not connected",
-  "state.session_expired": "Session expired",
-  "state.no_session": "Please login",
-  "state.retrying": "Retrying...",
-  "state.uploading": "Uploading...",
-  "state.downloading": "Downloading...",
-  "state.processing": "Processing...",
-  "state.please_wait": "Please wait...",
-  "file.size_mb": "MB",
-  "profile.edit": "Edit profile",
-  "profile.chat": "Chat",
   "home": {
     "insights": {
       "title": "Platform Insights"
@@ -240,6 +158,24 @@
         "ecoFriendly": "Eco-friendly"
       }
     },
+    "category": {
+      "studios": "Studios",
+      "apartments": "Apartments",
+      "houses": "Houses",
+      "rooms": "Rooms",
+      "coliving": "Co-living",
+      "luxury": "Luxury",
+      "newListings": "New listings",
+      "nearYou": "Near you",
+      "beachfront": "Beachfront",
+      "cabins": "Cabins",
+      "pools": "Pools",
+      "mountain": "Mountain",
+      "cityBreaks": "City breaks",
+      "countryside": "Countryside",
+      "instantBook": "Instant book",
+      "petFriendly": "Pet friendly"
+    },
     "horizon": {
       "title": "Join Horizon",
       "description": "Horizon is a global initiative offering fair housing, healthcare, and travel support. Now integrated with Homiio.",
@@ -268,7 +204,8 @@
       "errorDescription": "Please try again.",
       "retry": "Retry",
       "results": "Results",
-      "filtered": "filtered"
+      "filtered": "filtered",
+      "continue": "Continue browsing"
     },
     "saved": {
       "title": "Saved Properties",
@@ -303,7 +240,9 @@
       "propertyInspection": {
         "title": "Property Inspection Checklist: What to Look For",
         "description": "A comprehensive guide to inspecting potential rental properties and identifying potential issues."
-      }
+      },
+      "subtitle": "Practical guides from local tenants, legal experts, and the Homiio editorial team.",
+      "eyebrow": "Renting smarter"
     },
     "faq": {
       "title": "Frequently Asked Questions",
@@ -327,6 +266,23 @@
     "cityShowcase": {
       "title": "Explore {{place}}",
       "defaultPlace": "Spain"
+    },
+    "nearby": {
+      "title": "Homes in {{city}}"
+    },
+    "recommended": {
+      "title": "Recommended homes",
+      "eyebrow": "For you"
+    },
+    "hostCta": {
+      "cta": "Become a host",
+      "subtitle": "Reach verified renters across Spain — free to list, fair fees, real human support.",
+      "title": "List your space, find a great tenant"
+    },
+    "footerStrip": {
+      "support": "Real support, real people",
+      "fair": "Fair agreements",
+      "verified": "Verified listings"
     }
   },
   "agent": {
@@ -432,6 +388,9 @@
       "subtitle": "Turn the homes around you into income.",
       "cta": "Become an agent",
       "trust": "No license needed. Work from your phone."
+    },
+    "join": {
+      "error": "Could not start earning right now. Please try again."
     }
   },
   "tips": {
@@ -470,7 +429,9 @@
     "notificationsDescription": "Get notified when new properties match this search",
     "disableNotifications": "Disable notifications",
     "withFilters": "With filters",
-    "error": "Error",
+    "error": {
+      "title": "Could not load homes"
+    },
     "enterSearchQuery": "Please enter a search query first",
     "deleteSearch": "Delete Search",
     "deleteSearchConfirm": "Are you sure you want to delete the search \"{{name}}\"?",
@@ -479,14 +440,49 @@
     "duplicateExact": "You already saved this exact search",
     "tryDifferentName": "Please choose a different name",
     "more": "more",
-    "Eco-friendly": "Eco-friendly",
-    "Co-living": "Co-living",
-    "Furnished": "Furnished",
-    "Pets Allowed": "Pets Allowed",
-    "Verified": "Verified",
-    "Search with": "Search with",
     "filters": {
-      "listingType": "Listing type"
+      "listingType": "Listing type",
+      "propertyType": "Property Type",
+      "nightlyPrice": "Nightly price",
+      "monthlyPrice": "Monthly price",
+      "checkIn": "Check-in",
+      "checkOut": "Check-out",
+      "addDate": "Add date",
+      "guests": "Guests",
+      "instantBook": "Instant book",
+      "cancellationPolicy": "Cancellation policy",
+      "moveInDate": "Move-in date",
+      "leaseDuration": {
+        "3Months": "3 months",
+        "6Months": "6 months",
+        "12Months": "12 months",
+        "flexible": "Flexible"
+      },
+      "maxDeposit": "Max deposit",
+      "amenities": "Amenities",
+      "amenity": {
+        "wifi": "Wi-Fi",
+        "parking": "Parking",
+        "gym": "Gym",
+        "pool": "Pool",
+        "balcony": "Balcony",
+        "garden": "Garden",
+        "elevator": "Elevator",
+        "airConditioning": "Air conditioning",
+        "heating": "Heating",
+        "dishwasher": "Dishwasher",
+        "washingMachine": "Washing machine"
+      },
+      "propertyTypeVacation": {
+        "wholeHouses": "Whole houses",
+        "privateRooms": "Private rooms"
+      },
+      "cancellation": {
+        "flexible": "Flexible",
+        "moderate": "Moderate",
+        "strict": "Strict",
+        "superStrict": "Super strict"
+      }
     },
     "mode": {
       "label": "Browse mode",
@@ -495,7 +491,6 @@
       "buy": "Buy",
       "exchange": "Exchange"
     },
-    "Advanced Filters": "Advanced Filters",
     "types": {
       "apartments": "Apartments",
       "houses": "Houses",
@@ -517,7 +512,16 @@
       "rooms": "Rooms",
       "studios": "Studios",
       "coliving": "Co-living",
-      "publicHousing": "Public Housing"
+      "publicHousing": "Public Housing",
+      "couchsurfing": "Couchsurfing",
+      "roommates": "Roommates",
+      "hostel": "Hostel",
+      "guesthouse": "Guesthouse",
+      "campsite": "Campsite",
+      "boat": "Boat",
+      "treehouse": "Treehouse",
+      "yurt": "Yurt",
+      "other": "Other"
     },
     "areas": {
       "downtown": "Downtown",
@@ -602,7 +606,87 @@
       }
     },
     "editSearch": "Edit Search",
-    "searchQueryPlaceholder": "Enter your search query"
+    "searchQueryPlaceholder": "Enter your search query",
+    "actions": {
+      "save": "Save",
+      "search": "Search",
+      "clearAll": "Clear all",
+      "searchArea": "Search this area",
+      "sort": "Sort",
+      "filters": "Filters",
+      "saved": "Saved"
+    },
+    "summary": {
+      "edit": "Edit search",
+      "anyPrice": "Any price",
+      "addDates": "Add dates",
+      "anyTime": "Any time",
+      "anyType": "Any type",
+      "anywhere": "Anywhere",
+      "mapArea": "Map area",
+      "typeCount": "{{count}} types"
+    },
+    "step": {
+      "dates": {
+        "title": "When?",
+        "weekday": {
+          "Mo": "Mo",
+          "Tu": "Tu",
+          "We": "We",
+          "Th": "Th",
+          "Fr": "Fr",
+          "Sa": "Sa",
+          "Su": "Su"
+        }
+      },
+      "type": {
+        "title": "What type of place?"
+      },
+      "price": {
+        "max": "Maximum",
+        "any": "Any",
+        "min": "Minimum",
+        "title": "Price range",
+        "perMonth": "per month",
+        "perNight": "per night"
+      }
+    },
+    "header": {
+      "geocoding": "Looking up location...",
+      "noResults": "No homes match this search",
+      "loading": "Searching homes...",
+      "count": "{{count}} homes"
+    },
+    "recent": {
+      "title": "Recent searches"
+    },
+    "input": {
+      "placeholder": "Search cities, neighborhoods, or addresses"
+    },
+    "panel": {
+      "title": "Search"
+    },
+    "fab": {
+      "map": "Map",
+      "list": "List"
+    },
+    "empty": {
+      "action": "Edit search",
+      "description": "Try widening your area or relaxing your filters.",
+      "title": "No homes match this search"
+    },
+    "sort": {
+      "title": "Sort by",
+      "recommended": "Recommended",
+      "priceAsc": "Price: Low to high",
+      "priceDesc": "Price: High to low",
+      "newest": "Newest first"
+    },
+    "save": {
+      "title": "Save this search",
+      "namePlaceholder": "Give your search a name",
+      "enableNotifications": "Enable notifications"
+    }
   },
   "profile": {
     "title": "Profile",
@@ -631,12 +715,19 @@
       "properties": "My Properties",
       "contracts": "My Contracts",
       "trustScore": "Trust Score",
-      "settings": "Settings"
+      "settings": "Settings",
+      "account": "Account",
+      "profile": "Profile",
+      "activity": "Activity"
     },
     "stats": {
       "propertiesCount": "Properties",
       "contractsCount": "Contracts",
-      "trustScore": "Trust Score"
+      "trustScore": "Trust Score",
+      "stays": "Stays",
+      "applications": "Applications",
+      "applicationsApproved": "{{count}} approved",
+      "saved": "Saved"
     },
     "actions": {
       "manageProperties": "Manage Properties",
@@ -653,7 +744,323 @@
       "deleteFailed": "Failed to delete profile"
     },
     "exchanges": "Exchanges",
-    "exchangesDescription": "Your home swaps and hosting requests."
+    "exchangesDescription": "Your home swaps and hosting requests.",
+    "edit": {
+      "noProfile": "No profile found to update.",
+      "updateSuccess": "Profile updated successfully!",
+      "updateFailed": "Failed to update profile",
+      "sections": {
+        "agencyInformation": "Agency Information",
+        "agencyVerification": "Agency Verification",
+        "teamManagement": "Team Management",
+        "businessSettings": "Business Settings",
+        "businessInformation": "Business Information",
+        "businessVerification": "Business Verification",
+        "cooperativeInformation": "Cooperative Information",
+        "cooperativeSettings": "Cooperative Settings",
+        "personalInformation": "Personal Information",
+        "propertyPreferences": "Property Preferences",
+        "references": "References",
+        "rentalHistory": "Rental History",
+        "trustScore": "Trust Score",
+        "settings": "Settings"
+      },
+      "labels": {
+        "businessType": "Business Type *",
+        "legalCompanyName": "Legal Company Name *",
+        "description": "Description",
+        "licenseNumber": "License Number",
+        "taxId": "Tax ID",
+        "yearEstablished": "Year Established",
+        "employeeCount": "Number of Employees",
+        "specialties": "Specialties",
+        "verificationStatus": "Verification Status",
+        "profileVisibility": "Profile Visibility",
+        "notifications": "Notifications",
+        "emailNotifications": "Email Notifications",
+        "pushNotifications": "Push Notifications",
+        "legalName": "Legal Name *",
+        "industry": "Industry",
+        "bio": "Bio",
+        "occupation": "Occupation",
+        "employer": "Employer",
+        "annualIncome": "Annual Income ($)",
+        "employmentStatus": "Employment Status",
+        "moveInDate": "Move-in Date",
+        "leaseDuration": "Lease Duration",
+        "maxRent": "Maximum Rent ($)",
+        "rentPeriod": "Rent Period",
+        "minBedrooms": "Min Bedrooms",
+        "minBathrooms": "Min Bathrooms",
+        "propertyTypes": "Property Types",
+        "preferredAmenities": "Preferred Amenities",
+        "additionalPreferences": "Additional Preferences",
+        "name": "Name",
+        "relationship": "Relationship",
+        "phone": "Phone",
+        "email": "Email",
+        "address": "Address",
+        "startDate": "Start Date",
+        "endDate": "End Date",
+        "monthlyRent": "Monthly Rent ($)",
+        "reasonForLeaving": "Reason for Leaving",
+        "landlordContact": "Landlord Contact",
+        "privacy": "Privacy"
+      },
+      "subtitles": {
+        "agencyVerification": "Complete these verifications to build trust with clients",
+        "businessVerification": "Complete these verifications to build trust with clients",
+        "businessSettings": "Configure your business profile settings",
+        "cooperativeSettings": "Configure your cooperative profile settings"
+      },
+      "placeholders": {
+        "legalCompanyName": "Enter your legal company name",
+        "description": "Describe your business...",
+        "licenseNumber": "Enter license number",
+        "taxId": "Enter tax ID",
+        "yearEstablished": "e.g., 2020",
+        "industry": "Enter industry",
+        "cooperativeLegalName": "Enter cooperative legal name",
+        "cooperativeDescription": "Describe your cooperative...",
+        "bio": "Tell us about yourself...",
+        "occupation": "e.g., Software Engineer",
+        "employer": "e.g., Tech Corp",
+        "annualIncome": "e.g., 75000",
+        "moveInDate": "YYYY-MM-DD",
+        "maxRent": "Enter maximum rent",
+        "fullName": "Full name",
+        "phoneNumber": "Phone number",
+        "emailAddress": "Email address",
+        "fullAddress": "Full address",
+        "landlordName": "Landlord name",
+        "phone": "Phone",
+        "email": "Email",
+        "endDateOptional": "YYYY-MM-DD (optional)",
+        "monthlyRent": "e.g., 1500"
+      },
+      "options": {
+        "agencyBusinessType": {
+          "real_estate_agency": "Real Estate Agency",
+          "property_management": "Property Management",
+          "brokerage": "Brokerage",
+          "developer": "Developer",
+          "other": "Other"
+        },
+        "agencySpecialty": {
+          "residential": "Residential",
+          "commercial": "Commercial",
+          "luxury": "Luxury",
+          "student_housing": "Student Housing",
+          "senior_housing": "Senior Housing",
+          "vacation_rentals": "Vacation Rentals"
+        },
+        "businessType": {
+          "small_business": "Small Business",
+          "startup": "Startup",
+          "freelancer": "Freelancer",
+          "consultant": "Consultant",
+          "other": "Other"
+        },
+        "employmentStatus": {
+          "employed": "Employed",
+          "self_employed": "Self Employed",
+          "student": "Student",
+          "retired": "Retired",
+          "unemployed": "Unemployed",
+          "other": "Other"
+        },
+        "leaseDuration": {
+          "monthly": "Monthly",
+          "3_months": "3 Months",
+          "6_months": "6 Months",
+          "yearly": "Yearly",
+          "flexible": "Flexible"
+        },
+        "priceUnit": {
+          "day": "Day",
+          "night": "Night",
+          "week": "Week",
+          "month": "Month",
+          "year": "Year"
+        },
+        "propertyType": {
+          "apartment": "Apartment",
+          "house": "House",
+          "room": "Room",
+          "studio": "Studio"
+        },
+        "amenity": {
+          "parking": "Parking",
+          "gym": "Gym",
+          "pool": "Pool",
+          "washer": "Washer",
+          "dishwasher": "Dishwasher",
+          "balcony": "Balcony",
+          "elevator": "Elevator",
+          "ac": "Ac",
+          "heating": "Heating",
+          "internet": "Internet"
+        },
+        "referenceRelationship": {
+          "landlord": "Landlord",
+          "employer": "Employer",
+          "personal": "Personal",
+          "other": "Other"
+        },
+        "reasonForLeaving": {
+          "lease_ended": "Lease Ended",
+          "bought_home": "Bought Home",
+          "job_relocation": "Job Relocation",
+          "family_reasons": "Family Reasons",
+          "upgrade": "Upgrade",
+          "other": "Other"
+        },
+        "profileVisibility": {
+          "public": "Public",
+          "private": "Private",
+          "contacts_only": "Contacts Only"
+        }
+      },
+      "verification": {
+        "businessLicenseTitle": "Business License",
+        "businessLicenseDescription": "Upload your business license for verification",
+        "insuranceTitle": "Insurance",
+        "insuranceDescription": "Provide proof of business insurance",
+        "bondingTitle": "Bonding",
+        "bondingDescription": "Provide surety bond information",
+        "backgroundCheckTitle": "Background Check",
+        "backgroundCheckDescription": "Complete background check for all team members"
+      },
+      "toggles": {
+        "emailNotifications": "Email Notifications",
+        "pushNotifications": "Push Notifications",
+        "petFriendly": "Pet Friendly",
+        "smokingAllowed": "Smoking Allowed",
+        "furnished": "Furnished",
+        "parkingRequired": "Parking Required",
+        "accessibilityFeatures": "Accessibility Features",
+        "showContactInfo": "Show Contact Info",
+        "showIncome": "Show Income",
+        "showRentalHistory": "Show Rental History",
+        "showReferences": "Show References"
+      },
+      "team": {
+        "subtitle": "Manage your team members and their roles",
+        "memberLabel": "Member {{index}}",
+        "addedLabel": "Added: {{date}}",
+        "emptyText": "No team members added yet.",
+        "addMember": "+ Add Team Member"
+      },
+      "actions": {
+        "addReference": "+ Add Reference",
+        "addHistory": "+ Add History",
+        "remove": "Remove",
+        "referenceLabel": "Reference {{index}}",
+        "rentalLabel": "Rental {{index}}"
+      }
+    },
+    "create": {
+      "selectType": "Please select a profile type.",
+      "selectBusinessType": "Please select a business type.",
+      "cooperativeLegalNameRequired": "Please enter a legal name for the cooperative.",
+      "createdSuccess": "{{type}} created successfully!",
+      "headerTitle": "Create Profile",
+      "createButton": "Create",
+      "chooseType": "Choose Business Profile Type",
+      "types": {
+        "agency": {
+          "title": "Agency Profile",
+          "description": "For real estate agencies and property management"
+        },
+        "business": {
+          "title": "Business Profile",
+          "description": "For small businesses and freelancers"
+        },
+        "cooperative": {
+          "title": "Cooperative Profile",
+          "description": "For housing or member-owned cooperatives"
+        }
+      },
+      "sections": {
+        "agencyInfo": "Agency Information",
+        "businessInfo": "Business Information",
+        "cooperativeInfo": "Cooperative Information",
+        "whatsNext": "What's Next?",
+        "profileSetup": "Profile Setup"
+      },
+      "whatsNext": {
+        "description": "After creating your {{type}} profile, you can customize preferences, add verification documents, and build your trust score."
+      },
+      "placeholders": {
+        "agencyDescription": "Describe your agency...",
+        "businessDescription": "Describe your business...",
+        "licenseOptional": "Enter license number (if applicable)",
+        "cooperativeLegalName": "Cooperative Legal Name",
+        "cooperativeDescription": "Describe the cooperative"
+      },
+      "options": {
+        "agencySpecialty": {
+          "residential": "Residential",
+          "commercial": "Commercial",
+          "investment": "Investment",
+          "rental": "Rental",
+          "new_construction": "New Construction"
+        },
+        "businessSpecialty": {
+          "consulting": "Consulting",
+          "technology": "Technology",
+          "design": "Design",
+          "marketing": "Marketing",
+          "finance": "Finance",
+          "healthcare": "Healthcare",
+          "education": "Education",
+          "retail": "Retail",
+          "services": "Services"
+        }
+      }
+    },
+    "toast": {
+      "loadFailed": "Failed to load profiles",
+      "createSuccess": "Profile created successfully",
+      "createFailed": "Failed to create profile",
+      "updateSuccess": "Profile updated successfully",
+      "updateFailed": "Failed to update profile",
+      "deleteSuccess": "Profile deleted successfully",
+      "deleteFailed": "Failed to delete profile",
+      "activateSuccess": "Profile activated successfully",
+      "activateFailed": "Failed to activate profile"
+    },
+    "trustScoreHint": "Complete your profile information to improve your trust score.",
+    "trustScoreSubtitle": "Build trust with landlords and roommates through verification and positive interactions.",
+    "established": "Established",
+    "serviceAreas": "Service areas",
+    "specialties": "Specialties",
+    "about": "About",
+    "preferences": "Preferences",
+    "budget": "Budget",
+    "employer": "Employer",
+    "occupation": "Occupation",
+    "listings": "Listings",
+    "switchConfirm": "Switch",
+    "switchMessage": "Activate {{name}}?",
+    "switchTitle": "Switch profile?",
+    "subscriptionsDescription": "Manage Homiio Plus or buy one-time file analysis.",
+    "subscriptions": "Subscriptions",
+    "createNewDescription": "Add a business, agency, or cooperative profile.",
+    "createNew": "Create new profile",
+    "active": "Active",
+    "activeFooter": "Active: {{name}}",
+    "stays": "Stays",
+    "applications": "My applications",
+    "trustScoreCta": "View trust score",
+    "loadFailedHint": "Please try again later.",
+    "loadFailed": "Failed to load profile",
+    "switchFailed": "Failed to switch profile",
+    "switched": "Switched to {{name}}",
+    "invalidProfile": "Invalid profile data",
+    "trustScorePage": {
+      "title": "Trust Score"
+    }
   },
   "trust": {
     "loadingVerification": "Loading verification status...",
@@ -666,7 +1073,79 @@
     "verified": "Verified",
     "completeVerification": "Complete Verification",
     "yourScoreIs": "Your trust score is",
-    "improveScore": "Improve Score"
+    "improveScore": "Improve Score",
+    "manager": {
+      "loading": "Loading trust score...",
+      "error": "Error loading trust score",
+      "noData": "No personal trust score data found",
+      "title": "Trust Score",
+      "subtitle": "Build trust with landlords and roommates",
+      "scoreDescription": "Your overall trust score is {{score}}/100",
+      "factorsTitle": "Trust Factors",
+      "factorsSubtitle": "Improve these factors to increase your trust score",
+      "quickActionsTitle": "Quick Actions to Improve Score",
+      "completeProfile": "Complete Profile",
+      "cancel": "Cancel",
+      "editProfile": "Edit Profile",
+      "factorAlertBody": "{{description}}\n\nCurrent Score: {{score}}/100\n\nTo improve: {{action}}",
+      "factors": {
+        "verification": {
+          "label": "Identity Verification",
+          "description": "Complete identity verification to build trust",
+          "action": "Add personal information and income details"
+        },
+        "reviews": {
+          "label": "User Reviews",
+          "description": "Get positive reviews from landlords and roommates",
+          "action": "Add references from previous landlords"
+        },
+        "payment_history": {
+          "label": "Payment History",
+          "description": "Maintain a good payment history",
+          "action": "Add rental history with payment records"
+        },
+        "communication": {
+          "label": "Communication",
+          "description": "Respond promptly to messages and requests",
+          "action": "Complete your profile bio and contact info"
+        },
+        "rental_history": {
+          "label": "Rental History",
+          "description": "Build a positive rental history",
+          "action": "Add your previous rental addresses"
+        },
+        "default": {
+          "description": "Improve this factor to increase your trust score",
+          "action": "Complete your profile to improve this factor"
+        }
+      },
+      "actions": {
+        "personalInfo": {
+          "title": "Complete Personal Info",
+          "description": "Add your occupation, income, and employment details to build trust."
+        },
+        "references": {
+          "title": "Add References",
+          "description": "Include references from previous landlords and employers."
+        },
+        "rentalHistory": {
+          "title": "Add Rental History",
+          "description": "Document your rental history to show your reliability as a tenant."
+        }
+      }
+    },
+    "score": {
+      "levels": {
+        "excellent": "Excellent",
+        "good": "Good",
+        "average": "Average",
+        "fair": "Fair",
+        "needsImprovement": "Needs Improvement"
+      },
+      "breakdown": "Trust Score Breakdown",
+      "recalculate": "Recalculate",
+      "recalculating": "Recalculating..."
+    }
   },
   "notifications": {
     "title": "Notifications",
@@ -727,9 +1206,6 @@
     "share": "Share",
     "contact": "Contact",
     "bookViewing": "Book Viewing",
-    "Housing Authority": "Housing Authority",
-    "Apply on State Website": "Apply on State Website",
-    "Contact Housing Authority": "Contact Housing Authority",
     "my": {
       "title": "My Properties",
       "edit": "Edit",
@@ -741,7 +1217,15 @@
       "emptyDescription": "You haven't created any properties yet. Start by adding your first property listing.",
       "createFirst": "Create Your First Property",
       "errorTitle": "Error Loading Properties",
-      "errorDescription": "There was an error loading your properties. Please try again."
+      "errorDescription": "There was an error loading your properties. Please try again.",
+      "markRented": "Mark as rented",
+      "markSold": "Mark as sold",
+      "transactMessage": "This closes \"{{title}}\" and removes it from active listings. This cannot be undone.",
+      "markRentedTitle": "Mark as rented?",
+      "markSoldTitle": "Mark as sold?",
+      "transactError": "Could not close this listing",
+      "transactDone": "Listing marked as closed",
+      "transactCommission": "Deal closed — commission recorded"
     },
     "details": {
       "price": "Price",
@@ -767,6 +1251,41 @@
         "duplex": "Duplex",
         "penthouse": "Penthouse"
       }
+    },
+    "actions": {
+      "create": "Add property",
+      "recent": "Recently viewed"
+    },
+    "empty": {
+      "action": "Clear filters",
+      "description": "Try relaxing your filters.",
+      "title": "No homes available"
+    },
+    "error": {
+      "title": "Could not load homes"
+    },
+    "header": {
+      "empty": "No homes available",
+      "loading": "Loading homes…"
+    },
+    "city": {
+      "verifiedProperties": "Verified Properties",
+      "verifiedOnly": "Verified Only",
+      "ecoFriendly": "Eco-Friendly",
+      "ecoFriendlyOnly": "Eco-Friendly Only",
+      "loadingProperties": "Loading properties...",
+      "notFound": "City not found",
+      "properties": "Properties",
+      "population": "Population",
+      "availableProperties": "Available Properties",
+      "propertiesFound": "properties found",
+      "sortBy": "Sort By",
+      "sortNewest": "Newest First",
+      "sortPriceAsc": "Price: Low to High",
+      "sortPriceDesc": "Price: High to Low",
+      "noPropertiesFound": "No properties found",
+      "tryAdjustFilters": "Try adjusting your filters or check back later",
+      "clearFilters": "Clear Filters"
     }
   },
   "payments": {
@@ -802,6 +1321,116 @@
       "download": "Download",
       "sign": "Sign",
       "renew": "Renew"
+    },
+    "list": {
+      "title": "Rental Contracts",
+      "eyebrow": "Agreements",
+      "subtitle": "Track every lease you sign or issue and pull up key terms in seconds.",
+      "filterAll": "All",
+      "filterActive": "Active",
+      "filterPending": "Pending",
+      "filterExpired": "Expired",
+      "filterDrafts": "Drafts",
+      "noRentalPropertiesTitle": "No rental contracts",
+      "noRentalPropertiesDescription": "You don't have any rental properties yet. Start by browsing available properties or listing your own.",
+      "browseProperties": "Browse properties",
+      "loadError": "Couldn't load contracts",
+      "tryAgain": "Please try again.",
+      "emptyTitle": "No contracts found",
+      "emptyAllDescription": "You don't have any rental contracts yet",
+      "emptyFilteredDescription": "No {{filter}} contracts to show",
+      "newContract": "New contract",
+      "createNew": "Create new contract"
+    },
+    "card": {
+      "start": "Start",
+      "end": "End",
+      "landlord": "Landlord",
+      "tenant": "Tenant",
+      "perMonth": "/ month",
+      "share": "Share",
+      "download": "Download",
+      "accessibility": "Contract {{title}}"
+    },
+    "detail": {
+      "title": "Contract",
+      "invalidIdTitle": "Invalid contract id",
+      "invalidIdDescription": "The link is missing the contract reference.",
+      "unavailableTitle": "Contract unavailable",
+      "unavailableDescription": "This contract could not be loaded.",
+      "term": "Term",
+      "rent": "Rent",
+      "start": "Start",
+      "end": "End",
+      "monthlyRent": "Monthly rent",
+      "securityDeposit": "Security deposit",
+      "signatures": "Signatures",
+      "landlord": "Landlord",
+      "tenant": "Tenant",
+      "payments": "Payment schedule",
+      "documents": "Documents",
+      "addDocument": "Add document",
+      "sign": "Sign contract",
+      "terminate": "Terminate lease",
+      "deleteDraft": "Delete draft",
+      "confirmSignTitle": "Sign this lease?",
+      "confirmSignBody": "Your signature confirms you accept the lease terms.",
+      "confirmTerminateTitle": "Terminate this lease?",
+      "confirmTerminateBody": "This ends the lease for all parties.",
+      "confirmDeleteTitle": "Delete this draft?",
+      "confirmDeleteBody": "This draft will be permanently removed.",
+      "toastSigned": "Lease signed",
+      "toastSignFailed": "Could not sign the lease",
+      "toastTerminated": "Lease terminated",
+      "toastTerminateFailed": "Could not terminate the lease",
+      "toastDeleted": "Draft deleted",
+      "toastDeleteFailed": "Could not delete the draft",
+      "toastDocumentAdded": "Document added",
+      "toastDocumentFailed": "Could not add the document",
+      "toastOpenDocumentFailed": "Could not open the document.",
+      "permissionRequired": "Media library permission is required to attach a document.",
+      "propertyFallback": "Property",
+      "goBack": "Go back",
+      "dueDay": "Day {{day}} of the month",
+      "dueDayLabel": "Due day",
+      "signed": "Signed",
+      "signaturePending": "Pending",
+      "emptyDocuments": "No documents attached.",
+      "addShort": "Add",
+      "signLease": "Sign lease",
+      "confirmSignExtended": "By signing you agree to the lease terms. Once both parties sign, the lease becomes active.",
+      "confirmSignAction": "Sign",
+      "confirmTerminateShortTitle": "Terminate lease?",
+      "confirmTerminateExtended": "This records a termination notice and ends the lease. This cannot be undone.",
+      "confirmDeleteExtended": "This permanently removes the draft lease.",
+      "confirmDeleteAction": "Delete",
+      "openDocument": "Open document {{name}}"
+    },
+    "documentType": {
+      "lease_agreement": "Lease agreement",
+      "addendum": "Addendum",
+      "inspection_report": "Inspection report",
+      "insurance": "Insurance",
+      "other": "Other"
+    },
+    "new": {
+      "title": "New contract",
+      "noApplicationTitle": "Start from an application",
+      "noApplicationDescription": "Leases are created from an approved tenant application. Open an approved application and choose \"Create lease\".",
+      "viewApplications": "View applications",
+      "applicationUnavailableTitle": "Application unavailable",
+      "loadFailedDescription": "This application could not be loaded.",
+      "goBack": "Go back",
+      "subtitle": "Create a draft lease from this application. You can edit the terms and sign it on the next screen.",
+      "seededTerms": "Seeded terms",
+      "moveIn": "Move-in",
+      "leaseTerm": "Lease term",
+      "leaseTermMonths": "{{count}} months",
+      "notApprovedWarning": "This application is not approved yet. Approve it first to create a lease.",
+      "createButton": "Create draft lease",
+      "toastCreated": "Draft lease created",
+      "toastCreateFailed": "Could not create the lease",
+      "propertyFallback": "Property"
     }
   },
   "roommates": {
@@ -815,6 +1444,185 @@
       "message": "Message",
       "connect": "Connect",
       "viewProfile": "View Profile"
+    },
+    "tabs": {
+      "discover": "Discover",
+      "requests": "Requests",
+      "matches": "Matches",
+      "rooms": "Rooms"
+    },
+    "alert": {
+      "requestSent": "Roommate request sent successfully!",
+      "requestFailed": "Failed to send roommate request",
+      "accepted": "Roommate request accepted!",
+      "acceptFailed": "Failed to accept roommate request",
+      "declined": "Roommate request declined",
+      "declineFailed": "Failed to decline roommate request",
+      "relationshipEnded": "Roommate relationship ended",
+      "relationshipEndFailed": "Failed to end roommate relationship",
+      "toggleFailed": "Failed to toggle roommate matching",
+      "preferencesSaved": "Your roommate preferences were updated.",
+      "preferencesFailed": "Failed to save roommate preferences. Please try again.",
+      "successTitle": "Success",
+      "errorTitle": "Error"
+    },
+    "screen": {
+      "title": "Roommates",
+      "eyebrow": "Together",
+      "signInTitle": "Sign in to find roommates",
+      "signInDescription": "Discover compatible roommates and manage your requests.",
+      "signIn": "Sign in",
+      "loadError": "Couldn't load roommates",
+      "loadRequestsError": "Couldn't load requests",
+      "loadRelationshipsError": "Couldn't load relationships",
+      "tryAgain": "Please try again.",
+      "personalProfileRequired": "Personal profile required",
+      "personalProfileDescription": "Roommate matching is only available for personal profiles. Switch to your personal profile to use this feature.",
+      "roomSearchPersonalOnly": "Room search is only available for personal profiles. Switch to your personal profile to use this feature.",
+      "switchToPersonal": "Switch to personal profile",
+      "emptyDiscoverTitle": "No roommates found",
+      "emptyDiscoverDescription": "We couldn't find anyone matching your preferences. Try adjusting your settings.",
+      "enableMatchingTitle": "Enable roommate matching",
+      "enableMatchingDescription": "Turn on roommate matching to discover potential roommates based on your preferences.",
+      "enabling": "Enabling…",
+      "emptyRequestsTitle": "No requests yet",
+      "emptyRequestsDescription": "When you send or receive roommate requests, they'll appear here.",
+      "discoverRoommates": "Discover roommates",
+      "emptyRelationshipsTitle": "No active relationships",
+      "emptyRelationshipsDescription": "When you accept roommate requests, your relationships will appear here.",
+      "emptyRoomsTitle": "No rooms listed",
+      "emptyRoomsDescription": "Room listings from your network will appear here.",
+      "enableMatching": "Enable matching",
+      "updatePreferences": "Update preferences",
+      "editPreferences": "Edit preferences",
+      "matchingEnabled": "Roommate matching enabled",
+      "matchingDisabled": "Roommate matching disabled",
+      "fallbackName": "Roommate"
+    },
+    "profileDetail": {
+      "title": "Roommate",
+      "loadError": "Couldn't load profile",
+      "loadErrorDescription": "We couldn't load this roommate profile. Please try again.",
+      "about": "About",
+      "preferencesTitle": "Roommate preferences",
+      "budget": "Budget",
+      "moveIn": "Move-in",
+      "leaseLength": "Lease length",
+      "notSpecified": "Not specified",
+      "trust": "Trust",
+      "verified": "Verified",
+      "references": "References",
+      "rentalHistory": "Rental history",
+      "sending": "Sending…",
+      "sendRequest": "Send roommate request",
+      "requestSentTitle": "Request sent",
+      "requestSentBody": "Your roommate request was sent.",
+      "requestFailedTitle": "Could not send request",
+      "requestFailedBody": "We could not send your request. Please try again."
+    },
+    "preferencesPage": {
+      "title": "Roommate preferences",
+      "eyebrow": "Sharing a place",
+      "subtitle": "Let other Homiio users find you when their preferences and yours line up.",
+      "enableTitle": "Enable roommate matching",
+      "enableDescription": "Allow other users to discover your profile for matching.",
+      "budgetTimeline": "Budget & timeline",
+      "monthlyBudget": "Monthly budget (€)",
+      "min": "Min",
+      "max": "Max",
+      "moveInDate": "Move-in date",
+      "leaseLength": "Lease length",
+      "roommateSection": "Roommate",
+      "preferredGender": "Preferred gender",
+      "ageRange": "Age range",
+      "lifestyle": "Lifestyle",
+      "smoking": "Smoking",
+      "pets": "Pets",
+      "partying": "Partying",
+      "cleanliness": "Cleanliness",
+      "schedule": "Schedule",
+      "saving": "Saving…",
+      "save": "Save preferences",
+      "personalProfileRequired": "Personal profile required",
+      "personalProfileDescription": "Roommate preferences are only available for personal profiles. Please switch to your personal profile to manage your roommate settings.",
+      "switchToPersonal": "Switch to personal profile",
+      "options": {
+        "gender": {
+          "any": "Any",
+          "male": "Male",
+          "female": "Female"
+        },
+        "lifestyle": {
+          "yes": "Yes",
+          "no": "No",
+          "prefer_not": "No pref."
+        },
+        "cleanliness": {
+          "very_clean": "Very clean",
+          "clean": "Clean",
+          "average": "Average",
+          "relaxed": "Relaxed"
+        },
+        "schedule": {
+          "early_bird": "Early bird",
+          "night_owl": "Night owl",
+          "flexible": "Flexible"
+        },
+        "lease": {
+          "monthly": "Monthly",
+          "3_months": "3 months",
+          "6_months": "6 months",
+          "yearly": "Yearly",
+          "flexible": "Flexible"
+        }
+      }
+    },
+    "request": {
+      "accept": "Accept",
+      "decline": "Decline",
+      "viewProfile": "View profile",
+      "sent": "Sent",
+      "received": "Received",
+      "pending": "Pending",
+      "accepted": "Accepted",
+      "declined": "Declined",
+      "responsePlaceholder": "Add an optional message..."
+    },
+    "relationship": {
+      "title": "Roommate Relationship",
+      "duration": "Duration: {{duration}}",
+      "started": "Started: {{date}}",
+      "endedOn": "Ended on {{date}}",
+      "statusActive": "Active",
+      "statusInactive": "Inactive",
+      "statusEnded": "Ended",
+      "statusUnknown": "Unknown",
+      "durationDays": "{{count}} days",
+      "durationMonth": "{{count}} month",
+      "durationMonths": "{{count}} months",
+      "durationYear": "{{count}} year",
+      "durationYears": "{{count}} years",
+      "percentMatch": "{{score}}% Match",
+      "roommatesSection": "Roommates",
+      "endRelationship": "End Relationship",
+      "confirmEndTitle": "End Relationship",
+      "confirmEndBody": "Are you sure you want to end this roommate relationship? This action cannot be undone.",
+      "confirmEndAction": "End Relationship",
+      "message": "Message"
+    },
+    "match": {
+      "compatibility": "{{score}}% match",
+      "excellent": "Excellent Match",
+      "good": "Good Match",
+      "fair": "Fair Match",
+      "preferences": "Preferences",
+      "flexible": "Flexible",
+      "messageLabel": "Add a message (optional):",
+      "messagePlaceholder": "Hi! I think we'd be great roommates...",
+      "viewProfile": "View Profile",
+      "sendRequest": "Send Request",
+      "connect": "Connect",
+      "fallbackName": "Roommate"
     }
   },
   "safety": {
@@ -836,7 +1644,53 @@
     "description": "Global initiative for fair housing, healthcare, and travel support",
     "benefits": "Benefits",
     "join": "Join Horizon",
-    "learnMore": "Learn More"
+    "learnMore": "Learn More",
+    "page": {
+      "benefits": {
+        "fairHousing": {
+          "title": "Fair Housing",
+          "description": "Access to affordable housing in 120+ cities worldwide with standardized ethical rental agreements"
+        },
+        "healthcare": {
+          "title": "Healthcare Access",
+          "description": "Universal healthcare coverage with partner clinics and telehealth services in every Horizon city"
+        },
+        "travel": {
+          "title": "Travel Network",
+          "description": "Discounted transportation and accommodation when traveling between Horizon locations"
+        },
+        "community": {
+          "title": "Community Support",
+          "description": "Connect with local members for cultural integration, language exchange, and social activities"
+        }
+      },
+      "heroTitle": "Global Housing Initiative",
+      "heroSubtitle": "Creating a world of ethical housing, healthcare, and mobility",
+      "aboutTitle": "About Horizon",
+      "aboutBody1": "Horizon is a global initiative designed to make housing more accessible, affordable, and ethical for everyone. By joining a network of properties across 120+ cities worldwide, members gain access to fair housing, healthcare benefits, and travel support.",
+      "aboutBody2": "Our mission is to create sustainable living environments that foster community and wellbeing while reducing the environmental impact of housing.",
+      "benefitsTitle": "Member Benefits",
+      "howItWorksTitle": "How It Works",
+      "steps": {
+        "apply": {
+          "title": "Apply for Membership",
+          "description": "Complete your profile and submit a membership application with your housing needs and preferences."
+        },
+        "verify": {
+          "title": "Get Verified",
+          "description": "Our team reviews your application and verifies your identity and background information."
+        },
+        "access": {
+          "title": "Access the Network",
+          "description": "Once approved, browse and book properties across our global network with priority access."
+        }
+      },
+      "joinTitle": "Ready to join Horizon?",
+      "joinSubtitle": "Apply today and take the first step toward ethical, accessible housing worldwide.",
+      "storiesTitle": "Member Stories",
+      "story1": "Horizon made my relocation so much easier. I found an ethical apartment in Berlin within a week and the healthcare coverage saved me when I needed emergency care.",
+      "story2": "As a digital nomad, having access to quality housing in multiple cities has been life-changing. The community aspect is what makes Horizon truly special."
+    }
   },
   "settings": {
     "title": "Settings",
@@ -849,7 +1703,8 @@
       "supportFeedback": "Support & Feedback",
       "preferences": "App Preferences",
       "quickActions": "Quick Actions",
-      "data": "Data Management"
+      "data": "Data Management",
+      "notifications": "Notifications"
     },
     "aboutHomiio": {
       "appName": "Homiio",
@@ -905,8 +1760,27 @@
       "title": "Currency",
       "selectCurrency": "Select your preferred currency",
       "description": "This will be used to display prices throughout the app",
-      "currencyChanged": "Currency changed successfully"
-    }
+      "currencyChanged": "Currency changed successfully",
+      "errorChanging": "Failed to change currency. Please try again."
+    },
+    "language": {
+      "title": "Language",
+      "choose": "Choose a language",
+      "footer": "Changing the language updates labels across the app immediately.",
+      "emptyTitle": "No languages found",
+      "emptyDescription": "No language options are currently available",
+      "subtitle": "Select your preferred language"
+    },
+    "notifications": {
+      "detailDesc": "Choose which alerts you receive",
+      "detail": "Notification categories"
+    },
+    "account": {
+      "filesDescription": "Manage uploaded documents",
+      "files": "Files"
+    },
+    "signOutFailed": "Failed to sign out",
+    "signOutSuccess": "Signed out"
   },
   "common": {
     "cancel": "Cancel",
@@ -955,14 +1829,7 @@
     "view": "View",
     "details": "Details",
     "more": "More",
-    "Sign in to save searches": "Sign in to save searches",
-    "Go to Search": "Go to Search",
-    "No saved searches yet": "No saved searches yet",
-    "Create New Search": "Create New Search",
-    "View All": "View All",
-    "Sign in to create property alerts": "Sign in to create property alerts",
     "Creating...": "Creating...",
-    "Create Alert": "Create Alert",
     "less": "Less",
     "all": "All",
     "none": "None",
@@ -970,9 +1837,11 @@
     "noData": "No data available",
     "noResults": "No results found",
     "tryAgain": "Try again",
-    "goBack": "Go back",
+    "goBack": "Go Back",
     "goHome": "Go home",
-    "signIn": "Sign in"
+    "signIn": "Sign in",
+    "month": "month",
+    "reset": "Reset"
   },
   "sindi": {
     "name": "Sindi",
@@ -1094,7 +1963,9 @@
     },
     "errors": {
       "connection": "Connection Error",
-      "connectionMessage": "Please check your connection and try again."
+      "connectionMessage": "Please check your connection and try again.",
+      "uploadFailedTitle": "Upload failed",
+      "uploadAnalyzeFailed": "Could not analyze the file."
     },
     "shared": {
       "loading": "Loading Shared Conversation",
@@ -1136,6 +2007,18 @@
         "title": "Start Your Conversation",
         "subtitle": "Ask Sindi about tenant rights, housing search, or any housing-related questions. I'm here to help you fight for housing justice."
       }
+    },
+    "settings": {
+      "resetMessage": "This will reset all Sindi preferences to their defaults.",
+      "resetTitle": "Reset Sindi?",
+      "reset": "Reset Sindi to defaults",
+      "actions": "Actions",
+      "tipsDescription": "Surface inline guidance while you chat.",
+      "tips": "Show tips & hints",
+      "behaviorFooter": "Tune how Sindi behaves while you browse properties.",
+      "behavior": "Behavior",
+      "title": "Sindi preferences",
+      "resetDone": "Sindi preferences reset."
     }
   },
   "sidebar": {
@@ -1201,69 +2084,81 @@
     "close": "Close menu"
   },
   "saved": {
-    "header": "Saved",
-    "title": "Saved Properties",
-    "tabs": {
-      "all": "All",
-      "recent": "Recent",
-      "noted": "With Notes",
-      "quickSaves": "Quick Saves",
-      "folders": "Folders",
-      "profiles": "Profiles",
-      "searches": "Saved Searches"
+    "toast": {
+      "loadFoldersFailed": "Failed to load folders",
+      "folderCreated": "Folder created successfully",
+      "folderCreateFailed": "Failed to create folder",
+      "folderUpdated": "Folder updated successfully",
+      "folderUpdateFailed": "Failed to update folder",
+      "folderDeleted": "Folder deleted successfully",
+      "folderDeleteFailed": "Failed to delete folder",
+      "propertySaved": "Property saved successfully",
+      "propertySaveFailed": "Failed to save property",
+      "propertyRemoved": "Property removed from saved",
+      "propertyUnsaveFailed": "Failed to unsave property",
+      "propertySavedToFolder": "Property saved to folder",
+      "saveToFolderFailed": "Failed to save to folder"
     },
-    "view": {
-      "list": "List",
-      "grid": "Grid"
+    "folder": {
+      "title": "Save to Folder",
+      "createNew": "Create New Folder",
+      "folderNamePlaceholder": "Folder name",
+      "chooseColor": "Choose Color",
+      "chooseEmoji": "Choose Emoji",
+      "creating": "Creating...",
+      "createAndSave": "Create & Save",
+      "propertyCount_one": "{{count}} property",
+      "propertyCount_other": "{{count}} properties",
+      "alertFolderNameRequired": "Please enter a folder name",
+      "alertDefaultFolderRename": "Default folder cannot be renamed."
     },
-    "searchPlaceholder": "Search your saved items...",
-    "profilesLabel": "profiles",
-    "adjustFilters": "Try adjusting your search or filter criteria",
-    "sort": {
-      "recent": "Recently Saved",
-      "price-low": "Price: Low to High",
-      "price-high": "Price: High to Low",
-      "title": "Property Name",
-      "notes": "Most Notes"
-    },
-    "emptyTitle": "No Saved Properties",
-    "emptyDescription": "You haven't saved any properties yet. Start exploring and save properties you love!",
-    "startExploring": "Start Exploring",
+    "folderNamePlaceholder": "Folder name",
     "editFolder": "Edit Folder",
     "defaultFolder": "Default Folder",
-    "folderNamePlaceholder": "Folder name",
+    "exploreCta": "Explore properties",
+    "noFolderItemsDescription": "Save properties to add them to this folder.",
+    "noFolderItems": "This folder is empty",
+    "noFolderDescription": "This folder might have been removed.",
     "noFolder": "Folder not found",
-    "noFolderDescription": "This folder may have been removed",
-    "noFolderItems": "No properties in this folder",
-    "noFolderItemsDescription": "Save properties to this folder to see them here",
-    "unsave": {
-      "title": "Unsave Property",
-      "message": "Are you sure you want to remove \"{{title}}\" from your saved properties?",
-      "confirm": "Unsave",
-      "cancel": "Cancel"
+    "title": "Folder",
+    "loadFailed": "We couldn't load this folder",
+    "noPropertiesDescription": "Save properties to see them here.",
+    "adjustFilters": "Try a different filter or clear your search.",
+    "noProperties": "No saved properties",
+    "noResults": "No matches",
+    "createFolder": "Create folder",
+    "noFoldersDescription": "Create folders to organise the places you like.",
+    "noFolders": "No folders yet",
+    "tabs": {
+      "recent": "Recent",
+      "folders": "Folders",
+      "label": "Saved view"
     },
+    "searchPlaceholder": "Search saved properties",
+    "header": "Saved",
     "notes": {
-      "title": "Property Notes",
-      "placeholder": "Add notes about this property...",
-      "save": "Save Notes",
-      "cancel": "Cancel"
-    },
-    "actions": {
-      "addNotes": "Add Notes",
-      "editNotes": "Edit Notes",
-      "unsave": "Unsave",
-      "viewProperty": "View Property"
-    },
-    "errors": {
-      "unsaveFailed": "Failed to unsave property",
-      "updateNotesFailed": "Failed to update notes",
-      "loadFailed": "Error loading saved properties"
-    },
-    "sorting": {
-      "newest": "Newest First",
-      "oldest": "Oldest First",
-      "alphabetical": "Alphabetical"
+      "title": "Notes"
     }
+  },
+  "imageUpload": {
+    "permissionTitle": "Permission Required",
+    "permissionMessage": "Sorry, we need camera roll permissions to upload images.",
+    "maxImagesTitle": "Maximum Images Reached",
+    "maxImagesMessage": "You can upload a maximum of {{max}} images.",
+    "selectFailed": "Failed to select images. Please try again.",
+    "photoFailed": "Failed to take photo. Please try again.",
+    "uploadFailed": "Failed to upload some images. Please try again.",
+    "deleteTitle": "Delete Image",
+    "deleteMessage": "Are you sure you want to delete this image?",
+    "deleteFailed": "Failed to delete image. Please try again.",
+    "choosePhotos": "Choose Photos",
+    "takePhoto": "Take Photo",
+    "uploading": "Uploading images...",
+    "imageCount": "{{current}} of {{max}} images uploaded",
+    "primary": "Primary",
+    "addMore": "Add More",
+    "helperText": "Upload high-quality images of your property. Include photos of all rooms, exterior, and any special features.",
+    "helperPrimaryNote": " The first image will be set as the primary image."
   },
   "property": {
     "loading": "Loading property details...",
@@ -1408,7 +2303,157 @@
       "listedDaysAgo_other": "Listed {{count}} days ago",
       "saved_one": "{{count}} saved",
       "saved_other": "{{count}} saved"
-    }
+    },
+    "toast": {
+      "createSuccess": "Property created successfully",
+      "updateSuccess": "Property updated successfully",
+      "deleteSuccess": "Property deleted successfully",
+      "createFailed": "Failed to create property",
+      "updateFailed": "Failed to update property",
+      "deleteFailed": "Failed to delete property",
+      "shareCopied": "Property details copied to clipboard",
+      "shareFailed": "Failed to share property",
+      "shareTitle": "Share Property"
+    },
+    "drafts": {
+      "title": "Drafts",
+      "emptyTitle": "No drafts found",
+      "emptyDescription": "You don't have any saved property drafts yet. Start creating a property to save drafts automatically.",
+      "createFirst": "Create new property",
+      "deleteTitle": "Delete draft",
+      "deleteMessage": "Are you sure you want to delete this draft? This action cannot be undone.",
+      "toastDeleted": "Draft deleted successfully",
+      "toastDeleteFailed": "Failed to delete draft",
+      "toastLoadFailed": "Failed to load draft"
+    },
+    "description": {
+      "showMore": "Show more",
+      "showLess": "Show less"
+    },
+    "external": {
+      "contactTitle": "Contact on listing"
+    },
+    "location": {
+      "title": "Where you'll be"
+    },
+    "cta": {
+      "apply": "Apply",
+      "reserve": "Reserve"
+    },
+    "host": {
+      "verified": "Verified",
+      "responseRate": "Typically responds within an hour",
+      "hostingSince": "Hosting since",
+      "hostedBy": "Hosted by",
+      "openProfile": "Open host profile",
+      "publicSubtitle": "Government-managed affordable housing",
+      "publicAuthority": "Public Housing Authority",
+      "superHost": "Super host"
+    },
+    "report": {
+      "reason": {
+        "inaccurate": "Inaccurate information",
+        "scam": "Suspected scam or fraud",
+        "inappropriate": "Inappropriate content",
+        "unavailable": "Already rented or unavailable",
+        "other": "Something else"
+      },
+      "actions": {
+        "submit": "Submit report"
+      },
+      "notice": "False or abusive reports may affect your account. Only report genuine problems.",
+      "section": {
+        "contactHelp": "Share an email if you’re happy for us to follow up about this report.",
+        "contact": "Contact email (optional)",
+        "detailsHelp": "Add anything that helps us understand the problem.",
+        "details": "Details (optional)",
+        "detailsRequired": "Details",
+        "reason": "Why are you reporting this?"
+      },
+      "field": {
+        "detailsPlaceholder": "Describe what’s inaccurate, suspicious or inappropriate…"
+      },
+      "intro": "Tell us what’s wrong with this listing. Reports are confidential and reviewed by our team — they are never shared with the host.",
+      "title": "Report this listing",
+      "success": "Thanks — your report has been submitted.",
+      "error": {
+        "invalidForm": "Please choose a reason before submitting.",
+        "generic": "Something went wrong. Please try again.",
+        "notFound": "This listing no longer exists.",
+        "auth": "Please sign in to report a listing.",
+        "detailsRequired": "Please add a few details about the problem.",
+        "invalidReason": "Please choose a reason for your report."
+      }
+    },
+    "about": {
+      "title": "About this property"
+    },
+    "sleep": {
+      "title": "Where you'll sleep",
+      "oneBed": "1 bed",
+      "mainBedroom": "Main bedroom"
+    },
+    "reviews": {
+      "writeAction": "Write a review",
+      "emptyDescription": "Be the first to share what it was like to live here.",
+      "emptyTitle": "No reviews yet",
+      "errorTitle": "Could not load reviews",
+      "disclaimer": "Community-verified reviews about the building. Experiences may vary by unit.",
+      "title": "Reviews",
+      "evidence": "With evidence",
+      "verified": "Verified",
+      "recommend": "Recommend",
+      "count": "reviews",
+      "countWithNumber": "({{count}} reviews)"
+    },
+    "notFoundHelp": "It may have been removed or the link is broken.",
+    "sections": {
+      "photoGallery": "Photo Gallery",
+      "viewAll": "View All",
+      "features": "Property Features",
+      "furnished": "Furnished",
+      "partiallyFurnished": "Partially Furnished",
+      "unfurnished": "Unfurnished",
+      "balcony": "Balcony",
+      "garden": "Garden",
+      "elevator": "Elevator",
+      "overview": "Property Overview",
+      "bedrooms": "Bedrooms",
+      "bathrooms": "Bathrooms",
+      "size": "Size",
+      "floor": "Floor",
+      "details": "Property Details",
+      "notSpecified": "Not specified",
+      "yearBuilt": "Year Built",
+      "parkingSpaces": "Parking Spaces",
+      "pricingAndCosts": "Pricing & Costs",
+      "rent": "Rent",
+      "deposit": "Deposit",
+      "utilitiesIncluded": "Utilities Included",
+      "nightlyRent": "Nightly Rent",
+      "monthlyRent": "Monthly Rent",
+      "sourcedFrom": "Sourced from",
+      "availability": "Availability",
+      "availableFrom": "Available From",
+      "leaseTerm": "Lease Term",
+      "location": "Location",
+      "nearbyAmenities": "Nearby Amenities",
+      "publicTransport": "Public Transport",
+      "schools": "Schools",
+      "shopping": "Shopping"
+    },
+    "neighborhood": {
+      "title": "Neighborhood",
+      "listings": "Listings",
+      "avgRentPerMonth": "Avg. rent / mo",
+      "onParWithCity": "On par with the city average",
+      "listingCount": "{{count}} listings",
+      "avgAmountPerMonth": "Avg. {{amount}}/mo",
+      "pctVsCity": "{{pct}}% {{dir}} than the city average",
+      "cheaper": "cheaper",
+      "pricier": "pricier"
+    },
+    "fraudWarning": "Never pay or transfer funds outside the Homio platform"
   },
   "viewings": {
     "title": "Viewings",
@@ -1428,7 +2473,8 @@
       "timeInPast": "Scheduled time must be in the future.",
       "authRequired": "Please sign in to request a viewing.",
       "notFound": "Viewing request not found.",
-      "cannotCancel": "Cannot cancel this viewing request."
+      "cannotCancel": "Cannot cancel this viewing request.",
+      "externalProperty": "Cannot book viewings for external properties"
     },
     "selectDate": "Select Date",
     "availableTimeSlots": "Available Time Slots",
@@ -1451,6 +2497,10 @@
     },
     "cancel": {
       "confirmMessage": "Are you sure you want to cancel this viewing request?"
+    },
+    "banner": {
+      "viewDetails": "View details",
+      "hasViewing": "You have a viewing scheduled"
     }
   },
   "donations": {
@@ -1727,7 +2777,775 @@
       "loanAmount": "Loan amount",
       "totalInterest": "Total interest",
       "totalPaid": "Total paid"
+    },
+    "cta": {
+      "housingAuthority": "Housing Authority",
+      "landlord": "Landlord",
+      "applyOnStateWebsite": "Apply on State Website",
+      "viewOnSourceWebsite": "View on Source Website",
+      "callNow": "Call Now",
+      "moreByOwner": "More properties by this owner"
     }
   },
-  "goBack": "Go back"
+  "goBack": "Go back",
+  "notFound": {
+    "title": "Page Not Found",
+    "message": "The page you are looking for does not exist.",
+    "goBack": "Go Back"
+  },
+  "statusBadge": {
+    "draft": "Draft",
+    "pending": "Pending",
+    "pendingSignatures": "Pending signatures",
+    "active": "Active",
+    "expired": "Expired",
+    "terminated": "Terminated",
+    "cancelled": "Cancelled",
+    "processing": "Processing",
+    "completed": "Completed",
+    "failed": "Failed",
+    "refunded": "Refunded",
+    "success": "Success",
+    "warning": "Warning",
+    "error": "Error",
+    "info": "Info",
+    "investigating": "Investigating",
+    "resolved": "Resolved",
+    "online": "Online",
+    "offline": "Offline",
+    "unknown": "Unknown",
+    "application": {
+      "submitted": "Submitted",
+      "reviewing": "Reviewing",
+      "approved": "Approved",
+      "rejected": "Rejected",
+      "withdrawn": "Withdrawn"
+    },
+    "reservation": {
+      "pending": "Pending",
+      "confirmed": "Confirmed",
+      "declined": "Declined",
+      "cancelled": "Cancelled",
+      "completed": "Completed"
+    }
+  },
+  "applications": {
+    "list": {
+      "title": "My applications",
+      "filterAll": "All",
+      "filterActive": "Active",
+      "filterDecided": "Decided",
+      "filterWithdrawn": "Withdrawn",
+      "signInTitle": "Sign in to see your applications",
+      "signInDescription": "Track tenant applications you've sent to landlords.",
+      "signIn": "Sign in",
+      "loadError": "Couldn't load your applications",
+      "tryAgain": "Please try again.",
+      "retry": "Retry",
+      "emptyAllTitle": "No applications yet.",
+      "emptyFilteredTitle": "Nothing in this view.",
+      "emptyAllDescription": "Browse listings and submit an application to a long-term rental.",
+      "emptyFilteredDescription": "Try a different filter or submit a new application.",
+      "exploreStays": "Explore stays",
+      "today": "Today",
+      "thisWeek": "This week",
+      "earlier": "Earlier"
+    },
+    "card": {
+      "propertyFallback": "Property",
+      "applicantFallback": "Applicant",
+      "monthLease": "{{count}}-month lease",
+      "moveIn": "Move-in",
+      "submitted": "Submitted {{date}}",
+      "perMonth": "/ month",
+      "accessibility": "Application {{id}}"
+    },
+    "toast": {
+      "openDocumentFailed": "Could not open the document.",
+      "withdrawn": "Application withdrawn",
+      "withdrawFailed": "Could not withdraw application"
+    },
+    "documentType": {
+      "id": "ID",
+      "income": "Income",
+      "reference": "Reference",
+      "other": "Other"
+    },
+    "landlord": {
+      "toastOpenDocumentFailed": "Could not open the document.",
+      "toastUpdateFailed": "Could not update application",
+      "review": {
+        "reviewing": {
+          "title": "Mark as reviewing?",
+          "message": "Lets the applicant know you have their application open. You can still approve or reject afterwards.",
+          "confirm": "Mark as reviewing",
+          "successToast": "Application moved to reviewing"
+        },
+        "approve": {
+          "title": "Approve application?",
+          "message": "The applicant will be notified and can move forward to sign the lease.",
+          "confirm": "Approve",
+          "successToast": "Application approved"
+        },
+        "reject": {
+          "title": "Reject application?",
+          "message": "The applicant will be notified. This cannot be undone — but they can submit a new application later.",
+          "confirm": "Reject",
+          "successToast": "Application rejected"
+        }
+      }
+    },
+    "field": {
+      "moveInDate": "Move-in date",
+      "notesPlaceholder": "Anything else the landlord should know about you?",
+      "removeDocument": "Remove document",
+      "pickDocuments": "Add documents",
+      "addReference": "Add another reference",
+      "email": "Email",
+      "phone": "Phone number",
+      "relationship": "Relationship",
+      "namePlaceholder": "Jane Doe",
+      "name": "Full name",
+      "removeReference": "Remove reference",
+      "referenceIndex": "Reference {{index}}",
+      "employment": "Employment status",
+      "monthlyIncomePlaceholder": "e.g. 2400",
+      "monthlyIncome": "Gross monthly income",
+      "leaseTermCustomPlaceholder": "Number of months",
+      "leaseTermCustom": "Other",
+      "leaseTerm": "Lease term",
+      "leaseTermMonths": "{{count}} months",
+      "moveInHelper": "Within the next 6 months."
+    },
+    "employment": {
+      "employed": "Employed",
+      "selfEmployed": "Self-employed",
+      "student": "Student",
+      "retired": "Retired",
+      "unemployed": "Unemployed",
+      "other": "Other"
+    },
+    "relationship": {
+      "landlord": "Previous landlord",
+      "employer": "Employer",
+      "personal": "Personal",
+      "other": "Other"
+    },
+    "docType": {
+      "id": "ID",
+      "income": "Income proof",
+      "reference": "Reference letter",
+      "other": "Other"
+    },
+    "cta": {
+      "apply": "Apply to rent",
+      "subtitle": "Submit a quick application with your move-in date, income and references — the landlord reviews and replies inside Homiio.",
+      "title": "Interested in this place?",
+      "addMoveIn": "Add move-in date"
+    },
+    "detail": {
+      "viewStatus": "View status",
+      "alreadySubmittedBody": "You already have an application in review for this property.",
+      "alreadySubmitted": "Application submitted"
+    },
+    "actions": {
+      "submit": "Submit application"
+    },
+    "section": {
+      "notes": "Notes to landlord (optional)",
+      "documentsHelp": "Upload up to {{max}} PDFs or images (10 MB each). Pick a category per file.",
+      "documents": "Documents (optional)",
+      "referencesHelp": "Add 1 to 3 contacts the landlord can call to vouch for you.",
+      "references": "References",
+      "finances": "Income & employment",
+      "timing": "Move-in & lease term"
+    },
+    "apply": {
+      "title": "Apply to rent"
+    },
+    "success": {
+      "submitted": "Application submitted"
+    },
+    "error": {
+      "invalidForm": "Please complete every required field.",
+      "generic": "Something went wrong. Please try again.",
+      "auth": "Please sign in to apply.",
+      "notApplicable": "This property does not accept long-term applications.",
+      "external": "External listings cannot be applied to from Homiio.",
+      "alreadyApplied": "You already have an active application for this property."
+    },
+    "documents": {
+      "pickFailed": "Could not pick documents",
+      "tooLarge": "{{name}} is over 10 MB and was skipped.",
+      "limit": "You can upload up to {{max}} documents per application."
+    }
+  },
+  "reservations": {
+    "card": {
+      "propertyFallback": "Property",
+      "night": "night",
+      "nights": "nights",
+      "guest": "guest",
+      "guests": "guests",
+      "hostGuestSuffix": "(guest)",
+      "accessibility": "Reservation {{id}}"
+    },
+    "detail": {
+      "title": "Reservation",
+      "invalidId": "Invalid reservation id",
+      "invalidIdDescription": "The link is missing the reservation reference.",
+      "unavailable": "Reservation unavailable",
+      "unavailableDescription": "This reservation could not be loaded.",
+      "goBack": "Go back",
+      "tripDetails": "Trip details",
+      "checkIn": "Check-in",
+      "checkOut": "Check-out",
+      "guests": "Guests",
+      "nights": "Nights",
+      "price": "Price",
+      "approve": "Approve",
+      "decline": "Decline",
+      "cancelReservation": "Cancel reservation",
+      "cancelPolicyNote": "Cancellation is no longer possible under the {{policy}} policy. Contact your host if you need to make changes.",
+      "confirmCancelTitle": "Cancel reservation?",
+      "confirmCancelBody": "This will release the dates back to the host and end the booking.",
+      "confirmCancelAction": "Yes, cancel",
+      "confirmApproveTitle": "Approve reservation?",
+      "confirmApproveBody": "The guest will be notified and the dates will be marked confirmed on your calendar.",
+      "confirmDeclineTitle": "Decline reservation?",
+      "confirmDeclineBody": "The guest will be notified that this request was declined.",
+      "toastConfirmed": "Reservation confirmed",
+      "toastDeclined": "Reservation declined",
+      "toastCancelled": "Reservation cancelled",
+      "toastUpdateFailed": "Update failed"
+    }
+  },
+  "reviews": {
+    "card": {
+      "anonymous": "Anonymous",
+      "verifiedResident": "Verified Resident",
+      "verified": "Verified",
+      "confident": "{{score}}% confident",
+      "proof": "proof",
+      "proofs": "proofs",
+      "karma": "{{score}} karma",
+      "livedMonths": "Lived {{count}} months",
+      "perMonth": "{{price}} {{currency}}/month",
+      "moreIssues": "+{{count}} more",
+      "positive": "Positive:",
+      "negative": "Negative:",
+      "helpful": "Helpful ({{count}})",
+      "report": "Report",
+      "reply": "Reply",
+      "recommends": "✓ Recommends",
+      "doesNotRecommend": "✗ Does not recommend",
+      "underReview": "Under Review",
+      "alertThankYouTitle": "Thank you",
+      "alertThankYouBody": "Your feedback has been recorded.",
+      "alertReportTitle": "Report Review",
+      "alertReportBody": "Are you sure you want to report this review for inappropriate content?",
+      "alertReportConfirm": "Report",
+      "alertReportedTitle": "Reported",
+      "alertReportedBody": "This review has been reported to our moderation team.",
+      "alertReplyTitle": "Reply to Review",
+      "alertReplyBody": "Reply functionality will allow landlords and property managers to respond to reviews."
+    },
+    "write": {
+      "validationTitle": "Validation Error",
+      "streetRequired": "Please provide a street address.",
+      "cityRequired": "Please provide a city.",
+      "postalCodeRequired": "Please provide a postal code.",
+      "countryRequired": "Please provide a country.",
+      "opinionRequired": "Please provide your opinion about this address.",
+      "opinionMinLength": "Your opinion must be at least 10 characters long.",
+      "priceRequired": "Please provide a valid price.",
+      "datesRequired": "Please provide both start and end dates.",
+      "recommendationRequired": "Please indicate whether you would recommend this address.",
+      "ratingRequired": "Please provide a rating from 1 to 5.",
+      "submitSuccess": "Your review has been submitted successfully!",
+      "submitFailed": "Failed to submit review",
+      "submitFailedRetry": "Failed to submit review. Please try again.",
+      "loadAddressFailed": "Couldn't load address",
+      "title": "Write review"
+    }
+  },
+  "subscriptions": {
+    "title": "Subscriptions",
+    "alertError": "Error",
+    "alertSuccess": "Success",
+    "authRequired": "Authentication required",
+    "checkoutFailed": "Failed to start checkout",
+    "portalFailed": "Failed to open subscription management",
+    "syncSuccess": "Subscription status synced from Stripe",
+    "syncFailed": "Failed to sync subscription",
+    "cancelImmediateSuccess": "Subscription canceled immediately",
+    "cancelFailed": "Failed to cancel subscription",
+    "cancelEndOfPeriodSuccess": "Subscription will be canceled at the end of the current period",
+    "debugFailed": "Failed to debug subscription",
+    "plusActive": "Homiio Plus active",
+    "plusInactive": "Upgrade to Homiio Plus",
+    "manage": "Manage subscription",
+    "sync": "Sync from Stripe",
+    "cancel": "Cancel subscription",
+    "cancelImmediate": "Cancel immediately",
+    "cancelEndOfPeriod": "Cancel at period end",
+    "fileCredits": "{{count}} file credits",
+    "since": "Member since {{date}}",
+    "canceledOn": "Canceled on {{date}}",
+    "lastPayment": "Last payment {{date}}",
+    "products": {
+      "plus": "Homiio Plus",
+      "plusDescription": "Priority support and premium features",
+      "file": "File credits",
+      "fileDescription": "Extra document storage credits",
+      "founder": "Founder",
+      "founderDescription": "Support Homiio and unlock founder perks"
+    },
+    "subscribe": "Subscribe",
+    "buyCredits": "Buy credits",
+    "becomeFounder": "Become a founder",
+    "page": {
+      "headerTitle": "Homiio+",
+      "headerSubtitle": "Your ethical housing ally",
+      "introText": "Your subscription gives you access to Sindi, the legal assistant that scans your rental contracts and flags abusive clauses. No ads, no speculation, no data selling.",
+      "payPerContract": {
+        "title": "Pay per contract",
+        "price": "5 € per contract review",
+        "description": "Perfect for one-time use.",
+        "reviewButton": "Review Contract"
+      },
+      "plus": {
+        "title": "Homiio+ Subscription",
+        "price": "9.99 €/month",
+        "description": "Includes up to 10 contracts per month free. From the 11th contract onwards: 2.50 € each.",
+        "activeBadge": "Active subscription",
+        "canceledBadge": "Canceled on {{date}}",
+        "featureHistory": "Unlimited contract history",
+        "featureAlerts": "Legal alerts & notifications",
+        "featureSupport": "Priority support",
+        "manage": "Manage subscription",
+        "resubscribe": "Resubscribe",
+        "subscribeNow": "Subscribe now"
+      },
+      "founder": {
+        "title": "Founder supporter",
+        "price": "Contribution from 10 €/month",
+        "description": "Support Homiio's independence. Get recognition in the app + early access to features.",
+        "becomeSupporter": "Become a Supporter"
+      },
+      "footer": "Every euro keeps Homiio ethical, independent, and community-driven.",
+      "starting": "Starting…",
+      "back": "Back",
+      "notAvailable": "N/A",
+      "cancelImmediateTitle": "Cancel Immediately",
+      "cancelImmediateBody": "This will immediately cancel your subscription and you will lose access to Homiio+ features. Are you sure?",
+      "no": "No",
+      "yesCancelNow": "Yes, Cancel Now"
+    }
+  },
+  "recentlyViewed": {
+    "trackFailed": "Failed to track property view",
+    "clearSuccess": "Recently viewed properties cleared",
+    "clearFailed": "Failed to clear recently viewed properties"
+  },
+  "host": {
+    "calendar": {
+      "title": "Host calendar",
+      "signInTitle": "Sign in to manage your calendar",
+      "signInDescription": "Block dates and track bookings from one place.",
+      "signIn": "Sign in",
+      "loadPropertiesError": "Couldn't load your properties",
+      "tryAgain": "Please try again.",
+      "emptyTitle": "Add your first property",
+      "emptyDescription": "List a place so guests can request dates here.",
+      "createListing": "Create listing",
+      "chooseProperty": "Choose property",
+      "legendConfirmed": "Confirmed",
+      "legendPending": "Pending",
+      "legendBlocked": "Blocked",
+      "legendAvailable": "Available",
+      "availabilityError": "Couldn't load availability",
+      "blockTitle": "Block these dates",
+      "blockBodyRange": "Block from {{start}} to {{end}}.",
+      "blockBodySingle": "Choose how long these dates are unavailable.",
+      "blockConfirm": "Block",
+      "blockReasonLabel": "Reason (optional)",
+      "blockReasonPlaceholder": "Maintenance, personal use, ...",
+      "toastBlocked": "Dates blocked",
+      "toastBlockFailed": "Block failed",
+      "propertyNotFound": "Property not found",
+      "property": "Property"
+    },
+    "reservations": {
+      "title": "Reservations",
+      "allReservations": "All reservations",
+      "signInTitle": "Sign in to manage reservations",
+      "signInDescription": "Approve or decline guest requests from one place.",
+      "signIn": "Sign in",
+      "filterAll": "All",
+      "loadError": "Couldn't load reservations",
+      "tryAgain": "Please try again.",
+      "emptyTitle": "No reservations yet",
+      "emptyDescription": "Guest requests will appear here once someone books.",
+      "toastConfirmed": "Reservation confirmed",
+      "toastDeclined": "Reservation declined",
+      "toastUpdateFailed": "Update failed",
+      "confirm": "Confirm",
+      "decline": "Decline",
+      "approve": "Approve",
+      "view": "View",
+      "filterPending": "Pending",
+      "filterConfirmed": "Confirmed",
+      "filterDeclined": "Declined",
+      "filterCancelled": "Cancelled",
+      "filterCompleted": "Completed"
+    }
+  },
+  "stays": {
+    "list": {
+      "title": "Stays",
+      "filterAll": "All",
+      "filterUpcoming": "Upcoming",
+      "filterPast": "Past",
+      "filterCancelled": "Cancelled",
+      "groupUpcoming": "Upcoming",
+      "groupPast": "Past",
+      "groupCancelled": "Cancelled",
+      "signInTitle": "Sign in to see your stays",
+      "signInDescription": "Track short-term bookings you've made.",
+      "signIn": "Sign in",
+      "loadError": "Couldn't load stays",
+      "tryAgain": "Please try again.",
+      "emptyAllTitle": "No stays yet",
+      "emptyFilteredTitle": "Nothing in this view.",
+      "emptyAllDescription": "Once you book a place it will show up here.",
+      "emptyFilteredDescription": "Try a different filter or explore new stays.",
+      "exploreStays": "Explore stays"
+    }
+  },
+  "booking": {
+    "toast": {
+      "pickDates": "Pick check-in and check-out dates first",
+      "minStay": "Minimum stay is {{count}} {{unit}}",
+      "maxStay": "Maximum stay is {{count}} {{unit}}",
+      "night": "night",
+      "nights": "nights",
+      "failed": "Booking failed"
+    },
+    "accessibility": {
+      "selectDates": "Select dates",
+      "selectGuests": "Select guests",
+      "close": "Close"
+    }
+  },
+  "addresses": {
+    "detail": {
+      "title": "Address",
+      "loadError": "Couldn't load this address",
+      "tryAgain": "Please try again.",
+      "propertiesSection": "Properties",
+      "reviewsSection": "Reviews",
+      "emptyPropertiesTitle": "No properties here yet",
+      "emptyPropertiesDescription": "Listings at this address will appear here.",
+      "emptyReviewsTitle": "No reviews yet",
+      "emptyReviewsDescription": "Be the first to share your experience at this address.",
+      "writeReview": "Write a review",
+      "switchLevel": "Switch level",
+      "buildingLevel": "Building",
+      "unitLevel": "Unit",
+      "notFound": "Address not found",
+      "notFoundDescription": "We couldn't find any details for this address.",
+      "storiesTitle": "Stories from residents",
+      "tabOverall": "Overall",
+      "tabApartments": "Apartments",
+      "tabCommunity": "Community",
+      "tabArea": "Area",
+      "tabProperties": "Properties ({{count}})",
+      "tabReviews": "Reviews ({{count}})"
+    },
+    "display": {
+      "copySuccess": "Address copied to clipboard",
+      "copyFailed": "Failed to copy address",
+      "mapsFailed": "Failed to open maps"
+    }
+  },
+  "propertyCreate": {
+    "location": {
+      "title": "Location",
+      "instructions": "📍 Address Details: Fill in the complete address information. Our system uses a hierarchical structure:\n• STREET level: Street name only\n• BUILDING level: Street + number + building details\n• UNIT level: Building + floor + unit/apartment details\nReviews and listings are organized by these levels for better organization.",
+      "country": "Country or Region",
+      "countryPickerTitle": "Country or Region",
+      "state": "State / Province / Region",
+      "statePickerTitle": "State / Province / Region",
+      "city": "City",
+      "street": "Street",
+      "number": "Number",
+      "postalCode": "Postal code",
+      "floor": "Floor",
+      "unit": "Unit / Apartment",
+      "showFloor": "Show floor field",
+      "hideFloor": "Hide floor field",
+      "selectCountry": "Select country or region",
+      "streetPlaceholder": "Street name",
+      "unitOptional": "Unit/Apartment Number (optional)",
+      "unitPlaceholder": "Apartment, suite, etc. (optional)",
+      "buildingNameOptional": "Building Name (optional)",
+      "buildingNamePlaceholder": "e.g., Torre Barcelona",
+      "blockOptional": "Block (optional)",
+      "blockPlaceholder": "e.g., Block A",
+      "entranceOptional": "Entrance/Door (optional)",
+      "entrancePlaceholder": "e.g., Door 1, Entrance B",
+      "subunitOptional": "Sub-unit (optional)",
+      "subunitPlaceholder": "e.g., Room A",
+      "numberPlaceholder": "Enter number",
+      "floorPlaceholder": "Enter floor",
+      "floorPublic": "Public",
+      "floorPrivate": "Private",
+      "floorPrivacyHint": "ℹ️ Will be shown as approximate for privacy",
+      "neighborhoodOptional": "Neighborhood (optional)",
+      "neighborhoodPlaceholder": "e.g., Gràcia, Sant Andreu, Eixample",
+      "districtOptional": "District (optional)",
+      "districtPlaceholder": "e.g., Administrative district",
+      "poBoxOptional": "PO Box (optional)",
+      "poBoxPlaceholder": "e.g., PO Box 123",
+      "referenceOptional": "Reference (optional)",
+      "referencePlaceholder": "e.g., Near Metro Station",
+      "cityDistrict": "City/District",
+      "cityDistrictPlaceholder": "City or district",
+      "selectState": "Select state/province/region",
+      "zipPostalCode": "ZIP/Postal Code",
+      "zipPlaceholder": "ZIP or postal code",
+      "availableFrom": "Available From",
+      "availableFromPlaceholder": "Available from date",
+      "leaseTerm": "Lease Term",
+      "leaseTermPlaceholder": "Lease term"
+    },
+    "amenities": {
+      "title": "Amenities",
+      "subtitle": "Select the amenities available at this property.",
+      "rulesTitle": "Amenities & Rules",
+      "houseRules": "House Rules",
+      "petsAllowed": "Pets Allowed",
+      "smokingAllowed": "Smoking Allowed",
+      "partiesAllowed": "Parties Allowed",
+      "guestsAllowed": "Guests Allowed",
+      "maxGuests": "Maximum Number of Guests",
+      "maxGuestsPlaceholder": "e.g., 2",
+      "yes": "Yes",
+      "no": "No"
+    }
+  },
+  "searchBar": {
+    "search": "Search",
+    "long": {
+      "propertyType": "Property type",
+      "moveIn": "Move-in",
+      "where": "Where",
+      "where.value": "Any city",
+      "moveIn.value": "Add date",
+      "propertyType.value": "Any type"
+    },
+    "vacation": {
+      "where": "Where",
+      "when": "When",
+      "who": "Who",
+      "where.value": "Any destination",
+      "when.value": "Add dates",
+      "who.value": "Add guests"
+    },
+    "mode": {
+      "vacation": "Vacation",
+      "longTerm": "Long-term",
+      "hint": "Switch between long-term rentals and vacation stays",
+      "label": "Rental mode"
+    }
+  },
+  "error": {
+    "publicHousing": {
+      "openFailed": "Could not open the housing website"
+    },
+    "call": {
+      "failed": "Could not open phone dialer",
+      "noPhone": "No phone number available",
+      "notAllowed": "Owner does not accept calls"
+    },
+    "profile": {
+      "notFound": "Owner profile not found"
+    },
+    "auth": {
+      "required": "Please sign in to call the owner"
+    },
+    "contact": {
+      "noPhone": "No phone number available for this listing",
+      "openFailed": "Could not open contact link"
+    },
+    "source": {
+      "openFailed": "Could not open the source website",
+      "noUrl": "Source website URL not available"
+    },
+    "boundary": {
+      "title": "Something went wrong",
+      "message": "An unexpected issue interrupted what you were doing. You can try again, or send us a quick report so we can investigate.",
+      "retry": "Try again",
+      "reportIssue": "Report issue",
+      "errorId": "Error ID",
+      "copyIdHint": "Tap to copy ID",
+      "copiedToClipboard": "Copied to clipboard",
+      "showDetails": "Show technical details",
+      "hideDetails": "Hide technical details",
+      "technicalDetails": "Technical details",
+      "maxRetriesTitle": "Still not working",
+      "maxRetriesMessage": "You've reached the retry limit. Please report the issue so we can take a look.",
+      "forceRetry": "Force retry",
+      "reportCopiedTitle": "Report copied",
+      "reportCopiedMessage": "The error report has been copied to your clipboard.",
+      "reportFailedTitle": "Couldn't copy",
+      "reportFailedMessage": "We couldn't copy the report to your clipboard. Please try again.",
+      "errorMessage": "Error message",
+      "errorType": "Error type",
+      "stackTrace": "Stack trace",
+      "componentStack": "Component stack",
+      "deviceInformation": "Device information"
+    },
+    "loadNotifications": "Error loading notifications"
+  },
+  "notification": {
+    "settings": {
+      "android": {
+        "openSettings": "Open system settings",
+        "title": "Android Settings",
+        "description": "You can manage notification channels and advanced settings in your device's Settings app under Apps > Homiio > Notifications."
+      },
+      "ios": {
+        "openSettings": "Open system settings",
+        "title": "iOS Settings",
+        "description": "For more granular control, you can also manage notification settings in your device's Settings app under Notifications > Homiio."
+      },
+      "test": {
+        "title": "Test Notifications",
+        "description": "Send test notifications to verify your settings are working correctly."
+      },
+      "property": {
+        "title": "Property Notifications",
+        "description": "New properties, price changes, and viewing reminders"
+      },
+      "message": {
+        "title": "Message Notifications",
+        "description": "New messages from agents, landlords, and other users"
+      },
+      "contract": {
+        "title": "Contract Notifications",
+        "description": "Contract updates, signatures, and important deadlines"
+      },
+      "payment": {
+        "title": "Payment Notifications",
+        "description": "Payment confirmations, reminders, and receipts"
+      },
+      "reminder": {
+        "title": "Reminder Notifications",
+        "description": "Viewing reminders, application deadlines, and follow-ups"
+      },
+      "system": {
+        "title": "System Notifications",
+        "description": "App updates, maintenance, and important announcements"
+      },
+      "marketing": {
+        "title": "Marketing Notifications",
+        "description": "Promotional offers, newsletters, and special deals"
+      },
+      "sound": {
+        "title": "Sound",
+        "description": "Play sound when notifications arrive"
+      },
+      "badge": {
+        "title": "Badge Count",
+        "description": "Show unread count on app icon"
+      },
+      "push": {
+        "title": "Push Notifications",
+        "description": "Receive notifications even when app is closed"
+      },
+      "title": "Notification Settings",
+      "categories": "Notification Categories",
+      "behavior": "Notification Behavior",
+      "manage": "Manage Notifications",
+      "clearAll": "Clear All Notifications",
+      "updated": "Settings updated",
+      "error": "Failed to update settings"
+    },
+    "test": {
+      "success": "Test notification sent",
+      "property": "Test Property",
+      "message": "Test Message",
+      "reminder": "Test Reminder",
+      "repeating": "Test Repeating",
+      "error": "Failed to send test notification"
+    },
+    "empty": {
+      "filteredTitle": "No matches",
+      "title": "No notifications",
+      "message": "You're all caught up! New notifications will appear here.",
+      "filtered": "No notifications match your current filter"
+    },
+    "filter": {
+      "label": "Filter notifications",
+      "all": "All",
+      "unread": "Unread"
+    },
+    "scheduled": {
+      "label": "Scheduled notification",
+      "title": "Scheduled Notifications",
+      "clearAll": "Clear All"
+    },
+    "markAllRead": {
+      "action": "Mark all as read",
+      "success": "All notifications marked as read",
+      "error": "Failed to mark all as read"
+    },
+    "permissions": {
+      "enabled": {
+        "title": "Notifications Enabled",
+        "description": "You will receive notifications for enabled categories."
+      },
+      "disabled": {
+        "title": "Notifications Disabled",
+        "description": "Enable notifications to receive updates about properties, messages, and more."
+      },
+      "title": "Enable Notifications",
+      "message": "Get notified about new properties, messages, and important updates.",
+      "enable": "Enable Notifications",
+      "granted": "Notification permissions granted",
+      "denied": "Notification permissions denied",
+      "error": "Failed to request permissions"
+    },
+    "welcome": {
+      "title": "Welcome to Homiio! 👋",
+      "body": "Thanks for trying out our app. Start exploring now!"
+    },
+    "search": {
+      "placeholder": "Search notifications..."
+    },
+    "delete": {
+      "title": "Delete Notification",
+      "message": "Are you sure you want to delete this notification?",
+      "success": "Notification deleted",
+      "error": "Failed to delete notification"
+    },
+    "clearAll": {
+      "title": "Clear All Notifications",
+      "message": "This will clear all notifications and reset the badge count. This action cannot be undone.",
+      "success": "All notifications cleared",
+      "error": "Failed to clear notifications"
+    }
+  },
+  "address": {
+    "display": {
+      "mapPlaceholder": "Map view available",
+      "copy": "Copy",
+      "openInMaps": "Open in Maps"
+    }
+  },
+  "inbox": {
+    "title": "Inbox"
+  }
 }

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -14,128 +14,96 @@
       "transportation": "Aparcamiento y transporte",
       "community": "Espacios comunes",
       "other": "Más"
-    }
+    },
+    "airConditioning": "Aire acondicionado",
+    "airPurifier": "Sistema de purificación de aire",
+    "balcony": "Balcón privado",
+    "bbqArea": "Zona de barbacoa",
+    "bikeStorage": "Almacenamiento seguro para bicicletas",
+    "builtInShelving": "Estanterías empotradas",
+    "cableTv": "Preparado para TV por cable",
+    "ceilingFans": "Ventiladores de techo",
+    "coatCloset": "Armario de entrada",
+    "communityRoom": "Sala comunitaria",
+    "conferenceRoom": "Sala de reuniones",
+    "coworkingSpace": "Espacio de coworking",
+    "daycare": "Guardería en el edificio",
+    "dimmerSwitches": "Interruptores reguladores",
+    "dishwasher": "Lavavajillas",
+    "dogPark": "Zona de ejercicio para mascotas",
+    "doubleVanity": "Doble lavabo",
+    "dryer": "Secadora en la vivienda",
+    "electricity": "Electricidad incluida",
+    "elevator": "Acceso con ascensor",
+    "energyEfficient": "Electrodomésticos eficientes",
+    "evCharging": "Carga para vehículo eléctrico",
+    "familyRoom": "Sala de actividades familiar",
+    "fiberInternet": "Internet de fibra",
+    "firePit": "Zona con fogata",
+    "fireSafety": "Sistema de seguridad contra incendios",
+    "garbageDisposal": "Triturador de basura",
+    "gardenAccess": "Acceso al jardín",
+    "gardenSpace": "Huerto comunitario",
+    "grabBars": "Barras de apoyo",
+    "graniteCounters": "Encimeras de granito",
+    "greenRoof": "Techo verde",
+    "gym": "Gimnasio",
+    "hardwoodFloors": "Suelo de madera",
+    "heatedFloors": "Suelo radiante",
+    "heating": "Calefacción adecuada",
+    "homeOffice": "Espacio de oficina en casa",
+    "hotTub": "Bañera de hidromasaje",
+    "humidifier": "Humidificador central",
+    "iceMaker": "Máquina de hielo",
+    "insulation": "Aislamiento adecuado",
+    "intercom": "Portero automático",
+    "jettedTub": "Bañera de hidromasaje",
+    "kitchen": "Cocina",
+    "laundryRoom": "Lavandería compartida",
+    "ledLighting": "Iluminación LED",
+    "linenCloset": "Armario de ropa blanca",
+    "mailRoom": "Sala de paquetería y correo",
+    "microwave": "Microondas",
+    "mobilityAssistance": "Accesibilidad y movilidad",
+    "naturalLight": "Luz natural abundante",
+    "oven": "Horno",
+    "pantry": "Despensa",
+    "parkingSpace": "Plaza de aparcamiento",
+    "pendantLighting": "Iluminación de diseño",
+    "petFriendly": "Se admiten mascotas",
+    "printingStation": "Centro de impresión y copias",
+    "publicTransitAccess": "Acceso al transporte público",
+    "rainwaterCollection": "Recogida de agua de lluvia",
+    "rampAccess": "Acceso con rampa",
+    "recyclingProgram": "Programa de reciclaje integral",
+    "refrigerator": "Frigorífico de tamaño completo",
+    "rooftopDeck": "Terraza en la azotea",
+    "secureEntry": "Acceso controlado",
+    "securityCameras": "Cámaras de seguridad",
+    "seniorServices": "Servicios de apoyo para mayores",
+    "smartDoorbell": "Timbre con vídeo",
+    "smartHome": "Hogar inteligente",
+    "solarPanels": "Energía solar",
+    "stainlessAppliances": "Electrodomésticos de acero inoxidable",
+    "storageUnit": "Espacio de almacenamiento",
+    "stove": "Cocina",
+    "studyRoom": "Espacio de estudio tranquilo",
+    "swimmingPool": "Piscina",
+    "teenRoom": "Sala de actividades para adolescentes",
+    "tileFloors": "Suelo de baldosas",
+    "trashPickup": "Recogida de residuos",
+    "usbOutlets": "Enchufes USB",
+    "walkInCloset": "Vestidor",
+    "walkInShower": "Ducha a ras de suelo",
+    "washingMachine": "Lavadora en la vivienda",
+    "water": "Agua y alcantarillado incluidos",
+    "waterFilter": "Sistema de filtrado de agua",
+    "wheelchairAccessible": "Accesible en silla de ruedas",
+    "wholeHouseFan": "Ventilador de toda la casa",
+    "wideDoorways": "Puertas anchas",
+    "wifi": "Internet de alta velocidad",
+    "wineFridge": "Nevera para vinos"
   },
-  "Home": "Inicio",
-  "Search": "Buscar",
-  "Notifications": "Notificaciones",
-  "Messages": "Mensajes",
-  "New Post": "Nueva Publicación",
-  "What's happening?": "¿Qué está pasando?",
-  "Post": "Publicar",
-  "Save": "Guardar",
-  "Settings": "Configuración",
-  "Language": "Idioma",
-  "Primary Color": "Color Principal",
-  "Apply Settings": "Aplicar Configuración",
-  "Welcome to Homiio! 👋": "¡Bienvenido a Homiio! 👋",
-  "Thanks for trying out our app. Start exploring now!": "Gracias por probar nuestra aplicación. ¡Comienza a explorar ahora!",
-  "This screen doesn't exist.": "Esta pantalla no existe.",
-  "Go to home screen!": "¡Ve a la pantalla de inicio!",
-  "Hey, how are you?": "¡Hola, cómo estás?",
-  "Let's catch up soon!": "¡Pongámonos al día pronto!",
-  "liked your Post": "le gustó tu publicación",
-  "reposted your Post": "republicó tu publicación",
-  "This is a sample post": "Esta es una publicación de ejemplo",
-  "Another example post": "Otra publicación de ejemplo",
-  "Customize your view": "Personaliza tu vista",
-  "These settings affect all the Mention accounts on this device.": "Esta configuración afecta a todas las cuentas de Homiio en este dispositivo.",
-  "Account": "Cuenta",
-  "Manage your account settings": "Gestiona la configuración de tu cuenta",
-  "Notification preferences": "Preferencias de notificaciones",
-  "Privacy and security settings": "Configuración de privacidad y seguridad",
-  "Appearance": "Apariencia",
-  "Theme, font size, colors": "Tema, tamaño de fuente, colores",
-  "Help & Support": "Ayuda y Soporte",
-  "Get help and support": "Obtén ayuda y soporte",
-  "About": "Acerca de",
-  "About this app": "Acerca de esta aplicación",
-  "Battery": "Batería",
-  "Loading...": "Cargando...",
-  "Trends for you": "Tendencias para ti",
-  "Show more": "Mostrar más",
-  "posts": "publicaciones",
-  "File Manager": "Administrador de Archivos",
-  "Filter files by name": "Filtrar archivos por nombre",
-  "Filter files by date (MM/DD/YYYY)": "Filtrar archivos por fecha (DD/MM/AAAA)",
-  "Filter files by type (e.g., image, video)": "Filtrar archivos por tipo (ej., imagen, video)",
-  "Who to follow": "A quién seguir",
-  "Search...": "Buscar...",
-  "No results found for": "No se encontraron resultados para",
-  "Follow": "Seguir",
-  "Following": "Siguiendo",
-  "Explore": "Explorar",
-  "Chat": "Chat",
-  "Bookmarks": "Marcadores",
-  "Feeds": "Fuentes",
-  "Lists": "Listas",
-  "Videos": "Videos",
-  "Sign Up": "Registrarse",
-  "Sign In": "Iniciar Sesión",
-  "Join the conversation": "Únete a la conversación",
-  "error.socket.not_connected": "No conectado al servidor de chat",
-  "error.message.send_timeout": "Tiempo de espera al enviar mensaje. Por favor, inténtalo de nuevo.",
-  "error.message.edit_timeout": "Tiempo de espera al editar. Por favor, inténtalo de nuevo.",
-  "error.message.delete_timeout": "Tiempo de espera al eliminar. Por favor, inténtalo de nuevo.",
-  "error.signup.missing_fields": "Por favor, completa todos los campos",
-  "error.signup.failed": "Error en el registro:",
-  "error.boundary.title": "Algo salió mal",
-  "error.boundary.message": "Un problema inesperado interrumpió lo que estabas haciendo. Puedes volver a intentarlo o enviarnos un informe rápido para que lo revisemos.",
-  "error.boundary.retry": "Reintentar",
-  "error.boundary.reportIssue": "Informar del problema",
-  "error.boundary.errorId": "ID de error",
-  "error.boundary.copyIdHint": "Toca para copiar el ID",
-  "error.boundary.copiedToClipboard": "Copiado al portapapeles",
-  "error.boundary.showDetails": "Mostrar detalles técnicos",
-  "error.boundary.hideDetails": "Ocultar detalles técnicos",
-  "error.boundary.technicalDetails": "Detalles técnicos",
-  "error.boundary.maxRetriesTitle": "Sigue sin funcionar",
-  "error.boundary.maxRetriesMessage": "Has alcanzado el límite de reintentos. Por favor, informa del problema para que podamos revisarlo.",
-  "error.boundary.forceRetry": "Forzar reintento",
-  "error.boundary.reportCopiedTitle": "Informe copiado",
-  "error.boundary.reportCopiedMessage": "El informe del error se ha copiado al portapapeles.",
-  "error.boundary.reportFailedTitle": "No se pudo copiar",
-  "error.boundary.reportFailedMessage": "No pudimos copiar el informe al portapapeles. Por favor, inténtalo de nuevo.",
-  "error.boundary.errorMessage": "Mensaje de error",
-  "error.boundary.errorType": "Tipo de error",
-  "error.boundary.stackTrace": "Traza de pila",
-  "error.boundary.componentStack": "Pila de componentes",
-  "error.boundary.deviceInformation": "Información del dispositivo",
-  "error.file_selection": "Error al procesar los archivos seleccionados. Por favor, inténtalo de nuevo.",
-  "error.login_required": "Por favor, inicia sesión para gestionar archivos",
-  "error.load_notifications": "Error al cargar notificaciones",
-  "error.fetch_trends": "Error al cargar tendencias",
-  "error.signup.password_mismatch": "Las contraseñas no coinciden",
-  "error.validation.token_expired": "El token ha expirado",
-  "error.validation.token_invalid": "El formato del token no es válido",
-  "error.validation.token_signature": "La firma del token no es válida",
-  "error.auth.invalid_token": "Token de autenticación inválido",
-  "error.chat.forward_failed": "No se pudo reenviar el mensaje",
-  "error.chat.delete_failed": "No se pudo eliminar el mensaje",
-  "error.chat.send_failed": "Error al enviar mensaje",
-  "error.chat.load_failed": "Error al cargar mensajes",
-  "error.data.fetch_failed": "Error al obtener datos: {{message}}",
-  "error.users.fetch_failed": "Error al obtener usuarios: {{message}}",
-  "inbox.title": "Buzón",
-  "notification.welcome.title": "¡Bienvenido a Homiio! 👋",
-  "notification.welcome.body": "Gracias por probar nuestra aplicación. ¡Comienza a explorar ahora!",
-  "success.signup": "Registro exitoso",
-  "action.retry": "Reintentar",
-  "status.loading": "Cargando...",
-  "state.loading": "Cargando...",
-  "state.no_results": "Sin resultados",
-  "state.empty_state": "Nada que mostrar",
-  "state.not_connected": "No conectado",
-  "state.session_expired": "Sesión expirada",
-  "state.no_session": "Por favor, inicia sesión",
-  "state.retrying": "Reintentando...",
-  "state.uploading": "Subiendo...",
-  "state.downloading": "Descargando...",
-  "state.processing": "Procesando...",
-  "state.please_wait": "Por favor, espera...",
-  "file.size_mb": "MB",
-  "profile.edit": "Editar perfil",
-  "profile.chat": "Chat",
   "home": {
     "insights": {
       "title": "Información de la Plataforma"
@@ -203,7 +171,8 @@
       "errorDescription": "Por favor, inténtalo de nuevo.",
       "retry": "Reintentar",
       "results": "Resultados",
-      "filtered": "filtrados"
+      "filtered": "filtrados",
+      "continue": "Continue browsing"
     },
     "saved": {
       "title": "Propiedades Guardadas",
@@ -216,7 +185,32 @@
       "noFolderItemsDescription": "Guarda propiedades en esta carpeta para verlas aquí"
     },
     "tips": {
-      "article": "Artículo"
+      "article": "Artículo",
+      "title": "Rental Tips & Guides",
+      "categories": {
+        "search": "Search",
+        "safety": "Safety",
+        "legal": "Legal",
+        "inspection": "Inspection"
+      },
+      "firstTimeRenting": {
+        "title": "First Time Renting? Here's Your Complete Guide",
+        "description": "Everything you need to know about finding, viewing, and securing your first rental property."
+      },
+      "avoidScams": {
+        "title": "How to Avoid Rental Scams: Red Flags to Watch For",
+        "description": "Learn to identify common rental scams and protect yourself from fraud when searching for a new home."
+      },
+      "rentalAgreement": {
+        "title": "Understanding Your Rental Agreement: Key Terms Explained",
+        "description": "Break down complex legal terms and understand what you're signing before committing to a rental."
+      },
+      "propertyInspection": {
+        "title": "Property Inspection Checklist: What to Look For",
+        "description": "A comprehensive guide to inspecting potential rental properties and identifying potential issues."
+      },
+      "subtitle": "Practical guides from local tenants, legal experts, and the Homiio editorial team.",
+      "eyebrow": "Renting smarter"
     },
     "faq": {
       "title": "Preguntas Frecuentes",
@@ -240,6 +234,43 @@
     "cityShowcase": {
       "title": "Explora {{place}}",
       "defaultPlace": "España"
+    },
+    "noProfilesTitle": "No Saved Profiles",
+    "noProfilesDescription": "Follow profiles to see them here",
+    "recommended": {
+      "title": "Recommended homes",
+      "eyebrow": "For you"
+    },
+    "hostCta": {
+      "cta": "Become a host",
+      "subtitle": "Reach verified renters across Spain — free to list, fair fees, real human support.",
+      "title": "List your space, find a great tenant"
+    },
+    "footerStrip": {
+      "support": "Real support, real people",
+      "fair": "Fair agreements",
+      "verified": "Verified listings"
+    },
+    "nearby": {
+      "title": "Homes in {{city}}"
+    },
+    "category": {
+      "studios": "Estudios",
+      "apartments": "Apartamentos",
+      "houses": "Casas",
+      "rooms": "Habitaciones",
+      "coliving": "Co-living",
+      "luxury": "Lujo",
+      "newListings": "Nuevos anuncios",
+      "nearYou": "Cerca de ti",
+      "beachfront": "Frente al mar",
+      "cabins": "Cabañas",
+      "pools": "Piscinas",
+      "mountain": "Montaña",
+      "cityBreaks": "Escapadas urbanas",
+      "countryside": "Campo",
+      "instantBook": "Reserva instantánea",
+      "petFriendly": "Admite mascotas"
     }
   },
   "agent": {
@@ -345,6 +376,9 @@
       "subtitle": "Convierte los hogares que te rodean en ingresos.",
       "cta": "Hazte agente",
       "trust": "Sin licencia. Trabaja desde tu móvil."
+    },
+    "join": {
+      "error": "Could not start earning right now. Please try again."
     }
   },
   "search": {
@@ -364,20 +398,57 @@
     "enableNotifications": "Habilitar Notificaciones",
     "notificationsDescription": "Recibe notificaciones cuando nuevas propiedades coincidan con esta búsqueda",
     "withFilters": "Con filtros",
-    "error": "Error",
+    "error": {
+      "title": "Could not load homes"
+    },
     "enterSearchQuery": "Por favor ingresa una consulta de búsqueda primero",
     "deleteSearch": "Eliminar Búsqueda",
     "deleteSearchConfirm": "¿Estás seguro de que quieres eliminar la búsqueda \"{{name}}\"?",
     "viewAllSaved": "Ver Todas Guardadas",
     "more": "más",
-    "Eco-friendly": "Ecológico",
-    "Co-living": "Convivencia",
-    "Furnished": "Amueblado",
-    "Pets Allowed": "Mascotas Permitidas",
-    "Verified": "Verificado",
-    "Search with": "Buscar con",
     "filters": {
-      "listingType": "Tipo de anuncio"
+      "listingType": "Tipo de anuncio",
+      "propertyType": "Tipo de propiedad",
+      "nightlyPrice": "Precio por noche",
+      "monthlyPrice": "Precio mensual",
+      "checkIn": "Entrada",
+      "checkOut": "Salida",
+      "addDate": "Añadir fecha",
+      "guests": "Huéspedes",
+      "instantBook": "Reserva instantánea",
+      "cancellationPolicy": "Política de cancelación",
+      "moveInDate": "Fecha de mudanza",
+      "leaseDuration": {
+        "3Months": "3 meses",
+        "6Months": "6 meses",
+        "12Months": "12 meses",
+        "flexible": "Flexible"
+      },
+      "maxDeposit": "Depósito máximo",
+      "amenities": "Comodidades",
+      "amenity": {
+        "wifi": "Wi-Fi",
+        "parking": "Aparcamiento",
+        "gym": "Gimnasio",
+        "pool": "Piscina",
+        "balcony": "Balcón",
+        "garden": "Jardín",
+        "elevator": "Ascensor",
+        "airConditioning": "Aire acondicionado",
+        "heating": "Calefacción",
+        "dishwasher": "Lavavajillas",
+        "washingMachine": "Lavadora"
+      },
+      "propertyTypeVacation": {
+        "wholeHouses": "Casas enteras",
+        "privateRooms": "Habitaciones privadas"
+      },
+      "cancellation": {
+        "flexible": "Flexible",
+        "moderate": "Moderada",
+        "strict": "Estricta",
+        "superStrict": "Muy estricta"
+      }
     },
     "mode": {
       "label": "Modo de búsqueda",
@@ -386,7 +457,6 @@
       "buy": "Comprar",
       "exchange": "Intercambio"
     },
-    "Advanced Filters": "Filtros Avanzados",
     "types": {
       "apartments": "Apartamentos",
       "houses": "Casas",
@@ -408,7 +478,16 @@
       "rooms": "Habitaciones",
       "studios": "Estudios",
       "coliving": "Convivencia",
-      "publicHousing": "Vivienda Pública"
+      "publicHousing": "Vivienda Pública",
+      "couchsurfing": "Couchsurfing",
+      "roommates": "Roommates",
+      "hostel": "Hostel",
+      "guesthouse": "Guesthouse",
+      "campsite": "Campsite",
+      "boat": "Boat",
+      "treehouse": "Treehouse",
+      "yurt": "Yurt",
+      "other": "Other"
     },
     "areas": {
       "downtown": "Centro",
@@ -493,7 +572,97 @@
       }
     },
     "editSearch": "Editar búsqueda",
-    "searchQueryPlaceholder": "Introduce tu consulta de búsqueda"
+    "searchQueryPlaceholder": "Introduce tu consulta de búsqueda",
+    "placeholder": {
+      "suggestion1": "Find your dream apartment in Barcelona...",
+      "suggestion2": "Looking for a pet-friendly home?",
+      "suggestion3": "Discover eco-friendly properties...",
+      "suggestion4": "Search for furnished studios near you..."
+    },
+    "disableNotifications": "Disable notifications",
+    "duplicateName": "A search with this name already exists",
+    "duplicateExact": "You already saved this exact search",
+    "tryDifferentName": "Please choose a different name",
+    "actions": {
+      "save": "Save",
+      "search": "Search",
+      "clearAll": "Clear all",
+      "searchArea": "Search this area",
+      "sort": "Sort",
+      "filters": "Filters",
+      "saved": "Saved"
+    },
+    "summary": {
+      "edit": "Edit search",
+      "anyPrice": "Any price",
+      "addDates": "Add dates",
+      "anyTime": "Any time",
+      "anyType": "Any type",
+      "anywhere": "Anywhere",
+      "mapArea": "Map area",
+      "typeCount": "{{count}} types"
+    },
+    "step": {
+      "dates": {
+        "title": "When?",
+        "weekday": {
+          "Mo": "Lu",
+          "Tu": "Ma",
+          "We": "Mi",
+          "Th": "Ju",
+          "Fr": "Vi",
+          "Sa": "Sá",
+          "Su": "Do"
+        }
+      },
+      "type": {
+        "title": "What type of place?"
+      },
+      "price": {
+        "max": "Maximum",
+        "any": "Any",
+        "min": "Minimum",
+        "title": "Price range",
+        "perMonth": "per month",
+        "perNight": "per night"
+      }
+    },
+    "header": {
+      "geocoding": "Looking up location...",
+      "noResults": "No homes match this search",
+      "loading": "Searching homes...",
+      "count": "{{count}} homes"
+    },
+    "recent": {
+      "title": "Recent searches"
+    },
+    "input": {
+      "placeholder": "Search cities, neighborhoods, or addresses"
+    },
+    "panel": {
+      "title": "Search"
+    },
+    "fab": {
+      "map": "Map",
+      "list": "List"
+    },
+    "empty": {
+      "action": "Edit search",
+      "description": "Try widening your area or relaxing your filters.",
+      "title": "No homes match this search"
+    },
+    "sort": {
+      "title": "Ordenar por",
+      "recommended": "Recomendado",
+      "priceAsc": "Precio: de menor a mayor",
+      "priceDesc": "Precio: de mayor a menor",
+      "newest": "Más recientes"
+    },
+    "save": {
+      "title": "Save this search",
+      "namePlaceholder": "Give your search a name",
+      "enableNotifications": "Enable notifications"
+    }
   },
   "profile": {
     "title": "Perfil",
@@ -522,12 +691,19 @@
       "properties": "Mis Propiedades",
       "contracts": "Mis Contratos",
       "trustScore": "Puntuación de Confianza",
-      "settings": "Configuración"
+      "settings": "Configuración",
+      "account": "Account",
+      "profile": "Profile",
+      "activity": "Activity"
     },
     "stats": {
       "propertiesCount": "Propiedades",
       "contractsCount": "Contratos",
-      "trustScore": "Puntuación de Confianza"
+      "trustScore": "Puntuación de Confianza",
+      "stays": "Stays",
+      "applications": "Applications",
+      "saved": "Saved",
+      "applicationsApproved": "{{count}} aprobadas"
     },
     "actions": {
       "manageProperties": "Gestionar Propiedades",
@@ -544,7 +720,323 @@
       "deleteFailed": "Error al eliminar perfil"
     },
     "exchanges": "Intercambios",
-    "exchangesDescription": "Tus intercambios de casa y solicitudes de alojamiento."
+    "exchangesDescription": "Tus intercambios de casa y solicitudes de alojamiento.",
+    "edit": {
+      "noProfile": "No se encontró un perfil para actualizar.",
+      "updateSuccess": "¡Perfil actualizado correctamente!",
+      "updateFailed": "No se pudo actualizar el perfil",
+      "sections": {
+        "agencyInformation": "Información de la agencia",
+        "agencyVerification": "Agency Verification",
+        "teamManagement": "Team Management",
+        "businessSettings": "Business Settings",
+        "businessInformation": "Información del negocio",
+        "businessVerification": "Business Verification",
+        "cooperativeInformation": "Información de la cooperativa",
+        "cooperativeSettings": "Cooperative Settings",
+        "personalInformation": "Información personal",
+        "propertyPreferences": "Preferencias de propiedad",
+        "references": "References",
+        "rentalHistory": "Rental History",
+        "trustScore": "Trust Score",
+        "settings": "Settings"
+      },
+      "labels": {
+        "businessType": "Tipo de negocio *",
+        "legalCompanyName": "Nombre legal de la empresa *",
+        "description": "Descripción",
+        "licenseNumber": "License Number",
+        "taxId": "Tax ID",
+        "yearEstablished": "Year Established",
+        "employeeCount": "Number of Employees",
+        "specialties": "Specialties",
+        "verificationStatus": "Verification Status",
+        "profileVisibility": "Profile Visibility",
+        "notifications": "Notifications",
+        "emailNotifications": "Email Notifications",
+        "pushNotifications": "Push Notifications",
+        "legalName": "Legal Name *",
+        "industry": "Industry",
+        "bio": "Biografía",
+        "occupation": "Occupation",
+        "employer": "Employer",
+        "annualIncome": "Annual Income ($)",
+        "employmentStatus": "Employment Status",
+        "moveInDate": "Move-in Date",
+        "leaseDuration": "Lease Duration",
+        "maxRent": "Maximum Rent ($)",
+        "rentPeriod": "Rent Period",
+        "minBedrooms": "Min Bedrooms",
+        "minBathrooms": "Min Bathrooms",
+        "propertyTypes": "Property Types",
+        "preferredAmenities": "Preferred Amenities",
+        "additionalPreferences": "Additional Preferences",
+        "name": "Name",
+        "relationship": "Relationship",
+        "phone": "Phone",
+        "email": "Email",
+        "address": "Address",
+        "startDate": "Start Date",
+        "endDate": "End Date",
+        "monthlyRent": "Monthly Rent ($)",
+        "reasonForLeaving": "Reason for Leaving",
+        "landlordContact": "Landlord Contact",
+        "privacy": "Privacy"
+      },
+      "subtitles": {
+        "agencyVerification": "Complete these verifications to build trust with clients",
+        "businessVerification": "Complete these verifications to build trust with clients",
+        "businessSettings": "Configure your business profile settings",
+        "cooperativeSettings": "Configure your cooperative profile settings"
+      },
+      "placeholders": {
+        "legalCompanyName": "Enter your legal company name",
+        "description": "Describe your business...",
+        "licenseNumber": "Enter license number",
+        "taxId": "Enter tax ID",
+        "yearEstablished": "e.g., 2020",
+        "industry": "Enter industry",
+        "cooperativeLegalName": "Enter cooperative legal name",
+        "cooperativeDescription": "Describe your cooperative...",
+        "bio": "Cuéntanos sobre ti...",
+        "occupation": "p. ej., Ingeniero de software",
+        "employer": "p. ej., Tech Corp",
+        "annualIncome": "p. ej., 75000",
+        "moveInDate": "AAAA-MM-DD",
+        "maxRent": "Introduce el alquiler máximo",
+        "fullName": "Nombre completo",
+        "phoneNumber": "Número de teléfono",
+        "emailAddress": "Correo electrónico",
+        "fullAddress": "Dirección completa",
+        "landlordName": "Nombre del arrendador",
+        "phone": "Teléfono",
+        "email": "Correo",
+        "endDateOptional": "AAAA-MM-DD (opcional)",
+        "monthlyRent": "p. ej., 1500"
+      },
+      "options": {
+        "agencyBusinessType": {
+          "real_estate_agency": "Agencia inmobiliaria",
+          "property_management": "Gestión de propiedades",
+          "brokerage": "Corretaje",
+          "developer": "Promotora",
+          "other": "Otro"
+        },
+        "agencySpecialty": {
+          "residential": "Residencial",
+          "commercial": "Comercial",
+          "luxury": "Lujo",
+          "student_housing": "Vivienda estudiantil",
+          "senior_housing": "Vivienda senior",
+          "vacation_rentals": "Alquiler vacacional"
+        },
+        "businessType": {
+          "small_business": "Pequeña empresa",
+          "startup": "Startup",
+          "freelancer": "Autónomo",
+          "consultant": "Consultor",
+          "other": "Otro"
+        },
+        "employmentStatus": {
+          "employed": "Empleado",
+          "self_employed": "Autónomo",
+          "student": "Estudiante",
+          "retired": "Jubilado",
+          "unemployed": "Desempleado",
+          "other": "Otro"
+        },
+        "leaseDuration": {
+          "monthly": "Mensual",
+          "3_months": "3 meses",
+          "6_months": "6 meses",
+          "yearly": "Anual",
+          "flexible": "Flexible"
+        },
+        "priceUnit": {
+          "day": "Día",
+          "night": "Noche",
+          "week": "Semana",
+          "month": "Mes",
+          "year": "Año"
+        },
+        "propertyType": {
+          "apartment": "Apartamento",
+          "house": "Casa",
+          "room": "Habitación",
+          "studio": "Estudio"
+        },
+        "amenity": {
+          "parking": "Aparcamiento",
+          "gym": "Gimnasio",
+          "pool": "Piscina",
+          "washer": "Lavadora",
+          "dishwasher": "Lavavajillas",
+          "balcony": "Balcón",
+          "elevator": "Ascensor",
+          "ac": "Aire acondicionado",
+          "heating": "Calefacción",
+          "internet": "Internet"
+        },
+        "referenceRelationship": {
+          "landlord": "Arrendador",
+          "employer": "Empleador",
+          "personal": "Personal",
+          "other": "Otro"
+        },
+        "reasonForLeaving": {
+          "lease_ended": "Fin de contrato",
+          "bought_home": "Compró vivienda",
+          "job_relocation": "Traslado laboral",
+          "family_reasons": "Motivos familiares",
+          "upgrade": "Mejora",
+          "other": "Otro"
+        },
+        "profileVisibility": {
+          "public": "Público",
+          "private": "Privado",
+          "contacts_only": "Solo contactos"
+        }
+      },
+      "verification": {
+        "businessLicenseTitle": "Licencia comercial",
+        "businessLicenseDescription": "Sube tu licencia comercial para verificación",
+        "insuranceTitle": "Seguro",
+        "insuranceDescription": "Aporta prueba del seguro comercial",
+        "bondingTitle": "Fianza",
+        "bondingDescription": "Aporta información de la fianza",
+        "backgroundCheckTitle": "Verificación de antecedentes",
+        "backgroundCheckDescription": "Completa la verificación de antecedentes de todo el equipo"
+      },
+      "toggles": {
+        "emailNotifications": "Notificaciones por correo",
+        "pushNotifications": "Notificaciones push",
+        "petFriendly": "Admite mascotas",
+        "smokingAllowed": "Fumar permitido",
+        "furnished": "Amueblado",
+        "parkingRequired": "Aparcamiento obligatorio",
+        "accessibilityFeatures": "Accesibilidad",
+        "showContactInfo": "Mostrar datos de contacto",
+        "showIncome": "Mostrar ingresos",
+        "showRentalHistory": "Mostrar historial de alquiler",
+        "showReferences": "Mostrar referencias"
+      },
+      "team": {
+        "subtitle": "Gestiona los miembros del equipo y sus roles",
+        "memberLabel": "Miembro {{index}}",
+        "addedLabel": "Añadido: {{date}}",
+        "emptyText": "Aún no hay miembros en el equipo.",
+        "addMember": "+ Añadir miembro del equipo"
+      },
+      "actions": {
+        "addReference": "+ Añadir referencia",
+        "addHistory": "+ Añadir historial",
+        "remove": "Eliminar",
+        "referenceLabel": "Referencia {{index}}",
+        "rentalLabel": "Alquiler {{index}}"
+      }
+    },
+    "create": {
+      "selectType": "Selecciona un tipo de perfil.",
+      "selectBusinessType": "Selecciona un tipo de negocio.",
+      "cooperativeLegalNameRequired": "Introduce el nombre legal de la cooperativa.",
+      "createdSuccess": "¡{{type}} creado correctamente!",
+      "headerTitle": "Create Profile",
+      "createButton": "Create",
+      "chooseType": "Choose Business Profile Type",
+      "types": {
+        "agency": {
+          "title": "Agency Profile",
+          "description": "For real estate agencies and property management"
+        },
+        "business": {
+          "title": "Business Profile",
+          "description": "For small businesses and freelancers"
+        },
+        "cooperative": {
+          "title": "Cooperative Profile",
+          "description": "For housing or member-owned cooperatives"
+        }
+      },
+      "sections": {
+        "agencyInfo": "Agency Information",
+        "businessInfo": "Business Information",
+        "cooperativeInfo": "Cooperative Information",
+        "whatsNext": "What's Next?",
+        "profileSetup": "Profile Setup"
+      },
+      "whatsNext": {
+        "description": "After creating your {{type}} profile, you can customize preferences, add verification documents, and build your trust score."
+      },
+      "placeholders": {
+        "agencyDescription": "Describe your agency...",
+        "businessDescription": "Describe your business...",
+        "licenseOptional": "Enter license number (if applicable)",
+        "cooperativeLegalName": "Cooperative Legal Name",
+        "cooperativeDescription": "Describe the cooperative"
+      },
+      "options": {
+        "agencySpecialty": {
+          "residential": "Residential",
+          "commercial": "Commercial",
+          "investment": "Investment",
+          "rental": "Rental",
+          "new_construction": "New Construction"
+        },
+        "businessSpecialty": {
+          "consulting": "Consulting",
+          "technology": "Technology",
+          "design": "Design",
+          "marketing": "Marketing",
+          "finance": "Finance",
+          "healthcare": "Healthcare",
+          "education": "Education",
+          "retail": "Retail",
+          "services": "Services"
+        }
+      }
+    },
+    "toast": {
+      "loadFailed": "No se pudieron cargar los perfiles",
+      "createSuccess": "Perfil creado correctamente",
+      "createFailed": "No se pudo crear el perfil",
+      "updateSuccess": "Perfil actualizado correctamente",
+      "updateFailed": "No se pudo actualizar el perfil",
+      "deleteSuccess": "Perfil eliminado correctamente",
+      "deleteFailed": "No se pudo eliminar el perfil",
+      "activateSuccess": "Perfil activado correctamente",
+      "activateFailed": "No se pudo activar el perfil"
+    },
+    "trustScoreHint": "Complete your profile information to improve your trust score.",
+    "trustScoreSubtitle": "Build trust with landlords and roommates through verification and positive interactions.",
+    "established": "Established",
+    "serviceAreas": "Service areas",
+    "specialties": "Specialties",
+    "about": "About",
+    "preferences": "Preferences",
+    "budget": "Budget",
+    "employer": "Employer",
+    "occupation": "Occupation",
+    "listings": "Listings",
+    "switchConfirm": "Switch",
+    "switchMessage": "Activate {{name}}?",
+    "switchTitle": "Switch profile?",
+    "subscriptionsDescription": "Manage Homiio Plus or buy one-time file analysis.",
+    "subscriptions": "Subscriptions",
+    "createNewDescription": "Add a business, agency, or cooperative profile.",
+    "createNew": "Create new profile",
+    "active": "Active",
+    "activeFooter": "Active: {{name}}",
+    "stays": "Stays",
+    "applications": "My applications",
+    "trustScoreCta": "View trust score",
+    "loadFailedHint": "Please try again later.",
+    "loadFailed": "Failed to load profile",
+    "switchFailed": "Failed to switch profile",
+    "switched": "Switched to {{name}}",
+    "invalidProfile": "Invalid profile data",
+    "trustScorePage": {
+      "title": "Trust Score"
+    }
   },
   "trust": {
     "loadingVerification": "Cargando estado de verificación...",
@@ -557,7 +1049,79 @@
     "verified": "Verificado",
     "completeVerification": "Completar verificación",
     "yourScoreIs": "Tu puntuación de confianza es",
-    "improveScore": "Mejorar puntuación"
+    "improveScore": "Mejorar puntuación",
+    "manager": {
+      "loading": "Cargando puntuación de confianza...",
+      "error": "Error al cargar la puntuación de confianza",
+      "noData": "No se encontraron datos de puntuación personal",
+      "title": "Puntuación de confianza",
+      "subtitle": "Genera confianza con arrendadores y compañeros de piso",
+      "scoreDescription": "Tu puntuación global es {{score}}/100",
+      "factorsTitle": "Factores de confianza",
+      "factorsSubtitle": "Mejora estos factores para aumentar tu puntuación",
+      "quickActionsTitle": "Acciones rápidas para mejorar",
+      "completeProfile": "Completar perfil",
+      "cancel": "Cancelar",
+      "editProfile": "Editar perfil",
+      "factorAlertBody": "{{description}}\n\nPuntuación actual: {{score}}/100\n\nPara mejorar: {{action}}",
+      "factors": {
+        "verification": {
+          "label": "Verificación de identidad",
+          "description": "Completa la verificación de identidad para generar confianza",
+          "action": "Añade información personal y datos de ingresos"
+        },
+        "reviews": {
+          "label": "Reseñas de usuarios",
+          "description": "Obtén reseñas positivas de arrendadores y compañeros",
+          "action": "Añade referencias de arrendadores anteriores"
+        },
+        "payment_history": {
+          "label": "Historial de pagos",
+          "description": "Mantén un buen historial de pagos",
+          "action": "Añade historial de alquiler con registros de pago"
+        },
+        "communication": {
+          "label": "Comunicación",
+          "description": "Responde con prontitud a mensajes y solicitudes",
+          "action": "Completa la biografía y la información de contacto"
+        },
+        "rental_history": {
+          "label": "Historial de alquiler",
+          "description": "Construye un historial de alquiler positivo",
+          "action": "Añade tus direcciones de alquiler anteriores"
+        },
+        "default": {
+          "description": "Mejora este factor para aumentar tu puntuación",
+          "action": "Completa tu perfil para mejorar este factor"
+        }
+      },
+      "actions": {
+        "personalInfo": {
+          "title": "Completar información personal",
+          "description": "Añade tu ocupación, ingresos y datos laborales para generar confianza."
+        },
+        "references": {
+          "title": "Añadir referencias",
+          "description": "Incluye referencias de arrendadores y empleadores anteriores."
+        },
+        "rentalHistory": {
+          "title": "Añadir historial de alquiler",
+          "description": "Documenta tu historial de alquiler para demostrar fiabilidad."
+        }
+      }
+    },
+    "score": {
+      "levels": {
+        "excellent": "Excelente",
+        "good": "Bueno",
+        "average": "Medio",
+        "fair": "Regular",
+        "needsImprovement": "Necesita mejorar"
+      },
+      "breakdown": "Desglose de la puntuación de confianza",
+      "recalculate": "Recalcular",
+      "recalculating": "Recalculando…"
+    }
   },
   "notifications": {
     "title": "Notificaciones",
@@ -598,9 +1162,6 @@
     "share": "Compartir",
     "contact": "Contactar",
     "bookViewing": "Reservar Visita",
-    "Housing Authority": "Autoridad de Vivienda",
-    "Apply on State Website": "Aplicar en el Sitio Web del Estado",
-    "Contact Housing Authority": "Contactar Autoridad de Vivienda",
     "my": {
       "title": "Mis Propiedades",
       "edit": "Editar",
@@ -612,7 +1173,15 @@
       "emptyDescription": "Aún no has creado ninguna propiedad. Comienza agregando tu primera lista de propiedad.",
       "createFirst": "Crear Tu Primera Propiedad",
       "errorTitle": "Error al Cargar Propiedades",
-      "errorDescription": "Hubo un error al cargar tus propiedades. Por favor, inténtalo de nuevo."
+      "errorDescription": "Hubo un error al cargar tus propiedades. Por favor, inténtalo de nuevo.",
+      "markRented": "Mark as rented",
+      "markSold": "Mark as sold",
+      "transactMessage": "This closes \"{{title}}\" and removes it from active listings. This cannot be undone.",
+      "markRentedTitle": "Mark as rented?",
+      "markSoldTitle": "Mark as sold?",
+      "transactError": "Could not close this listing",
+      "transactDone": "Listing marked as closed",
+      "transactCommission": "Deal closed — commission recorded"
     },
     "details": {
       "price": "Precio",
@@ -638,6 +1207,61 @@
         "duplex": "Dúplex",
         "penthouse": "Ático"
       }
+    },
+    "type": {
+      "title": "{{type}}",
+      "subtitle": "{{count}} {{type}} available",
+      "empty": "No {{type}} available at the moment",
+      "filters": {
+        "title": "Filters",
+        "price": "Price Range",
+        "bedrooms": "Bedrooms",
+        "bathrooms": "Bathrooms",
+        "amenities": "Amenities",
+        "sort": {
+          "title": "Sort By",
+          "newest": "Newest First",
+          "priceAsc": "Price: Low to High",
+          "priceDesc": "Price: High to Low"
+        },
+        "apply": "Apply Filters",
+        "clear": "Clear All"
+      }
+    },
+    "actions": {
+      "create": "Add property",
+      "recent": "Recently viewed"
+    },
+    "empty": {
+      "action": "Clear filters",
+      "description": "Try relaxing your filters.",
+      "title": "No homes available"
+    },
+    "error": {
+      "title": "Could not load homes"
+    },
+    "header": {
+      "empty": "No homes available",
+      "loading": "Loading homes…"
+    },
+    "city": {
+      "verifiedProperties": "Verified Properties",
+      "verifiedOnly": "Verified Only",
+      "ecoFriendly": "Eco-Friendly",
+      "ecoFriendlyOnly": "Eco-Friendly Only",
+      "loadingProperties": "Loading properties...",
+      "notFound": "City not found",
+      "properties": "Properties",
+      "population": "Population",
+      "availableProperties": "Available Properties",
+      "propertiesFound": "properties found",
+      "sortBy": "Sort By",
+      "sortNewest": "Newest First",
+      "sortPriceAsc": "Price: Low to High",
+      "sortPriceDesc": "Price: High to Low",
+      "noPropertiesFound": "No properties found",
+      "tryAdjustFilters": "Try adjusting your filters or check back later",
+      "clearFilters": "Clear Filters"
     }
   },
   "property": {
@@ -764,7 +1388,176 @@
       "listedDaysAgo_other": "Publicado hace {{count}} días",
       "saved_one": "{{count}} guardado",
       "saved_other": "{{count}} guardados"
-    }
+    },
+    "loading": "Loading property details...",
+    "error": "Error",
+    "notFound": "Property not found",
+    "bed": "Bed",
+    "bath": "Bath",
+    "pricingReviewNeeded": "Pricing Review Needed",
+    "bedrooms": "Number of Bedrooms",
+    "bathrooms": "Number of Bathrooms",
+    "customNumber": {
+      "title": "Enter Custom Number",
+      "placeholder": "Enter number",
+      "confirm": "Confirm",
+      "cancel": "Cancel"
+    },
+    "suggestedRent": "Suggested: ${{amount}}/month",
+    "maxEthicalRent": "Max Ethical: ${{amount}}/month",
+    "ethicalPricingWarning": "Your price exceeds the ethical maximum. Consider lowering it to make housing more accessible.",
+    "warningBullet": "• {{warning}}",
+    "ethicalPricing": "Ethical Pricing",
+    "toast": {
+      "createSuccess": "Propiedad creada correctamente",
+      "updateSuccess": "Propiedad actualizada correctamente",
+      "deleteSuccess": "Propiedad eliminada correctamente",
+      "createFailed": "No se pudo crear la propiedad",
+      "updateFailed": "No se pudo actualizar la propiedad",
+      "deleteFailed": "No se pudo eliminar la propiedad",
+      "shareCopied": "Detalles de la propiedad copiados al portapapeles",
+      "shareFailed": "No se pudo compartir la propiedad",
+      "shareTitle": "Compartir propiedad"
+    },
+    "drafts": {
+      "title": "Borradores",
+      "emptyTitle": "No hay borradores",
+      "emptyDescription": "Aún no tienes borradores guardados. Empieza a crear una propiedad para guardarlos automáticamente.",
+      "createFirst": "Crear nueva propiedad",
+      "deleteTitle": "Eliminar borrador",
+      "deleteMessage": "¿Seguro que quieres eliminar este borrador? Esta acción no se puede deshacer.",
+      "toastDeleted": "Borrador eliminado correctamente",
+      "toastDeleteFailed": "No se pudo eliminar el borrador",
+      "toastLoadFailed": "No se pudo cargar el borrador"
+    },
+    "description": {
+      "showMore": "Show more",
+      "showLess": "Show less"
+    },
+    "external": {
+      "contactTitle": "Contact on listing"
+    },
+    "location": {
+      "title": "Where you'll be"
+    },
+    "cta": {
+      "apply": "Apply",
+      "reserve": "Reserve"
+    },
+    "host": {
+      "verified": "Verified",
+      "responseRate": "Typically responds within an hour",
+      "hostingSince": "Hosting since",
+      "hostedBy": "Hosted by",
+      "openProfile": "Open host profile",
+      "publicSubtitle": "Government-managed affordable housing",
+      "publicAuthority": "Public Housing Authority",
+      "superHost": "Super host"
+    },
+    "report": {
+      "actions": {
+        "submit": "Enviar denuncia"
+      },
+      "notice": "Las denuncias falsas o abusivas pueden afectar tu cuenta. Denuncia solo problemas reales.",
+      "section": {
+        "contactHelp": "Comparte un correo si quieres que te contactemos sobre esta denuncia.",
+        "contact": "Correo de contacto (opcional)",
+        "detailsHelp": "Añade cualquier detalle que nos ayude a entender el problema.",
+        "details": "Detalles (opcional)",
+        "detailsRequired": "Detalles",
+        "reason": "¿Por qué denuncias este anuncio?"
+      },
+      "field": {
+        "detailsPlaceholder": "Describe qué es inexacto, sospechoso o inapropiado…"
+      },
+      "intro": "Cuéntanos qué falla en este anuncio. Las denuncias son confidenciales y las revisa nuestro equipo — nunca se comparten con el anfitrión.",
+      "title": "Denunciar este anuncio",
+      "success": "Gracias — tu denuncia se ha enviado.",
+      "error": {
+        "invalidForm": "Elige un motivo antes de enviar.",
+        "generic": "Algo salió mal. Inténtalo de nuevo.",
+        "notFound": "Este anuncio ya no existe.",
+        "auth": "Inicia sesión para denunciar un anuncio.",
+        "detailsRequired": "Añade algunos detalles sobre el problema.",
+        "invalidReason": "Elige un motivo para tu denuncia."
+      },
+      "reason": {
+        "inaccurate": "Información inexacta",
+        "scam": "Posible estafa o fraude",
+        "inappropriate": "Contenido inapropiado",
+        "unavailable": "Ya alquilado o no disponible",
+        "other": "Otro motivo"
+      }
+    },
+    "about": {
+      "title": "About this property"
+    },
+    "sleep": {
+      "title": "Where you'll sleep",
+      "oneBed": "1 bed",
+      "mainBedroom": "Main bedroom"
+    },
+    "reviews": {
+      "writeAction": "Write a review",
+      "emptyDescription": "Be the first to share what it was like to live here.",
+      "emptyTitle": "No reviews yet",
+      "errorTitle": "Could not load reviews",
+      "disclaimer": "Community-verified reviews about the building. Experiences may vary by unit.",
+      "title": "Reviews",
+      "evidence": "With evidence",
+      "verified": "Verified",
+      "recommend": "Recommend",
+      "count": "reviews",
+      "countWithNumber": "({{count}} reseñas)"
+    },
+    "notFoundHelp": "It may have been removed or the link is broken.",
+    "sections": {
+      "photoGallery": "Galería de fotos",
+      "viewAll": "Ver todo",
+      "features": "Características",
+      "furnished": "Amueblado",
+      "partiallyFurnished": "Parcialmente amueblado",
+      "unfurnished": "Sin amueblar",
+      "balcony": "Balcón",
+      "garden": "Jardín",
+      "elevator": "Ascensor",
+      "overview": "Resumen",
+      "bedrooms": "Dormitorios",
+      "bathrooms": "Baños",
+      "size": "Tamaño",
+      "floor": "Planta",
+      "details": "Detalles",
+      "notSpecified": "No especificado",
+      "yearBuilt": "Año de construcción",
+      "parkingSpaces": "Plazas de aparcamiento",
+      "pricingAndCosts": "Precio y costes",
+      "rent": "Alquiler",
+      "deposit": "Depósito",
+      "utilitiesIncluded": "Servicios incluidos",
+      "nightlyRent": "Alquiler por noche",
+      "monthlyRent": "Alquiler mensual",
+      "sourcedFrom": "Fuente",
+      "availability": "Disponibilidad",
+      "availableFrom": "Disponible desde",
+      "leaseTerm": "Duración del contrato",
+      "location": "Ubicación",
+      "nearbyAmenities": "Servicios cercanos",
+      "publicTransport": "Transporte público",
+      "schools": "Colegios",
+      "shopping": "Comercios"
+    },
+    "neighborhood": {
+      "title": "Neighborhood",
+      "listings": "Listings",
+      "avgRentPerMonth": "Avg. rent / mo",
+      "onParWithCity": "On par with the city average",
+      "listingCount": "{{count}} listings",
+      "avgAmountPerMonth": "Avg. {{amount}}/mo",
+      "pctVsCity": "{{pct}}% {{dir}} than the city average",
+      "cheaper": "cheaper",
+      "pricier": "pricier"
+    },
+    "fraudWarning": "Never pay or transfer funds outside the Homio platform"
   },
   "viewings": {
     "title": "Visitas",
@@ -784,7 +1577,8 @@
       "timeInPast": "La hora programada debe ser en el futuro.",
       "authRequired": "Por favor inicia sesión para solicitar una visita.",
       "notFound": "Solicitud de visita no encontrada.",
-      "cannotCancel": "No se puede cancelar esta solicitud de visita."
+      "cannotCancel": "No se puede cancelar esta solicitud de visita.",
+      "externalProperty": "Cannot book viewings for external properties"
     },
     "selectDate": "Seleccionar fecha",
     "availableTimeSlots": "Horarios disponibles",
@@ -807,6 +1601,10 @@
     },
     "cancel": {
       "confirmMessage": "¿Estás seguro de que quieres cancelar esta solicitud de visita?"
+    },
+    "banner": {
+      "viewDetails": "View details",
+      "hasViewing": "You have a viewing scheduled"
     }
   },
   "payments": {
@@ -842,6 +1640,116 @@
       "download": "Descargar",
       "sign": "Firmar",
       "renew": "Renovar"
+    },
+    "list": {
+      "title": "Contratos de alquiler",
+      "eyebrow": "Acuerdos",
+      "subtitle": "Haz seguimiento de cada contrato que firmes o emitas y consulta los términos clave al instante.",
+      "filterAll": "Todos",
+      "filterActive": "Activos",
+      "filterPending": "Pendientes",
+      "filterExpired": "Vencidos",
+      "filterDrafts": "Borradores",
+      "noRentalPropertiesTitle": "Sin contratos de alquiler",
+      "noRentalPropertiesDescription": "Aún no tienes propiedades en alquiler. Empieza explorando propiedades disponibles o publicando la tuya.",
+      "browseProperties": "Explorar propiedades",
+      "loadError": "No se pudieron cargar los contratos",
+      "tryAgain": "Inténtalo de nuevo.",
+      "emptyTitle": "No se encontraron contratos",
+      "emptyAllDescription": "Aún no tienes contratos de alquiler",
+      "emptyFilteredDescription": "No hay contratos {{filter}} que mostrar",
+      "newContract": "Nuevo contrato",
+      "createNew": "Crear nuevo contrato"
+    },
+    "card": {
+      "start": "Inicio",
+      "end": "Fin",
+      "landlord": "Arrendador",
+      "tenant": "Inquilino",
+      "perMonth": "/ mes",
+      "share": "Compartir",
+      "download": "Descargar",
+      "accessibility": "Contrato {{title}}"
+    },
+    "detail": {
+      "title": "Contrato",
+      "invalidIdTitle": "ID de contrato no válido",
+      "invalidIdDescription": "El enlace no incluye la referencia del contrato.",
+      "unavailableTitle": "Contrato no disponible",
+      "unavailableDescription": "No se pudo cargar este contrato.",
+      "term": "Plazo",
+      "rent": "Alquiler",
+      "start": "Inicio",
+      "end": "Fin",
+      "monthlyRent": "Alquiler mensual",
+      "securityDeposit": "Depósito de garantía",
+      "signatures": "Firmas",
+      "landlord": "Arrendador",
+      "tenant": "Inquilino",
+      "payments": "Calendario de pagos",
+      "documents": "Documentos",
+      "addDocument": "Añadir documento",
+      "sign": "Firmar contrato",
+      "terminate": "Rescindir contrato",
+      "deleteDraft": "Eliminar borrador",
+      "confirmSignTitle": "¿Firmar este contrato?",
+      "confirmSignBody": "Tu firma confirma que aceptas los términos del contrato.",
+      "confirmTerminateTitle": "¿Rescindir este contrato?",
+      "confirmTerminateBody": "Esto finaliza el contrato para todas las partes.",
+      "confirmDeleteTitle": "¿Eliminar este borrador?",
+      "confirmDeleteBody": "Este borrador se eliminará permanentemente.",
+      "toastSigned": "Contrato firmado",
+      "toastSignFailed": "No se pudo firmar el contrato",
+      "toastTerminated": "Contrato rescindido",
+      "toastTerminateFailed": "No se pudo rescindir el contrato",
+      "toastDeleted": "Borrador eliminado",
+      "toastDeleteFailed": "No se pudo eliminar el borrador",
+      "toastDocumentAdded": "Documento añadido",
+      "toastDocumentFailed": "No se pudo añadir el documento",
+      "toastOpenDocumentFailed": "No se pudo abrir el documento.",
+      "permissionRequired": "Se requiere permiso de la biblioteca multimedia para adjuntar un documento.",
+      "propertyFallback": "Propiedad",
+      "goBack": "Volver",
+      "dueDay": "Día {{day}} del mes",
+      "signed": "Firmado",
+      "signaturePending": "Pendiente",
+      "emptyDocuments": "No hay documentos adjuntos.",
+      "addShort": "Añadir",
+      "signLease": "Firmar contrato",
+      "confirmSignExtended": "Al firmar aceptas los términos del contrato. Cuando ambas partes firmen, el contrato quedará activo.",
+      "confirmSignAction": "Firmar",
+      "confirmTerminateShortTitle": "¿Terminar contrato?",
+      "confirmTerminateExtended": "Esto registra un aviso de terminación y finaliza el contrato. No se puede deshacer.",
+      "confirmDeleteExtended": "Esto elimina permanentemente el borrador del contrato.",
+      "confirmDeleteAction": "Eliminar",
+      "openDocument": "Abrir documento {{name}}",
+      "dueDayLabel": "Día de pago"
+    },
+    "new": {
+      "title": "Nuevo contrato",
+      "noApplicationTitle": "Empieza desde una solicitud",
+      "noApplicationDescription": "Los contratos se crean desde una solicitud de inquilino aprobada. Abre una solicitud aprobada y elige \"Crear contrato\".",
+      "viewApplications": "Ver solicitudes",
+      "applicationUnavailableTitle": "Solicitud no disponible",
+      "loadFailedDescription": "No se pudo cargar esta solicitud.",
+      "goBack": "Volver",
+      "subtitle": "Crea un borrador de contrato desde esta solicitud. Podrás editar los términos y firmarlo en la siguiente pantalla.",
+      "seededTerms": "Términos iniciales",
+      "moveIn": "Entrada",
+      "leaseTerm": "Duración del contrato",
+      "leaseTermMonths": "{{count}} meses",
+      "notApprovedWarning": "Esta solicitud aún no está aprobada. Apruébala primero para crear un contrato.",
+      "createButton": "Crear borrador de contrato",
+      "toastCreated": "Borrador de contrato creado",
+      "toastCreateFailed": "No se pudo crear el contrato",
+      "propertyFallback": "Propiedad"
+    },
+    "documentType": {
+      "lease_agreement": "Contrato de arrendamiento",
+      "addendum": "Anexo",
+      "inspection_report": "Informe de inspección",
+      "insurance": "Seguro",
+      "other": "Otro"
     }
   },
   "roommates": {
@@ -855,6 +1763,185 @@
       "message": "Mensaje",
       "connect": "Conectar",
       "viewProfile": "Ver Perfil"
+    },
+    "tabs": {
+      "discover": "Descubrir",
+      "requests": "Solicitudes",
+      "matches": "Coincidencias",
+      "rooms": "Habitaciones"
+    },
+    "alert": {
+      "requestSent": "¡Solicitud de compañero de piso enviada correctamente!",
+      "requestFailed": "No se pudo enviar la solicitud de compañero de piso",
+      "accepted": "¡Solicitud de compañero de piso aceptada!",
+      "acceptFailed": "No se pudo aceptar la solicitud de compañero de piso",
+      "declined": "Solicitud de compañero de piso rechazada",
+      "declineFailed": "No se pudo rechazar la solicitud de compañero de piso",
+      "relationshipEnded": "Relación de compañeros de piso finalizada",
+      "relationshipEndFailed": "No se pudo finalizar la relación de compañeros de piso",
+      "toggleFailed": "No se pudo cambiar la búsqueda de compañeros de piso",
+      "preferencesSaved": "Tus preferencias de compañero de piso se actualizaron.",
+      "preferencesFailed": "No se pudieron guardar las preferencias de compañero de piso. Inténtalo de nuevo.",
+      "successTitle": "Éxito",
+      "errorTitle": "Error"
+    },
+    "screen": {
+      "title": "Compañeros de piso",
+      "signInTitle": "Inicia sesión para encontrar compañeros",
+      "signInDescription": "Descubre compañeros compatibles y gestiona tus solicitudes.",
+      "signIn": "Iniciar sesión",
+      "loadError": "No se pudieron cargar los compañeros",
+      "tryAgain": "Inténtalo de nuevo.",
+      "emptyDiscoverTitle": "Aún no hay coincidencias",
+      "emptyDiscoverDescription": "Completa tu perfil de compañero para empezar a descubrir coincidencias.",
+      "emptyRequestsTitle": "No hay solicitudes",
+      "emptyRequestsDescription": "Las solicitudes entrantes y salientes aparecerán aquí.",
+      "emptyRelationshipsTitle": "Aún no hay coincidencias",
+      "emptyRelationshipsDescription": "Las solicitudes aceptadas se convierten en coincidencias aquí.",
+      "emptyRoomsTitle": "No hay habitaciones listadas",
+      "emptyRoomsDescription": "Los anuncios de habitaciones de tu red aparecerán aquí.",
+      "enableMatching": "Activar búsqueda de compañeros",
+      "editPreferences": "Editar preferencias",
+      "fallbackName": "Compañero",
+      "eyebrow": "Juntos",
+      "loadRequestsError": "No se pudieron cargar las solicitudes",
+      "loadRelationshipsError": "No se pudieron cargar las relaciones",
+      "personalProfileRequired": "Perfil personal requerido",
+      "personalProfileDescription": "La búsqueda de compañeros solo está disponible para perfiles personales. Cambia a tu perfil personal para usar esta función.",
+      "roomSearchPersonalOnly": "Room search is only available for personal profiles. Switch to your personal profile to use this feature.",
+      "switchToPersonal": "Cambiar a perfil personal",
+      "enableMatchingTitle": "Activar búsqueda de compañeros",
+      "enableMatchingDescription": "Activa la búsqueda de compañeros para descubrir coincidencias según tus preferencias.",
+      "enabling": "Activando…",
+      "discoverRoommates": "Descubrir compañeros",
+      "updatePreferences": "Actualizar preferencias",
+      "matchingEnabled": "Búsqueda de compañeros activada",
+      "matchingDisabled": "Búsqueda de compañeros desactivada"
+    },
+    "request": {
+      "accept": "Accept",
+      "decline": "Decline",
+      "viewProfile": "View profile",
+      "sent": "Sent",
+      "received": "Received",
+      "pending": "Pending",
+      "accepted": "Accepted",
+      "declined": "Declined",
+      "responsePlaceholder": "Add an optional message..."
+    },
+    "relationship": {
+      "endRelationship": "End relationship",
+      "confirmEndTitle": "End roommate relationship?",
+      "confirmEndBody": "You will no longer appear as roommates.",
+      "message": "Message",
+      "title": "Relación de compañeros",
+      "duration": "Duración: {{duration}}",
+      "started": "Inicio: {{date}}",
+      "endedOn": "Finalizó el {{date}}",
+      "statusActive": "Activa",
+      "statusInactive": "Inactiva",
+      "statusEnded": "Finalizada",
+      "statusUnknown": "Desconocida",
+      "durationDays": "{{count}} days",
+      "durationMonth": "{{count}} month",
+      "durationMonths": "{{count}} months",
+      "durationYear": "{{count}} year",
+      "durationYears": "{{count}} years",
+      "percentMatch": "{{score}}% de coincidencia",
+      "roommatesSection": "Compañeros",
+      "confirmEndAction": "Finalizar relación"
+    },
+    "match": {
+      "compatibility": "{{score}}% match",
+      "viewProfile": "View profile",
+      "connect": "Connect",
+      "excellent": "Excelente coincidencia",
+      "good": "Buena coincidencia",
+      "fair": "Coincidencia aceptable",
+      "preferences": "Preferencias",
+      "flexible": "Flexible",
+      "messageLabel": "Añade un mensaje (opcional):",
+      "messagePlaceholder": "¡Hola! Creo que seríamos buenos compañeros de piso...",
+      "sendRequest": "Enviar solicitud",
+      "fallbackName": "Roommate"
+    },
+    "profileDetail": {
+      "title": "Compañero",
+      "loadError": "No se pudo cargar el perfil",
+      "loadErrorDescription": "No pudimos cargar este perfil de compañero. Inténtalo de nuevo.",
+      "about": "Acerca de",
+      "preferencesTitle": "Preferencias de compañero",
+      "budget": "Presupuesto",
+      "moveIn": "Mudanza",
+      "leaseLength": "Duración del contrato",
+      "notSpecified": "No especificado",
+      "trust": "Confianza",
+      "verified": "Verificado",
+      "references": "Referencias",
+      "rentalHistory": "Historial de alquiler",
+      "sending": "Enviando…",
+      "sendRequest": "Enviar solicitud de compañero",
+      "requestSentTitle": "Solicitud enviada",
+      "requestSentBody": "Tu solicitud de compañero fue enviada.",
+      "requestFailedTitle": "No se pudo enviar la solicitud",
+      "requestFailedBody": "No pudimos enviar tu solicitud. Inténtalo de nuevo."
+    },
+    "preferencesPage": {
+      "title": "Preferencias de compañero",
+      "eyebrow": "Compartir piso",
+      "subtitle": "Permite que otros usuarios de Homiio te encuentren cuando vuestras preferencias coincidan.",
+      "enableTitle": "Activar búsqueda de compañeros",
+      "enableDescription": "Permite que otros usuarios descubran tu perfil para coincidencias.",
+      "budgetTimeline": "Presupuesto y plazos",
+      "monthlyBudget": "Presupuesto mensual (€)",
+      "min": "Mín",
+      "max": "Máx",
+      "moveInDate": "Fecha de mudanza",
+      "leaseLength": "Duración del contrato",
+      "roommateSection": "Compañero",
+      "preferredGender": "Género preferido",
+      "ageRange": "Rango de edad",
+      "lifestyle": "Estilo de vida",
+      "smoking": "Fumar",
+      "pets": "Mascotas",
+      "partying": "Fiestas",
+      "cleanliness": "Limpieza",
+      "schedule": "Horario",
+      "saving": "Guardando…",
+      "save": "Guardar preferencias",
+      "personalProfileRequired": "Personal profile required",
+      "personalProfileDescription": "Roommate preferences are only available for personal profiles. Please switch to your personal profile to manage your roommate settings.",
+      "switchToPersonal": "Switch to personal profile",
+      "options": {
+        "gender": {
+          "any": "Any",
+          "male": "Male",
+          "female": "Female"
+        },
+        "lifestyle": {
+          "yes": "Yes",
+          "no": "No",
+          "prefer_not": "No pref."
+        },
+        "cleanliness": {
+          "very_clean": "Very clean",
+          "clean": "Clean",
+          "average": "Average",
+          "relaxed": "Relaxed"
+        },
+        "schedule": {
+          "early_bird": "Early bird",
+          "night_owl": "Night owl",
+          "flexible": "Flexible"
+        },
+        "lease": {
+          "monthly": "Monthly",
+          "3_months": "3 months",
+          "6_months": "6 months",
+          "yearly": "Yearly",
+          "flexible": "Flexible"
+        }
+      }
     }
   },
   "safety": {
@@ -872,11 +1959,57 @@
     }
   },
   "horizon": {
-    "title": "Iniciativa Horizon",
+    "title": "Horizon Initiative",
     "description": "Iniciativa global para vivienda justa, atención médica y apoyo de viaje",
     "benefits": "Beneficios",
     "join": "Únete a Horizon",
-    "learnMore": "Saber Más"
+    "learnMore": "Saber Más",
+    "page": {
+      "benefits": {
+        "fairHousing": {
+          "title": "Vivienda justa",
+          "description": "Acceso a vivienda asequible en más de 120 ciudades con contratos éticos estandarizados"
+        },
+        "healthcare": {
+          "title": "Acceso a la salud",
+          "description": "Cobertura sanitaria universal con clínicas asociadas y telemedicina en cada ciudad Horizon"
+        },
+        "travel": {
+          "title": "Red de viajes",
+          "description": "Transporte y alojamiento con descuento al viajar entre ubicaciones Horizon"
+        },
+        "community": {
+          "title": "Apoyo comunitario",
+          "description": "Conecta con miembros locales para integración cultural, intercambio de idiomas y actividades sociales"
+        }
+      },
+      "heroTitle": "Iniciativa global de vivienda",
+      "heroSubtitle": "Creando un mundo de vivienda, salud y movilidad éticas",
+      "aboutTitle": "Sobre Horizon",
+      "aboutBody1": "Horizon es una iniciativa global diseñada para hacer la vivienda más accesible, asequible y ética para todos. Al unirte a una red de propiedades en más de 120 ciudades, los miembros acceden a vivienda justa, beneficios sanitarios y apoyo de viaje.",
+      "aboutBody2": "Nuestra misión es crear entornos de vida sostenibles que fomenten la comunidad y el bienestar, reduciendo el impacto ambiental de la vivienda.",
+      "benefitsTitle": "Beneficios para miembros",
+      "howItWorksTitle": "Cómo funciona",
+      "steps": {
+        "apply": {
+          "title": "Solicitar membresía",
+          "description": "Completa tu perfil y envía una solicitud con tus necesidades y preferencias de vivienda."
+        },
+        "verify": {
+          "title": "Verificación",
+          "description": "Nuestro equipo revisa tu solicitud y verifica tu identidad e información de antecedentes."
+        },
+        "access": {
+          "title": "Accede a la red",
+          "description": "Una vez aprobado, explora y reserva propiedades en nuestra red global con acceso prioritario."
+        }
+      },
+      "joinTitle": "¿Listo para unirte a Horizon?",
+      "joinSubtitle": "Solicítalo hoy y da el primer paso hacia una vivienda ética y accesible en todo el mundo.",
+      "storiesTitle": "Historias de miembros",
+      "story1": "Horizon facilitó mucho mi mudanza. Encontré un piso ético en Berlín en una semana y la cobertura sanitaria me ayudó cuando necesité atención urgente.",
+      "story2": "Como nómada digital, tener acceso a vivienda de calidad en varias ciudades ha cambiado mi vida. El aspecto comunitario es lo que hace especial a Horizon."
+    }
   },
   "settings": {
     "title": "Configuración",
@@ -889,7 +2022,8 @@
       "supportFeedback": "Soporte y Comentarios",
       "preferences": "Preferencias de la App",
       "quickActions": "Acciones Rápidas",
-      "data": "Gestión de Datos"
+      "data": "Gestión de Datos",
+      "notifications": "Notifications"
     },
     "aboutHomiio": {
       "appName": "Homiio",
@@ -945,8 +2079,27 @@
       "title": "Moneda",
       "selectCurrency": "Selecciona tu moneda preferida",
       "description": "Esto se usará para mostrar precios en toda la aplicación",
-      "currencyChanged": "Moneda cambiada exitosamente"
-    }
+      "currencyChanged": "Moneda cambiada exitosamente",
+      "errorChanging": "Failed to change currency. Please try again."
+    },
+    "language": {
+      "title": "Language",
+      "choose": "Elige un idioma",
+      "footer": "Cambiar el idioma actualiza las etiquetas de la app al instante.",
+      "emptyTitle": "No se encontraron idiomas",
+      "emptyDescription": "No hay opciones de idioma disponibles",
+      "subtitle": "Select your preferred language"
+    },
+    "notifications": {
+      "detailDesc": "Choose which alerts you receive",
+      "detail": "Notification categories"
+    },
+    "account": {
+      "filesDescription": "Manage uploaded documents",
+      "files": "Files"
+    },
+    "signOutFailed": "Failed to sign out",
+    "signOutSuccess": "Signed out"
   },
   "common": {
     "cancel": "Cancelar",
@@ -961,8 +2114,8 @@
     "loading": "Cargando...",
     "retry": "Reintentar",
     "save": "Guardar",
-    "saving": "Guardando...",
-    "name": "Nombre",
+    "saving": "Saving...",
+    "name": "Name",
     "emoji": "Emoji",
     "color": "Color",
     "delete": "Eliminar",
@@ -995,14 +2148,7 @@
     "view": "Ver",
     "details": "Detalles",
     "more": "Más",
-    "Sign in to save searches": "Inicia sesión para guardar búsquedas",
-    "Go to Search": "Ir a Buscar",
-    "No saved searches yet": "Aún no hay búsquedas guardadas",
-    "Create New Search": "Crear Nueva Búsqueda",
-    "View All": "Ver Todo",
-    "Sign in to create property alerts": "Inicia sesión para crear alertas de propiedades",
     "Creating...": "Creando...",
-    "Create Alert": "Crear Alerta",
     "less": "Menos",
     "all": "Todo",
     "none": "Ninguno",
@@ -1010,9 +2156,11 @@
     "noData": "No hay datos disponibles",
     "noResults": "No se encontraron resultados",
     "tryAgain": "Intentar de nuevo",
-    "goBack": "Volver",
+    "goBack": "Go Back",
     "goHome": "Ir al inicio",
-    "signIn": "Iniciar sesión"
+    "signIn": "Iniciar sesión",
+    "month": "month",
+    "reset": "Reset"
   },
   "sindi": {
     "name": "Sindi",
@@ -1134,7 +2282,9 @@
     },
     "errors": {
       "connection": "Error de Conexión",
-      "connectionMessage": "Por favor verifica tu conexión e inténtalo de nuevo."
+      "connectionMessage": "Por favor verifica tu conexión e inténtalo de nuevo.",
+      "uploadFailedTitle": "Error al subir",
+      "uploadAnalyzeFailed": "No se pudo analizar el archivo."
     },
     "shared": {
       "loading": "Cargando Conversación Compartida",
@@ -1176,6 +2326,18 @@
         "title": "Inicia Tu Conversación",
         "subtitle": "Pregúntale a Sindi sobre derechos de inquilinos, búsqueda de vivienda, o cualquier pregunta relacionada con vivienda. Estoy aquí para ayudarte a luchar por la justicia habitacional."
       }
+    },
+    "settings": {
+      "resetMessage": "This will reset all Sindi preferences to their defaults.",
+      "resetTitle": "Reset Sindi?",
+      "reset": "Reset Sindi to defaults",
+      "actions": "Actions",
+      "tipsDescription": "Surface inline guidance while you chat.",
+      "tips": "Show tips & hints",
+      "behaviorFooter": "Tune how Sindi behaves while you browse properties.",
+      "behavior": "Behavior",
+      "title": "Sindi preferences",
+      "resetDone": "Sindi preferences reset."
     }
   },
   "sidebar": {
@@ -1196,7 +2358,8 @@
       "tips": "Consejos",
       "hostCalendar": "Calendario de anfitrión",
       "hostReservations": "Reservas de anfitrión",
-      "landlordApplications": "Bandeja de solicitudes"
+      "landlordApplications": "Bandeja de solicitudes",
+      "insights": "Insights"
     },
     "actions": {
       "addProperty": "Agregar Propiedad",
@@ -1248,7 +2411,9 @@
       "noted": "Con notas",
       "quickSaves": "Guardados rápidos",
       "folders": "Carpetas",
-      "profiles": "Perfiles"
+      "profiles": "Perfiles",
+      "searches": "Saved Searches",
+      "label": "Saved view"
     },
     "view": {
       "list": "Lista",
@@ -1303,7 +2468,63 @@
       "newest": "Más Recientes Primero",
       "oldest": "Más Antiguos Primero",
       "alphabetical": "Alfabético"
-    }
+    },
+    "toast": {
+      "loadFoldersFailed": "No se pudieron cargar las carpetas",
+      "folderCreated": "Carpeta creada correctamente",
+      "folderCreateFailed": "No se pudo crear la carpeta",
+      "folderUpdated": "Carpeta actualizada correctamente",
+      "folderUpdateFailed": "No se pudo actualizar la carpeta",
+      "folderDeleted": "Carpeta eliminada correctamente",
+      "folderDeleteFailed": "No se pudo eliminar la carpeta",
+      "propertySaved": "Propiedad guardada correctamente",
+      "propertySaveFailed": "No se pudo guardar la propiedad",
+      "propertyRemoved": "Propiedad eliminada de guardados",
+      "propertyUnsaveFailed": "No se pudo quitar de guardados",
+      "propertySavedToFolder": "Propiedad guardada en la carpeta",
+      "saveToFolderFailed": "No se pudo guardar en la carpeta"
+    },
+    "folder": {
+      "title": "Guardar en carpeta",
+      "createNew": "Crear carpeta nueva",
+      "folderNamePlaceholder": "Nombre de la carpeta",
+      "chooseColor": "Elegir color",
+      "chooseEmoji": "Elegir emoji",
+      "creating": "Creando...",
+      "createAndSave": "Crear y guardar",
+      "propertyCount_one": "{{count}} propiedad",
+      "propertyCount_other": "{{count}} propiedades",
+      "alertFolderNameRequired": "Introduce un nombre para la carpeta",
+      "alertDefaultFolderRename": "La carpeta predeterminada no se puede renombrar."
+    },
+    "exploreCta": "Explore properties",
+    "loadFailed": "We couldn't load this folder",
+    "noPropertiesDescription": "Save properties to see them here.",
+    "noProperties": "No saved properties",
+    "noResults": "No matches",
+    "createFolder": "Create folder",
+    "noFoldersDescription": "Create folders to organise the places you like.",
+    "noFolders": "No folders yet"
+  },
+  "imageUpload": {
+    "permissionTitle": "Permiso requerido",
+    "permissionMessage": "Necesitamos permiso para acceder a la galería y subir imágenes.",
+    "maxImagesTitle": "Máximo de imágenes alcanzado",
+    "maxImagesMessage": "Puedes subir un máximo de {{max}} imágenes.",
+    "selectFailed": "No se pudieron seleccionar las imágenes. Inténtalo de nuevo.",
+    "photoFailed": "No se pudo tomar la foto. Inténtalo de nuevo.",
+    "uploadFailed": "No se pudieron subir algunas imágenes. Inténtalo de nuevo.",
+    "deleteTitle": "Eliminar imagen",
+    "deleteMessage": "¿Seguro que quieres eliminar esta imagen?",
+    "deleteFailed": "No se pudo eliminar la imagen. Inténtalo de nuevo.",
+    "choosePhotos": "Choose Photos",
+    "takePhoto": "Take Photo",
+    "uploading": "Uploading images...",
+    "imageCount": "{{current}} of {{max}} images uploaded",
+    "primary": "Primary",
+    "addMore": "Add More",
+    "helperText": "Upload high-quality images of your property. Include photos of all rooms, exterior, and any special features.",
+    "helperPrimaryNote": " The first image will be set as the primary image."
   },
   "donations": {
     "widget": {
@@ -1506,7 +2727,7 @@
       "forSale": "En venta",
       "exchange": "Intercambio",
       "verified": "Verificado",
-      "eco": "Eco",
+      "eco": "Ecológico",
       "instantBook": "Reserva inmediata"
     },
     "offering": {
@@ -1579,7 +2800,800 @@
       "loanAmount": "Importe del préstamo",
       "totalInterest": "Intereses totales",
       "totalPaid": "Total pagado"
+    },
+    "cta": {
+      "housingAuthority": "Vivienda pública",
+      "landlord": "Arrendador",
+      "applyOnStateWebsite": "Solicitar en la web oficial",
+      "viewOnSourceWebsite": "Ver en el portal de origen",
+      "callNow": "Llamar ahora",
+      "moreByOwner": "Más propiedades de este propietario"
     }
   },
-  "goBack": "Volver"
+  "goBack": "Volver",
+  "app": {
+    "welcome": {
+      "title": "Welcome to Homiio! 👋",
+      "subtitle": "Thanks for trying out our app. Start exploring now!"
+    },
+    "errors": {
+      "screenNotExist": "This screen doesn't exist.",
+      "goHome": "Go to home screen!",
+      "noResults": "No results found for"
+    },
+    "loading": "Loading...",
+    "battery": "Battery"
+  },
+  "tips": {
+    "article": "Article",
+    "all": "All",
+    "loadError": "Couldn't load tips",
+    "tryAgain": "Please try again.",
+    "emptyTitle": "No tips yet",
+    "emptyDescription": "Check back soon for new rental guides and advice.",
+    "unavailable": "Article unavailable",
+    "missingSlug": "This tip could not be loaded.",
+    "loadFailed": "This tip could not be loaded.",
+    "related": "Related tips"
+  },
+  "notFound": {
+    "title": "Página no encontrada",
+    "message": "La página que buscas no existe.",
+    "goBack": "Volver"
+  },
+  "statusBadge": {
+    "draft": "Borrador",
+    "pending": "Pendiente",
+    "pendingSignatures": "Firmas pendientes",
+    "active": "Activo",
+    "expired": "Vencido",
+    "terminated": "Rescindido",
+    "cancelled": "Cancelado",
+    "processing": "Procesando",
+    "completed": "Completado",
+    "failed": "Fallido",
+    "refunded": "Reembolsado",
+    "success": "Éxito",
+    "warning": "Advertencia",
+    "error": "Error",
+    "info": "Información",
+    "investigating": "En investigación",
+    "resolved": "Resuelto",
+    "online": "En línea",
+    "offline": "Sin conexión",
+    "unknown": "Desconocido",
+    "application": {
+      "submitted": "Enviada",
+      "reviewing": "En revisión",
+      "approved": "Aprobada",
+      "rejected": "Rechazada",
+      "withdrawn": "Retirada"
+    },
+    "reservation": {
+      "pending": "Pendiente",
+      "confirmed": "Confirmada",
+      "declined": "Rechazada",
+      "cancelled": "Cancelada",
+      "completed": "Completada"
+    }
+  },
+  "applications": {
+    "list": {
+      "title": "Mis solicitudes",
+      "filterAll": "Todas",
+      "filterActive": "Activas",
+      "filterDecided": "Decididas",
+      "filterWithdrawn": "Retiradas",
+      "signInTitle": "Inicia sesión para ver tus solicitudes",
+      "signInDescription": "Haz seguimiento de las solicitudes de inquilino que has enviado a arrendadores.",
+      "signIn": "Iniciar sesión",
+      "loadError": "No se pudieron cargar tus solicitudes",
+      "tryAgain": "Inténtalo de nuevo.",
+      "retry": "Reintentar",
+      "emptyAllTitle": "Aún no hay solicitudes.",
+      "emptyFilteredTitle": "Nada en esta vista.",
+      "emptyAllDescription": "Explora anuncios y envía una solicitud para un alquiler a largo plazo.",
+      "emptyFilteredDescription": "Prueba otro filtro o envía una nueva solicitud.",
+      "exploreStays": "Explorar alojamientos",
+      "today": "Hoy",
+      "thisWeek": "Esta semana",
+      "earlier": "Anteriores"
+    },
+    "card": {
+      "propertyFallback": "Propiedad",
+      "applicantFallback": "Solicitante",
+      "monthLease": "Contrato de {{count}} meses",
+      "moveIn": "Entrada",
+      "submitted": "Enviada el {{date}}",
+      "perMonth": "/ mes",
+      "accessibility": "Solicitud {{id}}"
+    },
+    "toast": {
+      "openDocumentFailed": "No se pudo abrir el documento.",
+      "withdrawn": "Solicitud retirada",
+      "withdrawFailed": "No se pudo retirar la solicitud"
+    },
+    "documentType": {
+      "id": "Identificación",
+      "income": "Ingresos",
+      "reference": "Referencia",
+      "other": "Otro"
+    },
+    "landlord": {
+      "toastOpenDocumentFailed": "No se pudo abrir el documento.",
+      "review": {
+        "reviewing": {
+          "title": "¿Marcar como en revisión?",
+          "message": "El solicitante sabrá que tienes su solicitud abierta. Podrás aprobar o rechazar después.",
+          "confirm": "Marcar como en revisión",
+          "successToast": "Solicitud marcada como en revisión"
+        },
+        "approve": {
+          "title": "¿Aprobar solicitud?",
+          "message": "Se notificará al solicitante y podrá avanzar para firmar el contrato.",
+          "confirm": "Aprobar",
+          "successToast": "Solicitud aprobada"
+        },
+        "reject": {
+          "title": "¿Rechazar solicitud?",
+          "message": "Se notificará al solicitante. No se puede deshacer, pero puede enviar una nueva solicitud más adelante.",
+          "confirm": "Rechazar",
+          "successToast": "Solicitud rechazada"
+        }
+      },
+      "toastUpdateFailed": "No se pudo actualizar la solicitud"
+    },
+    "field": {
+      "moveInDate": "Move-in date",
+      "notesPlaceholder": "Anything else the landlord should know about you?",
+      "removeDocument": "Remove document",
+      "pickDocuments": "Add documents",
+      "addReference": "Add another reference",
+      "email": "Email",
+      "phone": "Phone number",
+      "relationship": "Relationship",
+      "namePlaceholder": "Jane Doe",
+      "name": "Full name",
+      "removeReference": "Remove reference",
+      "referenceIndex": "Reference {{index}}",
+      "employment": "Employment status",
+      "monthlyIncomePlaceholder": "e.g. 2400",
+      "monthlyIncome": "Gross monthly income",
+      "leaseTermCustomPlaceholder": "Number of months",
+      "leaseTermCustom": "Other",
+      "leaseTerm": "Lease term",
+      "moveInHelper": "Within the next 6 months.",
+      "leaseTermMonths": "{{count}} months"
+    },
+    "cta": {
+      "apply": "Apply to rent",
+      "subtitle": "Submit a quick application with your move-in date, income and references — the landlord reviews and replies inside Homiio.",
+      "title": "Interested in this place?",
+      "addMoveIn": "Add move-in date"
+    },
+    "detail": {
+      "viewStatus": "View status",
+      "alreadySubmittedBody": "You already have an application in review for this property.",
+      "alreadySubmitted": "Application submitted"
+    },
+    "actions": {
+      "submit": "Submit application"
+    },
+    "section": {
+      "notes": "Notes to landlord (optional)",
+      "documentsHelp": "Upload up to {{max}} PDFs or images (10 MB each). Pick a category per file.",
+      "documents": "Documents (optional)",
+      "referencesHelp": "Add 1 to 3 contacts the landlord can call to vouch for you.",
+      "references": "References",
+      "finances": "Income & employment",
+      "timing": "Move-in & lease term"
+    },
+    "apply": {
+      "title": "Apply to rent"
+    },
+    "success": {
+      "submitted": "Application submitted"
+    },
+    "error": {
+      "invalidForm": "Please complete every required field.",
+      "generic": "Something went wrong. Please try again.",
+      "auth": "Please sign in to apply.",
+      "notApplicable": "This property does not accept long-term applications.",
+      "external": "External listings cannot be applied to from Homiio.",
+      "alreadyApplied": "You already have an active application for this property."
+    },
+    "documents": {
+      "pickFailed": "Could not pick documents",
+      "tooLarge": "{{name}} supera los 10 MB y se omitió.",
+      "limit": "Puedes subir hasta {{max}} documentos por solicitud."
+    },
+    "employment": {
+      "employed": "Employed",
+      "selfEmployed": "Self-employed",
+      "student": "Student",
+      "retired": "Retired",
+      "unemployed": "Unemployed",
+      "other": "Other"
+    },
+    "relationship": {
+      "landlord": "Previous landlord",
+      "employer": "Employer",
+      "personal": "Personal",
+      "other": "Other"
+    },
+    "docType": {
+      "id": "ID",
+      "income": "Income proof",
+      "reference": "Reference letter",
+      "other": "Other"
+    }
+  },
+  "reservations": {
+    "card": {
+      "propertyFallback": "Propiedad",
+      "night": "noche",
+      "nights": "noches",
+      "guest": "huésped",
+      "guests": "huéspedes",
+      "hostGuestSuffix": "(huésped)",
+      "accessibility": "Reserva {{id}}"
+    },
+    "detail": {
+      "title": "Reserva",
+      "invalidId": "ID de reserva no válido",
+      "invalidIdDescription": "El enlace no incluye la referencia de la reserva.",
+      "unavailable": "Reserva no disponible",
+      "unavailableDescription": "No se pudo cargar esta reserva.",
+      "goBack": "Volver",
+      "tripDetails": "Detalles del viaje",
+      "checkIn": "Entrada",
+      "checkOut": "Salida",
+      "guests": "Huéspedes",
+      "nights": "Noches",
+      "price": "Precio",
+      "approve": "Aprobar",
+      "decline": "Rechazar",
+      "cancelReservation": "Cancelar reserva",
+      "cancelPolicyNote": "Cancellation is no longer possible under the {{policy}} policy. Contact your host if you need to make changes.",
+      "confirmCancelTitle": "Cancel reservation?",
+      "confirmCancelBody": "This will release the dates back to the host and end the booking.",
+      "confirmCancelAction": "Yes, cancel",
+      "confirmApproveTitle": "Approve reservation?",
+      "confirmApproveBody": "The guest will be notified and the dates will be marked confirmed on your calendar.",
+      "confirmDeclineTitle": "Decline reservation?",
+      "confirmDeclineBody": "The guest will be notified that this request was declined.",
+      "toastConfirmed": "Reserva confirmada",
+      "toastDeclined": "Reserva rechazada",
+      "toastCancelled": "Reserva cancelada",
+      "toastUpdateFailed": "No se pudo actualizar"
+    }
+  },
+  "reviews": {
+    "card": {
+      "anonymous": "Anónimo",
+      "verifiedResident": "Residente verificado",
+      "verified": "Verificado",
+      "confident": "{{score}}% de confianza",
+      "proof": "prueba",
+      "proofs": "pruebas",
+      "karma": "{{score}} karma",
+      "livedMonths": "Vivió {{count}} meses",
+      "perMonth": "{{price}} {{currency}}/mes",
+      "moreIssues": "+{{count}} más",
+      "positive": "Positivo:",
+      "negative": "Negativo:",
+      "helpful": "Útil ({{count}})",
+      "report": "Reportar",
+      "reply": "Responder",
+      "recommends": "✓ Recomienda",
+      "doesNotRecommend": "✗ No recomienda",
+      "underReview": "En revisión",
+      "alertThankYouTitle": "Gracias",
+      "alertThankYouBody": "Tu comentario ha sido registrado.",
+      "alertReportTitle": "Reportar reseña",
+      "alertReportBody": "¿Seguro que quieres reportar esta reseña por contenido inapropiado?",
+      "alertReportConfirm": "Reportar",
+      "alertReportedTitle": "Reportada",
+      "alertReportedBody": "Esta reseña ha sido reportada a nuestro equipo de moderación.",
+      "alertReplyTitle": "Responder a la reseña",
+      "alertReplyBody": "La función de respuesta permitirá a arrendadores y administradores de propiedades responder a las reseñas."
+    },
+    "write": {
+      "validationTitle": "Error de validación",
+      "streetRequired": "Introduce una dirección.",
+      "cityRequired": "Introduce una ciudad.",
+      "postalCodeRequired": "Introduce un código postal.",
+      "countryRequired": "Introduce un país.",
+      "opinionRequired": "Comparte tu opinión sobre esta dirección.",
+      "opinionMinLength": "Tu opinión debe tener al menos 10 caracteres.",
+      "priceRequired": "Introduce un precio válido.",
+      "datesRequired": "Introduce las fechas de inicio y fin.",
+      "recommendationRequired": "Indica si recomendarías esta dirección.",
+      "ratingRequired": "Asigna una valoración del 1 al 5.",
+      "submitSuccess": "¡Tu reseña se ha enviado correctamente!",
+      "submitFailed": "No se pudo enviar la reseña",
+      "submitFailedRetry": "No se pudo enviar la reseña. Inténtalo de nuevo.",
+      "loadAddressFailed": "Couldn't load address",
+      "title": "Write review"
+    }
+  },
+  "subscriptions": {
+    "title": "Suscripciones",
+    "alertError": "Error",
+    "alertSuccess": "Éxito",
+    "authRequired": "Autenticación requerida",
+    "checkoutFailed": "No se pudo iniciar el pago",
+    "portalFailed": "No se pudo abrir la gestión de suscripciones",
+    "syncSuccess": "Estado de suscripción sincronizado desde Stripe",
+    "syncFailed": "No se pudo sincronizar la suscripción",
+    "cancelImmediateSuccess": "Suscripción cancelada inmediatamente",
+    "cancelFailed": "No se pudo cancelar la suscripción",
+    "cancelEndOfPeriodSuccess": "La suscripción se cancelará al final del periodo actual",
+    "debugFailed": "No se pudo depurar la suscripción",
+    "plusActive": "Homiio Plus active",
+    "plusInactive": "Upgrade to Homiio Plus",
+    "manage": "Manage subscription",
+    "sync": "Sync from Stripe",
+    "cancel": "Cancel subscription",
+    "cancelImmediate": "Cancel immediately",
+    "cancelEndOfPeriod": "Cancel at period end",
+    "fileCredits": "{{count}} file credits",
+    "since": "Member since {{date}}",
+    "canceledOn": "Canceled on {{date}}",
+    "lastPayment": "Last payment {{date}}",
+    "products": {
+      "plus": "Homiio Plus",
+      "plusDescription": "Priority support and premium features",
+      "file": "File credits",
+      "fileDescription": "Extra document storage credits",
+      "founder": "Founder",
+      "founderDescription": "Support Homiio and unlock founder perks"
+    },
+    "subscribe": "Subscribe",
+    "buyCredits": "Buy credits",
+    "becomeFounder": "Become a founder",
+    "page": {
+      "headerTitle": "Homiio+",
+      "headerSubtitle": "Tu aliado de vivienda ética",
+      "introText": "Tu suscripción te da acceso a Sindi, el asistente legal que analiza tus contratos de alquiler y señala cláusulas abusivas. Sin anuncios, sin especulación, sin venta de datos.",
+      "payPerContract": {
+        "title": "Pago por contrato",
+        "price": "5 € por revisión de contrato",
+        "description": "Perfecto para un uso puntual.",
+        "reviewButton": "Revisar contrato"
+      },
+      "plus": {
+        "title": "Suscripción Homiio+",
+        "price": "9,99 €/mes",
+        "description": "Incluye hasta 10 contratos al mes gratis. A partir del 11.º contrato: 2,50 € cada uno.",
+        "activeBadge": "Suscripción activa",
+        "canceledBadge": "Cancelada el {{date}}",
+        "featureHistory": "Historial ilimitado de contratos",
+        "featureAlerts": "Alertas y notificaciones legales",
+        "featureSupport": "Soporte prioritario",
+        "manage": "Gestionar suscripción",
+        "resubscribe": "Volver a suscribirse",
+        "subscribeNow": "Suscribirse ahora"
+      },
+      "founder": {
+        "title": "Patrocinador fundador",
+        "price": "Aportación desde 10 €/mes",
+        "description": "Apoya la independencia de Homiio. Obtén reconocimiento en la app y acceso anticipado a funciones.",
+        "becomeSupporter": "Hazte patrocinador"
+      },
+      "footer": "Cada euro mantiene Homiio ético, independiente y orientado a la comunidad.",
+      "starting": "Iniciando…",
+      "back": "Volver",
+      "notAvailable": "N/D",
+      "cancelImmediateTitle": "Cancelar inmediatamente",
+      "cancelImmediateBody": "Esto cancelará tu suscripción de inmediato y perderás el acceso a las funciones de Homiio+. ¿Estás seguro?",
+      "no": "No",
+      "yesCancelNow": "Sí, cancelar ahora"
+    }
+  },
+  "recentlyViewed": {
+    "trackFailed": "No se pudo registrar la visita a la propiedad",
+    "clearSuccess": "Propiedades vistas recientemente borradas",
+    "clearFailed": "No se pudieron borrar las propiedades vistas recientemente"
+  },
+  "host": {
+    "calendar": {
+      "title": "Calendario de anfitrión",
+      "signInTitle": "Inicia sesión para gestionar tu calendario",
+      "signInDescription": "Bloquea fechas y haz seguimiento de reservas desde un solo lugar.",
+      "signIn": "Iniciar sesión",
+      "loadPropertiesError": "No se pudieron cargar tus propiedades",
+      "tryAgain": "Inténtalo de nuevo.",
+      "emptyTitle": "Añade tu primera propiedad",
+      "emptyDescription": "Publica un alojamiento para que los huéspedes puedan solicitar fechas aquí.",
+      "createListing": "Crear anuncio",
+      "chooseProperty": "Elegir propiedad",
+      "legendConfirmed": "Confirmada",
+      "legendPending": "Pendiente",
+      "legendBlocked": "Bloqueada",
+      "legendAvailable": "Disponible",
+      "availabilityError": "No se pudo cargar la disponibilidad",
+      "blockTitle": "Bloquear estas fechas",
+      "blockBodyRange": "Bloquear del {{start}} al {{end}}.",
+      "blockBodySingle": "Elige cuánto tiempo estarán indisponibles estas fechas.",
+      "blockConfirm": "Bloquear",
+      "blockReasonLabel": "Motivo (opcional)",
+      "blockReasonPlaceholder": "Mantenimiento, uso personal, ...",
+      "toastBlocked": "Fechas bloqueadas",
+      "toastBlockFailed": "No se pudo bloquear",
+      "propertyNotFound": "Propiedad no encontrada",
+      "property": "Propiedad"
+    },
+    "reservations": {
+      "title": "Reservas",
+      "allReservations": "Todas las reservas",
+      "signInTitle": "Inicia sesión para gestionar reservas",
+      "signInDescription": "Aprueba o rechaza solicitudes de huéspedes desde un solo lugar.",
+      "signIn": "Iniciar sesión",
+      "filterAll": "Todas",
+      "loadError": "No se pudieron cargar las reservas",
+      "tryAgain": "Inténtalo de nuevo.",
+      "emptyTitle": "Aún no hay reservas",
+      "emptyDescription": "Las solicitudes de huéspedes aparecerán aquí cuando alguien reserve.",
+      "toastConfirmed": "Reserva confirmada",
+      "toastDeclined": "Reserva rechazada",
+      "toastUpdateFailed": "No se pudo actualizar",
+      "confirm": "Confirmar",
+      "decline": "Rechazar",
+      "approve": "Aprobar",
+      "view": "Ver",
+      "filterPending": "Pendiente",
+      "filterConfirmed": "Confirmada",
+      "filterDeclined": "Rechazada",
+      "filterCancelled": "Cancelada",
+      "filterCompleted": "Completada"
+    }
+  },
+  "stays": {
+    "list": {
+      "title": "Estancias",
+      "filterAll": "Todas",
+      "filterUpcoming": "Próximas",
+      "filterPast": "Pasadas",
+      "filterCancelled": "Canceladas",
+      "groupUpcoming": "Próximas",
+      "groupPast": "Pasadas",
+      "groupCancelled": "Canceladas",
+      "signInTitle": "Inicia sesión para ver tus estancias",
+      "signInDescription": "Haz seguimiento de las reservas de corta estancia que hayas hecho.",
+      "signIn": "Iniciar sesión",
+      "loadError": "No se pudieron cargar las estancias",
+      "tryAgain": "Inténtalo de nuevo.",
+      "emptyAllTitle": "Aún no hay estancias",
+      "emptyFilteredTitle": "Nada en esta vista.",
+      "emptyAllDescription": "Cuando reserves un alojamiento aparecerá aquí.",
+      "emptyFilteredDescription": "Prueba otro filtro o explora nuevas estancias.",
+      "exploreStays": "Explorar estancias"
+    }
+  },
+  "addresses": {
+    "detail": {
+      "title": "Address",
+      "loadError": "No se pudo cargar esta dirección",
+      "tryAgain": "Inténtalo de nuevo.",
+      "propertiesSection": "Propiedades",
+      "reviewsSection": "Reseñas",
+      "emptyPropertiesTitle": "Aún no hay propiedades aquí",
+      "emptyPropertiesDescription": "Los anuncios en esta dirección aparecerán aquí.",
+      "emptyReviewsTitle": "Aún no hay reseñas",
+      "emptyReviewsDescription": "Sé el primero en compartir tu experiencia en esta dirección.",
+      "writeReview": "Escribir una reseña",
+      "switchLevel": "Cambiar nivel",
+      "buildingLevel": "Edificio",
+      "unitLevel": "Unidad",
+      "notFound": "Dirección no encontrada",
+      "notFoundDescription": "No encontramos detalles para esta dirección.",
+      "storiesTitle": "Historias de residentes",
+      "tabOverall": "General",
+      "tabApartments": "Apartamentos",
+      "tabCommunity": "Comunidad",
+      "tabArea": "Zona",
+      "tabProperties": "Propiedades ({{count}})",
+      "tabReviews": "Reseñas ({{count}})"
+    },
+    "display": {
+      "copySuccess": "Dirección copiada al portapapeles",
+      "copyFailed": "No se pudo copiar la dirección",
+      "mapsFailed": "No se pudo abrir mapas"
+    }
+  },
+  "propertyCreate": {
+    "location": {
+      "title": "Location",
+      "instructions": "📍 Address Details: Fill in the complete address information. Our system uses a hierarchical structure:\n• STREET level: Street name only\n• BUILDING level: Street + number + building details\n• UNIT level: Building + floor + unit/apartment details\nReviews and listings are organized by these levels for better organization.",
+      "country": "Country or Region",
+      "countryPickerTitle": "Country or Region",
+      "state": "State / Province / Region",
+      "statePickerTitle": "State / Province / Region",
+      "city": "City",
+      "street": "Street",
+      "number": "Number",
+      "postalCode": "Postal code",
+      "floor": "Floor",
+      "unit": "Unit / Apartment",
+      "showFloor": "Show floor field",
+      "hideFloor": "Hide floor field",
+      "selectCountry": "Select country or region",
+      "streetPlaceholder": "Street name",
+      "unitOptional": "Unit/Apartment Number (optional)",
+      "unitPlaceholder": "Apartment, suite, etc. (optional)",
+      "buildingNameOptional": "Nombre del edificio (opcional)",
+      "buildingNamePlaceholder": "p. ej., Torre Barcelona",
+      "blockOptional": "Bloque (opcional)",
+      "blockPlaceholder": "p. ej., Bloque A",
+      "entranceOptional": "Entrada/Puerta (opcional)",
+      "entrancePlaceholder": "p. ej., Puerta 1, Entrada B",
+      "subunitOptional": "Subunidad (opcional)",
+      "subunitPlaceholder": "p. ej., Habitación A",
+      "numberPlaceholder": "Introduce el número",
+      "floorPlaceholder": "Introduce la planta",
+      "floorPublic": "Público",
+      "floorPrivate": "Privado",
+      "floorPrivacyHint": "ℹ️ Se mostrará de forma aproximada por privacidad",
+      "neighborhoodOptional": "Barrio (opcional)",
+      "neighborhoodPlaceholder": "p. ej., Gràcia, Sant Andreu, Eixample",
+      "districtOptional": "Distrito (opcional)",
+      "districtPlaceholder": "p. ej., Distrito administrativo",
+      "poBoxOptional": "Apartado postal (opcional)",
+      "poBoxPlaceholder": "p. ej., Apartado 123",
+      "referenceOptional": "Referencia (opcional)",
+      "referencePlaceholder": "p. ej., Cerca del metro",
+      "cityDistrict": "Ciudad/Distrito",
+      "cityDistrictPlaceholder": "Ciudad o distrito",
+      "selectState": "Selecciona provincia/región",
+      "zipPostalCode": "Código postal",
+      "zipPlaceholder": "Código postal",
+      "availableFrom": "Disponible desde",
+      "availableFromPlaceholder": "Fecha de disponibilidad",
+      "leaseTerm": "Duración del contrato",
+      "leaseTermPlaceholder": "Duración del contrato"
+    },
+    "amenities": {
+      "title": "Amenities",
+      "subtitle": "Select the amenities available at this property.",
+      "rulesTitle": "Servicios y normas",
+      "houseRules": "House Rules",
+      "petsAllowed": "Pets Allowed",
+      "smokingAllowed": "Smoking Allowed",
+      "partiesAllowed": "Parties Allowed",
+      "guestsAllowed": "Invitados permitidos",
+      "maxGuests": "Número máximo de invitados",
+      "maxGuestsPlaceholder": "e.g., 2",
+      "yes": "Yes",
+      "no": "No"
+    }
+  },
+  "booking": {
+    "toast": {
+      "pickDates": "Selecciona primero las fechas de entrada y salida",
+      "minStay": "Estancia mínima de {{count}} {{unit}}",
+      "maxStay": "Estancia máxima de {{count}} {{unit}}",
+      "night": "noche",
+      "nights": "noches",
+      "failed": "Error en la reserva"
+    },
+    "accessibility": {
+      "selectDates": "Select dates",
+      "selectGuests": "Select guests",
+      "close": "Close"
+    }
+  },
+  "searchBar": {
+    "search": "Buscar",
+    "long": {
+      "propertyType": "Tipo de propiedad",
+      "moveIn": "Fecha de entrada",
+      "where": "Dónde",
+      "where.value": "Cualquier ciudad",
+      "moveIn.value": "Añadir fecha",
+      "propertyType.value": "Cualquier tipo"
+    },
+    "vacation": {
+      "where": "Dónde",
+      "when": "Cuándo",
+      "who": "Quién",
+      "where.value": "Cualquier destino",
+      "when.value": "Añadir fechas",
+      "who.value": "Añadir huéspedes"
+    },
+    "mode": {
+      "vacation": "Vacaciones",
+      "longTerm": "Largo plazo",
+      "hint": "Cambia entre alquileres a largo plazo y estancias vacacionales",
+      "label": "Modo de alquiler"
+    }
+  },
+  "error": {
+    "publicHousing": {
+      "openFailed": "No se pudo abrir el sitio web de vivienda"
+    },
+    "call": {
+      "failed": "No se pudo abrir el marcador telefónico",
+      "noPhone": "No hay número de teléfono disponible",
+      "notAllowed": "El propietario no acepta llamadas"
+    },
+    "profile": {
+      "notFound": "Perfil del propietario no encontrado"
+    },
+    "auth": {
+      "required": "Inicia sesión para llamar al propietario"
+    },
+    "contact": {
+      "noPhone": "No hay teléfono disponible para este anuncio",
+      "openFailed": "No se pudo abrir el enlace de contacto"
+    },
+    "source": {
+      "openFailed": "No se pudo abrir el sitio web de origen",
+      "noUrl": "URL del sitio de origen no disponible"
+    },
+    "boundary": {
+      "title": "Algo salió mal",
+      "message": "Un problema inesperado interrumpió lo que estabas haciendo. Puedes volver a intentarlo o enviarnos un informe rápido para que lo revisemos.",
+      "retry": "Reintentar",
+      "reportIssue": "Informar del problema",
+      "errorId": "ID de error",
+      "copyIdHint": "Toca para copiar el ID",
+      "copiedToClipboard": "Copiado al portapapeles",
+      "showDetails": "Mostrar detalles técnicos",
+      "hideDetails": "Ocultar detalles técnicos",
+      "technicalDetails": "Detalles técnicos",
+      "maxRetriesTitle": "Sigue sin funcionar",
+      "maxRetriesMessage": "Has alcanzado el límite de reintentos. Por favor, informa del problema para que podamos revisarlo.",
+      "forceRetry": "Forzar reintento",
+      "reportCopiedTitle": "Informe copiado",
+      "reportCopiedMessage": "El informe del error se ha copiado al portapapeles.",
+      "reportFailedTitle": "No se pudo copiar",
+      "reportFailedMessage": "No pudimos copiar el informe al portapapeles. Por favor, inténtalo de nuevo.",
+      "errorMessage": "Mensaje de error",
+      "errorType": "Tipo de error",
+      "stackTrace": "Traza de pila",
+      "componentStack": "Pila de componentes",
+      "deviceInformation": "Información del dispositivo"
+    },
+    "loadNotifications": "Error al cargar notificaciones"
+  },
+  "notification": {
+    "settings": {
+      "android": {
+        "openSettings": "Abrir ajustes del sistema",
+        "title": "Ajustes de Android",
+        "description": "Gestiona los canales de notificación en Ajustes > Apps > Homiio > Notificaciones."
+      },
+      "ios": {
+        "openSettings": "Abrir ajustes del sistema",
+        "title": "Ajustes de iOS",
+        "description": "Para un control más detallado, gestiona las notificaciones en Ajustes > Notificaciones > Homiio."
+      },
+      "test": {
+        "title": "Probar notificaciones",
+        "description": "Envía notificaciones de prueba para verificar que tus ajustes funcionan correctamente."
+      },
+      "property": {
+        "title": "Notificaciones de propiedades",
+        "description": "Nuevas propiedades, cambios de precio y recordatorios de visitas"
+      },
+      "message": {
+        "title": "Notificaciones de mensajes",
+        "description": "Nuevos mensajes de agentes, propietarios y otros usuarios"
+      },
+      "contract": {
+        "title": "Notificaciones de contratos",
+        "description": "Actualizaciones de contratos, firmas y plazos importantes"
+      },
+      "payment": {
+        "title": "Notificaciones de pagos",
+        "description": "Confirmaciones de pago, recordatorios y recibos"
+      },
+      "reminder": {
+        "title": "Notificaciones de recordatorios",
+        "description": "Recordatorios de visitas, plazos de solicitudes y seguimientos"
+      },
+      "system": {
+        "title": "Notificaciones del sistema",
+        "description": "Actualizaciones de la app, mantenimiento y anuncios importantes"
+      },
+      "marketing": {
+        "title": "Notificaciones de marketing",
+        "description": "Ofertas promocionales, boletines y descuentos especiales"
+      },
+      "sound": {
+        "title": "Sonido",
+        "description": "Reproducir sonido al recibir notificaciones"
+      },
+      "badge": {
+        "title": "Contador de insignia",
+        "description": "Mostrar el número de no leídas en el icono de la app"
+      },
+      "push": {
+        "title": "Notificaciones push",
+        "description": "Recibir notificaciones aunque la app esté cerrada"
+      },
+      "title": "Ajustes de notificaciones",
+      "categories": "Categorías de notificaciones",
+      "behavior": "Comportamiento de notificaciones",
+      "manage": "Gestionar notificaciones",
+      "clearAll": "Borrar todas las notificaciones",
+      "updated": "Ajustes actualizados",
+      "error": "No se pudieron actualizar los ajustes"
+    },
+    "test": {
+      "success": "Notificación de prueba enviada",
+      "property": "Probar propiedad",
+      "message": "Probar mensaje",
+      "reminder": "Probar recordatorio",
+      "repeating": "Probar repetición",
+      "error": "No se pudo enviar la notificación de prueba"
+    },
+    "empty": {
+      "filteredTitle": "Sin coincidencias",
+      "title": "Sin notificaciones",
+      "message": "¡Estás al día! Las nuevas notificaciones aparecerán aquí.",
+      "filtered": "Ninguna notificación coincide con el filtro actual"
+    },
+    "filter": {
+      "label": "Filtrar notificaciones",
+      "all": "Todas",
+      "unread": "No leídas"
+    },
+    "scheduled": {
+      "label": "Notificación programada",
+      "title": "Notificaciones programadas",
+      "clearAll": "Borrar todo"
+    },
+    "markAllRead": {
+      "action": "Marcar todo como leído",
+      "success": "Todas las notificaciones marcadas como leídas",
+      "error": "No se pudieron marcar todas como leídas"
+    },
+    "permissions": {
+      "enabled": {
+        "title": "Notificaciones activadas",
+        "description": "Recibirás notificaciones de las categorías activadas."
+      },
+      "disabled": {
+        "title": "Notificaciones desactivadas",
+        "description": "Activa las notificaciones para recibir novedades sobre propiedades, mensajes y más."
+      },
+      "title": "Activar notificaciones",
+      "message": "Recibe avisos sobre nuevas propiedades, mensajes y actualizaciones importantes.",
+      "enable": "Activar notificaciones",
+      "granted": "Permisos de notificación concedidos",
+      "denied": "Permisos de notificación denegados",
+      "error": "No se pudieron solicitar los permisos"
+    },
+    "welcome": {
+      "title": "¡Bienvenido a Homiio! 👋",
+      "body": "Gracias por probar nuestra aplicación. ¡Comienza a explorar ahora!"
+    },
+    "search": {
+      "placeholder": "Buscar notificaciones..."
+    },
+    "delete": {
+      "title": "Eliminar notificación",
+      "message": "¿Seguro que quieres eliminar esta notificación?",
+      "success": "Notificación eliminada",
+      "error": "No se pudo eliminar la notificación"
+    },
+    "clearAll": {
+      "title": "Borrar todas las notificaciones",
+      "message": "Se borrarán todas las notificaciones y se reiniciará el contador. Esta acción no se puede deshacer.",
+      "success": "Todas las notificaciones borradas",
+      "error": "No se pudieron borrar las notificaciones"
+    }
+  },
+  "address": {
+    "display": {
+      "mapPlaceholder": "Map view available",
+      "copy": "Copy",
+      "openInMaps": "Open in Maps"
+    }
+  },
+  "inbox": {
+    "title": "Buzón"
+  }
 }

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -14,155 +14,96 @@
       "transportation": "Parcheggio e trasporti",
       "community": "Spazi comuni",
       "other": "Altro"
-    }
+    },
+    "airConditioning": "Aria condizionata",
+    "airPurifier": "Sistema di purificazione dell'aria",
+    "balcony": "Balcone privato",
+    "bbqArea": "Area barbecue",
+    "bikeStorage": "Deposito bici sicuro",
+    "builtInShelving": "Scaffalature integrate",
+    "cableTv": "Predisposizione TV via cavo",
+    "ceilingFans": "Ventilatori a soffitto",
+    "coatCloset": "Guardaroba d'ingresso",
+    "communityRoom": "Sala comune",
+    "conferenceRoom": "Sala riunioni",
+    "coworkingSpace": "Spazio di coworking",
+    "daycare": "Asilo nido in loco",
+    "dimmerSwitches": "Interruttori dimmer",
+    "dishwasher": "Lavastoviglie",
+    "dogPark": "Area attività per animali",
+    "doubleVanity": "Doppio lavabo",
+    "dryer": "Asciugatrice in unità",
+    "electricity": "Elettricità inclusa",
+    "elevator": "Accesso con ascensore",
+    "energyEfficient": "Elettrodomestici efficienti",
+    "evCharging": "Ricarica veicolo elettrico",
+    "familyRoom": "Sala attività familiare",
+    "fiberInternet": "Internet in fibra",
+    "firePit": "Area con fuoco",
+    "fireSafety": "Sistema antincendio",
+    "garbageDisposal": "Tritarifiuti",
+    "gardenAccess": "Accesso al giardino",
+    "gardenSpace": "Orto comunitario",
+    "grabBars": "Maniglie di sicurezza",
+    "graniteCounters": "Piani in granito",
+    "greenRoof": "Tetto verde",
+    "gym": "Palestra",
+    "hardwoodFloors": "Pavimento in legno",
+    "heatedFloors": "Pavimento riscaldato",
+    "heating": "Riscaldamento adeguato",
+    "homeOffice": "Spazio ufficio in casa",
+    "hotTub": "Vasca idromassaggio",
+    "humidifier": "Umidificatore centralizzato",
+    "iceMaker": "Macchina del ghiaccio",
+    "insulation": "Isolamento adeguato",
+    "intercom": "Citofono",
+    "jettedTub": "Vasca idromassaggio",
+    "kitchen": "Cucina",
+    "laundryRoom": "Lavanderia condivisa",
+    "ledLighting": "Illuminazione LED",
+    "linenCloset": "Ripostiglio biancheria",
+    "mailRoom": "Sala pacchi e posta",
+    "microwave": "Microonde",
+    "mobilityAssistance": "Accessibilità e mobilità",
+    "naturalLight": "Luce naturale abbondante",
+    "oven": "Forno",
+    "pantry": "Dispensa",
+    "parkingSpace": "Posto auto",
+    "pendantLighting": "Illuminazione di design",
+    "petFriendly": "Animali ammessi",
+    "printingStation": "Centro stampa e copie",
+    "publicTransitAccess": "Accesso ai trasporti pubblici",
+    "rainwaterCollection": "Raccolta acqua piovana",
+    "rampAccess": "Accesso con rampa",
+    "recyclingProgram": "Programma di riciclaggio completo",
+    "refrigerator": "Frigorifero full-size",
+    "rooftopDeck": "Terrazza sul tetto",
+    "secureEntry": "Accesso controllato",
+    "securityCameras": "Telecamere di sicurezza",
+    "seniorServices": "Servizi di supporto per anziani",
+    "smartDoorbell": "Campanello video",
+    "smartHome": "Casa intelligente",
+    "solarPanels": "Energia solare",
+    "stainlessAppliances": "Elettrodomestici in acciaio",
+    "storageUnit": "Spazio di archiviazione",
+    "stove": "Piano cottura",
+    "studyRoom": "Spazio studio tranquillo",
+    "swimmingPool": "Piscina",
+    "teenRoom": "Sala attività per adolescenti",
+    "tileFloors": "Pavimento in piastrelle",
+    "trashPickup": "Raccolta rifiuti",
+    "usbOutlets": "Prese USB",
+    "walkInCloset": "Cabina armadio",
+    "walkInShower": "Doccia walk-in",
+    "washingMachine": "Lavatrice in unità",
+    "water": "Acqua e fognatura incluse",
+    "waterFilter": "Sistema di filtrazione acqua",
+    "wheelchairAccessible": "Accessibile in sedia a rotelle",
+    "wholeHouseFan": "Ventilatore per tutta la casa",
+    "wideDoorways": "Porte larghe",
+    "wifi": "Internet ad alta velocità",
+    "wineFridge": "Frigo per vini"
   },
-  "Home": "Home",
-  "Search": "Cerca",
-  "Notifications": "Notifiche",
-  "Messages": "Messaggi",
-  "New Post": "Nuovo Post",
-  "What's happening?": "Cosa sta succedendo?",
-  "Post": "Pubblica",
-  "Save": "Salva",
-  "Settings": "Impostazioni",
-  "Language": "Lingua",
-  "Primary Color": "Colore Principale",
-  "Apply Settings": "Applica Impostazioni",
-  "Welcome to Homiio! 👋": "Benvenuto su Homiio! 👋",
-  "Thanks for trying out our app. Start exploring now!": "Grazie per aver provato la nostra app. Inizia a esplorare ora!",
-  "This screen doesn't exist.": "Questa schermata non esiste.",
-  "Go to home screen!": "Vai alla schermata home!",
-  "Hey, how are you?": "Ciao, come stai?",
-  "Let's catch up soon!": "Aggiorniamoci presto!",
-  "liked your Post": "è piaciuto il tuo Post",
-  "reposted your Post": "ha ripostato il tuo Post",
-  "This is a sample post": "Questo è un post di esempio",
-  "Another example post": "Un altro post di esempio",
-  "Customize your view": "Personalizza la tua vista",
-  "These settings affect all the Mention accounts on this device.": "Queste impostazioni influenzano tutti gli account Mention su questo dispositivo.",
-  "Account": "Account",
-  "Manage your account settings": "Gestisci le impostazioni del tuo account",
-  "Notification preferences": "Preferenze notifiche",
-  "Privacy and security settings": "Impostazioni privacy e sicurezza",
-  "Appearance": "Aspetto",
-  "Theme, font size, colors": "Tema, dimensione font, colori",
-  "Help & Support": "Aiuto e Supporto",
-  "Get help and support": "Ottieni aiuto e supporto",
-  "About": "Informazioni",
-  "About this app": "Informazioni su questa app",
-  "Battery": "Batteria",
-  "Loading...": "Caricamento...",
-  "Trends for you": "Tendenze per te",
-  "Show more": "Mostra di più",
-  "posts": "post",
-  "File Manager": "Gestore File",
-  "Filter files by name": "Filtra file per nome",
-  "Filter files by date (MM/DD/YYYY)": "Filtra file per data (MM/GG/AAAA)",
-  "Filter files by type (e.g., image, video)": "Filtra file per tipo (es., immagine, video)",
-  "Who to follow": "Chi seguire",
-  "Search...": "Cerca...",
-  "No results found for": "Nessun risultato trovato per",
-  "Follow": "Segui",
-  "Following": "Seguito",
-  "Explore": "Esplora",
-  "Chat": "Chat",
-  "Bookmarks": "Segnalibri",
-  "Feeds": "Feed",
-  "Lists": "Liste",
-  "Videos": "Video",
-  "Sign Up": "Registrati",
-  "Sign In": "Accedi",
-  "Join the conversation": "Unisciti alla conversazione",
-  "Ask Kaana Anything": "Chiedi qualsiasi cosa a Kaana",
-  "Are you sure you want to delete this file?": "Sei sicuro di voler eliminare questo file?",
-  "No files found. Upload some files to get started!": "Nessun file trovato. Carica alcuni file per iniziare!",
-  "Clear Logs": "Cancella log",
-  "Log": "Registro",
-  "All": "Tutto",
-  "Users": "Utenti",
-  "Posts": "Post",
-  "Profiles": "Profili",
-  "No results": "Nessun risultato",
-  "mentioned you": "ti ha menzionato",
-  "shared your post": "ha condiviso il tuo post",
-  "Version": "Versione",
-  "copied to clipboard": "copiato negli appunti",
-  "Invite link copied to clipboard": "Link di invito copiato negli appunti",
-  "Join": "Unisciti",
-  "Privacy Settings": "Impostazioni privacy",
-  "Help Center": "Centro assistenza",
-  "Report a problem": "Segnala un problema",
-  "Terms of Service": "Termini di servizio",
-  "Privacy Policy": "Informativa sulla privacy",
-  "kaana.placeholder.fight_club": "Qual è la prima regola del Fight Club?",
-  "kaana.placeholder.adam_mosseri": "Chi è Adam Mosseri?",
-  "kaana.placeholder.enric_duran": "Dove si nasconde Enric Duran?",
-  "kaana.placeholder.javascript": "Scrivi un metodo Javascript per invertire una stringa",
-  "kaana.placeholder.pc_build": "Come assemblare il tuo PC?",
-  "kaana.placeholder.nate": "Come sta Nate Isern?",
-  "error.socket.not_connected": "Non connesso al server di chat",
-  "error.message.send_timeout": "Timeout invio messaggio. Riprova.",
-  "error.message.edit_timeout": "Timeout modifica. Riprova.",
-  "error.message.delete_timeout": "Timeout eliminazione. Riprova.",
-  "error.signup.missing_fields": "Compila tutti i campi",
-  "error.signup.failed": "Registrazione fallita:",
-  "error.signup.password_mismatch": "Le password non corrispondono",
-  "error.boundary.title": "Qualcosa è andato storto",
-  "error.boundary.message": "Un problema inatteso ha interrotto quello che stavi facendo. Puoi riprovare o inviarci una segnalazione rapida così possiamo indagare.",
-  "error.boundary.retry": "Riprova",
-  "error.boundary.reportIssue": "Segnala il problema",
-  "error.boundary.errorId": "ID errore",
-  "error.boundary.copyIdHint": "Tocca per copiare l'ID",
-  "error.boundary.copiedToClipboard": "Copiato negli appunti",
-  "error.boundary.showDetails": "Mostra dettagli tecnici",
-  "error.boundary.hideDetails": "Nascondi dettagli tecnici",
-  "error.boundary.technicalDetails": "Dettagli tecnici",
-  "error.boundary.maxRetriesTitle": "Continua a non funzionare",
-  "error.boundary.maxRetriesMessage": "Hai raggiunto il limite di tentativi. Segnala il problema così possiamo dargli un'occhiata.",
-  "error.boundary.forceRetry": "Forza riprova",
-  "error.boundary.reportCopiedTitle": "Segnalazione copiata",
-  "error.boundary.reportCopiedMessage": "La segnalazione dell'errore è stata copiata negli appunti.",
-  "error.boundary.reportFailedTitle": "Non è stato possibile copiare",
-  "error.boundary.reportFailedMessage": "Non siamo riusciti a copiare la segnalazione negli appunti. Riprova.",
-  "error.boundary.errorMessage": "Messaggio di errore",
-  "error.boundary.errorType": "Tipo di errore",
-  "error.boundary.stackTrace": "Stack trace",
-  "error.boundary.componentStack": "Stack dei componenti",
-  "error.boundary.deviceInformation": "Informazioni dispositivo",
-  "inbox.title": "Posta",
-  "notification.welcome.title": "Benvenuto su Homiio! 👋",
-  "notification.welcome.body": "Grazie per aver provato la nostra app. Inizia a esplorare ora!",
-  "success.signup": "Registrazione completata",
-  "action.retry": "Riprova",
-  "status.loading": "Caricamento...",
-  "state.loading": "Caricamento...",
-  "state.no_results": "Nessun risultato",
-  "state.empty_state": "Niente da mostrare",
-  "state.not_connected": "Non connesso",
-  "state.session_expired": "Sessione scaduta",
-  "state.no_session": "Accedi",
-  "state.retrying": "Riprovo...",
-  "state.uploading": "Caricamento...",
-  "state.downloading": "Download...",
-  "state.processing": "Elaborazione...",
-  "state.please_wait": "Attendi...",
-  "error.file_selection": "Errore nell'elaborazione dei file selezionati. Riprova.",
-  "error.login_required": "Accedi per gestire i file",
-  "error.load_notifications": "Errore nel caricamento delle notifiche",
-  "error.fetch_trends": "Errore nel caricamento delle tendenze",
-  "file.size_mb": "MB",
-  "profile.edit": "Modifica profilo",
-  "profile.chat": "Chat",
-  "error.validation.token_expired": "Il token è scaduto",
-  "error.validation.token_invalid": "Il formato del token non è valido",
-  "error.validation.token_signature": "La firma del token non è valida",
-  "error.auth.invalid_token": "Token di autenticazione non valido",
-  "error.chat.forward_failed": "Impossibile inoltrare il messaggio",
-  "error.chat.delete_failed": "Impossibile eliminare il messaggio",
-  "error.chat.send_failed": "Impossibile inviare il messaggio",
-  "error.chat.load_failed": "Impossibile caricare i messaggi",
-  "error.data.fetch_failed": "Errore nel recupero dei dati: {{message}}",
-  "error.users.fetch_failed": "Errore nel recupero degli utenti: {{message}}",
   "settings": {
     "title": "Impostazioni",
     "signOut": "Esci",
@@ -174,7 +115,8 @@
       "supportFeedback": "Supporto e Feedback",
       "preferences": "Preferenze App",
       "quickActions": "Azioni Rapide",
-      "data": "Gestione Dati"
+      "data": "Gestione Dati",
+      "notifications": "Notifications"
     },
     "aboutHomiio": {
       "appName": "Homiio",
@@ -230,8 +172,27 @@
       "title": "Valuta",
       "selectCurrency": "Seleziona la tua valuta preferita",
       "description": "Questo verrà utilizzato per visualizzare i prezzi in tutta l'app",
-      "currencyChanged": "Valuta cambiata con successo"
-    }
+      "currencyChanged": "Valuta cambiata con successo",
+      "errorChanging": "Failed to change currency. Please try again."
+    },
+    "language": {
+      "title": "Language",
+      "choose": "Scegli una lingua",
+      "footer": "Cambiare la lingua aggiorna subito le etichette dell'app.",
+      "emptyTitle": "Nessuna lingua trovata",
+      "emptyDescription": "Nessuna opzione lingua disponibile",
+      "subtitle": "Select your preferred language"
+    },
+    "notifications": {
+      "detailDesc": "Choose which alerts you receive",
+      "detail": "Notification categories"
+    },
+    "account": {
+      "filesDescription": "Manage uploaded documents",
+      "files": "Files"
+    },
+    "signOutFailed": "Failed to sign out",
+    "signOutSuccess": "Signed out"
   },
   "common": {
     "cancel": "Annulla",
@@ -242,7 +203,7 @@
     "maybeLater": "Forse Dopo",
     "rateNow": "Valuta Ora",
     "success": "Successo",
-    "error": "Errore",
+    "error": "Error",
     "loading": "Caricamento...",
     "retry": "Riprova",
     "save": "Salva",
@@ -283,9 +244,22 @@
     "noData": "Nessun dato disponibile",
     "noResults": "Nessun risultato trovato",
     "tryAgain": "Riprova",
-    "goBack": "Torna indietro",
+    "goBack": "Go Back",
     "goHome": "Vai alla home",
-    "signIn": "Accedi"
+    "signIn": "Accedi",
+    "saving": "Saving...",
+    "name": "Name",
+    "emoji": "Emoji",
+    "color": "Colore",
+    "Creating": {
+      "": {
+        "": {
+          "": "Creating..."
+        }
+      }
+    },
+    "month": "month",
+    "reset": "Reset"
   },
   "home": {
     "hero": {
@@ -338,7 +312,8 @@
       "gridLongTerm": "Monolocali a Barcellona",
       "gridVacation": "Appartamenti al mare a València",
       "gridBuy": "Case in vendita a Barcellona",
-      "gridExchange": "Scambi di casa in Spagna"
+      "gridExchange": "Scambi di casa in Spagna",
+      "empty": "No featured properties available at the moment"
     },
     "recentlyViewed": {
       "title": "Visualizzate di Recente",
@@ -349,10 +324,18 @@
       "errorDescription": "Per favore, riprova.",
       "retry": "Riprova",
       "results": "Risultati",
-      "filtered": "filtrati"
+      "filtered": "filtrati",
+      "continue": "Continue browsing"
     },
     "saved": {
-      "title": "Proprietà Salvate"
+      "title": "Proprietà Salvate",
+      "editFolder": "Edit Folder",
+      "defaultFolder": "Default Folder",
+      "folderNamePlaceholder": "Folder name",
+      "noFolder": "Folder not found",
+      "noFolderDescription": "This folder may have been removed",
+      "noFolderItems": "No properties in this folder",
+      "noFolderItemsDescription": "Save properties to this folder to see them here"
     },
     "viewAll": "Visualizza Tutto",
     "tips": {
@@ -378,7 +361,9 @@
       "propertyInspection": {
         "title": "Lista di controllo per l'ispezione della proprietà: Cosa cercare",
         "description": "Una guida completa per ispezionare potenziali proprietà in affitto e identificare possibili problemi."
-      }
+      },
+      "subtitle": "Practical guides from local tenants, legal experts, and the Homiio editorial team.",
+      "eyebrow": "Renting smarter"
     },
     "faq": {
       "title": "Domande Frequenti",
@@ -402,6 +387,46 @@
     "cityShowcase": {
       "title": "Esplora {{place}}",
       "defaultPlace": "Spagna"
+    },
+    "insights": {
+      "title": "Platform Insights"
+    },
+    "noProfilesTitle": "No Saved Profiles",
+    "noProfilesDescription": "Follow profiles to see them here",
+    "recommended": {
+      "title": "Recommended homes",
+      "eyebrow": "For you"
+    },
+    "hostCta": {
+      "cta": "Become a host",
+      "subtitle": "Reach verified renters across Spain — free to list, fair fees, real human support.",
+      "title": "List your space, find a great tenant"
+    },
+    "footerStrip": {
+      "support": "Real support, real people",
+      "fair": "Fair agreements",
+      "verified": "Verified listings"
+    },
+    "nearby": {
+      "title": "Homes in {{city}}"
+    },
+    "category": {
+      "studios": "Monolocali",
+      "apartments": "Appartamenti",
+      "houses": "Case",
+      "rooms": "Stanze",
+      "coliving": "Co-living",
+      "luxury": "Lusso",
+      "newListings": "Nuovi annunci",
+      "nearYou": "Vicino a te",
+      "beachfront": "Fronte mare",
+      "cabins": "Baita",
+      "pools": "Piscine",
+      "mountain": "Montagna",
+      "cityBreaks": "Weekend in città",
+      "countryside": "Campagna",
+      "instantBook": "Prenotazione immediata",
+      "petFriendly": "Animali ammessi"
     }
   },
   "agent": {
@@ -507,10 +532,22 @@
       "subtitle": "Trasforma le case intorno a te in reddito.",
       "cta": "Diventa agente",
       "trust": "Nessuna licenza. Lavora dal telefono."
+    },
+    "join": {
+      "error": "Could not start earning right now. Please try again."
     }
   },
   "tips": {
-    "article": "Articolo"
+    "article": "Articolo",
+    "all": "All",
+    "loadError": "Couldn't load tips",
+    "tryAgain": "Please try again.",
+    "emptyTitle": "No tips yet",
+    "emptyDescription": "Check back soon for new rental guides and advice.",
+    "unavailable": "Article unavailable",
+    "missingSlug": "This tip could not be loaded.",
+    "loadFailed": "This tip could not be loaded.",
+    "related": "Related tips"
   },
   "search": {
     "title": "Cerca",
@@ -537,7 +574,16 @@
       "rooms": "Camere",
       "studios": "Monolocali",
       "coliving": "Co-living",
-      "publicHousing": "Edilizia Popolare"
+      "publicHousing": "Edilizia Popolare",
+      "couchsurfing": "Couchsurfing",
+      "roommates": "Roommates",
+      "hostel": "Hostel",
+      "guesthouse": "Guesthouse",
+      "campsite": "Campsite",
+      "boat": "Boat",
+      "treehouse": "Treehouse",
+      "yurt": "Yurt",
+      "other": "Other"
     },
     "areas": {
       "downtown": "Centro",
@@ -546,7 +592,48 @@
       "residentialArea": "Area Residenziale"
     },
     "filters": {
-      "listingType": "Tipo di annuncio"
+      "listingType": "Tipo di annuncio",
+      "propertyType": "Tipo di immobile",
+      "nightlyPrice": "Prezzo a notte",
+      "monthlyPrice": "Prezzo mensile",
+      "checkIn": "Check-in",
+      "checkOut": "Check-out",
+      "addDate": "Aggiungi data",
+      "guests": "Ospiti",
+      "instantBook": "Prenotazione immediata",
+      "cancellationPolicy": "Politica di cancellazione",
+      "moveInDate": "Data di trasloco",
+      "leaseDuration": {
+        "3Months": "3 mesi",
+        "6Months": "6 mesi",
+        "12Months": "12 mesi",
+        "flexible": "Flessibile"
+      },
+      "maxDeposit": "Deposito massimo",
+      "amenities": "Servizi",
+      "amenity": {
+        "wifi": "Wi-Fi",
+        "parking": "Parcheggio",
+        "gym": "Palestra",
+        "pool": "Piscina",
+        "balcony": "Balcone",
+        "garden": "Giardino",
+        "elevator": "Ascensore",
+        "airConditioning": "Aria condizionata",
+        "heating": "Riscaldamento",
+        "dishwasher": "Lavastoviglie",
+        "washingMachine": "Lavatrice"
+      },
+      "propertyTypeVacation": {
+        "wholeHouses": "Case intere",
+        "privateRooms": "Stanze private"
+      },
+      "cancellation": {
+        "flexible": "Flessibile",
+        "moderate": "Moderata",
+        "strict": "Rigida",
+        "superStrict": "Molto rigida"
+      }
     },
     "mode": {
       "label": "Modalità di ricerca",
@@ -632,7 +719,118 @@
       }
     },
     "editSearch": "Modifica ricerca",
-    "searchQueryPlaceholder": "Inserisci la tua query di ricerca"
+    "searchQueryPlaceholder": "Inserisci la tua query di ricerca",
+    "placeholder": {
+      "suggestion1": "Find your dream apartment in Barcelona...",
+      "suggestion2": "Looking for a pet-friendly home?",
+      "suggestion3": "Discover eco-friendly properties...",
+      "suggestion4": "Search for furnished studios near you..."
+    },
+    "savedSearches": "Saved Searches",
+    "saveSearch": "Save Search",
+    "searchQuery": "Search Query",
+    "searchName": "Search Name",
+    "searchNamePlaceholder": "Enter a name for this search",
+    "enableNotifications": "Enable notifications",
+    "notificationsDescription": "Get notified when new properties match this search",
+    "disableNotifications": "Disable notifications",
+    "withFilters": "With filters",
+    "error": {
+      "title": "Could not load homes"
+    },
+    "enterSearchQuery": "Please enter a search query first",
+    "deleteSearch": "Delete Search",
+    "deleteSearchConfirm": "Are you sure you want to delete the search \"{{name}}\"?",
+    "viewAllSaved": "View All Saved",
+    "duplicateName": "A search with this name already exists",
+    "duplicateExact": "You already saved this exact search",
+    "tryDifferentName": "Please choose a different name",
+    "more": "more",
+    "errorLoadingData": "Failed to load data",
+    "noPropertyTypesAvailable": "No property types available",
+    "noCitiesAvailable": "No cities available",
+    "noPropertyTypes": "No property types available",
+    "searching": "Searching...",
+    "actions": {
+      "save": "Save",
+      "search": "Search",
+      "clearAll": "Clear all",
+      "searchArea": "Search this area",
+      "sort": "Sort",
+      "filters": "Filters",
+      "saved": "Saved"
+    },
+    "summary": {
+      "edit": "Edit search",
+      "anyPrice": "Any price",
+      "addDates": "Add dates",
+      "anyTime": "Any time",
+      "anyType": "Any type",
+      "anywhere": "Anywhere",
+      "mapArea": "Map area",
+      "typeCount": "{{count}} types"
+    },
+    "step": {
+      "dates": {
+        "title": "When?",
+        "weekday": {
+          "Mo": "Lu",
+          "Tu": "Ma",
+          "We": "Me",
+          "Th": "Gi",
+          "Fr": "Ve",
+          "Sa": "Sa",
+          "Su": "Do"
+        }
+      },
+      "type": {
+        "title": "What type of place?"
+      },
+      "price": {
+        "max": "Maximum",
+        "any": "Any",
+        "min": "Minimum",
+        "title": "Price range",
+        "perMonth": "per month",
+        "perNight": "per night"
+      }
+    },
+    "header": {
+      "geocoding": "Looking up location...",
+      "noResults": "No homes match this search",
+      "loading": "Searching homes...",
+      "count": "{{count}} homes"
+    },
+    "recent": {
+      "title": "Recent searches"
+    },
+    "input": {
+      "placeholder": "Search cities, neighborhoods, or addresses"
+    },
+    "panel": {
+      "title": "Search"
+    },
+    "fab": {
+      "map": "Map",
+      "list": "List"
+    },
+    "empty": {
+      "action": "Edit search",
+      "description": "Try widening your area or relaxing your filters.",
+      "title": "No homes match this search"
+    },
+    "sort": {
+      "title": "Ordina per",
+      "recommended": "Consigliati",
+      "priceAsc": "Prezzo: dal più basso",
+      "priceDesc": "Prezzo: dal più alto",
+      "newest": "Più recenti"
+    },
+    "save": {
+      "title": "Save this search",
+      "namePlaceholder": "Give your search a name",
+      "enableNotifications": "Enable notifications"
+    }
   },
   "profile": {
     "editProfile": "Modifica Profilo",
@@ -642,7 +840,371 @@
     "trustScore": "Punteggio di Fiducia",
     "logOut": "Esci",
     "exchanges": "Scambi",
-    "exchangesDescription": "I tuoi scambi casa e le richieste di ospitalità."
+    "exchangesDescription": "I tuoi scambi casa e le richieste di ospitalità.",
+    "title": "Profile",
+    "tabs": {
+      "listings": "Listings",
+      "about": "About"
+    },
+    "loading": "Loading profile...",
+    "signInRequired": "Sign in required",
+    "signInMessage": "Please sign in to view your profile",
+    "createProfile": "Create Profile",
+    "deleteProfile": "Delete Profile",
+    "types": {
+      "personal": "Personal Profile",
+      "agency": "Agency Profile",
+      "business": "Business Profile"
+    },
+    "sections": {
+      "overview": "Overview",
+      "properties": "My Properties",
+      "contracts": "My Contracts",
+      "trustScore": "Trust Score",
+      "settings": "Settings",
+      "account": "Account",
+      "profile": "Profile",
+      "activity": "Activity"
+    },
+    "stats": {
+      "propertiesCount": "Properties",
+      "contractsCount": "Contracts",
+      "trustScore": "Trust Score",
+      "stays": "Stays",
+      "applications": "Applications",
+      "saved": "Saved",
+      "applicationsApproved": "{{count}} approvate"
+    },
+    "actions": {
+      "manageProperties": "Manage Properties",
+      "viewContracts": "View Contracts",
+      "editProfile": "Edit Profile",
+      "shareProfile": "Share Profile",
+      "signOut": "Sign Out"
+    },
+    "noProfilesTitle": "No Profiles Found",
+    "noProfilesMessage": "You don't have any profiles yet. Create your first profile to get started!",
+    "errors": {
+      "loadFailed": "Failed to load profiles",
+      "updateFailed": "Failed to update profile",
+      "deleteFailed": "Failed to delete profile"
+    },
+    "edit": {
+      "noProfile": "Nessun profilo trovato da aggiornare.",
+      "updateSuccess": "Profilo aggiornato con successo!",
+      "updateFailed": "Impossibile aggiornare il profilo",
+      "sections": {
+        "agencyInformation": "Agency Information",
+        "agencyVerification": "Agency Verification",
+        "teamManagement": "Team Management",
+        "businessSettings": "Business Settings",
+        "businessInformation": "Informazioni aziendali",
+        "businessVerification": "Business Verification",
+        "cooperativeInformation": "Informazioni cooperativa",
+        "cooperativeSettings": "Cooperative Settings",
+        "personalInformation": "Informazioni personali",
+        "propertyPreferences": "Property Preferences",
+        "references": "References",
+        "rentalHistory": "Rental History",
+        "trustScore": "Trust Score",
+        "settings": "Settings"
+      },
+      "labels": {
+        "businessType": "Business Type *",
+        "legalCompanyName": "Legal Company Name *",
+        "description": "Description",
+        "licenseNumber": "License Number",
+        "taxId": "Tax ID",
+        "yearEstablished": "Year Established",
+        "employeeCount": "Number of Employees",
+        "specialties": "Specialties",
+        "verificationStatus": "Verification Status",
+        "profileVisibility": "Profile Visibility",
+        "notifications": "Notifications",
+        "emailNotifications": "Email Notifications",
+        "pushNotifications": "Push Notifications",
+        "legalName": "Legal Name *",
+        "industry": "Industry",
+        "bio": "Biografia",
+        "occupation": "Occupation",
+        "employer": "Employer",
+        "annualIncome": "Annual Income ($)",
+        "employmentStatus": "Employment Status",
+        "moveInDate": "Move-in Date",
+        "leaseDuration": "Lease Duration",
+        "maxRent": "Maximum Rent ($)",
+        "rentPeriod": "Rent Period",
+        "minBedrooms": "Min Bedrooms",
+        "minBathrooms": "Min Bathrooms",
+        "propertyTypes": "Property Types",
+        "preferredAmenities": "Preferred Amenities",
+        "additionalPreferences": "Additional Preferences",
+        "name": "Name",
+        "relationship": "Relationship",
+        "phone": "Phone",
+        "email": "Email",
+        "address": "Address",
+        "startDate": "Start Date",
+        "endDate": "End Date",
+        "monthlyRent": "Monthly Rent ($)",
+        "reasonForLeaving": "Reason for Leaving",
+        "landlordContact": "Landlord Contact",
+        "privacy": "Privacy"
+      },
+      "subtitles": {
+        "agencyVerification": "Complete these verifications to build trust with clients",
+        "businessVerification": "Complete these verifications to build trust with clients",
+        "businessSettings": "Configure your business profile settings",
+        "cooperativeSettings": "Configure your cooperative profile settings"
+      },
+      "placeholders": {
+        "legalCompanyName": "Enter your legal company name",
+        "description": "Describe your business...",
+        "licenseNumber": "Enter license number",
+        "taxId": "Enter tax ID",
+        "yearEstablished": "e.g., 2020",
+        "industry": "Enter industry",
+        "cooperativeLegalName": "Enter cooperative legal name",
+        "cooperativeDescription": "Describe your cooperative...",
+        "bio": "Raccontaci di te...",
+        "occupation": "es., Ingegnere software",
+        "employer": "es., Tech Corp",
+        "annualIncome": "es., 75000",
+        "moveInDate": "AAAA-MM-GG",
+        "maxRent": "Inserisci l'affitto massimo",
+        "fullName": "Nome completo",
+        "phoneNumber": "Numero di telefono",
+        "emailAddress": "Indirizzo email",
+        "fullAddress": "Indirizzo completo",
+        "landlordName": "Nome del proprietario",
+        "phone": "Telefono",
+        "email": "Email",
+        "endDateOptional": "AAAA-MM-GG (opzionale)",
+        "monthlyRent": "es., 1500"
+      },
+      "options": {
+        "agencyBusinessType": {
+          "real_estate_agency": "Agenzia immobiliare",
+          "property_management": "Gestione immobiliare",
+          "brokerage": "Intermediazione",
+          "developer": "Sviluppatore",
+          "other": "Altro"
+        },
+        "agencySpecialty": {
+          "residential": "Residenziale",
+          "commercial": "Commerciale",
+          "luxury": "Lusso",
+          "student_housing": "Alloggi studenti",
+          "senior_housing": "Alloggi senior",
+          "vacation_rentals": "Affitti vacanza"
+        },
+        "businessType": {
+          "small_business": "Piccola impresa",
+          "startup": "Startup",
+          "freelancer": "Libero professionista",
+          "consultant": "Consulente",
+          "other": "Altro"
+        },
+        "employmentStatus": {
+          "employed": "Dipendente",
+          "self_employed": "Autonomo",
+          "student": "Studente",
+          "retired": "Pensionato",
+          "unemployed": "Disoccupato",
+          "other": "Altro"
+        },
+        "leaseDuration": {
+          "monthly": "Mensile",
+          "3_months": "3 mesi",
+          "6_months": "6 mesi",
+          "yearly": "Annuale",
+          "flexible": "Flessibile"
+        },
+        "priceUnit": {
+          "day": "Giorno",
+          "night": "Notte",
+          "week": "Settimana",
+          "month": "Mese",
+          "year": "Anno"
+        },
+        "propertyType": {
+          "apartment": "Appartamento",
+          "house": "Casa",
+          "room": "Stanza",
+          "studio": "Monolocale"
+        },
+        "amenity": {
+          "parking": "Parcheggio",
+          "gym": "Palestra",
+          "pool": "Piscina",
+          "washer": "Lavatrice",
+          "dishwasher": "Lavastoviglie",
+          "balcony": "Balcone",
+          "elevator": "Ascensore",
+          "ac": "Aria condizionata",
+          "heating": "Riscaldamento",
+          "internet": "Internet"
+        },
+        "referenceRelationship": {
+          "landlord": "Proprietario",
+          "employer": "Datore di lavoro",
+          "personal": "Personale",
+          "other": "Altro"
+        },
+        "reasonForLeaving": {
+          "lease_ended": "Contratto terminato",
+          "bought_home": "Ha comprato casa",
+          "job_relocation": "Trasferimento lavoro",
+          "family_reasons": "Motivi familiari",
+          "upgrade": "Miglioramento",
+          "other": "Altro"
+        },
+        "profileVisibility": {
+          "public": "Pubblico",
+          "private": "Privato",
+          "contacts_only": "Solo contatti"
+        }
+      },
+      "verification": {
+        "businessLicenseTitle": "Licenza commerciale",
+        "businessLicenseDescription": "Carica la licenza commerciale per la verifica",
+        "insuranceTitle": "Assicurazione",
+        "insuranceDescription": "Fornisci prova dell'assicurazione commerciale",
+        "bondingTitle": "Fideiussione",
+        "bondingDescription": "Fornisci informazioni sulla fideiussione",
+        "backgroundCheckTitle": "Controllo precedenti",
+        "backgroundCheckDescription": "Completa il controllo precedenti per tutto il team"
+      },
+      "toggles": {
+        "emailNotifications": "Notifiche email",
+        "pushNotifications": "Notifiche push",
+        "petFriendly": "Animali ammessi",
+        "smokingAllowed": "Fumo consentito",
+        "furnished": "Arredato",
+        "parkingRequired": "Parcheggio richiesto",
+        "accessibilityFeatures": "Accessibilità",
+        "showContactInfo": "Mostra contatti",
+        "showIncome": "Mostra reddito",
+        "showRentalHistory": "Mostra storico affitti",
+        "showReferences": "Mostra referenze"
+      },
+      "team": {
+        "subtitle": "Gestisci i membri del team e i loro ruoli",
+        "memberLabel": "Membro {{index}}",
+        "addedLabel": "Aggiunto: {{date}}",
+        "emptyText": "Nessun membro del team ancora.",
+        "addMember": "+ Aggiungi membro del team"
+      },
+      "actions": {
+        "addReference": "+ Aggiungi referenza",
+        "addHistory": "+ Aggiungi storico",
+        "remove": "Rimuovi",
+        "referenceLabel": "Referenza {{index}}",
+        "rentalLabel": "Affitto {{index}}"
+      }
+    },
+    "create": {
+      "selectType": "Seleziona un tipo di profilo.",
+      "selectBusinessType": "Seleziona un tipo di attività.",
+      "cooperativeLegalNameRequired": "Inserisci la ragione sociale della cooperativa.",
+      "createdSuccess": "{{type}} creato con successo!",
+      "headerTitle": "Create Profile",
+      "createButton": "Create",
+      "chooseType": "Choose Business Profile Type",
+      "types": {
+        "agency": {
+          "title": "Agency Profile",
+          "description": "For real estate agencies and property management"
+        },
+        "business": {
+          "title": "Business Profile",
+          "description": "For small businesses and freelancers"
+        },
+        "cooperative": {
+          "title": "Cooperative Profile",
+          "description": "For housing or member-owned cooperatives"
+        }
+      },
+      "sections": {
+        "agencyInfo": "Agency Information",
+        "businessInfo": "Business Information",
+        "cooperativeInfo": "Cooperative Information",
+        "whatsNext": "What's Next?",
+        "profileSetup": "Profile Setup"
+      },
+      "whatsNext": {
+        "description": "After creating your {{type}} profile, you can customize preferences, add verification documents, and build your trust score."
+      },
+      "placeholders": {
+        "agencyDescription": "Describe your agency...",
+        "businessDescription": "Describe your business...",
+        "licenseOptional": "Enter license number (if applicable)",
+        "cooperativeLegalName": "Cooperative Legal Name",
+        "cooperativeDescription": "Describe the cooperative"
+      },
+      "options": {
+        "agencySpecialty": {
+          "residential": "Residential",
+          "commercial": "Commercial",
+          "investment": "Investment",
+          "rental": "Rental",
+          "new_construction": "New Construction"
+        },
+        "businessSpecialty": {
+          "consulting": "Consulting",
+          "technology": "Technology",
+          "design": "Design",
+          "marketing": "Marketing",
+          "finance": "Finance",
+          "healthcare": "Healthcare",
+          "education": "Education",
+          "retail": "Retail",
+          "services": "Services"
+        }
+      }
+    },
+    "toast": {
+      "loadFailed": "Impossibile caricare i profili",
+      "createSuccess": "Profilo creato con successo",
+      "createFailed": "Impossibile creare il profilo",
+      "updateSuccess": "Profilo aggiornato con successo",
+      "updateFailed": "Impossibile aggiornare il profilo",
+      "deleteSuccess": "Profilo eliminato con successo",
+      "deleteFailed": "Impossibile eliminare il profilo",
+      "activateSuccess": "Profilo attivato con successo",
+      "activateFailed": "Impossibile attivare il profilo"
+    },
+    "trustScoreHint": "Complete your profile information to improve your trust score.",
+    "trustScoreSubtitle": "Build trust with landlords and roommates through verification and positive interactions.",
+    "established": "Established",
+    "serviceAreas": "Service areas",
+    "specialties": "Specialties",
+    "about": "About",
+    "preferences": "Preferences",
+    "budget": "Budget",
+    "employer": "Employer",
+    "occupation": "Occupation",
+    "listings": "Listings",
+    "switchConfirm": "Switch",
+    "switchMessage": "Activate {{name}}?",
+    "switchTitle": "Switch profile?",
+    "subscriptionsDescription": "Manage Homiio Plus or buy one-time file analysis.",
+    "subscriptions": "Subscriptions",
+    "createNewDescription": "Add a business, agency, or cooperative profile.",
+    "createNew": "Create new profile",
+    "active": "Active",
+    "activeFooter": "Active: {{name}}",
+    "stays": "Stays",
+    "applications": "My applications",
+    "trustScoreCta": "View trust score",
+    "loadFailedHint": "Please try again later.",
+    "loadFailed": "Failed to load profile",
+    "switchFailed": "Failed to switch profile",
+    "switched": "Switched to {{name}}",
+    "invalidProfile": "Invalid profile data",
+    "trustScorePage": {
+      "title": "Trust Score"
+    }
   },
   "notifications": {
     "title": "Notifiche",
@@ -694,7 +1256,15 @@
       "emptyDescription": "Non hai ancora creato nessuna proprietà. Inizia aggiungendo la tua prima lista di proprietà.",
       "createFirst": "Crea la Tua Prima Proprietà",
       "errorTitle": "Errore nel Caricamento delle Proprietà",
-      "errorDescription": "Si è verificato un errore nel caricamento delle tue proprietà. Riprova."
+      "errorDescription": "Si è verificato un errore nel caricamento delle tue proprietà. Riprova.",
+      "markRented": "Mark as rented",
+      "markSold": "Mark as sold",
+      "transactMessage": "This closes \"{{title}}\" and removes it from active listings. This cannot be undone.",
+      "markRentedTitle": "Mark as rented?",
+      "markSoldTitle": "Mark as sold?",
+      "transactError": "Could not close this listing",
+      "transactDone": "Listing marked as closed",
+      "transactCommission": "Deal closed — commission recorded"
     },
     "details": {
       "price": "Prezzo",
@@ -720,6 +1290,61 @@
         "duplex": "Duplex",
         "penthouse": "Attico"
       }
+    },
+    "type": {
+      "title": "{{type}}",
+      "subtitle": "{{count}} {{type}} available",
+      "empty": "No {{type}} available at the moment",
+      "filters": {
+        "title": "Filters",
+        "price": "Price Range",
+        "bedrooms": "Bedrooms",
+        "bathrooms": "Bathrooms",
+        "amenities": "Amenities",
+        "sort": {
+          "title": "Sort By",
+          "newest": "Newest First",
+          "priceAsc": "Price: Low to High",
+          "priceDesc": "Price: High to Low"
+        },
+        "apply": "Apply Filters",
+        "clear": "Clear All"
+      }
+    },
+    "actions": {
+      "create": "Add property",
+      "recent": "Recently viewed"
+    },
+    "empty": {
+      "action": "Clear filters",
+      "description": "Try relaxing your filters.",
+      "title": "No homes available"
+    },
+    "error": {
+      "title": "Could not load homes"
+    },
+    "header": {
+      "empty": "No homes available",
+      "loading": "Loading homes…"
+    },
+    "city": {
+      "verifiedProperties": "Verified Properties",
+      "verifiedOnly": "Verified Only",
+      "ecoFriendly": "Eco-Friendly",
+      "ecoFriendlyOnly": "Eco-Friendly Only",
+      "loadingProperties": "Loading properties...",
+      "notFound": "City not found",
+      "properties": "Properties",
+      "population": "Population",
+      "availableProperties": "Available Properties",
+      "propertiesFound": "properties found",
+      "sortBy": "Sort By",
+      "sortNewest": "Newest First",
+      "sortPriceAsc": "Price: Low to High",
+      "sortPriceDesc": "Price: High to Low",
+      "noPropertiesFound": "No properties found",
+      "tryAdjustFilters": "Try adjusting your filters or check back later",
+      "clearFilters": "Clear Filters"
     }
   },
   "property": {
@@ -846,7 +1471,176 @@
       "listedDaysAgo_other": "Pubblicato {{count}} giorni fa",
       "saved_one": "{{count}} salvato",
       "saved_other": "{{count}} salvati"
-    }
+    },
+    "loading": "Loading property details...",
+    "error": "Errore",
+    "notFound": "Property not found",
+    "bed": "Bed",
+    "bath": "Bath",
+    "pricingReviewNeeded": "Pricing Review Needed",
+    "bedrooms": "Number of Bedrooms",
+    "bathrooms": "Number of Bathrooms",
+    "customNumber": {
+      "title": "Enter Custom Number",
+      "placeholder": "Enter number",
+      "confirm": "Confirm",
+      "cancel": "Cancel"
+    },
+    "suggestedRent": "Suggested: ${{amount}}/month",
+    "maxEthicalRent": "Max Ethical: ${{amount}}/month",
+    "ethicalPricingWarning": "Your price exceeds the ethical maximum. Consider lowering it to make housing more accessible.",
+    "warningBullet": "• {{warning}}",
+    "ethicalPricing": "Ethical Pricing",
+    "toast": {
+      "createSuccess": "Proprietà creata con successo",
+      "updateSuccess": "Proprietà aggiornata con successo",
+      "deleteSuccess": "Proprietà eliminata con successo",
+      "createFailed": "Impossibile creare la proprietà",
+      "updateFailed": "Impossibile aggiornare la proprietà",
+      "deleteFailed": "Impossibile eliminare la proprietà",
+      "shareCopied": "Dettagli proprietà copiati negli appunti",
+      "shareFailed": "Impossibile condividere la proprietà",
+      "shareTitle": "Share Property"
+    },
+    "drafts": {
+      "title": "Bozze",
+      "emptyTitle": "Nessuna bozza",
+      "emptyDescription": "Non hai ancora bozze salvate. Inizia a creare una proprietà per salvarle automaticamente.",
+      "createFirst": "Crea nuova proprietà",
+      "deleteTitle": "Elimina bozza",
+      "deleteMessage": "Sei sicuro di voler eliminare questa bozza? Questa azione non può essere annullata.",
+      "toastDeleted": "Bozza eliminata con successo",
+      "toastDeleteFailed": "Impossibile eliminare la bozza",
+      "toastLoadFailed": "Impossibile caricare la bozza"
+    },
+    "description": {
+      "showMore": "Show more",
+      "showLess": "Show less"
+    },
+    "external": {
+      "contactTitle": "Contact on listing"
+    },
+    "location": {
+      "title": "Where you'll be"
+    },
+    "cta": {
+      "apply": "Apply",
+      "reserve": "Reserve"
+    },
+    "host": {
+      "verified": "Verified",
+      "responseRate": "Typically responds within an hour",
+      "hostingSince": "Hosting since",
+      "hostedBy": "Hosted by",
+      "openProfile": "Open host profile",
+      "publicSubtitle": "Government-managed affordable housing",
+      "publicAuthority": "Public Housing Authority",
+      "superHost": "Super host"
+    },
+    "report": {
+      "actions": {
+        "submit": "Invia segnalazione"
+      },
+      "notice": "Segnalazioni false o abusive possono influire sul tuo account. Segnala solo problemi reali.",
+      "section": {
+        "contactHelp": "Condividi un'email se vuoi che ti contattiamo riguardo a questa segnalazione.",
+        "contact": "Email di contatto (opzionale)",
+        "detailsHelp": "Aggiungi qualsiasi dettaglio che ci aiuti a capire il problema.",
+        "details": "Dettagli (opzionale)",
+        "detailsRequired": "Dettagli",
+        "reason": "Perché stai segnalando questo annuncio?"
+      },
+      "field": {
+        "detailsPlaceholder": "Descrivi cosa è impreciso, sospetto o inappropriato…"
+      },
+      "intro": "Dicci cosa non va in questo annuncio. Le segnalazioni sono riservate e vengono esaminate dal nostro team — non vengono mai condivise con l'host.",
+      "title": "Segnala questo annuncio",
+      "success": "Grazie — la tua segnalazione è stata inviata.",
+      "error": {
+        "invalidForm": "Scegli un motivo prima di inviare.",
+        "generic": "Qualcosa è andato storto. Riprova.",
+        "notFound": "Questo annuncio non esiste più.",
+        "auth": "Accedi per segnalare un annuncio.",
+        "detailsRequired": "Aggiungi alcuni dettagli sul problema.",
+        "invalidReason": "Scegli un motivo per la tua segnalazione."
+      },
+      "reason": {
+        "inaccurate": "Informazioni inesatte",
+        "scam": "Possibile truffa o frode",
+        "inappropriate": "Contenuto inappropriato",
+        "unavailable": "Già affittato o non disponibile",
+        "other": "Altro motivo"
+      }
+    },
+    "about": {
+      "title": "About this property"
+    },
+    "sleep": {
+      "title": "Where you'll sleep",
+      "oneBed": "1 bed",
+      "mainBedroom": "Main bedroom"
+    },
+    "reviews": {
+      "writeAction": "Write a review",
+      "emptyDescription": "Be the first to share what it was like to live here.",
+      "emptyTitle": "No reviews yet",
+      "errorTitle": "Could not load reviews",
+      "disclaimer": "Community-verified reviews about the building. Experiences may vary by unit.",
+      "title": "Reviews",
+      "evidence": "With evidence",
+      "verified": "Verified",
+      "recommend": "Recommend",
+      "count": "reviews",
+      "countWithNumber": "({{count}} recensioni)"
+    },
+    "notFoundHelp": "It may have been removed or the link is broken.",
+    "sections": {
+      "photoGallery": "Galleria foto",
+      "viewAll": "Vedi tutto",
+      "features": "Caratteristiche",
+      "furnished": "Arredato",
+      "partiallyFurnished": "Parzialmente arredato",
+      "unfurnished": "Non arredato",
+      "balcony": "Balcone",
+      "garden": "Giardino",
+      "elevator": "Ascensore",
+      "overview": "Panoramica",
+      "bedrooms": "Camere da letto",
+      "bathrooms": "Bagni",
+      "size": "Dimensioni",
+      "floor": "Piano",
+      "details": "Dettagli",
+      "notSpecified": "Non specificato",
+      "yearBuilt": "Anno di costruzione",
+      "parkingSpaces": "Posti auto",
+      "pricingAndCosts": "Prezzo e costi",
+      "rent": "Affitto",
+      "deposit": "Deposito",
+      "utilitiesIncluded": "Utenze incluse",
+      "nightlyRent": "Affitto a notte",
+      "monthlyRent": "Affitto mensile",
+      "sourcedFrom": "Fonte",
+      "availability": "Disponibilità",
+      "availableFrom": "Disponibile dal",
+      "leaseTerm": "Durata del contratto",
+      "location": "Posizione",
+      "nearbyAmenities": "Servizi nelle vicinanze",
+      "publicTransport": "Trasporto pubblico",
+      "schools": "Scuole",
+      "shopping": "Negozi"
+    },
+    "neighborhood": {
+      "title": "Neighborhood",
+      "listings": "Listings",
+      "avgRentPerMonth": "Avg. rent / mo",
+      "onParWithCity": "On par with the city average",
+      "listingCount": "{{count}} listings",
+      "avgAmountPerMonth": "Avg. {{amount}}/mo",
+      "pctVsCity": "{{pct}}% {{dir}} than the city average",
+      "cheaper": "cheaper",
+      "pricier": "pricier"
+    },
+    "fraudWarning": "Never pay or transfer funds outside the Homio platform"
   },
   "viewings": {
     "title": "Visite",
@@ -866,7 +1660,8 @@
       "timeInPast": "L'orario programmato deve essere nel futuro.",
       "authRequired": "Accedi per richiedere una visita.",
       "notFound": "Richiesta di visita non trovata.",
-      "cannotCancel": "Impossibile cancellare questa richiesta di visita."
+      "cannotCancel": "Impossibile cancellare questa richiesta di visita.",
+      "externalProperty": "Cannot book viewings for external properties"
     },
     "selectDate": "Seleziona data",
     "availableTimeSlots": "Fasce orarie disponibili",
@@ -889,6 +1684,10 @@
     },
     "cancel": {
       "confirmMessage": "Sei sicuro di voler cancellare questa richiesta di visita?"
+    },
+    "banner": {
+      "viewDetails": "View details",
+      "hasViewing": "You have a viewing scheduled"
     }
   },
   "payments": {
@@ -924,6 +1723,116 @@
       "download": "Scarica",
       "sign": "Firma",
       "renew": "Rinnova"
+    },
+    "list": {
+      "title": "Contratti di affitto",
+      "eyebrow": "Accordi",
+      "subtitle": "Tieni traccia di ogni contratto che firmi o emetti e consulta i termini chiave in pochi secondi.",
+      "filterAll": "Tutti",
+      "filterActive": "Attivi",
+      "filterPending": "In attesa",
+      "filterExpired": "Scaduti",
+      "filterDrafts": "Bozze",
+      "noRentalPropertiesTitle": "Nessun contratto di affitto",
+      "noRentalPropertiesDescription": "Non hai ancora proprietà in affitto. Inizia esplorando gli annunci disponibili o pubblicando la tua.",
+      "browseProperties": "Esplora proprietà",
+      "loadError": "Impossibile caricare i contratti",
+      "tryAgain": "Riprova.",
+      "emptyTitle": "Nessun contratto trovato",
+      "emptyAllDescription": "Non hai ancora contratti di affitto",
+      "emptyFilteredDescription": "Nessun contratto {{filter}} da mostrare",
+      "newContract": "Nuovo contratto",
+      "createNew": "Crea nuovo contratto"
+    },
+    "card": {
+      "start": "Inizio",
+      "end": "Fine",
+      "landlord": "Proprietario",
+      "tenant": "Inquilino",
+      "perMonth": "/ mese",
+      "share": "Condividi",
+      "download": "Scarica",
+      "accessibility": "Contratto {{title}}"
+    },
+    "detail": {
+      "title": "Contratto",
+      "invalidIdTitle": "ID contratto non valido",
+      "invalidIdDescription": "Il link non include il riferimento del contratto.",
+      "unavailableTitle": "Contratto non disponibile",
+      "unavailableDescription": "Impossibile caricare questo contratto.",
+      "term": "Durata",
+      "rent": "Affitto",
+      "start": "Inizio",
+      "end": "Fine",
+      "monthlyRent": "Affitto mensile",
+      "securityDeposit": "Deposito cauzionale",
+      "signatures": "Firme",
+      "landlord": "Proprietario",
+      "tenant": "Inquilino",
+      "payments": "Calendario pagamenti",
+      "documents": "Documenti",
+      "addDocument": "Aggiungi documento",
+      "sign": "Firma contratto",
+      "terminate": "Risolvi contratto",
+      "deleteDraft": "Elimina bozza",
+      "confirmSignTitle": "Firmare questo contratto?",
+      "confirmSignBody": "La tua firma conferma che accetti i termini del contratto.",
+      "confirmTerminateTitle": "Risolvere questo contratto?",
+      "confirmTerminateBody": "Questo termina il contratto per tutte le parti.",
+      "confirmDeleteTitle": "Eliminare questa bozza?",
+      "confirmDeleteBody": "Questa bozza verrà rimossa definitivamente.",
+      "toastSigned": "Contratto firmato",
+      "toastSignFailed": "Impossibile firmare il contratto",
+      "toastTerminated": "Contratto risolto",
+      "toastTerminateFailed": "Impossibile risolvere il contratto",
+      "toastDeleted": "Bozza eliminata",
+      "toastDeleteFailed": "Impossibile eliminare la bozza",
+      "toastDocumentAdded": "Documento aggiunto",
+      "toastDocumentFailed": "Impossibile aggiungere il documento",
+      "toastOpenDocumentFailed": "Impossibile aprire il documento.",
+      "permissionRequired": "È richiesto il permesso della libreria multimediale per allegare un documento.",
+      "propertyFallback": "Proprietà",
+      "goBack": "Go back",
+      "dueDay": "Day {{day}} of the month",
+      "signed": "Signed",
+      "signaturePending": "Pending",
+      "emptyDocuments": "No documents attached.",
+      "addShort": "Add",
+      "signLease": "Sign lease",
+      "confirmSignExtended": "By signing you agree to the lease terms. Once both parties sign, the lease becomes active.",
+      "confirmSignAction": "Sign",
+      "confirmTerminateShortTitle": "Terminate lease?",
+      "confirmTerminateExtended": "This records a termination notice and ends the lease. This cannot be undone.",
+      "confirmDeleteExtended": "This permanently removes the draft lease.",
+      "confirmDeleteAction": "Delete",
+      "openDocument": "Open document {{name}}",
+      "dueDayLabel": "Due day"
+    },
+    "new": {
+      "title": "Nuovo contratto",
+      "noApplicationTitle": "Inizia da una candidatura",
+      "noApplicationDescription": "I contratti si creano da una domanda di inquilino approvata. Apri una domanda approvata e scegli \"Crea contratto\".",
+      "viewApplications": "Vedi candidature",
+      "applicationUnavailableTitle": "Domanda non disponibile",
+      "loadFailedDescription": "Impossibile caricare questa domanda.",
+      "goBack": "Indietro",
+      "subtitle": "Crea una bozza di contratto da questa domanda. Puoi modificare i termini e firmarlo nella schermata successiva.",
+      "seededTerms": "Termini iniziali",
+      "moveIn": "Ingresso",
+      "leaseTerm": "Durata contratto",
+      "leaseTermMonths": "{{count}} mesi",
+      "notApprovedWarning": "Questa domanda non è ancora approvata. Approvala prima di creare un contratto.",
+      "createButton": "Crea bozza contratto",
+      "toastCreated": "Bozza contratto creata",
+      "toastCreateFailed": "Impossibile creare il contratto",
+      "propertyFallback": "Proprietà"
+    },
+    "documentType": {
+      "lease_agreement": "Contratto di locazione",
+      "addendum": "Addendum",
+      "inspection_report": "Verbale di ispezione",
+      "insurance": "Assicurazione",
+      "other": "Altro"
     }
   },
   "roommates": {
@@ -937,6 +1846,185 @@
       "message": "Messaggio",
       "connect": "Connetti",
       "viewProfile": "Visualizza Profilo"
+    },
+    "tabs": {
+      "discover": "Scopri",
+      "requests": "Richieste",
+      "matches": "Corrispondenze",
+      "rooms": "Stanze"
+    },
+    "alert": {
+      "requestSent": "Richiesta di coinquilino inviata con successo!",
+      "requestFailed": "Impossibile inviare la richiesta di coinquilino",
+      "accepted": "Richiesta di coinquilino accettata!",
+      "acceptFailed": "Impossibile accettare la richiesta di coinquilino",
+      "declined": "Richiesta di coinquilino rifiutata",
+      "declineFailed": "Impossibile rifiutare la richiesta di coinquilino",
+      "relationshipEnded": "Relazione di coinquilini terminata",
+      "relationshipEndFailed": "Impossibile terminare la relazione di coinquilini",
+      "toggleFailed": "Impossibile attivare/disattivare la ricerca coinquilini",
+      "preferencesSaved": "Le tue preferenze coinquilino sono state aggiornate.",
+      "preferencesFailed": "Impossibile salvare le preferenze coinquilino. Riprova.",
+      "successTitle": "Successo",
+      "errorTitle": "Errore"
+    },
+    "screen": {
+      "title": "Coinquilini",
+      "signInTitle": "Sign in to find roommates",
+      "signInDescription": "Discover compatible roommates and manage your requests.",
+      "signIn": "Sign in",
+      "loadError": "Couldn't load roommates",
+      "tryAgain": "Please try again.",
+      "emptyDiscoverTitle": "No matches yet",
+      "emptyDiscoverDescription": "Complete your roommate profile to start discovering matches.",
+      "emptyRequestsTitle": "No requests",
+      "emptyRequestsDescription": "Incoming and outgoing roommate requests will appear here.",
+      "emptyRelationshipsTitle": "No matches yet",
+      "emptyRelationshipsDescription": "Accepted roommate requests become matches here.",
+      "emptyRoomsTitle": "No rooms listed",
+      "emptyRoomsDescription": "Room listings from your network will appear here.",
+      "enableMatching": "Enable roommate matching",
+      "editPreferences": "Edit preferences",
+      "fallbackName": "Coinquilino",
+      "eyebrow": "Insieme",
+      "loadRequestsError": "Couldn't load requests",
+      "loadRelationshipsError": "Couldn't load relationships",
+      "personalProfileRequired": "Profilo personale richiesto",
+      "personalProfileDescription": "La ricerca coinquilini è disponibile solo per i profili personali. Passa al tuo profilo personale per usare questa funzione.",
+      "roomSearchPersonalOnly": "Room search is only available for personal profiles. Switch to your personal profile to use this feature.",
+      "switchToPersonal": "Passa al profilo personale",
+      "enableMatchingTitle": "Attiva ricerca coinquilini",
+      "enableMatchingDescription": "Turn on roommate matching to discover potential roommates based on your preferences.",
+      "enabling": "Enabling…",
+      "discoverRoommates": "Scopri coinquilini",
+      "updatePreferences": "Update preferences",
+      "matchingEnabled": "Roommate matching enabled",
+      "matchingDisabled": "Roommate matching disabled"
+    },
+    "request": {
+      "accept": "Accept",
+      "decline": "Decline",
+      "viewProfile": "View profile",
+      "sent": "Sent",
+      "received": "Received",
+      "pending": "Pending",
+      "accepted": "Accepted",
+      "declined": "Declined",
+      "responsePlaceholder": "Add an optional message..."
+    },
+    "relationship": {
+      "endRelationship": "End relationship",
+      "confirmEndTitle": "End roommate relationship?",
+      "confirmEndBody": "You will no longer appear as roommates.",
+      "message": "Message",
+      "title": "Roommate Relationship",
+      "duration": "Duration: {{duration}}",
+      "started": "Started: {{date}}",
+      "endedOn": "Ended on {{date}}",
+      "statusActive": "Active",
+      "statusInactive": "Inactive",
+      "statusEnded": "Ended",
+      "statusUnknown": "Unknown",
+      "durationDays": "{{count}} days",
+      "durationMonth": "{{count}} month",
+      "durationMonths": "{{count}} months",
+      "durationYear": "{{count}} year",
+      "durationYears": "{{count}} years",
+      "percentMatch": "{{score}}% Match",
+      "roommatesSection": "Roommates",
+      "confirmEndAction": "End Relationship"
+    },
+    "match": {
+      "compatibility": "{{score}}% match",
+      "viewProfile": "View profile",
+      "connect": "Connect",
+      "excellent": "Excellent Match",
+      "good": "Good Match",
+      "fair": "Fair Match",
+      "preferences": "Preferences",
+      "flexible": "Flexible",
+      "messageLabel": "Add a message (optional):",
+      "messagePlaceholder": "Hi! I think we'd be great roommates...",
+      "sendRequest": "Send Request",
+      "fallbackName": "Roommate"
+    },
+    "profileDetail": {
+      "title": "Coinquilino",
+      "loadError": "Couldn't load profile",
+      "loadErrorDescription": "We couldn't load this roommate profile. Please try again.",
+      "about": "About",
+      "preferencesTitle": "Roommate preferences",
+      "budget": "Budget",
+      "moveIn": "Move-in",
+      "leaseLength": "Lease length",
+      "notSpecified": "Not specified",
+      "trust": "Trust",
+      "verified": "Verified",
+      "references": "References",
+      "rentalHistory": "Rental history",
+      "sending": "Sending…",
+      "sendRequest": "Invia richiesta coinquilino",
+      "requestSentTitle": "Request sent",
+      "requestSentBody": "Your roommate request was sent.",
+      "requestFailedTitle": "Could not send request",
+      "requestFailedBody": "We could not send your request. Please try again."
+    },
+    "preferencesPage": {
+      "title": "Preferenze coinquilino",
+      "eyebrow": "Sharing a place",
+      "subtitle": "Let other Homiio users find you when their preferences and yours line up.",
+      "enableTitle": "Enable roommate matching",
+      "enableDescription": "Allow other users to discover your profile for matching.",
+      "budgetTimeline": "Budget & timeline",
+      "monthlyBudget": "Monthly budget (€)",
+      "min": "Min",
+      "max": "Max",
+      "moveInDate": "Move-in date",
+      "leaseLength": "Lease length",
+      "roommateSection": "Roommate",
+      "preferredGender": "Preferred gender",
+      "ageRange": "Age range",
+      "lifestyle": "Lifestyle",
+      "smoking": "Smoking",
+      "pets": "Pets",
+      "partying": "Partying",
+      "cleanliness": "Cleanliness",
+      "schedule": "Schedule",
+      "saving": "Saving…",
+      "save": "Salva preferenze",
+      "personalProfileRequired": "Personal profile required",
+      "personalProfileDescription": "Roommate preferences are only available for personal profiles. Please switch to your personal profile to manage your roommate settings.",
+      "switchToPersonal": "Switch to personal profile",
+      "options": {
+        "gender": {
+          "any": "Any",
+          "male": "Male",
+          "female": "Female"
+        },
+        "lifestyle": {
+          "yes": "Yes",
+          "no": "No",
+          "prefer_not": "No pref."
+        },
+        "cleanliness": {
+          "very_clean": "Very clean",
+          "clean": "Clean",
+          "average": "Average",
+          "relaxed": "Relaxed"
+        },
+        "schedule": {
+          "early_bird": "Early bird",
+          "night_owl": "Night owl",
+          "flexible": "Flexible"
+        },
+        "lease": {
+          "monthly": "Monthly",
+          "3_months": "3 months",
+          "6_months": "6 months",
+          "yearly": "Yearly",
+          "flexible": "Flexible"
+        }
+      }
     }
   },
   "safety": {
@@ -954,11 +2042,57 @@
     }
   },
   "horizon": {
-    "title": "Iniziativa Horizon",
+    "title": "Horizon Initiative",
     "description": "Iniziativa globale per alloggi equi, assistenza sanitaria e supporto per i viaggi",
     "benefits": "Benefici",
     "join": "Unisciti a Horizon",
-    "learnMore": "Scopri di Più"
+    "learnMore": "Scopri di Più",
+    "page": {
+      "benefits": {
+        "fairHousing": {
+          "title": "Abitazione equa",
+          "description": "Accesso a alloggi accessibili in oltre 120 città con contratti etici standardizzati"
+        },
+        "healthcare": {
+          "title": "Accesso alla sanità",
+          "description": "Copertura sanitaria universale con cliniche partner e telemedicina in ogni città Horizon"
+        },
+        "travel": {
+          "title": "Rete di viaggi",
+          "description": "Trasporti e alloggi scontati viaggiando tra le sedi Horizon"
+        },
+        "community": {
+          "title": "Supporto alla comunità",
+          "description": "Connettiti con membri locali per integrazione culturale, scambio linguistico e attività sociali"
+        }
+      },
+      "heroTitle": "Iniziativa globale per l'abitazione",
+      "heroSubtitle": "Creare un mondo di abitazione, sanità e mobilità etiche",
+      "aboutTitle": "Informazioni su Horizon",
+      "aboutBody1": "Horizon è un'iniziativa globale per rendere l'abitazione più accessibile, conveniente ed etica per tutti. Unendoti a una rete di proprietà in oltre 120 città, i membri accedono ad alloggi equi, benefici sanitari e supporto di viaggio.",
+      "aboutBody2": "La nostra missione è creare ambienti di vita sostenibili che favoriscano comunità e benessere, riducendo l'impatto ambientale dell'abitazione.",
+      "benefitsTitle": "Vantaggi per i membri",
+      "howItWorksTitle": "Come funziona",
+      "steps": {
+        "apply": {
+          "title": "Richiedi l'iscrizione",
+          "description": "Completa il profilo e invia una domanda con le tue esigenze e preferenze abitative."
+        },
+        "verify": {
+          "title": "Verifica",
+          "description": "Il nostro team esamina la domanda e verifica identità e informazioni di background."
+        },
+        "access": {
+          "title": "Accedi alla rete",
+          "description": "Una volta approvato, esplora e prenota proprietà nella rete globale con accesso prioritario."
+        }
+      },
+      "joinTitle": "Pronto a unirti a Horizon?",
+      "joinSubtitle": "Candidati oggi e fai il primo passo verso un'abitazione etica e accessibile in tutto il mondo.",
+      "storiesTitle": "Storie dei membri",
+      "story1": "Horizon ha reso il mio trasloco molto più semplice. Ho trovato un appartamento etico a Berlino in una settimana e la copertura sanitaria mi ha aiutato in un'emergenza.",
+      "story2": "Come nomade digitale, avere accesso ad alloggi di qualità in più città ha cambiato la mia vita. L'aspetto comunitario rende Horizon davvero speciale."
+    }
   },
   "sindi": {
     "name": "Sindi",
@@ -1080,7 +2214,62 @@
     },
     "errors": {
       "connection": "Errore di Connessione",
-      "connectionMessage": "Controlla la tua connessione e riprova."
+      "connectionMessage": "Controlla la tua connessione e riprova.",
+      "uploadFailedTitle": "Caricamento non riuscito",
+      "uploadAnalyzeFailed": "Impossibile analizzare il file."
+    },
+    "shared": {
+      "loading": "Loading Shared Conversation",
+      "loadingMessage": "Loading conversation...",
+      "subtitle": "Shared Conversation",
+      "badge": "Shared Conversation",
+      "footer": "Powered by Sindi - Your AI Housing Justice Advocate",
+      "error": {
+        "title": "Conversation Not Found",
+        "notFound": "This shared conversation could not be found or has expired.",
+        "failed": "Failed to load shared conversation. Please try again.",
+        "description": "The conversation may have been removed or the link may be invalid."
+      },
+      "empty": {
+        "title": "Empty Conversation",
+        "subtitle": "This shared conversation doesn't have any messages yet."
+      }
+    },
+    "share": {
+      "text": "Check out this conversation with Sindi, your AI housing justice advocate",
+      "success": {
+        "title": "Conversation Shared",
+        "copied": "Share link copied to clipboard!"
+      },
+      "error": {
+        "title": "Cannot Share Conversation",
+        "saveFirst": "Please save the conversation by sending a message before sharing.",
+        "emptyConversation": "Cannot share an empty conversation. Please add some messages first.",
+        "failed": "Failed to generate share link. Please try again."
+      }
+    },
+    "conversation": {
+      "title": "Conversation",
+      "subtitle": "AI Housing Justice Advocate",
+      "loading": "Loading Conversation",
+      "loadingMessage": "Loading conversation...",
+      "error": "Conversation Error",
+      "empty": {
+        "title": "Start Your Conversation",
+        "subtitle": "Ask Sindi about tenant rights, housing search, or any housing-related questions. I'm here to help you fight for housing justice."
+      }
+    },
+    "settings": {
+      "resetMessage": "This will reset all Sindi preferences to their defaults.",
+      "resetTitle": "Reset Sindi?",
+      "reset": "Reset Sindi to defaults",
+      "actions": "Actions",
+      "tipsDescription": "Surface inline guidance while you chat.",
+      "tips": "Show tips & hints",
+      "behaviorFooter": "Tune how Sindi behaves while you browse properties.",
+      "behavior": "Behavior",
+      "title": "Sindi preferences",
+      "resetDone": "Sindi preferences reset."
     }
   },
   "sidebar": {
@@ -1101,7 +2290,8 @@
       "tips": "Consigli",
       "hostCalendar": "Calendario host",
       "hostReservations": "Prenotazioni host",
-      "landlordApplications": "Casella candidature"
+      "landlordApplications": "Casella candidature",
+      "insights": "Insights"
     },
     "actions": {
       "addProperty": "Aggiungi Proprietà",
@@ -1176,7 +2366,95 @@
       "newest": "Prima i Più Recenti",
       "oldest": "Prima i Più Vecchi",
       "alphabetical": "Alfabetico"
-    }
+    },
+    "header": "Saved",
+    "tabs": {
+      "all": "All",
+      "recent": "Recent",
+      "noted": "With Notes",
+      "quickSaves": "Quick Saves",
+      "folders": "Folders",
+      "profiles": "Profiles",
+      "searches": "Saved Searches",
+      "label": "Saved view"
+    },
+    "view": {
+      "list": "List",
+      "grid": "Grid"
+    },
+    "searchPlaceholder": "Search your saved items...",
+    "profilesLabel": "profiles",
+    "adjustFilters": "Try adjusting your search or filter criteria",
+    "sort": {
+      "recent": "Recently Saved",
+      "price-low": "Price: Low to High",
+      "price-high": "Price: High to Low",
+      "title": "Property Name",
+      "notes": "Most Notes"
+    },
+    "editFolder": "Edit Folder",
+    "defaultFolder": "Default Folder",
+    "folderNamePlaceholder": "Folder name",
+    "noFolder": "Folder not found",
+    "noFolderDescription": "This folder may have been removed",
+    "noFolderItems": "No properties in this folder",
+    "noFolderItemsDescription": "Save properties to this folder to see them here",
+    "toast": {
+      "loadFoldersFailed": "Failed to load folders",
+      "folderCreated": "Folder created successfully",
+      "folderCreateFailed": "Failed to create folder",
+      "folderUpdated": "Folder updated successfully",
+      "folderUpdateFailed": "Failed to update folder",
+      "folderDeleted": "Folder deleted successfully",
+      "folderDeleteFailed": "Failed to delete folder",
+      "propertySaved": "Proprietà salvata correttamente",
+      "propertySaveFailed": "Failed to save property",
+      "propertyRemoved": "Property removed from saved",
+      "propertyUnsaveFailed": "Failed to unsave property",
+      "propertySavedToFolder": "Proprietà salvata nella cartella",
+      "saveToFolderFailed": "Impossibile salvare nella cartella"
+    },
+    "folder": {
+      "title": "Salva in cartella",
+      "createNew": "Crea nuova cartella",
+      "folderNamePlaceholder": "Nome cartella",
+      "chooseColor": "Scegli colore",
+      "chooseEmoji": "Scegli emoji",
+      "creating": "Creazione...",
+      "createAndSave": "Crea e salva",
+      "propertyCount_one": "{{count}} proprietà",
+      "propertyCount_other": "{{count}} proprietà",
+      "alertFolderNameRequired": "Inserisci un nome per la cartella",
+      "alertDefaultFolderRename": "La cartella predefinita non può essere rinominata."
+    },
+    "exploreCta": "Explore properties",
+    "loadFailed": "We couldn't load this folder",
+    "noPropertiesDescription": "Save properties to see them here.",
+    "noProperties": "No saved properties",
+    "noResults": "No matches",
+    "createFolder": "Create folder",
+    "noFoldersDescription": "Create folders to organise the places you like.",
+    "noFolders": "No folders yet"
+  },
+  "imageUpload": {
+    "permissionTitle": "Permesso richiesto",
+    "permissionMessage": "Serve l'accesso alla galleria per caricare le immagini.",
+    "maxImagesTitle": "Numero massimo di immagini raggiunto",
+    "maxImagesMessage": "Puoi caricare al massimo {{max}} immagini.",
+    "selectFailed": "Impossibile selezionare le immagini. Riprova.",
+    "photoFailed": "Impossibile scattare la foto. Riprova.",
+    "uploadFailed": "Impossibile caricare alcune immagini. Riprova.",
+    "deleteTitle": "Elimina immagine",
+    "deleteMessage": "Eliminare questa immagine?",
+    "deleteFailed": "Impossibile eliminare l'immagine. Riprova.",
+    "choosePhotos": "Choose Photos",
+    "takePhoto": "Take Photo",
+    "uploading": "Uploading images...",
+    "imageCount": "{{current}} of {{max}} images uploaded",
+    "primary": "Primary",
+    "addMore": "Add More",
+    "helperText": "Upload high-quality images of your property. Include photos of all rooms, exterior, and any special features.",
+    "helperPrimaryNote": " The first image will be set as the primary image."
   },
   "listing": {
     "exchange": {
@@ -1303,7 +2581,7 @@
       "forSale": "In vendita",
       "exchange": "Scambio",
       "verified": "Verificato",
-      "eco": "Eco",
+      "eco": "Ecologico",
       "instantBook": "Prenotazione immediata"
     },
     "offering": {
@@ -1376,7 +2654,949 @@
       "loanAmount": "Importo del prestito",
       "totalInterest": "Interessi totali",
       "totalPaid": "Totale pagato"
+    },
+    "cta": {
+      "housingAuthority": "Ente per l'abitazione",
+      "landlord": "Proprietario",
+      "applyOnStateWebsite": "Richiedi sul sito ufficiale",
+      "viewOnSourceWebsite": "Vedi sul portale di origine",
+      "callNow": "Chiama ora",
+      "moreByOwner": "Altri immobili di questo proprietario"
     }
   },
-  "goBack": "Indietro"
+  "goBack": "Indietro",
+  "app": {
+    "welcome": {
+      "title": "Welcome to Homiio! 👋",
+      "subtitle": "Thanks for trying out our app. Start exploring now!"
+    },
+    "errors": {
+      "screenNotExist": "This screen doesn't exist.",
+      "goHome": "Go to home screen!",
+      "noResults": "No results found for"
+    },
+    "loading": "Loading...",
+    "battery": "Battery"
+  },
+  "trust": {
+    "loadingVerification": "Loading verification status...",
+    "loadingScore": "Loading trust score...",
+    "errorVerification": "Unable to load verification status",
+    "errorScore": "Unable to load trust score",
+    "viewDetails": "View Details",
+    "noVerification": "No verification data",
+    "noScore": "No trust score data",
+    "verified": "Verified",
+    "completeVerification": "Complete Verification",
+    "yourScoreIs": "Your trust score is",
+    "improveScore": "Improve Score",
+    "manager": {
+      "loading": "Caricamento punteggio di fiducia...",
+      "error": "Errore nel caricamento del punteggio",
+      "noData": "Nessun dato di punteggio personale trovato",
+      "title": "Punteggio di fiducia",
+      "subtitle": "Costruisci fiducia con proprietari e coinquilini",
+      "scoreDescription": "Il tuo punteggio complessivo è {{score}}/100",
+      "factorsTitle": "Fattori di fiducia",
+      "factorsSubtitle": "Migliora questi fattori per aumentare il punteggio",
+      "quickActionsTitle": "Azioni rapide per migliorare",
+      "completeProfile": "Completa profilo",
+      "cancel": "Annulla",
+      "editProfile": "Modifica profilo",
+      "factorAlertBody": "{{description}}\n\nPunteggio attuale: {{score}}/100\n\nPer migliorare: {{action}}",
+      "factors": {
+        "verification": {
+          "label": "Verifica identità",
+          "description": "Completa la verifica dell'identità per costruire fiducia",
+          "action": "Aggiungi informazioni personali e dati sul reddito"
+        },
+        "reviews": {
+          "label": "Recensioni utenti",
+          "description": "Ottieni recensioni positive da proprietari e coinquilini",
+          "action": "Aggiungi referenze di precedenti proprietari"
+        },
+        "payment_history": {
+          "label": "Storico pagamenti",
+          "description": "Mantieni un buono storico dei pagamenti",
+          "action": "Aggiungi storico affitti con registri di pagamento"
+        },
+        "communication": {
+          "label": "Comunicazione",
+          "description": "Rispondi tempestivamente a messaggi e richieste",
+          "action": "Completa bio e informazioni di contatto"
+        },
+        "rental_history": {
+          "label": "Storico affitti",
+          "description": "Costruisci uno storico affitti positivo",
+          "action": "Aggiungi i tuoi precedenti indirizzi di affitto"
+        },
+        "default": {
+          "description": "Migliora questo fattore per aumentare il punteggio",
+          "action": "Completa il profilo per migliorare questo fattore"
+        }
+      },
+      "actions": {
+        "personalInfo": {
+          "title": "Completa informazioni personali",
+          "description": "Aggiungi occupazione, reddito e dati lavorativi per costruire fiducia."
+        },
+        "references": {
+          "title": "Aggiungi referenze",
+          "description": "Includi referenze di precedenti proprietari e datori di lavoro."
+        },
+        "rentalHistory": {
+          "title": "Aggiungi storico affitti",
+          "description": "Documenta il tuo storico affitti per dimostrare affidabilità."
+        }
+      }
+    },
+    "score": {
+      "levels": {
+        "excellent": "Eccellente",
+        "good": "Buono",
+        "average": "Nella media",
+        "fair": "Discreto",
+        "needsImprovement": "Da migliorare"
+      },
+      "breakdown": "Dettaglio punteggio di fiducia",
+      "recalculate": "Ricalcola",
+      "recalculating": "Ricalcolo in corso…"
+    }
+  },
+  "donations": {
+    "widget": {
+      "title": "Support Our Mission",
+      "description": "Help us build the future of ethical housing. Your support makes a difference.",
+      "button": "Donate to Homiio"
+    },
+    "page": {
+      "title": "Donate to Homiio",
+      "subtitle": "Support the future of ethical housing",
+      "description": "Your contribution helps us build a transparent, fair, and ethical housing platform that benefits everyone in the rental ecosystem.",
+      "chooseContribution": "Choose Your Contribution",
+      "frequency": {
+        "label": "Donation frequency",
+        "monthly": "Monthly",
+        "oneTime": "One-time",
+        "perMonth": "/mo"
+      },
+      "error": {
+        "title": "Something went wrong",
+        "generic": "Unable to process your donation. Please try again later."
+      },
+      "tiers": {
+        "supporter": {
+          "title": "One-time donation",
+          "subtitle": "Help with a small contribution",
+          "button": "Donate Now"
+        },
+        "monthly": {
+          "title": "Monthly supporter",
+          "subtitle": "Become a regular supporter",
+          "button": "Start Supporting"
+        },
+        "founder": {
+          "title": "Founder supporter",
+          "subtitle": "Join our founding supporters",
+          "button": "Become a Founder"
+        }
+      },
+      "impact": {
+        "title": "What Your Support Enables",
+        "areas": {
+          "development": {
+            "title": "Platform Development",
+            "description": "Continuous improvement of our housing platform"
+          },
+          "safety": {
+            "title": "Trust & Safety",
+            "description": "Enhanced verification and fraud prevention"
+          },
+          "legal": {
+            "title": "Legal Integration",
+            "description": "Sindi legal support and transparent contracts"
+          },
+          "innovation": {
+            "title": "Innovation",
+            "description": "FairCoin payments and energy monitoring"
+          },
+          "community": {
+            "title": "Community Building",
+            "description": "Growing the ethical housing movement"
+          }
+        }
+      },
+      "mission": {
+        "title": "Why Support Homiio?",
+        "description": "We're building more than just a rental platform—we're creating a complete ecosystem for ethical housing. Your support helps us:",
+        "goals": [
+          "Fight against rental abuse and hidden fees",
+          "Create transparent processes for tenants and landlords",
+          "Integrate innovative payment methods like FairCoin",
+          "Provide legal support through our Sindi integration",
+          "Build sustainable, community-driven solutions"
+        ]
+      }
+    }
+  },
+  "notFound": {
+    "title": "Pagina non trovata",
+    "message": "La pagina che cerchi non esiste.",
+    "goBack": "Torna indietro"
+  },
+  "statusBadge": {
+    "draft": "Bozza",
+    "pending": "In attesa",
+    "pendingSignatures": "Firme in attesa",
+    "active": "Attivo",
+    "expired": "Scaduto",
+    "terminated": "Risolto",
+    "cancelled": "Annullato",
+    "processing": "In elaborazione",
+    "completed": "Completato",
+    "failed": "Fallito",
+    "refunded": "Rimborsato",
+    "success": "Successo",
+    "warning": "Avviso",
+    "error": "Errore",
+    "info": "Info",
+    "investigating": "In indagine",
+    "resolved": "Risolto",
+    "online": "Online",
+    "offline": "Offline",
+    "unknown": "Sconosciuto",
+    "application": {
+      "submitted": "Inviata",
+      "reviewing": "In revisione",
+      "approved": "Approvata",
+      "rejected": "Rifiutata",
+      "withdrawn": "Ritirata"
+    },
+    "reservation": {
+      "pending": "In attesa",
+      "confirmed": "Confermata",
+      "declined": "Rifiutata",
+      "cancelled": "Annullata",
+      "completed": "Completata"
+    }
+  },
+  "applications": {
+    "list": {
+      "title": "Le mie candidature",
+      "filterAll": "Tutte",
+      "filterActive": "Attive",
+      "filterDecided": "Decise",
+      "filterWithdrawn": "Ritirate",
+      "signInTitle": "Accedi per vedere le tue candidature",
+      "signInDescription": "Tieni traccia delle candidature inquilino inviate ai proprietari.",
+      "signIn": "Accedi",
+      "loadError": "Impossibile caricare le tue candidature",
+      "tryAgain": "Riprova.",
+      "retry": "Riprova",
+      "emptyAllTitle": "Nessuna candidatura ancora.",
+      "emptyFilteredTitle": "Niente in questa vista.",
+      "emptyAllDescription": "Sfoglia gli annunci e invia una candidatura per un affitto a lungo termine.",
+      "emptyFilteredDescription": "Prova un filtro diverso o invia una nuova candidatura.",
+      "exploreStays": "Esplora soggiorni",
+      "today": "Oggi",
+      "thisWeek": "Questa settimana",
+      "earlier": "Precedenti"
+    },
+    "card": {
+      "propertyFallback": "Proprietà",
+      "applicantFallback": "Candidato",
+      "monthLease": "Contratto di {{count}} mesi",
+      "moveIn": "Ingresso",
+      "submitted": "Inviata il {{date}}",
+      "perMonth": "/ mese",
+      "accessibility": "Candidatura {{id}}"
+    },
+    "toast": {
+      "openDocumentFailed": "Impossibile aprire il documento.",
+      "withdrawn": "Candidatura ritirata",
+      "withdrawFailed": "Impossibile ritirare la candidatura"
+    },
+    "documentType": {
+      "id": "Documento d'identità",
+      "income": "Reddito",
+      "reference": "Referenza",
+      "other": "Altro"
+    },
+    "landlord": {
+      "toastOpenDocumentFailed": "Impossibile aprire il documento.",
+      "review": {
+        "reviewing": {
+          "title": "Segnare come in revisione?",
+          "message": "Il candidato saprà che hai aperto la sua domanda. Potrai ancora approvare o rifiutare in seguito.",
+          "confirm": "Segna come in revisione",
+          "successToast": "Domanda segnata come in revisione"
+        },
+        "approve": {
+          "title": "Approvare la domanda?",
+          "message": "Il candidato verrà notificato e potrà procedere alla firma del contratto.",
+          "confirm": "Approva",
+          "successToast": "Domanda approvata"
+        },
+        "reject": {
+          "title": "Rifiutare la domanda?",
+          "message": "Il candidato verrà notificato. Non può essere annullato, ma potrà inviare una nuova domanda in seguito.",
+          "confirm": "Rifiuta",
+          "successToast": "Domanda rifiutata"
+        }
+      },
+      "toastUpdateFailed": "Impossibile aggiornare la domanda"
+    },
+    "field": {
+      "moveInDate": "Move-in date",
+      "notesPlaceholder": "Anything else the landlord should know about you?",
+      "removeDocument": "Remove document",
+      "pickDocuments": "Add documents",
+      "addReference": "Add another reference",
+      "email": "Email",
+      "phone": "Phone number",
+      "relationship": "Relationship",
+      "namePlaceholder": "Jane Doe",
+      "name": "Full name",
+      "removeReference": "Remove reference",
+      "referenceIndex": "Reference {{index}}",
+      "employment": "Employment status",
+      "monthlyIncomePlaceholder": "e.g. 2400",
+      "monthlyIncome": "Gross monthly income",
+      "leaseTermCustomPlaceholder": "Number of months",
+      "leaseTermCustom": "Other",
+      "leaseTerm": "Lease term",
+      "moveInHelper": "Within the next 6 months.",
+      "leaseTermMonths": "{{count}} months"
+    },
+    "cta": {
+      "apply": "Apply to rent",
+      "subtitle": "Submit a quick application with your move-in date, income and references — the landlord reviews and replies inside Homiio.",
+      "title": "Interested in this place?",
+      "addMoveIn": "Add move-in date"
+    },
+    "detail": {
+      "viewStatus": "View status",
+      "alreadySubmittedBody": "You already have an application in review for this property.",
+      "alreadySubmitted": "Application submitted"
+    },
+    "actions": {
+      "submit": "Submit application"
+    },
+    "section": {
+      "notes": "Notes to landlord (optional)",
+      "documentsHelp": "Upload up to {{max}} PDFs or images (10 MB each). Pick a category per file.",
+      "documents": "Documents (optional)",
+      "referencesHelp": "Add 1 to 3 contacts the landlord can call to vouch for you.",
+      "references": "References",
+      "finances": "Income & employment",
+      "timing": "Move-in & lease term"
+    },
+    "apply": {
+      "title": "Apply to rent"
+    },
+    "success": {
+      "submitted": "Application submitted"
+    },
+    "error": {
+      "invalidForm": "Please complete every required field.",
+      "generic": "Something went wrong. Please try again.",
+      "auth": "Please sign in to apply.",
+      "notApplicable": "This property does not accept long-term applications.",
+      "external": "External listings cannot be applied to from Homiio.",
+      "alreadyApplied": "You already have an active application for this property."
+    },
+    "documents": {
+      "pickFailed": "Could not pick documents",
+      "tooLarge": "{{name}} supera i 10 MB ed è stato ignorato.",
+      "limit": "Puoi caricare fino a {{max}} documenti per candidatura."
+    },
+    "employment": {
+      "employed": "Employed",
+      "selfEmployed": "Self-employed",
+      "student": "Student",
+      "retired": "Retired",
+      "unemployed": "Unemployed",
+      "other": "Other"
+    },
+    "relationship": {
+      "landlord": "Previous landlord",
+      "employer": "Employer",
+      "personal": "Personal",
+      "other": "Other"
+    },
+    "docType": {
+      "id": "ID",
+      "income": "Income proof",
+      "reference": "Reference letter",
+      "other": "Other"
+    }
+  },
+  "reservations": {
+    "card": {
+      "propertyFallback": "Proprietà",
+      "night": "notte",
+      "nights": "notti",
+      "guest": "ospite",
+      "guests": "ospiti",
+      "hostGuestSuffix": "(ospite)",
+      "accessibility": "Prenotazione {{id}}"
+    },
+    "detail": {
+      "title": "Prenotazione",
+      "invalidId": "ID prenotazione non valido",
+      "invalidIdDescription": "Il link non include il riferimento della prenotazione.",
+      "unavailable": "Prenotazione non disponibile",
+      "unavailableDescription": "Impossibile caricare questa prenotazione.",
+      "goBack": "Indietro",
+      "tripDetails": "Dettagli del soggiorno",
+      "checkIn": "Check-in",
+      "checkOut": "Check-out",
+      "guests": "Ospiti",
+      "nights": "Notti",
+      "price": "Prezzo",
+      "approve": "Approva",
+      "decline": "Rifiuta",
+      "cancelReservation": "Cancel reservation",
+      "cancelPolicyNote": "Cancellation is no longer possible under the {{policy}} policy. Contact your host if you need to make changes.",
+      "confirmCancelTitle": "Cancel reservation?",
+      "confirmCancelBody": "This will release the dates back to the host and end the booking.",
+      "confirmCancelAction": "Yes, cancel",
+      "confirmApproveTitle": "Approve reservation?",
+      "confirmApproveBody": "The guest will be notified and the dates will be marked confirmed on your calendar.",
+      "confirmDeclineTitle": "Decline reservation?",
+      "confirmDeclineBody": "The guest will be notified that this request was declined.",
+      "toastConfirmed": "Reservation confirmed",
+      "toastDeclined": "Reservation declined",
+      "toastCancelled": "Reservation cancelled",
+      "toastUpdateFailed": "Update failed"
+    }
+  },
+  "reviews": {
+    "card": {
+      "anonymous": "Anonimo",
+      "verifiedResident": "Residente verificato",
+      "verified": "Verificato",
+      "confident": "{{score}}% di fiducia",
+      "proof": "prova",
+      "proofs": "prove",
+      "karma": "{{score}} karma",
+      "livedMonths": "Ha vissuto {{count}} mesi",
+      "perMonth": "{{price}} {{currency}}/mese",
+      "moreIssues": "+{{count}} altri",
+      "positive": "Positivo:",
+      "negative": "Negativo:",
+      "helpful": "Utile ({{count}})",
+      "report": "Segnala",
+      "reply": "Rispondi",
+      "recommends": "✓ Consiglia",
+      "doesNotRecommend": "✗ Non consiglia",
+      "underReview": "In revisione",
+      "alertThankYouTitle": "Grazie",
+      "alertThankYouBody": "Il tuo feedback è stato registrato.",
+      "alertReportTitle": "Segnala recensione",
+      "alertReportBody": "Sei sicuro di voler segnalare questa recensione per contenuti inappropriati?",
+      "alertReportConfirm": "Segnala",
+      "alertReportedTitle": "Segnalata",
+      "alertReportedBody": "Questa recensione è stata segnalata al nostro team di moderazione.",
+      "alertReplyTitle": "Rispondi alla recensione",
+      "alertReplyBody": "La funzione di risposta permetterà a proprietari e gestori immobiliari di rispondere alle recensioni."
+    },
+    "write": {
+      "validationTitle": "Errore di validazione",
+      "streetRequired": "Inserisci un indirizzo.",
+      "cityRequired": "Inserisci una città.",
+      "postalCodeRequired": "Inserisci un codice postale.",
+      "countryRequired": "Inserisci un paese.",
+      "opinionRequired": "Condividi la tua opinione su questo indirizzo.",
+      "opinionMinLength": "La tua opinione deve avere almeno 10 caratteri.",
+      "priceRequired": "Inserisci un prezzo valido.",
+      "datesRequired": "Inserisci le date di inizio e fine.",
+      "recommendationRequired": "Indica se consiglieresti questo indirizzo.",
+      "ratingRequired": "Assegna una valutazione da 1 a 5.",
+      "submitSuccess": "La tua recensione è stata inviata con successo!",
+      "submitFailed": "Impossibile inviare la recensione",
+      "submitFailedRetry": "Impossibile inviare la recensione. Riprova.",
+      "loadAddressFailed": "Couldn't load address",
+      "title": "Write review"
+    }
+  },
+  "subscriptions": {
+    "title": "Abbonamenti",
+    "alertError": "Errore",
+    "alertSuccess": "Successo",
+    "authRequired": "Autenticazione richiesta",
+    "checkoutFailed": "Impossibile avviare il pagamento",
+    "portalFailed": "Impossibile aprire la gestione abbonamenti",
+    "syncSuccess": "Stato abbonamento sincronizzato da Stripe",
+    "syncFailed": "Impossibile sincronizzare l'abbonamento",
+    "cancelImmediateSuccess": "Abbonamento annullato immediatamente",
+    "cancelFailed": "Impossibile annullare l'abbonamento",
+    "cancelEndOfPeriodSuccess": "L'abbonamento verrà annullato alla fine del periodo corrente",
+    "debugFailed": "Impossibile eseguire il debug dell'abbonamento",
+    "plusActive": "Homiio Plus active",
+    "plusInactive": "Upgrade to Homiio Plus",
+    "manage": "Manage subscription",
+    "sync": "Sync from Stripe",
+    "cancel": "Cancel subscription",
+    "cancelImmediate": "Cancel immediately",
+    "cancelEndOfPeriod": "Cancel at period end",
+    "fileCredits": "{{count}} file credits",
+    "since": "Member since {{date}}",
+    "canceledOn": "Canceled on {{date}}",
+    "lastPayment": "Last payment {{date}}",
+    "products": {
+      "plus": "Homiio Plus",
+      "plusDescription": "Priority support and premium features",
+      "file": "File credits",
+      "fileDescription": "Extra document storage credits",
+      "founder": "Founder",
+      "founderDescription": "Support Homiio and unlock founder perks"
+    },
+    "subscribe": "Subscribe",
+    "buyCredits": "Buy credits",
+    "becomeFounder": "Become a founder",
+    "page": {
+      "headerTitle": "Homiio+",
+      "headerSubtitle": "Il tuo alleato per un'abitazione etica",
+      "introText": "Your subscription gives you access to Sindi, the legal assistant that scans your rental contracts and flags abusive clauses. No ads, no speculation, no data selling.",
+      "payPerContract": {
+        "title": "Pay per contract",
+        "price": "5 € per contract review",
+        "description": "Perfect for one-time use.",
+        "reviewButton": "Review Contract"
+      },
+      "plus": {
+        "title": "Homiio+ Subscription",
+        "price": "9.99 €/month",
+        "description": "Includes up to 10 contracts per month free. From the 11th contract onwards: 2.50 € each.",
+        "activeBadge": "Active subscription",
+        "canceledBadge": "Canceled on {{date}}",
+        "featureHistory": "Unlimited contract history",
+        "featureAlerts": "Legal alerts & notifications",
+        "featureSupport": "Priority support",
+        "manage": "Manage subscription",
+        "resubscribe": "Resubscribe",
+        "subscribeNow": "Subscribe now"
+      },
+      "founder": {
+        "title": "Founder supporter",
+        "price": "Contribution from 10 €/month",
+        "description": "Support Homiio's independence. Get recognition in the app + early access to features.",
+        "becomeSupporter": "Become a Supporter"
+      },
+      "footer": "Every euro keeps Homiio ethical, independent, and community-driven.",
+      "starting": "Starting…",
+      "back": "Indietro",
+      "notAvailable": "N/A",
+      "cancelImmediateTitle": "Cancel Immediately",
+      "cancelImmediateBody": "This will immediately cancel your subscription and you will lose access to Homiio+ features. Are you sure?",
+      "no": "No",
+      "yesCancelNow": "Yes, Cancel Now"
+    }
+  },
+  "recentlyViewed": {
+    "trackFailed": "Impossibile registrare la visualizzazione della proprietà",
+    "clearSuccess": "Proprietà visualizzate di recente cancellate",
+    "clearFailed": "Impossibile cancellare le proprietà visualizzate di recente"
+  },
+  "host": {
+    "calendar": {
+      "title": "Calendario host",
+      "signInTitle": "Accedi per gestire il calendario",
+      "signInDescription": "Blocca date e monitora le prenotazioni da un unico posto.",
+      "signIn": "Accedi",
+      "loadPropertiesError": "Impossibile caricare le tue proprietà",
+      "tryAgain": "Riprova.",
+      "emptyTitle": "Aggiungi la tua prima proprietà",
+      "emptyDescription": "Pubblica un alloggio così gli ospiti possono richiedere date qui.",
+      "createListing": "Crea annuncio",
+      "chooseProperty": "Scegli proprietà",
+      "legendConfirmed": "Confermata",
+      "legendPending": "In attesa",
+      "legendBlocked": "Bloccata",
+      "legendAvailable": "Disponibile",
+      "availabilityError": "Impossibile caricare la disponibilità",
+      "blockTitle": "Blocca queste date",
+      "blockBodyRange": "Block from {{start}} to {{end}}.",
+      "blockBodySingle": "Choose how long these dates are unavailable.",
+      "blockConfirm": "Blocca",
+      "blockReasonLabel": "Reason (optional)",
+      "blockReasonPlaceholder": "Maintenance, personal use, ...",
+      "toastBlocked": "Date bloccate",
+      "toastBlockFailed": "Impossibile bloccare",
+      "propertyNotFound": "Proprietà non trovata",
+      "property": "Proprietà"
+    },
+    "reservations": {
+      "title": "Prenotazioni",
+      "allReservations": "All reservations",
+      "signInTitle": "Sign in to manage reservations",
+      "signInDescription": "Approve or decline guest requests from one place.",
+      "signIn": "Sign in",
+      "filterAll": "All",
+      "loadError": "Couldn't load reservations",
+      "tryAgain": "Please try again.",
+      "emptyTitle": "No reservations yet",
+      "emptyDescription": "Guest requests will appear here once someone books.",
+      "toastConfirmed": "Reservation confirmed",
+      "toastDeclined": "Reservation declined",
+      "toastUpdateFailed": "Update failed",
+      "confirm": "Confirm",
+      "decline": "Decline",
+      "approve": "Approva",
+      "view": "Vedi",
+      "filterPending": "Pending",
+      "filterConfirmed": "Confirmed",
+      "filterDeclined": "Declined",
+      "filterCancelled": "Cancelled",
+      "filterCompleted": "Completed"
+    }
+  },
+  "stays": {
+    "list": {
+      "title": "Soggiorni",
+      "filterAll": "Tutti",
+      "filterUpcoming": "In arrivo",
+      "filterPast": "Passati",
+      "filterCancelled": "Annullati",
+      "groupUpcoming": "Upcoming",
+      "groupPast": "Past",
+      "groupCancelled": "Cancelled",
+      "signInTitle": "Sign in to see your stays",
+      "signInDescription": "Track short-term bookings you've made.",
+      "signIn": "Sign in",
+      "loadError": "Couldn't load stays",
+      "tryAgain": "Please try again.",
+      "emptyAllTitle": "No stays yet",
+      "emptyFilteredTitle": "Nothing in this view.",
+      "emptyAllDescription": "Once you book a place it will show up here.",
+      "emptyFilteredDescription": "Try a different filter or explore new stays.",
+      "exploreStays": "Esplora soggiorni"
+    }
+  },
+  "addresses": {
+    "detail": {
+      "title": "Address",
+      "loadError": "Impossibile caricare questo indirizzo",
+      "tryAgain": "Riprova.",
+      "propertiesSection": "Proprietà",
+      "reviewsSection": "Recensioni",
+      "emptyPropertiesTitle": "Nessuna proprietà qui ancora",
+      "emptyPropertiesDescription": "Gli annunci a questo indirizzo appariranno qui.",
+      "emptyReviewsTitle": "Nessuna recensione ancora",
+      "emptyReviewsDescription": "Sii il primo a condividere la tua esperienza a questo indirizzo.",
+      "writeReview": "Scrivi una recensione",
+      "switchLevel": "Cambia livello",
+      "buildingLevel": "Edificio",
+      "unitLevel": "Unità",
+      "notFound": "Indirizzo non trovato",
+      "notFoundDescription": "We couldn't find any details for this address.",
+      "storiesTitle": "Storie dei residenti",
+      "tabOverall": "Generale",
+      "tabApartments": "Appartamenti",
+      "tabCommunity": "Comunità",
+      "tabArea": "Zona",
+      "tabProperties": "Proprietà ({{count}})",
+      "tabReviews": "Recensioni ({{count}})"
+    },
+    "display": {
+      "copySuccess": "Indirizzo copiato negli appunti",
+      "copyFailed": "Impossibile copiare l'indirizzo",
+      "mapsFailed": "Impossibile aprire le mappe"
+    }
+  },
+  "propertyCreate": {
+    "location": {
+      "title": "Location",
+      "instructions": "📍 Address Details: Fill in the complete address information. Our system uses a hierarchical structure:\n• STREET level: Street name only\n• BUILDING level: Street + number + building details\n• UNIT level: Building + floor + unit/apartment details\nReviews and listings are organized by these levels for better organization.",
+      "country": "Country or Region",
+      "countryPickerTitle": "Country or Region",
+      "state": "State / Province / Region",
+      "statePickerTitle": "State / Province / Region",
+      "city": "City",
+      "street": "Street",
+      "number": "Number",
+      "postalCode": "Postal code",
+      "floor": "Floor",
+      "unit": "Unit / Apartment",
+      "showFloor": "Show floor field",
+      "hideFloor": "Hide floor field",
+      "selectCountry": "Select country or region",
+      "streetPlaceholder": "Street name",
+      "unitOptional": "Unit/Apartment Number (optional)",
+      "unitPlaceholder": "Apartment, suite, etc. (optional)",
+      "buildingNameOptional": "Nome edificio (opzionale)",
+      "buildingNamePlaceholder": "es., Torre Barcelona",
+      "blockOptional": "Blocco (opzionale)",
+      "blockPlaceholder": "es., Blocco A",
+      "entranceOptional": "Ingresso/Porta (opzionale)",
+      "entrancePlaceholder": "es., Porta 1, Ingresso B",
+      "subunitOptional": "Subunità (opzionale)",
+      "subunitPlaceholder": "es., Stanza A",
+      "numberPlaceholder": "Inserisci il numero",
+      "floorPlaceholder": "Inserisci il piano",
+      "floorPublic": "Pubblico",
+      "floorPrivate": "Privato",
+      "floorPrivacyHint": "ℹ️ Sarà mostrato in modo approssimativo per privacy",
+      "neighborhoodOptional": "Quartiere (opzionale)",
+      "neighborhoodPlaceholder": "es., Gràcia, Sant Andreu, Eixample",
+      "districtOptional": "Distretto (opzionale)",
+      "districtPlaceholder": "es., Distretto amministrativo",
+      "poBoxOptional": "Casella postale (opzionale)",
+      "poBoxPlaceholder": "es., Casella 123",
+      "referenceOptional": "Riferimento (opzionale)",
+      "referencePlaceholder": "es., Vicino alla metro",
+      "cityDistrict": "Città/Distretto",
+      "cityDistrictPlaceholder": "Città o distretto",
+      "selectState": "Seleziona provincia/regione",
+      "zipPostalCode": "CAP",
+      "zipPlaceholder": "Codice postale",
+      "availableFrom": "Disponibile da",
+      "availableFromPlaceholder": "Data di disponibilità",
+      "leaseTerm": "Durata contratto",
+      "leaseTermPlaceholder": "Durata contratto"
+    },
+    "amenities": {
+      "title": "Amenities",
+      "subtitle": "Select the amenities available at this property.",
+      "rulesTitle": "Servizi e regole",
+      "houseRules": "House Rules",
+      "petsAllowed": "Pets Allowed",
+      "smokingAllowed": "Smoking Allowed",
+      "partiesAllowed": "Parties Allowed",
+      "guestsAllowed": "Guests Allowed",
+      "maxGuests": "Maximum Number of Guests",
+      "maxGuestsPlaceholder": "e.g., 2",
+      "yes": "Yes",
+      "no": "No"
+    }
+  },
+  "booking": {
+    "toast": {
+      "pickDates": "Seleziona prima le date di check-in e check-out",
+      "minStay": "Soggiorno minimo di {{count}} {{unit}}",
+      "maxStay": "Soggiorno massimo di {{count}} {{unit}}",
+      "night": "notte",
+      "nights": "notti",
+      "failed": "Prenotazione non riuscita"
+    },
+    "accessibility": {
+      "selectDates": "Select dates",
+      "selectGuests": "Select guests",
+      "close": "Close"
+    }
+  },
+  "searchBar": {
+    "search": "Cerca",
+    "long": {
+      "propertyType": "Tipo di immobile",
+      "moveIn": "Data di ingresso",
+      "where": "Dove",
+      "where.value": "Qualsiasi città",
+      "moveIn.value": "Aggiungi data",
+      "propertyType.value": "Qualsiasi tipo"
+    },
+    "vacation": {
+      "where": "Dove",
+      "when": "Quando",
+      "who": "Chi",
+      "where.value": "Qualsiasi destinazione",
+      "when.value": "Aggiungi date",
+      "who.value": "Aggiungi ospiti"
+    },
+    "mode": {
+      "vacation": "Vacanza",
+      "longTerm": "Lungo termine",
+      "hint": "Passa tra affitti a lungo termine e soggiorni vacanza",
+      "label": "Modalità di affitto"
+    }
+  },
+  "error": {
+    "publicHousing": {
+      "openFailed": "Impossibile aprire il sito web abitativo"
+    },
+    "call": {
+      "failed": "Impossibile aprire il compositore telefonico",
+      "noPhone": "Nessun numero di telefono disponibile",
+      "notAllowed": "Il proprietario non accetta chiamate"
+    },
+    "profile": {
+      "notFound": "Profilo del proprietario non trovato"
+    },
+    "auth": {
+      "required": "Accedi per chiamare il proprietario"
+    },
+    "contact": {
+      "noPhone": "Nessun telefono disponibile per questo annuncio",
+      "openFailed": "Impossibile aprire il link di contatto"
+    },
+    "source": {
+      "openFailed": "Impossibile aprire il sito web di origine",
+      "noUrl": "URL del sito di origine non disponibile"
+    },
+    "boundary": {
+      "title": "Qualcosa è andato storto",
+      "message": "Un problema inatteso ha interrotto quello che stavi facendo. Puoi riprovare o inviarci una segnalazione rapida così possiamo indagare.",
+      "retry": "Riprova",
+      "reportIssue": "Segnala il problema",
+      "errorId": "ID errore",
+      "copyIdHint": "Tocca per copiare l'ID",
+      "copiedToClipboard": "Copiato negli appunti",
+      "showDetails": "Mostra dettagli tecnici",
+      "hideDetails": "Nascondi dettagli tecnici",
+      "technicalDetails": "Dettagli tecnici",
+      "maxRetriesTitle": "Continua a non funzionare",
+      "maxRetriesMessage": "Hai raggiunto il limite di tentativi. Segnala il problema così possiamo dargli un'occhiata.",
+      "forceRetry": "Forza riprova",
+      "reportCopiedTitle": "Segnalazione copiata",
+      "reportCopiedMessage": "La segnalazione dell'errore è stata copiata negli appunti.",
+      "reportFailedTitle": "Non è stato possibile copiare",
+      "reportFailedMessage": "Non siamo riusciti a copiare la segnalazione negli appunti. Riprova.",
+      "errorMessage": "Messaggio di errore",
+      "errorType": "Tipo di errore",
+      "stackTrace": "Stack trace",
+      "componentStack": "Stack dei componenti",
+      "deviceInformation": "Informazioni dispositivo"
+    },
+    "loadNotifications": "Errore nel caricamento delle notifiche"
+  },
+  "notification": {
+    "settings": {
+      "android": {
+        "openSettings": "Apri impostazioni di sistema",
+        "title": "Android Settings",
+        "description": "You can manage notification channels and advanced settings in your device's Settings app under Apps > Homiio > Notifications."
+      },
+      "ios": {
+        "openSettings": "Apri impostazioni di sistema",
+        "title": "iOS Settings",
+        "description": "For more granular control, you can also manage notification settings in your device's Settings app under Notifications > Homiio."
+      },
+      "test": {
+        "title": "Test Notifications",
+        "description": "Invia notifiche di prova per verificare che le impostazioni funzionino correttamente."
+      },
+      "property": {
+        "title": "Property Notifications",
+        "description": "New properties, price changes, and viewing reminders"
+      },
+      "message": {
+        "title": "Message Notifications",
+        "description": "New messages from agents, landlords, and other users"
+      },
+      "contract": {
+        "title": "Contract Notifications",
+        "description": "Contract updates, signatures, and important deadlines"
+      },
+      "payment": {
+        "title": "Payment Notifications",
+        "description": "Payment confirmations, reminders, and receipts"
+      },
+      "reminder": {
+        "title": "Reminder Notifications",
+        "description": "Viewing reminders, application deadlines, and follow-ups"
+      },
+      "system": {
+        "title": "System Notifications",
+        "description": "App updates, maintenance, and important announcements"
+      },
+      "marketing": {
+        "title": "Marketing Notifications",
+        "description": "Promotional offers, newsletters, and special deals"
+      },
+      "sound": {
+        "title": "Sound",
+        "description": "Play sound when notifications arrive"
+      },
+      "badge": {
+        "title": "Badge Count",
+        "description": "Show unread count on app icon"
+      },
+      "push": {
+        "title": "Push Notifications",
+        "description": "Receive notifications even when app is closed"
+      },
+      "title": "Notification Settings",
+      "categories": "Notification Categories",
+      "behavior": "Notification Behavior",
+      "manage": "Manage Notifications",
+      "clearAll": "Clear All Notifications",
+      "updated": "Settings updated",
+      "error": "Failed to update settings"
+    },
+    "test": {
+      "success": "Notifica di prova inviata",
+      "property": "Test Property",
+      "message": "Test Message",
+      "reminder": "Test Reminder",
+      "repeating": "Test Repeating",
+      "error": "Failed to send test notification"
+    },
+    "empty": {
+      "filteredTitle": "Nessuna corrispondenza",
+      "title": "No notifications",
+      "message": "You're all caught up! New notifications will appear here.",
+      "filtered": "No notifications match your current filter"
+    },
+    "filter": {
+      "label": "Filtra notifiche",
+      "all": "All",
+      "unread": "Unread"
+    },
+    "scheduled": {
+      "label": "Notifica programmata",
+      "title": "Scheduled Notifications",
+      "clearAll": "Clear All"
+    },
+    "markAllRead": {
+      "action": "Segna tutto come letto",
+      "success": "All notifications marked as read",
+      "error": "Failed to mark all as read"
+    },
+    "permissions": {
+      "enabled": {
+        "title": "Notifications Enabled",
+        "description": "Riceverai notifiche per le categorie abilitate."
+      },
+      "disabled": {
+        "title": "Notifications Disabled",
+        "description": "Abilita le notifiche per ricevere aggiornamenti su immobili, messaggi e altro."
+      },
+      "title": "Enable Notifications",
+      "message": "Get notified about new properties, messages, and important updates.",
+      "enable": "Enable Notifications",
+      "granted": "Notification permissions granted",
+      "denied": "Notification permissions denied",
+      "error": "Failed to request permissions"
+    },
+    "welcome": {
+      "title": "Benvenuto su Homiio! 👋",
+      "body": "Grazie per aver provato la nostra app. Inizia a esplorare ora!"
+    },
+    "search": {
+      "placeholder": "Search notifications..."
+    },
+    "delete": {
+      "title": "Delete Notification",
+      "message": "Are you sure you want to delete this notification?",
+      "success": "Notification deleted",
+      "error": "Failed to delete notification"
+    },
+    "clearAll": {
+      "title": "Clear All Notifications",
+      "message": "This will clear all notifications and reset the badge count. This action cannot be undone.",
+      "success": "All notifications cleared",
+      "error": "Failed to clear notifications"
+    }
+  },
+  "address": {
+    "display": {
+      "mapPlaceholder": "Map view available",
+      "copy": "Copy",
+      "openInMaps": "Open in Maps"
+    }
+  },
+  "inbox": {
+    "title": "Posta"
+  }
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -16,6 +16,7 @@
     "test": "jest --ci",
     "test:watch": "jest --watch",
     "lint": "expo lint",
+    "check:i18n": "bun scripts/check-locale-parity.ts",
     "clean": "rm -rf dist .expo"
   },
   "dependencies": {

--- a/packages/frontend/scripts/check-locale-parity.ts
+++ b/packages/frontend/scripts/check-locale-parity.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const LOCALES_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'locales');
+const LOCALES = ['en', 'es', 'ca-ES', 'it'] as const;
+
+function flattenKeys(obj: Record<string, unknown>, prefix = ''): Set<string> {
+  const keys = new Set<string>();
+  for (const [key, value] of Object.entries(obj)) {
+    if (prefix === '' && key.includes('.') && (typeof value === 'string' || Array.isArray(value))) {
+      keys.add(key);
+      continue;
+    }
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      for (const nested of flattenKeys(value as Record<string, unknown>, path)) {
+        keys.add(nested);
+      }
+    } else {
+      keys.add(path);
+    }
+  }
+  return keys;
+}
+
+function loadKeys(locale: (typeof LOCALES)[number]): Set<string> {
+  const file = locale === 'en' ? 'en.json' : `${locale}.json`;
+  return flattenKeys(JSON.parse(readFileSync(join(LOCALES_DIR, file), 'utf8')) as Record<string, unknown>);
+}
+
+const enKeys = loadKeys('en');
+let failed = false;
+
+for (const locale of LOCALES) {
+  if (locale === 'en') continue;
+  const missing = [...enKeys].filter((key) => !loadKeys(locale).has(key));
+  if (missing.length > 0) {
+    failed = true;
+    console.error(`[${locale}] missing ${missing.length} keys from en`);
+  }
+}
+
+if (failed) {
+  console.error('Locale parity check FAILED.');
+  process.exit(1);
+}
+
+console.log('Locale parity check passed.');

--- a/packages/frontend/scripts/sync-locale-keys.ts
+++ b/packages/frontend/scripts/sync-locale-keys.ts
@@ -1,0 +1,59 @@
+/**
+ * Copy missing keys from en.json into es/ca-ES/it (English placeholder for manual translation).
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const LOCALES_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'locales');
+type JsonObject = Record<string, unknown>;
+
+function isPlainObject(v: unknown): v is JsonObject {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function flatten(obj: JsonObject, prefix = ''): Map<string, unknown> {
+  const out = new Map<string, unknown>();
+  for (const [key, value] of Object.entries(obj)) {
+    if (prefix === '' && key.includes('.') && (typeof value === 'string' || Array.isArray(value))) {
+      out.set(key, value);
+      continue;
+    }
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (isPlainObject(value)) {
+      for (const [k, v] of flatten(value, path)) out.set(k, v);
+    } else out.set(path, value);
+  }
+  return out;
+}
+
+function setNested(obj: JsonObject, parts: string[], value: unknown): void {
+  let cursor: JsonObject = obj;
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    const part = parts[i];
+    if (!isPlainObject(cursor[part])) cursor[part] = {};
+    cursor = cursor[part] as JsonObject;
+  }
+  cursor[parts[parts.length - 1]] = value;
+}
+
+function enUsesFlatKey(en: JsonObject, path: string): boolean {
+  return Object.prototype.hasOwnProperty.call(en, path);
+}
+
+const en = JSON.parse(readFileSync(join(LOCALES_DIR, 'en.json'), 'utf8')) as JsonObject;
+const enFlat = flatten(en);
+
+for (const localeFile of ['es.json', 'ca-ES.json', 'it.json']) {
+  const target = JSON.parse(readFileSync(join(LOCALES_DIR, localeFile), 'utf8')) as JsonObject;
+  const targetFlat = flatten(target);
+  let copied = 0;
+  for (const [key, value] of enFlat) {
+    if (targetFlat.has(key)) continue;
+    if (enUsesFlatKey(en, key)) target[key] = value;
+    else setNested(target, key.split('.'), value);
+    copied += 1;
+  }
+  writeFileSync(join(LOCALES_DIR, localeFile), `${JSON.stringify(target, null, 2)}\n`, 'utf8');
+  console.log(`[${localeFile}] copied ${copied} missing keys`);
+}

--- a/packages/frontend/store/trustScoreStore.ts
+++ b/packages/frontend/store/trustScoreStore.ts
@@ -6,10 +6,9 @@ interface TrustScoreState {
   score: number;
   factors: Array<{
     id: string;
-    name: string;
+    type: string;
     score: number;
     weight: number;
-    description: string;
   }>;
   history: Array<{
     date: string;

--- a/packages/frontend/utils/dateLocale.ts
+++ b/packages/frontend/utils/dateLocale.ts
@@ -39,6 +39,22 @@ function resolveLocale(language: string | undefined): Locale {
   }
 }
 
+/** BCP-47 tag for `Date#toLocaleDateString` / `Intl` from an i18next language code. */
+export function getDateLocale(language?: string): string {
+  const tag = (language ?? i18next.language ?? 'en-US').toLowerCase();
+  const base = tag.split('-')[0];
+  switch (base) {
+    case 'es':
+      return 'es-ES';
+    case 'ca':
+      return 'ca-ES';
+    case 'it':
+      return 'it-IT';
+    default:
+      return 'en-US';
+  }
+}
+
 /** The `date-fns` locale matching the active i18next language (English fallback). */
 export function getDateFnsLocale(): Locale {
   return resolveLocale(i18next.language);

--- a/packages/frontend/utils/languagePreference.ts
+++ b/packages/frontend/utils/languagePreference.ts
@@ -1,0 +1,24 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import i18n from 'i18next';
+
+const STORAGE_KEY = 'homiio.language';
+
+export const SUPPORTED_LANGUAGE_CODES = ['en-US', 'es-ES', 'ca-ES', 'it-IT'] as const;
+export type SupportedLanguageCode = (typeof SUPPORTED_LANGUAGE_CODES)[number];
+
+export function isSupportedLanguage(code: string): code is SupportedLanguageCode {
+  return (SUPPORTED_LANGUAGE_CODES as readonly string[]).includes(code);
+}
+
+export async function getStoredLanguage(): Promise<SupportedLanguageCode | null> {
+  const stored = await AsyncStorage.getItem(STORAGE_KEY);
+  if (stored && isSupportedLanguage(stored)) {
+    return stored;
+  }
+  return null;
+}
+
+export async function setStoredLanguage(code: SupportedLanguageCode): Promise<void> {
+  await AsyncStorage.setItem(STORAGE_KEY, code);
+  await i18n.changeLanguage(code);
+}

--- a/packages/frontend/utils/propertyPricing.ts
+++ b/packages/frontend/utils/propertyPricing.ts
@@ -49,7 +49,7 @@ export function resolveHeadlinePrice(
   const offering = resolvePrimaryOffering(
     property,
     browseMode,
-    t('listing.exchange.free', 'Free'),
+    t('listing.exchange.free'),
   );
 
   let priceLabel: string;

--- a/packages/frontend/utils/propertyTitleGenerator.ts
+++ b/packages/frontend/utils/propertyTitleGenerator.ts
@@ -33,32 +33,16 @@ export interface PropertyData {
 
 export type TitleFormat = 'default' | 'short' | 'large';
 
-/**
- * Safe translation function with fallbacks
- * @param key - Translation key
- * @param fallback - Fallback value if translation is missing
- * @returns Translated text or fallback
- */
-function safeTranslate(key: string, fallback: string): string {
-  try {
-    const translation = i18next.t(key);
-    // Check if translation exists and is not the same as the key (which means it failed)
-    return translation && translation !== key ? translation : fallback;
-  } catch (error) {
-    console.warn(`Translation failed for key: ${key}`, error);
-    return fallback;
-  }
+function translate(key: string): string {
+  return i18next.t(key);
 }
 
 function translatedPropertyType(type: PropertyType): string {
-  return safeTranslate(
-    `properties.titles.types.${type}`,
-    safeTranslate('properties.titles.types.apartment', 'Apartment'),
-  );
+  return translate(`properties.titles.types.${type}`);
 }
 
 function locationNotSpecified(): string {
-  return safeTranslate('properties.titles.locationNotSpecified', 'Location not specified');
+  return translate('properties.titles.locationNotSpecified');
 }
 
 /**
@@ -94,8 +78,7 @@ export function generateLargePropertyTitle(propertyData: PropertyData): string {
 
   const propertyType = translatedPropertyType(type);
 
-  // Get "for rent in" text in current language with fallback
-  const forRentText = safeTranslate('properties.titles.forRent', 'for rent in');
+  const forRentText = translate('properties.titles.forRent');
 
   const location = buildLargeTitleLocation(
     {
@@ -152,12 +135,12 @@ export function generateDetailedPropertyTitle(
   const { bedrooms = 0, bathrooms = 0 } = propertyData;
 
   const formatBedrooms = (count: number): string => {
-    const bedroomText = safeTranslate('properties.details.bedrooms', 'Bedrooms');
+    const bedroomText = translate('properties.details.bedrooms');
     const bedroomLabel = count === 1 ? bedroomText.slice(0, -1) : bedroomText;
     return `${count} ${bedroomLabel.toLowerCase()}`;
   };
   const formatBathrooms = (count: number): string => {
-    const bathroomText = safeTranslate('properties.details.bathrooms', 'Bathrooms');
+    const bathroomText = translate('properties.details.bathrooms');
     const bathroomLabel = count === 1 ? bathroomText.slice(0, -1) : bathroomText;
     return `${count} ${bathroomLabel.toLowerCase()}`;
   };

--- a/packages/frontend/utils/propertyUtils.ts
+++ b/packages/frontend/utils/propertyUtils.ts
@@ -174,20 +174,19 @@ export function resolvePrimaryOffering(
 
 /**
  * A short, display-ready summary of a single offering, used by the "Also
- * available" line. `i18nKey`/`fallback` resolve via i18n at render time so this
+ * available" line. `i18nKey` resolves via i18n at render time so this
  * pure helper stays translation-agnostic.
  */
 export interface OfferingSummary {
   offering: OfferingType;
   i18nKey: string;
-  fallback: string;
 }
 
-const OFFERING_SUMMARY_META: Record<OfferingType, { i18nKey: string; fallback: string }> = {
-  [OfferingType.LONG_TERM_RENT]: { i18nKey: 'listing.offering.summary.longTerm', fallback: 'Monthly' },
-  [OfferingType.SHORT_TERM_RENT]: { i18nKey: 'listing.offering.summary.nightly', fallback: 'By night' },
-  [OfferingType.SALE]: { i18nKey: 'listing.offering.summary.sale', fallback: 'For sale' },
-  [OfferingType.EXCHANGE]: { i18nKey: 'listing.offering.summary.exchange', fallback: 'Exchange' },
+const OFFERING_SUMMARY_META: Record<OfferingType, { i18nKey: string }> = {
+  [OfferingType.LONG_TERM_RENT]: { i18nKey: 'listing.offering.summary.longTerm' },
+  [OfferingType.SHORT_TERM_RENT]: { i18nKey: 'listing.offering.summary.nightly' },
+  [OfferingType.SALE]: { i18nKey: 'listing.offering.summary.sale' },
+  [OfferingType.EXCHANGE]: { i18nKey: 'listing.offering.summary.exchange' },
 };
 
 /** Stable display order for the "Also available" summaries. */
@@ -215,7 +214,6 @@ export function resolveOfferingSummaries(
   ).map((offering) => ({
     offering,
     i18nKey: OFFERING_SUMMARY_META[offering].i18nKey,
-    fallback: OFFERING_SUMMARY_META[offering].fallback,
   }));
 }
 


### PR DESCRIPTION
## Summary

- Migrate Homiio frontend screens, components, hooks, and utilities from hardcoded strings to nested i18n keys (`t('...')`) across the full app surface.
- Add locale parity tooling (`check:i18n`, `sync-locale-keys.ts`) and `languagePreference.ts` for persisted language selection; sync `en`, `es`, `ca-ES`, and `it` catalogs.
- Remove inline translation fallbacks in property title/pricing helpers; wire amenity `nameKey`s and saved-property toasts through locale files.

## Test plan

- [x] `cd packages/frontend && bun run check:i18n` — locale parity passes
- [x] `cd packages/frontend && bun run test` — 31 tests pass
- [x] `cd packages/frontend && bun run build` — web export succeeds
- [ ] Manual QA: switch language in Settings → Language; verify home, search, property detail, profile, and saved flows render translated copy
- [ ] Manual QA: cold-start app and confirm language preference persists across reload

## Excluded from this PR

Listing-provider scraper work, backend provider tests, shared-types ethical-pricing changes, and probe/tmp artifacts remain unstaged on the working tree.


Made with [Cursor](https://cursor.com)