### PR TITLE
refactor(ownership): purge property profileId read paths

### DIFF
--- a/packages/backend/__tests__/integration/neighborhoodMetrics.test.ts
+++ b/packages/backend/__tests__/integration/neighborhoodMetrics.test.ts
@@ -71,22 +71,24 @@ async function seedAddress(
   });
 }
 
-async function seedProfile(): Promise<{ _id: unknown }> {
-  return Profile.create({
-    oxyUserId: `oxy-${Math.random().toString(36).slice(2)}`,
+async function seedProfile(): Promise<{ _id: unknown; oxyUserId: string }> {
+  const oxyUserId = `oxy-${Math.random().toString(36).slice(2)}`;
+  const profile = await Profile.create({
+    oxyUserId,
     profileType: ProfileType.PERSONAL,
     isActive: true,
     personalProfile: {},
   });
+  return profile;
 }
 
 async function seedListing(
-  profileId: unknown,
+  oxyUserId: string,
   addressId: unknown,
   monthlyAmount: number,
 ): Promise<{ _id: unknown }> {
   return Property.create({
-    profileId,
+    oxyUserId,
     addressId,
     type: PropertyType.APARTMENT,
     bedrooms: 2,
@@ -103,7 +105,7 @@ describe('GET /api/neighborhoods/by-property/:propertyId', () => {
     const gracia = await seedNeighborhood(geo, 'Gracia');
     const profile = await seedProfile();
     const address = await seedAddress(geo, gracia._id);
-    const listing = await seedListing(profile._id, address._id, 1000);
+    const listing = await seedListing(String(profile.oxyUserId), address._id, 1000);
 
     const res = await request(buildApp()).get(`/api/neighborhoods/by-property/${listing._id}`);
 
@@ -127,7 +129,7 @@ describe('GET /api/neighborhoods/by-property/:propertyId', () => {
     const geo = await seedCity();
     const profile = await seedProfile();
     const address = await seedAddress(geo, undefined);
-    const listing = await seedListing(profile._id, address._id, 1000);
+    const listing = await seedListing(profile.oxyUserId, address._id, 1000);
 
     const res = await request(buildApp()).get(`/api/neighborhoods/by-property/${listing._id}`);
 
@@ -150,8 +152,8 @@ describe('GET /api/neighborhoods/by-name', () => {
     const profile = await seedProfile();
 
     // Gracia: one 800€ listing. Eixample: one 2000€ listing. City avg = 1400€.
-    await seedListing(profile._id, (await seedAddress(geo, gracia._id))._id, 800);
-    await seedListing(profile._id, (await seedAddress(geo, eixample._id))._id, 2000);
+    await seedListing(profile.oxyUserId, (await seedAddress(geo, gracia._id))._id, 800);
+    await seedListing(profile.oxyUserId, (await seedAddress(geo, eixample._id))._id, 2000);
 
     const res = await request(buildApp())
       .get('/api/neighborhoods/by-name')
@@ -184,9 +186,9 @@ describe('GET /api/neighborhoods/popular', () => {
     const profile = await seedProfile();
 
     // Gracia: 2 listings, Eixample: 1 listing.
-    await seedListing(profile._id, (await seedAddress(geo, gracia._id))._id, 900);
-    await seedListing(profile._id, (await seedAddress(geo, gracia._id))._id, 1100);
-    await seedListing(profile._id, (await seedAddress(geo, eixample._id))._id, 2000);
+    await seedListing(profile.oxyUserId, (await seedAddress(geo, gracia._id))._id, 900);
+    await seedListing(profile.oxyUserId, (await seedAddress(geo, gracia._id))._id, 1100);
+    await seedListing(profile.oxyUserId, (await seedAddress(geo, eixample._id))._id, 2000);
 
     const res = await request(buildApp())
       .get('/api/neighborhoods/popular')
@@ -222,7 +224,7 @@ describe('GET /api/neighborhoods/search', () => {
     const gracia = await seedNeighborhood(geo, 'Gracia');
     await seedNeighborhood(geo, 'Eixample');
     const profile = await seedProfile();
-    await seedListing(profile._id, (await seedAddress(geo, gracia._id))._id, 1000);
+    await seedListing(profile.oxyUserId, (await seedAddress(geo, gracia._id))._id, 1000);
 
     const res = await request(buildApp())
       .get('/api/neighborhoods/search')
@@ -268,7 +270,7 @@ describe('GET /api/neighborhoods/by-location', () => {
     const gracia = await seedNeighborhood(geo, 'Gracia');
     const profile = await seedProfile();
     const address = await seedAddress(geo, gracia._id, [2.17, 41.39]);
-    await seedListing(profile._id, address._id, 1000);
+    await seedListing(profile.oxyUserId, address._id, 1000);
 
     const res = await request(buildApp())
       .get('/api/neighborhoods/by-location')

--- a/packages/backend/__tests__/integration/partnerCommission.test.ts
+++ b/packages/backend/__tests__/integration/partnerCommission.test.ts
@@ -25,7 +25,7 @@ import {
 
 import { createProperty } from '../../controllers/property/create';
 import { markPropertyTransacted } from '../../controllers/property/transact';
-import { createProfile, createAddress, models } from '../helpers/factories';
+import { createAddress, models } from '../helpers/factories';
 
 const partnerController = require('../../controllers/partnerController');
 const roomController = require('../../controllers/roomController');
@@ -170,10 +170,9 @@ describe('partner earn close-deal loop', () => {
     const referralCode: string = joinRes.body.data.partner.referralCode;
     const partner = await Partner.findOne({ referralCode });
 
-    const owner = await createProfile('oxy-owner');
     const address = await createAddress();
     const parent = await Property.create({
-      profileId: owner._id,
+      oxyUserId: 'oxy-owner',
       addressId: address._id,
       type: PropertyType.APARTMENT,
       bedrooms: 3,
@@ -186,7 +185,7 @@ describe('partner earn close-deal loop', () => {
     // never accepts a referral code, but the trigger must still fire if a room
     // is sourced).
     const room = await Property.create({
-      profileId: owner._id,
+      oxyUserId: 'oxy-owner',
       addressId: address._id,
       parentPropertyId: parent._id,
       type: PropertyType.ROOM,
@@ -221,7 +220,6 @@ describe('partner earn close-deal loop', () => {
     const propertyId: string = createRes.body.data.id ?? createRes.body.data._id;
 
     // A different, unrelated user cannot close the owner's deal.
-    await createProfile('oxy-intruder');
     const intruderApp = buildApp('oxy-intruder');
     const markRes = await request(intruderApp)
       .post(`/properties/${propertyId}/mark-transacted`)

--- a/packages/backend/controllers/profile/crud.ts
+++ b/packages/backend/controllers/profile/crud.ts
@@ -505,6 +505,31 @@ export async function activateProfile(req: any, res: any, next: any) {
 }
 
 /**
+ * Get the active public profile for an Oxy user id (read-only).
+ */
+export async function getPublicProfileByOxyUserId(req: any, res: any, next: any) {
+  try {
+    const { oxyUserId } = req.params;
+    if (!oxyUserId) {
+      return res.status(400).json(
+        errorResponse('Oxy user id is required', 'OXY_USER_ID_REQUIRED'),
+      );
+    }
+
+    const profile = await Profile.findActiveByOxyUserId(oxyUserId);
+    if (!profile) {
+      return res.status(404).json(
+        errorResponse('Profile not found', 'PROFILE_NOT_FOUND'),
+      );
+    }
+
+    res.json(successResponse(profile, 'Profile retrieved successfully'));
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
  * Get profile by ID
  */
 export async function getProfileById(req: any, res: any, next: any) {

--- a/packages/backend/controllers/profile/savedProperties.ts
+++ b/packages/backend/controllers/profile/savedProperties.ts
@@ -259,30 +259,15 @@ export async function getProfileProperties(req: any, res: any, next: any) {
       );
     }
 
-    // Get the active profile for the current user
-    const activeProfile = await Profile.findActiveByOxyUserId(oxyUserId);
-
-    if (!activeProfile) {
-      return res.json(
-        successResponse({
-          properties: [],
-          total: 0,
-          page: parseInt(page),
-          totalPages: 0
-        }, "No profile found for user")
-      );
-    }
-
-    // Query database for user's properties using profileId
     const skip = (parseInt(page) - 1) * parseInt(limit);
     const [properties, total] = await Promise.all([
-      Property.find({ profileId: activeProfile._id, status: { $ne: 'archived' } })
+      Property.find({ oxyUserId, status: { $ne: 'archived' } })
         .populate('addressId')
         .skip(skip)
         .limit(parseInt(limit))
         .sort({ createdAt: -1 })
         .lean(),
-      Property.countDocuments({ profileId: activeProfile._id, status: { $ne: 'archived' } })
+      Property.countDocuments({ oxyUserId, status: { $ne: 'archived' } })
     ]);
 
     const totalPages = Math.ceil(total / parseInt(limit));

--- a/packages/backend/controllers/profileController.ts
+++ b/packages/backend/controllers/profileController.ts
@@ -14,6 +14,7 @@ const handlerNames: Array<keyof typeof profileHandlers> = [
   'deleteProfile',
   'activateProfile',
   'getProfileById',
+  'getPublicProfileByOxyUserId',
   'updateActiveProfile',
   'getAgencyMemberships',
   'addAgencyMember',

--- a/packages/backend/controllers/property/batch.ts
+++ b/packages/backend/controllers/property/batch.ts
@@ -17,12 +17,14 @@ export async function getPropertiesByIds(req: ControllerRequest, res: Controller
 
 export async function getPropertiesByOwner(req: ControllerRequest, res: ControllerResponse, next: ControllerNext) {
   try {
-    const { profileId } = req.params;
+    const { oxyUserId } = req.params;
     const exclude = getQueryString(req.query.exclude);
     const page = getQueryInteger(req.query.page, 1);
     const limit = getQueryInteger(req.query.limit, 10);
-    if (!mongoose.Types.ObjectId.isValid(profileId)) return next(new AppError('Invalid profile ID',400,'INVALID_ID'));
-    const query: Record<string, unknown> = { profileId: new mongoose.Types.ObjectId(profileId), status:'active' };
+    if (!oxyUserId || typeof oxyUserId !== 'string') {
+      return next(new AppError('Invalid owner id', 400, 'INVALID_ID'));
+    }
+    const query: Record<string, unknown> = { oxyUserId, status: 'active' };
     if (exclude && mongoose.Types.ObjectId.isValid(exclude)) query._id = { $ne: new mongoose.Types.ObjectId(exclude) };
     const skip = (page - 1) * limit;
     const [properties,total] = await Promise.all([

--- a/packages/backend/controllers/property/list.ts
+++ b/packages/backend/controllers/property/list.ts
@@ -114,7 +114,7 @@ export const getProperties = async (req: Request, res: Response, next: NextFunct
       excludeIds,
       sortBy = 'createdAt',
       sortOrder = 'desc',
-      profileId,
+      oxyUserId: ownerOxyUserId,
       addressId,
       lat,
       lng,
@@ -135,7 +135,7 @@ export const getProperties = async (req: Request, res: Response, next: NextFunct
     const filters: any = {};
     // Public feed: never surface soft-deleted (archived) listings.
     filters.deletedAt = null;
-    if (profileId) filters.profileId = profileId;
+    if (ownerOxyUserId) filters.oxyUserId = String(ownerOxyUserId);
     if (type) filters.type = type;
     
     // Handle direct addressId filter

--- a/packages/backend/controllers/property/searchQueryBuilder.ts
+++ b/packages/backend/controllers/property/searchQueryBuilder.ts
@@ -106,7 +106,7 @@ const EXCHANGE_MODE_VALUES: ReadonlySet<string> = new Set(Object.values(Exchange
 interface PropertyDoc {
   _id: Types.ObjectId;
   addressId: Types.ObjectId;
-  profileId: Types.ObjectId;
+  oxyUserId: string;
   type: string;
   status: string;
   deletedAt: Date | null;

--- a/packages/backend/routes/properties.ts
+++ b/packages/backend/routes/properties.ts
@@ -28,7 +28,7 @@ router.post("/:propertyId/report", asyncHandler(reportController.createListingRe
 router.get("/me/list", asyncHandler(propertyController.getMyProperties));
 
 // Owner properties (requires authentication)
-router.get("/owner/:profileId", asyncHandler(propertyController.getPropertiesByOwner));
+router.get("/owner/:oxyUserId", asyncHandler(propertyController.getPropertiesByOwner));
 
 export default function() {
   return router;

--- a/packages/backend/routes/public.ts
+++ b/packages/backend/routes/public.ts
@@ -216,6 +216,7 @@ export default function () {
 
   // Public profile route (read-only)
   const profileController = require('../controllers/profileController');
+  router.get('/public/profiles/by-user/:oxyUserId', asyncHandler(profileController.getPublicProfileByOxyUserId));
   router.get('/public/profiles/:profileId', asyncHandler(profileController.getProfileById));
 
   // Public shared conversation endpoint (no authentication required)

--- a/packages/frontend/app/host/calendar.tsx
+++ b/packages/frontend/app/host/calendar.tsx
@@ -44,7 +44,6 @@ import { HostCalendarGrid, HostCalendarSelection } from '@/components/HostCalend
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ErrorState } from '@/components/ui/ErrorState';
 import { SectionEyebrow } from '@/components/ui/SectionEyebrow';
-import { useProfile } from '@/context/ProfileContext';
 import {
   reservationKeys,
   usePropertyAvailabilityQuery,
@@ -75,10 +74,7 @@ export default function HostCalendarScreen() {
   const router = useRouter();
   const { oxyServices, activeSessionId } = useOxy();
   const isAuthed = Boolean(oxyServices && activeSessionId);
-  const { primaryProfile } = useProfile();
-  const profileId = primaryProfile?._id ?? primaryProfile?.id;
-
-  const propertiesQuery = useUserProperties(profileId);
+  const propertiesQuery = useUserProperties();
   const properties = propertiesQuery.data?.properties ?? [];
   const [selectedPropertyId, setSelectedPropertyId] = useState<string | null>(
     null,

--- a/packages/frontend/app/properties/[id]/index.tsx
+++ b/packages/frontend/app/properties/[id]/index.tsx
@@ -188,34 +188,16 @@ export default function PropertyDetailPage() {
   const [stickyHeaderVisible, setStickyHeaderVisible] = useState(false);
   const [exchangeSheetVisible, setExchangeSheetVisible] = useState(false);
 
-  // Normalize landlord id (handles legacy MongoDB $oid envelopes).
-  const landlordProfileId = useMemo<string | undefined>(() => {
-    const profileId = apiProperty?.profileId;
-    if (!profileId) return undefined;
-    if (
-      typeof profileId === 'object' &&
-      profileId !== null &&
-      '$oid' in profileId &&
-      typeof (profileId as { $oid?: unknown }).$oid === 'string'
-    ) {
-      return (profileId as { $oid: string }).$oid;
-    }
-    if (typeof profileId === 'string') return profileId;
-    return undefined;
-  }, [apiProperty?.profileId]);
+  const landlordOxyUserId = apiProperty?.oxyUserId;
 
-  // Fetch landlord profile + their other listings. The listing owner is public
-  // info shown on a public page, so this reads the public (no-auth) profile
-  // route and the public properties list — it must populate for logged-out
-  // visitors and never 401.
   useEffect(() => {
     const fetchLandlordData = async () => {
-      if (!landlordProfileId) return;
+      if (!landlordOxyUserId) return;
       try {
-        const profile = await profileService.getPublicProfileById(landlordProfileId);
+        const profile = await profileService.getPublicProfileByOxyUserId(landlordOxyUserId);
         setLandlordProfile(profile);
         const { properties } = await propertyService.getOwnerProperties(
-          landlordProfileId,
+          landlordOxyUserId,
           typeof id === 'string' ? id : '',
         );
         setOwnerProperties(properties);
@@ -225,7 +207,7 @@ export default function PropertyDetailPage() {
       }
     };
     fetchLandlordData();
-  }, [landlordProfileId, id]);
+  }, [landlordOxyUserId, id]);
 
   // Property view-model derived from the API payload.
   const property = useMemo<PropertyDetailViewModel | null>(() => {

--- a/packages/frontend/app/properties/my.tsx
+++ b/packages/frontend/app/properties/my.tsx
@@ -30,7 +30,6 @@ import { PropertyResultsGridSkeleton } from '@/components/ui/PropertyResultsGrid
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ErrorState } from '@/components/ui/ErrorState';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
-import { useProfile } from '@/context/ProfileContext';
 import { useUserProperties, useDeleteProperty } from '@/hooks/usePropertyQueries';
 import { useMarkPropertyTransacted } from '@/hooks/usePartner';
 import { generatePropertyTitle } from '@/utils/propertyTitleGenerator';
@@ -81,10 +80,7 @@ function terminalStatusFor(offerings: readonly string[] | undefined): PropertySt
 export default function MyPropertiesScreen() {
   const { t } = useTranslation();
   const router = useRouter();
-  const { primaryProfile } = useProfile();
-  const profileId = primaryProfile?._id ?? primaryProfile?.id;
-
-  const { data, isLoading, error, refetch } = useUserProperties(profileId);
+  const { data, isLoading, error, refetch } = useUserProperties();
   const { deleteProperty, loading: isDeleting } = useDeleteProperty();
   const markTransacted = useMarkPropertyTransacted();
 

--- a/packages/frontend/components/exchange/ExchangeRequestBottomSheet.tsx
+++ b/packages/frontend/components/exchange/ExchangeRequestBottomSheet.tsx
@@ -27,7 +27,6 @@ import {
   AvailabilityCalendar,
   type AvailabilityCalendarRange,
 } from '@/components/AvailabilityCalendar';
-import { useProfile } from '@/context/ProfileContext';
 import { useCreateExchangeRequest } from '@/hooks/useExchangeQueries';
 import { useUserProperties } from '@/hooks/usePropertyQueries';
 import { getPropertyTitle, hasOffering } from '@/utils/propertyUtils';
@@ -82,8 +81,6 @@ export const ExchangeRequestBottomSheet: React.FC<ExchangeRequestBottomSheetProp
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { oxyServices, activeSessionId } = useOxy();
-  const { primaryProfile } = useProfile();
-
   const listingMode = property.exchange?.mode ?? ExchangeMode.BOTH;
   const allowsBoth = listingMode === ExchangeMode.BOTH;
 
@@ -98,8 +95,7 @@ export const ExchangeRequestBottomSheet: React.FC<ExchangeRequestBottomSheetProp
   const [message, setMessage] = useState('');
   const [calendarTarget, setCalendarTarget] = useState<CalendarTarget>(null);
 
-  const profileId = primaryProfile?._id ?? primaryProfile?.id;
-  const myPropertiesQuery = useUserProperties(profileId);
+  const myPropertiesQuery = useUserProperties();
 
   const myExchangeProperties = useMemo<Property[]>(() => {
     const target = propertyId(property);

--- a/packages/frontend/components/widgets/PropertyBookingWidget.tsx
+++ b/packages/frontend/components/widgets/PropertyBookingWidget.tsx
@@ -36,37 +36,17 @@ interface PropertyBookingWidgetProps {
 
 const STICKY_TOP_OFFSET = 80;
 
-/** Normalize a profile id off a property, handling legacy `$oid` envelopes. */
-function resolveProfileId(profileId: Property['profileId']): string | undefined {
-  if (!profileId) return undefined;
-  if (
-    typeof profileId === 'object' &&
-    profileId !== null &&
-    '$oid' in profileId &&
-    typeof (profileId as { $oid?: unknown }).$oid === 'string'
-  ) {
-    return (profileId as { $oid: string }).$oid;
-  }
-  if (typeof profileId === 'string') return profileId;
-  return undefined;
-}
-
 export function PropertyBookingWidget({ propertyId }: PropertyBookingWidgetProps) {
   const { t } = useTranslation();
   const { mode: rentalMode } = useRentalMode();
   const { property: apiProperty } = useProperty(propertyId ?? '');
 
-  const landlordProfileId = resolveProfileId(apiProperty?.profileId);
+  const landlordOxyUserId = apiProperty?.oxyUserId;
 
-  // Host profile for the card's host line + Super-host badge. This is the
-  // listing OWNER's public profile, so it reads from the public (no-auth)
-  // profile route — it must render for logged-out visitors without 401ing.
-  // Shares the `['profile', id]` cache key so it doesn't duplicate any other
-  // profile load.
   const { data: landlordProfile = null } = useQuery<Profile | null>({
-    queryKey: ['profile', landlordProfileId],
-    enabled: Boolean(landlordProfileId),
-    queryFn: () => profileService.getPublicProfileById(landlordProfileId ?? ''),
+    queryKey: ['profile-by-oxy', landlordOxyUserId],
+    enabled: Boolean(landlordOxyUserId),
+    queryFn: () => profileService.getPublicProfileByOxyUserId(landlordOxyUserId ?? ''),
   });
 
   if (!propertyId || !apiProperty) {

--- a/packages/frontend/hooks/useHostStatus.ts
+++ b/packages/frontend/hooks/useHostStatus.ts
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
 import { useOxy } from '@oxyhq/services';
-import { useProfile } from '@/context/ProfileContext';
 import { propertyService } from '@/services/propertyService';
 
 /**
@@ -16,18 +15,15 @@ export function useHostStatus(): {
   isLoading: boolean;
 } {
   const { oxyServices, activeSessionId } = useOxy();
-  const { primaryProfile } = useProfile();
-  const profileId = primaryProfile?._id ?? primaryProfile?.id;
   const isAuthed = Boolean(oxyServices && activeSessionId);
 
   const query = useQuery({
-    queryKey: ['host-status', profileId ?? ''],
+    queryKey: ['host-status'],
     queryFn: async () => {
-      if (!profileId) return 0;
-      const result = await propertyService.getOwnerProperties(profileId);
+      const result = await propertyService.getMyProperties(1, 1);
       return result.total;
     },
-    enabled: isAuthed && Boolean(profileId),
+    enabled: isAuthed,
     staleTime: 1000 * 60 * 5,
   });
 

--- a/packages/frontend/hooks/useLeaseQueries.ts
+++ b/packages/frontend/hooks/useLeaseQueries.ts
@@ -6,7 +6,6 @@ import {
   type UseQueryResult,
 } from '@tanstack/react-query';
 import { useOxy } from '@oxyhq/services';
-import { useProfile } from '@/context/ProfileContext';
 import { CreateLeaseData, Lease, LeaseDocument, UpdateLeaseData } from '@homiio/shared-types';
 import {
   LeaseFilters,
@@ -67,18 +66,15 @@ export function useHasRentalProperties(): {
   isLoading: boolean;
 } {
   const { oxyServices, activeSessionId } = useOxy();
-  const { primaryProfile } = useProfile();
-  const profileId = primaryProfile?._id ?? primaryProfile?.id;
   const isAuthed = Boolean(oxyServices && activeSessionId);
 
   const query = useQuery({
-    queryKey: ['owner-properties-count', profileId ?? ''],
+    queryKey: ['owner-properties-count'],
     queryFn: async () => {
-      if (!profileId) return 0;
-      const result = await propertyService.getOwnerProperties(profileId);
+      const result = await propertyService.getMyProperties(1, 1);
       return result.total;
     },
-    enabled: isAuthed && Boolean(profileId),
+    enabled: isAuthed,
     staleTime: 1000 * 60 * 5,
   });
 

--- a/packages/frontend/hooks/usePropertyQueries.ts
+++ b/packages/frontend/hooks/usePropertyQueries.ts
@@ -9,6 +9,7 @@ import {
 import { toast } from '@/lib/sonner';
 import i18next from 'i18next';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useOxy } from '@oxyhq/services';
 
 /** Area-scale lookups (price insights, nearby services) are comparatively
  *  expensive to compute server-side and change slowly (they aggregate a whole
@@ -325,70 +326,22 @@ export const useDeleteProperty = () => {
   };
 };
 
-// Hook for user's owned properties
-export const useUserProperties = (profileId?: string) => {
-  const { loading, error } = usePropertySelectors();
-  const { setLoading, setError } = usePropertyStore();
+// Hook for the authenticated user's owned properties (session oxyUserId)
+export const useUserProperties = () => {
+  const { oxyServices, activeSessionId } = useOxy();
+  const isAuthed = Boolean(oxyServices && activeSessionId);
 
-  const [userProperties, setUserProperties] = useState<Property[]>([]);
-  const [pagination, setPagination] = useState({
-    page: 1,
-    total: 0,
-    totalPages: 1,
+  const query = useQuery({
+    queryKey: ['my-properties'],
+    queryFn: () => propertyService.getMyProperties(),
+    enabled: isAuthed,
+    staleTime: 1000 * 60,
   });
 
-  const fetchUserProperties = useCallback(
-    async (_page = 1, _limit = 10) => {
-      if (!profileId) {
-        console.warn('No profile ID provided to fetch user properties');
-        return { properties: [], total: 0, page: 1, totalPages: 1 };
-      }
-
-      try {
-        setLoading('properties', true);
-        setError(null);
-
-        // Use propertyService to get owner properties
-        const response = await propertyService.getOwnerProperties(profileId);
-
-        const result = {
-          properties: response.properties || [],
-          total: response.total || 0,
-          page: response.page || 1,
-          totalPages: response.totalPages || 1,
-        };
-
-        setUserProperties(result.properties);
-        setPagination({
-          page: result.page,
-          total: result.total,
-          totalPages: result.totalPages,
-        });
-
-        return result;
-      } catch (error: any) {
-        const errorMessage = error.message || 'Failed to fetch user properties';
-        setError(errorMessage);
-        return { properties: [], total: 0, page: 1, totalPages: 1 };
-      } finally {
-        setLoading('properties', false);
-      }
-    },
-    [setLoading, setError, profileId],
-  );
-
-  // Load properties on mount
-  useEffect(() => {
-    fetchUserProperties();
-  }, [fetchUserProperties]);
-
   return {
-    data: {
-      properties: userProperties,
-      ...pagination,
-    },
-    isLoading: loading.properties,
-    error,
-    refetch: () => fetchUserProperties(),
+    data: query.data,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
   };
 };

--- a/packages/frontend/services/profileService.ts
+++ b/packages/frontend/services/profileService.ts
@@ -262,6 +262,13 @@ class ProfileService {
    * property-detail page) so the read never 401s. `requireAuth: false` keeps the
    * client from sending an `Authorization` header it doesn't have.
    */
+  async getPublicProfileByOxyUserId(oxyUserId: string): Promise<Profile> {
+    const response = await api.get(`/api/public/profiles/by-user/${encodeURIComponent(oxyUserId)}`, {
+      requireAuth: false,
+    });
+    return response.data.data;
+  }
+
   async getPublicProfileById(profileId: string): Promise<Profile> {
     const response = await api.get(`/api/public/profiles/${profileId}`, {
       requireAuth: false,

--- a/packages/frontend/services/propertyService.ts
+++ b/packages/frontend/services/propertyService.ts
@@ -119,9 +119,32 @@ class PropertyService {
     }
   }
 
-  // Get properties by owner
+  // Get properties owned by the authenticated user (session oxyUserId)
+  async getMyProperties(page = 1, limit = 10): Promise<{
+    properties: Property[];
+    total: number;
+    page: number;
+    totalPages: number;
+  }> {
+    try {
+      const response = await api.get(`${this.baseUrl}/me/list`, {
+        params: { page, limit },
+      });
+      const pagination = response.data.pagination ?? {};
+      return {
+        properties: response.data.data || [],
+        total: pagination.total || 0,
+        page: pagination.page || page,
+        totalPages: pagination.totalPages || 1,
+      };
+    } catch {
+      return { properties: [], total: 0, page: 1, totalPages: 1 };
+    }
+  }
+
+  // Get published properties owned by an Oxy user id
   async getOwnerProperties(
-    profileId: string,
+    oxyUserId: string,
     excludePropertyId?: string,
   ): Promise<{
     properties: Property[];
@@ -132,11 +155,11 @@ class PropertyService {
     try {
       const response = await api.get(`${this.baseUrl}`, {
         params: {
-          profileId,
+          oxyUserId,
           excludeIds: excludePropertyId,
           sortBy: 'createdAt',
-          sortOrder: 'desc'
-        }
+          sortOrder: 'desc',
+        },
       });
       return {
         properties: response.data.data || response.data.results || response.data.properties || [],

--- a/packages/shared-types/src/property.ts
+++ b/packages/shared-types/src/property.ts
@@ -168,7 +168,7 @@ export interface PropertyCharacteristics {
 export interface Property {
   _id: string; // MongoDB ObjectId
   id?: string; // Optional fallback
-  profileId?: string; // Optional for external properties
+  oxyUserId?: string;
   // External sourcing metadata
   source?: string; // Source name (e.g., 'fotocasa', 'internal')
   sourceId?: string; // External source ID


### PR DESCRIPTION
## Summary
- Replace Property `profileId` filters with `oxyUserId` on list, batch owner, and saved-property routes
- Frontend my listings, host status, and calendar now use `GET /properties/me/list` (session-scoped)
- Add `GET /api/public/profiles/by-user/:oxyUserId` for landlord display on property detail

## Follow-up (not in this PR)
- Migrate domain schemas still on `*ProfileId` (applications, viewings, exchanges, reservations, roommate requests)
- Collapse Profile multi-identity fields (`profileType`, `isActive`, `members`, `trustScore`)
- Saved / RecentlyViewed / Conversation collections: `profileId` → `oxyUserId`

## Test plan
- [x] Backend ownership integration tests (31 passed)
- [x] Backend tsc green
- [ ] Manual: `/properties/my` loads owned listings when signed in
- [ ] Manual: property detail shows landlord card + other listings via `oxyUserId`


Made with [Cursor](https://cursor.com)