### PR TITLE
feat(home): dynamic home feed + Mention-style infinite scroll

### DIFF
--- a/packages/backend/__tests__/unit/cityPropertiesPagination.test.ts
+++ b/packages/backend/__tests__/unit/cityPropertiesPagination.test.ts
@@ -1,0 +1,141 @@
+/**
+ * `GET /api/cities/:id/properties` pagination contract.
+ *
+ * Covers the flat `hasMore` / `totalPages` aliases the infinite city hook reads
+ * (added for parity with `/properties/search`) and the server-side `minBathrooms`
+ * filter, so the city grid can paginate + filter without breaking under offset
+ * pagination.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { Types } from 'mongoose';
+import { OfferingType, PropertyType, PropertyStatus } from '@homiio/shared-types';
+
+import cityRoutes from '../../routes/cities';
+
+const { Country, Region, City, Address, Property } = require('../../models');
+const { errorHandler } = require('../../middlewares/errorHandler');
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/cities', cityRoutes());
+  app.use(errorHandler);
+  return app;
+}
+
+async function seedSpainCity(name: string): Promise<{ cityId: Types.ObjectId; countryId: Types.ObjectId; regionId: Types.ObjectId }> {
+  const country = await Country.findOneAndUpdate(
+    { code: 'ES' },
+    { $setOnInsert: { code: 'ES', name: 'Spain', currency: 'EUR' } },
+    { upsert: true, new: true, setDefaultsOnInsert: true },
+  );
+  const region = await Region.findOneAndUpdate(
+    { countryId: country._id, name: 'Catalonia' },
+    { $setOnInsert: { countryId: country._id, name: 'Catalonia' } },
+    { upsert: true, new: true, setDefaultsOnInsert: true },
+  );
+  const city = await City.create({
+    countryId: country._id,
+    regionId: region._id,
+    name,
+    currency: 'EUR',
+    propertiesCount: 0,
+  });
+  return { cityId: city._id, countryId: country._id, regionId: region._id };
+}
+
+/** Seed one published external listing resolvable to the given city. */
+async function seedProperty(
+  geo: { cityId: Types.ObjectId; countryId: Types.ObjectId; regionId: Types.ObjectId },
+  index: number,
+  bathrooms: number,
+): Promise<void> {
+  const address = await Address.create({
+    countryId: geo.countryId,
+    regionId: geo.regionId,
+    cityId: geo.cityId,
+    countryCode: 'ES',
+    street: `Carrer Test ${index}`,
+    postal_code: '08001',
+    coordinates: { type: 'Point', coordinates: [2.17 + index * 0.001, 41.38] },
+  });
+  await Property.create({
+    addressId: address._id,
+    type: PropertyType.APARTMENT,
+    bedrooms: 2,
+    bathrooms,
+    offerings: [OfferingType.LONG_TERM_RENT],
+    longTermRent: { monthlyAmount: 900 + index, currency: 'EUR' },
+    status: PropertyStatus.PUBLISHED,
+    isExternal: true,
+    source: 'fixture',
+    sourceId: `city-pagination-${index}`,
+    sourceUrl: `https://fixtures.homiio.com/city-${index}`,
+    images: [],
+  });
+}
+
+describe('GET /api/cities/:id/properties pagination aliases', () => {
+  it('returns flat hasMore/totalPages and paginates by page', async () => {
+    const app = buildApp();
+    const geo = await seedSpainCity('Barcelona');
+    // 5 listings, 2 per page → 3 pages.
+    for (let i = 0; i < 5; i += 1) {
+      await seedProperty(geo, i, 1);
+    }
+
+    const page1 = await request(app)
+      .get(`/api/cities/${geo.cityId}/properties`)
+      .query({ limit: 2, page: 1 });
+
+    expect(page1.status).toBe(200);
+    expect(page1.body.success).toBe(true);
+    expect(page1.body.data.properties).toHaveLength(2);
+    expect(page1.body.data.total).toBeUndefined(); // total stays nested in pagination
+    expect(page1.body.data.pagination.total).toBe(5);
+    expect(page1.body.data.totalPages).toBe(3);
+    expect(page1.body.data.hasMore).toBe(true);
+
+    const page3 = await request(app)
+      .get(`/api/cities/${geo.cityId}/properties`)
+      .query({ limit: 2, page: 3 });
+
+    expect(page3.body.data.properties).toHaveLength(1);
+    expect(page3.body.data.totalPages).toBe(3);
+    // Last page: (3-1)*2 + 1 === 5, so nothing more to load.
+    expect(page3.body.data.hasMore).toBe(false);
+  });
+
+  it('applies the server-side minBathrooms filter', async () => {
+    const app = buildApp();
+    const geo = await seedSpainCity('Girona');
+    await seedProperty(geo, 0, 1);
+    await seedProperty(geo, 1, 2);
+    await seedProperty(geo, 2, 3);
+
+    const res = await request(app)
+      .get(`/api/cities/${geo.cityId}/properties`)
+      .query({ minBathrooms: 2 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.pagination.total).toBe(2);
+    expect(res.body.data.hasMore).toBe(false);
+    for (const property of res.body.data.properties) {
+      expect(property.bathrooms).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it('returns hasMore=false with no matching addresses', async () => {
+    const app = buildApp();
+    const geo = await seedSpainCity('Sitges');
+
+    const res = await request(app).get(`/api/cities/${geo.cityId}/properties`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.properties).toHaveLength(0);
+    expect(res.body.data.hasMore).toBe(false);
+    expect(res.body.data.totalPages).toBe(0);
+  });
+});

--- a/packages/backend/__tests__/unit/searchQueryBuilder.test.ts
+++ b/packages/backend/__tests__/unit/searchQueryBuilder.test.ts
@@ -1,10 +1,11 @@
-import { OfferingType } from '@homiio/shared-types';
+import { ExchangeMode, OfferingType } from '@homiio/shared-types';
 import {
   buildSearchPlan,
   buildSort,
   FIELD_HAS_IMAGES,
   FIELD_PRICE_ETHICS_FAIRNESS_SCORE,
   FIELD_PRICE_ETHICS_IS_FAIR_PRICE,
+  FIELD_SHORT_TERM_INSTANT_BOOK,
   SORT_FAIRNESS,
 } from '../../controllers/property/searchQueryBuilder';
 
@@ -84,5 +85,37 @@ describe('buildSort image-first priority', () => {
     expect(Object.keys(sort)[0]).toBe(FIELD_HAS_IMAGES);
     expect(sort[FIELD_HAS_IMAGES]).toBe(-1);
     expect(sort.score).toEqual({ $meta: 'textScore' });
+  });
+});
+
+describe('buildSearchPlan category-lens filters', () => {
+  it('adds petFriendly when petFriendly=true (home "Pet friendly" lens)', () => {
+    const { filter } = buildSearchPlan({ petFriendly: 'true' });
+    expect(filter.petFriendly).toBe(true);
+  });
+
+  it('ignores petFriendly when not a literal boolean', () => {
+    const { filter } = buildSearchPlan({ petFriendly: 'maybe' });
+    expect(filter.petFriendly).toBeUndefined();
+  });
+
+  it('adds instantBook when instantBook=true (home "Instant book" lens)', () => {
+    const { filter } = buildSearchPlan({ instantBook: 'true' });
+    expect(filter[FIELD_SHORT_TERM_INSTANT_BOOK]).toBe(true);
+  });
+
+  it('applies exchangeMode only for an EXCHANGE offering', () => {
+    const swap = buildSearchPlan({
+      offering: OfferingType.EXCHANGE,
+      exchangeMode: ExchangeMode.SWAP,
+    });
+    expect(swap.filter['exchange.mode']).toEqual({
+      $in: [ExchangeMode.SWAP, ExchangeMode.BOTH],
+    });
+
+    // Without the exchange offering the mode is ignored (never stacks onto a
+    // non-exchange query).
+    const ignored = buildSearchPlan({ exchangeMode: ExchangeMode.SWAP });
+    expect(ignored.filter['exchange.mode']).toBeUndefined();
   });
 });

--- a/packages/backend/controllers/cityController.ts
+++ b/packages/backend/controllers/cityController.ts
@@ -50,6 +50,7 @@ interface PropertyFilters {
   verified?: string;
   eco?: string;
   minBedrooms?: string;
+  minBathrooms?: string;
   maxPrice?: string;
   minPrice?: string;
 }
@@ -218,6 +219,7 @@ class CityController {
         verified,
         eco,
         minBedrooms,
+        minBathrooms,
         maxPrice,
         minPrice,
       }: PropertyFilters = req.query;
@@ -239,7 +241,16 @@ class CityController {
         return res.json({
           success: true,
           message: 'Properties retrieved successfully',
-          data: { city, properties: [], pagination: { page: numericPage, limit: numericLimit, total: 0, pages: 0 } },
+          // Flat `hasMore`/`totalPages` aliases mirror `/properties/search` so
+          // the infinite city hook reads paging metadata the same way; the
+          // `pagination` key is kept so `normalizeEnvelope` preserves the envelope.
+          data: {
+            city,
+            properties: [],
+            pagination: { page: numericPage, limit: numericLimit, total: 0, pages: 0 },
+            hasMore: false,
+            totalPages: 0,
+          },
         });
       }
 
@@ -251,6 +262,7 @@ class CityController {
       if (verified === 'true') query.isVerified = true;
       if (eco === 'true') query.isEcoFriendly = true;
       if (minBedrooms) query.bedrooms = { $gte: Number(minBedrooms) };
+      if (minBathrooms) query.bathrooms = { $gte: Number(minBathrooms) };
       if (minPrice || maxPrice) {
         const priceRange: { $gte?: number; $lte?: number } = {};
         if (minPrice) priceRange.$gte = Number(minPrice);
@@ -292,12 +304,17 @@ class CityController {
         await city.save();
       }
 
+      const pages = Math.ceil(total / numericLimit);
       res.json({
         success: true,
         data: {
           city,
           properties,
-          pagination: { page: numericPage, limit: numericLimit, total, pages: Math.ceil(total / numericLimit) },
+          pagination: { page: numericPage, limit: numericLimit, total, pages },
+          // Flat aliases for parity with `/properties/search` — the infinite city
+          // hook reads `hasMore` in `getNextPageParam` and `totalPages` for display.
+          hasMore: skip + properties.length < total,
+          totalPages: pages,
         },
       });
     } catch (error) {

--- a/packages/backend/controllers/property/searchQueryBuilder.ts
+++ b/packages/backend/controllers/property/searchQueryBuilder.ts
@@ -444,6 +444,8 @@ export function buildSearchPlan(
   if (eco !== undefined) filter.isEcoFriendly = eco;
   const instantBook = parseBoolParam(query.instantBook);
   if (instantBook !== undefined) filter[FIELD_SHORT_TERM_INSTANT_BOOK] = instantBook;
+  const petFriendly = parseBoolParam(query.petFriendly);
+  if (petFriendly !== undefined) filter.petFriendly = petFriendly;
   const hasPhotos = parseBoolParam(query.hasPhotos);
   if (hasPhotos === true) filter['images.url'] = { $exists: true, $nin: [null, ''] };
   const fairPrice = parseBoolParam(query.fairPrice);

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -22,12 +22,13 @@
  * so it does not participate. Long-form marketing copy (FAQ, stats, trust
  * grids) does NOT live on the home page — it belongs on /about.
  */
-import React, { useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { View, RefreshControl, Pressable } from 'react-native';
 import { Image } from 'expo-image';
 import { useQueryClient } from '@tanstack/react-query';
 import { Menu } from 'lucide-react-native';
 import Animated, {
+  FadeInDown,
   interpolate,
   useAnimatedStyle,
   useSharedValue,
@@ -38,14 +39,23 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 import { H1, P } from '@oxyhq/bloom/typography';
 
-import { OfferingType, type City, type Property } from '@homiio/shared-types';
+import { OfferingType, PropertyType, type City, type Property } from '@homiio/shared-types';
 
 import {
   HOME_FEED_LIMIT,
   isNearYouBlocked,
   useHomeFeedProperties,
   useUserCoordinates,
+  type UserCoordinates,
 } from '@/hooks/useHomeFeed';
+import { usePropertySearch } from '@/hooks/usePropertySearch';
+import { getCategoryFilters } from '@/store/getCategoryFilters';
+import type { HomeCategory } from '@/store/homeCategoryStore';
+import { DEFAULT_SEARCH_QUERY } from '@/store/searchQueryStore';
+import { PropertyResultsGrid } from '@/components/ui/PropertyResultsGrid';
+import { PropertyResultsGridSkeleton } from '@/components/ui/PropertyResultsGridSkeleton';
+import { LoadMoreSentinel } from '@/components/common/LoadMoreSentinel';
+import { SectionEyebrow } from '@/components/ui/SectionEyebrow';
 import { cityQueryKeys, usePopularCities } from '@/hooks/useCityQueries';
 import { cityCountryName, cityRegionName } from '@/utils/cityDisplay';
 import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
@@ -125,6 +135,58 @@ function resolveExplorePlace(
   return fallbackCountry ?? defaultPlace;
 }
 
+/**
+ * Seed the endless "Explore more homes" feed from the live home state (browse
+ * offering + selected category + device location). Reuses `getCategoryFilters` —
+ * the single source of truth for what each home category means — and translates
+ * its `PropertyFilters` output into the `SearchQuery` shape `usePropertySearch`
+ * consumes. Because every dimension folds into `searchQueryKey`, tapping a
+ * category chip re-keys the feed and refilters it in place.
+ */
+function buildExploreFeedQuery(
+  offering: OfferingType,
+  category: HomeCategory | null,
+  userLocation: UserCoordinates | null | undefined,
+): SearchQuery {
+  const filters = getCategoryFilters(category, {
+    userLocation: userLocation ?? null,
+    offering,
+  });
+
+  // `near_you` resolves to a lat/lng + a 25km radius, which equals the search
+  // endpoint's default radius when only a center is sent — so we seed the
+  // location with the coordinates and an EMPTY label. An empty label makes
+  // `buildSearchParams` emit lat/lng WITHOUT a free-text `q` (a non-empty label
+  // is text-matched, which a pure geo lens must not do).
+  const location =
+    typeof filters.lat === 'number' && typeof filters.lng === 'number'
+      ? {
+          label: '',
+          shortLabel: '',
+          center: [filters.lng, filters.lat] as [number, number],
+        }
+      : undefined;
+
+  return {
+    ...DEFAULT_SEARCH_QUERY,
+    offering,
+    // Newest-first (the backend already ranks image-bearing listings first) so
+    // freshly added homes surface on top each visit (freshness, Part 4).
+    sortBy: 'createdAt',
+    sortOrder: 'desc',
+    propertyTypes: filters.type ? [filters.type as PropertyType] : [],
+    amenities: filters.amenities ?? [],
+    // "Luxury" maps to a monthly-rent floor (or a sale-price floor when buying).
+    // `buildSearchParams` routes `priceMin` to the sale-price param for a SALE
+    // offering, so one `priceMin` seed covers both the rent and sale buckets.
+    priceMin: filters.minRent ?? filters.minSalePrice,
+    instantBook: filters.instantBook,
+    petFriendly: filters.petFriendly,
+    exchangeMode: filters.exchangeMode,
+    location,
+  };
+}
+
 export default function HomePage() {
   const { t } = useTranslation();
   const router = useRouter();
@@ -162,6 +224,26 @@ export default function HomePage() {
     useRecentlyViewed();
   const { savedProperties, isLoading: savedLoading, loadSavedProperties } =
     useSavedPropertiesContext();
+
+  // Endless "Explore more homes" feed — the terminal, never-ending band below the
+  // curated sections. Seeded live from the browse offering + active category +
+  // location so a category chip tap re-keys it (React Query refetches page 1) and
+  // it refilters instantly. Same `usePropertySearch` engine + image-first,
+  // newest-first order as the search/browse screens.
+  const exploreQuery = useMemo(
+    () => buildExploreFeedQuery(browseOffering, activeCategory, userLocation),
+    [browseOffering, activeCategory, userLocation],
+  );
+  const exploreFeed = usePropertySearch(exploreQuery, { enabled: !nearYouBlocked });
+  const exploreProperties = exploreFeed.properties;
+  const exploreInitialLoading = exploreFeed.isLoading && exploreProperties.length === 0;
+  // Guarded loader (matches Mention's `handleLoadMore`): native fires it via
+  // `PageScrollView onEndReached`, web via the `LoadMoreSentinel` at the feed end.
+  const loadMoreExplore = useCallback(() => {
+    if (exploreFeed.hasNextPage && !exploreFeed.isFetchingNextPage) {
+      void exploreFeed.fetchNextPage();
+    }
+  }, [exploreFeed.hasNextPage, exploreFeed.isFetchingNextPage, exploreFeed.fetchNextPage]);
 
   const properties = feedData?.properties;
   const propertiesLoading = feedLoading;
@@ -222,6 +304,7 @@ export default function HomePage() {
         ),
         loadSavedProperties(),
         refetchRecentlyViewed(),
+        exploreFeed.refetch(),
       ]);
     } finally {
       setRefreshing(false);
@@ -250,6 +333,7 @@ export default function HomePage() {
         className="flex-1"
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
         showsVerticalScrollIndicator={false}
+        onEndReached={loadMoreExplore}
       >
         <View className="relative h-[400px] w-full justify-end overflow-hidden pt-[max(0.5rem,env(safe-area-inset-top))] md:h-[360px] xl:h-[min(400px,45vh)]">
           <Animated.View
@@ -377,21 +461,25 @@ export default function HomePage() {
           />
 
           {cities.length > 0 ? (
-            <CityShowcaseSection
-              title={t('home.cityShowcase.title', { place: explorePlace })}
-              items={cities}
-              onPressCity={(city) => router.push(`/properties/city/${city._id}`)}
-            />
+            <Animated.View entering={FadeInDown.duration(420)}>
+              <CityShowcaseSection
+                title={t('home.cityShowcase.title', { place: explorePlace })}
+                items={cities}
+                onPressCity={(city) => router.push(`/properties/city/${city._id}`)}
+              />
+            </Animated.View>
           ) : null}
 
           {gridProperties.length > 0 ? (
-            <FeaturedGridSection
-              title={featuredGridTitle}
-              items={gridProperties}
-              onPropertyPress={(property) =>
-                router.push(`/properties/${property._id || property.id}`)
-              }
-            />
+            <Animated.View entering={FadeInDown.duration(420)}>
+              <FeaturedGridSection
+                title={featuredGridTitle}
+                items={gridProperties}
+                onPropertyPress={(property) =>
+                  router.push(`/properties/${property._id || property.id}`)
+                }
+              />
+            </Animated.View>
           ) : null}
 
           {recentlyViewedProperties && recentlyViewedProperties.length > 0 ? (
@@ -467,6 +555,51 @@ export default function HomePage() {
               />
             </>
           )}
+
+          {/* Explore more homes — the terminal, endless band. Curated sections
+              above give way to an image-first, category-driven feed that keeps
+              appending pages (web: the sentinel; native: PageScrollView
+              onEndReached). It reacts live to the category strip via its query
+              key. Rendered with the shared PropertyResultsGrid so it behaves
+              exactly like the search/browse grids. */}
+          <Animated.View entering={FadeInDown.duration(420)} className="gap-4">
+            <View className={PAGE_GUTTER_CLASS}>
+              <SectionEyebrow>{t('home.explore.eyebrow')}</SectionEyebrow>
+              <H1 className="text-[26px] font-bold leading-8 tracking-tight text-foreground">
+                {t('home.explore.title')}
+              </H1>
+            </View>
+
+            {exploreInitialLoading ? (
+              <View className={PAGE_GUTTER_CLASS}>
+                <PropertyResultsGridSkeleton count={8} />
+              </View>
+            ) : exploreProperties.length === 0 ? (
+              <View className={`py-2 ${PAGE_GUTTER_CLASS}`}>
+                <P className="text-sm text-muted-foreground">{feedEmptyText}</P>
+              </View>
+            ) : (
+              <View className={PAGE_GUTTER_CLASS}>
+                <PropertyResultsGrid
+                  properties={exploreProperties}
+                  onPropertyPress={(property) =>
+                    router.push(`/properties/${property._id || property.id}`)
+                  }
+                />
+                {exploreFeed.isFetchingNextPage ? (
+                  <View className="pt-6">
+                    <PropertyResultsGridSkeleton count={4} />
+                  </View>
+                ) : null}
+                {/* Web-only pagination trigger; native paginates via
+                    PageScrollView onEndReached. Inert on native. */}
+                <LoadMoreSentinel
+                  enabled={exploreFeed.hasNextPage}
+                  onLoadMore={loadMoreExplore}
+                />
+              </View>
+            )}
+          </Animated.View>
         </View>
       </PageScrollView>
     </View>

--- a/packages/frontend/app/(tabs)/saved/index.tsx
+++ b/packages/frontend/app/(tabs)/saved/index.tsx
@@ -44,6 +44,8 @@ import { EmptyState } from '@/components/ui/EmptyState';
 import { ErrorState } from '@/components/ui/ErrorState';
 import { ListSkeleton } from '@/components/ui/ListSkeleton';
 import { PropertyResultsGrid } from '@/components/ui/PropertyResultsGrid';
+import { LoadMoreSentinel } from '@/components/common/LoadMoreSentinel';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import savedPropertyService from '@/services/savedPropertyService';
 import savedPropertyFolderService, {
   type SavedPropertyFolder,
@@ -62,6 +64,12 @@ const RECENCY_CHIPS: { value: RecencyFilter; label: string }[] = [
 ];
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Saved has no backend list endpoint, so the Recent grid reveals its in-memory
+ *  array incrementally: an initial window, grown a page at a time via the same
+ *  sentinel (web) / onEndReached (native) primitive as the server-paginated grids. */
+const SAVED_INITIAL_WINDOW = 24;
+const SAVED_WINDOW_STEP = 24;
 
 export default function SavedPropertiesScreen() {
   const { t } = useTranslation();
@@ -151,6 +159,33 @@ export default function SavedPropertiesScreen() {
       }
     });
   }, [savedProperties, searchQuery, recency, dataUpdatedAt]);
+
+  // Incremental reveal for the Recent grid. Reset the window when the filter set
+  // changes — the "adjust state during render" pattern (React's sanctioned way to
+  // reset state on a derived change) keeps it effect-free.
+  const [visibleCount, setVisibleCount] = useState(SAVED_INITIAL_WINDOW);
+  const filterSignature = `${tab}|${searchQuery}|${recency}`;
+  const [prevSignature, setPrevSignature] = useState(filterSignature);
+  if (filterSignature !== prevSignature) {
+    setPrevSignature(filterSignature);
+    setVisibleCount(SAVED_INITIAL_WINDOW);
+  }
+  const visibleRecent = useMemo(
+    () => filteredRecent.slice(0, visibleCount),
+    [filteredRecent, visibleCount],
+  );
+  const hasMoreRecent = visibleCount < filteredRecent.length;
+  const loadMoreRecent = useCallback(() => {
+    setVisibleCount((count) =>
+      count < filteredRecent.length
+        ? Math.min(count + SAVED_WINDOW_STEP, filteredRecent.length)
+        : count,
+    );
+  }, [filteredRecent.length]);
+  const { onScroll: handleRecentScroll } = useInfiniteScroll({
+    onEndReached: loadMoreRecent,
+    enabled: hasMoreRecent,
+  });
 
   const handleRefresh = useCallback(async () => {
     await Promise.all([
@@ -302,6 +337,8 @@ export default function SavedPropertiesScreen() {
         <ScrollView
           contentContainerStyle={styles.gridContent}
           showsVerticalScrollIndicator={false}
+          onScroll={handleRecentScroll}
+          scrollEventThrottle={16}
           refreshControl={
             <RefreshControl
               refreshing={isRefreshing}
@@ -331,10 +368,16 @@ export default function SavedPropertiesScreen() {
               />
             </View>
           ) : (
-            <PropertyResultsGrid
-              properties={filteredRecent}
-              onPropertyPress={handlePropertyPress}
-            />
+            <>
+              <PropertyResultsGrid
+                properties={visibleRecent}
+                onPropertyPress={handlePropertyPress}
+              />
+              {/* Reveal is synchronous (a client-side slice grows), so no loading
+                  skeleton — the next window renders instantly. Web reveals via the
+                  sentinel; native via the ScrollView onScroll. */}
+              <LoadMoreSentinel enabled={hasMoreRecent} onLoadMore={loadMoreRecent} />
+            </>
           )}
         </ScrollView>
       )}

--- a/packages/frontend/app/properties/city/[id].tsx
+++ b/packages/frontend/app/properties/city/[id].tsx
@@ -3,26 +3,57 @@ import {
   View,
   Text,
   StyleSheet,
-  FlatList,
+  Platform,
+  ScrollView,
   ActivityIndicator,
+  type ViewStyle,
 } from 'react-native';
 import { Image } from 'expo-image';
 import { useTranslation } from 'react-i18next';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { colors } from '@/styles/colors';
 import { shadowToken } from '@/styles/shadows';
+import { spacing } from '@/constants/styles';
 
 import { Header } from '@/components/Header';
-import { PropertyCard } from '@/components/PropertyCard';
+import { PropertyResultsGrid } from '@/components/ui/PropertyResultsGrid';
+import { PropertyResultsGridSkeleton } from '@/components/ui/PropertyResultsGridSkeleton';
+import { LoadMoreSentinel } from '@/components/common/LoadMoreSentinel';
 import { Property } from '@homiio/shared-types';
-import { useCity, usePropertiesByCity } from '@/hooks/useCityQueries';
+import { useCity } from '@/hooks/useCityQueries';
+import {
+  useInfiniteCityProperties,
+  type CityPropertyFilters,
+  type CitySortBy,
+} from '@/hooks/useInfiniteCityProperties';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { cityCountryName, getCityImageSource } from '@/utils/cityDisplay';
 import { LinearGradient } from 'expo-linear-gradient';
 import { EmptyState } from '@/components/ui/EmptyState';
+import { ErrorState } from '@/components/ui/ErrorState';
 import { FiltersBar } from '@/components/FiltersBar';
 import { FiltersBottomSheet, type FilterSection, type FilterValue } from '@/components/FiltersBar/FiltersBottomSheet';
 
 import { BottomSheetContext } from '@/context/BottomSheetContext';
+
+/** Number of skeleton cards shown during the first properties load. */
+const SKELETON_COUNT = 6;
+
+interface CityFilterState {
+  verified: boolean;
+  ecoFriendly: boolean;
+  bedrooms: string;
+  bathrooms: string;
+  sortBy: CitySortBy;
+}
+
+const DEFAULT_FILTERS: CityFilterState = {
+  verified: false,
+  ecoFriendly: false,
+  bedrooms: '',
+  bathrooms: '',
+  sortBy: 'newest',
+};
 
 export default function CityPropertiesPage() {
   const { t } = useTranslation();
@@ -32,29 +63,47 @@ export default function CityPropertiesPage() {
   const [headerHeight, setHeaderHeight] = useState(0);
   const bottomSheet = useContext(BottomSheetContext);
 
-  // City + its published properties from the DB (relational geo + self-hosted
-  // cover image). React Query owns loading/error/caching — no local effects.
+  // City detail (hero + stats) from the DB-owned relational geo layer.
   const { data: city, isLoading: cityLoading, isError: cityError } = useCity(cityId);
-  const { data: cityProperties, isLoading: propertiesLoading } = usePropertiesByCity(cityId, {
-    limit: 50,
-    sort: 'createdAt',
-  });
-  const properties = useMemo<Property[]>(
-    () => cityProperties?.properties ?? [],
-    [cityProperties],
-  );
-  const loading = cityLoading || propertiesLoading;
-  const error = cityError ? 'City not found' : null;
   const cityImageSource = getCityImageSource(city ?? undefined, 'large');
   const countryName = cityCountryName(city ?? undefined);
 
-  const [filters, setFilters] = useState({
-    verified: false,
-    ecoFriendly: false,
-    bedrooms: '',
-    bathrooms: '',
-    amenities: [] as string[],
-    sortBy: 'newest'
+  const [filters, setFilters] = useState<CityFilterState>(DEFAULT_FILTERS);
+
+  // Server-resolved filters so the infinite grid paginates correctly (no
+  // client-side re-filtering of already-loaded pages). `verified`/`eco` map to
+  // the Property flags; bedrooms/bathrooms to the min-count params.
+  const propertyFilters = useMemo<CityPropertyFilters>(
+    () => ({
+      verified: filters.verified,
+      eco: filters.ecoFriendly,
+      minBedrooms: filters.bedrooms ? Number(filters.bedrooms) : undefined,
+      minBathrooms: filters.bathrooms ? Number(filters.bathrooms) : undefined,
+    }),
+    [filters.verified, filters.ecoFriendly, filters.bedrooms, filters.bathrooms],
+  );
+
+  const {
+    properties,
+    total,
+    isLoading: propertiesLoading,
+    isError: propertiesError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+  } = useInfiniteCityProperties(cityId, filters.sortBy, propertyFilters);
+
+  // Shared infinite-scroll primitive: native fires `onScroll` end-detect, web
+  // uses the `<LoadMoreSentinel>` at the grid's end.
+  const handleEndReached = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const { onScroll: handleListScroll } = useInfiniteScroll({
+    onEndReached: handleEndReached,
+    enabled: hasNextPage,
   });
 
   const filterSections: FilterSection[] = useMemo(() => [
@@ -125,81 +174,61 @@ export default function CityPropertiesPage() {
         onFilterChange={handleFilterChange}
         onApply={bottomSheet.closeBottomSheet}
         onClear={() => {
-          setFilters({
-            verified: false,
-            ecoFriendly: false,
-            bedrooms: '',
-            bathrooms: '',
-            amenities: [],
-            sortBy: 'newest'
-          });
+          setFilters(prev => ({
+            ...DEFAULT_FILTERS,
+            sortBy: prev.sortBy,
+          }));
           bottomSheet.closeBottomSheet();
         }}
       />
     );
   }, [bottomSheet, filterSections, handleFilterChange]);
 
-  const getFilteredAndSortedProperties = () => {
-    if (!properties || !Array.isArray(properties)) {
-      return [];
-    }
+  const handleOpenSort = useCallback(() => {
+    bottomSheet.openBottomSheet(
+      <FiltersBottomSheet
+        sections={[
+          {
+            id: 'sort',
+            title: t('properties.city.sortBy'),
+            type: 'chips',
+            options: [
+              { id: 'newest', label: t('properties.city.sortNewest'), value: 'newest' },
+              { id: 'priceAsc', label: t('properties.city.sortPriceAsc'), value: 'priceAsc' },
+              { id: 'priceDesc', label: t('properties.city.sortPriceDesc'), value: 'priceDesc' },
+            ],
+            value: filters.sortBy,
+          }
+        ]}
+        onFilterChange={(_, value) =>
+          setFilters(prev => ({ ...prev, sortBy: String(value) as CitySortBy }))
+        }
+        onApply={bottomSheet.closeBottomSheet}
+        onClear={() => {
+          setFilters(prev => ({ ...prev, sortBy: 'newest' }));
+          bottomSheet.closeBottomSheet();
+        }}
+      />
+    );
+  }, [bottomSheet, filters.sortBy, t]);
 
-    let result = [...properties];
+  const activeFiltersCount =
+    (filters.verified ? 1 : 0) +
+    (filters.ecoFriendly ? 1 : 0) +
+    (filters.bedrooms ? 1 : 0) +
+    (filters.bathrooms ? 1 : 0);
 
-    // Apply filters
-    if (filters.verified) {
-      result = result.filter(p => p.status === 'published');
-    }
-
-    if (filters.ecoFriendly) {
-      result = result.filter(p =>
-        p.amenities?.some((a: string) =>
-          a.toLowerCase().includes('eco') ||
-          a.toLowerCase().includes('green') ||
-          a.toLowerCase().includes('solar')
-        )
-      );
-    }
-
-    if (filters.bedrooms) {
-      result = result.filter(p => (p.bedrooms || 0) >= parseInt(filters.bedrooms));
-    }
-
-    if (filters.bathrooms) {
-      result = result.filter(p => (p.bathrooms || 0) >= parseInt(filters.bathrooms));
-    }
-
-    // Apply sorting. Sort by the listing's headline rent — monthly when present,
-    // else the nightly rate for vacation-only listings — so the order is stable.
-    const sortPrice = (p: Property): number =>
-      p.longTermRent?.monthlyAmount ?? p.shortTermRent?.nightlyRate ?? 0;
-    switch (filters.sortBy) {
-      case 'priceAsc':
-        result.sort((a, b) => sortPrice(a) - sortPrice(b));
-        break;
-      case 'priceDesc':
-        result.sort((a, b) => sortPrice(b) - sortPrice(a));
-        break;
-      case 'newest':
-      default:
-        result.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-        break;
-    }
-
-    return result;
-  };
-
-  const renderPropertyItem = ({ item }: { item: Property }) => (
-    <PropertyCard
-      property={item}
+  const handlePropertyPress = useCallback(
+    (property: Property) => {
       // The city-properties endpoint returns lean docs (only `_id`, no `id`
       // virtual), so prefer `_id` for navigation.
-      onPress={() => router.push(`/properties/${item._id || item.id}`)}
-      style={styles.propertyCard}
-    />
+      const propertyId = property._id || property.id;
+      if (propertyId) router.push(`/properties/${propertyId}`);
+    },
+    [router],
   );
 
-  if (loading) {
+  if (cityLoading) {
     return (
       <View style={styles.safeArea}>
         <View
@@ -224,7 +253,7 @@ export default function CityPropertiesPage() {
     );
   }
 
-  if (error || !city) {
+  if (cityError || !city) {
     return (
       <View style={styles.safeArea}>
         <View
@@ -242,7 +271,7 @@ export default function CityPropertiesPage() {
         <View style={{ paddingTop: headerHeight, flex: 1 }}>
           <EmptyState
             icon="alert-circle"
-            title={error || t('properties.city.notFound')}
+            title={t('properties.city.notFound')}
             actionText={t('common.goBack')}
             actionIcon="arrow-back"
             onAction={() => router.back()}
@@ -251,6 +280,44 @@ export default function CityPropertiesPage() {
       </View>
     );
   }
+
+  const propertiesBody = () => {
+    if (propertiesLoading && properties.length === 0) {
+      return <PropertyResultsGridSkeleton count={SKELETON_COUNT} />;
+    }
+    if (propertiesError) {
+      return (
+        <ErrorState
+          title={t('properties.city.notFound')}
+          retryLabel={t('common.tryAgain')}
+          onRetry={() => void refetch()}
+        />
+      );
+    }
+    if (properties.length === 0) {
+      return (
+        <EmptyState
+          icon="home-outline"
+          title={t('properties.city.noPropertiesFound')}
+          description={t('properties.city.tryAdjustFilters')}
+          actionText={t('properties.city.clearFilters')}
+          actionIcon="refresh"
+          onAction={() => setFilters(DEFAULT_FILTERS)}
+        />
+      );
+    }
+    return (
+      <>
+        <PropertyResultsGrid properties={properties} onPropertyPress={handlePropertyPress} />
+        {isFetchingNextPage ? (
+          <View style={styles.nextPageSkeleton}>
+            <PropertyResultsGridSkeleton count={2} />
+          </View>
+        ) : null}
+        <LoadMoreSentinel enabled={hasNextPage} onLoadMore={handleEndReached} />
+      </>
+    );
+  };
 
   return (
     <View style={styles.safeArea}>
@@ -266,7 +333,13 @@ export default function CityPropertiesPage() {
           }}
         />
       </View>
-      <View style={{ paddingTop: headerHeight, flex: 1 }}>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={{ paddingTop: headerHeight, paddingBottom: spacing['4xl'] }}
+        onScroll={handleListScroll}
+        scrollEventThrottle={16}
+        showsVerticalScrollIndicator={false}
+      >
         {/* Hero Section — DB-stored cover image (self-hosted) behind a scrim,
             falling back to a brand gradient when the city has no cover image. */}
         <View style={styles.heroSection}>
@@ -322,79 +395,21 @@ export default function CityPropertiesPage() {
             <View>
               <Text style={styles.sectionTitle}>{t('properties.city.availableProperties')}</Text>
               <Text style={styles.propertiesSubtitle}>
-                {getFilteredAndSortedProperties().length} {t('properties.city.propertiesFound')}
+                {total} {t('properties.city.propertiesFound')}
               </Text>
             </View>
           </View>
 
           <FiltersBar
-            activeFiltersCount={
-              Object.values(filters).filter(value =>
-                value !== false &&
-                value !== '' &&
-                value !== 'newest' &&
-                (Array.isArray(value) ? value.length > 0 : true)
-              ).length
-            }
+            activeFiltersCount={activeFiltersCount}
             onFilterPress={handleOpenFilters}
             sortBy={filters.sortBy}
-            onSortPress={() => {
-              bottomSheet.openBottomSheet(
-                <FiltersBottomSheet
-                  sections={[
-                    {
-                      id: 'sort',
-                      title: t('properties.city.sortBy'),
-                      type: 'chips',
-                      options: [
-                        { id: 'newest', label: t('properties.city.sortNewest'), value: 'newest' },
-                        { id: 'priceAsc', label: t('properties.city.sortPriceAsc'), value: 'priceAsc' },
-                        { id: 'priceDesc', label: t('properties.city.sortPriceDesc'), value: 'priceDesc' },
-                      ],
-                      value: filters.sortBy
-                    }
-                  ]}
-                  onFilterChange={(_, value) => setFilters(prev => ({ ...prev, sortBy: value.toString() }))}
-                  onApply={bottomSheet.closeBottomSheet}
-                  onClear={() => {
-                    setFilters(prev => ({ ...prev, sortBy: 'newest' }));
-                    bottomSheet.closeBottomSheet();
-                  }}
-                />
-              );
-            }}
+            onSortPress={handleOpenSort}
           />
 
-          {/* Properties List */}
-          <FlatList
-            data={getFilteredAndSortedProperties()}
-            renderItem={renderPropertyItem}
-            keyExtractor={(item) => item._id || item.id || Math.random().toString()}
-            scrollEnabled={false}
-            contentContainerStyle={styles.propertiesList}
-            ListEmptyComponent={
-              <EmptyState
-                icon="home-outline"
-                title={t('properties.city.noPropertiesFound')}
-                description={t('properties.city.tryAdjustFilters')}
-                actionText={t('properties.city.clearFilters')}
-                actionIcon="refresh"
-                onAction={() => {
-                  setFilters(prev => ({
-                    ...prev,
-                    verified: false,
-                    ecoFriendly: false,
-                    bedrooms: '',
-                    bathrooms: '',
-                    amenities: [],
-                    sortBy: 'newest'
-                  }));
-                }}
-              />
-            }
-          />
+          <View style={styles.propertiesList}>{propertiesBody()}</View>
         </View>
-      </View>
+      </ScrollView>
     </View>
   );
 }
@@ -404,9 +419,10 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.background,
   },
-  container: {
-    flex: 1,
-  },
+  scroll: Platform.select<ViewStyle>({
+    web: { flex: 1, overflow: 'auto' } as unknown as ViewStyle,
+    default: { flex: 1 },
+  }) as ViewStyle,
   loadingContainer: {
     flex: 1,
     justifyContent: 'center',
@@ -516,67 +532,13 @@ const styles = StyleSheet.create({
     color: colors.COLOR_BLACK_LIGHT_3,
     marginTop: 4,
   },
-  sortContainer: {
-    flexDirection: 'row',
-    gap: 12,
-  },
-  sortButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 8,
-    paddingHorizontal: 12,
-    backgroundColor: colors.white,
-    borderRadius: 20,
-    ...shadowToken({ y: 1, blur: 3, color: colors.shadow, opacity: 0.1, elevation: 2 }),
-  },
-  sortButtonText: {
-    fontSize: 14,
-    color: colors.COLOR_BLACK_LIGHT_3,
-    marginLeft: 6,
-    fontWeight: '500',
-  },
-  activeSortButtonText: {
-    color: colors.primaryColor,
-    fontWeight: '600',
-  },
-
-  // Filters
-  filtersScroll: {
-    paddingRight: 20,
-    marginBottom: 24,
-  },
-  filterChip: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 10,
-    paddingHorizontal: 16,
-    backgroundColor: colors.white,
-    borderRadius: 25,
-    marginRight: 12,
-    ...shadowToken({ y: 1, blur: 3, color: colors.shadow, opacity: 0.1, elevation: 2 }),
-  },
-  activeFilterChip: {
-    backgroundColor: colors.primaryColor,
-  },
-  filterChipText: {
-    marginLeft: 8,
-    fontSize: 14,
-    color: colors.COLOR_BLACK,
-    fontWeight: '500',
-  },
-  activeFilterChipText: {
-    color: colors.primaryForeground,
-  },
 
   // Properties List
   propertiesList: {
-    gap: 16,
+    marginTop: spacing.lg,
   },
-  propertyCard: {
-    backgroundColor: colors.white,
-    borderRadius: 16,
-    overflow: 'hidden',
-    ...shadowToken({ y: 2, blur: 8, color: colors.shadow, opacity: 0.08, elevation: 3 }),
+  nextPageSkeleton: {
+    marginTop: spacing.lg,
   },
   stickyHeaderWrapper: {
     zIndex: 100,

--- a/packages/frontend/app/properties/index.tsx
+++ b/packages/frontend/app/properties/index.tsx
@@ -27,6 +27,7 @@ import { Text as BloomText } from '@oxyhq/bloom/typography';
 
 import { PropertyResultsGrid } from '@/components/ui/PropertyResultsGrid';
 import { PropertyResultsGridSkeleton } from '@/components/ui/PropertyResultsGridSkeleton';
+import { LoadMoreSentinel } from '@/components/common/LoadMoreSentinel';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ErrorState } from '@/components/ui/ErrorState';
 import { SearchSummaryBar } from '@/components/search/SearchSummaryBar';
@@ -45,6 +46,7 @@ import type {
 
 import { BottomSheetContext } from '@/context/BottomSheetContext';
 import { usePropertySearch } from '@/hooks/usePropertySearch';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { DEFAULT_SEARCH_QUERY } from '@/store/searchQueryStore';
 import { colors } from '@/styles/colors';
 import { cardShadow, hairline, radius, spacing } from '@/constants/styles';
@@ -218,11 +220,18 @@ export default function PropertiesScreen() {
     );
   }, [bottomSheet, query, handleSheetFilterChange, patchQuery]);
 
+  // Shared infinite-scroll primitive: native fires `onScroll` end-detect, web
+  // uses the `<LoadMoreSentinel>` at the grid's end. Both funnel through the same
+  // guarded loader (no hand-rolled distance math).
   const handleEndReached = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {
       void fetchNextPage();
     }
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const { onScroll: handleListScroll } = useInfiniteScroll({
+    onEndReached: handleEndReached,
+    enabled: hasNextPage,
+  });
 
   const resultsHeading = useMemo(() => {
     if (isLoading) {
@@ -331,13 +340,8 @@ export default function PropertiesScreen() {
       <ScrollView
         style={styles.listScroll}
         contentContainerStyle={styles.listScrollContent}
-        onScroll={({ nativeEvent }) => {
-          const { layoutMeasurement, contentOffset, contentSize } = nativeEvent;
-          const distanceFromEnd =
-            contentSize.height - (layoutMeasurement.height + contentOffset.y);
-          if (distanceFromEnd < layoutMeasurement.height) handleEndReached();
-        }}
-        scrollEventThrottle={200}
+        onScroll={handleListScroll}
+        scrollEventThrottle={16}
         showsVerticalScrollIndicator={false}
       >
         <View style={styles.resultsHeader}>
@@ -350,6 +354,7 @@ export default function PropertiesScreen() {
             style={styles.gridPadding}
           />
         ) : null}
+        <LoadMoreSentinel enabled={hasNextPage} onLoadMore={handleEndReached} />
       </ScrollView>
       <View style={[styles.fab, cardShadow.md, { bottom: insets.bottom + spacing['3xl'] }]}>
         <Button

--- a/packages/frontend/app/properties/type/[type].tsx
+++ b/packages/frontend/app/properties/type/[type].tsx
@@ -23,6 +23,7 @@ import { useTranslation } from 'react-i18next';
 import { PropertyListHeader } from '@/components/ui/PropertyListHeader';
 import { PropertyResultsGrid } from '@/components/ui/PropertyResultsGrid';
 import { PropertyResultsGridSkeleton } from '@/components/ui/PropertyResultsGridSkeleton';
+import { LoadMoreSentinel } from '@/components/common/LoadMoreSentinel';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ErrorState } from '@/components/ui/ErrorState';
 import { SearchActionPill } from '@/components/search/SearchActionPill';
@@ -39,6 +40,7 @@ import type {
 } from '@/components/search/types';
 import { BottomSheetContext } from '@/context/BottomSheetContext';
 import { usePropertySearch } from '@/hooks/usePropertySearch';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { DEFAULT_SEARCH_QUERY } from '@/store/searchQueryStore';
 import { colors } from '@/styles/colors';
 import { contentClamp, spacing } from '@/constants/styles';
@@ -219,11 +221,17 @@ export default function PropertyTypeScreen() {
     );
   }, [bottomSheet, query.sortBy, query.sortOrder, patchQuery]);
 
+  // Shared infinite-scroll primitive: native fires `onScroll` end-detect, web
+  // uses the `<LoadMoreSentinel>` at the grid's end (no hand-rolled distance math).
   const handleEndReached = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {
       void fetchNextPage();
     }
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const { onScroll: handleListScroll } = useInfiniteScroll({
+    onEndReached: handleEndReached,
+    enabled: hasNextPage,
+  });
 
   const typeName = getTypeName(typeId);
   const subtitle = isLoading
@@ -281,13 +289,8 @@ export default function PropertyTypeScreen() {
       <ScrollView
         style={styles.scroll}
         contentContainerStyle={styles.scrollContent}
-        onScroll={({ nativeEvent }) => {
-          const { layoutMeasurement, contentOffset, contentSize } = nativeEvent;
-          const distanceFromEnd =
-            contentSize.height - (layoutMeasurement.height + contentOffset.y);
-          if (distanceFromEnd < layoutMeasurement.height) handleEndReached();
-        }}
-        scrollEventThrottle={200}
+        onScroll={handleListScroll}
+        scrollEventThrottle={16}
         showsVerticalScrollIndicator={false}
       >
         <ScrollView
@@ -316,6 +319,7 @@ export default function PropertyTypeScreen() {
         {isFetchingNextPage ? (
           <PropertyResultsGridSkeleton count={2} style={styles.gridPadding} />
         ) : null}
+        <LoadMoreSentinel enabled={hasNextPage} onLoadMore={handleEndReached} />
       </ScrollView>
     </View>
   );

--- a/packages/frontend/components/HomeCarouselSection.tsx
+++ b/packages/frontend/components/HomeCarouselSection.tsx
@@ -16,6 +16,7 @@ import {
   NativeSyntheticEvent,
   NativeScrollEvent,
 } from 'react-native';
+import Animated, { FadeInDown } from 'react-native-reanimated';
 import { Ionicons } from '@expo/vector-icons';
 import { useMediaQuery } from 'react-responsive';
 
@@ -189,7 +190,7 @@ export function HomeCarouselSection<T>({
   const disableLeftArrow = scrollX <= 0;
 
   return (
-    <View>
+    <Animated.View entering={FadeInDown.duration(420)}>
       <View className={`mb-4 flex-row items-end justify-between gap-4 ${PAGE_GUTTER_CLASS}`}>
         <View className="min-w-0 flex-1 shrink">
           {eyebrow ? <SectionEyebrow>{eyebrow}</SectionEyebrow> : null}
@@ -277,6 +278,6 @@ export function HomeCarouselSection<T>({
           </ScrollView>
         )}
       </View>
-    </View>
+    </Animated.View>
   );
 }

--- a/packages/frontend/components/PageScrollView.tsx
+++ b/packages/frontend/components/PageScrollView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import {
   Platform,
   View,
@@ -7,10 +7,13 @@ import {
   type ViewStyle,
 } from 'react-native';
 import Animated, {
+  runOnJS,
   useAnimatedScrollHandler,
   useSharedValue,
   type SharedValue,
 } from 'react-native-reanimated';
+
+import { END_REACHED_THRESHOLD } from '@/hooks/useInfiniteScroll';
 
 const IS_WEB = Platform.OS === 'web';
 
@@ -30,6 +33,18 @@ interface PageScrollViewProps {
   /** Native-only — ignored on web where the document is the scroll owner. */
   refreshControl?: React.ReactElement<RefreshControlProps>;
   showsVerticalScrollIndicator?: boolean;
+  /**
+   * NATIVE-only infinite-scroll trigger. Fired (guarded, once per approach) when
+   * the native `Animated.ScrollView` scrolls past {@link onEndReachedThreshold}
+   * of its content. On web the document is the scroll owner, so a screen pairs
+   * this with a `<LoadMoreSentinel>` at the feed's end and the sentinel drives
+   * web pagination instead. The consumer's own
+   * `if (hasNextPage && !isFetchingNextPage) fetchNextPage()` guard keeps this
+   * idempotent.
+   */
+  onEndReached?: () => void;
+  /** Fraction of content height past which `onEndReached` fires (0–1). */
+  onEndReachedThreshold?: number;
 }
 
 /**
@@ -52,15 +67,46 @@ export function PageScrollView({
   contentContainerStyle,
   refreshControl,
   showsVerticalScrollIndicator,
+  onEndReached,
+  onEndReachedThreshold = END_REACHED_THRESHOLD,
 }: PageScrollViewProps) {
   const fallbackScrollY = useSharedValue(0);
   const value = scrollY ?? fallbackScrollY;
 
-  const scrollHandler = useAnimatedScrollHandler({
-    onScroll: (event) => {
-      value.value = event.contentOffset.y;
+  // Keep the latest `onEndReached` without regenerating the worklet handler.
+  const onEndReachedRef = useRef(onEndReached);
+  onEndReachedRef.current = onEndReached;
+  const fireEndReached = useCallback(() => {
+    onEndReachedRef.current?.();
+  }, []);
+  const endEnabled = onEndReached != null;
+  // Re-arm on the UI thread once scrolled back above the threshold, so the burst
+  // of worklet `onScroll` events near the bottom hops to JS at most once per
+  // approach.
+  const endArmed = useSharedValue(true);
+
+  const scrollHandler = useAnimatedScrollHandler(
+    {
+      onScroll: (event) => {
+        value.value = event.contentOffset.y;
+        if (!endEnabled) return;
+        const { contentOffset, layoutMeasurement, contentSize } = event;
+        if (contentSize.height <= 0) return;
+        const reachedEnd =
+          contentOffset.y + layoutMeasurement.height >=
+          contentSize.height * onEndReachedThreshold;
+        if (!reachedEnd) {
+          endArmed.value = true;
+          return;
+        }
+        if (endArmed.value) {
+          endArmed.value = false;
+          runOnJS(fireEndReached)();
+        }
+      },
     },
-  });
+    [value, endArmed, endEnabled, onEndReachedThreshold, fireEndReached],
+  );
 
   useEffect(() => {
     if (!IS_WEB) return;

--- a/packages/frontend/components/PropertyCard.tsx
+++ b/packages/frontend/components/PropertyCard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { View, Image, StyleSheet, Pressable, TouchableOpacity, ViewStyle, Platform } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { colors } from '@/styles/colors';
@@ -29,6 +29,29 @@ import { prefetchProperty, prefetchPropertyStats } from '@/utils/queryPrefetch';
 import { PropertyCardSkeleton } from './ui/skeletons/PropertyCardSkeleton';
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
+
+const IS_WEB = Platform.OS === 'web';
+
+/** A listing counts as "new" (badge) while its `createdAt` is within this window. */
+const NEW_LISTING_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Card scale while hovered (web pointer) — a subtle Airbnb-style lift. */
+const HOVER_SCALE = 1.02;
+/** Card scale while pressed — a tactile push-down (native + web tap). */
+const PRESS_SCALE = 0.97;
+
+/**
+ * Web-only CSS transition so the hover/press scale eases instead of snapping.
+ * `transitionProperty` is a web value RN's `ViewStyle` lacks, so this block is
+ * web-cast (the sanctioned pattern for web-only CSS in this codebase).
+ */
+const WEB_INTERACTION_TRANSITION: ViewStyle | null = IS_WEB
+  ? ({
+      transitionProperty: 'transform',
+      transitionDuration: '160ms',
+      transitionTimingFunction: 'ease-out',
+    } as unknown as ViewStyle)
+  : null;
 
 function shouldShowInstantBook(
   property: Property,
@@ -219,6 +242,31 @@ export function PropertyCard({
     [property, mode],
   );
 
+  // Hover (web pointer) + press micro-interaction. Static-array styles driven by
+  // state, never the NativeWind-incompatible function-form `style` (AGENTS.md
+  // §NativeWind Pressable). Web hover uses `onPointerEnter/Leave` on the outer
+  // card wrapper; press is threaded through the inner Pressables below.
+  const [hovered, setHovered] = useState(false);
+  const [pressed, setPressed] = useState(false);
+  const handleInteractionPressIn = useCallback(() => {
+    setPressed(true);
+    handlePressIn();
+  }, [handlePressIn]);
+  const handleInteractionPressOut = useCallback(() => {
+    setPressed(false);
+  }, []);
+  const interactionScale = pressed ? PRESS_SCALE : hovered ? HOVER_SCALE : 1;
+
+  // "New" freshness badge — pure frontend, no pagination risk. Memoized on
+  // `createdAt` so `Date.now()` is captured once per listing (the 7-day boundary
+  // rarely flips mid-session) rather than read impurely on every render.
+  const isNew = useMemo(() => {
+    const createdAt = property?.createdAt;
+    if (!createdAt) return false;
+    const created = new Date(createdAt).getTime();
+    return Number.isFinite(created) && Date.now() - created <= NEW_LISTING_WINDOW_MS;
+  }, [property?.createdAt]);
+
   // Show skeleton loading state
   if (isLoading) {
     return (
@@ -372,12 +420,24 @@ export function PropertyCard({
           opposite corner from the save heart (top-right), so they never
           overlap; the carousel dots sit bottom-centre, also clear.
 
-          Order (offerings lead, then provenance/status): rating → offerings →
-          instant book → verified → eco. The compact ("small") card is too
-          small to host any of this — its photo shows only the save heart — so
-          the whole stack is suppressed on compact as well as grid. */}
-      {!isGrid && !isCompact && (
+          Order (freshness leads, then offerings, then provenance/status): new →
+          rating → offerings → instant book → verified → eco. The compact
+          ("small") card is too small to host any of this — its photo shows only
+          the save heart — so the whole stack is suppressed on compact. The grid
+          variant stays photo-first, so it renders ONLY the freshness chip (the
+          rich chips are gated on `!isGrid`). */}
+      {!isCompact && (isNew || !isGrid) && (
         <View style={styles.mediaChipStack}>
+          {isNew ? (
+            <View style={styles.newChip}>
+              <BloomText style={styles.newChipText}>
+                {t('listing.badge.new', 'New')}
+              </BloomText>
+            </View>
+          ) : null}
+
+          {!isGrid ? (
+            <>
           {finalShowRating && propertyData.rating ? (
             <MediaChip
               icon="star"
@@ -417,6 +477,8 @@ export function PropertyCard({
 
           {/* Eco — icon-only leaf, green accent. */}
           {isEco ? <MediaChip icon="leaf" accent={colors.success} /> : null}
+            </>
+          ) : null}
         </View>
       )}
 
@@ -572,10 +634,18 @@ export function PropertyCard({
 
   return (
     <View
+      // Web hover lift: pointer enter/leave fire on the card's own boundary
+      // (they don't bubble from inner children), mapping to mouseenter/mouseleave
+      // on RN-Web. No-op on native — touch never produces hover.
+      onPointerEnter={IS_WEB ? () => setHovered(true) : undefined}
+      onPointerLeave={IS_WEB ? () => setHovered(false) : undefined}
       style={[
         styles.container,
+        WEB_INTERACTION_TRANSITION,
         style as ViewStyle,
         isProcessing ? { opacity: 0.7 } : null,
+        // Interaction transform last so the hover/press scale always wins.
+        { transform: [{ scale: interactionScale }] },
       ]}
     >
       {useCarousel ? (
@@ -591,7 +661,8 @@ export function PropertyCard({
             aspectRatio={mediaAspectRatio}
             borderRadius={isGrid ? radius.photo : radius.lg}
             onPress={onPress}
-            onPressIn={handlePressIn}
+            onPressIn={handleInteractionPressIn}
+            onPressOut={handleInteractionPressOut}
             onLongPress={onLongPress}
             accessibilityLabel={propertyData.title}
           >
@@ -600,7 +671,8 @@ export function PropertyCard({
           <Pressable
             style={styles.contentPressable}
             onPress={onPress}
-            onPressIn={handlePressIn}
+            onPressIn={handleInteractionPressIn}
+            onPressOut={handleInteractionPressOut}
             onLongPress={onLongPress}
             accessibilityRole="button"
             accessibilityLabel={propertyData.title}
@@ -615,7 +687,8 @@ export function PropertyCard({
             orientation === 'horizontal' ? styles.horizontalBody : null,
           ]}
           onPress={onPress}
-          onPressIn={handlePressIn}
+          onPressIn={handleInteractionPressIn}
+          onPressOut={handleInteractionPressOut}
           onLongPress={onLongPress}
           accessibilityRole="button"
           accessibilityLabel={propertyData.title}
@@ -851,6 +924,29 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     alignItems: 'flex-start',
     gap: spacing.xs,
+  },
+  /**
+   * Freshness "New" chip — a solid brand pill leading the top-left stack. Sized
+   * to `CHIP_HEIGHT_MD` (28) so it aligns on the same baseline as the frosted
+   * `MediaChip`s beside it; a solid brand fill (vs. the frosted chips) makes the
+   * freshness signal read first. Uses `primaryForeground` on the primary fill.
+   */
+  newChip: {
+    height: 28,
+    paddingHorizontal: spacing.md,
+    borderRadius: radius.pill,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.primaryColor,
+    ...(Platform.OS === 'web'
+      ? { boxShadow: boxShadow({ y: 1, blur: 3, color: colors.COLOR_BLACK, opacity: 0.12 }) }
+      : { boxShadow: boxShadow({ y: 1, blur: 3, color: colors.COLOR_BLACK, opacity: 0.1 }), elevation: 2 }),
+  },
+  newChipText: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: colors.primaryForeground,
+    letterSpacing: 0.2,
   },
   // Property type in the meta line below the photo (icon + label), replacing the
   // former on-photo type chip.

--- a/packages/frontend/components/common/LoadMoreSentinel.tsx
+++ b/packages/frontend/components/common/LoadMoreSentinel.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useRef } from 'react';
+import { Platform, View } from 'react-native';
+
+interface LoadMoreSentinelProps {
+  /** Fired when the sentinel nears the viewport (web) — wire to `fetchNextPage`. */
+  onLoadMore: () => void;
+  /** Only observe while there is more to load (no next page ⇒ no trigger). */
+  enabled: boolean;
+  /** Pre-fetch distance ahead of the viewport bottom (web IntersectionObserver rootMargin). */
+  rootMargin?: string;
+}
+
+const SENTINEL_STYLE = { height: 1 } as const;
+
+/**
+ * Web infinite-scroll trigger for the document-scroll surfaces (home, search,
+ * browse, city, saved). Homiio's web pages scroll the DOCUMENT — there is no
+ * page-level `ScrollView` with an `onEndReached` — so a list that paginates
+ * renders this 1px marker at its end: when it enters the viewport (`rootMargin`
+ * px early) `onLoadMore` fires. Inert on native, where the same lists paginate
+ * via the surface's own `onScroll` end-detect (`useInfiniteScroll`) instead — so
+ * a screen wires BOTH (this for web, `onScroll`/`onEndReached` for native) and
+ * each platform uses the one that applies. Ported from Mention's `LoadMoreSentinel`.
+ */
+export function LoadMoreSentinel({ onLoadMore, enabled, rootMargin = '600px' }: LoadMoreSentinelProps) {
+  const viewRef = useRef<View>(null);
+  // Keep the latest callback without re-subscribing the observer every render.
+  const onLoadMoreRef = useRef(onLoadMore);
+  onLoadMoreRef.current = onLoadMore;
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' || typeof window === 'undefined' || !('IntersectionObserver' in window)) {
+      return;
+    }
+    if (!enabled) return;
+
+    // react-native-web exposes the underlying DOM node via `_nativeNode`/
+    // `getNode()` (neither is on the typed View ref), with the ref itself as a
+    // last resort. Narrow structurally instead of `as any`.
+    const ref = viewRef.current as
+      | (View & { _nativeNode?: Element; getNode?: () => Element })
+      | null;
+    const element: Element | View | null = ref?._nativeNode ?? ref?.getNode?.() ?? ref;
+    if (!element || (element as Partial<Element>).nodeType === undefined) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          onLoadMoreRef.current();
+        }
+      },
+      { rootMargin },
+    );
+    observer.observe(element as Element);
+    return () => observer.disconnect();
+  }, [enabled, rootMargin]);
+
+  return <View ref={viewRef} style={SENTINEL_STYLE} />;
+}

--- a/packages/frontend/components/property/PropertyImageCarousel.tsx
+++ b/packages/frontend/components/property/PropertyImageCarousel.tsx
@@ -85,6 +85,8 @@ interface PropertyImageCarouselProps {
   onPress?: () => void;
   /** Fires immediately before the press settles, used to prefetch detail data. */
   onPressIn?: () => void;
+  /** Fires when the press is released/cancelled (drives the card's pressed lift). */
+  onPressOut?: () => void;
   onLongPress?: () => void;
   /** Notifies the parent of the active page (e.g. to sync external chrome). */
   onIndexChange?: (index: number) => void;
@@ -115,6 +117,7 @@ interface CarouselPageProps {
   fillWhenUnmeasured?: boolean;
   onPress?: () => void;
   onPressIn?: () => void;
+  onPressOut?: () => void;
   onLongPress?: () => void;
   accessibilityLabel?: string;
 }
@@ -138,12 +141,14 @@ const CarouselPage: React.FC<CarouselPageProps> = ({
   fillWhenUnmeasured = false,
   onPress,
   onPressIn,
+  onPressOut,
   onLongPress,
   accessibilityLabel,
 }) => (
   <Pressable
     onPress={onPress}
     onPressIn={onPressIn}
+    onPressOut={onPressOut}
     onLongPress={onLongPress}
     accessibilityRole="button"
     accessibilityLabel={accessibilityLabel}
@@ -260,6 +265,7 @@ export const PropertyImageCarousel: React.FC<PropertyImageCarouselProps> = ({
   borderRadius,
   onPress,
   onPressIn,
+  onPressOut,
   onLongPress,
   onIndexChange,
   accessibilityLabel,
@@ -353,11 +359,12 @@ export const PropertyImageCarousel: React.FC<PropertyImageCarouselProps> = ({
         height={pageHeight}
         onPress={onPress}
         onPressIn={onPressIn}
+        onPressOut={onPressOut}
         onLongPress={onLongPress}
         accessibilityLabel={accessibilityLabel}
       />
     ),
-    [containerWidth, pageHeight, onPress, onPressIn, onLongPress, accessibilityLabel],
+    [containerWidth, pageHeight, onPress, onPressIn, onPressOut, onLongPress, accessibilityLabel],
   );
 
   const isMultiPage = sources.length > 1;
@@ -408,6 +415,7 @@ export const PropertyImageCarousel: React.FC<PropertyImageCarouselProps> = ({
           fillWhenUnmeasured
           onPress={onPress}
           onPressIn={onPressIn}
+          onPressOut={onPressOut}
           onLongPress={onLongPress}
           accessibilityLabel={accessibilityLabel}
         />

--- a/packages/frontend/components/search/SearchResultsView.tsx
+++ b/packages/frontend/components/search/SearchResultsView.tsx
@@ -28,6 +28,8 @@ import { Button } from '@oxyhq/bloom/button';
 import { Text as BloomText } from '@oxyhq/bloom/typography';
 
 import { useSavedSearches } from '@/hooks/useSavedSearches';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { LoadMoreSentinel } from '@/components/common/LoadMoreSentinel';
 import MapView, { type MapApi } from '@/components/Map';
 import { PropertyResultsGrid } from '@/components/ui/PropertyResultsGrid';
 import { PropertyResultsGridSkeleton } from '@/components/ui/PropertyResultsGridSkeleton';
@@ -382,11 +384,18 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
     );
   }, [bottomSheet, canSaveSearch, onRequireAuth, query]);
 
+  // Shared infinite-scroll primitive: native fires `onScroll` end-detect, web
+  // uses the `<LoadMoreSentinel>` below. Both funnel through the same guarded
+  // loader, replacing the hand-rolled `ScrollView.onScroll` distance math.
   const handleEndReached = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {
       void fetchNextPage();
     }
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const { onScroll: handleListScroll } = useInfiniteScroll({
+    onEndReached: handleEndReached,
+    enabled: hasNextPage,
+  });
 
   const resultsHeading = useMemo(() => {
     if (isLoading) {
@@ -520,13 +529,8 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
     <ScrollView
       style={styles.listScroll}
       contentContainerStyle={styles.listScrollContent}
-      onScroll={({ nativeEvent }) => {
-        const { layoutMeasurement, contentOffset, contentSize } = nativeEvent;
-        const distanceFromEnd =
-          contentSize.height - (layoutMeasurement.height + contentOffset.y);
-        if (distanceFromEnd < layoutMeasurement.height) handleEndReached();
-      }}
-      scrollEventThrottle={200}
+      onScroll={handleListScroll}
+      scrollEventThrottle={16}
       showsVerticalScrollIndicator={false}
     >
       <View style={styles.resultsHeader}>
@@ -539,6 +543,7 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
           style={styles.gridPadding}
         />
       ) : null}
+      <LoadMoreSentinel enabled={hasNextPage} onLoadMore={handleEndReached} />
     </ScrollView>
   );
 

--- a/packages/frontend/components/search/types.ts
+++ b/packages/frontend/components/search/types.ts
@@ -8,7 +8,7 @@
  * them without a cycle.
  */
 import { OfferingType } from '@homiio/shared-types';
-import type { PropertyType } from '@homiio/shared-types';
+import type { ExchangeMode, PropertyType } from '@homiio/shared-types';
 
 /**
  * A geographic bounding box in the same `{ west, south, east, north }` shape the
@@ -94,6 +94,19 @@ export interface SearchQuery {
   sortOrder: SearchSortOrder;
   /** When true, only listings with `priceEthics.isFairPrice`. */
   fairPrice?: boolean;
+  /**
+   * Short-term-only: restrict to instant-bookable listings. Carried here (not
+   * only in the filters sheet) so a home category like "Instant book" can seed
+   * the endless feed through the same query path.
+   */
+  instantBook?: boolean;
+  /** Restrict to pet-friendly listings (home "Pet friendly" category lens). */
+  petFriendly?: boolean;
+  /**
+   * Exchange-only: restrict to a swap/host exchange mode. Only meaningful when
+   * `offering` is {@link OfferingType.EXCHANGE}; the backend ignores it otherwise.
+   */
+  exchangeMode?: ExchangeMode;
 }
 
 /** The ordered steps the panel walks through (Dates only in short-term mode). */

--- a/packages/frontend/hooks/useInfiniteCityProperties.ts
+++ b/packages/frontend/hooks/useInfiniteCityProperties.ts
@@ -1,0 +1,138 @@
+/**
+ * useInfiniteCityProperties — paginated React Query hook for a city's published
+ * listings, mirroring {@link usePropertySearch} against
+ * `GET /api/cities/:id/properties`.
+ *
+ * The endpoint returns `{ city, properties, pagination, hasMore, totalPages }`
+ * (the flat `hasMore`/`totalPages` aliases were added for parity with
+ * `/properties/search`), so `getNextPageParam` reads `hasMore` exactly like the
+ * search hook. Filters (verified / eco / bedrooms / bathrooms) and the sort are
+ * resolved SERVER-side so pagination stays correct — no client-side re-filtering
+ * of already-loaded pages.
+ */
+import {
+  useInfiniteQuery,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+} from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { api } from '@/utils/api';
+import type { Property } from '@homiio/shared-types';
+
+/** Per-page size (the city endpoint caps limit server-side). */
+const PAGE_SIZE = 24;
+/** Results stay fresh for a minute of paging before a refetch. */
+const STALE_TIME_MS = 1000 * 60;
+/** Cache retention after the query goes inactive. */
+const GC_TIME_MS = 1000 * 60 * 10;
+
+/** Sort options the city screen exposes, mapped to the backend `sort` param. */
+export type CitySortBy = 'newest' | 'priceAsc' | 'priceDesc';
+
+const CITY_SORT_PARAM: Record<CitySortBy, string> = {
+  newest: 'createdAt',
+  priceAsc: 'price_asc',
+  priceDesc: 'price_desc',
+};
+
+/** Server-resolved filters for a city's property list. */
+export interface CityPropertyFilters {
+  verified?: boolean;
+  eco?: boolean;
+  minBedrooms?: number;
+  minBathrooms?: number;
+}
+
+/** Raw response body (post-`normalizeEnvelope`) for the city properties endpoint. */
+interface CityPropertiesResponseBody {
+  properties?: Property[];
+  pagination?: { page: number; limit: number; total: number; pages: number };
+  hasMore?: boolean;
+  totalPages?: number;
+}
+
+/** One page of results plus paging metadata used by `getNextPageParam`. */
+interface CityPropertiesPage {
+  properties: Property[];
+  page: number;
+  total: number;
+  hasMore: boolean;
+}
+
+/** Build the endpoint query params for a page. Pure so the key derives from it. */
+function buildCityParams(
+  sortBy: CitySortBy,
+  filters: CityPropertyFilters,
+): Record<string, string | number> {
+  const params: Record<string, string | number> = {
+    limit: PAGE_SIZE,
+    sort: CITY_SORT_PARAM[sortBy],
+  };
+  if (filters.verified) params.verified = 'true';
+  if (filters.eco) params.eco = 'true';
+  if (typeof filters.minBedrooms === 'number' && filters.minBedrooms > 0) {
+    params.minBedrooms = filters.minBedrooms;
+  }
+  if (typeof filters.minBathrooms === 'number' && filters.minBathrooms > 0) {
+    params.minBathrooms = filters.minBathrooms;
+  }
+  return params;
+}
+
+export type CityPropertiesResult = UseInfiniteQueryResult<
+  InfiniteData<CityPropertiesPage>,
+  Error
+> & {
+  /** All loaded properties flattened across pages. */
+  properties: Property[];
+  /** Total match count reported by the server. */
+  total: number;
+};
+
+export function useInfiniteCityProperties(
+  cityId: string | undefined,
+  sortBy: CitySortBy,
+  filters: CityPropertyFilters = {},
+): CityPropertiesResult {
+  const baseParams = useMemo(
+    () => buildCityParams(sortBy, filters),
+    [sortBy, filters.verified, filters.eco, filters.minBedrooms, filters.minBathrooms],
+  );
+  // `page`/`limit` are excluded from the key (the infinite query owns paging) so
+  // all pages of one city+sort+filter set share a cache entry.
+  const key = useMemo(
+    () => ['cityProperties', cityId ?? '', baseParams] as const,
+    [cityId, baseParams],
+  );
+
+  const result = useInfiniteQuery({
+    queryKey: key,
+    initialPageParam: 1,
+    enabled: Boolean(cityId),
+    staleTime: STALE_TIME_MS,
+    gcTime: GC_TIME_MS,
+    queryFn: async ({ pageParam }): Promise<CityPropertiesPage> => {
+      const { data } = await api.get<CityPropertiesResponseBody>(
+        `/api/cities/${cityId}/properties`,
+        { params: { ...baseParams, page: pageParam }, requireAuth: false },
+      );
+      return {
+        properties: data.properties ?? [],
+        page: data.pagination?.page ?? pageParam,
+        total: data.pagination?.total ?? (data.properties?.length ?? 0),
+        hasMore: data.hasMore ?? false,
+      };
+    },
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore ? lastPage.page + 1 : undefined,
+  });
+
+  const properties = useMemo<Property[]>(
+    () => result.data?.pages.flatMap((p) => p.properties) ?? [],
+    [result.data],
+  );
+  const total = result.data?.pages[0]?.total ?? 0;
+
+  return { ...result, properties, total };
+}

--- a/packages/frontend/hooks/useInfiniteScroll.ts
+++ b/packages/frontend/hooks/useInfiniteScroll.ts
@@ -1,0 +1,80 @@
+/**
+ * useInfiniteScroll — the NATIVE half of Homiio's Mention-style infinite-scroll
+ * primitive.
+ *
+ * Homiio uses ONE scroll owner per surface (document on web, the screen's own
+ * `ScrollView`/`Animated.ScrollView` on native — see `AGENTS.md` §Scroll
+ * ownership), so the web and native paginate triggers differ:
+ *
+ *  - WEB → a {@link LoadMoreSentinel} at the list's end fires against the
+ *    document scroll (an `IntersectionObserver`), exactly like Mention's web path.
+ *  - NATIVE → the surface's existing scroll owner detects that it is near the
+ *    bottom and calls `onEndReached`. This hook is that detector: it returns an
+ *    `onScroll` handler a plain `ScrollView` spreads onto its own `onScroll`, so
+ *    no screen re-derives the distance math it used to hand-roll.
+ *
+ * The home page's `Animated.ScrollView` (a Reanimated worklet handler that also
+ * drives hero parallax) can't consume a JS synthetic-event handler, so it wires
+ * the equivalent end-detect inline in `PageScrollView` using
+ * {@link END_REACHED_THRESHOLD}; every other native surface uses this hook.
+ *
+ * The guarded `loadMore` (`if (hasNextPage && !isFetchingNextPage) fetchNextPage()`)
+ * lives in each consumer, matching Mention's `handleLoadMore`; this hook only
+ * decides WHEN the end is reached.
+ */
+import { useCallback, useRef } from 'react';
+import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+
+/**
+ * Fraction of the scroll extent past which the surface is treated as "at the
+ * end". `0.7` pre-fetches the next page while ~30% of the current content is
+ * still below the fold, so paging feels seamless rather than hitting a hard
+ * bottom. Shared with `PageScrollView` so home and every other surface use the
+ * same trigger point.
+ */
+export const END_REACHED_THRESHOLD = 0.7;
+
+interface UseInfiniteScrollOptions {
+  /** Guarded next-page loader — invoked once each time the end is approached. */
+  onEndReached: () => void;
+  /** Only fire while there is more to load (no next page ⇒ no trigger). */
+  enabled: boolean;
+  /** Fraction of the content height past which the end is reached (0–1). */
+  threshold?: number;
+}
+
+interface UseInfiniteScrollResult {
+  onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+}
+
+export function useInfiniteScroll({
+  onEndReached,
+  enabled,
+  threshold = END_REACHED_THRESHOLD,
+}: UseInfiniteScrollOptions): UseInfiniteScrollResult {
+  // Re-arm only after the user scrolls back above the threshold, so the burst of
+  // `onScroll` events fired while lingering near the bottom triggers `onEndReached`
+  // at most once per approach (the consumer's own guard is the second line of
+  // defence, but this keeps us from spamming it every frame).
+  const armedRef = useRef(true);
+
+  const onScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, layoutMeasurement, contentSize } = event.nativeEvent;
+      if (contentSize.height <= 0) return;
+      const reachedEnd =
+        contentOffset.y + layoutMeasurement.height >= contentSize.height * threshold;
+      if (!reachedEnd) {
+        armedRef.current = true;
+        return;
+      }
+      if (enabled && armedRef.current) {
+        armedRef.current = false;
+        onEndReached();
+      }
+    },
+    [enabled, threshold, onEndReached],
+  );
+
+  return { onScroll };
+}

--- a/packages/frontend/hooks/usePropertySearch.ts
+++ b/packages/frontend/hooks/usePropertySearch.ts
@@ -137,6 +137,19 @@ export function buildSearchParams(query: SearchQuery): Record<string, string | n
   if (query.fairPrice === true) {
     params.fairPrice = 'true';
   }
+  // Category-lens flags. The backend gates `instantBook`/`petFriendly` on the
+  // boolean and `exchangeMode` on `offering === EXCHANGE`, so these are safe to
+  // always emit when set; they also fold into `searchQueryKey` so toggling a
+  // home category re-keys the feed and refetches.
+  if (query.instantBook === true) {
+    params.instantBook = 'true';
+  }
+  if (query.petFriendly === true) {
+    params.petFriendly = 'true';
+  }
+  if (query.exchangeMode) {
+    params.exchangeMode = query.exchangeMode;
+  }
 
   return params;
 }

--- a/packages/frontend/locales/ca-ES.json
+++ b/packages/frontend/locales/ca-ES.json
@@ -245,6 +245,10 @@
       "title": "Recommended homes",
       "eyebrow": "For you"
     },
+    "explore": {
+      "eyebrow": "Continua explorant",
+      "title": "Explora més habitatges"
+    },
     "hostCta": {
       "cta": "Become a host",
       "subtitle": "Reach verified renters across Spain — free to list, fair fees, real human support.",
@@ -2547,7 +2551,8 @@
       "verified": "Verificat",
       "eco": "Ecològic",
       "instantBook": "Reserva immediata",
-      "fairPrice": "Preu just"
+      "fairPrice": "Preu just",
+      "new": "Nou"
     },
     "offering": {
       "stepTitle": "Com ho ofereixes?",

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -260,6 +260,10 @@
       "title": "Recommended homes",
       "eyebrow": "For you"
     },
+    "explore": {
+      "eyebrow": "Keep exploring",
+      "title": "Explore more homes"
+    },
     "hostCta": {
       "cta": "Become a host",
       "subtitle": "Reach verified renters across Spain — free to list, fair fees, real human support.",
@@ -2583,7 +2587,8 @@
       "verified": "Verified",
       "eco": "Eco",
       "instantBook": "Instant book",
-      "fairPrice": "Fair price"
+      "fairPrice": "Fair price",
+      "new": "New"
     },
     "offering": {
       "stepTitle": "How are you offering this?",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -224,6 +224,10 @@
       "title": "Recommended homes",
       "eyebrow": "For you"
     },
+    "explore": {
+      "eyebrow": "Sigue explorando",
+      "title": "Explora más viviendas"
+    },
     "hostCta": {
       "cta": "Become a host",
       "subtitle": "Reach verified renters across Spain — free to list, fair fees, real human support.",
@@ -2602,7 +2606,8 @@
       "verified": "Verificado",
       "eco": "Ecológico",
       "instantBook": "Reserva inmediata",
-      "fairPrice": "Precio justo"
+      "fairPrice": "Precio justo",
+      "new": "Nuevo"
     },
     "offering": {
       "stepTitle": "¿Cómo lo ofreces?",

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -380,6 +380,10 @@
       "title": "Recommended homes",
       "eyebrow": "For you"
     },
+    "explore": {
+      "eyebrow": "Continua a esplorare",
+      "title": "Esplora altre case"
+    },
     "hostCta": {
       "cta": "Become a host",
       "subtitle": "Reach verified renters across Spain — free to list, fair fees, real human support.",
@@ -2543,7 +2547,8 @@
       "verified": "Verificato",
       "eco": "Ecologico",
       "instantBook": "Prenotazione immediata",
-      "fairPrice": "Prezzo giusto"
+      "fairPrice": "Prezzo giusto",
+      "new": "Nuovo"
     },
     "offering": {
       "stepTitle": "Come lo offri?",


### PR DESCRIPTION
## Summary
- Reusable infinite-scroll primitive: `LoadMoreSentinel` + `useInfiniteScroll` hook + `PageScrollView` `onEndReached` wiring
- Home endless category-driven feed (`app/(tabs)/index.tsx`)
- `PropertyCard` hover/press states, `isNew` badge, `FadeInDown` reveal animations
- `SearchQuery`/`buildSearchParams` extended with `petFriendly` + matching backend `searchQueryBuilder` support
- Unified search/properties/type screens onto the shared infinite-scroll pattern
- City page (`[id].tsx`) converted to infinite scroll + backend `cityController` `hasMore`/`totalPages` pagination aliases + `minBathrooms` filter support
- Saved properties screen: incremental reveal
- New backend test coverage: `__tests__/unit/cityPropertiesPagination.test.ts` + category-lens cases added to `__tests__/unit/searchQueryBuilder.test.ts`

**Not in scope:**
- Personalized-ranked home feed is a deferred follow-up, not part of this PR
- The `hasImages` image-first-sort feature is already merged on `main` (PR #160) and is NOT part of this diff

## Test plan
- [x] `bun run build` exit 0 (shared-types -> listing-providers -> backend + frontend web export)
- [x] Backend jest: 62/62 suites, 503/503 tests passed
- [x] Frontend `tsc --noEmit`: 11 pre-existing error lines across 6 files, confirmed identical against an `origin/main` baseline worktree (zero new errors introduced by this branch)
- [x] Style audit: `grep -rn "style={({" app components --include=*.tsx` returns only the documented `SearchSummaryBar.tsx` comment — no real function-form `Pressable` styles