### PR TITLE
fix(cities): require cover images for home showcase

### DIFF
--- a/packages/backend/__tests__/unit/cityCoverSync.test.ts
+++ b/packages/backend/__tests__/unit/cityCoverSync.test.ts
@@ -1,0 +1,304 @@
+/**
+ * City cover sync + popular cities filter.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { Types } from 'mongoose';
+import { OfferingType, PropertyType, PropertyStatus } from '@homiio/shared-types';
+
+import { ensureCover, syncMissingCovers } from '../../services/cityCoverSyncService';
+import cityRoutes from '../../routes/cities';
+
+const { Country, Region, City, Address, Property, Image } = require('../../models');
+const { errorHandler } = require('../../middlewares/errorHandler');
+
+const TEST_IMAGE_URL = 'https://api.homiio.test/api/images/file/test/medium.webp';
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/cities', cityRoutes());
+  app.use(errorHandler);
+  return app;
+}
+
+function sampleVariantStrings(): {
+  original: string;
+  small: string;
+  medium: string;
+  large: string;
+} {
+  return {
+    original: TEST_IMAGE_URL,
+    small: TEST_IMAGE_URL,
+    medium: TEST_IMAGE_URL,
+    large: TEST_IMAGE_URL,
+  };
+}
+
+async function createImage(entityId: Types.ObjectId, isPrimary = true): Promise<{ _id: Types.ObjectId }> {
+  return Image.create({
+    entityType: 'property',
+    entityId,
+    keys: sampleVariantStrings(),
+    urls: sampleVariantStrings(),
+    format: 'webp',
+    bytes: 1024,
+    isPrimary,
+    order: 0,
+  });
+}
+
+interface GeoSeed {
+  country: { _id: Types.ObjectId };
+  region: { _id: Types.ObjectId };
+  city: { _id: Types.ObjectId; name: string };
+}
+
+async function ensureSpainGeo(): Promise<{ country: { _id: Types.ObjectId }; region: { _id: Types.ObjectId } }> {
+  const country = await Country.findOneAndUpdate(
+    { code: 'ES' },
+    { $setOnInsert: { code: 'ES', name: 'Spain', currency: 'EUR' } },
+    { upsert: true, new: true, setDefaultsOnInsert: true },
+  );
+  const region = await Region.findOneAndUpdate(
+    { countryId: country._id, name: 'Catalonia' },
+    { $setOnInsert: { countryId: country._id, name: 'Catalonia' } },
+    { upsert: true, new: true, setDefaultsOnInsert: true },
+  );
+  return { country, region };
+}
+
+async function seedGeo(cityName: string, options: { coverImageId?: Types.ObjectId } = {}): Promise<GeoSeed> {
+  const { country, region } = await ensureSpainGeo();
+  const city = await City.create({
+    countryId: country._id,
+    regionId: region._id,
+    name: cityName,
+    currency: 'EUR',
+    propertiesCount: 1,
+    ...options,
+  });
+  return { country, region, city };
+}
+
+describe('cityCoverSyncService.ensureCover', () => {
+  it('links the primary listing image id when the city has no cover', async () => {
+    const geo = await seedGeo('Valencia');
+    const property = await Property.create({
+      addressId: (
+        await Address.create({
+          countryId: geo.country._id,
+          regionId: geo.region._id,
+          cityId: geo.city._id,
+          countryCode: 'ES',
+          street: 'Carrer Test 1',
+          postal_code: '46001',
+          coordinates: { type: 'Point', coordinates: [-0.37, 39.47] },
+        })
+      )._id,
+      type: PropertyType.APARTMENT,
+      bedrooms: 1,
+      offerings: [OfferingType.LONG_TERM_RENT],
+      longTermRent: { monthlyAmount: 900, currency: 'EUR' },
+      status: PropertyStatus.PUBLISHED,
+      isExternal: true,
+      source: 'fixture',
+      sourceId: 'valencia-cover-1',
+      sourceUrl: 'https://fixtures.homiio.com/valencia',
+      images: [],
+    });
+    const image = await createImage(property._id);
+    property.images = [
+      {
+        imageId: image._id,
+        url: TEST_IMAGE_URL,
+        isPrimary: true,
+        order: 0,
+        urls: sampleVariantStrings(),
+      },
+    ];
+    await property.save();
+
+    await ensureCover(geo.city._id);
+
+    const updated = await City.findById(geo.city._id).lean();
+    expect(String(updated?.coverImageId)).toBe(String(image._id));
+    expect(updated?.imageIds?.map(String)).toEqual([String(image._id)]);
+  });
+
+  it('no-ops on a second call (idempotent)', async () => {
+    const geo = await seedGeo('Seville');
+    const property = await Property.create({
+      addressId: (
+        await Address.create({
+          countryId: geo.country._id,
+          regionId: geo.region._id,
+          cityId: geo.city._id,
+          countryCode: 'ES',
+          street: 'Carrer Test 2',
+          postal_code: '41001',
+          coordinates: { type: 'Point', coordinates: [-5.99, 37.39] },
+        })
+      )._id,
+      type: PropertyType.APARTMENT,
+      bedrooms: 1,
+      offerings: [OfferingType.LONG_TERM_RENT],
+      longTermRent: { monthlyAmount: 900, currency: 'EUR' },
+      status: PropertyStatus.PUBLISHED,
+      isExternal: true,
+      source: 'fixture',
+      sourceId: 'seville-cover-1',
+      sourceUrl: 'https://fixtures.homiio.com/seville',
+      images: [],
+    });
+    const firstImage = await createImage(property._id);
+    property.images = [
+      {
+        imageId: firstImage._id,
+        url: TEST_IMAGE_URL,
+        isPrimary: true,
+        order: 0,
+        urls: sampleVariantStrings(),
+      },
+    ];
+    await property.save();
+
+    await ensureCover(geo.city._id);
+
+    const secondImage = await createImage(property._id, false);
+    property.images.push({
+      imageId: secondImage._id,
+      url: TEST_IMAGE_URL,
+      isPrimary: false,
+      order: 1,
+      urls: sampleVariantStrings(),
+    });
+    await property.save();
+
+    await ensureCover(geo.city._id);
+
+    const updated = await City.findById(geo.city._id).lean();
+    expect(String(updated?.coverImageId)).toBe(String(firstImage._id));
+  });
+
+  it('skips implausible city names', async () => {
+    const geo = await seedGeo('Penn Street');
+    const property = await Property.create({
+      addressId: (
+        await Address.create({
+          countryId: geo.country._id,
+          regionId: geo.region._id,
+          cityId: geo.city._id,
+          countryCode: 'ES',
+          street: 'Carrer Test 4',
+          postal_code: '08001',
+          coordinates: { type: 'Point', coordinates: [2.17, 41.39] },
+        })
+      )._id,
+      type: PropertyType.APARTMENT,
+      bedrooms: 1,
+      offerings: [OfferingType.LONG_TERM_RENT],
+      longTermRent: { monthlyAmount: 900, currency: 'EUR' },
+      status: PropertyStatus.PUBLISHED,
+      isExternal: true,
+      source: 'fixture',
+      sourceId: 'penn-street-cover-1',
+      sourceUrl: 'https://fixtures.homiio.com/penn',
+      images: [],
+    });
+    const image = await createImage(property._id);
+    property.images = [
+      {
+        imageId: image._id,
+        url: TEST_IMAGE_URL,
+        isPrimary: true,
+        order: 0,
+        urls: sampleVariantStrings(),
+      },
+    ];
+    await property.save();
+
+    await ensureCover(geo.city._id);
+
+    const updated = await City.findById(geo.city._id).lean();
+    expect(updated?.coverImageId).toBeUndefined();
+  });
+});
+
+describe('cityCoverSyncService.syncMissingCovers', () => {
+  it('processes cities that have listings but no cover', async () => {
+    const geo = await seedGeo('Bilbao');
+    const property = await Property.create({
+      addressId: (
+        await Address.create({
+          countryId: geo.country._id,
+          regionId: geo.region._id,
+          cityId: geo.city._id,
+          countryCode: 'ES',
+          street: 'Carrer Test 3',
+          postal_code: '48001',
+          coordinates: { type: 'Point', coordinates: [-2.93, 43.26] },
+        })
+      )._id,
+      type: PropertyType.APARTMENT,
+      bedrooms: 1,
+      offerings: [OfferingType.LONG_TERM_RENT],
+      longTermRent: { monthlyAmount: 900, currency: 'EUR' },
+      status: PropertyStatus.PUBLISHED,
+      isExternal: true,
+      source: 'fixture',
+      sourceId: 'bilbao-cover-1',
+      sourceUrl: 'https://fixtures.homiio.com/bilbao',
+      images: [],
+    });
+    const image = await createImage(property._id);
+    property.images = [
+      {
+        imageId: image._id,
+        url: TEST_IMAGE_URL,
+        isPrimary: true,
+        order: 0,
+        urls: sampleVariantStrings(),
+      },
+    ];
+    await property.save();
+
+    const processed = await syncMissingCovers({ limit: 10 });
+    expect(processed).toBe(1);
+
+    const updated = await City.findById(geo.city._id).lean();
+    expect(String(updated?.coverImageId)).toBe(String(image._id));
+  });
+});
+
+describe('GET /api/cities/popular', () => {
+  const app = buildApp();
+
+  it('excludes cities without a cover or with implausible names', async () => {
+    const withCover = await seedGeo('Madrid');
+    const coverImage = await createImage(new Types.ObjectId());
+    await City.findByIdAndUpdate(withCover.city._id, { coverImageId: coverImage._id });
+
+    await seedGeo('Penn Street');
+    await seedGeo('Girona');
+
+    const res = await request(app).get('/api/cities/popular?limit=10').expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].name).toBe('Madrid');
+    expect(res.body.data[0].coverImageId.urls).toBeDefined();
+  });
+
+  it('excludes cities whose cover image failed to populate', async () => {
+    const geo = await seedGeo('Barcelona', {
+      coverImageId: new Types.ObjectId(),
+    });
+
+    const res = await request(app).get('/api/cities/popular?limit=10').expect(200);
+
+    expect(res.body.data.find((city: { name: string }) => city.name === geo.city.name)).toBeUndefined();
+  });
+});

--- a/packages/backend/__tests__/unit/plausibleCityName.test.ts
+++ b/packages/backend/__tests__/unit/plausibleCityName.test.ts
@@ -1,0 +1,32 @@
+import { isPlausibleCityName } from '../../utils/plausibleCityName';
+
+describe('isPlausibleCityName', () => {
+  it('accepts real city names', () => {
+    expect(isPlausibleCityName('Madrid')).toBe(true);
+    expect(isPlausibleCityName('Barcelona')).toBe(true);
+    expect(isPlausibleCityName('New York')).toBe(true);
+    expect(isPlausibleCityName('San Francisco')).toBe(true);
+  });
+
+  it('rejects empty, whitespace, and too-short names', () => {
+    expect(isPlausibleCityName('')).toBe(false);
+    expect(isPlausibleCityName('   ')).toBe(false);
+    expect(isPlausibleCityName('A')).toBe(false);
+    expect(isPlausibleCityName(null)).toBe(false);
+    expect(isPlausibleCityName(undefined)).toBe(false);
+  });
+
+  it('rejects names containing digits', () => {
+    expect(isPlausibleCityName('141 Chester Road')).toBe(false);
+    expect(isPlausibleCityName('District 9')).toBe(false);
+  });
+
+  it('rejects street and building tokens', () => {
+    expect(isPlausibleCityName('Penn Street')).toBe(false);
+    expect(isPlausibleCityName('141 Chester Road')).toBe(false);
+    expect(isPlausibleCityName('Albany House')).toBe(false);
+    expect(isPlausibleCityName('Calle Mayor')).toBe(false);
+    expect(isPlausibleCityName('Avenida Diagonal')).toBe(false);
+    expect(isPlausibleCityName('Plaza Catalunya')).toBe(false);
+  });
+});

--- a/packages/backend/controllers/cityController.ts
+++ b/packages/backend/controllers/cityController.ts
@@ -9,6 +9,7 @@
 import { Request, Response } from 'express';
 import { Types } from 'mongoose';
 import { City, Country, Region, Property, Address } from '../models';
+import { isPlausibleCityName } from '../utils/plausibleCityName';
 const {
   serializePropertyAddresses,
   ADDRESS_GEO_POPULATE,
@@ -121,8 +122,15 @@ class CityController {
   async getPopularCities(req: Request, res: Response) {
     try {
       const { limit = DEFAULT_POPULAR_LIMIT } = req.query;
-      const cities = await City.getPopularCities(Number(limit)).populate(GEO_POPULATE);
-      res.json({ success: true, data: cities });
+      const numericLimit = Number(limit);
+      const fetchLimit = Math.max(numericLimit * 2, numericLimit);
+      const cities = await City.getPopularCities(fetchLimit).populate(GEO_POPULATE);
+
+      const filtered = cities
+        .filter((city) => isPlausibleCityName(city.name) && hasPopulatedCoverImage(city.coverImageId))
+        .slice(0, numericLimit);
+
+      res.json({ success: true, data: filtered });
     } catch (error) {
       res.status(500).json({ success: false, message: 'Failed to fetch popular cities', error: (error as Error).message });
     }
@@ -373,6 +381,15 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/** True when populate resolved coverImageId to an Image doc with variant urls. */
+function hasPopulatedCoverImage(coverImageId: unknown): boolean {
+  if (coverImageId == null || typeof coverImageId !== 'object') {
+    return false;
+  }
+  const urls = (coverImageId as { urls?: unknown }).urls;
+  return urls != null && typeof urls === 'object';
+}
+
 /** Resolve a country ref (id or name/code) to a Country `_id`, or null. */
 async function resolveCountryRef(input: { countryId?: string; country?: string }): Promise<Types.ObjectId | null> {
   if (input.countryId && Types.ObjectId.isValid(input.countryId)) {
@@ -407,4 +424,4 @@ async function resolveRegionRef(input: { regionId?: string; state?: string; coun
   return null;
 }
 
-export default new CityController();
+module.exports = new CityController();

--- a/packages/backend/models/schemas/CitySchema.ts
+++ b/packages/backend/models/schemas/CitySchema.ts
@@ -67,10 +67,8 @@ const citySchema = new mongoose.Schema({
     default: 'EUR'
   },
   /**
-   * The city's cover photo: the `_id` of an Image (`entityType: 'city'`,
-   * `entityId` = this city's `_id`). Set at seed time from the curated city
-   * image stored in our own object storage, so there is no live external image
-   * dependency at runtime.
+   * The city's cover photo: the `_id` of an existing Image document (typically
+   * a re-hosted listing photo linked by `cityCoverSyncService.ensureCover`).
    */
   coverImageId: {
     type: mongoose.Schema.Types.ObjectId,
@@ -115,9 +113,12 @@ citySchema.virtual('neighborhoods', {
   foreignField: 'cityId'
 });
 
-// Static method to get popular cities
+// Static method to get popular cities (only those with a linked cover image).
 citySchema.statics.getPopularCities = function(limit = 10) {
-  return this.find({ isActive: true })
+  return this.find({
+    isActive: true,
+    coverImageId: { $exists: true, $ne: null },
+  })
     .sort({ propertiesCount: -1, name: 1 })
     .limit(limit);
 };

--- a/packages/backend/services/cityCoverSyncService.ts
+++ b/packages/backend/services/cityCoverSyncService.ts
@@ -1,0 +1,97 @@
+/**
+ * Assigns city cover photos by linking an existing listing Image id — no
+ * re-upload, no external APIs, no manual seed.
+ */
+
+import { Types } from 'mongoose';
+import { City, Property, Address } from '../models';
+import { isPlausibleCityName } from '../utils/plausibleCityName';
+import { Logger } from '../utils/logger';
+
+const logger = new Logger('CityCoverSyncService');
+
+function resolvePrimaryImageId(
+  images: Array<{ imageId?: Types.ObjectId | null; isPrimary?: boolean }> | undefined,
+): Types.ObjectId | null {
+  if (!images?.length) {
+    return null;
+  }
+  const primary = images.find((img) => img.isPrimary && img.imageId);
+  if (primary?.imageId) {
+    return primary.imageId;
+  }
+  const first = images.find((img) => img.imageId);
+  return first?.imageId ?? null;
+}
+
+/** Link a listing Image id as this city's cover when none is set yet. */
+export async function ensureCover(cityId: Types.ObjectId | string): Promise<void> {
+  try {
+    const city = await City.findById(cityId).select('name coverImageId imageIds').lean();
+    if (!city) {
+      return;
+    }
+    if (city.coverImageId) {
+      return;
+    }
+    if (!isPlausibleCityName(city.name)) {
+      return;
+    }
+
+    const addresses = await Address.find({ cityId: city._id }).select('_id').lean();
+    const addressIds = addresses.map((addr) => addr._id);
+    if (addressIds.length === 0) {
+      return;
+    }
+
+    const baseQuery = {
+      addressId: { $in: addressIds },
+      status: 'published',
+      'images.imageId': { $exists: true, $ne: null },
+    };
+
+    let property = await Property.findOne({ ...baseQuery, 'images.isPrimary': true })
+      .select('images')
+      .lean();
+    if (!property) {
+      property = await Property.findOne(baseQuery).select('images').lean();
+    }
+
+    const imageId = resolvePrimaryImageId(property?.images);
+    if (!imageId) {
+      return;
+    }
+
+    const update: Record<string, unknown> = { coverImageId: imageId };
+    if (!city.imageIds?.length) {
+      update.imageIds = [imageId];
+    }
+
+    await City.updateOne({ _id: city._id }, { $set: update });
+    logger.info('Linked city cover from listing image', {
+      cityId: String(city._id),
+      imageId: String(imageId),
+    });
+  } catch (error) {
+    logger.error('Failed to ensure city cover', error);
+  }
+}
+
+/** Backfill covers for active cities that have listings but no cover yet. */
+export async function syncMissingCovers(options: { limit?: number } = {}): Promise<number> {
+  const limit = options.limit ?? 50;
+  const cities = await City.find({
+    isActive: true,
+    propertiesCount: { $gt: 0 },
+    $or: [{ coverImageId: { $exists: false } }, { coverImageId: null }],
+  })
+    .select('_id')
+    .limit(limit)
+    .lean();
+
+  for (const city of cities) {
+    await ensureCover(city._id);
+  }
+
+  return cities.length;
+}

--- a/packages/backend/services/cron.ts
+++ b/packages/backend/services/cron.ts
@@ -3,6 +3,7 @@ import { Logger } from '../utils/logger';
 import { HealthService } from './healthService';
 import { CleanupService } from './cleanupService';
 import { MetricsService } from '../utils/metrics';
+import { syncMissingCovers } from './cityCoverSyncService';
 
 // Initialize services
 const logger = new Logger('CronService');
@@ -34,8 +35,9 @@ class CronJobManager {
   init(): void {
     this.setupHealthCheckJob();
     this.setupCleanupJob();
+    this.setupCityCoverSyncJob();
 
-    this.logger.info('Cron jobs initialized (health + cleanup; scrape loop retired)');
+    this.logger.info('Cron jobs initialized (health + cleanup + city covers; scrape loop retired)');
   }
 
   /**
@@ -68,6 +70,40 @@ class CronJobManager {
     this.jobs.set('cleanup', job);
     this.jobStatus.set('cleanup', { isRunning: true, lastRun: undefined, nextRun: undefined });
     job.start();
+  }
+
+  /**
+   * Setup city cover sync job - runs every hour
+   */
+  private setupCityCoverSyncJob(): void {
+    const job = cron.schedule('0 * * * *', async () => {
+      await this.runCityCoverSync();
+    }, {
+      timezone: 'UTC',
+      scheduled: false,
+    });
+
+    this.jobs.set('cityCovers', job);
+    this.jobStatus.set('cityCovers', { isRunning: true, lastRun: undefined, nextRun: undefined });
+    job.start();
+  }
+
+  /**
+   * Backfill city cover images from listing photos
+   */
+  private async runCityCoverSync(): Promise<void> {
+    const status = this.jobStatus.get('cityCovers');
+    if (status) {
+      status.lastRun = new Date();
+      status.isRunning = true;
+    }
+
+    try {
+      const processed = await syncMissingCovers({ limit: 50 });
+      this.logger.info('City cover sync completed', { processed });
+    } catch (error) {
+      this.logger.error('City cover sync failed', error);
+    }
   }
 
   /**

--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -26,6 +26,7 @@ import {
   validateNormalizedListing,
 } from '@homiio/listing-providers';
 import { Property, Address, type IProperty } from '../../models';
+import { ensureCover } from '../cityCoverSyncService';
 import type { AddressCanonicalInput } from '../../models/Address';
 import { validateOfferings } from '../../models/schemas/offeringValidation';
 import { forwardGeocode, reverseGeocode } from '../geocodingService';
@@ -102,6 +103,13 @@ export class IngestionService {
       property.set('images', refs);
       await property.save();
       imageCount = refs.length;
+    }
+
+    if (imageCount > 0) {
+      const address = await Address.findById(property.addressId).select('cityId').lean();
+      if (address?.cityId) {
+        void ensureCover(address.cityId);
+      }
     }
 
     const result: IngestResult = {

--- a/packages/backend/utils/plausibleCityName.ts
+++ b/packages/backend/utils/plausibleCityName.ts
@@ -1,0 +1,38 @@
+/**
+ * Heuristic filter for city names that should appear in user-facing geo pickers.
+ * Rejects street/building-level labels that geo resolution sometimes creates.
+ */
+
+const MIN_NAME_LENGTH = 2;
+
+/** Whole-word tokens that indicate a street or building, not a municipality. */
+const STREET_BUILDING_TOKENS = [
+  'street',
+  'road',
+  'avenue',
+  'lane',
+  'house',
+  'calle',
+  'avenida',
+  'plaza',
+] as const;
+
+const STREET_BUILDING_PATTERN = new RegExp(
+  `\\b(?:${STREET_BUILDING_TOKENS.join('|')})\\b`,
+  'i',
+);
+
+/** Returns true when `name` looks like a real city/municipality label. */
+export function isPlausibleCityName(name: string | null | undefined): boolean {
+  const trimmed = name?.trim() ?? '';
+  if (trimmed.length < MIN_NAME_LENGTH) {
+    return false;
+  }
+  if (/\d/.test(trimmed)) {
+    return false;
+  }
+  if (STREET_BUILDING_PATTERN.test(trimmed)) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- Popular cities on the home screen now require `coverImageId`
- Add `CityCoverSyncService` to backfill covers from ingested listing photos
- Add `plausibleCityName` filter to skip junk city names from ingest
- Wire cron + ingest triggers to keep city covers fresh
- Fix `cityController` export for popular cities query

## Test plan
- [x] `bun run test` — 59 suites / 476 tests passed
- [x] `bun run build` — green
- [x] `bun install --frozen-lockfile` — green

Made with [Cursor](https://cursor.com)