### PR TITLE
fix(listing-providers): add evaluate to SessionPage for Docker tsc

### DIFF
--- a/packages/listing-providers/src/session.ts
+++ b/packages/listing-providers/src/session.ts
@@ -153,6 +153,7 @@ export interface SessionPage {
   waitForTimeout(ms: number): Promise<void>;
   route(pattern: string, handler: (route: PwRoute) => void | Promise<void>): Promise<void>;
   request: PwAPIRequestContext;
+  evaluate<R, A>(fn: (arg: A) => R | Promise<R>, arg: A): Promise<Awaited<R>>;
 }
 
 /** Browser context — exposes `request` and {@link exportStorageState}. */


### PR DESCRIPTION
Unblocks deploy: session.ts fetchViaPageEvaluate needs page.evaluate on SessionPage interface.

Made with [Cursor](https://cursor.com)