### PR TITLE
fix(backend): unblock Docker tsc build for deploy

### DIFF
--- a/packages/backend/controllers/cityController.ts
+++ b/packages/backend/controllers/cityController.ts
@@ -423,4 +423,6 @@ async function resolveRegionRef(input: { regionId?: string; state?: string; coun
   return null;
 }
 
-module.exports = new CityController();
+const cityController = new CityController();
+export default cityController;
+module.exports = cityController;

--- a/packages/backend/services/cityCoverSyncService.ts
+++ b/packages/backend/services/cityCoverSyncService.ts
@@ -10,6 +10,13 @@ import { Logger } from '../utils/logger';
 
 const logger = new Logger('CityCoverSyncService');
 
+type CityCoverFields = {
+  _id: Types.ObjectId;
+  name: string;
+  coverImageId?: Types.ObjectId | null;
+  imageIds?: Types.ObjectId[];
+};
+
 function resolvePrimaryImageId(
   images: Array<{ imageId?: Types.ObjectId | null; isPrimary?: boolean }> | undefined,
 ): Types.ObjectId | null {
@@ -27,7 +34,7 @@ function resolvePrimaryImageId(
 /** Link a listing Image id as this city's cover when none is set yet. */
 export async function ensureCover(cityId: Types.ObjectId | string): Promise<void> {
   try {
-    const city = await City.findById(cityId).select('name coverImageId imageIds').lean();
+    const city = await City.findById(cityId).select('name coverImageId imageIds').lean<CityCoverFields>();
     if (!city) {
       return;
     }


### PR DESCRIPTION
## Summary
- Unblocks the failed `Deploy to AWS` run after #143 merged
- `cityController`: add `export default` (public.ts ES import; matches imageController)
- `cityCoverSyncService`: type lean city cover fields so `imageIds.length` compiles

## Test plan
- [x] `bun run build` in packages/backend — clean
- [x] `jest __tests__/unit/cityCoverSync.test.ts` — 8 passed


Made with [Cursor](https://cursor.com)