### PR TITLE
fix(backend): source city covers from Wikimedia Commons

### DIFF
--- a/packages/backend/__tests__/unit/cityCoverSync.test.ts
+++ b/packages/backend/__tests__/unit/cityCoverSync.test.ts
@@ -7,13 +7,29 @@ import request from 'supertest';
 import { Types } from 'mongoose';
 import { OfferingType, PropertyType, PropertyStatus } from '@homiio/shared-types';
 
-import { ensureCover, syncMissingCovers } from '../../services/cityCoverSyncService';
+import imageUploadService from '../../services/imageUploadService';
+import { ensureCover, syncCovers, syncMissingCovers } from '../../services/cityCoverSyncService';
 import cityRoutes from '../../routes/cities';
 
 const { Country, Region, City, Address, Property, Image } = require('../../models');
 const { errorHandler } = require('../../middlewares/errorHandler');
 
+jest.mock('../../services/imageUploadService', () => ({
+  __esModule: true,
+  default: {
+    createImageForEntity: jest.fn(),
+    isStorageConfigured: jest.fn(() => false),
+    resolveStoredImageUrl: jest.fn((url: string) => url),
+  },
+}));
+
 const TEST_IMAGE_URL = 'https://api.homiio.test/api/images/file/test/medium.webp';
+const WIKIMEDIA_IMAGE_URL =
+  'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/example.jpg/1280px-example.jpg';
+
+const originalFetch = global.fetch;
+const mockedCreateImageForEntity = imageUploadService.createImageForEntity as jest.Mock;
+const mockedIsStorageConfigured = imageUploadService.isStorageConfigured as jest.Mock;
 
 function buildApp(): Express {
   const app = express();
@@ -37,9 +53,46 @@ function sampleVariantStrings(): {
   };
 }
 
-async function createImage(entityId: Types.ObjectId, isPrimary = true): Promise<{ _id: Types.ObjectId }> {
+function mockWikimediaFetch(): void {
+  (global as { fetch: typeof originalFetch }).fetch = jest.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('commons.wikimedia.org/w/api.php')) {
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: async () => ({
+          query: {
+            pages: {
+              '12345': {
+                imageinfo: [
+                  {
+                    url: WIKIMEDIA_IMAGE_URL,
+                    thumburl: WIKIMEDIA_IMAGE_URL,
+                    mime: 'image/jpeg',
+                  },
+                ],
+              },
+            },
+          },
+        }),
+      };
+    }
+    if (url === WIKIMEDIA_IMAGE_URL) {
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => 'image/jpeg' },
+        arrayBuffer: async () => Uint8Array.from([0xff, 0xd8, 0xff, 0xd9]).buffer,
+      };
+    }
+    throw new Error(`Unexpected fetch URL in test: ${url}`);
+  }) as typeof fetch;
+}
+
+async function createImage(entityId: Types.ObjectId, entityType = 'property', isPrimary = true): Promise<{ _id: Types.ObjectId }> {
   return Image.create({
-    entityType: 'property',
+    entityType,
     entityId,
     keys: sampleVariantStrings(),
     urls: sampleVariantStrings(),
@@ -83,52 +136,49 @@ async function seedGeo(cityName: string, options: { coverImageId?: Types.ObjectI
   return { country, region, city };
 }
 
+beforeEach(() => {
+  mockWikimediaFetch();
+  mockedIsStorageConfigured.mockReturnValue(false);
+  mockedCreateImageForEntity.mockReset();
+});
+
+afterEach(() => {
+  (global as { fetch: typeof originalFetch }).fetch = originalFetch;
+  jest.clearAllMocks();
+});
+
 describe('cityCoverSyncService.ensureCover', () => {
-  it('links the primary listing image id when the city has no cover', async () => {
+  it('stores a Wikimedia city image when the city has no cover', async () => {
     const geo = await seedGeo('Valencia');
-    const property = await Property.create({
-      addressId: (
-        await Address.create({
-          countryId: geo.country._id,
-          regionId: geo.region._id,
-          cityId: geo.city._id,
-          countryCode: 'ES',
-          street: 'Carrer Test 1',
-          postal_code: '46001',
-          coordinates: { type: 'Point', coordinates: [-0.37, 39.47] },
-        })
-      )._id,
-      type: PropertyType.APARTMENT,
-      bedrooms: 1,
-      offerings: [OfferingType.LONG_TERM_RENT],
-      longTermRent: { monthlyAmount: 900, currency: 'EUR' },
-      status: PropertyStatus.PUBLISHED,
-      isExternal: true,
-      source: 'fixture',
-      sourceId: 'valencia-cover-1',
-      sourceUrl: 'https://fixtures.homiio.com/valencia',
-      images: [],
+    const cityImageId = new Types.ObjectId();
+    mockedCreateImageForEntity.mockResolvedValue({
+      _id: cityImageId,
+      entityType: 'city',
+      entityId: geo.city._id,
+      keys: sampleVariantStrings(),
+      urls: sampleVariantStrings(),
     });
-    const image = await createImage(property._id);
-    property.images = [
-      {
-        imageId: image._id,
-        url: TEST_IMAGE_URL,
-        isPrimary: true,
-        order: 0,
-        urls: sampleVariantStrings(),
-      },
-    ];
-    await property.save();
 
     await ensureCover(geo.city._id);
 
+    expect(mockedCreateImageForEntity).toHaveBeenCalledWith(
+      'city',
+      geo.city._id,
+      expect.objectContaining({ mimetype: 'image/jpeg' }),
+      expect.objectContaining({
+        isPrimary: true,
+        order: 0,
+        caption: 'Valencia, Spain',
+        allowUnconfiguredStorage: true,
+      }),
+    );
+
     const updated = await City.findById(geo.city._id).lean();
-    expect(String(updated?.coverImageId)).toBe(String(image._id));
-    expect(updated?.imageIds?.map(String)).toEqual([String(image._id)]);
+    expect(String(updated?.coverImageId)).toBe(String(cityImageId));
+    expect(updated?.imageIds?.map(String)).toEqual([String(cityImageId)]);
   });
 
-  it('no-ops on a second call (idempotent)', async () => {
+  it('does not use listing image ids even when published properties exist', async () => {
     const geo = await seedGeo('Seville');
     const property = await Property.create({
       addressId: (
@@ -153,10 +203,10 @@ describe('cityCoverSyncService.ensureCover', () => {
       sourceUrl: 'https://fixtures.homiio.com/seville',
       images: [],
     });
-    const firstImage = await createImage(property._id);
+    const listingImage = await createImage(property._id, 'property');
     property.images = [
       {
-        imageId: firstImage._id,
+        imageId: listingImage._id,
         url: TEST_IMAGE_URL,
         isPrimary: true,
         order: 0,
@@ -165,26 +215,37 @@ describe('cityCoverSyncService.ensureCover', () => {
     ];
     await property.save();
 
-    await ensureCover(geo.city._id);
-
-    const secondImage = await createImage(property._id, false);
-    property.images.push({
-      imageId: secondImage._id,
-      url: TEST_IMAGE_URL,
-      isPrimary: false,
-      order: 1,
+    const cityImageId = new Types.ObjectId();
+    mockedCreateImageForEntity.mockResolvedValue({
+      _id: cityImageId,
+      entityType: 'city',
+      entityId: geo.city._id,
+      keys: sampleVariantStrings(),
       urls: sampleVariantStrings(),
     });
-    await property.save();
 
     await ensureCover(geo.city._id);
 
+    expect(mockedCreateImageForEntity).toHaveBeenCalledTimes(1);
     const updated = await City.findById(geo.city._id).lean();
-    expect(String(updated?.coverImageId)).toBe(String(firstImage._id));
+    expect(String(updated?.coverImageId)).toBe(String(cityImageId));
+    expect(String(updated?.coverImageId)).not.toBe(String(listingImage._id));
   });
 
-  it('skips implausible city names', async () => {
-    const geo = await seedGeo('Penn Street');
+  it('no-ops on a second call when a city-owned cover already exists', async () => {
+    const geo = await seedGeo('Bilbao');
+    const existingCityImage = await createImage(geo.city._id, 'city');
+    await City.findByIdAndUpdate(geo.city._id, { coverImageId: existingCityImage._id });
+
+    await ensureCover(geo.city._id);
+
+    expect(mockedCreateImageForEntity).not.toHaveBeenCalled();
+    const updated = await City.findById(geo.city._id).lean();
+    expect(String(updated?.coverImageId)).toBe(String(existingCityImage._id));
+  });
+
+  it('replaces a property-linked cover when force is true', async () => {
+    const geo = await seedGeo('Girona');
     const property = await Property.create({
       addressId: (
         await Address.create({
@@ -192,9 +253,9 @@ describe('cityCoverSyncService.ensureCover', () => {
           regionId: geo.region._id,
           cityId: geo.city._id,
           countryCode: 'ES',
-          street: 'Carrer Test 4',
-          postal_code: '08001',
-          coordinates: { type: 'Point', coordinates: [2.17, 41.39] },
+          street: 'Carrer Test 5',
+          postal_code: '17001',
+          coordinates: { type: 'Point', coordinates: [2.82, 41.98] },
         })
       )._id,
       type: PropertyType.APARTMENT,
@@ -204,32 +265,107 @@ describe('cityCoverSyncService.ensureCover', () => {
       status: PropertyStatus.PUBLISHED,
       isExternal: true,
       source: 'fixture',
-      sourceId: 'penn-street-cover-1',
-      sourceUrl: 'https://fixtures.homiio.com/penn',
+      sourceId: 'girona-cover-1',
+      sourceUrl: 'https://fixtures.homiio.com/girona',
       images: [],
     });
-    const image = await createImage(property._id);
-    property.images = [
-      {
-        imageId: image._id,
-        url: TEST_IMAGE_URL,
-        isPrimary: true,
-        order: 0,
-        urls: sampleVariantStrings(),
-      },
-    ];
-    await property.save();
+    const listingImage = await createImage(property._id, 'property');
+    await City.findByIdAndUpdate(geo.city._id, { coverImageId: listingImage._id });
+
+    const replacementCityImageId = new Types.ObjectId();
+    mockedCreateImageForEntity.mockResolvedValue({
+      _id: replacementCityImageId,
+      entityType: 'city',
+      entityId: geo.city._id,
+      keys: sampleVariantStrings(),
+      urls: sampleVariantStrings(),
+    });
+
+    await ensureCover(geo.city._id, { force: true });
+
+    expect(mockedCreateImageForEntity).toHaveBeenCalledTimes(1);
+    const updated = await City.findById(geo.city._id).lean();
+    expect(String(updated?.coverImageId)).toBe(String(replacementCityImageId));
+    expect(String(updated?.coverImageId)).not.toBe(String(listingImage._id));
+  });
+
+  it('replaces a property-linked cover without force', async () => {
+    const geo = await seedGeo('Zaragoza');
+    const property = await Property.create({
+      addressId: (
+        await Address.create({
+          countryId: geo.country._id,
+          regionId: geo.region._id,
+          cityId: geo.city._id,
+          countryCode: 'ES',
+          street: 'Carrer Test 6',
+          postal_code: '50001',
+          coordinates: { type: 'Point', coordinates: [-0.88, 41.65] },
+        })
+      )._id,
+      type: PropertyType.APARTMENT,
+      bedrooms: 1,
+      offerings: [OfferingType.LONG_TERM_RENT],
+      longTermRent: { monthlyAmount: 900, currency: 'EUR' },
+      status: PropertyStatus.PUBLISHED,
+      isExternal: true,
+      source: 'fixture',
+      sourceId: 'zaragoza-cover-1',
+      sourceUrl: 'https://fixtures.homiio.com/zaragoza',
+      images: [],
+    });
+    const listingImage = await createImage(property._id, 'property');
+    await City.findByIdAndUpdate(geo.city._id, { coverImageId: listingImage._id });
+
+    const replacementCityImageId = new Types.ObjectId();
+    mockedCreateImageForEntity.mockResolvedValue({
+      _id: replacementCityImageId,
+      entityType: 'city',
+      entityId: geo.city._id,
+      keys: sampleVariantStrings(),
+      urls: sampleVariantStrings(),
+    });
 
     await ensureCover(geo.city._id);
 
+    expect(mockedCreateImageForEntity).toHaveBeenCalledTimes(1);
+    const updated = await City.findById(geo.city._id).lean();
+    expect(String(updated?.coverImageId)).toBe(String(replacementCityImageId));
+  });
+
+  it('skips implausible city names', async () => {
+    const geo = await seedGeo('Penn Street');
+
+    await ensureCover(geo.city._id);
+
+    expect(mockedCreateImageForEntity).not.toHaveBeenCalled();
     const updated = await City.findById(geo.city._id).lean();
     expect(updated?.coverImageId).toBeUndefined();
   });
 });
 
-describe('cityCoverSyncService.syncMissingCovers', () => {
+describe('cityCoverSyncService.syncCovers', () => {
   it('processes cities that have listings but no cover', async () => {
     const geo = await seedGeo('Bilbao');
+    const cityImageId = new Types.ObjectId();
+    mockedCreateImageForEntity.mockResolvedValue({
+      _id: cityImageId,
+      entityType: 'city',
+      entityId: geo.city._id,
+      keys: sampleVariantStrings(),
+      urls: sampleVariantStrings(),
+    });
+
+    const processed = await syncCovers({ limit: 10, forceReplaceListingCovers: true });
+    expect(processed).toBe(1);
+
+    const updated = await City.findById(geo.city._id).lean();
+    expect(String(updated?.coverImageId)).toBe(String(cityImageId));
+    expect(mockedCreateImageForEntity).toHaveBeenCalledTimes(1);
+  });
+
+  it('replaces property-linked covers when forceReplaceListingCovers is true', async () => {
+    const geo = await seedGeo('Granada');
     const property = await Property.create({
       addressId: (
         await Address.create({
@@ -237,9 +373,9 @@ describe('cityCoverSyncService.syncMissingCovers', () => {
           regionId: geo.region._id,
           cityId: geo.city._id,
           countryCode: 'ES',
-          street: 'Carrer Test 3',
-          postal_code: '48001',
-          coordinates: { type: 'Point', coordinates: [-2.93, 43.26] },
+          street: 'Carrer Test 7',
+          postal_code: '18001',
+          coordinates: { type: 'Point', coordinates: [-3.6, 37.18] },
         })
       )._id,
       type: PropertyType.APARTMENT,
@@ -249,27 +385,28 @@ describe('cityCoverSyncService.syncMissingCovers', () => {
       status: PropertyStatus.PUBLISHED,
       isExternal: true,
       source: 'fixture',
-      sourceId: 'bilbao-cover-1',
-      sourceUrl: 'https://fixtures.homiio.com/bilbao',
+      sourceId: 'granada-cover-1',
+      sourceUrl: 'https://fixtures.homiio.com/granada',
       images: [],
     });
-    const image = await createImage(property._id);
-    property.images = [
-      {
-        imageId: image._id,
-        url: TEST_IMAGE_URL,
-        isPrimary: true,
-        order: 0,
-        urls: sampleVariantStrings(),
-      },
-    ];
-    await property.save();
+    const listingImage = await createImage(property._id, 'property');
+    await City.findByIdAndUpdate(geo.city._id, { coverImageId: listingImage._id });
+
+    const replacementCityImageId = new Types.ObjectId();
+    mockedCreateImageForEntity.mockResolvedValue({
+      _id: replacementCityImageId,
+      entityType: 'city',
+      entityId: geo.city._id,
+      keys: sampleVariantStrings(),
+      urls: sampleVariantStrings(),
+    });
 
     const processed = await syncMissingCovers({ limit: 10 });
     expect(processed).toBe(1);
 
     const updated = await City.findById(geo.city._id).lean();
-    expect(String(updated?.coverImageId)).toBe(String(image._id));
+    expect(String(updated?.coverImageId)).toBe(String(replacementCityImageId));
+    expect(String(updated?.coverImageId)).not.toBe(String(listingImage._id));
   });
 });
 
@@ -330,7 +467,7 @@ describe('GET /api/cities/popular', () => {
 
   it('excludes cities without a cover or with implausible names', async () => {
     const withCover = await seedGeo('Madrid');
-    const coverImage = await createImage(new Types.ObjectId());
+    const coverImage = await createImage(withCover.city._id, 'city');
     await City.findByIdAndUpdate(withCover.city._id, { coverImageId: coverImage._id });
 
     await seedGeo('Penn Street');

--- a/packages/backend/models/schemas/CitySchema.ts
+++ b/packages/backend/models/schemas/CitySchema.ts
@@ -67,8 +67,8 @@ const citySchema = new mongoose.Schema({
     default: 'EUR'
   },
   /**
-   * The city's cover photo: the `_id` of an existing Image document (typically
-   * a re-hosted listing photo linked by `cityCoverSyncService.ensureCover`).
+   * The city's cover photo: the `_id` of an Image document (`entityType: 'city'`,
+   * sourced from Wikimedia Commons by `cityCoverSyncService.ensureCover`).
    */
   coverImageId: {
     type: mongoose.Schema.Types.ObjectId,

--- a/packages/backend/scripts/seedImages.ts
+++ b/packages/backend/scripts/seedImages.ts
@@ -12,11 +12,10 @@
  *     seeder can embed it on the property — preserving the historical read shape
  *     while backing it with the Image collection.
  *
- *   - City covers: the six curated city images (the SAME URLs the frontend
- *     `CITY_SHOWCASE` array hardcodes) are fetched ONCE, processed and stored as
- *     `Image` docs (`entityType: 'city'`). The city's `coverImageId` is then set
- *     to point at our stored copy — so at runtime there is ZERO live external
- *     image dependency.
+ *   - City covers (local demo seed only): the six curated city images (the SAME
+ *     URLs the frontend `CITY_SHOWCASE` array hardcodes) are fetched ONCE,
+ *     processed and stored as `Image` docs (`entityType: 'city'`). Production
+ *     covers use `cityCoverSyncService` (Wikimedia Commons), not this seed path.
  *
  * Storage caveat: when object storage is not configured (no S3 credentials —
  * e.g. this local seed environment), the Image documents are still created with

--- a/packages/backend/services/cityCoverSyncService.ts
+++ b/packages/backend/services/cityCoverSyncService.ts
@@ -1,104 +1,294 @@
 /**
- * Assigns city cover photos by linking an existing listing Image id — no
- * re-upload, no external APIs, no manual seed.
+ * Assigns city cover photos from Wikimedia Commons — fetched once, stored as
+ * first-party `entityType: 'city'` images. Never links listing/property photos.
  */
 
 import { Types } from 'mongoose';
-import { City, Property, Address } from '../models';
+import { City, Country, Image } from '../models';
+import imageUploadService, { type ImageBufferInput } from './imageUploadService';
 import { isPlausibleCityName } from '../utils/plausibleCityName';
 import { Logger } from '../utils/logger';
 
 const logger = new Logger('CityCoverSyncService');
 
+const WIKIMEDIA_COMMONS_API = 'https://commons.wikimedia.org/w/api.php';
+const FETCH_TIMEOUT_MS = 20_000;
+const FETCH_USER_AGENT = 'Homiio-CityCoverSync/1.0 (+https://homiio.com)';
+const DEFAULT_IMAGE_MIME = 'image/jpeg';
+const BATCH_DELAY_MS = 300;
+
+const ACCEPTED_IMAGE_MIMES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+
 type CityCoverFields = {
   _id: Types.ObjectId;
   name: string;
+  countryId: Types.ObjectId;
   coverImageId?: Types.ObjectId | null;
   imageIds?: Types.ObjectId[];
 };
 
-function resolvePrimaryImageId(
-  images: Array<{ imageId?: Types.ObjectId | null; isPrimary?: boolean }> | undefined,
-): Types.ObjectId | null {
-  if (!images?.length) {
-    return null;
-  }
-  const primary = images.find((img) => img.isPrimary && img.imageId);
-  if (primary?.imageId) {
-    return primary.imageId;
-  }
-  const first = images.find((img) => img.imageId);
-  return first?.imageId ?? null;
+type EnsureCoverOptions = {
+  force?: boolean;
+};
+
+type SyncCoversOptions = {
+  limit?: number;
+  forceReplaceListingCovers?: boolean;
+};
+
+type WikimediaImageInfo = {
+  url?: string;
+  thumburl?: string;
+  mime?: string;
+};
+
+type WikimediaSearchResponse = {
+  query?: {
+    pages?: Record<string, { imageinfo?: WikimediaImageInfo[] }>;
+  };
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/** Link a listing Image id as this city's cover when none is set yet. */
-export async function ensureCover(cityId: Types.ObjectId | string): Promise<void> {
-  try {
-    const city = await City.findById(cityId).select('name coverImageId imageIds').lean<CityCoverFields>();
-    if (!city) {
-      return;
+function buildWikimediaSearchQueries(cityName: string, countryName: string): string[] {
+  return [
+    `${cityName} ${countryName} skyline`,
+    `${cityName} ${countryName} cityscape`,
+    `${cityName} ${countryName} panorama`,
+    `${cityName} ${countryName}`,
+  ];
+}
+
+function pickImageUrlFromSearchResponse(data: WikimediaSearchResponse): string | null {
+  const pages = data.query?.pages;
+  if (!pages) {
+    return null;
+  }
+
+  for (const page of Object.values(pages)) {
+    for (const info of page.imageinfo ?? []) {
+      const mime = info.mime?.toLowerCase();
+      if (mime && !ACCEPTED_IMAGE_MIMES.has(mime)) {
+        continue;
+      }
+      const url = info.thumburl ?? info.url;
+      if (url) {
+        return url;
+      }
     }
-    if (city.coverImageId) {
+  }
+
+  return null;
+}
+
+async function fetchWikimediaImageUrl(cityName: string, countryName: string): Promise<string | null> {
+  for (const query of buildWikimediaSearchQueries(cityName, countryName)) {
+    const params = new URLSearchParams({
+      action: 'query',
+      format: 'json',
+      generator: 'search',
+      gsrsearch: query,
+      gsrnamespace: '6',
+      gsrlimit: '5',
+      prop: 'imageinfo',
+      iiprop: 'url|mime',
+      iiurlwidth: '1280',
+    });
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const response = await fetch(`${WIKIMEDIA_COMMONS_API}?${params}`, {
+        signal: controller.signal,
+        headers: { 'User-Agent': FETCH_USER_AGENT },
+      });
+      if (!response.ok) {
+        logger.warn('Wikimedia search request failed', {
+          query,
+          status: response.status,
+        });
+        continue;
+      }
+
+      const data = (await response.json()) as WikimediaSearchResponse;
+      const imageUrl = pickImageUrlFromSearchResponse(data);
+      if (imageUrl) {
+        return imageUrl;
+      }
+    } catch (error) {
+      logger.warn('Wikimedia search error', { query, error });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  return null;
+}
+
+async function fetchImageBuffer(url: string): Promise<ImageBufferInput> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { 'User-Agent': FETCH_USER_AGENT },
+    });
+    if (!response.ok) {
+      throw new Error(`Image fetch failed: ${response.status} ${response.statusText}`);
+    }
+    const contentType = response.headers.get('content-type');
+    const mimetype =
+      contentType && contentType.startsWith('image/') ? contentType : DEFAULT_IMAGE_MIME;
+    const arrayBuffer = await response.arrayBuffer();
+    return { buffer: Buffer.from(arrayBuffer), mimetype };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function resolveCountryName(countryId: Types.ObjectId): Promise<string | null> {
+  const country = await Country.findById(countryId).select('name').lean<{ name?: string }>();
+  return country?.name?.trim() || null;
+}
+
+async function shouldSkipExistingCover(
+  coverImageId: Types.ObjectId,
+  force: boolean,
+): Promise<boolean> {
+  if (force) {
+    return false;
+  }
+  const coverImage = await Image.findById(coverImageId).select('entityType').lean<{ entityType?: string }>();
+  return coverImage?.entityType === 'city';
+}
+
+/** Fetch a Wikimedia cityscape and store it as this city's cover image. */
+export async function ensureCover(
+  cityId: Types.ObjectId | string,
+  options: EnsureCoverOptions = {},
+): Promise<void> {
+  try {
+    const city = await City.findById(cityId)
+      .select('name countryId coverImageId imageIds')
+      .lean<CityCoverFields>();
+    if (!city) {
       return;
     }
     if (!isPlausibleCityName(city.name)) {
       return;
     }
 
-    const addresses = await Address.find({ cityId: city._id }).select('_id').lean();
-    const addressIds = addresses.map((addr) => addr._id);
-    if (addressIds.length === 0) {
+    if (city.coverImageId) {
+      const skip = await shouldSkipExistingCover(city.coverImageId, options.force === true);
+      if (skip) {
+        return;
+      }
+    }
+
+    const countryName = await resolveCountryName(city.countryId);
+    if (!countryName) {
+      logger.warn('Skipping city cover sync — country not found', {
+        cityId: String(city._id),
+        countryId: String(city.countryId),
+      });
       return;
     }
 
-    const baseQuery = {
-      addressId: { $in: addressIds },
-      status: 'published',
-      'images.imageId': { $exists: true, $ne: null },
-    };
-
-    let property = await Property.findOne({ ...baseQuery, 'images.isPrimary': true })
-      .select('images')
-      .lean();
-    if (!property) {
-      property = await Property.findOne(baseQuery).select('images').lean();
-    }
-
-    const imageId = resolvePrimaryImageId(property?.images);
-    if (!imageId) {
+    const imageUrl = await fetchWikimediaImageUrl(city.name, countryName);
+    if (!imageUrl) {
+      logger.info('No Wikimedia cover found for city', {
+        cityId: String(city._id),
+        cityName: city.name,
+        countryName,
+      });
       return;
     }
 
-    const update: Record<string, unknown> = { coverImageId: imageId };
-    if (!city.imageIds?.length) {
-      update.imageIds = [imageId];
+    const input = await fetchImageBuffer(imageUrl);
+    const allowUnconfiguredStorage = !imageUploadService.isStorageConfigured();
+    const image = await imageUploadService.createImageForEntity('city', city._id, input, {
+      isPrimary: true,
+      order: 0,
+      caption: `${city.name}, ${countryName}`,
+      allowUnconfiguredStorage,
+    });
+
+    const update: Record<string, unknown> = { coverImageId: image._id };
+    const existingImageIds = city.imageIds?.map(String) ?? [];
+    if (!existingImageIds.includes(String(image._id))) {
+      update.imageIds = [...(city.imageIds ?? []), image._id];
     }
 
     await City.updateOne({ _id: city._id }, { $set: update });
-    logger.info('Linked city cover from listing image', {
+    logger.info('Stored city cover from Wikimedia', {
       cityId: String(city._id),
-      imageId: String(imageId),
+      imageId: String(image._id),
+      sourceUrl: imageUrl,
     });
   } catch (error) {
     logger.error('Failed to ensure city cover', error);
   }
 }
 
-/** Backfill covers for active cities that have listings but no cover yet. */
-export async function syncMissingCovers(options: { limit?: number } = {}): Promise<number> {
-  const limit = options.limit ?? 50;
-  const cities = await City.find({
-    isActive: true,
-    propertiesCount: { $gt: 0 },
-    $or: [{ coverImageId: { $exists: false } }, { coverImageId: null }],
-  })
-    .select('_id')
-    .limit(limit)
-    .lean();
+async function findCitiesNeedingCoverSync(
+  limit: number,
+  forceReplaceListingCovers: boolean,
+): Promise<Array<{ _id: Types.ObjectId }>> {
+  if (!forceReplaceListingCovers) {
+    return City.find({
+      isActive: true,
+      propertiesCount: { $gt: 0 },
+      $or: [{ coverImageId: { $exists: false } }, { coverImageId: null }],
+    })
+      .select('_id')
+      .limit(limit)
+      .lean();
+  }
 
-  for (const city of cities) {
-    await ensureCover(city._id);
+  return City.aggregate([
+    { $match: { isActive: true, propertiesCount: { $gt: 0 } } },
+    {
+      $lookup: {
+        from: 'images',
+        localField: 'coverImageId',
+        foreignField: '_id',
+        as: 'coverImage',
+      },
+    },
+    {
+      $match: {
+        $or: [
+          { coverImageId: { $exists: false } },
+          { coverImageId: null },
+          { coverImage: { $size: 0 } },
+          { 'coverImage.0.entityType': { $ne: 'city' } },
+        ],
+      },
+    },
+    { $project: { _id: 1 } },
+    { $limit: limit },
+  ]);
+}
+
+/** Backfill missing covers and optionally replace listing-linked covers. */
+export async function syncCovers(options: SyncCoversOptions = {}): Promise<number> {
+  const limit = options.limit ?? 50;
+  const forceReplaceListingCovers = options.forceReplaceListingCovers === true;
+  const cities = await findCitiesNeedingCoverSync(limit, forceReplaceListingCovers);
+
+  for (let index = 0; index < cities.length; index += 1) {
+    await ensureCover(cities[index]._id);
+    if (index < cities.length - 1) {
+      await sleep(BATCH_DELAY_MS);
+    }
   }
 
   return cities.length;
+}
+
+/** Backward-compatible alias for cron callers that still import syncMissingCovers. */
+export async function syncMissingCovers(options: { limit?: number } = {}): Promise<number> {
+  return syncCovers({ ...options, forceReplaceListingCovers: true });
 }

--- a/packages/backend/services/cron.ts
+++ b/packages/backend/services/cron.ts
@@ -3,7 +3,7 @@ import { Logger } from '../utils/logger';
 import { HealthService } from './healthService';
 import { CleanupService } from './cleanupService';
 import { MetricsService } from '../utils/metrics';
-import { syncMissingCovers } from './cityCoverSyncService';
+import { syncCovers } from './cityCoverSyncService';
 
 // Initialize services
 const logger = new Logger('CronService');
@@ -89,7 +89,7 @@ class CronJobManager {
   }
 
   /**
-   * Backfill city cover images from listing photos
+   * Backfill city cover images from Wikimedia Commons and replace listing-linked covers.
    */
   private async runCityCoverSync(): Promise<void> {
     const status = this.jobStatus.get('cityCovers');
@@ -99,7 +99,7 @@ class CronJobManager {
     }
 
     try {
-      const processed = await syncMissingCovers({ limit: 50 });
+      const processed = await syncCovers({ limit: 50, forceReplaceListingCovers: true });
       this.logger.info('City cover sync completed', { processed });
     } catch (error) {
       this.logger.error('City cover sync failed', error);

--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -105,11 +105,9 @@ export class IngestionService {
       imageCount = refs.length;
     }
 
-    if (imageCount > 0) {
-      const address = await Address.findById(property.addressId).select('cityId').lean();
-      if (address?.cityId) {
-        void ensureCover(address.cityId);
-      }
+    const address = await Address.findById(property.addressId).select('cityId').lean();
+    if (address?.cityId) {
+      void ensureCover(address.cityId);
     }
 
     const result: IngestResult = {


### PR DESCRIPTION
## Summary
- Replace listing-photo city covers with Wikimedia Commons cityscape fetch + first-party S3 storage (`entityType: 'city'`).
- `ensureCover` skips valid city-owned covers; replaces property-linked covers; supports `{ force: true }`.
- Hourly cron runs `syncCovers({ forceReplaceListingCovers: true })` to backfill missing covers and replace existing listing-linked ones.
- Ingest still triggers `ensureCover` after upsert (no longer gated on listing `imageCount`).

## Test plan
- [x] `jest __tests__/unit/cityCoverSync.test.ts -t cityCoverSyncService` — 8/8 pass (mocked Wikimedia + image upload)
- [ ] Verify hourly cron processes property-linked covers in staging/prod over subsequent runs


Made with [Cursor](https://cursor.com)