### PR TITLE
fix(ingest): correct geoCoordinates import path breaking Docker build

### DIFF
--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -30,7 +30,7 @@ import { ensureCover } from '../cityCoverSyncService';
 import type { AddressCanonicalInput } from '../../models/Address';
 import { validateOfferings } from '../../models/schemas/offeringValidation';
 import { forwardGeocode, reverseGeocode } from '../geocodingService';
-import { sanitizeGeoJsonCoordinates } from '../utils/geoCoordinates';
+import { sanitizeGeoJsonCoordinates } from '../../utils/geoCoordinates';
 import { ExternalMediaIngest } from './ExternalMediaIngest';
 import { schedulePriceEthicsScore } from '../priceEthicsService';
 import { Logger } from '../../utils/logger';


### PR DESCRIPTION
Deploy run 29119972257 failed: `IngestionService.ts(33,44): error TS2307: Cannot find module '../utils/geoCoordinates'`. File lives at `packages/backend/utils/geoCoordinates.ts`; from `services/ingestion/` the path is two levels up. Verified with local `bun run --filter @homiio/backend build` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)