### PR TITLE
fix(listing): unblock Fotocasa discover throughput and ingest

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -128,9 +128,11 @@ LISTING_DISCOVER_INTERVAL_HOURS=6
 # GB Rightmove/OTM: 4–8 is reasonable with LISTING_BROWSER_BLOCK_ASSETS=true;
 # each browser fetch uses residential proxy — monitor DataImpulse GB budget.
 LISTING_FETCH_CONCURRENCY=4
-# Comma-separated ES cities for Spanish portals (idealista, fotocasa, pisos, habitaclia).
+# Comma-separated ES cities for Spanish portals (idealista, pisos, habitaclia).
 # Unset → bundled default list (~69 provincial capitals + major metros). [optional]
 # LISTING_ES_CITIES=madrid,barcelona,valencia
+# Fotocasa-only discover cities (browser warm per city). Unset → 10 major metros.
+# LISTING_FOTOCASA_CITIES=madrid,barcelona,valencia
 # Market-wide discover page cap for ES providers (ceiling 500). Per-provider override:
 # LISTING_FOTOCASA_MAX_PAGES, LISTING_IDEALISTA_MAX_PAGES, etc. [optional]
 # LISTING_ES_MAX_PAGES=100

--- a/packages/backend/__tests__/unit/ingestionGeocode.test.ts
+++ b/packages/backend/__tests__/unit/ingestionGeocode.test.ts
@@ -133,3 +133,30 @@ describe('IngestionService.resolveAddress geocode fallbacks', () => {
     expect(address?.postal_code).toBe(EXTERNAL_POSTAL_FALLBACK);
   });
 });
+
+describe('IngestionService external description truncation', () => {
+  it('truncates portal descriptions to the Property schema maxlength', async () => {
+    mockedForwardGeocode.mockResolvedValue({
+      success: true,
+      data: {
+        coordinates: [-0.1276, 51.5074],
+        city: 'London',
+        country: 'United Kingdom',
+        postalCode: 'SW1A 1AA',
+      },
+    });
+    mockedReverseGeocode.mockResolvedValue({ success: false, error: 'No address found' });
+
+    const longDescription = 'x'.repeat(2500);
+    const listing: NormalizedListing = {
+      ...baseListing,
+      sourceId: 'long-description',
+      description: longDescription,
+    };
+
+    const result = await buildIngestionService().ingest(listing);
+    const property = await Property.findById(result.propertyId);
+    expect(property?.description).toHaveLength(2000);
+    expect(property?.description).toBe('x'.repeat(2000));
+  });
+});

--- a/packages/backend/__tests__/unit/listingCitiesAndDiscoverLimits.test.ts
+++ b/packages/backend/__tests__/unit/listingCitiesAndDiscoverLimits.test.ts
@@ -6,6 +6,8 @@ import {
   citiesFromEnv,
   citiesOptionsFromEnv,
   DEFAULT_MARKET_CITIES,
+  FOTOCASA_DEFAULT_CITIES,
+  fotocasaCitiesFromEnv,
   MAX_PAGES_CEILING,
   maxSearchPagesFromEnv,
   providerMaxSearchPages,
@@ -55,6 +57,21 @@ describe('citiesFromEnv', () => {
     const options = citiesOptionsFromEnv('GB');
     expect(options.cities.length).toBeGreaterThan(10);
     expect(options.cities).toContain('London');
+  });
+});
+
+describe('fotocasaCitiesFromEnv', () => {
+  it('uses LISTING_FOTOCASA_CITIES when set', () => {
+    process.env.LISTING_FOTOCASA_CITIES = 'madrid, barcelona';
+    expect(fotocasaCitiesFromEnv()).toEqual(['madrid', 'barcelona']);
+  });
+
+  it('falls back to Fotocasa defaults, not the full ES market list', () => {
+    delete process.env.LISTING_FOTOCASA_CITIES;
+    process.env.LISTING_ES_CITIES = 'madrid,barcelona,valencia,sevilla,malaga,bilbao,zaragoza,alicante,murcia,palma,las-palmas-de-gran-canaria';
+    const cities = fotocasaCitiesFromEnv();
+    expect(cities).toEqual([...FOTOCASA_DEFAULT_CITIES]);
+    expect(cities.length).toBe(10);
   });
 });
 

--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -36,6 +36,9 @@ import { Logger } from '../../utils/logger';
 /** Default TTL (days) for an ingested external listing when none is specified. */
 const DEFAULT_TTL_DAYS = 30;
 
+/** Property schema cap for portal descriptions (must match PropertySchema). */
+const MAX_EXTERNAL_DESCRIPTION_LENGTH = 2000;
+
 /** When portals omit a postcode and geocoders return none (Address requires a value). */
 const EXTERNAL_POSTAL_FALLBACK = '00000';
 
@@ -250,7 +253,13 @@ export class IngestionService {
     if (listing.longTermRent) fields.longTermRent = listing.longTermRent;
     if (listing.shortTermRent) fields.shortTermRent = listing.shortTermRent;
     if (listing.sale) fields.sale = listing.sale;
-    if (listing.description !== undefined) fields.description = listing.description;
+    if (listing.description !== undefined) {
+      const description = listing.description.trim();
+      fields.description =
+        description.length > MAX_EXTERNAL_DESCRIPTION_LENGTH
+          ? description.slice(0, MAX_EXTERNAL_DESCRIPTION_LENGTH)
+          : description;
+    }
     if (listing.bedrooms !== undefined) fields.bedrooms = listing.bedrooms;
     if (listing.bathrooms !== undefined) fields.bathrooms = listing.bathrooms;
     if (listing.squareFootage !== undefined) fields.squareFootage = listing.squareFootage;

--- a/packages/backend/worker.ts
+++ b/packages/backend/worker.ts
@@ -21,6 +21,7 @@ import {
   BluegroundPartnerListingError,
   ListingValidationError,
   NonHousingListingError,
+  fotocasaCitiesFromEnv,
   type ExternalListingRef,
   type FetchRuntime,
   type ListingFetchRuntimeHandle,
@@ -134,10 +135,22 @@ async function collectDiscoverRefs(data: DiscoverJobData): Promise<ExternalListi
   return refs;
 }
 
-/** The discover scopes to enqueue on boot: one per (provider, market). */
+/** Providers whose discover pass warms a browser session per city — enqueue one job per city. */
+const PER_CITY_DISCOVER_PROVIDERS = new Set<string>(['fotocasa']);
+
+/** The discover scopes to enqueue on boot: one per (provider, market), or per-city for browser-heavy portals. */
 function bootDiscoverJobs(): DiscoverJobData[] {
   return registry.all().flatMap((provider) =>
-    provider.markets.map((market) => ({ provider: provider.id, market })),
+    provider.markets.flatMap((market) => {
+      if (PER_CITY_DISCOVER_PROVIDERS.has(provider.id)) {
+        return fotocasaCitiesFromEnv().map((city) => ({
+          provider: provider.id,
+          market,
+          city,
+        }));
+      }
+      return [{ provider: provider.id, market }];
+    }),
   );
 }
 

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -134,6 +134,11 @@ export {
 } from './providers/idealista/fixtures';
 
 export { FotocasaProvider, isFotocasaChallenge, fotocasaSourceIdFromUrl } from './providers/fotocasa';
+export {
+  FOTOCASA_DEFAULT_CITIES,
+  fotocasaCitiesFromEnv,
+  fotocasaCitiesOptionsFromEnv,
+} from './providers/fotocasa/cities';
 export { parseFotocasaDetail, parseFotocasaSearch, type FotocasaRaw } from './providers/fotocasa/parse';
 export {
   parseFotocasaSearchads,
@@ -1069,7 +1074,7 @@ import { FixtureProvider } from './providers/fixture';
 import { HabitacliaProvider } from './providers/habitaclia';
 import { BluegroundProvider } from './providers/blueground';
 import { IdealistaProvider } from './providers/idealista';
-import { FotocasaProvider } from './providers/fotocasa';
+import { FotocasaProvider, fotocasaCitiesOptionsFromEnv } from './providers/fotocasa';
 import { PisosProvider } from './providers/pisos';
 import { MilanunciosProvider } from './providers/milanuncios';
 import { YaencontreProvider } from './providers/yaencontre';
@@ -1164,7 +1169,7 @@ export function createDefaultRegistry(): ProviderRegistry {
     new HabitacliaProvider(esOptions),
     new BluegroundProvider(),
     new IdealistaProvider(esOptions),
-    new FotocasaProvider(esOptions),
+    new FotocasaProvider(fotocasaCitiesOptionsFromEnv()),
     new PisosProvider(esOptions),
     new MilanunciosProvider(esOptions),
     new YaencontreProvider(esOptions),

--- a/packages/listing-providers/src/providers/fotocasa/cities.ts
+++ b/packages/listing-providers/src/providers/fotocasa/cities.ts
@@ -1,0 +1,41 @@
+/**
+ * Fotocasa discover city scope.
+ *
+ * Fotocasa discover warms a Playwright session per city — using the full
+ * `LISTING_ES_CITIES` list (~70 metros) makes a single discover job run for
+ * hours before any fetch jobs enqueue. This module keeps Fotocasa on a smaller
+ * default set with an optional `LISTING_FOTOCASA_CITIES` override.
+ */
+
+/** Default metros for Fotocasa browser discover (not the full ES market list). */
+export const FOTOCASA_DEFAULT_CITIES: readonly string[] = [
+  'madrid',
+  'barcelona',
+  'valencia',
+  'sevilla',
+  'malaga',
+  'bilbao',
+  'zaragoza',
+  'alicante',
+  'murcia',
+  'palma',
+];
+
+function parseCityList(raw: string | undefined): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map((city) => city.trim())
+    .filter(Boolean);
+}
+
+/** Cities for Fotocasa discover: `LISTING_FOTOCASA_CITIES` or {@link FOTOCASA_DEFAULT_CITIES}. */
+export function fotocasaCitiesFromEnv(): string[] {
+  const envCities = parseCityList(process.env.LISTING_FOTOCASA_CITIES);
+  if (envCities.length > 0) return envCities;
+  return [...FOTOCASA_DEFAULT_CITIES];
+}
+
+/** Provider options with the Fotocasa-specific city list. */
+export function fotocasaCitiesOptionsFromEnv(): { cities: readonly string[] } {
+  return { cities: fotocasaCitiesFromEnv() };
+}

--- a/packages/listing-providers/src/providers/fotocasa/index.ts
+++ b/packages/listing-providers/src/providers/fotocasa/index.ts
@@ -53,23 +53,12 @@ import {
   readFotocasaBrowserSessionHint,
   type FotocasaBrowserSessionHint,
 } from './sessionHints';
+import { FOTOCASA_DEFAULT_CITIES, fotocasaCitiesFromEnv } from './cities';
+
+export { FOTOCASA_DEFAULT_CITIES, fotocasaCitiesFromEnv, fotocasaCitiesOptionsFromEnv } from './cities';
 
 const PROVIDER_ID: ProviderId = 'fotocasa';
 const ES_PROXY_COUNTRY = 'es';
-
-/** ES cities enumerated when a discover job carries no explicit `city`. */
-const DEFAULT_CITIES: readonly string[] = [
-  'madrid',
-  'barcelona',
-  'valencia',
-  'sevilla',
-  'malaga',
-  'bilbao',
-  'zaragoza',
-  'alicante',
-  'murcia',
-  'palma',
-];
 
 const DEFAULT_MAX_SEARCH_PAGES = 75;
 const DEFAULT_TRANSACTION_TYPES: readonly FotocasaTransactionType[] = ['RENT', 'BUY'];
@@ -174,7 +163,7 @@ export class FotocasaProvider implements ListingProvider {
 
   constructor(options: FotocasaProviderOptions = {}) {
     this.runtime = options.runtime ?? createFetchRuntime();
-    this.cities = options.cities && options.cities.length > 0 ? options.cities : DEFAULT_CITIES;
+    this.cities = options.cities && options.cities.length > 0 ? options.cities : FOTOCASA_DEFAULT_CITIES;
     this.metrics = options.metrics ?? defaultProviderMetrics;
     this.maxSearchPages = providerMaxSearchPages(PROVIDER_ID, DEFAULT_MAX_SEARCH_PAGES, 'ES');
     this.transactionTypes = resolveTransactionTypes();


### PR DESCRIPTION
## Summary
- Scope Fotocasa discover to 10 default metros via `LISTING_FOTOCASA_CITIES` (not the full 67-city `LISTING_ES_CITIES` list that blocked fetch enqueue for hours)
- Enqueue per-city Fotocasa discover jobs so Madrid listings start fetching while other cities run
- Truncate external listing descriptions at 2000 chars to stop ingest validation failures seen in worker logs

## Test plan
- [x] `listingCitiesAndDiscoverLimits` + `fotocasaProvider` unit tests pass
- [x] `ingestionGeocode` description truncation test passes
- [ ] After deploy: worker logs show `Discover job enqueued fetch jobs { provider: fotocasa, count: >0 }`
- [ ] `GET /api/properties` scan shows `source=fotocasa` > 0 within ~30 min of worker boot


Made with [Cursor](https://cursor.com)