### PR TITLE
fix(home): unify gutters and expand category strip modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,10 +347,10 @@ Remove `LayoutScrollProvider` / layout scroll handler when not needed. No dual w
 
 ### Section stacking (NativeWind gap)
 
-Use NativeWind `gap-8 md:gap-12` on the section container — **not** per-section `marginTop: sectionGap` or `resolveSectionSpacing()`. Bottom padding: `pb-14` (home) / `pb-20` (agent).
+Use NativeWind `gap-6 md:gap-8` on the section container — **not** per-section `marginTop: sectionGap` or `resolveSectionSpacing()`. Bottom padding: `pb-14` (home) / `pb-20` (agent).
 
 - Drop `HomeCarouselSection` outer `marginBottom`.
-- Wide CTA rows: `flex-row items-stretch gap-8 md:gap-12`.
+- Wide CTA rows: `flex-row items-stretch gap-6 md:gap-8`.
 
 ### Design-token CSS (no hand-copied radius)
 

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -30,6 +30,7 @@ import {
   Pressable,
   useWindowDimensions,
 } from 'react-native';
+import { useQueryClient } from '@tanstack/react-query';
 import { Menu } from 'lucide-react-native';
 import Animated, {
   interpolate,
@@ -48,19 +49,20 @@ import { OfferingType, type City, type Property, type PropertyFilters } from '@h
 
 // Real data hooks
 import { useProperties } from '@/hooks';
-import { cityService } from '@/services/cityService';
-import { usePopularCities } from '@/hooks/useCityQueries';
+import { cityQueryKeys, usePopularCities } from '@/hooks/useCityQueries';
 import { cityCountryName, cityRegionName } from '@/utils/cityDisplay';
 import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
 import { useSavedPropertiesContext } from '@/context/SavedPropertiesContext';
 import { useRentalMode } from '@/context/RentalModeContext';
-import { useHomeCategoryStore } from '@/store/homeCategoryStore';
+import { useHomeCategoryStore, type HomeCategory } from '@/store/homeCategoryStore';
 import { getCategoryFilters } from '@/store/getCategoryFilters';
+import { resolveHomeCategory } from '@/store/homeCategories';
 
 // Components
 import { PropertyCard } from '@/components/PropertyCard';
 import { HomeCarouselSection } from '@/components/HomeCarouselSection';
 import { HomeCategoryStrip } from '@/components/HomeCategoryStrip';
+import { NearbyCityCarousel } from '@/components/NearbyCityCarousel';
 import { SearchSummaryBar } from '@/components/search/SearchSummaryBar';
 import { SearchPanel } from '@/components/search/SearchPanel';
 import type { SearchQuery, SearchStep } from '@/components/search/types';
@@ -74,7 +76,7 @@ import { useMediaQuery } from 'react-responsive';
 import { useIsScreenNotMobile } from '@/hooks/useOptimizedMediaQuery';
 import { useUIStore } from '@/store/uiStore';
 import { colors } from '@/styles/colors';
-import { spacing, tracker } from '@/constants/styles';
+import { spacing, tracker, PAGE_GUTTER_CLASS } from '@/constants/styles';
 
 /**
  * Hero photo used at the bottom of the home page Host CTA. Reuses a
@@ -110,21 +112,34 @@ function getDistance(lat1: number, lon1: number, lat2: number, lon2: number): nu
   return R * c;
 }
 
+function buildHomeFeedFilters(
+  offering: OfferingType,
+  category: HomeCategory | null,
+  userLocation: { latitude: number; longitude: number } | null,
+): PropertyFilters {
+  return {
+    limit: HOME_FEED_LIMIT,
+    status: 'published',
+    offering,
+    ...getCategoryFilters(category, { userLocation, offering }),
+  };
+}
+
 export default function HomePage() {
   const { t } = useTranslation();
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { offering: browseOffering, browseMode } = useRentalMode();
+  const { offering: browseOffering, browseMode, mode } = useRentalMode();
   const selectedCategory = useHomeCategoryStore((s) => s.category);
+  const queryClient = useQueryClient();
   const [refreshing, setRefreshing] = useState(false);
   // DB cities (with populated region/country + self-hosted cover image) power
   // both the Explore showcase and the nearby-city carousels.
-  const { data: cities = [] } = usePopularCities(EXPLORE_CITY_LIMIT);
+  const { data: cities = [], refetch: refetchCities } = usePopularCities(EXPLORE_CITY_LIMIT);
   const [userLocation, setUserLocation] = useState<{
     latitude: number;
     longitude: number;
   } | null>(null);
-  const [nearbyProperties, setNearbyProperties] = useState<Record<string, Property[]>>({});
   const isWide = useMediaQuery({ minWidth: 768 });
   const isXL = useMediaQuery({ minWidth: 1024 });
   // Matches the breakpoint that hides the persistent sidebar in _layout.tsx
@@ -258,80 +273,40 @@ export default function HomePage() {
     return fallbackCountry ?? t('home.cityShowcase.defaultPlace');
   }, [userLocation, citiesByDistance, activeQuery.location, cities, t]);
 
-  // Fetch properties for the two closest cities. The nearbyCities array
-  // changes only when location or cities change, so this is the
-  // intrinsic place to load by-city data.
-  useEffect(() => {
-    if (nearbyCities.length === 0) return;
-    let cancelled = false;
-    Promise.all(
-      nearbyCities.map(async (city) => {
-        const cityId = city._id;
-        try {
-          const res = await cityService.getPropertiesByCity(cityId, { limit: 8 });
-          return { cityId, properties: (res.properties as Property[]) || [] };
-        } catch {
-          return { cityId, properties: [] as Property[] };
-        }
-      }),
-    ).then((results) => {
-      if (cancelled) return;
-      const map: Record<string, Property[]> = {};
-      results.forEach((r) => {
-        map[r.cityId] = r.properties;
-      });
-      setNearbyProperties(map);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [nearbyCities]);
+  const activeCategory = resolveHomeCategory(selectedCategory, browseMode, mode);
 
   // Properties + cities loaded together on mount.
   const { properties, loading: propertiesLoading, loadProperties } = useProperties();
-  const { properties: recentlyViewedProperties } = useRecentlyViewed();
-  const { savedProperties, isLoading: savedLoading } = useSavedPropertiesContext();
-
-  // Scope the home feed to the active offering and optional category lens.
-  const categoryFilters = useMemo(
-    () => getCategoryFilters(selectedCategory, { userLocation }),
-    [selectedCategory, userLocation],
-  );
-
-  const feedFilters = useMemo<PropertyFilters>(
-    () => ({
-      limit: HOME_FEED_LIMIT,
-      status: 'published',
-      offering: browseOffering,
-      ...categoryFilters,
-    }),
-    [browseOffering, categoryFilters],
-  );
+  const { properties: recentlyViewedProperties, refetch: refetchRecentlyViewed } =
+    useRecentlyViewed();
+  const { savedProperties, isLoading: savedLoading, loadSavedProperties } =
+    useSavedPropertiesContext();
 
   useEffect(() => {
-    loadProperties(feedFilters);
-  }, [loadProperties, feedFilters]);
+    loadProperties(buildHomeFeedFilters(browseOffering, activeCategory, userLocation));
+  }, [loadProperties, browseOffering, activeCategory, userLocation]);
 
-  const featuredProperties = useMemo<Property[]>(() => {
-    if (!properties) return [];
-    return properties.slice(0, 8) as Property[];
-  }, [properties]);
+  const featuredProperties = properties ? (properties.slice(0, 8) as Property[]) : [];
+  const gridProperties = properties ? (properties.slice(8, HOME_FEED_LIMIT) as Property[]) : [];
 
-  const gridProperties = useMemo<Property[]>(() => {
-    if (!properties) return [];
-    return properties.slice(8, HOME_FEED_LIMIT) as Property[];
-  }, [properties]);
-
-  const showCategoryStrip = browseMode === 'long_term' || browseMode === 'vacation';
-
-  const onRefresh = useCallback(async () => {
+  const onRefresh = async () => {
     setRefreshing(true);
     try {
-      await loadProperties(feedFilters);
+      await Promise.all([
+        loadProperties(buildHomeFeedFilters(browseOffering, activeCategory, userLocation)),
+        refetchCities(),
+        ...nearbyCities.map((city) =>
+          queryClient.invalidateQueries({
+            queryKey: cityQueryKeys.properties(city._id, 8),
+          }),
+        ),
+        loadSavedProperties(),
+        refetchRecentlyViewed(),
+      ]);
     } finally {
       setRefreshing(false);
     }
-  }, [loadProperties, feedFilters]);
+  };
 
   // Sole scroll owner: the document on web (mirrored into `scrollY` by
   // `PageScrollView`), the screen's own `Animated.ScrollView` on native. Drives
@@ -379,6 +354,10 @@ export default function HomePage() {
     },
     [router],
   );
+
+  const handleViewAllFeatured = () => {
+    router.push('/explore');
+  };
 
   const handleBecomeHost = useCallback(() => {
     router.push('/properties/create');
@@ -516,15 +495,18 @@ export default function HomePage() {
             per-section `marginTop`. `pb-14` is bottom scroll padding;
             gap never adds space after the last child. */}
         <View className="gap-6 md:gap-8 pb-14">
-        {/* === Category strip (sticky on web) — rent modes only === */}
-        {showCategoryStrip ? <HomeCategoryStrip sticky /> : null}
+        {/* === Category strip (sticky on web) === */}
+        <HomeCategoryStrip sticky />
 
         {/* === Featured Properties carousel === */}
         <HomeCarouselSection
+          eyebrow={t('home.recommended.eyebrow')}
           title={t('home.featured.title')}
           items={featuredProperties}
           loading={propertiesLoading}
           emptyText={t('home.featured.empty')}
+          viewAllText={t('home.viewAll')}
+          onViewAll={() => router.push('/explore')}
           renderItem={(property) => (
             <PropertyCard
               property={property}
@@ -596,29 +578,9 @@ export default function HomePage() {
         ) : null}
 
         {/* === Nearby city carousels (only when location + properties available) === */}
-        {nearbyCities.map((city) => {
-          const cityId = city._id;
-          const cityProperties = nearbyProperties[cityId];
-          if (!cityProperties || cityProperties.length === 0) return null;
-          return (
-            <HomeCarouselSection
-              key={cityId}
-              title={t('home.nearby.title', { city: city.name })}
-              items={cityProperties}
-              loading={false}
-              renderItem={(property) => (
-                <PropertyCard
-                  property={property}
-                  variant="featured"
-                  // Home rows are themselves horizontal scrollers; an in-card
-                  // photo pager would fight the row swipe, so keep one photo here.
-                  enableImageCarousel={false}
-                  onPress={() => router.push(`/properties/${property._id || property.id}`)}
-                />
-              )}
-            />
-          );
-        })}
+        {nearbyCities.map((city) => (
+          <NearbyCityCarousel key={city._id} city={city} />
+        ))}
 
         {/* === Closing CTA banners ===
             Responsive 50/50 grid: side-by-side equal-height columns on wide
@@ -629,7 +591,7 @@ export default function HomePage() {
             so `alignItems: 'stretch'` equalises height. On narrow the two
             banners are plain scroll siblings and the page `gap` spaces them. */}
         {isWide ? (
-          <View className="flex-row items-stretch gap-6 px-8 md:gap-8">
+          <View className={`flex-row items-stretch gap-6 md:gap-8 ${PAGE_GUTTER_CLASS}`}>
             <HostCtaBanner
               fill
               title={t('home.hostCta.title')}

--- a/packages/frontend/components/CityShowcaseSection.tsx
+++ b/packages/frontend/components/CityShowcaseSection.tsx
@@ -22,7 +22,6 @@ import {
   Pressable,
   ScrollView,
   StyleSheet,
-  TouchableOpacity,
   View,
   useWindowDimensions,
 } from 'react-native';
@@ -36,7 +35,7 @@ import type { City } from '@homiio/shared-types';
 
 import { colors } from '@/styles/colors';
 import { textShadow } from '@/styles/shadows';
-import { cardShadow, gridGap, radius, spacing, tracker } from '@/constants/styles';
+import { cardShadow, gridGap, PAGE_GUTTER_CLASS, pagePadding, radius, spacing, tracker } from '@/constants/styles';
 import { cityRegionName, getCityImageSource } from '@/utils/cityDisplay';
 
 interface CityShowcaseSectionProps {
@@ -51,6 +50,7 @@ const CARD_GAP = gridGap.normal;
 export function CityShowcaseSection({ title, items, onPressCity }: CityShowcaseSectionProps) {
   const isWide = useMediaQuery({ minWidth: 768 });
   const isXL = useMediaQuery({ minWidth: 1280 });
+  const pageGutter = isWide ? pagePadding.desktop : pagePadding.mobile;
   const { width: windowWidth } = useWindowDimensions();
   const scrollRef = useRef<ScrollView>(null);
   const [scrollX, setScrollX] = useState(0);
@@ -65,7 +65,7 @@ export function CityShowcaseSection({ title, items, onPressCity }: CityShowcaseS
   const cardHeight = Math.round(cardWidth * 1.25);
 
   const totalContentWidth = items.length * cardWidth + (items.length - 1) * CARD_GAP;
-  const maxScroll = Math.max(0, totalContentWidth - containerWidth + spacing['2xl'] * 2);
+  const maxScroll = Math.max(0, totalContentWidth - containerWidth + pageGutter * 2);
   const canScrollLeft = scrollX > 4;
   const canScrollRight = scrollX < maxScroll - 4;
 
@@ -81,35 +81,39 @@ export function CityShowcaseSection({ title, items, onPressCity }: CityShowcaseS
   };
 
   return (
-    <View style={styles.section}>
-      <View style={styles.header}>
-        <H1 style={styles.title}>{title}</H1>
+    <View className="w-full">
+      <View className={`mb-4 flex-row items-end justify-between gap-4 ${PAGE_GUTTER_CLASS}`}>
+        <H1 className="min-w-0 flex-1 shrink text-[26px] font-bold leading-8 tracking-tight text-foreground">
+          {title}
+        </H1>
         {isWide && (canScrollLeft || canScrollRight) ? (
-          <View style={styles.arrowGroup}>
-            <TouchableOpacity
+          <View className="flex-row items-center gap-2">
+            <Pressable
               onPress={() => scrollByPage('left')}
               disabled={!canScrollLeft}
-              style={[styles.arrowButton, { opacity: canScrollLeft ? 1 : 0.3 }]}
+              className="h-8 w-8 items-center justify-center rounded-full bg-white"
+              style={[cardShadow.sm, { opacity: canScrollLeft ? 1 : 0.3 }]}
               accessibilityRole="button"
               accessibilityLabel="Scroll left"
             >
               <Ionicons name="chevron-back" size={16} color={colors.primaryColor} />
-            </TouchableOpacity>
-            <TouchableOpacity
+            </Pressable>
+            <Pressable
               onPress={() => scrollByPage('right')}
               disabled={!canScrollRight}
-              style={[styles.arrowButton, { opacity: canScrollRight ? 1 : 0.3 }]}
+              className="h-8 w-8 items-center justify-center rounded-full bg-white"
+              style={[cardShadow.sm, { opacity: canScrollRight ? 1 : 0.3 }]}
               accessibilityRole="button"
               accessibilityLabel="Scroll right"
             >
               <Ionicons name="chevron-forward" size={16} color={colors.primaryColor} />
-            </TouchableOpacity>
+            </Pressable>
           </View>
         ) : null}
       </View>
 
       <View
-        style={styles.scrollWrapper}
+        className="w-full"
         onLayout={(e) => setContainerWidth(e.nativeEvent.layout.width)}
       >
         <ScrollView
@@ -121,9 +125,9 @@ export function CityShowcaseSection({ title, items, onPressCity }: CityShowcaseS
           snapToAlignment="start"
           onScroll={handleScroll}
           scrollEventThrottle={16}
-          contentContainerStyle={styles.scrollContent}
+          contentContainerClassName={PAGE_GUTTER_CLASS}
         >
-          <View style={styles.rowFlex}>
+          <View className="flex-row gap-4">
             {items.map((city) => (
               <CityCard
                 key={city._id}
@@ -204,50 +208,6 @@ const CityCard: React.FC<CityCardProps> = ({ city, width, height, onPress }) => 
 };
 
 const styles = StyleSheet.create({
-  section: {
-    width: '100%',
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'flex-end',
-    justifyContent: 'space-between',
-    paddingHorizontal: spacing['2xl'],
-    marginBottom: spacing.lg,
-    gap: spacing.lg,
-  },
-  title: {
-    fontSize: 26,
-    color: colors.COLOR_BLACK,
-    fontWeight: '700',
-    letterSpacing: tracker.tight,
-    lineHeight: 32,
-    flex: 1,
-    flexShrink: 1,
-  },
-  arrowGroup: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.sm,
-  },
-  arrowButton: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    backgroundColor: colors.white,
-    alignItems: 'center',
-    justifyContent: 'center',
-    ...cardShadow.sm,
-  },
-  scrollWrapper: {
-    width: '100%',
-  },
-  scrollContent: {
-    paddingHorizontal: spacing['2xl'],
-  },
-  rowFlex: {
-    flexDirection: 'row',
-    gap: CARD_GAP,
-  },
   card: {
     position: 'relative',
     borderRadius: radius.photo,

--- a/packages/frontend/components/FeaturedGridSection.tsx
+++ b/packages/frontend/components/FeaturedGridSection.tsx
@@ -12,14 +12,12 @@
  * rows", "no shimmer carpets").
  */
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
-import { useMediaQuery } from 'react-responsive';
+import { View } from 'react-native';
 
 import { H1 } from '@oxyhq/bloom/typography';
 
 import { PropertyResultsGrid } from '@/components/ui/PropertyResultsGrid';
-import { colors } from '@/styles/colors';
-import { resolvePagePadding, spacing, tracker } from '@/constants/styles';
+import { PAGE_GUTTER_CLASS } from '@/constants/styles';
 import type { Property } from '@homiio/shared-types';
 
 interface FeaturedGridSectionProps {
@@ -41,15 +39,13 @@ export function FeaturedGridSection({
   onPropertyPress,
   maxColumns,
 }: FeaturedGridSectionProps) {
-  const isWide = useMediaQuery({ minWidth: 768 });
-
   if (items.length === 0) return null;
 
-  const horizontalPadding = resolvePagePadding(isWide);
-
   return (
-    <View style={[styles.section, { paddingHorizontal: horizontalPadding }]}>
-      <H1 style={styles.title}>{title}</H1>
+    <View className={`w-full ${PAGE_GUTTER_CLASS}`}>
+      <H1 className="mb-5 text-[26px] font-bold leading-8 tracking-tight text-foreground">
+        {title}
+      </H1>
       <PropertyResultsGrid
         properties={items}
         onPropertyPress={onPropertyPress}
@@ -58,17 +54,3 @@ export function FeaturedGridSection({
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  section: {
-    width: '100%',
-  },
-  title: {
-    fontSize: 26,
-    color: colors.COLOR_BLACK,
-    fontWeight: '700',
-    letterSpacing: tracker.tight,
-    lineHeight: 32,
-    marginBottom: spacing.xl,
-  },
-});

--- a/packages/frontend/components/HomeCarouselSection.tsx
+++ b/packages/frontend/components/HomeCarouselSection.tsx
@@ -11,7 +11,7 @@
 import React, { useRef, useState } from 'react';
 import {
   View,
-  TouchableOpacity,
+  Pressable,
   ScrollView,
   NativeSyntheticEvent,
   NativeScrollEvent,
@@ -22,7 +22,7 @@ import { useMediaQuery } from 'react-responsive';
 import { H1, Text as BloomText } from '@oxyhq/bloom/typography';
 
 import { colors } from '@/styles/colors';
-import { cardShadow, gridGap, spacing, tracker } from '@/constants/styles';
+import { cardShadow, gridGap, PAGE_GUTTER_CLASS, pagePadding } from '@/constants/styles';
 import { SectionEyebrow } from '@/components/ui/SectionEyebrow';
 
 interface HomeCarouselSectionProps<T> {
@@ -41,7 +41,6 @@ interface HomeCarouselSectionProps<T> {
 }
 
 const CARD_GAP = gridGap.normal;
-const HORIZONTAL_PADDING = spacing['2xl'] * 2;
 
 export function HomeCarouselSection<T>({
   eyebrow,
@@ -61,11 +60,12 @@ export function HomeCarouselSection<T>({
   const [scrollX, setScrollX] = useState(0);
   const [_isDragging, setIsDragging] = useState(false);
   const isWide = useMediaQuery({ minWidth: 768 });
+  const horizontalPadding = (isWide ? pagePadding.desktop : pagePadding.mobile) * 2;
 
   let calculatedCardWidth = maxCardWidth;
 
   if (containerWidth > 0) {
-    const availableWidth = Math.max(0, containerWidth - HORIZONTAL_PADDING);
+    const availableWidth = Math.max(0, containerWidth - horizontalPadding);
     const minCardsToFit = Math.max(
       1,
       Math.ceil((availableWidth + CARD_GAP) / (maxCardWidth + CARD_GAP)),
@@ -81,7 +81,7 @@ export function HomeCarouselSection<T>({
   }
 
   const totalCardsWidth = items.length * calculatedCardWidth + (items.length - 1) * CARD_GAP;
-  const availableScrollWidth = containerWidth - HORIZONTAL_PADDING;
+  const availableScrollWidth = containerWidth - horizontalPadding;
   const maxScroll = Math.max(0, totalCardsWidth - availableScrollWidth);
   const itemsPerPage =
     containerWidth > 0
@@ -190,27 +190,26 @@ export function HomeCarouselSection<T>({
 
   return (
     <View>
-      <View className="mb-4 flex-row items-end justify-between gap-4 px-4">
+      <View className={`mb-4 flex-row items-end justify-between gap-4 ${PAGE_GUTTER_CLASS}`}>
         <View className="min-w-0 flex-1 shrink">
           {eyebrow ? <SectionEyebrow>{eyebrow}</SectionEyebrow> : null}
           <H1
-            className="text-[26px] font-bold leading-8 text-foreground"
-            style={{ letterSpacing: tracker.tight }}
+            className="text-[26px] font-bold leading-8 tracking-tight text-foreground"
           >
             {title}
           </H1>
         </View>
         <View className="flex-row items-center gap-3">
-          {onViewAll && (
-            <TouchableOpacity onPress={onViewAll} hitSlop={8}>
+          {onViewAll ? (
+            <Pressable onPress={onViewAll} hitSlop={8} accessibilityRole="button">
               <BloomText className="text-sm font-semibold underline text-foreground">
                 {viewAllText}
               </BloomText>
-            </TouchableOpacity>
-          )}
+            </Pressable>
+          ) : null}
           {isWide && !(disableLeftArrow && disableRightArrow) ? (
             <View className="flex-row items-center gap-2">
-              <TouchableOpacity
+              <Pressable
                 onPress={handleScrollLeft}
                 disabled={disableLeftArrow}
                 className="h-8 w-8 items-center justify-center rounded-full bg-white"
@@ -219,8 +218,8 @@ export function HomeCarouselSection<T>({
                 accessibilityLabel="Scroll left"
               >
                 <Ionicons name="chevron-back" size={16} color={colors.primaryColor} />
-              </TouchableOpacity>
-              <TouchableOpacity
+              </Pressable>
+              <Pressable
                 onPress={handleScrollRight}
                 disabled={disableRightArrow}
                 className="h-8 w-8 items-center justify-center rounded-full bg-white"
@@ -229,7 +228,7 @@ export function HomeCarouselSection<T>({
                 accessibilityLabel="Scroll right"
               >
                 <Ionicons name="chevron-forward" size={16} color={colors.primaryColor} />
-              </TouchableOpacity>
+              </Pressable>
             </View>
           ) : null}
         </View>
@@ -239,7 +238,7 @@ export function HomeCarouselSection<T>({
         onLayout={(e) => setContainerWidth(e.nativeEvent.layout.width)}
       >
         {!loading && items.length === 0 && emptyText ? (
-          <View className="px-4 py-2">
+          <View className={`py-2 ${PAGE_GUTTER_CLASS}`}>
             <BloomText className="text-sm text-muted-foreground">{emptyText}</BloomText>
           </View>
         ) : (
@@ -248,7 +247,7 @@ export function HomeCarouselSection<T>({
             horizontal
             showsHorizontalScrollIndicator={false}
             className="flex-row"
-            contentContainerClassName="justify-start px-4"
+            contentContainerClassName={`justify-start ${PAGE_GUTTER_CLASS}`}
             scrollEnabled={true}
             onScrollBeginDrag={handleScrollBeginDrag}
             onScrollEndDrag={handleScrollEndDrag}

--- a/packages/frontend/components/HomeCategoryStrip.tsx
+++ b/packages/frontend/components/HomeCategoryStrip.tsx
@@ -1,23 +1,10 @@
 /**
  * Home category strip — Airbnb-2026 inspired horizontal scroller that
  * switches the home feed's lens (Studios / Apartments / Houses for
- * long-term; Beachfront / Cabins / Pools for vacation).
- *
- * Visual language:
- *   - Compact 40px isometric PNG render per category (full-color, never tinted)
- *     clipped to a `radius.lg` rounded square so it reads as a premium tile.
- *   - 12px label flush under the image (no tile/label gap), on a fixed-width
- *     item so labels line up across the row.
- *   - Active state = a soft rounded background highlight behind the whole
- *     item (icon + label) plus a dark + bold label and the image at full
- *     opacity; inactive = transparent background, muted label, image at
- *     0.85 opacity (dim the tile, don't recolor the render). The item keeps
- *     identical padding in both states so the layout never shifts.
- *   - On web: subtle scale-1.04 on hover (never re-tints).
- *
- * Spacing is anchored on the design-token `spacing`/`radius` scale.
+ * long-term; Beachfront / Cabins / Pools for vacation; sale/exchange
+ * buckets for buy and exchange browse modes).
  */
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import {
   Image,
   Platform,
@@ -36,35 +23,9 @@ import { PANEL_TOP_INSET } from '@oxyhq/bloom/content-panel';
 import { getIconArt, ICON_ART_PLACEHOLDER } from '@/constants/iconArt';
 import { useRentalMode } from '@/context/RentalModeContext';
 import { useIsScreenNotMobile } from '@/hooks/useOptimizedMediaQuery';
+import { homeCategoriesForMode, resolveHomeCategory } from '@/store/homeCategories';
 import { useHomeCategoryStore, type HomeCategory } from '@/store/homeCategoryStore';
-import { tracker } from '@/constants/styles';
-
-interface CategoryDef {
-  id: HomeCategory;
-  labelKey: string;
-}
-
-const LONG_TERM_CATEGORIES: CategoryDef[] = [
-  { id: 'studios', labelKey: 'home.category.studios' },
-  { id: 'apartments', labelKey: 'home.category.apartments' },
-  { id: 'houses', labelKey: 'home.category.houses' },
-  { id: 'rooms', labelKey: 'home.category.rooms' },
-  { id: 'coliving', labelKey: 'home.category.coliving' },
-  { id: 'luxury', labelKey: 'home.category.luxury' },
-  { id: 'new_listings', labelKey: 'home.category.newListings' },
-  { id: 'near_you', labelKey: 'home.category.nearYou' },
-];
-
-const VACATION_CATEGORIES: CategoryDef[] = [
-  { id: 'beachfront', labelKey: 'home.category.beachfront' },
-  { id: 'cabins', labelKey: 'home.category.cabins' },
-  { id: 'pools', labelKey: 'home.category.pools' },
-  { id: 'mountain', labelKey: 'home.category.mountain' },
-  { id: 'city_breaks', labelKey: 'home.category.cityBreaks' },
-  { id: 'countryside', labelKey: 'home.category.countryside' },
-  { id: 'instant_book', labelKey: 'home.category.instantBook' },
-  { id: 'pet_friendly', labelKey: 'home.category.petFriendly' },
-];
+import { PAGE_GUTTER_CLASS, tracker } from '@/constants/styles';
 
 /** Edge length of the isometric tile — compact so more categories fit on screen. */
 const TILE_SIZE = 40;
@@ -95,17 +56,6 @@ interface CategoryItemProps {
 
 const CategoryItem: React.FC<CategoryItemProps> = ({ active, label, image, onPress }) => {
   const [hovered, setHovered] = useState(false);
-
-  /**
-   * The isometric render is full-color, so we never tint it — active vs
-   * inactive is conveyed by image opacity (1 vs 0.85), the label color/weight,
-   * and a soft rounded background highlight behind the whole item. The
-   * highlight uses the lightest neutral fill (`COLOR_BLACK_LIGHT_8`, Bloom
-   * `backgroundSecondary`) so the selected category reads as a subtle pill
-   * without competing with the colorful tile. Padding is identical in both
-   * states (so the row never reflows on selection); only the background
-   * toggles. Hover on web nudges scale slightly only.
-   */
   const scale = hovered && Platform.OS === 'web' ? 1.04 : 1;
 
   return (
@@ -154,35 +104,17 @@ export const HomeCategoryStrip: React.FC<HomeCategoryStripProps> = ({
   sticky = false,
 }) => {
   const { t } = useTranslation();
-  const { mode } = useRentalMode();
+  const { mode, browseMode } = useRentalMode();
   const { colors: themeColors } = useTheme();
   const category = useHomeCategoryStore((s) => s.category);
   const setCategory = useHomeCategoryStore((s) => s.setCategory);
-
-  const items = useMemo(
-    () => (mode === 'vacation' ? VACATION_CATEGORIES : LONG_TERM_CATEGORIES),
-    [mode],
-  );
-
-  const handlePress = useCallback(
-    (next: HomeCategory) => {
-      setCategory(category === next ? null : next);
-    },
-    [category, setCategory],
-  );
+  const items = homeCategoriesForMode(browseMode, mode);
+  const activeCategory = resolveHomeCategory(category, browseMode, mode);
 
   const isWeb = Platform.OS === 'web';
   const isScreenNotMobile = useIsScreenNotMobile();
-  // Match Header: framed ContentPanel bleed-mask clips sticky at top:0.
   const framed = isWeb && isScreenNotMobile;
 
-  /**
-   * Solid page background on web + native so scrolled feed content never
-   * shows through the strip (`bg-background` on the wrapper). Web-only
-   * `position: sticky` lives outside the RN style system — inject via style
-   * and rely on react-native-web to pass it through. `top` stays numeric
-   * from PANEL_TOP_INSET when framed.
-   */
   const stickyStyle =
     sticky && isWeb
       ? ({
@@ -204,15 +136,15 @@ export const HomeCategoryStrip: React.FC<HomeCategoryStripProps> = ({
         showsHorizontalScrollIndicator={false}
         decelerationRate={isWeb ? 'normal' : 'fast'}
         snapToAlignment="start"
-        contentContainerClassName={isWeb ? 'gap-1 px-4' : 'gap-0.5 px-3'}
+        contentContainerClassName={isWeb ? `gap-1 ${PAGE_GUTTER_CLASS}` : `gap-0.5 ${PAGE_GUTTER_CLASS}`}
       >
         {items.map((item) => (
           <CategoryItem
             key={item.id}
-            active={category === item.id}
+            active={activeCategory === item.id}
             label={t(item.labelKey)}
             image={resolveCategoryImage(item.id)}
-            onPress={() => handlePress(item.id)}
+            onPress={() => setCategory(activeCategory === item.id ? null : item.id)}
           />
         ))}
       </ScrollView>

--- a/packages/frontend/components/NearbyCityCarousel.tsx
+++ b/packages/frontend/components/NearbyCityCarousel.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useRouter } from 'expo-router';
+
+import type { City, Property } from '@homiio/shared-types';
+
+import { PropertyCard } from '@/components/PropertyCard';
+import { HomeCarouselSection } from '@/components/HomeCarouselSection';
+import { usePropertiesByCity } from '@/hooks/useCityQueries';
+
+interface NearbyCityCarouselProps {
+  city: City;
+}
+
+export function NearbyCityCarousel({ city }: NearbyCityCarouselProps) {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const { data } = usePropertiesByCity(city._id, { limit: 8 });
+  const cityProperties = (data?.properties as Property[] | undefined) ?? [];
+
+  if (cityProperties.length === 0) return null;
+
+  return (
+    <HomeCarouselSection
+      title={t('home.nearby.title', { city: city.name })}
+      items={cityProperties}
+      loading={false}
+      renderItem={(property) => (
+        <PropertyCard
+          property={property}
+          variant="featured"
+          enableImageCarousel={false}
+          onPress={() => router.push(`/properties/${property._id || property.id}`)}
+        />
+      )}
+    />
+  );
+}

--- a/packages/frontend/constants/iconArt.ts
+++ b/packages/frontend/constants/iconArt.ts
@@ -17,6 +17,8 @@ export const ICON_ART: Partial<Record<string, ImageSourcePropType>> = {
   pools: require('@/assets/icon-art/pools.png'),
   mountain: require('@/assets/icon-art/mountain.png'),
   pet_friendly: require('@/assets/icon-art/pet_friendly.png'),
+  home_swap: require('@/assets/icon-art/tent.png'),
+  hosting: require('@/assets/icon-art/breakfast.png'),
 
   // Reserved home / feature art (no consumer yet)
   beach_chair: require('@/assets/icon-art/beach_chair.png'),

--- a/packages/frontend/constants/styles.ts
+++ b/packages/frontend/constants/styles.ts
@@ -337,6 +337,12 @@ export const resolvePagePadding = (isWide: boolean): number =>
   isWide ? pagePadding.desktop : pagePadding.mobile;
 
 /**
+ * NativeWind class for responsive horizontal page gutters. Matches
+ * {@link resolvePagePadding}: 16px mobile (`px-4`), 32px from `md` (`px-8`).
+ */
+export const PAGE_GUTTER_CLASS = 'px-4 md:px-8';
+
+/**
  * Minimum height for a full-bleed CTA banner rendered in grid (`fill`) mode —
  * i.e. two banners side-by-side as equal-height columns on wide screens. In
  * that mode the banners drop their intrinsic `aspectRatio` and stretch to the

--- a/packages/frontend/locales/ca-ES.json
+++ b/packages/frontend/locales/ca-ES.json
@@ -269,7 +269,9 @@
       "cityBreaks": "Escapades urbanes",
       "countryside": "Camp",
       "instantBook": "Reserva instantània",
-      "petFriendly": "Admet mascotes"
+      "petFriendly": "Admet mascotes",
+      "homeSwap": "Intercanvi de cases",
+      "hosting": "Allotjament"
     }
   },
   "agent": {

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -157,7 +157,9 @@
       "cityBreaks": "City breaks",
       "countryside": "Countryside",
       "instantBook": "Instant book",
-      "petFriendly": "Pet friendly"
+      "petFriendly": "Pet friendly",
+      "homeSwap": "Home swap",
+      "hosting": "Hosting"
     },
     "horizon": {
       "title": "Join Horizon",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -248,7 +248,9 @@
       "cityBreaks": "Escapadas urbanas",
       "countryside": "Campo",
       "instantBook": "Reserva instantánea",
-      "petFriendly": "Admite mascotas"
+      "petFriendly": "Admite mascotas",
+      "homeSwap": "Intercambio de casas",
+      "hosting": "Alojamiento"
     }
   },
   "agent": {

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -404,7 +404,9 @@
       "cityBreaks": "Weekend in città",
       "countryside": "Campagna",
       "instantBook": "Prenotazione immediata",
-      "petFriendly": "Animali ammessi"
+      "petFriendly": "Animali ammessi",
+      "homeSwap": "Scambio casa",
+      "hosting": "Ospitalità"
     }
   },
   "agent": {

--- a/packages/frontend/store/getCategoryFilters.ts
+++ b/packages/frontend/store/getCategoryFilters.ts
@@ -1,9 +1,15 @@
-import { PropertyType, type PropertyFilters } from '@homiio/shared-types';
+import {
+  ExchangeMode,
+  OfferingType,
+  PropertyType,
+  type PropertyFilters,
+} from '@homiio/shared-types';
 
 import type { HomeCategory } from './homeCategoryStore';
 
 interface CategoryFilterContext {
   userLocation?: { latitude: number; longitude: number } | null;
+  offering?: OfferingType;
 }
 
 /** Radius (km) for the "Near you" home-category lens. */
@@ -11,6 +17,9 @@ const NEAR_YOU_RADIUS_KM = 25;
 
 /** Monthly rent floor for the merchandised "Luxury" long-term bucket. */
 const LUXURY_MIN_RENT = 2500;
+
+/** Sale-price floor for the merchandised "Luxury" buy bucket. */
+const LUXURY_MIN_SALE_PRICE = 400_000;
 
 /**
  * Maps a selected {@link HomeCategory} to API-backed {@link PropertyFilters}.
@@ -21,6 +30,8 @@ export function getCategoryFilters(
   context: CategoryFilterContext = {},
 ): Partial<PropertyFilters> {
   if (!category) return {};
+
+  const offering = context.offering;
 
   switch (category) {
     case 'studios':
@@ -34,6 +45,9 @@ export function getCategoryFilters(
     case 'coliving':
       return { type: PropertyType.COLIVING };
     case 'luxury':
+      if (offering === OfferingType.SALE) {
+        return { minSalePrice: LUXURY_MIN_SALE_PRICE };
+      }
       return { minRent: LUXURY_MIN_RENT };
     case 'new_listings':
       // Default list sort is `createdAt desc` — no extra filter required.
@@ -59,6 +73,10 @@ export function getCategoryFilters(
       return { instantBook: true };
     case 'pet_friendly':
       return { petFriendly: true };
+    case 'home_swap':
+      return { exchangeMode: ExchangeMode.SWAP };
+    case 'hosting':
+      return { exchangeMode: ExchangeMode.HOST };
     default: {
       const _exhaustive: never = category;
       return _exhaustive;

--- a/packages/frontend/store/homeCategories.ts
+++ b/packages/frontend/store/homeCategories.ts
@@ -1,0 +1,75 @@
+import type { BrowseMode } from '@/components/search/types';
+import type { RentalMode } from '@/context/RentalModeContext';
+
+import type { HomeCategory } from './homeCategoryStore';
+
+export interface HomeCategoryDef {
+  id: HomeCategory;
+  labelKey: string;
+}
+
+const LONG_TERM_CATEGORIES: HomeCategoryDef[] = [
+  { id: 'studios', labelKey: 'home.category.studios' },
+  { id: 'apartments', labelKey: 'home.category.apartments' },
+  { id: 'houses', labelKey: 'home.category.houses' },
+  { id: 'rooms', labelKey: 'home.category.rooms' },
+  { id: 'coliving', labelKey: 'home.category.coliving' },
+  { id: 'luxury', labelKey: 'home.category.luxury' },
+  { id: 'new_listings', labelKey: 'home.category.newListings' },
+  { id: 'near_you', labelKey: 'home.category.nearYou' },
+];
+
+const VACATION_CATEGORIES: HomeCategoryDef[] = [
+  { id: 'beachfront', labelKey: 'home.category.beachfront' },
+  { id: 'cabins', labelKey: 'home.category.cabins' },
+  { id: 'pools', labelKey: 'home.category.pools' },
+  { id: 'mountain', labelKey: 'home.category.mountain' },
+  { id: 'city_breaks', labelKey: 'home.category.cityBreaks' },
+  { id: 'countryside', labelKey: 'home.category.countryside' },
+  { id: 'instant_book', labelKey: 'home.category.instantBook' },
+  { id: 'pet_friendly', labelKey: 'home.category.petFriendly' },
+];
+
+const BUY_CATEGORIES: HomeCategoryDef[] = [
+  { id: 'studios', labelKey: 'home.category.studios' },
+  { id: 'apartments', labelKey: 'home.category.apartments' },
+  { id: 'houses', labelKey: 'home.category.houses' },
+  { id: 'luxury', labelKey: 'home.category.luxury' },
+  { id: 'new_listings', labelKey: 'home.category.newListings' },
+  { id: 'near_you', labelKey: 'home.category.nearYou' },
+  { id: 'pet_friendly', labelKey: 'home.category.petFriendly' },
+];
+
+const EXCHANGE_CATEGORIES: HomeCategoryDef[] = [
+  { id: 'houses', labelKey: 'home.category.houses' },
+  { id: 'apartments', labelKey: 'home.category.apartments' },
+  { id: 'home_swap', labelKey: 'home.category.homeSwap' },
+  { id: 'hosting', labelKey: 'home.category.hosting' },
+  { id: 'beachfront', labelKey: 'home.category.beachfront' },
+  { id: 'city_breaks', labelKey: 'home.category.cityBreaks' },
+  { id: 'countryside', labelKey: 'home.category.countryside' },
+  { id: 'pet_friendly', labelKey: 'home.category.petFriendly' },
+  { id: 'near_you', labelKey: 'home.category.nearYou' },
+];
+
+export function homeCategoriesForMode(
+  browseMode: BrowseMode,
+  mode: RentalMode,
+): readonly HomeCategoryDef[] {
+  if (browseMode === 'buy') return BUY_CATEGORIES;
+  if (browseMode === 'exchange') return EXCHANGE_CATEGORIES;
+  if (mode === 'vacation') return VACATION_CATEGORIES;
+  return LONG_TERM_CATEGORIES;
+}
+
+/** Ignore a stored category that does not belong to the active browse mode. */
+export function resolveHomeCategory(
+  category: HomeCategory | null,
+  browseMode: BrowseMode,
+  mode: RentalMode,
+): HomeCategory | null {
+  if (!category) return null;
+  return homeCategoriesForMode(browseMode, mode).some((item) => item.id === category)
+    ? category
+    : null;
+}

--- a/packages/frontend/store/homeCategoryStore.ts
+++ b/packages/frontend/store/homeCategoryStore.ts
@@ -27,7 +27,10 @@ export type HomeCategory =
   | 'city_breaks'
   | 'countryside'
   | 'instant_book'
-  | 'pet_friendly';
+  | 'pet_friendly'
+  // Exchange
+  | 'home_swap'
+  | 'hosting';
 
 interface HomeCategoryState {
   /** Currently selected category, or null for "all". */


### PR DESCRIPTION
## Summary
- Unify home section gutters via `PAGE_GUTTER_CLASS` and `gap-6 md:gap-8` section stacking
- Expand category strip with new modes, `homeCategories` store, and `NearbyCityCarousel`
- Update home feed sections, locales, and AGENTS.md layout docs

## Test plan
- [ ] Home screen loads with consistent horizontal gutters on web and native
- [ ] Category strip modes render and navigate correctly
- [ ] Nearby city carousel appears when location data is available
- [ ] Locale strings display for new category/copy keys


Made with [Cursor](https://cursor.com)