### PR TITLE
fix(listings): unblock ES portal discover (Madrid per-city)

### DIFF
--- a/packages/backend/__tests__/unit/fotocasaProvider.test.ts
+++ b/packages/backend/__tests__/unit/fotocasaProvider.test.ts
@@ -557,6 +557,52 @@ describe('FotocasaProvider.fetch property JSON path', () => {
     expect(local.normalize(raw).sourceId).toBe('187654321');
   });
 
+  it('publishes from discover searchads card when property JSON is blocked', async () => {
+    const runtime: FetchRuntime = {
+      fetchHttp: async () => {
+        throw new Error('HTML ladder must not run for Fotocasa fetch');
+      },
+      fetchJson: async () => {
+        throw new Error('unused');
+      },
+      fetchText: async () => {
+        throw new Error('unused');
+      },
+      loadFixture: async () => {
+        throw new Error('unused');
+      },
+      openBrowserSession: async () => {
+        throw new Error('browser must not open when search card hint is present');
+      },
+    };
+
+    const local = new FotocasaProvider({ runtime });
+    const ref: ExternalListingRef = {
+      provider: 'fotocasa',
+      sourceId: '187654321',
+      url: 'https://www.fotocasa.es/es/alquiler/vivienda/madrid-capital/x/187654321/d',
+      hints: {
+        fotocasaSearchCard: {
+          warmCity: 'madrid',
+          card: {
+            propertyId: '187654321',
+            detailUrl: '/es/alquiler/vivienda/madrid-capital/calefaccion-ascensor/187654321/d',
+            transaction: { type: 'RENT', price: 1850 },
+            rooms: 3,
+            baths: 2,
+            surface: 95,
+            address: { municipality: 'Madrid' },
+          },
+        },
+      },
+    };
+
+    const raw = await local.fetch(ref, { runtime, signal: new AbortController().signal });
+    const listing = local.normalize(raw);
+    expect(listing.sourceId).toBe('187654321');
+    expect(listing.longTermRent?.monthlyAmount).toBe(1850);
+  });
+
   it('throws ChallengeError when property JSON and detail HTML stay blocked', async () => {
     const runtime: FetchRuntime = {
       fetchHttp: async () => {

--- a/packages/backend/__tests__/unit/listingCitiesAndDiscoverLimits.test.ts
+++ b/packages/backend/__tests__/unit/listingCitiesAndDiscoverLimits.test.ts
@@ -75,6 +75,35 @@ describe('fotocasaCitiesFromEnv', () => {
   });
 });
 
+describe('habitacliaCitiesFromEnv', () => {
+  it('uses LISTING_HABITACLIA_CITIES when set', () => {
+    process.env.LISTING_HABITACLIA_CITIES = 'madrid, barcelona';
+    const { habitacliaCitiesFromEnv } = require('@homiio/listing-providers');
+    expect(habitacliaCitiesFromEnv()).toEqual(['madrid', 'barcelona']);
+  });
+
+  it('defaults to madrid only', () => {
+    delete process.env.LISTING_HABITACLIA_CITIES;
+    process.env.LISTING_ES_CITIES = 'madrid,barcelona,valencia,sevilla';
+    const { habitacliaCitiesFromEnv, HABITACLIA_DEFAULT_CITIES } = require('@homiio/listing-providers');
+    expect(habitacliaCitiesFromEnv()).toEqual([...HABITACLIA_DEFAULT_CITIES]);
+  });
+});
+
+describe('idealistaCitiesFromEnv', () => {
+  it('uses LISTING_IDEALISTA_CITIES when set', () => {
+    process.env.LISTING_IDEALISTA_CITIES = 'madrid';
+    const { idealistaCitiesFromEnv } = require('@homiio/listing-providers');
+    expect(idealistaCitiesFromEnv()).toEqual(['madrid']);
+  });
+
+  it('defaults to madrid only', () => {
+    delete process.env.LISTING_IDEALISTA_CITIES;
+    const { idealistaCitiesFromEnv, IDEALISTA_DEFAULT_CITIES } = require('@homiio/listing-providers');
+    expect(idealistaCitiesFromEnv()).toEqual([...IDEALISTA_DEFAULT_CITIES]);
+  });
+});
+
 describe('discover pagination caps', () => {
   it('clamps env page caps to MAX_PAGES_CEILING', () => {
     process.env.LISTING_TEST_MAX = '9999';

--- a/packages/backend/scripts/enqueueDiscoverMadrid.ts
+++ b/packages/backend/scripts/enqueueDiscoverMadrid.ts
@@ -1,0 +1,121 @@
+/**
+ * Release stale BullMQ discover locks and enqueue Madrid-only discover jobs for
+ * ES browser portals. Run inside the VPC (or ECS one-off) with REDIS_URL set.
+ *
+ * Usage:
+ *   REDIS_URL=... bun run packages/backend/scripts/enqueueDiscoverMadrid.ts
+ *   REDIS_URL=... bun run packages/backend/scripts/enqueueDiscoverMadrid.ts --providers=fotocasa,habitaclia
+ */
+
+import { Queue } from 'bullmq';
+import {
+  QUEUE_NAMES,
+  discoverJobId,
+  parseRedisConnection,
+  type DiscoverJobData,
+} from '../services/ingestion/queues';
+
+const DISCOVER_LOCK_MS = 600_000;
+const MADRID = 'madrid';
+const DEFAULT_PROVIDERS = ['habitaclia', 'fotocasa', 'idealista'] as const;
+
+function parseProvidersArg(argv: string[]): string[] {
+  const flag = argv.find((entry) => entry.startsWith('--providers='));
+  if (!flag) return [...DEFAULT_PROVIDERS];
+  return flag
+    .slice('--providers='.length)
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+async function removeJob(
+  queue: Queue<DiscoverJobData>,
+  jobId: string,
+  reason: string,
+): Promise<boolean> {
+  const job = await queue.getJob(jobId);
+  if (!job) return false;
+  try {
+    await job.remove();
+    console.log(JSON.stringify({ action: 'removed', jobId, reason }));
+    return true;
+  } catch {
+    try {
+      await job.moveToFailed(new Error(reason), '0', true);
+      console.log(JSON.stringify({ action: 'force-failed', jobId, reason }));
+      return true;
+    } catch (error) {
+      console.log(
+        JSON.stringify({
+          action: 'skip',
+          jobId,
+          reason,
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      );
+      return false;
+    }
+  }
+}
+
+async function releaseStaleActive(queue: Queue<DiscoverJobData>): Promise<number> {
+  const staleBefore = Date.now() - DISCOVER_LOCK_MS;
+  const active = await queue.getJobs(['active'], 0, 50);
+  let released = 0;
+  for (const job of active) {
+    const processedOn = job.processedOn ?? 0;
+    if (processedOn > staleBefore) continue;
+    if (await removeJob(queue, job.id ?? '', 'stale active discover')) released += 1;
+  }
+  return released;
+}
+
+async function purgeLegacyMarketWide(
+  queue: Queue<DiscoverJobData>,
+  provider: string,
+): Promise<void> {
+  const legacyScope: DiscoverJobData = { provider, market: 'ES' };
+  const legacyId = discoverJobId(legacyScope);
+  await removeJob(queue, legacyId, `legacy market-wide ${provider} discover`);
+}
+
+async function main(): Promise<void> {
+  const redisUrl = process.env.REDIS_URL?.trim();
+  if (!redisUrl) throw new Error('REDIS_URL is required');
+
+  const providers = parseProvidersArg(process.argv.slice(2));
+  const prefix = process.env.LISTING_QUEUE_PREFIX || 'bull-homiio-listings';
+  const connection = parseRedisConnection(redisUrl);
+  const discoverQueue = new Queue<DiscoverJobData>(QUEUE_NAMES.discover, { connection, prefix });
+
+  const released = await releaseStaleActive(discoverQueue);
+  for (const provider of providers) {
+    await purgeLegacyMarketWide(discoverQueue, provider);
+  }
+
+  const enqueued: string[] = [];
+  for (const provider of providers) {
+    const data: DiscoverJobData = { provider, market: 'ES', city: MADRID };
+    const jobId = discoverJobId(data);
+    await removeJob(discoverQueue, jobId, 're-enqueue madrid discover');
+    await discoverQueue.add(QUEUE_NAMES.discover, data, { jobId });
+    enqueued.push(jobId);
+  }
+
+  const counts = await discoverQueue.getJobCounts('waiting', 'active', 'completed', 'failed', 'delayed');
+  console.log(
+    JSON.stringify({
+      releasedStaleActive: released,
+      enqueued,
+      discoverCounts: counts,
+    }),
+  );
+
+  await discoverQueue.close();
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/packages/backend/worker.ts
+++ b/packages/backend/worker.ts
@@ -22,6 +22,8 @@ import {
   ListingValidationError,
   NonHousingListingError,
   fotocasaCitiesFromEnv,
+  habitacliaCitiesFromEnv,
+  idealistaCitiesFromEnv,
   type ExternalListingRef,
   type FetchRuntime,
   type ListingFetchRuntimeHandle,
@@ -135,15 +137,21 @@ async function collectDiscoverRefs(data: DiscoverJobData): Promise<ExternalListi
   return refs;
 }
 
-/** Providers whose discover pass warms a browser session per city — enqueue one job per city. */
-const PER_CITY_DISCOVER_PROVIDERS = new Set<string>(['fotocasa']);
+/** Providers whose discover pass warms a browser session per city — one job per city. */
+function discoverCitiesForProvider(providerId: string): string[] | undefined {
+  if (providerId === 'fotocasa') return fotocasaCitiesFromEnv();
+  if (providerId === 'habitaclia') return habitacliaCitiesFromEnv();
+  if (providerId === 'idealista') return idealistaCitiesFromEnv();
+  return undefined;
+}
 
 /** The discover scopes to enqueue on boot: one per (provider, market), or per-city for browser-heavy portals. */
 function bootDiscoverJobs(): DiscoverJobData[] {
   return registry.all().flatMap((provider) =>
     provider.markets.flatMap((market) => {
-      if (PER_CITY_DISCOVER_PROVIDERS.has(provider.id)) {
-        return fotocasaCitiesFromEnv().map((city) => ({
+      const perCity = discoverCitiesForProvider(provider.id);
+      if (perCity) {
+        return perCity.map((city) => ({
           provider: provider.id,
           market,
           city,
@@ -228,19 +236,23 @@ async function removeDiscoverJobOrForceFail(
   }
 }
 
-/** Drop pre per-city Fotocasa discover scopes that can block the queue for hours. */
-async function purgeLegacyFotocasaDiscoverJobs(discoverQueue: BullQueue<DiscoverJobData>): Promise<void> {
-  const legacyScope: DiscoverJobData = { provider: 'fotocasa', market: 'ES' };
+/** Drop pre per-city discover scopes that can block the queue for hours. */
+async function purgeLegacyMarketWideDiscoverJobs(
+  discoverQueue: BullQueue<DiscoverJobData>,
+  provider: string,
+): Promise<void> {
+  const legacyScope: DiscoverJobData = { provider, market: 'ES' };
   const legacyId = discoverJobId(legacyScope);
   const legacyRepeatKey = `repeat-${legacyId}`;
 
   try {
     const removed = await discoverQueue.removeRepeatableByKey(legacyRepeatKey);
     if (removed) {
-      logger.warn('Removed legacy fotocasa repeat scheduler', { legacyRepeatKey });
+      logger.warn('Removed legacy repeat scheduler', { provider, legacyRepeatKey });
     }
   } catch (error) {
-    logger.warn('Could not remove legacy fotocasa repeat scheduler', {
+    logger.warn('Could not remove legacy repeat scheduler', {
+      provider,
       legacyRepeatKey,
       error: error instanceof Error ? error.message : String(error),
     });
@@ -248,20 +260,25 @@ async function purgeLegacyFotocasaDiscoverJobs(discoverQueue: BullQueue<Discover
 
   const legacyJob = await discoverQueue.getJob(legacyId);
   if (legacyJob) {
-    await removeDiscoverJobOrForceFail(legacyJob, 'legacy market-wide fotocasa discover');
+    await removeDiscoverJobOrForceFail(legacyJob, `legacy market-wide ${provider} discover`);
   }
 
   const activeJobs = await discoverQueue.getJobs(['active'], 0, 50);
   for (const job of activeJobs) {
-    if (job.data.provider !== 'fotocasa' || job.data.city) continue;
-    await removeDiscoverJobOrForceFail(job, 'superseded active fotocasa discover scope');
+    if (job.data.provider !== provider || job.data.city) continue;
+    await removeDiscoverJobOrForceFail(job, `superseded active ${provider} discover scope`);
   }
 
   const candidates = await discoverQueue.getJobs(['waiting', 'delayed'], 0, 200);
   for (const job of candidates) {
-    if (job.data.provider !== 'fotocasa' || job.data.city) continue;
-    await removeDiscoverJobOrForceFail(job, 'superseded fotocasa discover scope');
+    if (job.data.provider !== provider || job.data.city) continue;
+    await removeDiscoverJobOrForceFail(job, `superseded ${provider} discover scope`);
   }
+}
+
+/** Drop pre per-city Fotocasa discover scopes that can block the queue for hours. */
+async function purgeLegacyFotocasaDiscoverJobs(discoverQueue: BullQueue<DiscoverJobData>): Promise<void> {
+  await purgeLegacyMarketWideDiscoverJobs(discoverQueue, 'fotocasa');
 }
 
 async function releaseStaleActiveDiscoverJobs(discoverQueue: BullQueue<DiscoverJobData>): Promise<number> {
@@ -290,6 +307,9 @@ async function startBullMq(): Promise<() => Promise<void>> {
 
   // Purge ghost/scoped jobs before the discover worker can claim them.
   await purgeLegacyFotocasaDiscoverJobs(discoverQueue);
+  for (const provider of ['habitaclia', 'idealista'] as const) {
+    await purgeLegacyMarketWideDiscoverJobs(discoverQueue, provider);
+  }
   await releaseStaleActiveDiscoverJobs(discoverQueue);
 
   const discoverWorker = new Worker<DiscoverJobData>(

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -60,6 +60,11 @@ export type { FixtureRawListing, FixtureRawImage } from './providers/fixture/fix
 
 export { HabitacliaProvider } from './providers/habitaclia';
 export {
+  HABITACLIA_DEFAULT_CITIES,
+  habitacliaCitiesFromEnv,
+  habitacliaCitiesOptionsFromEnv,
+} from './providers/habitaclia/cities';
+export {
   parseHabitacliaDetail,
   parseHabitacliaSearch,
   habitacliaSourceIdFromUrl,
@@ -104,6 +109,11 @@ export type {
 } from './providers/blueground/fixtures';
 
 export { IdealistaProvider, isIdealistaChallenge, idealistaSourceIdFromUrl } from './providers/idealista';
+export {
+  IDEALISTA_DEFAULT_CITIES,
+  idealistaCitiesFromEnv,
+  idealistaCitiesOptionsFromEnv,
+} from './providers/idealista/cities';
 export { parseIdealistaDetail, parseIdealistaSearch, type IdealistaRaw } from './providers/idealista/parse';
 export {
   parseIdealistaGeoreach,
@@ -1076,8 +1086,10 @@ import type { ListingProvider } from './types';
 import { citiesOptionsFromEnv } from './cities';
 import { FixtureProvider } from './providers/fixture';
 import { HabitacliaProvider } from './providers/habitaclia';
+import { habitacliaCitiesOptionsFromEnv } from './providers/habitaclia/cities';
 import { BluegroundProvider } from './providers/blueground';
 import { IdealistaProvider } from './providers/idealista';
+import { idealistaCitiesOptionsFromEnv } from './providers/idealista/cities';
 import { FotocasaProvider, fotocasaCitiesOptionsFromEnv } from './providers/fotocasa';
 import { PisosProvider } from './providers/pisos';
 import { MilanunciosProvider } from './providers/milanuncios';
@@ -1170,9 +1182,9 @@ export function createDefaultRegistry(): ProviderRegistry {
   const plOptions = citiesOptionsFromEnv('PL');
   const nlOptions = citiesOptionsFromEnv('NL');
   const flaggedProviders: ListingProvider[] = [
-    new HabitacliaProvider(esOptions),
+    new HabitacliaProvider(habitacliaCitiesOptionsFromEnv()),
     new BluegroundProvider(),
-    new IdealistaProvider(esOptions),
+    new IdealistaProvider(idealistaCitiesOptionsFromEnv()),
     new FotocasaProvider(fotocasaCitiesOptionsFromEnv()),
     new PisosProvider(esOptions),
     new MilanunciosProvider(esOptions),

--- a/packages/listing-providers/src/providers/fotocasa/index.ts
+++ b/packages/listing-providers/src/providers/fotocasa/index.ts
@@ -44,13 +44,16 @@ import {
   parseFotocasaLocationSegments,
   parseFotocasaSearchads,
   parseFotocasaSsrSearch,
+  extractFotocasaSearchCards,
   type FotocasaLocationSegments,
   type FotocasaTransactionType,
 } from './searchads';
-import { fotocasaPropertyApiUrl, isFotocasaPropertyChallenge, parseFotocasaPropertyJson } from './property';
+import { fotocasaPropertyApiUrl, isFotocasaPropertyChallenge, parseFotocasaPropertyJson, parseFotocasaSearchCardRecord } from './property';
 import {
   fotocasaBrowserSessionHints,
+  fotocasaSearchCardHints,
   readFotocasaBrowserSessionHint,
+  readFotocasaSearchCardHint,
   type FotocasaBrowserSessionHint,
 } from './sessionHints';
 import { FOTOCASA_DEFAULT_CITIES, fotocasaCitiesFromEnv } from './cities';
@@ -135,14 +138,27 @@ function yieldRefs(
   limit: number,
   yielded: { count: number },
   browserSession?: FotocasaBrowserSessionHint,
+  searchCards?: Map<string, Record<string, unknown>>,
 ): ExternalListingRef[] {
   const out: ExternalListingRef[] = [];
-  const hints = browserSession ? fotocasaBrowserSessionHints(browserSession) : undefined;
   for (const ref of refs) {
     if (yielded.count >= limit) break;
     if (seen.has(ref.sourceId)) continue;
     seen.add(ref.sourceId);
-    out.push({ provider: PROVIDER_ID, sourceId: ref.sourceId, url: ref.url, hints });
+    const hints: Record<string, unknown> = {};
+    if (browserSession) {
+      Object.assign(hints, fotocasaBrowserSessionHints(browserSession));
+    }
+    const card = searchCards?.get(ref.sourceId);
+    if (card && browserSession) {
+      Object.assign(hints, fotocasaSearchCardHints(browserSession.warmCity, card));
+    }
+    out.push({
+      provider: PROVIDER_ID,
+      sourceId: ref.sourceId,
+      url: ref.url,
+      hints: Object.keys(hints).length > 0 ? hints : undefined,
+    });
     yielded.count += 1;
   }
   return out;
@@ -324,13 +340,17 @@ export class FotocasaProvider implements ListingProvider {
           });
           if (page === 1) {
             const ssrRefs = parseFotocasaSsrSearch(searchHtml);
+            const ssrCards = extractFotocasaSearchCards(searchHtml);
             if (ssrRefs.length > 0) {
-              collected.push(...yieldRefs(ssrRefs, seen, limit, yielded, browserSession));
+              collected.push(
+                ...yieldRefs(ssrRefs, seen, limit, yielded, browserSession, ssrCards),
+              );
             }
           }
           break;
         }
         if (status >= 400) break;
+        const searchCards = extractFotocasaSearchCards(response.body);
         pageRefs = parseFotocasaSearchads(response.body);
         if (page === 1 && pageRefs.length === 0) {
           pageRefs = parseFotocasaSsrSearch(searchHtml);
@@ -347,7 +367,9 @@ export class FotocasaProvider implements ListingProvider {
           url: requestUrl,
         });
         if (pageRefs.length === 0) break;
-        collected.push(...yieldRefs(pageRefs, seen, limit, yielded, browserSession));
+        collected.push(
+          ...yieldRefs(pageRefs, seen, limit, yielded, browserSession, searchCards),
+        );
       }
 
       if (sticky) {
@@ -410,6 +432,25 @@ export class FotocasaProvider implements ListingProvider {
    * Ladder HTML is last resort when the session pool is absent or warm-up fails.
    */
   async fetch(ref: ExternalListingRef, ctx: FetchContext): Promise<RawListing> {
+    const searchCard = readFotocasaSearchCardHint(ref.hints);
+    if (searchCard) {
+      try {
+        const payload = parseFotocasaSearchCardRecord(searchCard.card, ref.url, searchCard.warmCity);
+        this.metrics.record({
+          provider: this.id,
+          strategy: 'browser',
+          outcome: 'success',
+          status: 200,
+          latencyMs: 0,
+          url: ref.url,
+          detail: 'searchads-card (discover snapshot)',
+        });
+        return { ref, payload };
+      } catch {
+        // Fall through to warmed property JSON / HTML.
+      }
+    }
+
     if (!ctx.runtime.openBrowserSession) {
       throw new ChallengeError(ref.url, 'browser', 503);
     }

--- a/packages/listing-providers/src/providers/fotocasa/property.ts
+++ b/packages/listing-providers/src/providers/fotocasa/property.ts
@@ -130,6 +130,45 @@ function findPropertyRecord(parsed: unknown): Record<string, unknown> | undefine
 }
 
 /**
+ * Parse a searchads card record (from `realEstates[]`) into {@link FotocasaRaw}.
+ * Used when the property JSON API is PerimeterX-blocked but discover captured
+ * enough fields from searchads to publish.
+ */
+export function parseFotocasaSearchCardRecord(
+  record: Record<string, unknown>,
+  url: string,
+  fallbackCity?: string,
+): FotocasaRaw {
+  const enriched: Record<string, unknown> = { ...record };
+  const addressNode = isRecord(enriched.address) ? { ...enriched.address } : {};
+  if (fallbackCity && !readFotocasaCity(enriched) && !readFotocasaCity({ address: addressNode })) {
+    addressNode.municipality = fallbackCity;
+    enriched.address = addressNode;
+  }
+
+  const listing = fotocasaRecordToListing(enriched, url);
+  if (!listing || listing.price === undefined) {
+    throw new Error(`fotocasa: searchads card has no resolvable price at ${url}`);
+  }
+
+  const rawId =
+    asString(enriched.propertyId) ?? asString(enriched.id) ?? asString(enriched.realEstateId);
+  const sourceId =
+    rawId?.replace(/\D/g, '') ??
+    fotocasaSourceIdFromUrl(listing.url ?? url) ??
+    fotocasaSourceIdFromUrl(url);
+  if (!sourceId) {
+    throw new Error(`fotocasa: cannot derive a source id from searchads card at ${url}`);
+  }
+
+  return {
+    sourceId,
+    url: listing.url ?? url,
+    listing,
+  };
+}
+
+/**
  * Parse a Fotocasa `/property` JSON body into {@link FotocasaRaw}. Throws when
  * the body is a challenge page or carries no recognizable listing fields.
  */

--- a/packages/listing-providers/src/providers/fotocasa/searchads.ts
+++ b/packages/listing-providers/src/providers/fotocasa/searchads.ts
@@ -216,6 +216,38 @@ export function parseFotocasaLocationSegments(body: string): FotocasaLocationSeg
   return { ids, latitude, longitude };
 }
 
+function collectCardsFromUnknown(
+  value: unknown,
+  cards: Map<string, Record<string, unknown>>,
+): void {
+  if (Array.isArray(value)) {
+    for (const entry of value) collectCardsFromUnknown(entry, cards);
+    return;
+  }
+  if (!isRecord(value)) return;
+
+  const ref = refFromRecord(value);
+  if (ref) cards.set(ref.sourceId, value);
+
+  for (const key of ['realEstates', 'ads', 'items', 'results', 'data', 'content', 'html']) {
+    if (key in value) collectCardsFromUnknown(value[key], cards);
+  }
+}
+
+/** Extract searchads listing cards keyed by source id (for discover → fetch handoff). */
+export function extractFotocasaSearchCards(body: string): Map<string, Record<string, unknown>> {
+  const trimmed = body.trim();
+  const cards = new Map<string, Record<string, unknown>>();
+  if (trimmed.length === 0 || isFotocasaSearchadsChallenge(trimmed)) return cards;
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return cards;
+  try {
+    collectCardsFromUnknown(JSON.parse(trimmed) as unknown, cards);
+  } catch {
+    return cards;
+  }
+  return cards;
+}
+
 /**
  * Parse a searchads AJAX body (or SSR-embedded JSON) into de-duplicated listing
  * refs. Accepts `{ realEstates: [...] }` or raw HTML with detail links.

--- a/packages/listing-providers/src/providers/fotocasa/sessionHints.ts
+++ b/packages/listing-providers/src/providers/fotocasa/sessionHints.ts
@@ -8,11 +8,17 @@
 import type { BrowserStorageState } from '../../session';
 
 export const FOTOCASA_BROWSER_SESSION_HINT = 'fotocasaBrowserSession';
+export const FOTOCASA_SEARCH_CARD_HINT = 'fotocasaSearchCard';
 
 export interface FotocasaBrowserSessionHint {
   warmCity: string;
   storageState: BrowserStorageState;
   proxySessionId?: string;
+}
+
+export interface FotocasaSearchCardHint {
+  warmCity: string;
+  card: Record<string, unknown>;
 }
 
 function isBrowserStorageState(value: unknown): value is BrowserStorageState {
@@ -35,8 +41,32 @@ export function readFotocasaBrowserSessionHint(
   return { warmCity, storageState: record.storageState, proxySessionId };
 }
 
+function isSearchCardRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** Read a searchads card snapshot carried from discover when detail JSON is blocked. */
+export function readFotocasaSearchCardHint(
+  hints: Record<string, unknown> | undefined,
+): FotocasaSearchCardHint | undefined {
+  if (!hints) return undefined;
+  const raw = hints[FOTOCASA_SEARCH_CARD_HINT];
+  if (!raw || typeof raw !== 'object') return undefined;
+  const record = raw as Record<string, unknown>;
+  const warmCity = typeof record.warmCity === 'string' ? record.warmCity : undefined;
+  if (!warmCity || !isSearchCardRecord(record.card)) return undefined;
+  return { warmCity, card: record.card };
+}
+
 export function fotocasaBrowserSessionHints(
   session: FotocasaBrowserSessionHint,
 ): Record<string, unknown> {
   return { [FOTOCASA_BROWSER_SESSION_HINT]: session };
+}
+
+export function fotocasaSearchCardHints(
+  warmCity: string,
+  card: Record<string, unknown>,
+): Record<string, unknown> {
+  return { [FOTOCASA_SEARCH_CARD_HINT]: { warmCity, card } };
 }

--- a/packages/listing-providers/src/providers/habitaclia/cities.ts
+++ b/packages/listing-providers/src/providers/habitaclia/cities.ts
@@ -1,0 +1,29 @@
+/**
+ * Habitaclia discover city scope.
+ *
+ * Browser + listainmuebles discover warms a session per city. The full
+ * `LISTING_ES_CITIES` list (~70 metros) in one discover job blocks the
+ * single-concurrency queue for hours. Default to Madrid until coverage is broad.
+ */
+
+/** Default metros for Habitaclia browser discover. */
+export const HABITACLIA_DEFAULT_CITIES: readonly string[] = ['madrid'];
+
+function parseCityList(raw: string | undefined): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map((city) => city.trim())
+    .filter(Boolean);
+}
+
+/** Cities for Habitaclia discover: `LISTING_HABITACLIA_CITIES` or {@link HABITACLIA_DEFAULT_CITIES}. */
+export function habitacliaCitiesFromEnv(): string[] {
+  const envCities = parseCityList(process.env.LISTING_HABITACLIA_CITIES);
+  if (envCities.length > 0) return envCities;
+  return [...HABITACLIA_DEFAULT_CITIES];
+}
+
+/** Provider options with the Habitaclia-specific city list. */
+export function habitacliaCitiesOptionsFromEnv(): { cities: readonly string[] } {
+  return { cities: habitacliaCitiesFromEnv() };
+}

--- a/packages/listing-providers/src/providers/habitaclia/index.ts
+++ b/packages/listing-providers/src/providers/habitaclia/index.ts
@@ -23,7 +23,7 @@ import type {
   RawListing,
 } from '../../types';
 import { createFetchRuntime } from '../../runtime';
-import { fetchListingViaLadder } from '../../strategy';
+import { fetchListingViaLadder, ChallengeError } from '../../strategy';
 import { defaultProviderMetrics, type ProviderMetricsReader, type ProviderMetricsSink } from '../../metrics';
 import { providerMaxSearchPages } from '../../discoverLimits';
 import { BrowserSessionChallengeError, type BrowserSession, type BrowserStorageState } from '../../browserSession';
@@ -65,6 +65,7 @@ const DEFAULT_CITIES: readonly string[] = [
 ];
 const DEFAULT_MAX_SEARCH_PAGES = 50;
 const LISTAINMUEBLES_POST_TIMEOUT_MS = 45_000;
+const HABITACLIA_HTTP_SEARCH_TIMEOUT_MS = 90_000;
 const SUPPORTED_TYPES: ReadonlySet<string> = new Set(Object.values(PropertyType));
 
 function resolvePropertyType(raw: string): PropertyType {
@@ -141,7 +142,22 @@ export class HabitacliaProvider implements ListingProvider {
     const yielded = { count: 0 };
     const runtime = job.runtime ?? this.runtime;
 
-    // Cold HTTP + listainmuebles POST first (cheaper than a full browser warm).
+    for (const city of cities) {
+      if (yielded.count >= limit) return;
+      for await (const ref of this.discoverCityViaHttpListainmuebles(
+        runtime,
+        city,
+        job.signal,
+        seen,
+        limit,
+        yielded,
+      )) {
+        yield ref;
+      }
+    }
+    if (yielded.count >= limit) return;
+
+    // Cold HTTP search HTML + listainmuebles POST pagination.
     for (const city of cities) {
       if (yielded.count >= limit) return;
       for await (const ref of this.discoverCityViaHtml(runtime, city, job.signal, seen, limit, yielded)) {
@@ -166,6 +182,48 @@ export class HabitacliaProvider implements ListingProvider {
     }
 
     if (yielded.count > beforeSession) return;
+  }
+
+  /**
+   * HTTP-first listainmuebles: proxied search page → POST pagination without
+   * Playwright when Imperva allows same-origin XHR on a sticky ES exit.
+   */
+  private async *discoverCityViaHttpListainmuebles(
+    runtime: FetchRuntime,
+    city: string,
+    signal: AbortSignal | undefined,
+    seen: Set<string>,
+    limit: number,
+    yielded: { count: number },
+  ): AsyncIterable<ExternalListingRef> {
+    const referer = habitacliaWarmSearchUrl(city, 1);
+    const { status, body } = await runtime.fetchHttp(referer, {
+      signal,
+      proxyCountry: ES_PROXY_COUNTRY,
+      timeoutMs: HABITACLIA_HTTP_SEARCH_TIMEOUT_MS,
+      headers: {
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'es-ES,es;q=0.9,en;q=0.8',
+      },
+    });
+    if (status >= 400 || isHabitacliaChallenge(body)) return;
+
+    const pageRefs = parseHabitacliaSearch(body);
+    for (const ref of yieldRefs(pageRefs, seen, limit, yielded)) {
+      yield ref;
+    }
+
+    for (const ref of await this.discoverCityViaHttpAjax(
+      runtime,
+      city,
+      body,
+      signal,
+      seen,
+      limit,
+      yielded,
+    )) {
+      yield ref;
+    }
   }
 
   private habitacliaSessionOptions(city: string, sticky: boolean) {
@@ -358,18 +416,23 @@ export class HabitacliaProvider implements ListingProvider {
     for (let page = 1; page <= this.maxSearchPages; page += 1) {
       if (yielded.count >= limit) return;
       if (page > 1 && !runtime.fetchViaBrowser) break;
-      const { html } = await fetchListingViaLadder(runtime, habitacliaWarmSearchUrl(city, page), {
-        provider: this.id,
-        isChallenge: isHabitacliaChallenge,
-        metrics: this.metrics,
-        init: { signal, proxyCountry: ES_PROXY_COUNTRY },
-        tiers: page === 1 ? undefined : ['browser'],
-      });
-      if (page === 1) firstPageHtml = html;
-      const refs = parseHabitacliaSearch(html);
-      if (refs.length === 0) break;
-      for (const ref of yieldRefs(refs, seen, limit, yielded)) {
-        yield ref;
+      try {
+        const { html } = await fetchListingViaLadder(runtime, habitacliaWarmSearchUrl(city, page), {
+          provider: this.id,
+          isChallenge: isHabitacliaChallenge,
+          metrics: this.metrics,
+          init: { signal, proxyCountry: ES_PROXY_COUNTRY },
+          tiers: page === 1 ? undefined : ['browser'],
+        });
+        if (page === 1) firstPageHtml = html;
+        const refs = parseHabitacliaSearch(html);
+        if (refs.length === 0) break;
+        for (const ref of yieldRefs(refs, seen, limit, yielded)) {
+          yield ref;
+        }
+      } catch (error) {
+        if (error instanceof ChallengeError) return;
+        throw error;
       }
     }
 

--- a/packages/listing-providers/src/providers/idealista/cities.ts
+++ b/packages/listing-providers/src/providers/idealista/cities.ts
@@ -1,0 +1,28 @@
+/**
+ * Idealista discover city scope.
+ *
+ * Georeach discover warms a DataDome session per city. A market-wide job over
+ * the full ES city list blocks the worker queue for hours. Default to Madrid.
+ */
+
+/** Default metros for Idealista browser discover. */
+export const IDEALISTA_DEFAULT_CITIES: readonly string[] = ['madrid'];
+
+function parseCityList(raw: string | undefined): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map((city) => city.trim())
+    .filter(Boolean);
+}
+
+/** Cities for Idealista discover: `LISTING_IDEALISTA_CITIES` or {@link IDEALISTA_DEFAULT_CITIES}. */
+export function idealistaCitiesFromEnv(): string[] {
+  const envCities = parseCityList(process.env.LISTING_IDEALISTA_CITIES);
+  if (envCities.length > 0) return envCities;
+  return [...IDEALISTA_DEFAULT_CITIES];
+}
+
+/** Provider options with the Idealista-specific city list. */
+export function idealistaCitiesOptionsFromEnv(): { cities: readonly string[] } {
+  return { cities: idealistaCitiesFromEnv() };
+}


### PR DESCRIPTION
## Summary
- Habitaclia/Idealista discover scoped to Madrid by default (`LISTING_*_CITIES` overrides) with per-city BullMQ jobs instead of one 70-city lock.
- Worker purges legacy market-wide habitaclia/idealista/fotocasa discover jobs and releases stale active locks on boot.
- Habitaclia: HTTP listainmuebles-first path via ES proxy before Playwright warm.
- Fotocasa: ingest from searchads card snapshot when property JSON API stays PerimeterX-blocked.
- Ops script: `enqueueDiscoverMadrid.ts` for manual Madrid discover enqueue inside VPC.

## Test plan
- [x] `bun test` fotocasa/habitaclia/listingCities unit tests (51 pass)
- [ ] After deploy: verify API counts for `habitaclia` / `fotocasa` > 0 via Mongo or search sampling
- [ ] CloudWatch `/oxy/ecs` homiio-worker: Madrid discover jobs enqueue fetch within minutes


Made with [Cursor](https://cursor.com)