### PR TITLE
fix(home): wire category strip and polish feed UX

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -54,6 +54,8 @@ import { cityCountryName, cityRegionName } from '@/utils/cityDisplay';
 import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
 import { useSavedPropertiesContext } from '@/context/SavedPropertiesContext';
 import { useRentalMode } from '@/context/RentalModeContext';
+import { useHomeCategoryStore } from '@/store/homeCategoryStore';
+import { getCategoryFilters } from '@/store/getCategoryFilters';
 
 // Components
 import { PropertyCard } from '@/components/PropertyCard';
@@ -82,6 +84,9 @@ import { spacing, tracker } from '@/constants/styles';
 const HOST_CTA_IMAGE =
   'https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=1600&q=80';
 
+/** How many listings the home feed loads (carousel 0–8 + grid 8–16). */
+const HOME_FEED_LIMIT = 16;
+
 /** How many DB cities to surface in the home Explore showcase. */
 const EXPLORE_CITY_LIMIT = 8;
 
@@ -109,7 +114,8 @@ export default function HomePage() {
   const { t } = useTranslation();
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { offering: browseOffering } = useRentalMode();
+  const { offering: browseOffering, browseMode } = useRentalMode();
+  const selectedCategory = useHomeCategoryStore((s) => s.category);
   const [refreshing, setRefreshing] = useState(false);
   // DB cities (with populated region/country + self-hosted cover image) power
   // both the Explore showcase and the nearby-city carousels.
@@ -286,16 +292,20 @@ export default function HomePage() {
   const { properties: recentlyViewedProperties } = useRecentlyViewed();
   const { savedProperties, isLoading: savedLoading } = useSavedPropertiesContext();
 
-  // Scope the home feed to the active offering so switching Long-term /
-  // Vacation / Buy / Exchange reloads with the matching listings (reusing the
-  // SAME `offering` axis the search endpoint filters on — no forked logic).
+  // Scope the home feed to the active offering and optional category lens.
+  const categoryFilters = useMemo(
+    () => getCategoryFilters(selectedCategory, { userLocation }),
+    [selectedCategory, userLocation],
+  );
+
   const feedFilters = useMemo<PropertyFilters>(
     () => ({
-      limit: 12,
+      limit: HOME_FEED_LIMIT,
       status: 'published',
       offering: browseOffering,
+      ...categoryFilters,
     }),
-    [browseOffering],
+    [browseOffering, categoryFilters],
   );
 
   useEffect(() => {
@@ -309,8 +319,10 @@ export default function HomePage() {
 
   const gridProperties = useMemo<Property[]>(() => {
     if (!properties) return [];
-    return properties.slice(0, 8) as Property[];
+    return properties.slice(8, HOME_FEED_LIMIT) as Property[];
   }, [properties]);
+
+  const showCategoryStrip = browseMode === 'long_term' || browseMode === 'vacation';
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -504,27 +516,26 @@ export default function HomePage() {
             per-section `marginTop`. `pb-14` is bottom scroll padding;
             gap never adds space after the last child. */}
         <View className="gap-6 md:gap-8 pb-14">
-        {/* === Category strip (sticky on web) === */}
-        <HomeCategoryStrip sticky />
+        {/* === Category strip (sticky on web) — rent modes only === */}
+        {showCategoryStrip ? <HomeCategoryStrip sticky /> : null}
 
         {/* === Featured Properties carousel === */}
-        {featuredProperties.length > 0 ? (
-          <HomeCarouselSection
-            title={t('home.featured.title')}
-            items={featuredProperties}
-            loading={propertiesLoading}
-            renderItem={(property) => (
-              <PropertyCard
-                property={property}
-                variant="featured"
-                // Home rows are themselves horizontal scrollers; an in-card
-                // photo pager would fight the row swipe, so keep one photo here.
-                enableImageCarousel={false}
-                onPress={() => router.push(`/properties/${property._id || property.id}`)}
-              />
-            )}
-          />
-        ) : null}
+        <HomeCarouselSection
+          title={t('home.featured.title')}
+          items={featuredProperties}
+          loading={propertiesLoading}
+          emptyText={t('home.featured.empty')}
+          renderItem={(property) => (
+            <PropertyCard
+              property={property}
+              variant="featured"
+              // Home rows are themselves horizontal scrollers; an in-card
+              // photo pager would fight the row swipe, so keep one photo here.
+              enableImageCarousel={false}
+              onPress={() => router.push(`/properties/${property._id || property.id}`)}
+            />
+          )}
+        />
 
         {/* === City Showcase (DB cities, adaptive region/country title) === */}
         {cities.length > 0 ? (

--- a/packages/frontend/app/agent/index.tsx
+++ b/packages/frontend/app/agent/index.tsx
@@ -107,19 +107,19 @@ export default function AgentScreen() {
         className="flex-1"
         showsVerticalScrollIndicator={false}
       >
-        {/* Section rhythm owned here by NativeWind `gap` (24px mobile / 32px
-            web); each direct child is a page section with no per-section
-            `marginTop`. */}
-        <View className="gap-6 md:gap-8 pb-20">
-          <AgentHero
-            title={t('agent.hero.title')}
-            subtitle={t('agent.hero.subtitle')}
-            ctaLabel={ctaLabel}
-            onPressCta={handleHeroCta}
-            ctaLoading={joinMutation.isPending}
-            trustLine={t('agent.hero.trust')}
-          />
+        <AgentHero
+          title={t('agent.hero.title')}
+          subtitle={t('agent.hero.subtitle')}
+          ctaLabel={ctaLabel}
+          onPressCta={handleHeroCta}
+          ctaLoading={joinMutation.isPending}
+          trustLine={t('agent.hero.trust')}
+        />
 
+        {/* Section rhythm owned here by NativeWind `gap` (24px mobile / 32px
+            web); post-hero sections only. Hero sits outside so it does not
+            participate in the gap stack. */}
+        <View className="gap-6 md:gap-8 pb-20">
           <AgentHowItWorks />
 
           <EarningsCalculator />

--- a/packages/frontend/components/HomeCarouselSection.tsx
+++ b/packages/frontend/components/HomeCarouselSection.tsx
@@ -31,6 +31,8 @@ interface HomeCarouselSectionProps<T> {
   title: string;
   items: T[];
   loading: boolean;
+  /** Shown below the header when loading is false and `items` is empty. */
+  emptyText?: string;
   renderItem: (item: T, idx: number) => React.ReactNode;
   onViewAll?: () => void;
   viewAllText?: string;
@@ -46,6 +48,7 @@ export function HomeCarouselSection<T>({
   title,
   items,
   loading,
+  emptyText,
   renderItem,
   onViewAll,
   viewAllText = 'View All',
@@ -235,39 +238,45 @@ export function HomeCarouselSection<T>({
         className="flex-row items-center"
         onLayout={(e) => setContainerWidth(e.nativeEvent.layout.width)}
       >
-        <ScrollView
-          ref={carouselRef}
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          className="flex-row"
-          contentContainerClassName="justify-start px-4"
-          scrollEnabled={true}
-          onScrollBeginDrag={handleScrollBeginDrag}
-          onScrollEndDrag={handleScrollEndDrag}
-          onMomentumScrollEnd={handleMomentumScrollEnd}
-          onScroll={handleScroll}
-          scrollEventThrottle={8}
-          decelerationRate={0.8}
-          snapToInterval={calculatedCardWidth + CARD_GAP}
-          snapToAlignment="start"
-          bounces={false}
-        >
-          <View className="flex-row" style={{ gap: CARD_GAP }}>
-            {loading
-              ? Array.from({ length: 4 }).map((_, idx) => (
-                <View
-                  key={idx}
-                  className="h-[200px] rounded-2xl bg-muted"
-                  style={{ width: calculatedCardWidth }}
-                />
-              ))
-              : items.map((item, idx) => (
-                <View key={idx} style={{ width: calculatedCardWidth }}>
-                  {renderItem(item, idx)}
-                </View>
-              ))}
+        {!loading && items.length === 0 && emptyText ? (
+          <View className="px-4 py-2">
+            <BloomText className="text-sm text-muted-foreground">{emptyText}</BloomText>
           </View>
-        </ScrollView>
+        ) : (
+          <ScrollView
+            ref={carouselRef}
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            className="flex-row"
+            contentContainerClassName="justify-start px-4"
+            scrollEnabled={true}
+            onScrollBeginDrag={handleScrollBeginDrag}
+            onScrollEndDrag={handleScrollEndDrag}
+            onMomentumScrollEnd={handleMomentumScrollEnd}
+            onScroll={handleScroll}
+            scrollEventThrottle={8}
+            decelerationRate={0.8}
+            snapToInterval={calculatedCardWidth + CARD_GAP}
+            snapToAlignment="start"
+            bounces={false}
+          >
+            <View className="flex-row" style={{ gap: CARD_GAP }}>
+              {loading
+                ? Array.from({ length: 4 }).map((_, idx) => (
+                  <View
+                    key={idx}
+                    className="h-[200px] rounded-2xl bg-muted"
+                    style={{ width: calculatedCardWidth }}
+                  />
+                ))
+                : items.map((item, idx) => (
+                  <View key={idx} style={{ width: calculatedCardWidth }}>
+                    {renderItem(item, idx)}
+                  </View>
+                ))}
+            </View>
+          </ScrollView>
+        )}
       </View>
     </View>
   );

--- a/packages/frontend/components/search/SearchSummaryBar.tsx
+++ b/packages/frontend/components/search/SearchSummaryBar.tsx
@@ -284,7 +284,7 @@ export const SearchSummaryBar: React.FC<SearchSummaryBarProps> = ({
     return t('search.summary.typeCount', { count: query.propertyTypes.length });
   }, [query.propertyTypes, t]);
 
-  // Dates label for the wide pill's middle column.
+  // Dates label for the wide pill's middle column (vacation only).
   const datesLabel = useMemo(() => {
     if (query.dates?.start) {
       return query.dates.end
@@ -296,6 +296,20 @@ export const SearchSummaryBar: React.FC<SearchSummaryBarProps> = ({
     }
     return t('search.summary.addDates');
   }, [query.dates, isVacation, t]);
+
+  // Price label for the wide pill's middle column (long-term / buy / exchange).
+  const priceLabel = useMemo(() => {
+    if (query.priceMin !== undefined && query.priceMax !== undefined) {
+      return `€${query.priceMin}–€${query.priceMax}`;
+    }
+    if (query.priceMax !== undefined) {
+      return `≤ €${query.priceMax}`;
+    }
+    if (query.priceMin !== undefined) {
+      return `≥ €${query.priceMin}`;
+    }
+    return t('search.summary.anyPrice');
+  }, [query.priceMin, query.priceMax, t]);
 
   // Single-line summary segments (compact mode, results top bar).
   const segments = useMemo<SummarySegments>(() => {
@@ -335,7 +349,8 @@ export const SearchSummaryBar: React.FC<SearchSummaryBarProps> = ({
       t('searchBar.long.where');
     const middleColLabel = isVacation
       ? t('searchBar.vacation.when')
-      : t('searchBar.long.moveIn');
+      : t('search.step.price.title');
+    const middleColValue = isVacation ? datesLabel : priceLabel;
     const typeColLabel =
       t('searchBar.long.propertyType');
 
@@ -353,9 +368,9 @@ export const SearchSummaryBar: React.FC<SearchSummaryBarProps> = ({
         <PillColumn
           isNarrow={isNarrow}
           label={middleColLabel}
-          value={datesLabel}
-          onPress={() => openColumn(isVacation ? 'dates' : 'where')}
-          accessibilityLabel={`${middleColLabel}: ${datesLabel}`}
+          value={middleColValue}
+          onPress={() => openColumn(isVacation ? 'dates' : 'price')}
+          accessibilityLabel={`${middleColLabel}: ${middleColValue}`}
         />
         <View style={styles.divider} />
         <PillColumn

--- a/packages/frontend/store/getCategoryFilters.ts
+++ b/packages/frontend/store/getCategoryFilters.ts
@@ -1,0 +1,67 @@
+import { PropertyType, type PropertyFilters } from '@homiio/shared-types';
+
+import type { HomeCategory } from './homeCategoryStore';
+
+interface CategoryFilterContext {
+  userLocation?: { latitude: number; longitude: number } | null;
+}
+
+/** Radius (km) for the "Near you" home-category lens. */
+const NEAR_YOU_RADIUS_KM = 25;
+
+/** Monthly rent floor for the merchandised "Luxury" long-term bucket. */
+const LUXURY_MIN_RENT = 2500;
+
+/**
+ * Maps a selected {@link HomeCategory} to API-backed {@link PropertyFilters}.
+ * Returns an empty object when `category` is null ("all listings").
+ */
+export function getCategoryFilters(
+  category: HomeCategory | null,
+  context: CategoryFilterContext = {},
+): Partial<PropertyFilters> {
+  if (!category) return {};
+
+  switch (category) {
+    case 'studios':
+      return { type: PropertyType.STUDIO };
+    case 'apartments':
+      return { type: PropertyType.APARTMENT };
+    case 'houses':
+      return { type: PropertyType.HOUSE };
+    case 'rooms':
+      return { type: PropertyType.ROOM };
+    case 'coliving':
+      return { type: PropertyType.COLIVING };
+    case 'luxury':
+      return { minRent: LUXURY_MIN_RENT };
+    case 'new_listings':
+      // Default list sort is `createdAt desc` — no extra filter required.
+      return {};
+    case 'near_you': {
+      const loc = context.userLocation;
+      if (!loc) return {};
+      return { lat: loc.latitude, lng: loc.longitude, radius: NEAR_YOU_RADIUS_KM };
+    }
+    case 'beachfront':
+      return { amenities: ['waterfront_view'] };
+    case 'cabins':
+      return { type: PropertyType.HOUSE };
+    case 'pools':
+      return { amenities: ['swimming_pool'] };
+    case 'mountain':
+      return { type: PropertyType.HOUSE };
+    case 'city_breaks':
+      return { type: PropertyType.APARTMENT };
+    case 'countryside':
+      return { type: PropertyType.HOUSE };
+    case 'instant_book':
+      return { instantBook: true };
+    case 'pet_friendly':
+      return { petFriendly: true };
+    default: {
+      const _exhaustive: never = category;
+      return _exhaustive;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Wire `HomeCategoryStrip` selections into the home feed via `getCategoryFilters()`
- Always mount featured carousel with empty state; dedupe carousel vs grid slices (0–8 / 8–16)
- SearchSummaryBar middle column opens Price (not fake Move-in) for long-term/buy/exchange
- Move AgentHero outside gap container to match home hero spacing pattern

## Test plan
- [ ] Home: tap category strip items and confirm feed reloads with filtered listings
- [ ] Home: featured carousel shows skeleton while loading, empty message when no results
- [ ] Home: category strip hidden in buy/exchange browse modes
- [ ] Search bar (long-term): middle column shows price range and opens price step
- [ ] Agent page: hero has no extra gap above following sections


Made with [Cursor](https://cursor.com)