### PR TITLE
chore: purge profile-collapse locale and doc leftovers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,13 +78,13 @@ Leases are first-class Mongoose documents; the schema is the authority and `cont
 
 ## Notifications (CRITICAL)
 
-Event-driven in-app notifications have **one write chokepoint**: `services/notificationDispatchService.ts`. Controllers call `createForUser` / `createForProfile` for domain events (lease signed, viewing approved, roommate request, …) — never `Notification.create` directly. Dispatch is best-effort (swallow-and-log; domain action must succeed even if the mailbox write fails).
+Event-driven in-app notifications have **one write chokepoint**: `services/notificationDispatchService.ts`. Controllers call `createForUser` for domain events (lease signed, viewing approved, roommate request, …) — never `Notification.create` directly. Dispatch is best-effort (swallow-and-log; domain action must succeed even if the mailbox write fails).
 
 The frontend has **no realtime socket client** for notifications. Mailbox refresh is refetch-on-focus + React Query invalidation after writes (`NotificationContext`, `services/notificationService.ts`). See `packages/frontend/docs/NOTIFICATIONS.md`.
 
 ## Roommates
 
-Accepted roommate requests materialize a `RoommateRelationship` document (`models/schemas/RoommateRelationshipSchema.ts`). Routes: `GET /api/roommates/relationships`, `DELETE /api/roommates/relationships/:relationshipId`. Ownership and participant resolution use `Profile.findActiveByOxyUserId` — same rule as property/lease writes.
+Accepted roommate requests materialize a `RoommateRelationship` document (`models/schemas/RoommateRelationshipSchema.ts`). Routes: `GET /api/roommates/relationships`, `DELETE /api/roommates/relationships/:relationshipId`. Ownership and participant resolution use `Profile.findByOxyUserId` — same rule as property/lease writes.
 
 ## Partner Commissions (mark-transacted)
 

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -48,7 +48,7 @@ packages/backend/
 
 Uses `@oxyhq/core/server` (`createOxyAuthMiddleware`, `requireOxyAuth`, `getRequiredOxyUserId`). The linked Oxy client on the frontend owns token refresh — no app-local bearer parsers.
 
-Profile ownership resolves via `Profile.findActiveByOxyUserId` — never trust client-supplied profile ids.
+Profile ownership resolves via `Profile.findByOxyUserId` — never trust client-supplied profile ids.
 
 ## Key API areas
 

--- a/packages/backend/controllers/roommate/editableFields.ts
+++ b/packages/backend/controllers/roommate/editableFields.ts
@@ -3,7 +3,7 @@
  *
  * `updateRoommatePreferences` must NEVER spread `req.body` into the Mongoose
  * update: the profile document also holds owner/system fields (`oxyUserId`,
- * `profileType`, verification, trust score, agency membership, …) that a client
+ * verification, …) that a client
  * must not be able to reach through the roommate settings endpoint. The
  * controller instead picks ONLY the roommate-matching preference fields listed
  * here and writes them under `personalProfile.settings.roommate.preferences`.

--- a/packages/frontend/docs/NOTIFICATIONS.md
+++ b/packages/frontend/docs/NOTIFICATIONS.md
@@ -14,7 +14,7 @@ The notification system provides:
 
 ### Backend write chokepoint
 
-Domain events (lease signed, viewing approved, roommate request received, …) produce in-app notifications **only** through `packages/backend/services/notificationDispatchService.ts`. Controllers call `createForUser` / `createForProfile` — never `Notification.create` directly for event-driven notifications. Dispatch is best-effort: a notification failure must never break the domain action that triggered it.
+Domain events (lease signed, viewing approved, roommate request received, …) produce in-app notifications **only** through `packages/backend/services/notificationDispatchService.ts`. Controllers call `createForUser` — never `Notification.create` directly for event-driven notifications. Dispatch is best-effort: a notification failure must never break the domain action that triggered it.
 
 ## Architecture
 

--- a/packages/frontend/locales/ca-ES.json
+++ b/packages/frontend/locales/ca-ES.json
@@ -111,21 +111,6 @@
       "searchPlaceholder": "On vols viure?",
       "searchButton": "Cercar"
     },
-    "trust": {
-      "title": "Habitatge en Què Pots Confiar",
-      "verifiedListings": {
-        "title": "Llistats Verificats",
-        "description": "Totes les propietats verificades per autenticitat i condició"
-      },
-      "fairAgreements": {
-        "title": "Acords Justos",
-        "description": "Contractes transparents sense termes ocults"
-      },
-      "trustScore": {
-        "title": "Puntuació de Confiança",
-        "description": "Sistema de reputació tant per llogaters com per propietaris"
-      }
-    },
     "cities": {
       "title": "Ciutats Destacades",
       "properties": "propietats"
@@ -702,23 +687,16 @@
     "myProperties": "Les Meves Propietats",
     "savedProperties": "Propietats Guardades",
     "myContracts": "Els Meus Contractes",
-    "trustScore": "Puntuació de Confiança",
     "logOut": "Tancar Sessió",
     "loading": "Carregant perfil...",
     "signInRequired": "Inici de sessió requerit",
     "signInMessage": "Si us plau inicia sessió per veure el teu perfil",
     "createProfile": "Crear Perfil",
     "deleteProfile": "Eliminar Perfil",
-    "types": {
-      "personal": "Perfil Personal",
-      "agency": "Perfil d'Agència",
-      "business": "Perfil de Negoci"
-    },
     "sections": {
       "overview": "Resum",
       "properties": "Les Meves Propietats",
       "contracts": "Els Meus Contractes",
-      "trustScore": "Puntuació de Confiança",
       "settings": "Configuració",
       "account": "Account",
       "profile": "Profile",
@@ -727,7 +705,6 @@
     "stats": {
       "propertiesCount": "Propietats",
       "contractsCount": "Contractes",
-      "trustScore": "Puntuació de Confiança",
       "stays": "Stays",
       "applications": "Applications",
       "saved": "Saved",
@@ -766,7 +743,6 @@
         "propertyPreferences": "Property Preferences",
         "references": "References",
         "rentalHistory": "Rental History",
-        "trustScore": "Trust Score",
         "settings": "Settings"
       },
       "labels": {
@@ -1025,17 +1001,9 @@
     },
     "toast": {
       "loadFailed": "No s'han pogut carregar els perfils",
-      "createSuccess": "Perfil creat correctament",
-      "createFailed": "No s'ha pogut crear el perfil",
       "updateSuccess": "Perfil actualitzat correctament",
-      "updateFailed": "No s'ha pogut actualitzar el perfil",
-      "deleteSuccess": "Perfil eliminat correctament",
-      "deleteFailed": "No s'ha pogut eliminar el perfil",
-      "activateSuccess": "Perfil activat correctament",
-      "activateFailed": "No s'ha pogut activar el perfil"
+      "updateFailed": "No s'ha pogut actualitzar el perfil"
     },
-    "trustScoreHint": "Complete your profile information to improve your trust score.",
-    "trustScoreSubtitle": "Build trust with landlords and roommates through verification and positive interactions.",
     "established": "Established",
     "serviceAreas": "Service areas",
     "specialties": "Specialties",
@@ -1045,111 +1013,12 @@
     "employer": "Employer",
     "occupation": "Occupation",
     "listings": "Listings",
-    "switchConfirm": "Switch",
-    "switchMessage": "Activate {{name}}?",
-    "switchTitle": "Switch profile?",
     "subscriptionsDescription": "Manage Homiio Plus or buy one-time file analysis.",
     "subscriptions": "Subscriptions",
-    "createNewDescription": "Add a business, agency, or cooperative profile.",
-    "createNew": "Create new profile",
-    "active": "Active",
-    "activeFooter": "Active: {{name}}",
     "stays": "Stays",
     "applications": "My applications",
-    "trustScoreCta": "View trust score",
     "loadFailedHint": "Please try again later.",
-    "loadFailed": "Failed to load profile",
-    "switchFailed": "Failed to switch profile",
-    "switched": "Switched to {{name}}",
-    "invalidProfile": "Invalid profile data",
-    "trustScorePage": {
-      "title": "Trust Score"
-    }
-  },
-  "trust": {
-    "loadingVerification": "Carregant estat de verificació...",
-    "loadingScore": "Carregant puntuació de confiança...",
-    "errorVerification": "No es pot carregar l'estat de verificació",
-    "errorScore": "No es pot carregar la puntuació de confiança",
-    "viewDetails": "Veure detalls",
-    "noVerification": "Sense dades de verificació",
-    "noScore": "Sense dades de puntuació de confiança",
-    "verified": "Verificat",
-    "completeVerification": "Completar verificació",
-    "yourScoreIs": "La teva puntuació de confiança és",
-    "improveScore": "Millorar puntuació",
-    "manager": {
-      "loading": "Carregant puntuació de confiança...",
-      "error": "Error en carregar la puntuació de confiança",
-      "noData": "No s'han trobat dades de puntuació personal",
-      "title": "Puntuació de confiança",
-      "subtitle": "Genera confiança amb propietaris i companys de pis",
-      "scoreDescription": "La teva puntuació global és {{score}}/100",
-      "factorsTitle": "Factors de confiança",
-      "factorsSubtitle": "Millora aquests factors per augmentar la puntuació",
-      "quickActionsTitle": "Accions ràpides per millorar",
-      "completeProfile": "Completar perfil",
-      "cancel": "Cancel·lar",
-      "editProfile": "Editar perfil",
-      "factorAlertBody": "{{description}}\n\nPuntuació actual: {{score}}/100\n\nPer millorar: {{action}}",
-      "factors": {
-        "verification": {
-          "label": "Verificació d'identitat",
-          "description": "Completa la verificació d'identitat per generar confiança",
-          "action": "Afegeix informació personal i dades d'ingressos"
-        },
-        "reviews": {
-          "label": "Ressenyes d'usuaris",
-          "description": "Obtén ressenyes positives de propietaris i companys",
-          "action": "Afegeix referències de propietaris anteriors"
-        },
-        "payment_history": {
-          "label": "Historial de pagaments",
-          "description": "Mantén un bon historial de pagaments",
-          "action": "Afegeix historial de lloguer amb registres de pagament"
-        },
-        "communication": {
-          "label": "Comunicació",
-          "description": "Respon amb promptitud a missatges i sol·licituds",
-          "action": "Completa la biografia i la informació de contacte"
-        },
-        "rental_history": {
-          "label": "Historial de lloguer",
-          "description": "Construeix un historial de lloguer positiu",
-          "action": "Afegeix les teves adreces de lloguer anteriors"
-        },
-        "default": {
-          "description": "Millora aquest factor per augmentar la puntuació",
-          "action": "Completa el teu perfil per millorar aquest factor"
-        }
-      },
-      "actions": {
-        "personalInfo": {
-          "title": "Completar informació personal",
-          "description": "Afegeix la teva ocupació, ingressos i dades laborals per generar confiança."
-        },
-        "references": {
-          "title": "Afegir referències",
-          "description": "Inclou referències de propietaris i empresaris anteriors."
-        },
-        "rentalHistory": {
-          "title": "Afegir historial de lloguer",
-          "description": "Documenta el teu historial de lloguer per demostrar fiabilitat."
-        }
-      }
-    },
-    "score": {
-      "levels": {
-        "excellent": "Excel·lent",
-        "good": "Bo",
-        "average": "Mitjà",
-        "fair": "Regular",
-        "needsImprovement": "Cal millorar"
-      },
-      "breakdown": "Desglossament de la puntuació de confiança",
-      "recalculate": "Recalcular",
-      "recalculating": "Recalculant…"
-    }
+    "loadFailed": "Failed to load profile"
   },
   "notifications": {
     "title": "Notificacions",

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -127,23 +127,6 @@
       "searchPlaceholder": "Where do you want to live?",
       "searchButton": "Search"
     },
-    "noProfilesTitle": "No Saved Profiles",
-    "noProfilesDescription": "Follow profiles to see them here",
-    "trust": {
-      "title": "Housing You Can Trust",
-      "verifiedListings": {
-        "title": "Verified Listings",
-        "description": "All properties verified for authenticity and condition"
-      },
-      "fairAgreements": {
-        "title": "Fair Agreements",
-        "description": "Transparent contracts with no hidden terms"
-      },
-      "trustScore": {
-        "title": "Trust Score",
-        "description": "Reputation system for both tenants and landlords"
-      }
-    },
     "cities": {
       "title": "Featured Cities",
       "properties": "properties"
@@ -701,23 +684,16 @@
     "myProperties": "My Properties",
     "savedProperties": "Saved Properties",
     "myContracts": "My Contracts",
-    "trustScore": "Trust Score",
     "logOut": "Log Out",
     "loading": "Loading profile...",
     "signInRequired": "Sign in required",
     "signInMessage": "Please sign in to view your profile",
     "createProfile": "Create Profile",
     "deleteProfile": "Delete Profile",
-    "types": {
-      "personal": "Personal Profile",
-      "agency": "Agency Profile",
-      "business": "Business Profile"
-    },
     "sections": {
       "overview": "Overview",
       "properties": "My Properties",
       "contracts": "My Contracts",
-      "trustScore": "Trust Score",
       "settings": "Settings",
       "account": "Account",
       "profile": "Profile",
@@ -726,7 +702,6 @@
     "stats": {
       "propertiesCount": "Properties",
       "contractsCount": "Contracts",
-      "trustScore": "Trust Score",
       "stays": "Stays",
       "applications": "Applications",
       "applicationsApproved": "{{count}} approved",
@@ -765,7 +740,6 @@
         "propertyPreferences": "Property Preferences",
         "references": "References",
         "rentalHistory": "Rental History",
-        "trustScore": "Trust Score",
         "settings": "Settings"
       },
       "labels": {
@@ -1024,17 +998,9 @@
     },
     "toast": {
       "loadFailed": "Failed to load profiles",
-      "createSuccess": "Profile created successfully",
-      "createFailed": "Failed to create profile",
       "updateSuccess": "Profile updated successfully",
-      "updateFailed": "Failed to update profile",
-      "deleteSuccess": "Profile deleted successfully",
-      "deleteFailed": "Failed to delete profile",
-      "activateSuccess": "Profile activated successfully",
-      "activateFailed": "Failed to activate profile"
+      "updateFailed": "Failed to update profile"
     },
-    "trustScoreHint": "Complete your profile information to improve your trust score.",
-    "trustScoreSubtitle": "Build trust with landlords and roommates through verification and positive interactions.",
     "established": "Established",
     "serviceAreas": "Service areas",
     "specialties": "Specialties",
@@ -1044,111 +1010,12 @@
     "employer": "Employer",
     "occupation": "Occupation",
     "listings": "Listings",
-    "switchConfirm": "Switch",
-    "switchMessage": "Activate {{name}}?",
-    "switchTitle": "Switch profile?",
     "subscriptionsDescription": "Manage Homiio Plus or buy one-time file analysis.",
     "subscriptions": "Subscriptions",
-    "createNewDescription": "Add a business, agency, or cooperative profile.",
-    "createNew": "Create new profile",
-    "active": "Active",
-    "activeFooter": "Active: {{name}}",
     "stays": "Stays",
     "applications": "My applications",
-    "trustScoreCta": "View trust score",
     "loadFailedHint": "Please try again later.",
-    "loadFailed": "Failed to load profile",
-    "switchFailed": "Failed to switch profile",
-    "switched": "Switched to {{name}}",
-    "invalidProfile": "Invalid profile data",
-    "trustScorePage": {
-      "title": "Trust Score"
-    }
-  },
-  "trust": {
-    "loadingVerification": "Loading verification status...",
-    "loadingScore": "Loading trust score...",
-    "errorVerification": "Unable to load verification status",
-    "errorScore": "Unable to load trust score",
-    "viewDetails": "View Details",
-    "noVerification": "No verification data",
-    "noScore": "No trust score data",
-    "verified": "Verified",
-    "completeVerification": "Complete Verification",
-    "yourScoreIs": "Your trust score is",
-    "improveScore": "Improve Score",
-    "manager": {
-      "loading": "Loading trust score...",
-      "error": "Error loading trust score",
-      "noData": "No personal trust score data found",
-      "title": "Trust Score",
-      "subtitle": "Build trust with landlords and roommates",
-      "scoreDescription": "Your overall trust score is {{score}}/100",
-      "factorsTitle": "Trust Factors",
-      "factorsSubtitle": "Improve these factors to increase your trust score",
-      "quickActionsTitle": "Quick Actions to Improve Score",
-      "completeProfile": "Complete Profile",
-      "cancel": "Cancel",
-      "editProfile": "Edit Profile",
-      "factorAlertBody": "{{description}}\n\nCurrent Score: {{score}}/100\n\nTo improve: {{action}}",
-      "factors": {
-        "verification": {
-          "label": "Identity Verification",
-          "description": "Complete identity verification to build trust",
-          "action": "Add personal information and income details"
-        },
-        "reviews": {
-          "label": "User Reviews",
-          "description": "Get positive reviews from landlords and roommates",
-          "action": "Add references from previous landlords"
-        },
-        "payment_history": {
-          "label": "Payment History",
-          "description": "Maintain a good payment history",
-          "action": "Add rental history with payment records"
-        },
-        "communication": {
-          "label": "Communication",
-          "description": "Respond promptly to messages and requests",
-          "action": "Complete your profile bio and contact info"
-        },
-        "rental_history": {
-          "label": "Rental History",
-          "description": "Build a positive rental history",
-          "action": "Add your previous rental addresses"
-        },
-        "default": {
-          "description": "Improve this factor to increase your trust score",
-          "action": "Complete your profile to improve this factor"
-        }
-      },
-      "actions": {
-        "personalInfo": {
-          "title": "Complete Personal Info",
-          "description": "Add your occupation, income, and employment details to build trust."
-        },
-        "references": {
-          "title": "Add References",
-          "description": "Include references from previous landlords and employers."
-        },
-        "rentalHistory": {
-          "title": "Add Rental History",
-          "description": "Document your rental history to show your reliability as a tenant."
-        }
-      }
-    },
-    "score": {
-      "levels": {
-        "excellent": "Excellent",
-        "good": "Good",
-        "average": "Average",
-        "fair": "Fair",
-        "needsImprovement": "Needs Improvement"
-      },
-      "breakdown": "Trust Score Breakdown",
-      "recalculate": "Recalculate",
-      "recalculating": "Recalculating..."
-    }
+    "loadFailed": "Failed to load profile"
   },
   "notifications": {
     "title": "Notifications",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -114,21 +114,6 @@
       "searchPlaceholder": "¿Dónde quieres vivir?",
       "searchButton": "Buscar"
     },
-    "trust": {
-      "title": "Vivienda en la que Puedes Confiar",
-      "verifiedListings": {
-        "title": "Listados Verificados",
-        "description": "Todas las propiedades verificadas por autenticidad y condición"
-      },
-      "fairAgreements": {
-        "title": "Acuerdos Justos",
-        "description": "Contratos transparentes sin términos ocultos"
-      },
-      "trustScore": {
-        "title": "Puntuación de Confianza",
-        "description": "Sistema de reputación tanto para inquilinos como para propietarios"
-      }
-    },
     "cities": {
       "title": "Ciudades Destacadas",
       "properties": "propiedades"
@@ -677,23 +662,16 @@
     "myProperties": "Mis Propiedades",
     "savedProperties": "Propiedades Guardadas",
     "myContracts": "Mis Contratos",
-    "trustScore": "Puntuación de Confianza",
     "logOut": "Cerrar Sesión",
     "loading": "Cargando perfil...",
     "signInRequired": "Inicio de sesión requerido",
     "signInMessage": "Por favor inicia sesión para ver tu perfil",
     "createProfile": "Crear Perfil",
     "deleteProfile": "Eliminar Perfil",
-    "types": {
-      "personal": "Perfil Personal",
-      "agency": "Perfil de Agencia",
-      "business": "Perfil de Negocio"
-    },
     "sections": {
       "overview": "Resumen",
       "properties": "Mis Propiedades",
       "contracts": "Mis Contratos",
-      "trustScore": "Puntuación de Confianza",
       "settings": "Configuración",
       "account": "Account",
       "profile": "Profile",
@@ -702,7 +680,6 @@
     "stats": {
       "propertiesCount": "Propiedades",
       "contractsCount": "Contratos",
-      "trustScore": "Puntuación de Confianza",
       "stays": "Stays",
       "applications": "Applications",
       "saved": "Saved",
@@ -741,7 +718,6 @@
         "propertyPreferences": "Preferencias de propiedad",
         "references": "References",
         "rentalHistory": "Rental History",
-        "trustScore": "Trust Score",
         "settings": "Settings"
       },
       "labels": {
@@ -1000,17 +976,9 @@
     },
     "toast": {
       "loadFailed": "No se pudieron cargar los perfiles",
-      "createSuccess": "Perfil creado correctamente",
-      "createFailed": "No se pudo crear el perfil",
       "updateSuccess": "Perfil actualizado correctamente",
-      "updateFailed": "No se pudo actualizar el perfil",
-      "deleteSuccess": "Perfil eliminado correctamente",
-      "deleteFailed": "No se pudo eliminar el perfil",
-      "activateSuccess": "Perfil activado correctamente",
-      "activateFailed": "No se pudo activar el perfil"
+      "updateFailed": "No se pudo actualizar el perfil"
     },
-    "trustScoreHint": "Complete your profile information to improve your trust score.",
-    "trustScoreSubtitle": "Build trust with landlords and roommates through verification and positive interactions.",
     "established": "Established",
     "serviceAreas": "Service areas",
     "specialties": "Specialties",
@@ -1020,111 +988,12 @@
     "employer": "Employer",
     "occupation": "Occupation",
     "listings": "Listings",
-    "switchConfirm": "Switch",
-    "switchMessage": "Activate {{name}}?",
-    "switchTitle": "Switch profile?",
     "subscriptionsDescription": "Manage Homiio Plus or buy one-time file analysis.",
     "subscriptions": "Subscriptions",
-    "createNewDescription": "Add a business, agency, or cooperative profile.",
-    "createNew": "Create new profile",
-    "active": "Active",
-    "activeFooter": "Active: {{name}}",
     "stays": "Stays",
     "applications": "My applications",
-    "trustScoreCta": "View trust score",
     "loadFailedHint": "Please try again later.",
-    "loadFailed": "Failed to load profile",
-    "switchFailed": "Failed to switch profile",
-    "switched": "Switched to {{name}}",
-    "invalidProfile": "Invalid profile data",
-    "trustScorePage": {
-      "title": "Trust Score"
-    }
-  },
-  "trust": {
-    "loadingVerification": "Cargando estado de verificación...",
-    "loadingScore": "Cargando puntuación de confianza...",
-    "errorVerification": "No se puede cargar el estado de verificación",
-    "errorScore": "No se puede cargar la puntuación de confianza",
-    "viewDetails": "Ver detalles",
-    "noVerification": "Sin datos de verificación",
-    "noScore": "Sin datos de puntuación de confianza",
-    "verified": "Verificado",
-    "completeVerification": "Completar verificación",
-    "yourScoreIs": "Tu puntuación de confianza es",
-    "improveScore": "Mejorar puntuación",
-    "manager": {
-      "loading": "Cargando puntuación de confianza...",
-      "error": "Error al cargar la puntuación de confianza",
-      "noData": "No se encontraron datos de puntuación personal",
-      "title": "Puntuación de confianza",
-      "subtitle": "Genera confianza con arrendadores y compañeros de piso",
-      "scoreDescription": "Tu puntuación global es {{score}}/100",
-      "factorsTitle": "Factores de confianza",
-      "factorsSubtitle": "Mejora estos factores para aumentar tu puntuación",
-      "quickActionsTitle": "Acciones rápidas para mejorar",
-      "completeProfile": "Completar perfil",
-      "cancel": "Cancelar",
-      "editProfile": "Editar perfil",
-      "factorAlertBody": "{{description}}\n\nPuntuación actual: {{score}}/100\n\nPara mejorar: {{action}}",
-      "factors": {
-        "verification": {
-          "label": "Verificación de identidad",
-          "description": "Completa la verificación de identidad para generar confianza",
-          "action": "Añade información personal y datos de ingresos"
-        },
-        "reviews": {
-          "label": "Reseñas de usuarios",
-          "description": "Obtén reseñas positivas de arrendadores y compañeros",
-          "action": "Añade referencias de arrendadores anteriores"
-        },
-        "payment_history": {
-          "label": "Historial de pagos",
-          "description": "Mantén un buen historial de pagos",
-          "action": "Añade historial de alquiler con registros de pago"
-        },
-        "communication": {
-          "label": "Comunicación",
-          "description": "Responde con prontitud a mensajes y solicitudes",
-          "action": "Completa la biografía y la información de contacto"
-        },
-        "rental_history": {
-          "label": "Historial de alquiler",
-          "description": "Construye un historial de alquiler positivo",
-          "action": "Añade tus direcciones de alquiler anteriores"
-        },
-        "default": {
-          "description": "Mejora este factor para aumentar tu puntuación",
-          "action": "Completa tu perfil para mejorar este factor"
-        }
-      },
-      "actions": {
-        "personalInfo": {
-          "title": "Completar información personal",
-          "description": "Añade tu ocupación, ingresos y datos laborales para generar confianza."
-        },
-        "references": {
-          "title": "Añadir referencias",
-          "description": "Incluye referencias de arrendadores y empleadores anteriores."
-        },
-        "rentalHistory": {
-          "title": "Añadir historial de alquiler",
-          "description": "Documenta tu historial de alquiler para demostrar fiabilidad."
-        }
-      }
-    },
-    "score": {
-      "levels": {
-        "excellent": "Excelente",
-        "good": "Bueno",
-        "average": "Medio",
-        "fair": "Regular",
-        "needsImprovement": "Necesita mejorar"
-      },
-      "breakdown": "Desglose de la puntuación de confianza",
-      "recalculate": "Recalcular",
-      "recalculating": "Recalculando…"
-    }
+    "loadFailed": "Failed to load profile"
   },
   "notifications": {
     "title": "Notificaciones",

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -268,21 +268,6 @@
       "searchPlaceholder": "Dove vuoi vivere?",
       "searchButton": "Cerca"
     },
-    "trust": {
-      "title": "Abitazioni di cui Puoi Fidarti",
-      "verifiedListings": {
-        "title": "Annunci Verificati",
-        "description": "Tutte le proprietà verificate per autenticità e condizioni"
-      },
-      "fairAgreements": {
-        "title": "Accordi Equi",
-        "description": "Contratti trasparenti senza termini nascosti"
-      },
-      "trustScore": {
-        "title": "Punteggio di Fiducia",
-        "description": "Sistema di reputazione per inquilini e proprietari"
-      }
-    },
     "cities": {
       "title": "Città in Evidenza",
       "properties": "proprietà"
@@ -840,7 +825,6 @@
     "myProperties": "Le Mie Proprietà",
     "savedProperties": "Proprietà Salvate",
     "myContracts": "I Miei Contratti",
-    "trustScore": "Punteggio di Fiducia",
     "logOut": "Esci",
     "exchanges": "Scambi",
     "exchangesDescription": "I tuoi scambi casa e le richieste di ospitalità.",
@@ -854,16 +838,10 @@
     "signInMessage": "Please sign in to view your profile",
     "createProfile": "Create Profile",
     "deleteProfile": "Delete Profile",
-    "types": {
-      "personal": "Personal Profile",
-      "agency": "Agency Profile",
-      "business": "Business Profile"
-    },
     "sections": {
       "overview": "Overview",
       "properties": "My Properties",
       "contracts": "My Contracts",
-      "trustScore": "Trust Score",
       "settings": "Settings",
       "account": "Account",
       "profile": "Profile",
@@ -872,7 +850,6 @@
     "stats": {
       "propertiesCount": "Properties",
       "contractsCount": "Contracts",
-      "trustScore": "Trust Score",
       "stays": "Stays",
       "applications": "Applications",
       "saved": "Saved",
@@ -909,7 +886,6 @@
         "propertyPreferences": "Property Preferences",
         "references": "References",
         "rentalHistory": "Rental History",
-        "trustScore": "Trust Score",
         "settings": "Settings"
       },
       "labels": {
@@ -1168,17 +1144,9 @@
     },
     "toast": {
       "loadFailed": "Impossibile caricare i profili",
-      "createSuccess": "Profilo creato con successo",
-      "createFailed": "Impossibile creare il profilo",
       "updateSuccess": "Profilo aggiornato con successo",
-      "updateFailed": "Impossibile aggiornare il profilo",
-      "deleteSuccess": "Profilo eliminato con successo",
-      "deleteFailed": "Impossibile eliminare il profilo",
-      "activateSuccess": "Profilo attivato con successo",
-      "activateFailed": "Impossibile attivare il profilo"
+      "updateFailed": "Impossibile aggiornare il profilo"
     },
-    "trustScoreHint": "Complete your profile information to improve your trust score.",
-    "trustScoreSubtitle": "Build trust with landlords and roommates through verification and positive interactions.",
     "established": "Established",
     "serviceAreas": "Service areas",
     "specialties": "Specialties",
@@ -1188,26 +1156,12 @@
     "employer": "Employer",
     "occupation": "Occupation",
     "listings": "Listings",
-    "switchConfirm": "Switch",
-    "switchMessage": "Activate {{name}}?",
-    "switchTitle": "Switch profile?",
     "subscriptionsDescription": "Manage Homiio Plus or buy one-time file analysis.",
     "subscriptions": "Subscriptions",
-    "createNewDescription": "Add a business, agency, or cooperative profile.",
-    "createNew": "Create new profile",
-    "active": "Active",
-    "activeFooter": "Active: {{name}}",
     "stays": "Stays",
     "applications": "My applications",
-    "trustScoreCta": "View trust score",
     "loadFailedHint": "Please try again later.",
-    "loadFailed": "Failed to load profile",
-    "switchFailed": "Failed to switch profile",
-    "switched": "Switched to {{name}}",
-    "invalidProfile": "Invalid profile data",
-    "trustScorePage": {
-      "title": "Trust Score"
-    }
+    "loadFailed": "Failed to load profile"
   },
   "notifications": {
     "title": "Notifiche",
@@ -2691,91 +2645,6 @@
     },
     "loading": "Loading...",
     "battery": "Battery"
-  },
-  "trust": {
-    "loadingVerification": "Loading verification status...",
-    "loadingScore": "Loading trust score...",
-    "errorVerification": "Unable to load verification status",
-    "errorScore": "Unable to load trust score",
-    "viewDetails": "View Details",
-    "noVerification": "No verification data",
-    "noScore": "No trust score data",
-    "verified": "Verified",
-    "completeVerification": "Complete Verification",
-    "yourScoreIs": "Your trust score is",
-    "improveScore": "Improve Score",
-    "manager": {
-      "loading": "Caricamento punteggio di fiducia...",
-      "error": "Errore nel caricamento del punteggio",
-      "noData": "Nessun dato di punteggio personale trovato",
-      "title": "Punteggio di fiducia",
-      "subtitle": "Costruisci fiducia con proprietari e coinquilini",
-      "scoreDescription": "Il tuo punteggio complessivo è {{score}}/100",
-      "factorsTitle": "Fattori di fiducia",
-      "factorsSubtitle": "Migliora questi fattori per aumentare il punteggio",
-      "quickActionsTitle": "Azioni rapide per migliorare",
-      "completeProfile": "Completa profilo",
-      "cancel": "Annulla",
-      "editProfile": "Modifica profilo",
-      "factorAlertBody": "{{description}}\n\nPunteggio attuale: {{score}}/100\n\nPer migliorare: {{action}}",
-      "factors": {
-        "verification": {
-          "label": "Verifica identità",
-          "description": "Completa la verifica dell'identità per costruire fiducia",
-          "action": "Aggiungi informazioni personali e dati sul reddito"
-        },
-        "reviews": {
-          "label": "Recensioni utenti",
-          "description": "Ottieni recensioni positive da proprietari e coinquilini",
-          "action": "Aggiungi referenze di precedenti proprietari"
-        },
-        "payment_history": {
-          "label": "Storico pagamenti",
-          "description": "Mantieni un buono storico dei pagamenti",
-          "action": "Aggiungi storico affitti con registri di pagamento"
-        },
-        "communication": {
-          "label": "Comunicazione",
-          "description": "Rispondi tempestivamente a messaggi e richieste",
-          "action": "Completa bio e informazioni di contatto"
-        },
-        "rental_history": {
-          "label": "Storico affitti",
-          "description": "Costruisci uno storico affitti positivo",
-          "action": "Aggiungi i tuoi precedenti indirizzi di affitto"
-        },
-        "default": {
-          "description": "Migliora questo fattore per aumentare il punteggio",
-          "action": "Completa il profilo per migliorare questo fattore"
-        }
-      },
-      "actions": {
-        "personalInfo": {
-          "title": "Completa informazioni personali",
-          "description": "Aggiungi occupazione, reddito e dati lavorativi per costruire fiducia."
-        },
-        "references": {
-          "title": "Aggiungi referenze",
-          "description": "Includi referenze di precedenti proprietari e datori di lavoro."
-        },
-        "rentalHistory": {
-          "title": "Aggiungi storico affitti",
-          "description": "Documenta il tuo storico affitti per dimostrare affidabilità."
-        }
-      }
-    },
-    "score": {
-      "levels": {
-        "excellent": "Eccellente",
-        "good": "Buono",
-        "average": "Nella media",
-        "fair": "Discreto",
-        "needsImprovement": "Da migliorare"
-      },
-      "breakdown": "Dettaglio punteggio di fiducia",
-      "recalculate": "Ricalcola",
-      "recalculating": "Ricalcolo in corso…"
-    }
   },
   "donations": {
     "widget": {

--- a/packages/shared-types/README.md
+++ b/packages/shared-types/README.md
@@ -25,7 +25,6 @@ import { Property, Profile, City, PropertyType, PropertyStatus } from '@homiio/s
 #### Common Types
 - `PropertyType` - Enum for property types (apartment, house, room, etc.)
 - `PropertyStatus` - Enum for property status (available, occupied, etc.)
-- `ProfileType` - Enum for profile types (personal, agency, business, cooperative)
 - `ApiResponse<T>` - Generic API response interface
 - `Pagination` - Pagination interface
 - `Coordinates` - Geographic coordinates interface


### PR DESCRIPTION
## Summary
- Remove unused trust-score and multi-profile i18n keys from en/es/it/ca-ES after profile-collapse (#131)
- Update AGENTS.md, backend README, NOTIFICATIONS.md, and shared-types README to reflect `Profile.findByOxyUserId` and `createForUser`-only notification dispatch

## Test plan
- [x] Locale JSON validates (`node JSON.parse` on all four files)
- [x] Grep: no remaining `ProfileType`, `trustScore`, `activateProfile`, `findActiveByOxyUserId`, etc. in TS/TSX
- [ ] CI green


Made with [Cursor](https://cursor.com)