### PR TITLE
Remove provider-specific city allowlists that bypass market env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,11 +215,13 @@ Convenience path when you do not own a page: `runtime.openBrowserSession(options
 | `parse/nextData.ts` | `__NEXT_DATA__` / `__PAGE_MODEL__` / `__PRELOADED_STATE__` |
 | `parse/contact.ts` | phone/email/whatsapp → `NormalizedListing.contact` |
 | `parse/classifieds.ts` | housing category allowlist + `assertHousingListing` |
-| `parse/cities.ts` | `LISTING_*_CITIES` env city lists |
+| `parse/cities.ts` | `LISTING_*_CITIES` env city lists + `providerCitiesFromEnv()` |
 | `parse/price.ts` + `parse/listing.ts` | monthly/sale price sanity + ingest validation |
 | `session.ts` / `browserSession.ts` | Idealista-like warm + AJAX |
 
 Root shims (`contact.ts`, `classifieds.ts`, `jsonLd.ts`, `nextData.ts`, `cities.ts`) re-export `parse/` for short imports — prefer `parse/` for new code. Portal-specific AJAX URL builders stay under `providers/<name>/`.
+
+**Discover city lists (CRITICAL):** use `citiesFromEnv(market)` / `DEFAULT_MARKET_CITIES` — never hardcode a tiny per-provider city allowlist that bypasses `LISTING_<MARKET>_CITIES` and silently excludes metros. Optional per-provider narrowing: `providerCitiesFromEnv('LISTING_<PROVIDER>_CITIES', market)` (falls back to the market list). Browser-heavy ES portals enqueue **one discover job per city** in `worker.ts`; queue fairness is handled there, not by shrinking defaults.
 
 ### General classifieds portals (CRITICAL)
 

--- a/packages/backend/__tests__/unit/listingCitiesAndDiscoverLimits.test.ts
+++ b/packages/backend/__tests__/unit/listingCitiesAndDiscoverLimits.test.ts
@@ -6,7 +6,6 @@ import {
   citiesFromEnv,
   citiesOptionsFromEnv,
   DEFAULT_MARKET_CITIES,
-  FOTOCASA_DEFAULT_CITIES,
   fotocasaCitiesFromEnv,
   MAX_PAGES_CEILING,
   maxSearchPagesFromEnv,
@@ -66,12 +65,18 @@ describe('fotocasaCitiesFromEnv', () => {
     expect(fotocasaCitiesFromEnv()).toEqual(['madrid', 'barcelona']);
   });
 
-  it('falls back to Fotocasa defaults, not the full ES market list', () => {
+  it('falls back to the ES market list when provider env is unset', () => {
     delete process.env.LISTING_FOTOCASA_CITIES;
-    process.env.LISTING_ES_CITIES = 'madrid,barcelona,valencia,sevilla,malaga,bilbao,zaragoza,alicante,murcia,palma,las-palmas-de-gran-canaria';
+    delete process.env.LISTING_ES_CITIES;
     const cities = fotocasaCitiesFromEnv();
-    expect(cities).toEqual([...FOTOCASA_DEFAULT_CITIES]);
-    expect(cities.length).toBe(3);
+    expect(cities).toEqual([...DEFAULT_MARKET_CITIES.ES]);
+    expect(cities.length).toBeGreaterThan(10);
+  });
+
+  it('uses LISTING_ES_CITIES when provider env is unset but market env is set', () => {
+    delete process.env.LISTING_FOTOCASA_CITIES;
+    process.env.LISTING_ES_CITIES = 'madrid,barcelona,valencia';
+    expect(fotocasaCitiesFromEnv()).toEqual(['madrid', 'barcelona', 'valencia']);
   });
 });
 
@@ -82,11 +87,11 @@ describe('habitacliaCitiesFromEnv', () => {
     expect(habitacliaCitiesFromEnv()).toEqual(['madrid', 'barcelona']);
   });
 
-  it('defaults to madrid only', () => {
+  it('falls back to the ES market list', () => {
     delete process.env.LISTING_HABITACLIA_CITIES;
-    process.env.LISTING_ES_CITIES = 'madrid,barcelona,valencia,sevilla';
-    const { habitacliaCitiesFromEnv, HABITACLIA_DEFAULT_CITIES } = require('@homiio/listing-providers');
-    expect(habitacliaCitiesFromEnv()).toEqual([...HABITACLIA_DEFAULT_CITIES]);
+    delete process.env.LISTING_ES_CITIES;
+    const { habitacliaCitiesFromEnv } = require('@homiio/listing-providers');
+    expect(habitacliaCitiesFromEnv()).toEqual([...DEFAULT_MARKET_CITIES.ES]);
   });
 });
 
@@ -97,12 +102,12 @@ describe('pisosCitiesFromEnv', () => {
     expect(pisosCitiesFromEnv()).toEqual(['madrid', 'barcelona']);
   });
 
-  it('falls back to Pisos defaults, not the full ES market list', () => {
+  it('falls back to the ES market list', () => {
     delete process.env.LISTING_PISOS_CITIES;
-    process.env.LISTING_ES_CITIES = 'madrid,barcelona,valencia,sevilla,malaga,bilbao,zaragoza,alicante,murcia,palma,las-palmas-de-gran-canaria';
-    const { pisosCitiesFromEnv, PISOS_DEFAULT_CITIES } = require('@homiio/listing-providers');
-    expect(pisosCitiesFromEnv()).toEqual([...PISOS_DEFAULT_CITIES]);
-    expect(pisosCitiesFromEnv().length).toBe(10);
+    delete process.env.LISTING_ES_CITIES;
+    const { pisosCitiesFromEnv } = require('@homiio/listing-providers');
+    expect(pisosCitiesFromEnv()).toEqual([...DEFAULT_MARKET_CITIES.ES]);
+    expect(pisosCitiesFromEnv().length).toBeGreaterThan(10);
   });
 });
 
@@ -113,10 +118,11 @@ describe('idealistaCitiesFromEnv', () => {
     expect(idealistaCitiesFromEnv()).toEqual(['madrid']);
   });
 
-  it('defaults to madrid only', () => {
+  it('falls back to the ES market list', () => {
     delete process.env.LISTING_IDEALISTA_CITIES;
-    const { idealistaCitiesFromEnv, IDEALISTA_DEFAULT_CITIES } = require('@homiio/listing-providers');
-    expect(idealistaCitiesFromEnv()).toEqual([...IDEALISTA_DEFAULT_CITIES]);
+    delete process.env.LISTING_ES_CITIES;
+    const { idealistaCitiesFromEnv } = require('@homiio/listing-providers');
+    expect(idealistaCitiesFromEnv()).toEqual([...DEFAULT_MARKET_CITIES.ES]);
   });
 });
 

--- a/packages/listing-providers/src/cities.ts
+++ b/packages/listing-providers/src/cities.ts
@@ -4,6 +4,8 @@
 export {
   citiesFromEnv,
   citiesOptionsFromEnv,
+  providerCitiesFromEnv,
+  providerCitiesOptionsFromEnv,
   type ListingMarket,
 } from './parse/cities';
 export { DEFAULT_MARKET_CITIES } from './parse/defaultMarketCities';

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -60,7 +60,6 @@ export type { FixtureRawListing, FixtureRawImage } from './providers/fixture/fix
 
 export { HabitacliaProvider } from './providers/habitaclia';
 export {
-  HABITACLIA_DEFAULT_CITIES,
   habitacliaCitiesFromEnv,
   habitacliaCitiesOptionsFromEnv,
 } from './providers/habitaclia/cities';
@@ -110,7 +109,6 @@ export type {
 
 export { IdealistaProvider, isIdealistaChallenge, idealistaSourceIdFromUrl } from './providers/idealista';
 export {
-  IDEALISTA_DEFAULT_CITIES,
   idealistaCitiesFromEnv,
   idealistaCitiesOptionsFromEnv,
 } from './providers/idealista/cities';
@@ -145,7 +143,6 @@ export {
 
 export { FotocasaProvider, isFotocasaChallenge, fotocasaSourceIdFromUrl } from './providers/fotocasa';
 export {
-  FOTOCASA_DEFAULT_CITIES,
   fotocasaCitiesFromEnv,
   fotocasaCitiesOptionsFromEnv,
 } from './providers/fotocasa/cities';
@@ -456,7 +453,6 @@ export {
 // ES — pisos.com (JSON-LD + embedded detail JSON), feature-flagged OFF by default.
 export { PisosProvider, isPisosChallenge, pisosSourceIdFromUrl } from './providers/pisos';
 export {
-  PISOS_DEFAULT_CITIES,
   pisosCitiesFromEnv,
   pisosCitiesOptionsFromEnv,
 } from './providers/pisos/cities';
@@ -711,7 +707,13 @@ export {
   findJsonLdByType,
 } from './jsonLd';
 export { citySlug } from './slug';
-export { citiesFromEnv, citiesOptionsFromEnv, DEFAULT_MARKET_CITIES } from './cities';
+export {
+  citiesFromEnv,
+  citiesOptionsFromEnv,
+  providerCitiesFromEnv,
+  providerCitiesOptionsFromEnv,
+  DEFAULT_MARKET_CITIES,
+} from './cities';
 export {
   MAX_PAGES_CEILING,
   maxSearchPagesFromEnv,

--- a/packages/listing-providers/src/parse/cities.ts
+++ b/packages/listing-providers/src/parse/cities.ts
@@ -90,3 +90,22 @@ export function citiesFromEnv(market: ListingMarket): string[] {
 export function citiesOptionsFromEnv(market: ListingMarket): { cities: string[] } {
   return { cities: citiesFromEnv(market) };
 }
+
+/**
+ * Discover cities for one provider: optional `LISTING_<PROVIDER>_CITIES` override,
+ * otherwise the market list from `LISTING_<MARKET>_CITIES` / bundled defaults.
+ */
+export function providerCitiesFromEnv(providerEnvKey: string, market: ListingMarket): string[] {
+  const envRaw = process.env[providerEnvKey];
+  const envCities = market === 'US' ? parseUsCityList(envRaw) : parseCityList(envRaw);
+  if (envCities.length > 0) return envCities;
+  return citiesFromEnv(market);
+}
+
+/** Provider options with optional per-provider city override. */
+export function providerCitiesOptionsFromEnv(
+  providerEnvKey: string,
+  market: ListingMarket,
+): { cities: string[] } {
+  return { cities: providerCitiesFromEnv(providerEnvKey, market) };
+}

--- a/packages/listing-providers/src/providers/fotocasa/cities.ts
+++ b/packages/listing-providers/src/providers/fotocasa/cities.ts
@@ -1,34 +1,17 @@
 /**
- * Fotocasa discover city scope.
- *
- * Fotocasa discover warms a Playwright session per city — using the full
- * `LISTING_ES_CITIES` list (~70 metros) makes a single discover job run for
- * hours before any fetch jobs enqueue. This module keeps Fotocasa on a smaller
- * default set with an optional `LISTING_FOTOCASA_CITIES` override.
+ * Fotocasa discover city scope — `LISTING_FOTOCASA_CITIES` override, else `LISTING_ES_CITIES`.
  */
 
-/** Default metros for Fotocasa browser discover (not the full ES market list). */
-export const FOTOCASA_DEFAULT_CITIES: readonly string[] = [
-  'madrid',
-  'barcelona',
-  'valencia',
-];
+import { providerCitiesFromEnv, providerCitiesOptionsFromEnv } from '../../parse/cities';
 
-function parseCityList(raw: string | undefined): string[] {
-  return (raw ?? '')
-    .split(',')
-    .map((city) => city.trim())
-    .filter(Boolean);
-}
+const PROVIDER_CITIES_ENV = 'LISTING_FOTOCASA_CITIES';
 
-/** Cities for Fotocasa discover: `LISTING_FOTOCASA_CITIES` or {@link FOTOCASA_DEFAULT_CITIES}. */
+/** Cities for Fotocasa discover: `LISTING_FOTOCASA_CITIES` or the ES market list. */
 export function fotocasaCitiesFromEnv(): string[] {
-  const envCities = parseCityList(process.env.LISTING_FOTOCASA_CITIES);
-  if (envCities.length > 0) return envCities;
-  return [...FOTOCASA_DEFAULT_CITIES];
+  return providerCitiesFromEnv(PROVIDER_CITIES_ENV, 'ES');
 }
 
-/** Provider options with the Fotocasa-specific city list. */
+/** Provider options with the Fotocasa city list. */
 export function fotocasaCitiesOptionsFromEnv(): { cities: readonly string[] } {
-  return { cities: fotocasaCitiesFromEnv() };
+  return providerCitiesOptionsFromEnv(PROVIDER_CITIES_ENV, 'ES');
 }

--- a/packages/listing-providers/src/providers/fotocasa/index.ts
+++ b/packages/listing-providers/src/providers/fotocasa/index.ts
@@ -56,9 +56,9 @@ import {
   readFotocasaSearchCardHint,
   type FotocasaBrowserSessionHint,
 } from './sessionHints';
-import { FOTOCASA_DEFAULT_CITIES, fotocasaCitiesFromEnv } from './cities';
+import { fotocasaCitiesFromEnv } from './cities';
 
-export { FOTOCASA_DEFAULT_CITIES, fotocasaCitiesFromEnv, fotocasaCitiesOptionsFromEnv } from './cities';
+export { fotocasaCitiesFromEnv, fotocasaCitiesOptionsFromEnv } from './cities';
 
 const PROVIDER_ID: ProviderId = 'fotocasa';
 const ES_PROXY_COUNTRY = 'es';
@@ -180,7 +180,7 @@ export class FotocasaProvider implements ListingProvider {
 
   constructor(options: FotocasaProviderOptions = {}) {
     this.runtime = options.runtime ?? createFetchRuntime();
-    this.cities = options.cities && options.cities.length > 0 ? options.cities : FOTOCASA_DEFAULT_CITIES;
+    this.cities = options.cities && options.cities.length > 0 ? options.cities : fotocasaCitiesFromEnv();
     this.metrics = options.metrics ?? defaultProviderMetrics;
     this.maxSearchPages = providerMaxSearchPages(PROVIDER_ID, DEFAULT_MAX_SEARCH_PAGES, 'ES');
     this.transactionTypes = resolveTransactionTypes();

--- a/packages/listing-providers/src/providers/habitaclia/cities.ts
+++ b/packages/listing-providers/src/providers/habitaclia/cities.ts
@@ -1,29 +1,17 @@
 /**
- * Habitaclia discover city scope.
- *
- * Browser + listainmuebles discover warms a session per city. The full
- * `LISTING_ES_CITIES` list (~70 metros) in one discover job blocks the
- * single-concurrency queue for hours. Default to Madrid until coverage is broad.
+ * Habitaclia discover city scope — `LISTING_HABITACLIA_CITIES` override, else `LISTING_ES_CITIES`.
  */
 
-/** Default metros for Habitaclia browser discover. */
-export const HABITACLIA_DEFAULT_CITIES: readonly string[] = ['madrid'];
+import { providerCitiesFromEnv, providerCitiesOptionsFromEnv } from '../../parse/cities';
 
-function parseCityList(raw: string | undefined): string[] {
-  return (raw ?? '')
-    .split(',')
-    .map((city) => city.trim())
-    .filter(Boolean);
-}
+const PROVIDER_CITIES_ENV = 'LISTING_HABITACLIA_CITIES';
 
-/** Cities for Habitaclia discover: `LISTING_HABITACLIA_CITIES` or {@link HABITACLIA_DEFAULT_CITIES}. */
+/** Cities for Habitaclia discover: `LISTING_HABITACLIA_CITIES` or the ES market list. */
 export function habitacliaCitiesFromEnv(): string[] {
-  const envCities = parseCityList(process.env.LISTING_HABITACLIA_CITIES);
-  if (envCities.length > 0) return envCities;
-  return [...HABITACLIA_DEFAULT_CITIES];
+  return providerCitiesFromEnv(PROVIDER_CITIES_ENV, 'ES');
 }
 
-/** Provider options with the Habitaclia-specific city list. */
+/** Provider options with the Habitaclia city list. */
 export function habitacliaCitiesOptionsFromEnv(): { cities: readonly string[] } {
-  return { cities: habitacliaCitiesFromEnv() };
+  return providerCitiesOptionsFromEnv(PROVIDER_CITIES_ENV, 'ES');
 }

--- a/packages/listing-providers/src/providers/habitaclia/index.ts
+++ b/packages/listing-providers/src/providers/habitaclia/index.ts
@@ -40,6 +40,7 @@ import {
   isHabitacliaListainmueblesChallenge,
   parseHabitacliaListainmuebles,
 } from './listainmuebles';
+import { habitacliaCitiesFromEnv } from './cities';
 
 const PROVIDER_ID: ProviderId = 'habitaclia';
 const ES_PROXY_COUNTRY = 'es';
@@ -51,18 +52,6 @@ export function isHabitacliaChallenge(html: string): boolean {
   );
 }
 
-const DEFAULT_CITIES: readonly string[] = [
-  'barcelona',
-  'madrid',
-  'valencia',
-  'sevilla',
-  'malaga',
-  'bilbao',
-  'zaragoza',
-  'alicante',
-  'murcia',
-  'palma',
-];
 const DEFAULT_MAX_SEARCH_PAGES = 50;
 const LISTAINMUEBLES_POST_TIMEOUT_MS = 45_000;
 const HABITACLIA_HTTP_SEARCH_TIMEOUT_MS = 90_000;
@@ -130,7 +119,7 @@ export class HabitacliaProvider implements ListingProvider {
 
   constructor(options: HabitacliaProviderOptions = {}) {
     this.runtime = options.runtime ?? createFetchRuntime();
-    this.cities = options.cities && options.cities.length > 0 ? options.cities : DEFAULT_CITIES;
+    this.cities = options.cities && options.cities.length > 0 ? options.cities : habitacliaCitiesFromEnv();
     this.metrics = options.metrics ?? defaultProviderMetrics;
     this.maxSearchPages = providerMaxSearchPages(PROVIDER_ID, DEFAULT_MAX_SEARCH_PAGES, 'ES');
   }

--- a/packages/listing-providers/src/providers/idealista/cities.ts
+++ b/packages/listing-providers/src/providers/idealista/cities.ts
@@ -1,28 +1,17 @@
 /**
- * Idealista discover city scope.
- *
- * Georeach discover warms a DataDome session per city. A market-wide job over
- * the full ES city list blocks the worker queue for hours. Default to Madrid.
+ * Idealista discover city scope — `LISTING_IDEALISTA_CITIES` override, else `LISTING_ES_CITIES`.
  */
 
-/** Default metros for Idealista browser discover. */
-export const IDEALISTA_DEFAULT_CITIES: readonly string[] = ['madrid'];
+import { providerCitiesFromEnv, providerCitiesOptionsFromEnv } from '../../parse/cities';
 
-function parseCityList(raw: string | undefined): string[] {
-  return (raw ?? '')
-    .split(',')
-    .map((city) => city.trim())
-    .filter(Boolean);
-}
+const PROVIDER_CITIES_ENV = 'LISTING_IDEALISTA_CITIES';
 
-/** Cities for Idealista discover: `LISTING_IDEALISTA_CITIES` or {@link IDEALISTA_DEFAULT_CITIES}. */
+/** Cities for Idealista discover: `LISTING_IDEALISTA_CITIES` or the ES market list. */
 export function idealistaCitiesFromEnv(): string[] {
-  const envCities = parseCityList(process.env.LISTING_IDEALISTA_CITIES);
-  if (envCities.length > 0) return envCities;
-  return [...IDEALISTA_DEFAULT_CITIES];
+  return providerCitiesFromEnv(PROVIDER_CITIES_ENV, 'ES');
 }
 
-/** Provider options with the Idealista-specific city list. */
+/** Provider options with the Idealista city list. */
 export function idealistaCitiesOptionsFromEnv(): { cities: readonly string[] } {
-  return { cities: idealistaCitiesFromEnv() };
+  return providerCitiesOptionsFromEnv(PROVIDER_CITIES_ENV, 'ES');
 }

--- a/packages/listing-providers/src/providers/idealista/index.ts
+++ b/packages/listing-providers/src/providers/idealista/index.ts
@@ -60,23 +60,10 @@ import {
   parseIdealistaGeoreach,
 } from './georeach';
 import { idealistaSourceIdFromUrl, parseIdealistaDetail, parseIdealistaSearch, type IdealistaRaw } from './parse';
+import { idealistaCitiesFromEnv } from './cities';
 
 const ES_PROXY_COUNTRY = 'es';
 const PROVIDER_ID: ProviderId = 'idealista';
-
-/** ES cities enumerated when a discover job carries no explicit `city`. */
-const DEFAULT_CITIES: readonly string[] = [
-  'madrid',
-  'barcelona',
-  'valencia',
-  'sevilla',
-  'malaga',
-  'bilbao',
-  'zaragoza',
-  'alicante',
-  'murcia',
-  'palma',
-];
 
 const DEFAULT_MAX_SEARCH_PAGES = 50;
 
@@ -191,7 +178,7 @@ export class IdealistaProvider implements ListingProvider {
 
   constructor(options: IdealistaProviderOptions = {}) {
     this.runtime = options.runtime ?? createFetchRuntime();
-    this.cities = options.cities && options.cities.length > 0 ? options.cities : DEFAULT_CITIES;
+    this.cities = options.cities && options.cities.length > 0 ? options.cities : idealistaCitiesFromEnv();
     this.metrics = options.metrics ?? defaultProviderMetrics;
     this.maxSearchPages = providerMaxSearchPages(PROVIDER_ID, DEFAULT_MAX_SEARCH_PAGES, 'ES');
   }

--- a/packages/listing-providers/src/providers/pisos/cities.ts
+++ b/packages/listing-providers/src/providers/pisos/cities.ts
@@ -1,41 +1,17 @@
 /**
- * Pisos discover city scope.
- *
- * Pisos discover can warm a browser session per city and paginate deeply. A
- * single market-wide job over the full `LISTING_ES_CITIES` list blocks the
- * single-concurrency discover worker for hours before Fotocasa/Habitaclia jobs
- * run. Keep Pisos on its own default metros with `LISTING_PISOS_CITIES`.
+ * Pisos discover city scope — `LISTING_PISOS_CITIES` override, else `LISTING_ES_CITIES`.
  */
 
-/** Default metros for Pisos discover (matches the provider's historical scope). */
-export const PISOS_DEFAULT_CITIES: readonly string[] = [
-  'madrid',
-  'barcelona',
-  'valencia',
-  'sevilla',
-  'malaga',
-  'bilbao',
-  'zaragoza',
-  'alicante',
-  'murcia',
-  'palma',
-];
+import { providerCitiesFromEnv, providerCitiesOptionsFromEnv } from '../../parse/cities';
 
-function parseCityList(raw: string | undefined): string[] {
-  return (raw ?? '')
-    .split(',')
-    .map((city) => city.trim())
-    .filter(Boolean);
-}
+const PROVIDER_CITIES_ENV = 'LISTING_PISOS_CITIES';
 
-/** Cities for Pisos discover: `LISTING_PISOS_CITIES` or {@link PISOS_DEFAULT_CITIES}. */
+/** Cities for Pisos discover: `LISTING_PISOS_CITIES` or the ES market list. */
 export function pisosCitiesFromEnv(): string[] {
-  const envCities = parseCityList(process.env.LISTING_PISOS_CITIES);
-  if (envCities.length > 0) return envCities;
-  return [...PISOS_DEFAULT_CITIES];
+  return providerCitiesFromEnv(PROVIDER_CITIES_ENV, 'ES');
 }
 
-/** Provider options with the Pisos-specific city list. */
+/** Provider options with the Pisos city list. */
 export function pisosCitiesOptionsFromEnv(): { cities: readonly string[] } {
-  return { cities: pisosCitiesFromEnv() };
+  return providerCitiesOptionsFromEnv(PROVIDER_CITIES_ENV, 'ES');
 }

--- a/packages/listing-providers/src/providers/pisos/index.ts
+++ b/packages/listing-providers/src/providers/pisos/index.ts
@@ -49,9 +49,9 @@ import {
   type PisosBrowserSessionHint,
 } from './sessionHints';
 
-import { PISOS_DEFAULT_CITIES } from './cities';
+import { pisosCitiesFromEnv } from './cities';
 
-export { PISOS_DEFAULT_CITIES, pisosCitiesFromEnv, pisosCitiesOptionsFromEnv } from './cities';
+export { pisosCitiesFromEnv, pisosCitiesOptionsFromEnv } from './cities';
 
 const PROVIDER_ID: ProviderId = 'pisos';
 const ES_PROXY_COUNTRY = 'es';
@@ -126,7 +126,7 @@ export class PisosProvider implements ListingProvider {
 
   constructor(options: PisosProviderOptions = {}) {
     this.runtime = options.runtime ?? createFetchRuntime();
-    this.cities = options.cities && options.cities.length > 0 ? options.cities : PISOS_DEFAULT_CITIES;
+    this.cities = options.cities && options.cities.length > 0 ? options.cities : pisosCitiesFromEnv();
     this.metrics = options.metrics ?? defaultProviderMetrics;
     this.maxSearchPages = providerMaxSearchPages(PROVIDER_ID, DEFAULT_MAX_SEARCH_PAGES, 'ES');
   }


### PR DESCRIPTION
## Summary
- Remove `PISOS_DEFAULT_CITIES`, `FOTOCASA_DEFAULT_CITIES`, `HABITACLIA_DEFAULT_CITIES`, and `IDEALISTA_DEFAULT_CITIES` — they were tiny hardcoded ES lists that silently excluded metros when `LISTING_ES_CITIES` was set.
- Add shared `providerCitiesFromEnv()` so per-provider env overrides (`LISTING_PISOS_CITIES`, etc.) fall back to the market list (`LISTING_ES_CITIES` / `DEFAULT_MARKET_CITIES`).
- Document the rule in AGENTS.md: queue fairness is per-city job splitting in the worker, not shrunk defaults.

## Test plan
- [x] `bun test packages/backend/__tests__/unit/listingCitiesAndDiscoverLimits.test.ts` (18 pass)
- [x] `bun run build`


Made with [Cursor](https://cursor.com)