### PR TITLE
fix(geo): city coords + Wikimedia cover backfill

### DIFF
--- a/packages/backend/__tests__/unit/asCoordinate.test.ts
+++ b/packages/backend/__tests__/unit/asCoordinate.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Regression: EU price-style number parsing must NOT be used for lat/lng.
+ * "43.541" must stay 43.541 (Barreiros), not become 43541.
+ */
+
+import { asCoordinate, asNumberEu } from '@homiio/listing-providers';
+
+describe('asCoordinate (listing-providers)', () => {
+  it('keeps decimal degrees', () => {
+    expect(asCoordinate('43.541')).toBe(43.541);
+    expect(asCoordinate(43.541)).toBe(43.541);
+  });
+
+  it('accepts comma decimals', () => {
+    expect(asCoordinate('43,541')).toBe(43.541);
+  });
+
+  it('differs from asNumberEu which mangles three-digit groups', () => {
+    expect(asNumberEu('43.541')).toBe(43541);
+    expect(asCoordinate('43.541')).toBe(43.541);
+  });
+});

--- a/packages/backend/__tests__/unit/geoCoordinates.test.ts
+++ b/packages/backend/__tests__/unit/geoCoordinates.test.ts
@@ -1,0 +1,28 @@
+import {
+  isValidCoordinatePair,
+  sanitizeGeoJsonCoordinates,
+  sanitizeLatLngPair,
+  tryRepairCoordinate,
+} from '../../utils/geoCoordinates';
+
+describe('geoCoordinates', () => {
+  it('keeps valid lat/lng unchanged', () => {
+    expect(sanitizeLatLngPair(43.541, -7.294)).toEqual({ lat: 43.541, lng: -7.294 });
+    expect(isValidCoordinatePair(43.541, -7.294)).toBe(true);
+  });
+
+  it('repairs thousands-mangled Barreiros-style latitude', () => {
+    expect(tryRepairCoordinate(43541, 'lat')).toBe(43.541);
+    expect(sanitizeLatLngPair(43541, -7.294)).toEqual({ lat: 43.541, lng: -7.294 });
+  });
+
+  it('rejects irreparable values', () => {
+    expect(tryRepairCoordinate(999999, 'lat')).toBeUndefined();
+    expect(sanitizeLatLngPair(999999, -7.294)).toBeUndefined();
+  });
+
+  it('sanitizes GeoJSON [lng, lat] order', () => {
+    expect(sanitizeGeoJsonCoordinates([-7.294, 43541])).toEqual([-7.294, 43.541]);
+    expect(sanitizeGeoJsonCoordinates(undefined)).toBeUndefined();
+  });
+});

--- a/packages/backend/controllers/index.ts
+++ b/packages/backend/controllers/index.ts
@@ -3,6 +3,13 @@
  * Central export for all controller components
  */
 
+function resolveExport<T>(mod: T | { default: T }): T {
+  if (mod && typeof mod === 'object' && 'default' in mod && (mod as { default: T }).default) {
+    return (mod as { default: T }).default;
+  }
+  return mod as T;
+}
+
 const propertyController = require('./propertyController');
 const roomController = require('./roomController');
 const analyticsController = require('./analyticsController');
@@ -10,8 +17,8 @@ const notificationController = require('./notificationController');
 const leaseController = require('./leaseController');
 const profileController = require('./profileController');
 const telegramController = require('./telegramController');
-const cityController = require('./cityController');
-const imageController = require('./imageController');
+const cityController = resolveExport(require('./cityController'));
+const imageController = resolveExport(require('./imageController'));
 const billingController = require('./billingController');
 
 module.exports = {

--- a/packages/backend/services/cityCoordinateRepairService.ts
+++ b/packages/backend/services/cityCoordinateRepairService.ts
@@ -1,0 +1,68 @@
+/**
+ * One-shot / boot repair for City rows whose lat/lng were mangled by EU
+ * thousands-separator parsing (e.g. Barreiros lat 43541 → 43.541).
+ */
+
+import { City } from '../models';
+import { sanitizeLatLngPair } from '../utils/geoCoordinates';
+import { Logger } from '../utils/logger';
+
+const logger = new Logger('CityCoordinateRepair');
+
+type CityCoordsLean = {
+  _id: unknown;
+  name: string;
+  coordinates?: { lat?: number; lng?: number };
+};
+
+/**
+ * Find cities with out-of-range coordinates and repair when /1000 recovers a
+ * valid pair. Returns the number of cities updated.
+ */
+export async function repairCorruptCityCoordinates(limit = 200): Promise<number> {
+  const corrupt = await City.find({
+    $or: [
+      { 'coordinates.lat': { $gt: 90 } },
+      { 'coordinates.lat': { $lt: -90 } },
+      { 'coordinates.lng': { $gt: 180 } },
+      { 'coordinates.lng': { $lt: -180 } },
+    ],
+  })
+    .select('_id name coordinates')
+    .limit(limit)
+    .lean<CityCoordsLean[]>();
+
+  let repaired = 0;
+  for (const city of corrupt) {
+    const lat = city.coordinates?.lat;
+    const lng = city.coordinates?.lng;
+    if (typeof lat !== 'number' || typeof lng !== 'number') continue;
+
+    const pair = sanitizeLatLngPair(lat, lng);
+    if (!pair) {
+      logger.warn('Could not repair city coordinates', {
+        cityId: String(city._id),
+        name: city.name,
+        lat,
+        lng,
+      });
+      continue;
+    }
+
+    if (pair.lat === lat && pair.lng === lng) continue;
+
+    await City.updateOne(
+      { _id: city._id },
+      { $set: { 'coordinates.lat': pair.lat, 'coordinates.lng': pair.lng } },
+    );
+    repaired += 1;
+    logger.info('Repaired city coordinates', {
+      cityId: String(city._id),
+      name: city.name,
+      from: { lat, lng },
+      to: pair,
+    });
+  }
+
+  return repaired;
+}

--- a/packages/backend/services/cron.ts
+++ b/packages/backend/services/cron.ts
@@ -4,6 +4,7 @@ import { HealthService } from './healthService';
 import { CleanupService } from './cleanupService';
 import { MetricsService } from '../utils/metrics';
 import { syncCovers } from './cityCoverSyncService';
+import { repairCorruptCityCoordinates } from './cityCoordinateRepairService';
 
 // Initialize services
 const logger = new Logger('CronService');
@@ -36,8 +37,26 @@ class CronJobManager {
     this.setupHealthCheckJob();
     this.setupCleanupJob();
     this.setupCityCoverSyncJob();
+    // Boot sweeps: repair mangled coords + start Wikimedia cover backfill
+    // without waiting for the top of the hour.
+    void this.runBootHousekeeping();
 
     this.logger.info('Cron jobs initialized (health + cleanup + city covers; scrape loop retired)');
+  }
+
+  private async runBootHousekeeping(): Promise<void> {
+    try {
+      const repaired = await repairCorruptCityCoordinates(200);
+      this.logger.info('Boot city coordinate repair completed', { repaired });
+    } catch (error) {
+      this.logger.error('Boot city coordinate repair failed', error);
+    }
+    try {
+      const processed = await syncCovers({ limit: 100, forceReplaceListingCovers: true });
+      this.logger.info('Boot city cover sync completed', { processed });
+    } catch (error) {
+      this.logger.error('Boot city cover sync failed', error);
+    }
   }
 
   /**
@@ -73,10 +92,11 @@ class CronJobManager {
   }
 
   /**
-   * Setup city cover sync job - runs every hour
+   * Setup city cover sync job — every 15 minutes while listing-linked covers
+   * are still being replaced by Wikimedia cityscapes.
    */
   private setupCityCoverSyncJob(): void {
-    const job = cron.schedule('0 * * * *', async () => {
+    const job = cron.schedule('*/15 * * * *', async () => {
       await this.runCityCoverSync();
     }, {
       timezone: 'UTC',

--- a/packages/backend/services/geoResolutionService.ts
+++ b/packages/backend/services/geoResolutionService.ts
@@ -24,6 +24,7 @@
 import type { Model, Types } from 'mongoose';
 import { reverseGeocode, forwardGeocode, type AddressData } from './geocodingService';
 import { countryNameToCode, countryCodeToName, defaultCurrencyForCountry } from '../utils/countryData';
+import { sanitizeGeoJsonCoordinates } from '../utils/geoCoordinates';
 
 /** Resolved geo id chain returned to callers (Address stores these). */
 export interface ResolvedGeo {
@@ -203,7 +204,10 @@ async function upsertCity(
     isActive: true,
   };
   if (coordinates) {
-    setOnInsert.coordinates = { lng: coordinates[0], lat: coordinates[1] };
+    const sanitized = sanitizeGeoJsonCoordinates(coordinates);
+    if (sanitized) {
+      setOnInsert.coordinates = { lng: sanitized[0], lat: sanitized[1] };
+    }
   }
   const doc = await City.findOneAndUpdate(
     { regionId, name },

--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -30,6 +30,7 @@ import { ensureCover } from '../cityCoverSyncService';
 import type { AddressCanonicalInput } from '../../models/Address';
 import { validateOfferings } from '../../models/schemas/offeringValidation';
 import { forwardGeocode, reverseGeocode } from '../geocodingService';
+import { sanitizeGeoJsonCoordinates } from '../utils/geoCoordinates';
 import { ExternalMediaIngest } from './ExternalMediaIngest';
 import { schedulePriceEthicsScore } from '../priceEthicsService';
 import { Logger } from '../../utils/logger';
@@ -163,6 +164,14 @@ export class IngestionService {
         postalCode = resolved.postalCode;
       }
     }
+
+    const sanitized = sanitizeGeoJsonCoordinates(coordinates);
+    if (!sanitized) {
+      throw new IngestionValidationError(
+        `Invalid coordinates for external listing address: lat=${coordinates[1]} lng=${coordinates[0]}`,
+      );
+    }
+    coordinates = sanitized;
 
     if (!postalCode) {
       const reversed = await reverseGeocode(coordinates[0], coordinates[1]);

--- a/packages/backend/utils/geoCoordinates.ts
+++ b/packages/backend/utils/geoCoordinates.ts
@@ -1,0 +1,65 @@
+/**
+ * Geographic coordinate validation and repair for the geo write path.
+ *
+ * Listing parsers historically used EU price-style number coercion on lat/lng,
+ * turning values like "43.541" into 43541. This module guards persistence.
+ */
+
+const LAT_MIN = -90;
+const LAT_MAX = 90;
+const LNG_MIN = -180;
+const LNG_MAX = 180;
+
+export function isValidLatitude(lat: number): boolean {
+  return Number.isFinite(lat) && lat >= LAT_MIN && lat <= LAT_MAX;
+}
+
+export function isValidLongitude(lng: number): boolean {
+  return Number.isFinite(lng) && lng >= LNG_MIN && lng <= LNG_MAX;
+}
+
+export function isValidCoordinatePair(lat: number, lng: number): boolean {
+  return isValidLatitude(lat) && isValidLongitude(lng);
+}
+
+/** Attempt to recover coords mangled by thousands-separator parsing (e.g. 43541 → 43.541). */
+export function tryRepairCoordinate(value: number, kind: 'lat' | 'lng'): number | undefined {
+  if (!Number.isFinite(value)) return undefined;
+  const max = kind === 'lat' ? LAT_MAX : LNG_MAX;
+  const min = kind === 'lat' ? LAT_MIN : LNG_MIN;
+  if (value >= min && value <= max) return value;
+
+  const scaled = value / 1000;
+  if (scaled >= min && scaled <= max) return scaled;
+
+  return undefined;
+}
+
+export function sanitizeLatLngPair(
+  lat: number,
+  lng: number,
+): { lat: number; lng: number } | undefined {
+  let repairedLat = tryRepairCoordinate(lat, 'lat');
+  let repairedLng = tryRepairCoordinate(lng, 'lng');
+
+  if (repairedLat === undefined || repairedLng === undefined) {
+    return undefined;
+  }
+
+  if (!isValidCoordinatePair(repairedLat, repairedLng)) {
+    return undefined;
+  }
+
+  return { lat: repairedLat, lng: repairedLng };
+}
+
+/** GeoJSON order: [longitude, latitude]. */
+export function sanitizeGeoJsonCoordinates(
+  coordinates: [number, number] | undefined,
+): [number, number] | undefined {
+  if (!coordinates) return undefined;
+  const [lng, lat] = coordinates;
+  const pair = sanitizeLatLngPair(lat, lng);
+  if (!pair) return undefined;
+  return [pair.lng, pair.lat];
+}

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -52,7 +52,7 @@ export {
   NonHousingListingError,
   type HousingSignalInput,
 } from './parse/classifieds';
-export { isRecord, asString, asNumberEu, asNumberUs, deaccent, firstString } from './parse/guards';
+export { isRecord, asString, asNumberEu, asNumberUs, asCoordinate, deaccent, firstString } from './parse/guards';
 
 export { FixtureProvider } from './providers/fixture';
 export { FIXTURE_LISTINGS } from './providers/fixture/fixtures';

--- a/packages/listing-providers/src/parse/guards.ts
+++ b/packages/listing-providers/src/parse/guards.ts
@@ -41,6 +41,25 @@ export function asNumberEu(value: unknown): number | undefined {
 /** Alias used by most EU portal parsers. */
 export const asNumber = asNumberEu;
 
+/**
+ * Parse a geographic latitude/longitude value. Unlike {@link asNumberEu}, never
+ * treats dot-separated digit groups as thousands separators — "43.541" must stay
+ * 43.541 (Barreiros), not 43541.
+ */
+export function asCoordinate(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const cleaned = value.trim().replace(/[^0-9.,+-]/g, '');
+    if (!cleaned) return undefined;
+    const normalized = cleaned.includes(',') && !cleaned.includes('.')
+      ? cleaned.replace(',', '.')
+      : cleaned;
+    const parsed = Number.parseFloat(normalized);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
 /** Coerce US-style numeric strings (e.g. "1,234 sqft") to a number. */
 export function asNumberUs(value: unknown): number | undefined {
   if (typeof value === 'number' && Number.isFinite(value)) return value;

--- a/packages/listing-providers/src/parse/jsonLd.ts
+++ b/packages/listing-providers/src/parse/jsonLd.ts
@@ -5,7 +5,7 @@
  * {@link SchemaOrgListing}. Portal markup changes are fixed here.
  */
 
-import { asNumberEu, asNumberUs, asString, deaccent, isRecord } from './guards';
+import { asCoordinate, asNumberEu, asNumberUs, asString, deaccent, isRecord } from './guards';
 
 const LD_JSON_TYPE = 'application/ld+json';
 
@@ -150,8 +150,8 @@ function readEurAddress(value: unknown, defaultCountryCode: string): EurSchemaLi
 
 function readCoordinates(value: unknown): EurSchemaListing['coordinates'] {
   if (!isRecord(value)) return undefined;
-  const lat = asNumberEu(value.latitude);
-  const lng = asNumberEu(value.longitude);
+  const lat = asCoordinate(value.latitude);
+  const lng = asCoordinate(value.longitude);
   if (lat === undefined || lng === undefined) return undefined;
   return { lat, lng };
 }
@@ -381,8 +381,8 @@ function readUsAddress(value: unknown): SchemaOrgListing['address'] {
 
 function readUsCoordinates(value: unknown): SchemaOrgListing['coordinates'] {
   if (!isRecord(value)) return undefined;
-  const lat = asNumberUs(value.latitude);
-  const lng = asNumberUs(value.longitude);
+  const lat = asCoordinate(value.latitude);
+  const lng = asCoordinate(value.longitude);
   if (lat === undefined || lng === undefined) return undefined;
   return { lat, lng };
 }

--- a/packages/listing-providers/src/parse/nextData.ts
+++ b/packages/listing-providers/src/parse/nextData.ts
@@ -4,7 +4,7 @@
  * Providers must not re-declare these regexes — import from here.
  */
 
-import { asNumberEu, asString, isRecord } from './guards';
+import { asCoordinate, asNumberEu, asString, isRecord } from './guards';
 import type { EurSchemaListing } from './jsonLd';
 
 function extractScriptBodyById(html: string, scriptId: string): string | undefined {
@@ -216,8 +216,8 @@ export function eurListingFromNextDataCandidate(
     : isRecord(location?.coordinates)
       ? location.coordinates
       : undefined;
-  const lat = asNumberEu(geo?.latitude) ?? asNumberEu(geo?.lat);
-  const lng = asNumberEu(geo?.longitude) ?? asNumberEu(geo?.lng) ?? asNumberEu(geo?.lon);
+  const lat = asCoordinate(geo?.latitude) ?? asCoordinate(geo?.lat);
+  const lng = asCoordinate(geo?.longitude) ?? asCoordinate(geo?.lng) ?? asCoordinate(geo?.lon);
   const business =
     asString(isRecord(record.offers) ? record.offers.businessFunction : undefined)?.toLowerCase() ??
     '';

--- a/packages/listing-providers/src/providers/fotocasa/property.ts
+++ b/packages/listing-providers/src/providers/fotocasa/property.ts
@@ -7,7 +7,7 @@
  */
 
 import type { EsSchemaListing } from '../../parse/jsonLd';
-import { asNumberEu, asString, isRecord } from '../../parse/guards';
+import { asCoordinate, asNumberEu, asString, isRecord } from '../../parse/guards';
 import {
   collectNestedImages,
   eurListingFromNextDataCandidate,
@@ -70,8 +70,8 @@ function fotocasaRecordToListing(
   const operation = resolveOperation(record, url);
   const addressNode = isRecord(record.address) ? record.address : undefined;
   const location = isRecord(record.location) ? record.location : undefined;
-  const lat = asNumberEu(location?.latitude);
-  const lng = asNumberEu(location?.longitude);
+  const lat = asCoordinate(location?.latitude);
+  const lng = asCoordinate(location?.longitude);
   const detailUrl =
     asString(record.detailUrl) ??
     asString(record.url) ??

--- a/packages/listing-providers/src/providers/habitaclia/parse.ts
+++ b/packages/listing-providers/src/providers/habitaclia/parse.ts
@@ -12,7 +12,7 @@
  */
 
 import { HABITACLIA_BASE_URL, type HabitacliaRawImage, type HabitacliaRawListing } from './fixtures';
-import { asNumber, asString } from '../../parse/guards';
+import { asCoordinate, asNumber, asString } from '../../parse/guards';
 
 /** Match every `<script type="application/ld+json">…</script>` block. */
 const JSON_LD_RE =
@@ -223,8 +223,8 @@ function parseHabitacliaDetailFromJsonLd(node: Record<string, unknown>, url: str
       postalCode: asString(address['postalCode']),
       country: countryValue && countryValue.length > 2 ? countryValue : undefined,
       countryCode: countryValue && countryValue.length === 2 ? countryValue.toUpperCase() : 'ES',
-      lat: geo ? asNumber(geo['latitude']) : undefined,
-      lng: geo ? asNumber(geo['longitude']) : undefined,
+      lat: geo ? asCoordinate(geo['latitude']) : undefined,
+      lng: geo ? asCoordinate(geo['longitude']) : undefined,
     },
     bedrooms: asNumber(node['numberOfRooms']),
     bathrooms: asNumber(node['numberOfBathroomsTotal']),

--- a/packages/listing-providers/src/providers/mx/lamudi/parse.ts
+++ b/packages/listing-providers/src/providers/mx/lamudi/parse.ts
@@ -9,7 +9,7 @@
 import type { NormalizedListingContact } from '@homiio/shared-types';
 import { buildContact, extractContactFromHtml, mergeContact } from '../../../contact';
 import { collectJsonLdNodes, jsonLdTypes } from '../../../jsonLd';
-import { asNumberEu, asString, isRecord } from '../../../parse/guards';
+import { asCoordinate, asNumberEu, asString, isRecord } from '../../../parse/guards';
 import { isCloudflareChallenge } from '../../../parse/challenge';
 import { LAMUDI_BASE_URL } from './fixtures';
 
@@ -133,8 +133,8 @@ function nodeToRaw(node: Record<string, unknown>): LamudiRawListing | undefined 
       city,
       region: asString(address?.addressRegion),
       countryCode: 'MX',
-      lat: asNumberEu(geo?.latitude),
-      lng: asNumberEu(geo?.longitude),
+      lat: asCoordinate(geo?.latitude),
+      lng: asCoordinate(geo?.longitude),
     },
     images: collectImages(node),
     contact: buildContact({ phone: asString(node.telephone) }),

--- a/packages/listing-providers/src/providers/pisos/parse.ts
+++ b/packages/listing-providers/src/providers/pisos/parse.ts
@@ -10,7 +10,7 @@ import type { NormalizedListingContact } from '@homiio/shared-types';
 import { ldJsonScriptBodies } from '../../html';
 import { extractEsSchemaListings, type EsSchemaListing } from '../../parse/jsonLd';
 import { PISOS_BASE_URL } from './fixtures';
-import { asNumber } from '../../parse/guards';
+import { asCoordinate, asNumber } from '../../parse/guards';
 
 /** Raw payload `fetch()` hands to `normalize()`. */
 export interface PisosRaw {
@@ -218,8 +218,8 @@ export function readPisosLocationMapCoordinates(html: string): { lat: number; ln
   const match = html.match(/locationmap[^>]*data-params="([^"]+)"/i);
   if (!match) return undefined;
   const params = decodeHtmlEntities(match[1]);
-  const lat = asNumber(params.match(/(?:^|[&?])latitude=([^&]+)/)?.[1]);
-  const lng = asNumber(params.match(/(?:^|[&?])longitude=([^&]+)/)?.[1]);
+  const lat = asCoordinate(params.match(/(?:^|[&?])latitude=([^&]+)/)?.[1]);
+  const lng = asCoordinate(params.match(/(?:^|[&?])longitude=([^&]+)/)?.[1]);
   if (lat === undefined || lng === undefined) return undefined;
   return { lat, lng };
 }


### PR DESCRIPTION
## Summary
- Parse lat/lng with `asCoordinate` so values like `43.541` are not mangled to `43541` by EU price-style number parsing (Barreiros regression).
- Sanitize coordinates on ingest and city upsert; repair corrupt city coords on API boot.
- Speed Wikimedia city-cover backfill: boot sweep (100) + cron every 15 minutes with `forceReplaceListingCovers`.
- Unwrap ESM `default` exports in `controllers/index` so CJS city routes resolve handlers correctly.

## Test plan
- [x] `geoCoordinates` + `asCoordinate` + `cityCoverSync` + `plausibleCityName` unit tests (23 passed)
- [ ] After deploy: popular cities covers trend to `entityType: city`; Barreiros lat sane; `/api/cities/:id/properties` 200


Made with [Cursor](https://cursor.com)