### PR TITLE
fix(listing-providers): add evaluate to SessionPage type

### DIFF
--- a/packages/listing-providers/src/session.ts
+++ b/packages/listing-providers/src/session.ts
@@ -153,6 +153,7 @@ export interface SessionPage {
   waitForTimeout(ms: number): Promise<void>;
   route(pattern: string, handler: (route: PwRoute) => void | Promise<void>): Promise<void>;
   request: PwAPIRequestContext;
+  evaluate<R, A>(fn: (arg: A) => R | Promise<R>, arg: A): Promise<Awaited<R>>;
 }
 
 /** Browser context — exposes `request` and {@link exportStorageState}. */


### PR DESCRIPTION
## Summary
- Unblocks `Deploy to AWS` Docker build (`session.ts` TS2339)
- Adds `evaluate` to `SessionPage` interface used by `fetchViaPageEvaluate`

## Test plan
- [x] `bun run build` in listing-providers + backend — clean


Made with [Cursor](https://cursor.com)