### PR TITLE
fix(listing-providers): unblock Fotocasa SSR cards and Habitaclia discover

### DIFF
--- a/packages/backend/__tests__/unit/fotocasaProvider.test.ts
+++ b/packages/backend/__tests__/unit/fotocasaProvider.test.ts
@@ -14,6 +14,7 @@ import {
   parseFotocasaSearchads,
   parseFotocasaLocationSegments,
   parseFotocasaSsrSearch,
+  extractFotocasaSearchCards,
   parseFotocasaPropertyJson,
   isFotocasaSearchadsChallenge,
   isFotocasaPropertyChallenge,
@@ -149,6 +150,13 @@ describe('Fotocasa searchads + property JSON parsers', () => {
   it('parses SSR-embedded realEstates from warmed search HTML', () => {
     const refs = parseFotocasaSsrSearch(FOTOCASA_FIXTURE_SSR_SEARCH_HTML);
     expect(refs.map((ref) => ref.sourceId).sort()).toEqual(['187654321', '187654322']);
+  });
+
+  it('parses listing array when HTML also embeds a realEstates counter field', () => {
+    const html = `<!doctype html><html><body><script>window.__STATE__={"counters":{"realEstates":10529},"realEstates":[{"id":187654321,"price":1200,"address":{"municipality":"Madrid"},"detail":"/es/alquiler/vivienda/madrid-capital/x/187654321/d"},{"id":187654322,"price":950,"address":{"municipality":"Madrid"},"detail":"/es/alquiler/vivienda/madrid-capital/x/187654322/d"}],"totalItems":2};</script></body></html>`;
+    const refs = parseFotocasaSsrSearch(html);
+    expect(refs.map((ref) => ref.sourceId).sort()).toEqual(['187654321', '187654322']);
+    expect(extractFotocasaSearchCards(html).size).toBe(2);
   });
 
   it('treats PerimeterX challenge bodies as non-parseable', () => {

--- a/packages/listing-providers/src/browserSession.ts
+++ b/packages/listing-providers/src/browserSession.ts
@@ -123,6 +123,7 @@ class PlaywrightBrowserSession implements BrowserSession {
   async request(url: string, init?: BrowserSessionRequestInit): Promise<BrowserSessionRequestResult> {
     return fetchJsonInPage(this.page, url, {
       ...init,
+      referer: init?.referer ?? this.pageUrl(),
       timeoutMs: init?.timeoutMs ?? this.defaultTimeoutMs,
     });
   }

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -154,6 +154,7 @@ export {
   parseFotocasaSearchads,
   parseFotocasaLocationSegments,
   parseFotocasaSsrSearch,
+  extractFotocasaSearchCards,
   fotocasaSearchadsUrl,
   fotocasaUrlLocationSegmentsUrl,
   fotocasaWarmSearchUrl,

--- a/packages/listing-providers/src/providers/fotocasa/index.ts
+++ b/packages/listing-providers/src/providers/fotocasa/index.ts
@@ -137,6 +137,7 @@ function yieldRefs(
   seen: Set<string>,
   limit: number,
   yielded: { count: number },
+  warmCity: string,
   browserSession?: FotocasaBrowserSessionHint,
   searchCards?: Map<string, Record<string, unknown>>,
 ): ExternalListingRef[] {
@@ -150,8 +151,8 @@ function yieldRefs(
       Object.assign(hints, fotocasaBrowserSessionHints(browserSession));
     }
     const card = searchCards?.get(ref.sourceId);
-    if (card && browserSession) {
-      Object.assign(hints, fotocasaSearchCardHints(browserSession.warmCity, card));
+    if (card) {
+      Object.assign(hints, fotocasaSearchCardHints(warmCity, card));
     }
     out.push({
       provider: PROVIDER_ID,
@@ -343,13 +344,33 @@ export class FotocasaProvider implements ListingProvider {
             const ssrCards = extractFotocasaSearchCards(searchHtml);
             if (ssrRefs.length > 0) {
               collected.push(
-                ...yieldRefs(ssrRefs, seen, limit, yielded, browserSession, ssrCards),
+                ...yieldRefs(ssrRefs, seen, limit, yielded, city, browserSession, ssrCards),
               );
             }
           }
           break;
         }
-        if (status >= 400) break;
+        if (status >= 400) {
+          if (page === 1) {
+            const ssrRefs = parseFotocasaSsrSearch(searchHtml);
+            const ssrCards = extractFotocasaSearchCards(searchHtml);
+            if (ssrRefs.length > 0) {
+              this.metrics.record({
+                provider: this.id,
+                strategy: 'browser',
+                outcome: 'success',
+                status: 200,
+                latencyMs: Date.now() - start,
+                url: warmUrl,
+                detail: `searchads ${status} — SSR realEstates fallback (${transactionType})`,
+              });
+              collected.push(
+                ...yieldRefs(ssrRefs, seen, limit, yielded, city, browserSession, ssrCards),
+              );
+            }
+          }
+          break;
+        }
         const searchCards = extractFotocasaSearchCards(response.body);
         pageRefs = parseFotocasaSearchads(response.body);
         if (page === 1 && pageRefs.length === 0) {
@@ -368,7 +389,7 @@ export class FotocasaProvider implements ListingProvider {
         });
         if (pageRefs.length === 0) break;
         collected.push(
-          ...yieldRefs(pageRefs, seen, limit, yielded, browserSession, searchCards),
+          ...yieldRefs(pageRefs, seen, limit, yielded, city, browserSession, searchCards),
         );
       }
 
@@ -417,7 +438,8 @@ export class FotocasaProvider implements ListingProvider {
         });
         const refs = parseFotocasaSearch(html);
         if (refs.length === 0) return;
-        for (const ref of yieldRefs(refs, seen, limit, yielded)) {
+        const ssrCards = extractFotocasaSearchCards(html);
+        for (const ref of yieldRefs(refs, seen, limit, yielded, city, undefined, ssrCards)) {
           yield ref;
         }
       } catch (error) {

--- a/packages/listing-providers/src/providers/fotocasa/searchads.ts
+++ b/packages/listing-providers/src/providers/fotocasa/searchads.ts
@@ -150,7 +150,7 @@ export function isFotocasaSearchadsChallenge(body: string): boolean {
 }
 
 function refFromRecord(record: Record<string, unknown>): { sourceId: string; url: string } | undefined {
-  const rawId = record.propertyId ?? record.id ?? record.adId;
+  const rawId = record.propertyId ?? record.id ?? record.adId ?? record.realEstateId;
   const sourceId = asString(rawId)?.replace(/\D/g, '');
   if (!sourceId || !/^\d{5,}$/.test(sourceId)) return undefined;
 
@@ -234,16 +234,79 @@ function collectCardsFromUnknown(
   }
 }
 
+/** Pull the SSR-embedded `realEstates` JSON array from warmed search HTML. */
+function extractFotocasaSsrRealEstatesJson(html: string): string | undefined {
+  const marker = '"realEstates":[';
+  const keyIndex = html.indexOf(marker);
+  if (keyIndex < 0) return undefined;
+  const openBracket = keyIndex + '"realEstates":'.length;
+  return extractJsonArrayFromOpenBracket(html, openBracket);
+}
+
+/** Bracket-match a JSON array starting at `openBracket` (must be `[`). */
+function extractJsonArrayFromOpenBracket(html: string, openBracket: number): string | undefined {
+  if (html[openBracket] !== '[') return undefined;
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let index = openBracket; index < html.length; index += 1) {
+    const char = html[index];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (char === '\\' && inString) {
+      escape = true;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (char === '[') depth += 1;
+    if (char === ']') {
+      depth -= 1;
+      if (depth === 0) return html.slice(openBracket, index + 1);
+    }
+  }
+  return undefined;
+}
+
+/** Bracket-match a top-level JSON array value after `"key":`. */
+function extractJsonArrayAfterKey(html: string, key: string): string | undefined {
+  const marker = `"${key}":[`;
+  const keyIndex = html.indexOf(marker);
+  if (keyIndex < 0) return undefined;
+  const openBracket = keyIndex + `"${key}":`.length;
+  return extractJsonArrayFromOpenBracket(html, openBracket);
+}
+
 /** Extract searchads listing cards keyed by source id (for discover → fetch handoff). */
 export function extractFotocasaSearchCards(body: string): Map<string, Record<string, unknown>> {
   const trimmed = body.trim();
   const cards = new Map<string, Record<string, unknown>>();
-  if (trimmed.length === 0 || isFotocasaSearchadsChallenge(trimmed)) return cards;
-  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return cards;
-  try {
-    collectCardsFromUnknown(JSON.parse(trimmed) as unknown, cards);
-  } catch {
-    return cards;
+  if (trimmed.length === 0) return cards;
+
+  const ssrArray = extractFotocasaSsrRealEstatesJson(trimmed);
+  if (ssrArray) {
+    try {
+      collectCardsFromUnknown(JSON.parse(ssrArray) as unknown, cards);
+      if (cards.size > 0) return cards;
+    } catch {
+      // Fall through to JSON/HTML parsing.
+    }
+  }
+
+  if (isFotocasaSearchadsChallenge(trimmed)) return cards;
+
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      collectCardsFromUnknown(JSON.parse(trimmed) as unknown, cards);
+    } catch {
+      return cards;
+    }
   }
   return cards;
 }
@@ -285,10 +348,10 @@ export function parseFotocasaSearchads(body: string): { sourceId: string; url: s
  * (observed on warmed search pages when searchads XHR is not separately captured).
  */
 export function parseFotocasaSsrSearch(html: string): { sourceId: string; url: string }[] {
-  const match = html.match(/"realEstates"\s*:\s*(\[[\s\S]{0,200000}?\])\s*,\s*"/);
-  if (!match?.[1]) return parseFotocasaSearch(html);
+  const ssrArray = extractFotocasaSsrRealEstatesJson(html);
+  if (!ssrArray) return parseFotocasaSearch(html);
   try {
-    return parseFotocasaSearchads(match[1]);
+    return parseFotocasaSearchads(ssrArray);
   } catch {
     return parseFotocasaSearch(html);
   }

--- a/packages/listing-providers/src/providers/habitaclia/index.ts
+++ b/packages/listing-providers/src/providers/habitaclia/index.ts
@@ -46,7 +46,7 @@ const ES_PROXY_COUNTRY = 'es';
 
 export function isHabitacliaChallenge(html: string): boolean {
   if (html.trim().length < 512) return true;
-  return /acceso denegado|verifica|datadome|px-captcha|Pardon Our Interruption|hab_library/i.test(
+  return /acceso denegado|verifica que eres|datadome|px-captcha|Pardon Our Interruption|Request unsuccessful\. Incapsula/i.test(
     html,
   );
 }

--- a/packages/listing-providers/src/providers/habitaclia/listainmuebles.ts
+++ b/packages/listing-providers/src/providers/habitaclia/listainmuebles.ts
@@ -48,7 +48,7 @@ export function habitacliaWarmSearchUrl(city: string, page: number): string {
 export function isHabitacliaListainmueblesChallenge(body: string): boolean {
   const trimmed = body.trim();
   if (trimmed.length < 512) return true;
-  return /403 ERROR|Pardon Our Interruption|hab_library|Request unsuccessful\. Incapsula/i.test(
+  return /403 ERROR|Pardon Our Interruption|Request unsuccessful\. Incapsula/i.test(
     trimmed,
   );
 }

--- a/packages/listing-providers/src/session.ts
+++ b/packages/listing-providers/src/session.ts
@@ -173,6 +173,61 @@ function resolveReferer(target: InPageRequestTarget, init?: BrowserSessionReques
   return '';
 }
 
+/** Ensure cross-origin gateway URLs stay absolute for Playwright's request API. */
+function resolveAbsoluteRequestUrl(url: string, referer: string): string {
+  if (/^https?:\/\//i.test(url)) return url;
+  if (!referer) {
+    throw new Error(`Cannot resolve relative AJAX URL without referer: ${url}`);
+  }
+  return new URL(url, referer).toString();
+}
+
+function isCrossOriginRequest(pageUrl: string, requestUrl: string): boolean {
+  try {
+    return new URL(pageUrl).origin !== new URL(requestUrl).origin;
+  } catch {
+    return false;
+  }
+}
+
+async function fetchViaPageEvaluate(
+  page: SessionPage,
+  absoluteUrl: string,
+  referer: string,
+  init?: BrowserSessionRequestInit,
+): Promise<BrowserSessionRequestResult> {
+  const method = init?.method ?? 'GET';
+  const headers: Record<string, string> = {
+    Accept: 'application/json, text/javascript, text/html, */*; q=0.01',
+    'X-Requested-With': 'XMLHttpRequest',
+    ...(referer ? { Referer: referer } : {}),
+    ...init?.headers,
+  };
+  const payload = await page.evaluate(
+    async (args: {
+      url: string;
+      method: string;
+      headers: Record<string, string>;
+      body?: string;
+    }) => {
+      const response = await fetch(args.url, {
+        method: args.method,
+        headers: args.headers,
+        credentials: 'include',
+        body: args.method === 'POST' ? args.body : undefined,
+      });
+      return { status: response.status, body: await response.text() };
+    },
+    {
+      url: absoluteUrl,
+      method,
+      headers,
+      body: init?.data,
+    },
+  );
+  return payload;
+}
+
 /**
  * Abort image/CSS/font requests on a page (default ON in session pools — cheap
  * residential proxy GB). Safe to call when asset blocking is disabled (no-op).
@@ -288,6 +343,7 @@ export async function fetchJsonInPage(
 ): Promise<BrowserSessionRequestResult> {
   const timeout = init?.timeoutMs ?? DEFAULT_SESSION_TIMEOUT_MS;
   const referer = resolveReferer(target, init);
+  const absoluteUrl = resolveAbsoluteRequestUrl(url, referer);
   const headers = {
     Accept: 'application/json, text/javascript, text/html, */*; q=0.01',
     'X-Requested-With': 'XMLHttpRequest',
@@ -295,10 +351,13 @@ export async function fetchJsonInPage(
     ...init?.headers,
   };
   const method = init?.method ?? 'GET';
+  if (isSessionPage(target) && referer && isCrossOriginRequest(referer, absoluteUrl)) {
+    return fetchViaPageEvaluate(target, absoluteUrl, referer, init);
+  }
   const response =
     method === 'POST'
-      ? await target.request.post(url, { timeout, headers, data: init?.data })
-      : await target.request.get(url, { timeout, headers });
+      ? await target.request.post(absoluteUrl, { timeout, headers, data: init?.data })
+      : await target.request.get(absoluteUrl, { timeout, headers });
   const body = await response.text();
   return { status: response.status(), body };
 }


### PR DESCRIPTION
## Summary
- Fotocasa: extract 250KB SSR `realEstates` array (skip counter field), attach search cards before challenge false-positive, ingest via card snapshot when property JSON/searchads 404
- Habitaclia: remove `hab_library` from challenge detectors (false positive on real pages)
- Playwright: cross-origin gateway AJAX via page.evaluate + default referer

## Test plan
- [x] `bun test __tests__/unit/fotocasaProvider.test.ts` (26 pass)
- [x] `bun test __tests__/unit/habitacliaProvider.test.ts` (11 pass)
- [x] Live probe with ES proxy: fotocasa + habitaclia discover+fetch+normalize OK
- [ ] Post-deploy: API counts fotocasa > 0, habitaclia > 0


Made with [Cursor](https://cursor.com)