### PR TITLE
fix(listing): unblock ES portal discover and Fotocasa fetch ingest

### DIFF
--- a/packages/backend/__tests__/unit/fotocasaProvider.test.ts
+++ b/packages/backend/__tests__/unit/fotocasaProvider.test.ts
@@ -520,7 +520,44 @@ describe('FotocasaProvider.fetch property JSON path', () => {
     expect(local.normalize(raw).sourceId).toBe('187654321');
   });
 
-  it('throws ChallengeError when property JSON stays blocked after search warm-up', async () => {
+  it('falls back to detail HTML when property JSON is challenged', async () => {
+    const runtime: FetchRuntime = {
+      fetchHttp: async () => {
+        throw new Error('HTML ladder must not run for Fotocasa fetch');
+      },
+      fetchJson: async () => {
+        throw new Error('unused');
+      },
+      fetchText: async () => {
+        throw new Error('unused');
+      },
+      loadFixture: async () => {
+        throw new Error('unused');
+      },
+      openBrowserSession: async () => ({
+        request: async (url: string) =>
+          url.includes('/property?')
+            ? { status: 403, body: FOTOCASA_FIXTURE_SEARCHADS_CHALLENGE }
+            : { status: 403, body: FOTOCASA_FIXTURE_SEARCHADS_CHALLENGE },
+        warmNavigate: async () => undefined,
+        content: async () => FOTOCASA_FIXTURE_DETAIL_HTML,
+        pageUrl: () => 'https://www.fotocasa.es/es/alquiler/vivienda/madrid-capital/x/187654321/d',
+        exportStorageState: async () => ({ cookies: [] }),
+        close: async () => undefined,
+      }),
+    };
+
+    const local = new FotocasaProvider({ runtime });
+    const ref: ExternalListingRef = {
+      provider: 'fotocasa',
+      sourceId: '187654321',
+      url: 'https://www.fotocasa.es/es/alquiler/vivienda/madrid-capital/x/187654321/d',
+    };
+    const raw = await local.fetch(ref, { runtime, signal: new AbortController().signal });
+    expect(local.normalize(raw).sourceId).toBe('187654321');
+  });
+
+  it('throws ChallengeError when property JSON and detail HTML stay blocked', async () => {
     const runtime: FetchRuntime = {
       fetchHttp: async () => {
         throw new Error('HTML ladder must not run for Fotocasa fetch');
@@ -536,6 +573,9 @@ describe('FotocasaProvider.fetch property JSON path', () => {
       },
       openBrowserSession: async () => ({
         request: async () => ({ status: 403, body: FOTOCASA_FIXTURE_SEARCHADS_CHALLENGE }),
+        warmNavigate: async () => {
+          throw new Error('detail warm blocked');
+        },
         content: async () => FOTOCASA_FIXTURE_SEARCHADS_CHALLENGE,
         pageUrl: () => 'https://www.fotocasa.es/es/alquiler/viviendas/madrid-capital/todas-las-zonas/l',
         exportStorageState: async () => ({ cookies: [] }),

--- a/packages/backend/__tests__/unit/idealistaProvider.test.ts
+++ b/packages/backend/__tests__/unit/idealistaProvider.test.ts
@@ -180,7 +180,7 @@ describe('Idealista georeach AJAX parser', () => {
 describe('IdealistaProvider.discover georeach path', () => {
   it('yields refs from a warmed session georeach AJAX response', async () => {
     const runtime: FetchRuntime = {
-      fetchHttp: async () => ({ status: 500, body: '' }),
+      fetchHttp: async () => ({ status: 403, body: IDEALISTA_FIXTURE_GEOREACH_CHALLENGE }),
       fetchJson: async () => {
         throw new Error('unused');
       },
@@ -192,6 +192,7 @@ describe('IdealistaProvider.discover georeach path', () => {
       },
       openBrowserSession: async () => ({
         request: async () => ({ status: 200, body: IDEALISTA_FIXTURE_GEOREACH_JSON }),
+        warmNavigate: async () => undefined,
         content: async () => IDEALISTA_FIXTURE_SEARCH_HTML,
         pageUrl: () => 'https://www.idealista.com/alquiler-viviendas/madrid/',
         exportStorageState: async () => ({ cookies: [] }),
@@ -233,6 +234,7 @@ describe('IdealistaProvider.discover georeach path', () => {
       },
       openBrowserSession: async () => ({
         request: async () => ({ status: 403, body: IDEALISTA_FIXTURE_GEOREACH_CHALLENGE }),
+        warmNavigate: async () => undefined,
         content: async () => '<html>datadome</html>',
         pageUrl: () => 'https://www.idealista.com/alquiler-viviendas/madrid/',
         exportStorageState: async () => ({ cookies: [] }),

--- a/packages/backend/__tests__/unit/residentialProxy.test.ts
+++ b/packages/backend/__tests__/unit/residentialProxy.test.ts
@@ -185,7 +185,7 @@ describe('PlaywrightBrowserPool — residential proxy + asset blocking', () => {
     expect(counters.contexts).toHaveLength(1);
     expect(counters.contexts[0].proxy?.server).toBe('http://gw.dataimpulse.com:823');
     expect(counters.contexts[0].proxy?.username).toMatch(/^mylogin-session-/);
-    expect(counters.gotos[0].waitUntil).toBe('domcontentloaded');
+    expect(counters.gotos[0].waitUntil).toBe('commit');
 
     const aborted = counters.routes
       .filter((r) => BLOCKED_BROWSER_RESOURCE_TYPES.has(r.resourceType))

--- a/packages/listing-providers/src/browser.ts
+++ b/packages/listing-providers/src/browser.ts
@@ -273,9 +273,9 @@ export class PlaywrightBrowserPool implements UrlFetcher {
         else init.signal.addEventListener('abort', onAbort, { once: true });
       }
       try {
-        // Prefer domcontentloaded (esp. with asset blocking) over a blind
-        // networkidle/90s goto — then soft-wait for content selectors.
-        const waitUntil = this.blockAssets ? 'domcontentloaded' : 'load';
+        // Prefer commit (fast first byte) over domcontentloaded — ES portals
+        // behind residential proxy often never fire DCL within 90s.
+        const waitUntil = this.blockAssets ? 'commit' : 'load';
         await page.goto(url, { timeout, waitUntil });
         if (page.waitForSelector) {
           try {

--- a/packages/listing-providers/src/providers/fotocasa/index.ts
+++ b/packages/listing-providers/src/providers/fotocasa/index.ts
@@ -33,7 +33,7 @@ import { defaultProviderMetrics, type ProviderMetricsReader, type ProviderMetric
 import { providerMaxSearchPages } from '../../discoverLimits';
 import type { EsSchemaListing } from '../../parse/jsonLd';
 import { FOTOCASA_BASE_URL } from './fixtures';
-import { fotocasaSourceIdFromUrl, parseFotocasaSearch, type FotocasaRaw } from './parse';
+import { fotocasaSourceIdFromUrl, parseFotocasaDetail, parseFotocasaSearch, type FotocasaRaw } from './parse';
 import {
   fotocasaCityFromRefUrl,
   fotocasaDefaultLocationSegments,
@@ -498,6 +498,33 @@ export class FotocasaProvider implements ListingProvider {
         url: propertyUrl,
         detail: 'property API PerimeterX challenge after search warm-up',
       });
+
+      try {
+        await session.warmNavigate({
+          warmUrl: ref.url,
+          signal: ctx.signal,
+          contentSelector: 'script[type="application/ld+json"], main, h1',
+          isChallenge: isFotocasaChallenge,
+          challengeWaitMs: 30_000,
+        });
+        const detailHtml = await session.content();
+        const payload = parseFotocasaDetail(detailHtml, ref.url);
+        this.metrics.record({
+          provider: this.id,
+          strategy: 'browser',
+          outcome: 'success',
+          status: 200,
+          latencyMs: Date.now() - start,
+          url: ref.url,
+          detail: 'detail-html-fallback',
+        });
+        if (sticky) {
+          this.stickyStorageState = await session.exportStorageState();
+        }
+        return { ref, payload };
+      } catch {
+        // Detail HTML still challenged — caller throws ChallengeError.
+      }
       return undefined;
     } catch (error) {
       const detail =

--- a/packages/listing-providers/src/providers/habitaclia/index.ts
+++ b/packages/listing-providers/src/providers/habitaclia/index.ts
@@ -35,6 +35,7 @@ import {
   HABITACLIA_LISTING_CARD_SELECTOR,
   buildHabitacliaListainmueblesBody,
   extractHabitacliaListadoFormFields,
+  habitacliaWarmHomeUrl,
   habitacliaWarmSearchUrl,
   isHabitacliaListainmueblesChallenge,
   parseHabitacliaListainmuebles,
@@ -204,19 +205,26 @@ export class HabitacliaProvider implements ListingProvider {
       if (!firstCity) return;
 
       session = await runtime.openBrowserSession({
-        ...this.habitacliaSessionOptions(firstCity, sticky),
+        warmUrl: habitacliaWarmHomeUrl(),
+        contentSelector: HABITACLIA_LISTING_CARD_SELECTOR,
+        isChallenge: isHabitacliaChallenge,
+        stickyProxySession: sticky,
+        proxySessionId: this.stickyProxySessionId,
+        storageState: this.stickyStorageState,
+        blockAssets: true,
+        reloadAfterPolls: 4,
+        postChallengeSettleMs: 1_500,
+        challengeWaitMs: 60_000,
         signal,
       });
 
       for (const city of cities) {
         if (yielded.count >= limit) return;
 
-        if (city !== firstCity) {
-          await session.warmNavigate({
-            ...this.habitacliaSessionOptions(city, sticky),
-            signal,
-          });
-        }
+        await session.warmNavigate({
+          ...this.habitacliaSessionOptions(city, sticky),
+          signal,
+        });
 
         const searchHtml = await session.content();
         const formFields = extractHabitacliaListadoFormFields(searchHtml);

--- a/packages/listing-providers/src/providers/habitaclia/listainmuebles.ts
+++ b/packages/listing-providers/src/providers/habitaclia/listainmuebles.ts
@@ -31,6 +31,11 @@ function citySlug(city: string): string {
     .replace(/^_+|_+$/g, '');
 }
 
+/** Habitaclia homepage — Imperva clearance before city search POST. */
+export function habitacliaWarmHomeUrl(): string {
+  return `${HABITACLIA_BASE_URL}/`;
+}
+
 /** Build a Habitaclia rental search URL for a city + 1-based page number. */
 export function habitacliaWarmSearchUrl(city: string, page: number): string {
   const slug = citySlug(city);

--- a/packages/listing-providers/src/providers/idealista/georeach.ts
+++ b/packages/listing-providers/src/providers/idealista/georeach.ts
@@ -49,6 +49,11 @@ export function idealistaGeoreachUrl(city: string, page = 1): string {
   return `${base}?page=${page}`;
 }
 
+/** Idealista homepage — cheaper DataDome clearance before city search. */
+export function idealistaWarmHomeUrl(): string {
+  return `${IDEALISTA_BASE_URL}/`;
+}
+
 /** Idealista rental search page used to warm DataDome before georeach AJAX. */
 export function idealistaWarmSearchUrl(city: string, page = 1): string {
   const slug = citySlug(city);

--- a/packages/listing-providers/src/providers/idealista/index.ts
+++ b/packages/listing-providers/src/providers/idealista/index.ts
@@ -54,6 +54,7 @@ import {
 } from './contact';
 import {
   idealistaGeoreachUrl,
+  idealistaWarmHomeUrl,
   idealistaWarmSearchUrl,
   isIdealistaGeoreachChallenge,
   parseIdealistaGeoreach,
@@ -204,6 +205,10 @@ export class IdealistaProvider implements ListingProvider {
     for (const city of cities) {
       if (yielded.count >= limit) return;
 
+      const viaHttp = await this.discoverCityViaHttp(runtime, city, job.signal, seen, limit, yielded);
+      for (const ref of viaHttp) yield ref;
+      if (yielded.count >= limit) return;
+
       const viaAjax = runtime.openBrowserSession
         ? await this.discoverCityViaGeoreach(runtime, city, job.signal, seen, limit, yielded)
         : [];
@@ -216,6 +221,64 @@ export class IdealistaProvider implements ListingProvider {
           yield ref;
         }
       }
+    }
+  }
+
+  /**
+   * Proxied HTTP search page (page 1) before Playwright warm-up. Returns refs
+   * yielded (empty when blocked — caller continues to georeach session).
+   */
+  private async discoverCityViaHttp(
+    runtime: FetchRuntime,
+    city: string,
+    signal: AbortSignal | undefined,
+    seen: Set<string>,
+    limit: number,
+    yielded: { count: number },
+  ): Promise<ExternalListingRef[]> {
+    const start = Date.now();
+    const url = idealistaWarmSearchUrl(city, 1);
+    try {
+      const { status, body } = await runtime.fetchHttp(url, {
+        signal,
+        headers: {
+          ...IDEALISTA_AJAX_HEADERS,
+          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        },
+      });
+      if (status >= 400 || isIdealistaChallenge(body)) {
+        this.metrics.record({
+          provider: this.id,
+          strategy: 'http',
+          outcome: status === 403 || status === 429 ? 'challenge' : 'error',
+          status,
+          latencyMs: Date.now() - start,
+          url,
+          detail: 'search HTTP blocked before georeach',
+        });
+        return [];
+      }
+      const pageRefs = parseIdealistaSearch(body);
+      this.metrics.record({
+        provider: this.id,
+        strategy: 'http',
+        outcome: 'success',
+        status,
+        latencyMs: Date.now() - start,
+        url,
+        detail: pageRefs.length > 0 ? 'search-http' : 'search-http-empty',
+      });
+      return yieldRefs(pageRefs, seen, limit, yielded);
+    } catch (error) {
+      this.metrics.record({
+        provider: this.id,
+        strategy: 'http',
+        outcome: 'error',
+        latencyMs: Date.now() - start,
+        url,
+        detail: error instanceof Error ? error.message : String(error),
+      });
+      return [];
     }
   }
 
@@ -239,19 +302,29 @@ export class IdealistaProvider implements ListingProvider {
     }
 
     let session: BrowserSession | undefined;
+    const searchUrl = idealistaWarmSearchUrl(city, 1);
     const start = Date.now();
     try {
       session = await runtime.openBrowserSession({
-        warmUrl: idealistaWarmSearchUrl(city, 1),
+        warmUrl: idealistaWarmHomeUrl(),
         signal,
         contentSelector: IDEALISTA_CONTENT_SELECTOR,
         isChallenge: isIdealistaChallenge,
+        challengeWaitMs: 60_000,
         stickyProxySession: sticky,
         proxySessionId: this.stickyProxySessionId,
         storageState: this.stickyStorageState,
         blockAssets: true,
         locale: 'es-ES',
         acceptLanguage: 'es-ES,es;q=0.9,en;q=0.8',
+      });
+
+      await session.warmNavigate({
+        warmUrl: searchUrl,
+        signal,
+        contentSelector: IDEALISTA_CONTENT_SELECTOR,
+        isChallenge: isIdealistaChallenge,
+        challengeWaitMs: 45_000,
       });
 
       const collected: ExternalListingRef[] = [];


### PR DESCRIPTION
## Summary
- Switch Playwright ladder `goto` from `domcontentloaded` to `commit` (90s ES proxy timeouts)
- Idealista: HTTP-first discover + homepage warm before city search georeach
- Habitaclia: homepage warm before listainmuebles session
- Fotocasa: detail HTML fallback when property JSON API is challenged

## Evidence
Prod API counts for fotocasa/idealista/habitaclia were 0. CloudWatch showed discover enqueueing refs but fetch failing (Fotocasa JSON-LD/property API challenge; Idealista/Habitaclia `page.goto` 90s domcontentloaded timeouts). DataImpulse proxy is configured and logging in worker boot.

## Test plan
- [x] `jest fotocasaProvider idealistaProvider habitacliaProvider residentialProxy`
- [ ] Merge + deploy worker; verify `/api/public/properties?source=fotocasa&limit=1` count > 0 within 30m

Made with [Cursor](https://cursor.com)