### PR TITLE
fix(scripts): flush trailing price-ethics backfill batch

### DIFF
--- a/packages/backend/__tests__/unit/backfillPriceEthicsBatching.test.ts
+++ b/packages/backend/__tests__/unit/backfillPriceEthicsBatching.test.ts
@@ -1,0 +1,53 @@
+import {
+  finalBatchToFlush,
+  planBackfillBatches,
+  readyBatchAfterAppend,
+} from '../../scripts/backfillPriceEthicsBatching';
+
+describe('backfillPriceEthicsBatching', () => {
+  describe('readyBatchAfterAppend', () => {
+    it('returns null for a partial batch below the limit', () => {
+      expect(readyBatchAfterAppend(['a', 'b'], 50, 2, Number.MAX_SAFE_INTEGER)).toBeNull();
+    });
+
+    it('returns the batch when batch size is reached', () => {
+      const batch = Array.from({ length: 50 }, (_, i) => `id-${i}`);
+      expect(readyBatchAfterAppend(batch, 50, 50, Number.MAX_SAFE_INTEGER)).toEqual(batch);
+    });
+
+    it('returns the batch when the processing limit is reached', () => {
+      expect(readyBatchAfterAppend(['a', 'b', 'c'], 50, 30, 30)).toEqual(['a', 'b', 'c']);
+    });
+  });
+
+  describe('finalBatchToFlush', () => {
+    it('returns null for an empty batch', () => {
+      expect(finalBatchToFlush([])).toBeNull();
+    });
+
+    it('returns a copy of a non-empty trailing batch', () => {
+      expect(finalBatchToFlush(['x', 'y'])).toEqual(['x', 'y']);
+    });
+  });
+
+  describe('planBackfillBatches', () => {
+    const ids = Array.from({ length: 120 }, (_, i) => `id-${i}`);
+
+    it('flushes a final partial batch when total listings are below batch size', () => {
+      expect(planBackfillBatches(ids.slice(0, 20), 50, Number.MAX_SAFE_INTEGER)).toEqual([
+        ids.slice(0, 20),
+      ]);
+    });
+
+    it('splits full batches and flushes the remainder', () => {
+      expect(planBackfillBatches(ids.slice(0, 75), 50, Number.MAX_SAFE_INTEGER)).toEqual([
+        ids.slice(0, 50),
+        ids.slice(50, 75),
+      ]);
+    });
+
+    it('stops at the limit and does not emit extra batches', () => {
+      expect(planBackfillBatches(ids, 50, 30)).toEqual([ids.slice(0, 30)]);
+    });
+  });
+});

--- a/packages/backend/scripts/backfillPriceEthics.ts
+++ b/packages/backend/scripts/backfillPriceEthics.ts
@@ -14,6 +14,10 @@ require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') }
 import { PropertyStatus } from '@homiio/shared-types';
 import database from '../database/connection';
 import { scoreAndPersistProperty } from '../services/priceEthicsService';
+import {
+  finalBatchToFlush,
+  readyBatchAfterAppend,
+} from './backfillPriceEthicsBatching';
 
 const { Property } = require('../models');
 
@@ -115,13 +119,22 @@ async function main(): Promise<void> {
     batch.push(String(doc._id));
     processed += 1;
 
-    if (batch.length >= BATCH_SIZE || processed >= LIMIT) {
-      const result = await processBatch(batch);
+    const ready = readyBatchAfterAppend(batch, BATCH_SIZE, processed, LIMIT);
+    if (ready) {
+      const result = await processBatch(ready);
       scored += result.scored;
       failed += result.failed;
       console.log(`  batch done: ${processed}/${toProcess} processed (${scored} scored, ${failed} failed)`);
       batch = [];
     }
+  }
+
+  const remaining = finalBatchToFlush(batch);
+  if (remaining) {
+    const result = await processBatch(remaining);
+    scored += result.scored;
+    failed += result.failed;
+    console.log(`  batch done: ${processed}/${toProcess} processed (${scored} scored, ${failed} failed)`);
   }
 
   console.log(`Finished: ${scored} scored, ${failed} failed out of ${processed} processed`);

--- a/packages/backend/scripts/backfillPriceEthicsBatching.ts
+++ b/packages/backend/scripts/backfillPriceEthicsBatching.ts
@@ -1,0 +1,49 @@
+/** Returns a copy of the batch when it should flush mid-stream, otherwise null. */
+export function readyBatchAfterAppend(
+  batch: readonly string[],
+  batchSize: number,
+  processed: number,
+  limit: number,
+): string[] | null {
+  if (batch.length >= batchSize || processed >= limit) {
+    return [...batch];
+  }
+  return null;
+}
+
+/** Returns the trailing partial batch after the cursor ends, or null when empty. */
+export function finalBatchToFlush(batch: readonly string[]): string[] | null {
+  if (batch.length === 0) return null;
+  return [...batch];
+}
+
+/** Pure planner mirroring the cursor loop plus final flush — for unit tests. */
+export function planBackfillBatches(
+  ids: readonly string[],
+  batchSize: number,
+  limit: number,
+): string[][] {
+  const batches: string[][] = [];
+  let batch: string[] = [];
+  let processed = 0;
+
+  for (const id of ids) {
+    if (processed >= limit) break;
+
+    batch.push(id);
+    processed += 1;
+
+    const ready = readyBatchAfterAppend(batch, batchSize, processed, limit);
+    if (ready) {
+      batches.push(ready);
+      batch = [];
+    }
+  }
+
+  const remaining = finalBatchToFlush(batch);
+  if (remaining) {
+    batches.push(remaining);
+  }
+
+  return batches;
+}


### PR DESCRIPTION
## Summary
- Fix `backfillPriceEthics.ts` so the final partial batch is scored after the cursor ends (e.g. 20 listings with batch-size 50 previously scored 0).
- Extract `readyBatchAfterAppend` / `finalBatchToFlush` helpers and add unit tests covering partial batches, full batches, and limit handling.

## Test plan
- [x] `bunx jest __tests__/unit/backfillPriceEthicsBatching.test.ts` passes locally
- [ ] CI green (CodeQL, Socket, tests); board workflow failure alone is acceptable per prior ethical PR workflow


Made with [Cursor](https://cursor.com)