### PR TITLE
fix(home): center hero image crop with expo-image

### DIFF
--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -23,13 +23,8 @@
  * grids) does NOT live on the home page — it belongs on /about.
  */
 import React, { useState } from 'react';
-import {
-  View,
-  RefreshControl,
-  Image,
-  Pressable,
-  useWindowDimensions,
-} from 'react-native';
+import { View, RefreshControl, Pressable, useWindowDimensions } from 'react-native';
+import { Image } from 'expo-image';
 import { useQueryClient } from '@tanstack/react-query';
 import { Menu } from 'lucide-react-native';
 import Animated, {
@@ -273,8 +268,9 @@ export default function HomePage() {
           >
             <Image
               source={require('@/assets/images/hero.jpg')}
-              className="h-full w-full"
-              resizeMode="cover"
+              className="h-full w-full object-cover object-center"
+              contentFit="cover"
+              contentPosition="center"
             />
           </Animated.View>
 


### PR DESCRIPTION
## Summary
- Switch home hero from React Native `Image` to `expo-image` with `contentFit="cover"` and `contentPosition="center"` so the crop stays centered across breakpoints.

## Test plan
- [ ] Open home on web at narrow and wide widths — hero photo stays centered, not top-cropped
- [ ] Verify parallax scroll still works on the hero
- [ ] Smoke-check home on iOS/Android


Made with [Cursor](https://cursor.com)