### PR TITLE
fix(pisos): parse locationmap coords and correct stacked map pins

### DIFF
--- a/packages/backend/__tests__/unit/ingestionGeocode.test.ts
+++ b/packages/backend/__tests__/unit/ingestionGeocode.test.ts
@@ -3,6 +3,12 @@
  */
 
 import { OfferingType, PropertyType, type NormalizedListing } from '@homiio/shared-types';
+import {
+  PisosProvider,
+  parsePisosDetail,
+  PISOS_FIXTURE_DETAIL_HTML,
+  PISOS_FIXTURE_DETAIL_VALLADOLID_HTML,
+} from '@homiio/listing-providers';
 
 import { IngestionService } from '../../services/ingestion/IngestionService';
 import { ExternalMediaIngest } from '../../services/ingestion/ExternalMediaIngest';
@@ -131,6 +137,45 @@ describe('IngestionService.resolveAddress geocode fallbacks', () => {
 
     const address = await Address.findById(property.get('addressId'));
     expect(address?.postal_code).toBe(EXTERNAL_POSTAL_FALLBACK);
+  });
+
+  it('ingests two pisos listings with distinct portal coordinates into different geo points', async () => {
+    mockedReverseGeocode.mockResolvedValue({ success: false, error: 'No address found' });
+
+    const pisos = new PisosProvider();
+    const madridRaw = parsePisosDetail(
+      PISOS_FIXTURE_DETAIL_HTML,
+      'https://www.pisos.com/alquilar/piso-sol_barrio28012-20026385030_992099/',
+    );
+    const valladolidRaw = parsePisosDetail(
+      PISOS_FIXTURE_DETAIL_VALLADOLID_HTML,
+      'https://www.pisos.com/alquilar/piso-valladolid_capital_universidad-65009504308_106400/',
+    );
+    const madridListing = pisos.normalize({
+      ref: { provider: 'pisos', sourceId: madridRaw.sourceId, url: madridRaw.url },
+      payload: madridRaw,
+    });
+    const valladolidListing = pisos.normalize({
+      ref: { provider: 'pisos', sourceId: valladolidRaw.sourceId, url: valladolidRaw.url },
+      payload: valladolidRaw,
+    });
+
+    const service = buildIngestionService();
+    const madridResult = await service.ingest(madridListing);
+    const valladolidResult = await service.ingest(valladolidListing);
+
+    expect(mockedForwardGeocode).not.toHaveBeenCalled();
+
+    const madridProperty = await Property.findById(madridResult.propertyId);
+    const valladolidProperty = await Property.findById(valladolidResult.propertyId);
+    expect(madridProperty?.addressId).toBeTruthy();
+    expect(valladolidProperty?.addressId).toBeTruthy();
+    expect(String(madridProperty?.addressId)).not.toBe(String(valladolidProperty?.addressId));
+
+    const madridAddress = await Address.findById(madridProperty?.addressId);
+    const valladolidAddress = await Address.findById(valladolidProperty?.addressId);
+    expect(madridAddress?.coordinates?.coordinates).toEqual([-3.7083892232908435, 40.41593545782718]);
+    expect(valladolidAddress?.coordinates?.coordinates).toEqual([-4.7216201, 41.6531628]);
   });
 });
 

--- a/packages/backend/__tests__/unit/pisosProvider.test.ts
+++ b/packages/backend/__tests__/unit/pisosProvider.test.ts
@@ -10,6 +10,7 @@ import {
   mergePisosContact,
   pisosSourceIdFromUrl,
   PISOS_FIXTURE_DETAIL_HTML,
+  PISOS_FIXTURE_DETAIL_VALLADOLID_HTML,
   PISOS_FIXTURE_SEARCH_HTML,
   PISOS_FIXTURE_CONTACT_JSON,
 } from '@homiio/listing-providers';
@@ -41,6 +42,33 @@ describe('PisosProvider.normalize', () => {
     expect(listing.contact?.kind).toBe('agency');
     expect(listing.remoteImages.length).toBeGreaterThan(0);
     expect(listing.amenities).toEqual(expect.arrayContaining(['ascensor', 'balcon', 'soleado']));
+    expect(listing.address.city).toBe('Madrid Capital');
+    expect(listing.address.coordinates).toEqual({ lat: 40.41593545782718, lng: -3.7083892232908435 });
+  });
+
+  it('assigns distinct portal coordinates and cities for two detail fixtures', () => {
+    const madridPayload = parsePisosDetail(
+      PISOS_FIXTURE_DETAIL_HTML,
+      'https://www.pisos.com/alquilar/piso-sol_barrio28012-20026385030_992099/',
+    );
+    const valladolidPayload = parsePisosDetail(
+      PISOS_FIXTURE_DETAIL_VALLADOLID_HTML,
+      'https://www.pisos.com/alquilar/piso-valladolid_capital_universidad-65009504308_106400/',
+    );
+    const madrid = provider.normalize({
+      ref: { provider: 'pisos', sourceId: madridPayload.sourceId, url: madridPayload.url },
+      payload: madridPayload,
+    });
+    const valladolid = provider.normalize({
+      ref: { provider: 'pisos', sourceId: valladolidPayload.sourceId, url: valladolidPayload.url },
+      payload: valladolidPayload,
+    });
+
+    expect(madrid.address.city).toBe('Madrid Capital');
+    expect(valladolid.address.city).toBe('Valladolid Capital');
+    expect(madrid.address.coordinates).toEqual({ lat: 40.41593545782718, lng: -3.7083892232908435 });
+    expect(valladolid.address.coordinates).toEqual({ lat: 41.6531628, lng: -4.7216201 });
+    expect(madrid.address.coordinates).not.toEqual(valladolid.address.coordinates);
   });
 
   it('parses contact AJAX JSON', () => {

--- a/packages/backend/models/Address.ts
+++ b/packages/backend/models/Address.ts
@@ -366,6 +366,14 @@ AddressSchema.static('findOrCreateCanonical', async function findOrCreateCanonic
 
   const existing = await this.findOne({ normalizedKey });
   if (existing) {
+    const [existingLng, existingLat] = existing.coordinates.coordinates;
+    const [newLng, newLat] = coordinates;
+    const coordDrift =
+      Math.abs(existingLng - newLng) > 0.0005 || Math.abs(existingLat - newLat) > 0.0005;
+    if (coordDrift) {
+      existing.set('coordinates', { type: 'Point', coordinates: [newLng, newLat] });
+      await existing.save();
+    }
     return existing;
   }
 

--- a/packages/backend/scripts/requeue-pisos-coordinates.ts
+++ b/packages/backend/scripts/requeue-pisos-coordinates.ts
@@ -1,0 +1,122 @@
+/**
+ * Re-queue pisos.com listings stuck at the Madrid city-centroid for worker re-fetch.
+ *
+ * Root cause: detail pages omit JSON-LD; coords live on the locationmap widget.
+ * Listings ingested before that parser fix landed at ~40.416782,-3.703507.
+ *
+ * Usage:
+ *   bun run packages/backend/scripts/requeue-pisos-coordinates.ts
+ *   bun run packages/backend/scripts/requeue-pisos-coordinates.ts --apply
+ *
+ * Requires REDIS_URL (Valkey) for --apply. Mongo via standard backend .env.
+ */
+
+require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
+
+import { Queue } from 'bullmq';
+import { PropertyStatus } from '@homiio/shared-types';
+import type { ExternalListingRef } from '@homiio/listing-providers';
+import {
+  QUEUE_NAMES,
+  fetchJobId,
+  parseRedisConnection,
+  type FetchJobData,
+} from '../services/ingestion/queues';
+import database from '../database/connection';
+
+const { Property, Address } = require('../models');
+
+const APPLY = process.argv.includes('--apply');
+
+/** Nominatim Madrid centroid returned when street geocode failed and city defaulted to Madrid. */
+const MADRID_CENTROID_LAT = 40.416782;
+const MADRID_CENTROID_LNG = -3.703507;
+const COORD_EPSILON = 0.0002;
+
+function isMadridCentroid(lng: number, lat: number): boolean {
+  return (
+    Math.abs(lat - MADRID_CENTROID_LAT) <= COORD_EPSILON &&
+    Math.abs(lng - MADRID_CENTROID_LNG) <= COORD_EPSILON
+  );
+}
+
+async function main(): Promise<void> {
+  await database.connect();
+
+  const pisosProperties = await Property.find({
+    source: 'pisos',
+    isExternal: true,
+    status: PropertyStatus.PUBLISHED,
+    sourceUrl: { $exists: true, $type: 'string', $ne: '' },
+  })
+    .select({ sourceId: 1, sourceUrl: 1, addressId: 1 })
+    .lean();
+
+  const stuck: Array<{ sourceId: string; sourceUrl: string; ref: ExternalListingRef }> = [];
+
+  for (const doc of pisosProperties) {
+    const sourceId = typeof doc.sourceId === 'string' ? doc.sourceId : '';
+    const sourceUrl = typeof doc.sourceUrl === 'string' ? doc.sourceUrl : '';
+    if (!sourceId || !sourceUrl || !doc.addressId) continue;
+
+    const address = await Address.findById(doc.addressId).select({ coordinates: 1 }).lean();
+    const coords = address?.coordinates?.coordinates;
+    if (!Array.isArray(coords) || coords.length !== 2) continue;
+    const [lng, lat] = coords;
+    if (typeof lng !== 'number' || typeof lat !== 'number') continue;
+    if (!isMadridCentroid(lng, lat)) continue;
+
+    stuck.push({
+      sourceId,
+      sourceUrl,
+      ref: { provider: 'pisos', sourceId, url: sourceUrl },
+    });
+  }
+
+  console.log(
+    `${APPLY ? 'Re-queueing' : 'Would re-queue'} ${stuck.length} pisos listing(s) at Madrid centroid`,
+  );
+  for (const row of stuck.slice(0, 20)) {
+    console.log(`  - ${row.sourceId} ${row.sourceUrl}`);
+  }
+  if (stuck.length > 20) {
+    console.log(`  … and ${stuck.length - 20} more`);
+  }
+
+  if (!APPLY) {
+    await database.disconnect?.();
+    return;
+  }
+
+  const redisUrl = process.env.REDIS_URL?.trim();
+  if (!redisUrl) {
+    throw new Error('REDIS_URL is required for --apply');
+  }
+
+  const connection = parseRedisConnection(redisUrl);
+  const prefix = process.env.BULLMQ_PREFIX?.trim() || 'homiio';
+  const fetchQueue = new Queue<FetchJobData>(QUEUE_NAMES.fetch, { connection, prefix });
+
+  let enqueued = 0;
+  let skipped = 0;
+  for (const row of stuck) {
+    const jobId = fetchJobId(row.ref);
+    const existing = await fetchQueue.getJob(jobId);
+    const state = existing ? await existing.getState() : undefined;
+    if (state === 'waiting' || state === 'active' || state === 'delayed') {
+      skipped += 1;
+      continue;
+    }
+    await fetchQueue.add(QUEUE_NAMES.fetch, { ref: row.ref }, { jobId });
+    enqueued += 1;
+  }
+
+  console.log(`Enqueued ${enqueued} fetch job(s); skipped ${skipped} already pending/active`);
+  await fetchQueue.close();
+  await database.disconnect?.();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -454,11 +454,15 @@ export {
   parsePisosDetail,
   parsePisosSearch,
   mergePisosContact,
+  readPisosLocationMapCoordinates,
+  readPisosAscendingGeo,
+  postalCodeFromPisosUrl,
   type PisosRaw,
 } from './providers/pisos/parse';
 export {
   PISOS_BASE_URL,
   PISOS_FIXTURE_DETAIL_HTML,
+  PISOS_FIXTURE_DETAIL_VALLADOLID_HTML,
   PISOS_FIXTURE_SEARCH_HTML,
   PISOS_FIXTURE_CONTACT_JSON,
 } from './providers/pisos/fixtures';

--- a/packages/listing-providers/src/providers/pisos/fixtures.ts
+++ b/packages/listing-providers/src/providers/pisos/fixtures.ts
@@ -23,12 +23,19 @@ export const PISOS_FIXTURE_SEARCH_HTML = `<!doctype html>
 </script>
 </body></html>`;
 
-/** Detail page with embedded JSON blobs (price + contact phone). */
+/** Detail page with embedded JSON blobs (price + contact phone) + location map coords. */
 export const PISOS_FIXTURE_DETAIL_HTML = `<!doctype html>
 <html lang="es"><head><title>Piso en alquiler en Calle Mayor, 45</title></head><body>
 <input id="hdnIdPiso" name="hdnIdPiso" type="hidden" value="20026385030.992099" />
 <h1>Piso en alquiler en Calle Mayor, 45, cerca de Calle de Ciudad Rodrigo</h1>
+<div class="ascending-geo__row" data-zone="P00000000000028" data-ga-geoLevelName='provincia' property="itemListElement" typeof="ListItem">
+<a href="/alquiler/piso-madrid/" class="ascending-geo__result" property="item" typeof="WebPage"><span property="name">Madrid</span></a>
+</div>
+<div class="ascending-geo__row" data-zone="M00000000028079" data-ga-geoLevelName='municipio' property="itemListElement" typeof="ListItem">
+<a href="/alquiler/piso-madrid_capital/" class="ascending-geo__result" property="item" typeof="WebPage"><span property="name">Madrid Capital</span></a>
+</div>
 <div data-var='{"fechaModificacion":"17/06/2026","fechaPrimeraPublicacion":"04/05/2026","telefono":"919376345","caracteristicasInmueble":"ascensor,balcon,soleado","nHabitaciones":"2","nBanios":"2","superficieInmueble":"107","descuentoAplicado":"8"}'></div>
+<div class="locationmap" data-params="latitude=40.41593545782718&amp;longitude=-3.7083892232908435&amp;zoom=17&amp;showMarker=True"></div>
 <script>
 window.__pisosTrack = {"tipoContenido":"detalle","tipoOperacion":"alquiler","seccion":"alquiler","idioma":"ES","subseccion1":"casas-pisos","tipoContenidoA":"detalle-casas-pisos","provincia":"P00000000000028","municipio":"M00000000028079","distrito":"G00000002807901","precioInmueble":"2550","precio":"2550","tipoVendedor":"profesional","referenciaInmueble":"","marca":"196080","tipoInmueble":"casas-pisos","subTipoInmueble":"piso-apartamento"};
 var precio = 2550;
@@ -36,6 +43,23 @@ var precio = 2550;
 <img src="https://fotos.imghs.net/example/20026385030/1.jpg" />
 <img src="https://fotos.imghs.net/example/20026385030/2.jpg" />
 <p class="description">Piso luminoso junto a Ópera, 107 m², 2 habitaciones.</p>
+</body></html>`;
+
+/** Valladolid detail — no JSON-LD; coords only on the location map widget. */
+export const PISOS_FIXTURE_DETAIL_VALLADOLID_HTML = `<!doctype html>
+<html lang="es"><head><title>Piso en alquiler en Universidad</title></head><body>
+<input id="hdnIdPiso" name="hdnIdPiso" type="hidden" value="65009504308.106400" />
+<h1>Piso en alquiler en Universidad</h1>
+<div class="ascending-geo__row" data-zone="P00000000000047" data-ga-geoLevelName='provincia' property="itemListElement" typeof="ListItem">
+<a href="/alquiler/piso-valladolid/" class="ascending-geo__result" property="item" typeof="WebPage"><span property="name">Valladolid</span></a>
+</div>
+<div class="ascending-geo__row" data-zone="M00000000047186" data-ga-geoLevelName='municipio' property="itemListElement" typeof="ListItem">
+<a href="/alquiler/piso-valladolid_capital/" class="ascending-geo__result" property="item" typeof="WebPage"><span property="name">Valladolid Capital</span></a>
+</div>
+<div data-var='{"telefono":"883872390","nHabitaciones":"1","nBanios":"1","superficieInmueble":"45"}'></div>
+<div class="locationmap" data-params="latitude=41.6531628&amp;longitude=-4.7216201&amp;zoom=16&amp;showMarker=False"></div>
+<script>var precio = 650;</script>
+<p class="description">Loft con encanto en el casco histórico de valladolid.</p>
 </body></html>`;
 
 /** Recorded contact AJAX body from `/WebsiteUserInfo/GetNormalizedPhone`. */

--- a/packages/listing-providers/src/providers/pisos/parse.ts
+++ b/packages/listing-providers/src/providers/pisos/parse.ts
@@ -206,6 +206,57 @@ function readTrack(html: string): Record<string, unknown> | undefined {
   return readBalancedJsonAfter(html, '__pisosTrack');
 }
 
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex: string) => String.fromCharCode(Number.parseInt(hex, 16)));
+}
+
+/** Detail pages embed map coords in `locationmap` data-params (JSON-LD is search-only). */
+export function readPisosLocationMapCoordinates(html: string): { lat: number; lng: number } | undefined {
+  const match = html.match(/locationmap[^>]*data-params="([^"]+)"/i);
+  if (!match) return undefined;
+  const params = decodeHtmlEntities(match[1]);
+  const lat = asNumber(params.match(/(?:^|[&?])latitude=([^&]+)/)?.[1]);
+  const lng = asNumber(params.match(/(?:^|[&?])longitude=([^&]+)/)?.[1]);
+  if (lat === undefined || lng === undefined) return undefined;
+  return { lat, lng };
+}
+
+interface PisosAscendingGeo {
+  province?: string;
+  municipality?: string;
+  comarca?: string;
+}
+
+/** Breadcrumb geo rows (`ascending-geo__row`) carry province/municipality names. */
+export function readPisosAscendingGeo(html: string): PisosAscendingGeo {
+  const levels: PisosAscendingGeo = {};
+  let pos = 0;
+  while (pos < html.length) {
+    const rowStart = html.indexOf('ascending-geo__row', pos);
+    if (rowStart < 0) break;
+    const rowEnd = html.indexOf('</div>', rowStart);
+    if (rowEnd < 0) break;
+    const row = html.slice(rowStart, rowEnd);
+    pos = rowEnd + '</div>'.length;
+
+    const level = row.match(/data-ga-geoLevelName='([^']+)'/)?.[1];
+    const name = row.match(/<span property="name">([^<]+)<\/span>/)?.[1]?.trim();
+    if (!level || !name) continue;
+    if (level === 'provincia') levels.province = name;
+    else if (level === 'municipio') levels.municipality = name;
+    else if (level === 'comarca') levels.comarca = name;
+  }
+  return levels;
+}
+
+/** Five-digit postal codes are often embedded in the detail URL slug before the listing id. */
+export function postalCodeFromPisosUrl(url: string): string | undefined {
+  return url.match(/(\d{5})-\d+[._]\d+/)?.[1];
+}
+
 function amenityList(raw: unknown): string[] {
   if (typeof raw !== 'string' || raw.trim().length === 0) return [];
   return raw
@@ -257,8 +308,14 @@ export function parsePisosDetail(html: string, url: string): PisosRaw {
 
   const images = [...new Set(readPisosImageUrls(html))];
   const ld = extractEsSchemaListings(html)[0];
-  const city = ld?.address?.city ?? 'Madrid';
+  const geo = readPisosAscendingGeo(html);
+  const mapCoords = readPisosLocationMapCoordinates(html);
+  const city = geo.municipality ?? ld?.address?.city ?? geo.province ?? '';
+  if (!city) {
+    throw new Error(`pisos: listing ${resolvedId} has no resolvable city`);
+  }
   const street = ld?.address?.street ?? h1 ?? city;
+  const postalCode = ld?.address?.postalCode ?? postalCodeFromPisosUrl(url);
 
   const listing: EsSchemaListing = {
     types,
@@ -268,13 +325,13 @@ export function parsePisosDetail(html: string, url: string): PisosRaw {
     address: {
       street,
       city,
-      region: ld?.address?.region,
-      postalCode: ld?.address?.postalCode,
+      region: geo.province ?? ld?.address?.region,
+      postalCode,
       neighborhood: ld?.address?.neighborhood,
       country: ld?.address?.country,
       countryCode: ld?.address?.countryCode ?? 'ES',
     },
-    coordinates: ld?.coordinates,
+    coordinates: mapCoords ?? ld?.coordinates,
     images: images.length > 0 ? images : (ld?.images ?? []),
     bedrooms: asNumber(dataVar?.nHabitaciones) ?? ld?.bedrooms,
     bathrooms: asNumber(dataVar?.nBanios) ?? ld?.bathrooms,


### PR DESCRIPTION
## Summary
- Pisos detail pages have no JSON-LD; real lat/lng live on the `locationmap` widget and city on geo breadcrumbs.
- Parser previously defaulted city to Madrid and omitted portal coords, so ingest geocoded every listing to the same Madrid centroid (40.416782, -3.703507).
- Fix parser, update Address coords on re-sync drift, add requeue script for ~247 stuck listings.

## Test plan
- [x] `bun run test -- __tests__/unit/pisosProvider.test.ts __tests__/unit/ingestionGeocode.test.ts`
- [ ] After deploy: run `bun run packages/backend/scripts/requeue-pisos-coordinates.ts --apply` against prod
- [ ] Verify pisos listings show distinct map pins


Made with [Cursor](https://cursor.com)