### PR TITLE
feat(property): prioritize listings with images

### DIFF
--- a/packages/backend/__tests__/unit/searchQueryBuilder.test.ts
+++ b/packages/backend/__tests__/unit/searchQueryBuilder.test.ts
@@ -2,6 +2,7 @@ import { OfferingType } from '@homiio/shared-types';
 import {
   buildSearchPlan,
   buildSort,
+  FIELD_HAS_IMAGES,
   FIELD_PRICE_ETHICS_FAIRNESS_SCORE,
   FIELD_PRICE_ETHICS_IS_FAIR_PRICE,
   SORT_FAIRNESS,
@@ -28,7 +29,10 @@ describe('buildSort fairness', () => {
     const { params } = buildSearchPlan({ sortBy: 'fairness', sortOrder: 'desc' });
 
     expect(params.sortField).toBe(SORT_FAIRNESS);
+    // `hasImages: -1` is always the primary key so image-bearing listings rank
+    // first, with the requested ordering applied within each group.
     expect(buildSort(params, false)).toEqual({
+      [FIELD_HAS_IMAGES]: -1,
       [FIELD_PRICE_ETHICS_FAIRNESS_SCORE]: -1,
       createdAt: -1,
     });
@@ -42,8 +46,43 @@ describe('buildSort fairness', () => {
     });
 
     expect(buildSort(params, false)).toEqual({
+      [FIELD_HAS_IMAGES]: -1,
       [FIELD_PRICE_ETHICS_FAIRNESS_SCORE]: 1,
       createdAt: -1,
     });
+  });
+});
+
+describe('buildSort image-first priority', () => {
+  it('ranks image-bearing listings first for the default recency sort', () => {
+    const { params } = buildSearchPlan({});
+    const sort = buildSort(params, false);
+
+    expect(sort[FIELD_HAS_IMAGES]).toBe(-1);
+    // hasImages must be the FIRST key so it dominates the requested ordering.
+    expect(Object.keys(sort)[0]).toBe(FIELD_HAS_IMAGES);
+    expect(sort.createdAt).toBe(-1);
+  });
+
+  it('ranks image-bearing listings first when sorting by price', () => {
+    const { params } = buildSearchPlan({
+      sortBy: 'price',
+      sortOrder: 'asc',
+      offering: OfferingType.LONG_TERM_RENT,
+    });
+    const sort = buildSort(params, false);
+
+    expect(Object.keys(sort)[0]).toBe(FIELD_HAS_IMAGES);
+    expect(sort[FIELD_HAS_IMAGES]).toBe(-1);
+    expect(sort['longTermRent.monthlyAmount']).toBe(1);
+  });
+
+  it('ranks image-bearing listings first even ahead of text relevance', () => {
+    const { params } = buildSearchPlan({ sortBy: 'relevance', q: 'barcelona' });
+    const sort = buildSort(params, true);
+
+    expect(Object.keys(sort)[0]).toBe(FIELD_HAS_IMAGES);
+    expect(sort[FIELD_HAS_IMAGES]).toBe(-1);
+    expect(sort.score).toEqual({ $meta: 'textScore' });
   });
 });

--- a/packages/backend/controllers/cityController.ts
+++ b/packages/backend/controllers/cityController.ts
@@ -10,6 +10,7 @@ import { Request, Response } from 'express';
 import { Types } from 'mongoose';
 import { City, Country, Region, Property, Address } from '../models';
 import { isPlausibleCityName } from '../utils/plausibleCityName';
+import { FIELD_HAS_IMAGES } from './property/searchQueryBuilder';
 const {
   serializePropertyAddresses,
   ADDRESS_GEO_POPULATE,
@@ -257,7 +258,8 @@ class CityController {
         query['longTermRent.monthlyAmount'] = priceRange;
       }
 
-      const sortObj: Record<string, 1 | -1> = {};
+      // Image-bearing listings first (product rule), then the requested order.
+      const sortObj: Record<string, 1 | -1> = { [FIELD_HAS_IMAGES]: -1 };
       switch (sort) {
         case 'price_asc': sortObj['longTermRent.monthlyAmount'] = 1; break;
         case 'price_desc': sortObj['longTermRent.monthlyAmount'] = -1; break;

--- a/packages/backend/controllers/property/batch.ts
+++ b/packages/backend/controllers/property/batch.ts
@@ -3,6 +3,7 @@ import { successResponse, paginationResponse, AppError } from '../../middlewares
 import mongoose from 'mongoose';
 import type { ControllerNext, ControllerRequest, ControllerResponse } from '../controllerTypes';
 import { getQueryInteger, getQueryString } from '../queryParams';
+import { FIELD_HAS_IMAGES } from './searchQueryBuilder';
 
 export async function getPropertiesByIds(req: ControllerRequest, res: ControllerResponse, next: ControllerNext) {
   try {
@@ -28,7 +29,8 @@ export async function getPropertiesByOwner(req: ControllerRequest, res: Controll
     if (exclude && mongoose.Types.ObjectId.isValid(exclude)) query._id = { $ne: new mongoose.Types.ObjectId(exclude) };
     const skip = (page - 1) * limit;
     const [properties,total] = await Promise.all([
-      Property.find(query).populate('addressId').sort({ createdAt:-1 }).skip(skip).limit(limit).lean(),
+      // Image-bearing listings first (product rule), then newest.
+      Property.find(query).populate('addressId').sort({ [FIELD_HAS_IMAGES]:-1, createdAt:-1 }).skip(skip).limit(limit).lean(),
       Property.countDocuments(query)
     ]);
     res.json(paginationResponse(properties, page, limit, total, "Owner's properties retrieved successfully"));

--- a/packages/backend/controllers/property/geospatial.ts
+++ b/packages/backend/controllers/property/geospatial.ts
@@ -3,6 +3,7 @@ import { paginationResponse } from '../../middlewares/errorHandler';
 import { logger } from '../../middlewares/logging';
 import type { ControllerNext, ControllerRequest, ControllerResponse } from '../controllerTypes';
 import { getQueryInteger, getQueryNumber } from '../queryParams';
+import { FIELD_HAS_IMAGES } from './searchQueryBuilder';
 
 export async function findNearbyProperties(req: ControllerRequest, res: ControllerResponse, next: ControllerNext) {
   try {
@@ -219,8 +220,9 @@ export async function findNearbyProperties(req: ControllerRequest, res: Controll
     const pageNumber = getQueryInteger(page, 1);
     const limitNumber = getQueryInteger(limit, 10);
     const skip = (pageNumber - 1) * limitNumber;
+    // Image-bearing listings first (product rule), then newest.
     const [properties, total] = await Promise.all([
-      nearbyQuery.skip(skip).limit(limitNumber).lean(),
+      nearbyQuery.sort({ [FIELD_HAS_IMAGES]: -1, createdAt: -1 }).skip(skip).limit(limitNumber).lean(),
       nearbyQuery.clone().countDocuments()
     ]);
 
@@ -445,8 +447,9 @@ export async function findPropertiesInRadius(req: ControllerRequest, res: Contro
     const pageNumber = getQueryInteger(page, 1);
     const limitNumber = getQueryInteger(limit, 10);
     const skip = (pageNumber - 1) * limitNumber;
+    // Image-bearing listings first (product rule), then newest.
     const [properties, total] = await Promise.all([
-      radiusQuery.skip(skip).limit(limitNumber).lean(),
+      radiusQuery.sort({ [FIELD_HAS_IMAGES]: -1, createdAt: -1 }).skip(skip).limit(limitNumber).lean(),
       radiusQuery.clone().countDocuments()
     ]);
 

--- a/packages/backend/controllers/property/list.ts
+++ b/packages/backend/controllers/property/list.ts
@@ -9,6 +9,7 @@ import {
   FIELD_SHORT_TERM_INSTANT_BOOK,
   PRICE_FIELD_SALE,
   FIELD_PRICE_ETHICS_IS_FAIR_PRICE,
+  FIELD_HAS_IMAGES,
   buildSort,
   SORT_ASC,
   SORT_DESC,
@@ -47,6 +48,17 @@ function representativePrice(property: {
   shortTermRent?: { nightlyRate?: number };
 }): number {
   return property.longTermRent?.monthlyAmount || property.shortTermRent?.nightlyRate || 0;
+}
+
+/**
+ * Ground-truth image presence for the per-page re-sorts below (geo ranking and
+ * personalization). Read from the actual `images` array rather than the stored
+ * `hasImages` flag so the in-memory ordering can never contradict the data even
+ * if the denormalized flag is momentarily stale. The DB sort still uses the
+ * indexed `hasImages` field to decide page membership.
+ */
+function listingHasImages(property: { images?: unknown[] }): boolean {
+  return Array.isArray(property.images) && property.images.length > 0;
 }
 
 /** Map a representative price to a coarse low/medium/high preference bucket. */
@@ -376,6 +388,9 @@ export const getProperties = async (req: Request, res: Response, next: NextFunct
     }
 
     const sortByValue = String(sortBy);
+    // `hasImages: -1` is the primary key for EVERY branch so image-bearing
+    // listings always rank first (product rule). `buildSort` already prepends it
+    // for the known sort fields; the arbitrary-field fallback prepends it here.
     const sortOptions: Record<string, SortOrder | { $meta: 'textScore' }> = LIST_SORT_FIELDS.has(sortByValue)
       ? buildSort(
           {
@@ -387,7 +402,7 @@ export const getProperties = async (req: Request, res: Response, next: NextFunct
           },
           false,
         )
-      : { [sortByValue]: (sortOrder === 'desc' ? -1 : 1) as SortOrder };
+      : { [FIELD_HAS_IMAGES]: -1, [sortByValue]: (sortOrder === 'desc' ? -1 : 1) as SortOrder };
     const skip = (pageNumber - 1) * limitNumber;
 
     const [properties, total] = await Promise.all([
@@ -449,11 +464,14 @@ export const getProperties = async (req: Request, res: Response, next: NextFunct
             index,
             distance,
             savesCount,
+            hasImages: listingHasImages(p),
             inside: Number.isFinite(distance) && distance <= preferredRadiusMeters,
             prop: { ...p, isSaved: false }
           };
         });
         decorated.sort((a, b) => {
+          // Image-bearing listings first (product rule), then the geo ranking.
+          if (a.hasImages !== b.hasImages) return a.hasImages ? -1 : 1;
           if (a.inside !== b.inside) return a.inside ? -1 : 1;
           if (b.savesCount !== a.savesCount) return b.savesCount - a.savesCount;
           if (a.distance !== b.distance) return a.distance - b.distance;
@@ -546,7 +564,13 @@ export const getProperties = async (req: Request, res: Response, next: NextFunct
             if (isSaved) personalizedScore -= 20;
             return { ...property, personalizedScore, isSaved };
           });
-          personalized.sort((a, b) => (b.personalizedScore || 0) - (a.personalizedScore || 0));
+          personalized.sort((a, b) => {
+            // Image-bearing listings first (product rule), then personalization.
+            const aHasImages = listingHasImages(a);
+            const bHasImages = listingHasImages(b);
+            if (aHasImages !== bHasImages) return aHasImages ? -1 : 1;
+            return (b.personalizedScore || 0) - (a.personalizedScore || 0);
+          });
           ordered = personalized;
       } catch (error) {
         // Personalization is a best-effort enhancement: if it fails we fall back

--- a/packages/backend/controllers/property/searchQueryBuilder.ts
+++ b/packages/backend/controllers/property/searchQueryBuilder.ts
@@ -91,6 +91,13 @@ const SORT_FIELDS: ReadonlySet<string> = new Set([
 export const FIELD_PRICE_ETHICS_FAIRNESS_SCORE = 'priceEthics.fairnessScore';
 /** Mongo path for the fair-price badge/filter flag. */
 export const FIELD_PRICE_ETHICS_IS_FAIR_PRICE = 'priceEthics.isFairPrice';
+/**
+ * Denormalized boolean set true when a listing has ≥1 image (maintained by the
+ * Property schema hooks). Used as the PRIMARY sort key across every discovery
+ * feed so image-bearing listings always rank ahead of image-less ones, with the
+ * previous ordering preserved within each group. `-1` puts `true` first.
+ */
+export const FIELD_HAS_IMAGES = 'hasImages';
 
 export const SORT_ASC = 'asc';
 export const SORT_DESC = 'desc';
@@ -532,20 +539,25 @@ export function buildSort(
 ): Record<string, SortOrder | { $meta: 'textScore' }> {
   const direction: SortOrder = params.sortDirection === SORT_ASC ? 1 : -1;
 
+  // `hasImages: -1` is prepended to EVERY sort so listings that have images
+  // always rank ahead of image-less ones (product rule), with the requested
+  // ordering (price / relevance / fairness / recency) applied within each
+  // group. Index-backed via the `{ hasImages: -1, createdAt: -1 }` index; the
+  // primary key is set at the DB layer so pagination stays correct.
   if (params.sortField === SORT_PRICE) {
     const priceField = priceFieldForOffering(params.offering) ?? DEFAULT_PRICE_FIELD;
-    return { [priceField]: direction };
+    return { [FIELD_HAS_IMAGES]: -1, [priceField]: direction };
   }
   if (params.sortField === SORT_SALE_PRICE) {
-    return { [PRICE_FIELD_SALE]: direction };
+    return { [FIELD_HAS_IMAGES]: -1, [PRICE_FIELD_SALE]: direction };
   }
   if (params.sortField === SORT_RELEVANCE && hasTextScore) {
-    return { score: { $meta: 'textScore' }, createdAt: -1 };
+    return { [FIELD_HAS_IMAGES]: -1, score: { $meta: 'textScore' }, createdAt: -1 };
   }
   if (params.sortField === SORT_FAIRNESS) {
-    return { [FIELD_PRICE_ETHICS_FAIRNESS_SCORE]: direction, createdAt: -1 };
+    return { [FIELD_HAS_IMAGES]: -1, [FIELD_PRICE_ETHICS_FAIRNESS_SCORE]: direction, createdAt: -1 };
   }
-  return { createdAt: direction };
+  return { [FIELD_HAS_IMAGES]: -1, createdAt: direction };
 }
 
 /**

--- a/packages/backend/controllers/roomController.ts
+++ b/packages/backend/controllers/roomController.ts
@@ -13,6 +13,7 @@ import type { Request, Response, NextFunction } from 'express';
 import { Property, Address } from '../models';
 import { PropertyType, PropertyStatus } from '@homiio/shared-types';
 import { logger } from '../middlewares/logging';
+import { FIELD_HAS_IMAGES } from './property/searchQueryBuilder';
 import { AppError, successResponse, paginationResponse } from '../middlewares/errorHandler';
 import { requireSessionOxyUserId } from '../utils/sessionUser';
 import {
@@ -118,7 +119,8 @@ class RoomController {
         filters.status = { $ne: 'draft' };
       }
 
-      const sortOptions: Record<string, 1 | -1> = {};
+      // Image-bearing listings first (product rule), then the requested order.
+      const sortOptions: Record<string, 1 | -1> = { [FIELD_HAS_IMAGES]: -1 };
       sortOptions[String(sortBy)] = sortOrder === 'desc' ? -1 : 1;
 
       const [rooms, total] = await Promise.all([

--- a/packages/backend/models/Property.ts
+++ b/packages/backend/models/Property.ts
@@ -87,6 +87,13 @@ export interface IProperty extends Document {
       large?: string;
     };
   }>;
+  /**
+   * Denormalized flag: true when `images` holds at least one entry. Kept in
+   * lock-step with `images` by the schema pre-save / pre-update hooks so
+   * discovery feeds can rank image-bearing listings first with an index-backed
+   * sort. Always derived from `images` — never written directly.
+   */
+  hasImages?: boolean;
   status: PropertyStatus;
   floor?: number;
   hasElevator?: boolean;

--- a/packages/backend/models/schemas/PropertySchema.ts
+++ b/packages/backend/models/schemas/PropertySchema.ts
@@ -5,6 +5,7 @@
  */
 
 import type { IProperty } from '../Property';
+import type { Query, UpdateQuery } from 'mongoose';
 
 const mongoose = require('mongoose');
 const validator = require('validator');
@@ -534,6 +535,15 @@ const propertySchema = new mongoose.Schema({
     type: Number,
     default: -1
   },
+  // Denormalized image-presence flag: true when `images` holds at least one
+  // entry. Maintained in lock-step with `images` by the pre-save and pre-update
+  // hooks below, so discovery feeds can rank image-bearing listings ahead of
+  // image-less ones with an index-backed sort (`{ hasImages: -1, ... }`) that
+  // keeps pagination correct. Always derived from `images` — never set directly.
+  hasImages: {
+    type: Boolean,
+    default: false
+  },
   documents: [{
     name: {
       type: String,
@@ -728,6 +738,10 @@ propertySchema.index({ offerings: 1, 'exchange.mode': 1, status: 1 });
 // Price ethics sort/filter (fairness ranking, fair-price chip).
 propertySchema.index({ 'priceEthics.isFairPrice': 1 });
 propertySchema.index({ 'priceEthics.fairnessScore': -1 });
+// Image-first discovery ordering: rank listings that HAVE images ahead of those
+// that don't, newest first within each group. Backs the default feed/search sort
+// (`{ hasImages: -1, createdAt: -1 }`) so pagination stays index-backed.
+propertySchema.index({ hasImages: -1, createdAt: -1 });
 
 /**
  * Offerings must be non-empty and equal exactly the set of present priced
@@ -860,7 +874,54 @@ propertySchema.pre('save', function(this: IProperty, next: (err?: Error) => void
     }
   }
 
+  // Keep the denormalized image-presence flag in lock-step with `images` so
+  // discovery feeds can rank image-bearing listings first (see `hasImages`).
+  this.hasImages = Array.isArray(this.images) && this.images.length > 0;
+
   next();
+});
+
+/**
+ * Keep `hasImages` in lock-step with `images` on atomic updates. The pre-save
+ * hook above does NOT run for findOneAndUpdate / updateOne / updateMany, so the
+ * flag is re-derived here whenever an update actually sets `images` (in a
+ * top-level field, `$set`, or `$setOnInsert`). Updates that don't touch `images`
+ * leave the flag untouched; aggregation-pipeline updates (array form) are
+ * skipped — the ingestion/write paths use plain-document updates.
+ */
+propertySchema.pre(['findOneAndUpdate', 'updateOne', 'updateMany'], function (
+  this: Query<unknown, IProperty>
+): void {
+  const rawUpdate = this.getUpdate();
+  if (!rawUpdate || Array.isArray(rawUpdate)) return;
+  const update = rawUpdate as Record<string, unknown>;
+  const set = update.$set as Record<string, unknown> | undefined;
+  const setOnInsert = update.$setOnInsert as Record<string, unknown> | undefined;
+
+  let images: unknown;
+  let target: 'top' | 'set' | 'setOnInsert';
+  if (set && 'images' in set) {
+    images = set.images;
+    target = 'set';
+  } else if ('images' in update) {
+    images = update.images;
+    target = 'top';
+  } else if (setOnInsert && 'images' in setOnInsert) {
+    images = setOnInsert.images;
+    target = 'setOnInsert';
+  } else {
+    return;
+  }
+
+  const hasImages = Array.isArray(images) && images.length > 0;
+  if (target === 'top') {
+    update.hasImages = hasImages;
+  } else if (target === 'set') {
+    update.$set = { ...(set ?? {}), hasImages };
+  } else {
+    update.$setOnInsert = { ...(setOnInsert ?? {}), hasImages };
+  }
+  this.setUpdate(update as UpdateQuery<IProperty>);
 });
 
 // Static methods

--- a/packages/backend/services/cron.ts
+++ b/packages/backend/services/cron.ts
@@ -5,6 +5,7 @@ import { CleanupService } from './cleanupService';
 import { MetricsService } from '../utils/metrics';
 import { syncCovers } from './cityCoverSyncService';
 import { repairCorruptCityCoordinates } from './cityCoordinateRepairService';
+import { Property } from '../models';
 
 // Initialize services
 const logger = new Logger('CronService');
@@ -46,6 +47,11 @@ class CronJobManager {
 
   private async runBootHousekeeping(): Promise<void> {
     try {
+      await this.backfillPropertyHasImages();
+    } catch (error) {
+      this.logger.error('Boot hasImages backfill failed', error);
+    }
+    try {
       const repaired = await repairCorruptCityCoordinates(200);
       this.logger.info('Boot city coordinate repair completed', { repaired });
     } catch (error) {
@@ -56,6 +62,25 @@ class CronJobManager {
       this.logger.info('Boot city cover sync completed', { processed });
     } catch (error) {
       this.logger.error('Boot city cover sync failed', error);
+    }
+  }
+
+  /**
+   * One-time, idempotent backfill of the denormalized `hasImages` flag for
+   * legacy properties that predate the field. A pipeline update derives it from
+   * the ground-truth `images` array server-side in a single pass; the schema
+   * pre-save / pre-update hooks maintain it on every write thereafter. The
+   * `{ hasImages: { $exists: false } }` filter means it only ever touches
+   * un-migrated docs and becomes a no-op on subsequent boots.
+   */
+  private async backfillPropertyHasImages(): Promise<void> {
+    const result = await Property.updateMany(
+      { hasImages: { $exists: false } },
+      [{ $set: { hasImages: { $gt: [{ $size: { $ifNull: ['$images', []] } }, 0] } } }]
+    );
+    const modified = (result as { modifiedCount?: number }).modifiedCount ?? 0;
+    if (modified > 0) {
+      this.logger.info('Backfilled hasImages on legacy properties', { modified });
     }
   }
 


### PR DESCRIPTION
## Summary
- Add a denormalized `hasImages` boolean to the Property schema, kept in sync via pre-save/pre-update Mongoose hooks
- Back it with a compound `{ hasImages: -1, createdAt: -1 }` index
- Prepend `hasImages` as the primary sort key across every discovery surface: search, list, geospatial, batch, city, and room controllers
- Add an idempotent one-time boot backfill (`services/cron.ts`) to populate `hasImages` on legacy documents
- Extend `searchQueryBuilder` unit tests to cover the new sort behavior

## Test plan
Verified in an isolated main-based worktree (not the original mixed branch):
- [x] Backend `tsc` build clean
- [x] 50 test suites / 424 tests passing
- [x] `bun install --frozen-lockfile` clean (no lockfile drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)