### PR TITLE
fix(listing): route ES portal proxy through Spanish IPs

### DIFF
--- a/packages/backend/__tests__/unit/residentialProxy.test.ts
+++ b/packages/backend/__tests__/unit/residentialProxy.test.ts
@@ -11,6 +11,7 @@ import {
   createListingFetchRuntimeFromEnv,
   parseResidentialProxyUrl,
   toPlaywrightProxy,
+  withProxyCountryUsername,
   withStickySessionUsername,
   type PlaywrightModule,
 } from '@homiio/listing-providers';
@@ -80,6 +81,13 @@ describe('withStickySessionUsername', () => {
   });
 });
 
+describe('withProxyCountryUsername', () => {
+  it('appends DataImpulse __cr.<cc> geo param once', () => {
+    expect(withProxyCountryUsername('mylogin', 'es')).toBe('mylogin__cr.es');
+    expect(withProxyCountryUsername('mylogin__cr.es', 'es')).toBe('mylogin__cr.es');
+  });
+});
+
 describe('toPlaywrightProxy', () => {
   it('maps config to Playwright proxy options', () => {
     const config = parseResidentialProxyUrl(PROXY_URL);
@@ -91,6 +99,7 @@ describe('toPlaywrightProxy', () => {
       password: 'mypass',
     });
     expect(toPlaywrightProxy(config, 'sess1').username).toBe('mylogin-session-sess1');
+    expect(toPlaywrightProxy(config, 'sess1', 'es').username).toBe('mylogin__cr.es-session-sess1');
   });
 });
 

--- a/packages/listing-providers/src/browser.ts
+++ b/packages/listing-providers/src/browser.ts
@@ -247,7 +247,7 @@ export class PlaywrightBrowserPool implements UrlFetcher {
         javaScriptEnabled: true,
       };
       if (this.proxy) {
-        contextOptions.proxy = toPlaywrightProxy(this.proxy, sessionId);
+        contextOptions.proxy = toPlaywrightProxy(this.proxy, sessionId, init?.proxyCountry);
       }
       context = await browser.newContext(contextOptions);
       const page = await context.newPage();

--- a/packages/listing-providers/src/browserSession.ts
+++ b/packages/listing-providers/src/browserSession.ts
@@ -47,6 +47,8 @@ export interface BrowserSessionOptions extends WarmBrowserPageOptions {
   storageState?: BrowserStorageState;
   /** When sticky, pin this id instead of generating a new one. */
   proxySessionId?: string;
+  /** DataImpulse country targeting (`__cr.<cc>` on proxy username). */
+  proxyCountry?: string;
   /** Abort image/CSS/font requests (default ON — cheap residential GB). */
   blockAssets?: boolean;
 }
@@ -242,7 +244,7 @@ export class PlaywrightSessionPool {
         javaScriptEnabled: true,
       };
       if (this.proxy) {
-        contextOptions.proxy = toPlaywrightProxy(this.proxy, sessionId);
+        contextOptions.proxy = toPlaywrightProxy(this.proxy, sessionId, options.proxyCountry);
       }
       if (options.storageState) {
         contextOptions.storageState = options.storageState;

--- a/packages/listing-providers/src/providers/fotocasa/index.ts
+++ b/packages/listing-providers/src/providers/fotocasa/index.ts
@@ -55,6 +55,7 @@ import {
 } from './sessionHints';
 
 const PROVIDER_ID: ProviderId = 'fotocasa';
+const ES_PROXY_COUNTRY = 'es';
 
 /** ES cities enumerated when a discover job carries no explicit `city`. */
 const DEFAULT_CITIES: readonly string[] = [
@@ -280,6 +281,7 @@ export class FotocasaProvider implements ListingProvider {
         proxySessionId: this.stickyProxySessionId,
         storageState: this.stickyStorageState,
         blockAssets: true,
+        proxyCountry: ES_PROXY_COUNTRY,
       });
 
       const searchHtml = await session.content();
@@ -446,7 +448,10 @@ export class FotocasaProvider implements ListingProvider {
 
     let session: BrowserSession | undefined;
     const warmCity = discoverSession?.warmCity ?? fotocasaCityFromRefUrl(ref.url);
-    const warmUrl = fotocasaWarmSearchUrl(warmCity, 1);
+    const warmUrl =
+      discoverSession?.storageState?.cookies?.length
+        ? ref.url
+        : fotocasaWarmSearchUrl(warmCity, 1);
     const start = Date.now();
     try {
       session = await ctx.runtime.openBrowserSession({
@@ -459,6 +464,7 @@ export class FotocasaProvider implements ListingProvider {
         proxySessionId,
         storageState,
         blockAssets: true,
+        proxyCountry: ES_PROXY_COUNTRY,
       });
 
       const transactionType = ref.url.includes('/comprar') || ref.url.includes('/venta') ? 'BUY' : 'RENT';

--- a/packages/listing-providers/src/providers/habitaclia/index.ts
+++ b/packages/listing-providers/src/providers/habitaclia/index.ts
@@ -42,6 +42,7 @@ import {
 } from './listainmuebles';
 
 const PROVIDER_ID: ProviderId = 'habitaclia';
+const ES_PROXY_COUNTRY = 'es';
 
 export function isHabitacliaChallenge(html: string): boolean {
   if (html.trim().length < 512) return true;
@@ -176,6 +177,7 @@ export class HabitacliaProvider implements ListingProvider {
       blockAssets: true,
       reloadAfterPolls: 4,
       postChallengeSettleMs: 1_500,
+      proxyCountry: ES_PROXY_COUNTRY,
     } as const;
   }
 
@@ -324,6 +326,7 @@ export class HabitacliaProvider implements ListingProvider {
       if (yielded.count >= limit) break;
       const { status, body } = await runtime.fetchHttp(HABITACLIA_LISTAINMUEBLES_URL, {
         signal,
+        proxyCountry: ES_PROXY_COUNTRY,
         method: 'POST',
         body: buildHabitacliaListainmueblesBody(formFields, page),
         headers: {

--- a/packages/listing-providers/src/providers/idealista/index.ts
+++ b/packages/listing-providers/src/providers/idealista/index.ts
@@ -61,6 +61,7 @@ import {
 } from './georeach';
 import { idealistaSourceIdFromUrl, parseIdealistaDetail, parseIdealistaSearch, type IdealistaRaw } from './parse';
 
+const ES_PROXY_COUNTRY = 'es';
 const PROVIDER_ID: ProviderId = 'idealista';
 
 /** ES cities enumerated when a discover job carries no explicit `city`. */
@@ -241,6 +242,7 @@ export class IdealistaProvider implements ListingProvider {
     try {
       const { status, body } = await runtime.fetchHttp(url, {
         signal,
+        proxyCountry: ES_PROXY_COUNTRY,
         headers: {
           ...IDEALISTA_AJAX_HEADERS,
           Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
@@ -317,6 +319,7 @@ export class IdealistaProvider implements ListingProvider {
         blockAssets: true,
         locale: 'es-ES',
         acceptLanguage: 'es-ES,es;q=0.9,en;q=0.8',
+        proxyCountry: ES_PROXY_COUNTRY,
       });
 
       await session.warmNavigate({
@@ -518,6 +521,7 @@ export class IdealistaProvider implements ListingProvider {
         blockAssets: true,
         locale: 'es-ES',
         acceptLanguage: 'es-ES,es;q=0.9,en;q=0.8',
+        proxyCountry: ES_PROXY_COUNTRY,
       });
 
       // Contact AJAX first (JSON) while the DataDome session is warm.

--- a/packages/listing-providers/src/proxy.ts
+++ b/packages/listing-providers/src/proxy.ts
@@ -117,16 +117,39 @@ export function createProxySessionId(): string {
   return randomBytes(6).toString('hex');
 }
 
+/**
+ * DataImpulse geo targeting: append `__cr.<cc>` to the login when not already
+ * present (see https://docs.dataimpulse.com/proxies/parameters).
+ */
+export function withProxyCountryUsername(username: string, countryCode?: string): string {
+  const country = countryCode?.trim().toLowerCase();
+  if (!country || /__cr\./i.test(username)) return username;
+  return `${username}__cr.${country}`;
+}
+
+function resolveProxyUsername(
+  config: ResidentialProxyConfig,
+  sessionId?: string,
+  countryCode?: string,
+): string {
+  let username = withProxyCountryUsername(config.username, countryCode);
+  if (sessionId !== undefined) {
+    username = withStickySessionUsername(username, sessionId);
+  }
+  return username;
+}
+
 /** Map structured config to Playwright proxy options (optional sticky session). */
 export function toPlaywrightProxy(
   config: ResidentialProxyConfig,
   sessionId?: string,
+  countryCode?: string,
 ): PlaywrightProxyOptions {
-  const username =
-    sessionId !== undefined
-      ? withStickySessionUsername(config.username, sessionId)
-      : config.username;
-  return { server: config.server, username, password: config.password };
+  return {
+    server: config.server,
+    username: resolveProxyUsername(config, sessionId, countryCode),
+    password: config.password,
+  };
 }
 
 /**
@@ -136,13 +159,10 @@ export function toPlaywrightProxy(
 export function toEmbeddedProxyUrl(
   config: ResidentialProxyConfig,
   sessionId?: string,
+  countryCode?: string,
 ): string {
-  const username =
-    sessionId !== undefined
-      ? withStickySessionUsername(config.username, sessionId)
-      : config.username;
   const embedded = new URL(config.server);
-  embedded.username = username;
+  embedded.username = resolveProxyUsername(config, sessionId, countryCode);
   embedded.password = config.password;
   return embedded.toString();
 }
@@ -183,8 +203,9 @@ const proxiedFetchCache = new Map<string, Promise<ProxiedFetch>>();
 export async function createProxiedFetch(
   config: ResidentialProxyConfig,
   sessionId?: string,
+  countryCode?: string,
 ): Promise<ProxiedFetch> {
-  const embedded = toEmbeddedProxyUrl(config, sessionId);
+  const embedded = toEmbeddedProxyUrl(config, sessionId, countryCode);
   const cached = proxiedFetchCache.get(embedded);
   if (cached) return cached;
 

--- a/packages/listing-providers/src/runtime.ts
+++ b/packages/listing-providers/src/runtime.ts
@@ -100,7 +100,10 @@ export class HttpFetchRuntime implements FetchRuntime {
 
   async fetchHttp(url: string, init?: FetchRuntimeInit): Promise<{ status: number; body: string }> {
     const timeoutMs = init?.timeoutMs ?? this.defaultTimeoutMs;
-    const requestFetch = await this.resolveFetch();
+    const requestFetch =
+      init?.proxyCountry && this.proxy
+        ? await createProxiedFetch(this.proxy, undefined, init.proxyCountry)
+        : await this.resolveFetch();
     return withTimeout(timeoutMs, init?.signal, async (signal) => {
       const response = await requestFetch(url, {
         signal,

--- a/packages/listing-providers/src/types.ts
+++ b/packages/listing-providers/src/types.ts
@@ -139,6 +139,8 @@ export interface FetchRuntimeInit {
   signal?: AbortSignal;
   /** Per-request timeout in milliseconds. */
   timeoutMs?: number;
+  /** ISO country code for residential proxy geo (DataImpulse `__cr.<cc>`). */
+  proxyCountry?: string;
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD';
   body?: string;
 }


### PR DESCRIPTION
## Summary
- Append DataImpulse `__cr.es` geo param on proxy username for fotocasa/idealista/habitaclia browser + HTTP paths
- Fotocasa fetch warms detail URL directly when discover session cookies are present

## Evidence
Post-#124 deploy still showed Fotocasa `ChallengeError` 403 on fetch while discover enqueued refs. Proxy was configured but likely routing non-ES IPs (DataImpulse default).

## Test plan
- [x] jest residentialProxy + ES provider tests
- [ ] Merge + deploy; verify fotocasa/idealista/habitaclia counts > 0 in `/api/properties` within 30m

Made with [Cursor](https://cursor.com)