### PR TITLE
feat(frontend): flat Airbnb-2026 card consistency (ZoomableImage, no card scale, frosted chip, flat shadows)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,6 +382,15 @@ const [pressed, setPressed] = useState(false);
 - Canonical template: `packages/frontend/components/search/SearchSummaryBar.tsx`
 - Audit: `grep -rn "style={({" app components --include=*.tsx` must return ZERO.
 
+## Masked Image Zoom (ZoomableImage)
+
+Cards NEVER scale on hover/press ("cutrada"). The app-wide Airbnb-2026 move is the **image zooming inside the card's rounded mask** — the photo scales, the card stays put, corners stay clipped. There is **one** primitive: `components/ui/ZoomableImage.tsx`.
+
+- Wrap the `<Image>` (not the card): `<ZoomableImage borderRadius aspectRatio active style>` renders a `overflow:'hidden'` mask around an inner wrapper that applies `transform:[{scale: active?1.05:1}]`. Overlays (badges, scrim, heart, price) stay **siblings of** `ZoomableImage` so they don't zoom.
+- `active` = internal web hover (`onPointerEnter/Leave`, owned by the component) **OR** an external signal — a parent Pressable's press (native zoom) or a carousel's shared hover. It's its own component, so no hooks-in-`.map`; static style arrays only (§NativeWind Pressable).
+- Web transition + Safari corner-clip fix are baked in (web-cast `transitionProperty`/`willChange`, the sanctioned `as unknown as ViewStyle` web-CSS pattern). NEVER add a per-component variant — reuse this one.
+- Wired in: `PropertyImageCarousel`, `PropertyCard` (static path), `CityShowcaseSection`, `Host/AgentCtaBanner`, tips `TipCard`, `RoomList`. Card/banner/tile surfaces are otherwise **flat** — no `transform:[{scale}]` card interaction anywhere (audit: `grep -rnE "transform.*scale" components app` shows only `ZoomableImage`'s image-zoom + genuinely animated worklets).
+
 ## Infinite Scroll / Pagination Primitive
 
 Homiio has **one** reusable infinite-scroll primitive — never hand-roll `ScrollView.onScroll` distance math again. It respects the "one scroll owner per surface" rule above (web sentinel, native handler) rather than copying Mention's `FlatList.onEndReached`.

--- a/packages/frontend/app/tips/[slug].tsx
+++ b/packages/frontend/app/tips/[slug].tsx
@@ -25,7 +25,7 @@ import {
   toNewsroomLocale,
   type TipArticle,
 } from '@/services/tipsService';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
 const renderMarkdown = (content: string): React.ReactNode[] => {
@@ -282,7 +282,6 @@ const styles = StyleSheet.create({
     borderRadius: radius.xl,
     overflow: 'hidden',
     backgroundColor: colors.surfaceElevated,
-    ...withShadow('sm'),
   },
   heroImage: {
     width: '100%',
@@ -395,7 +394,8 @@ const styles = StyleSheet.create({
     backgroundColor: colors.surfaceElevated,
     borderRadius: radius.lg,
     overflow: 'hidden',
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   relatedCardPressed: {
     opacity: 0.92,

--- a/packages/frontend/app/tips/index.tsx
+++ b/packages/frontend/app/tips/index.tsx
@@ -22,8 +22,9 @@ import {
   toNewsroomLocale,
   type TipArticle,
 } from '@/services/tipsService';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
+import { ZoomableImage } from '@/components/ui/ZoomableImage';
 
 interface TipCardProps {
   tip: TipArticle;
@@ -49,13 +50,17 @@ const TipCard: React.FC<TipCardProps> = ({ tip, onPress, featured = false }) => 
     >
       <View style={[styles.tipImageContainer, featured && styles.tipImageFeatured]}>
         {tip.coverImageUrl ? (
-          <Image
-            source={{ uri: tip.coverImageUrl }}
-            style={styles.tipImage}
-            contentFit="cover"
-            transition={200}
-            cachePolicy="memory-disk"
-          />
+          // The photo zooms inside its mask on hover/press; the category badge is
+          // a sibling above the zoom, so it stays put and unclipped.
+          <ZoomableImage active={pressed} style={styles.tipImageFill}>
+            <Image
+              source={{ uri: tip.coverImageUrl }}
+              style={styles.tipImage}
+              contentFit="cover"
+              transition={200}
+              cachePolicy="memory-disk"
+            />
+          </ZoomableImage>
         ) : (
           <View style={styles.tipImagePlaceholder}>
             <Ionicons name="newspaper-outline" size={featured ? 48 : 32} color={colors.muted} />
@@ -265,7 +270,6 @@ const styles = StyleSheet.create({
     backgroundColor: colors.surfaceElevated,
     borderRadius: radius.lg,
     overflow: 'hidden',
-    ...withShadow('sm'),
   },
   tipCardFeatured: {
     borderRadius: radius.xl,
@@ -276,6 +280,14 @@ const styles = StyleSheet.create({
   tipImageContainer: {
     position: 'relative',
     height: 180,
+  },
+  // The masked zoom wrapper fills the image box so the photo scales inside it.
+  tipImageFill: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
   },
   tipImageFeatured: {
     height: 260,

--- a/packages/frontend/components/CityShowcaseSection.tsx
+++ b/packages/frontend/components/CityShowcaseSection.tsx
@@ -18,7 +18,6 @@ import React, { useRef, useState } from 'react';
 import {
   NativeScrollEvent,
   NativeSyntheticEvent,
-  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -37,6 +36,7 @@ import { colors } from '@/styles/colors';
 import { textShadow } from '@/styles/shadows';
 import { cardShadow, gridGap, PAGE_GUTTER_CLASS, pagePadding, radius, spacing, tracker } from '@/constants/styles';
 import { cityRegionName, getCityImageSource } from '@/utils/cityDisplay';
+import { ZoomableImage } from '@/components/ui/ZoomableImage';
 
 interface CityShowcaseSectionProps {
   title: string;
@@ -152,8 +152,7 @@ interface CityCardProps {
 }
 
 const CityCard: React.FC<CityCardProps> = ({ city, width, height, onPress }) => {
-  const [hovered, setHovered] = useState(false);
-  const isWeb = Platform.OS === 'web';
+  const [pressed, setPressed] = useState(false);
   const imageSource = getCityImageSource(city, 'large');
   // Subtitle: the city's region (e.g. "Catalonia"), resolved from the populated
   // region ref. Falls back to a short property-count line when no region name.
@@ -166,30 +165,30 @@ const CityCard: React.FC<CityCardProps> = ({ city, width, height, onPress }) => 
   return (
     <Pressable
       onPress={onPress}
-      onHoverIn={() => setHovered(true)}
-      onHoverOut={() => setHovered(false)}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
       accessibilityRole="button"
       accessibilityLabel={`Explore homes in ${city.name}`}
-      style={[
-        styles.card,
-        { width, height },
-        hovered && isWeb ? styles.cardHover : null,
-      ]}
+      style={[styles.card, { width, height }]}
     >
-      {imageSource ? (
-        <Image
-          source={imageSource}
-          style={styles.cardImage}
-          contentFit="cover"
-          transition={200}
-          cachePolicy="memory-disk"
-        />
-      ) : (
-        <LinearGradient
-          colors={[colors.primaryColor, colors.secondaryLight]}
-          style={[styles.cardImage, { pointerEvents: 'none' }]}
-        />
-      )}
+      {/* The photo zooms inside the card's rounded mask on hover/press; the card
+          itself never moves. Scrim + copy are siblings, so they stay put. */}
+      <ZoomableImage active={pressed} style={styles.cardMedia}>
+        {imageSource ? (
+          <Image
+            source={imageSource}
+            style={styles.cardImage}
+            contentFit="cover"
+            transition={200}
+            cachePolicy="memory-disk"
+          />
+        ) : (
+          <LinearGradient
+            colors={[colors.primaryColor, colors.secondaryLight]}
+            style={[styles.cardImage, { pointerEvents: 'none' }]}
+          />
+        )}
+      </ZoomableImage>
       <LinearGradient
         colors={['rgba(0,0,0,0)', 'rgba(0,0,0,0.55)']}
         locations={[0.4, 1]}
@@ -213,10 +212,15 @@ const styles = StyleSheet.create({
     borderRadius: radius.photo,
     overflow: 'hidden',
     backgroundColor: colors.COLOR_BLACK_LIGHT_7,
-    ...cardShadow.sm,
   },
-  cardHover: {
-    transform: [{ scale: 1.01 }],
+  // The masked zoom wrapper fills the card so the photo scales inside the
+  // rounded corners; the scrim and copy sit above it as siblings.
+  cardMedia: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
   },
   cardImage: {
     position: 'absolute',

--- a/packages/frontend/components/HomeCategoryStrip.tsx
+++ b/packages/frontend/components/HomeCategoryStrip.tsx
@@ -4,7 +4,7 @@
  * long-term; Beachfront / Cabins / Pools for vacation; sale/exchange
  * buckets for buy and exchange browse modes).
  */
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Image,
   Platform,
@@ -55,14 +55,9 @@ interface CategoryItemProps {
 }
 
 const CategoryItem: React.FC<CategoryItemProps> = ({ active, label, image, onPress }) => {
-  const [hovered, setHovered] = useState(false);
-  const scale = hovered && Platform.OS === 'web' ? 1.04 : 1;
-
   return (
     <Pressable
       onPress={onPress}
-      onHoverIn={() => setHovered(true)}
-      onHoverOut={() => setHovered(false)}
       className={
         active
           ? 'items-center justify-center rounded-2xl bg-secondary px-1 py-1'
@@ -71,7 +66,7 @@ const CategoryItem: React.FC<CategoryItemProps> = ({ active, label, image, onPre
       accessibilityRole="button"
       accessibilityState={{ selected: active }}
       accessibilityLabel={label}
-      style={{ width: ITEM_WIDTH, transform: [{ scale }] }}
+      style={{ width: ITEM_WIDTH }}
     >
       <View
         className="items-center justify-center overflow-hidden rounded-2xl"

--- a/packages/frontend/components/HostCtaBanner.tsx
+++ b/packages/frontend/components/HostCtaBanner.tsx
@@ -6,8 +6,8 @@
  *
  * Sits as a closing visual beat on the home page (paired with AgentCtaBanner).
  */
-import React, { useState } from 'react';
-import { Platform, StyleSheet, View } from 'react-native';
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useMediaQuery } from 'react-responsive';
@@ -18,12 +18,12 @@ import { Text as BloomText } from '@oxyhq/bloom/typography';
 import { colors } from '@/styles/colors';
 import {
   BANNER_FILL_MIN_HEIGHT,
-  cardShadow,
   radius,
   resolvePagePadding,
   spacing,
   tracker,
 } from '@/constants/styles';
+import { ZoomableImage } from '@/components/ui/ZoomableImage';
 
 interface HostCtaBannerProps {
   title: string;
@@ -57,36 +57,29 @@ export function HostCtaBanner({
   const horizontalPadding = fill ? 0 : resolvePagePadding(isWide);
   // Flatter than classic 16:9 so stacked/full-width cards stay compact.
   const aspectRatio = isWide ? 2.6 : 2.1;
-  const [hovered, setHovered] = useState(false);
-  const isWeb = Platform.OS === 'web';
 
   // The banner itself is NOT a pressable — only the Bloom Button below is the
   // tap target. Wrapping the whole banner in a Pressable while it also contains
   // a Button produces a nested <button> on web (invalid HTML + hydration error).
-  const hoverHandlers = isWeb
-    ? {
-        onMouseEnter: () => setHovered(true),
-        onMouseLeave: () => setHovered(false),
-      }
-    : {};
-
   return (
     <View style={fill ? styles.fillWrap : { paddingHorizontal: horizontalPadding }}>
       <View
-        {...hoverHandlers}
         style={[
           styles.banner,
           fill ? styles.bannerFill : { aspectRatio },
-          hovered && isWeb ? styles.bannerHover : null,
         ]}
       >
-        <Image
-          source={{ uri: imageUrl }}
-          style={styles.bannerImage}
-          contentFit="cover"
-          transition={250}
-          cachePolicy="memory-disk"
-        />
+        {/* The photo zooms inside the banner's rounded mask on hover; the banner
+            never moves. Scrim + copy are siblings, so they stay put. */}
+        <ZoomableImage style={styles.bannerMedia}>
+          <Image
+            source={{ uri: imageUrl }}
+            style={styles.bannerImage}
+            contentFit="cover"
+            transition={250}
+            cachePolicy="memory-disk"
+          />
+        </ZoomableImage>
         <LinearGradient
           colors={['rgba(0,0,0,0.55)', 'rgba(0,0,0,0.12)', 'rgba(0,0,0,0)']}
           start={{ x: 0, y: 1 }}
@@ -128,7 +121,6 @@ const styles = StyleSheet.create({
     borderRadius: radius.xl,
     overflow: 'hidden',
     backgroundColor: colors.COLOR_BLACK_LIGHT_7,
-    ...cardShadow.sm,
   },
   // Grid mode: no intrinsic aspect ratio — fill the column height (the taller
   // sibling defines it via row `alignItems: 'stretch'`) with a sensible floor
@@ -138,8 +130,14 @@ const styles = StyleSheet.create({
     flex: 1,
     minHeight: BANNER_FILL_MIN_HEIGHT,
   },
-  bannerHover: {
-    transform: [{ scale: 1.005 }],
+  // The masked zoom wrapper fills the banner so the photo scales inside the
+  // rounded corners; the scrim and copy sit above it as siblings.
+  bannerMedia: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
   },
   bannerImage: {
     position: 'absolute',

--- a/packages/frontend/components/PropertyCard.tsx
+++ b/packages/frontend/components/PropertyCard.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { View, Image, StyleSheet, Pressable, TouchableOpacity, ViewStyle, Platform } from 'react-native';
+import { View, Image, StyleSheet, Pressable, TouchableOpacity, ViewStyle } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { colors } from '@/styles/colors';
-import { boxShadow } from '@/styles/shadows';
 import { radius, spacing } from '@/constants/styles';
 import { PriceUnit, Property } from '@homiio/shared-types';
 import {
@@ -21,6 +20,7 @@ import { CurrencyFormatter } from './CurrencyFormatter';
 import { OfferingBadge } from './property/OfferingBadge';
 import { MediaChip } from './property/MediaChip';
 import { PropertyImageCarousel } from './property/PropertyImageCarousel';
+import { ZoomableImage } from '@/components/ui/ZoomableImage';
 import { ThemedText } from '@/components/ThemedText';
 import { Text as BloomText } from '@oxyhq/bloom/typography';
 import { Ionicons } from '@expo/vector-icons';
@@ -30,28 +30,8 @@ import { PropertyCardSkeleton } from './ui/skeletons/PropertyCardSkeleton';
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 
-const IS_WEB = Platform.OS === 'web';
-
 /** A listing counts as "new" (badge) while its `createdAt` is within this window. */
 const NEW_LISTING_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
-
-/** Card scale while hovered (web pointer) — a subtle Airbnb-style lift. */
-const HOVER_SCALE = 1.02;
-/** Card scale while pressed — a tactile push-down (native + web tap). */
-const PRESS_SCALE = 0.97;
-
-/**
- * Web-only CSS transition so the hover/press scale eases instead of snapping.
- * `transitionProperty` is a web value RN's `ViewStyle` lacks, so this block is
- * web-cast (the sanctioned pattern for web-only CSS in this codebase).
- */
-const WEB_INTERACTION_TRANSITION: ViewStyle | null = IS_WEB
-  ? ({
-      transitionProperty: 'transform',
-      transitionDuration: '160ms',
-      transitionTimingFunction: 'ease-out',
-    } as unknown as ViewStyle)
-  : null;
 
 function shouldShowInstantBook(
   property: Property,
@@ -242,20 +222,20 @@ export function PropertyCard({
     [property, mode],
   );
 
-  // Hover (web pointer) + press micro-interaction. Static-array styles driven by
-  // state, never the NativeWind-incompatible function-form `style` (AGENTS.md
-  // §NativeWind Pressable). Web hover uses `onPointerEnter/Leave` on the outer
-  // card wrapper; press is threaded through the inner Pressables below.
-  const [hovered, setHovered] = useState(false);
+  // Native press-zoom for the static-image path: the photo zooms inside its
+  // rounded mask via `ZoomableImage` (the card itself never scales). Web hover is
+  // owned by `ZoomableImage` internally; this only tracks the touch press so the
+  // image eases back out on release. Static-array styles driven by state, never
+  // the NativeWind-incompatible function-form `style` (AGENTS.md §NativeWind
+  // Pressable). The prefetch still fires on press-in.
   const [pressed, setPressed] = useState(false);
-  const handleInteractionPressIn = useCallback(() => {
+  const handleImagePressIn = useCallback(() => {
     setPressed(true);
     handlePressIn();
   }, [handlePressIn]);
-  const handleInteractionPressOut = useCallback(() => {
+  const handleImagePressOut = useCallback(() => {
     setPressed(false);
   }, []);
-  const interactionScale = pressed ? PRESS_SCALE : hovered ? HOVER_SCALE : 1;
 
   // "New" freshness badge — pure frontend, no pagination risk. Memoized on
   // `createdAt` so `Date.now()` is captured once per listing (the 7-day boundary
@@ -634,18 +614,10 @@ export function PropertyCard({
 
   return (
     <View
-      // Web hover lift: pointer enter/leave fire on the card's own boundary
-      // (they don't bubble from inner children), mapping to mouseenter/mouseleave
-      // on RN-Web. No-op on native — touch never produces hover.
-      onPointerEnter={IS_WEB ? () => setHovered(true) : undefined}
-      onPointerLeave={IS_WEB ? () => setHovered(false) : undefined}
       style={[
         styles.container,
-        WEB_INTERACTION_TRANSITION,
         style as ViewStyle,
         isProcessing ? { opacity: 0.7 } : null,
-        // Interaction transform last so the hover/press scale always wins.
-        { transform: [{ scale: interactionScale }] },
       ]}
     >
       {useCarousel ? (
@@ -661,8 +633,7 @@ export function PropertyCard({
             aspectRatio={mediaAspectRatio}
             borderRadius={isGrid ? radius.photo : radius.lg}
             onPress={onPress}
-            onPressIn={handleInteractionPressIn}
-            onPressOut={handleInteractionPressOut}
+            onPressIn={handlePressIn}
             onLongPress={onLongPress}
             accessibilityLabel={propertyData.title}
           >
@@ -671,8 +642,7 @@ export function PropertyCard({
           <Pressable
             style={styles.contentPressable}
             onPress={onPress}
-            onPressIn={handleInteractionPressIn}
-            onPressOut={handleInteractionPressOut}
+            onPressIn={handlePressIn}
             onLongPress={onLongPress}
             accessibilityRole="button"
             accessibilityLabel={propertyData.title}
@@ -687,8 +657,8 @@ export function PropertyCard({
             orientation === 'horizontal' ? styles.horizontalBody : null,
           ]}
           onPress={onPress}
-          onPressIn={handleInteractionPressIn}
-          onPressOut={handleInteractionPressOut}
+          onPressIn={handleImagePressIn}
+          onPressOut={handleImagePressOut}
           onLongPress={onLongPress}
           accessibilityRole="button"
           accessibilityLabel={propertyData.title}
@@ -706,7 +676,11 @@ export function PropertyCard({
                   : { width: '100%', aspectRatio: 1 },
             ]}
           >
-            <Image source={propertyData.imageSource} style={styles.image} resizeMode="cover" />
+            {/* The photo zooms inside the rounded mask on hover/press; the card
+                never moves. Badges are siblings of the zoom so they stay put. */}
+            <ZoomableImage active={pressed} style={styles.imageZoom}>
+              <Image source={propertyData.imageSource} style={styles.image} resizeMode="cover" />
+            </ZoomableImage>
             {mediaBadges}
           </View>
 
@@ -823,6 +797,15 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
   },
+  // The masked zoom wrapper fills the image box so the photo scales inside the
+  // card's rounded corners without nudging the layout.
+  imageZoom: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
   content: {
     flex: 1,
     justifyContent: 'space-between',
@@ -926,27 +909,23 @@ const styles = StyleSheet.create({
     gap: spacing.xs,
   },
   /**
-   * Freshness "New" chip — a solid brand pill leading the top-left stack. Sized
-   * to `CHIP_HEIGHT_MD` (28) so it aligns on the same baseline as the frosted
-   * `MediaChip`s beside it; a solid brand fill (vs. the frosted chips) makes the
-   * freshness signal read first. Uses `primaryForeground` on the primary fill.
+   * Freshness "New" chip — a compact frosted-white pill that matches the on-card
+   * Save heart (`rgba(255,255,255,0.95)`, black glyph) sitting in the opposite
+   * corner, so the overlay set reads as one flat Airbnb-style family. Shorter and
+   * tighter than a `MediaChip`; no shadow (Airbnb-flat).
    */
   newChip: {
-    height: 28,
-    paddingHorizontal: spacing.md,
+    height: 20,
+    paddingHorizontal: spacing.sm,
     borderRadius: radius.pill,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: colors.primaryColor,
-    ...(Platform.OS === 'web'
-      ? { boxShadow: boxShadow({ y: 1, blur: 3, color: colors.COLOR_BLACK, opacity: 0.12 }) }
-      : { boxShadow: boxShadow({ y: 1, blur: 3, color: colors.COLOR_BLACK, opacity: 0.1 }), elevation: 2 }),
+    backgroundColor: 'rgba(255, 255, 255, 0.95)',
   },
   newChipText: {
-    fontSize: 12,
+    fontSize: 11,
     fontWeight: '700',
-    color: colors.primaryForeground,
-    letterSpacing: 0.2,
+    color: colors.COLOR_BLACK,
   },
   // Property type in the meta line below the photo (icon + label), replacing the
   // former on-photo type chip.
@@ -981,9 +960,6 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     borderWidth: 1,
     borderColor: colors.COLOR_BLACK_LIGHT_6,
-    ...(Platform.OS === 'web'
-      ? { boxShadow: boxShadow({ y: 1, blur: 3, color: colors.COLOR_BLACK, opacity: 0.06 }) }
-      : { boxShadow: boxShadow({ y: 1, blur: 3, color: colors.COLOR_BLACK, opacity: 0.04 }), elevation: 1 }),
   },
   noteEmpty: {
     backgroundColor: colors.COLOR_BLACK_LIGHT_8,

--- a/packages/frontend/components/ReviewCard.tsx
+++ b/packages/frontend/components/ReviewCard.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { ThemedText } from './ThemedText';
 import { colors } from '@/styles/colors';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { formatLocalized } from '@/utils/dateLocale';
 
 export interface ReviewData {
@@ -365,7 +365,8 @@ const styles = StyleSheet.create({
         borderRadius: radius.lg,
         padding: spacing.xl,
         marginBottom: spacing.lg,
-        ...withShadow('sm'),
+        borderWidth: 1,
+        borderColor: colors.border,
     },
     compactCard: {
         padding: spacing.lg,

--- a/packages/frontend/components/RoomList.tsx
+++ b/packages/frontend/components/RoomList.tsx
@@ -14,7 +14,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
+import { ZoomableImage } from '@/components/ui/ZoomableImage';
 import { propertyService, type Property } from '@/services/propertyService';
 import { getPropertyTitle } from '@/utils/propertyUtils';
 import { logger } from '@/utils/logger';
@@ -59,11 +59,15 @@ const RoomCard = React.memo(({ property, matchScore }: RoomCardProps) => {
             {/* Room Image */}
             <View style={styles.imageContainer}>
                 {primaryImage ? (
-                    <Image
-                        source={{ uri: primaryImage }}
-                        style={styles.roomImage}
-                        resizeMode="cover"
-                    />
+                    // The photo zooms inside its mask on hover; the card never
+                    // moves. The match-score badge is a sibling above the zoom.
+                    <ZoomableImage style={styles.roomImageFill}>
+                        <Image
+                            source={{ uri: primaryImage }}
+                            style={styles.roomImage}
+                            resizeMode="cover"
+                        />
+                    </ZoomableImage>
                 ) : (
                     <View style={[styles.roomImage, styles.placeholderImage]}>
                         <Ionicons name="image-outline" size={32} color={colors.COLOR_BLACK_LIGHT_5} />
@@ -413,7 +417,8 @@ const styles = StyleSheet.create({
         backgroundColor: colors.white,
         borderRadius: 12,
         marginBottom: 16,
-        ...shadowToken({ y: 2, blur: 4, color: colors.COLOR_BLACK, opacity: 0.1, elevation: 3 }),
+        borderWidth: 1,
+        borderColor: colors.border,
         overflow: 'hidden',
     },
     imageContainer: {
@@ -423,6 +428,14 @@ const styles = StyleSheet.create({
     roomImage: {
         width: '100%',
         height: '100%',
+    },
+    // The masked zoom wrapper fills the image box so the photo scales inside it.
+    roomImageFill: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
     },
     placeholderImage: {
         backgroundColor: colors.mutedSubtle,

--- a/packages/frontend/components/agent/AgentCtaBanner.tsx
+++ b/packages/frontend/components/agent/AgentCtaBanner.tsx
@@ -8,8 +8,8 @@
  * Like `HostCtaBanner`, the banner itself is NOT pressable — only the Bloom
  * Button is the tap target — so web never renders a nested `<button>`.
  */
-import React, { useState } from 'react';
-import { Platform, StyleSheet, View } from 'react-native';
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useMediaQuery } from 'react-responsive';
@@ -20,12 +20,12 @@ import { Text as BloomText } from '@oxyhq/bloom/typography';
 import { colors } from '@/styles/colors';
 import {
   BANNER_FILL_MIN_HEIGHT,
-  cardShadow,
   radius,
   resolvePagePadding,
   spacing,
   tracker,
 } from '@/constants/styles';
+import { ZoomableImage } from '@/components/ui/ZoomableImage';
 
 interface AgentCtaBannerProps {
   title: string;
@@ -70,33 +70,26 @@ export function AgentCtaBanner({
   const horizontalPadding = fill ? 0 : resolvePagePadding(isWide);
   // Flatter than classic 16:9 so stacked/full-width cards stay compact.
   const aspectRatio = isWide ? 2.6 : 2.1;
-  const [hovered, setHovered] = useState(false);
-  const isWeb = Platform.OS === 'web';
-
-  const hoverHandlers = isWeb
-    ? {
-        onMouseEnter: () => setHovered(true),
-        onMouseLeave: () => setHovered(false),
-      }
-    : {};
 
   return (
     <View style={fill ? styles.fillWrap : { paddingHorizontal: horizontalPadding }}>
       <View
-        {...hoverHandlers}
         style={[
           styles.banner,
           fill ? styles.bannerFill : { aspectRatio },
-          hovered && isWeb ? styles.bannerHover : null,
         ]}
       >
-        <Image
-          source={{ uri: imageUrl }}
-          style={styles.bannerImage}
-          contentFit="cover"
-          transition={250}
-          cachePolicy="memory-disk"
-        />
+        {/* The photo zooms inside the banner's rounded mask on hover; the banner
+            never moves. Scrim + copy are siblings, so they stay put. */}
+        <ZoomableImage style={styles.bannerMedia}>
+          <Image
+            source={{ uri: imageUrl }}
+            style={styles.bannerImage}
+            contentFit="cover"
+            transition={250}
+            cachePolicy="memory-disk"
+          />
+        </ZoomableImage>
         <LinearGradient
           colors={['rgba(0,0,0,0.55)', 'rgba(0,0,0,0.12)', 'rgba(0,0,0,0)']}
           start={{ x: 0, y: 1 }}
@@ -141,7 +134,6 @@ const styles = StyleSheet.create({
     borderRadius: radius.xl,
     overflow: 'hidden',
     backgroundColor: colors.COLOR_BLACK_LIGHT_7,
-    ...cardShadow.sm,
   },
   // Grid mode: no intrinsic aspect ratio — fill the column height (the taller
   // sibling defines it via row `alignItems: 'stretch'`) with a sensible floor
@@ -151,8 +143,14 @@ const styles = StyleSheet.create({
     flex: 1,
     minHeight: BANNER_FILL_MIN_HEIGHT,
   },
-  bannerHover: {
-    transform: [{ scale: 1.005 }],
+  // The masked zoom wrapper fills the banner so the photo scales inside the
+  // rounded corners; the scrim and copy sit above it as siblings.
+  bannerMedia: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
   },
   bannerImage: {
     position: 'absolute',

--- a/packages/frontend/components/agent/AgentHero.tsx
+++ b/packages/frontend/components/agent/AgentHero.tsx
@@ -181,7 +181,6 @@ const styles = StyleSheet.create({
   },
   ctaActive: {
     opacity: 0.9,
-    transform: [{ scale: 0.99 }],
   },
   ctaDisabled: {
     opacity: 0.6,

--- a/packages/frontend/components/agent/RewardsTeaser.tsx
+++ b/packages/frontend/components/agent/RewardsTeaser.tsx
@@ -21,7 +21,6 @@ import { H1, Text as BloomText } from '@oxyhq/bloom/typography';
 
 import { colors } from '@/styles/colors';
 import {
-  cardShadow,
   ICON_SIZES,
   radius,
   resolvePagePadding,
@@ -184,7 +183,6 @@ const styles = StyleSheet.create({
     borderColor: colors.border,
     padding: spacing.xl,
     gap: spacing.md,
-    ...cardShadow.sm,
   },
   medal: {
     width: 48,

--- a/packages/frontend/components/property/MediaChip.tsx
+++ b/packages/frontend/components/property/MediaChip.tsx
@@ -16,14 +16,13 @@
  * present. Icon-only chips (no `label`) collapse to a square of that height.
  */
 import React from 'react';
-import { Platform, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
 import { Text as BloomText } from '@oxyhq/bloom/typography';
 
 import { colors } from '@/styles/colors';
 import { radius, spacing } from '@/constants/styles';
-import { boxShadow } from '@/styles/shadows';
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 
@@ -92,16 +91,15 @@ export const MediaChip: React.FC<MediaChipProps> = ({
 };
 
 const styles = StyleSheet.create({
-  // Shared backdrop + shape. The frosted near-white surface and soft shadow
-  // match the save heart so the whole overlay set reads as one family.
+  // Shared backdrop + shape. The frosted near-white surface (flat, no shadow)
+  // matches the save heart and the "new" chip so the whole overlay set reads as
+  // one flat Airbnb-style family.
   chip: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
     borderRadius: radius.pill,
     backgroundColor: 'rgba(255, 255, 255, 0.92)',
-    boxShadow: boxShadow({ y: 1, blur: 3, color: colors.COLOR_BLACK, opacity: 0.12 }),
-    ...(Platform.OS === 'web' ? null : { elevation: 2 }),
   },
   chipMedium: {
     height: CHIP_HEIGHT_MD,

--- a/packages/frontend/components/property/PropertyImageCarousel.tsx
+++ b/packages/frontend/components/property/PropertyImageCarousel.tsx
@@ -37,6 +37,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 
 import { colors } from '@/styles/colors';
+import { ZoomableImage } from '@/components/ui/ZoomableImage';
 import {
   type ImageDisplaySource,
   getPropertyImageSources,
@@ -85,8 +86,6 @@ interface PropertyImageCarouselProps {
   onPress?: () => void;
   /** Fires immediately before the press settles, used to prefetch detail data. */
   onPressIn?: () => void;
-  /** Fires when the press is released/cancelled (drives the card's pressed lift). */
-  onPressOut?: () => void;
   onLongPress?: () => void;
   /** Notifies the parent of the active page (e.g. to sync external chrome). */
   onIndexChange?: (index: number) => void;
@@ -117,7 +116,6 @@ interface CarouselPageProps {
   fillWhenUnmeasured?: boolean;
   onPress?: () => void;
   onPressIn?: () => void;
-  onPressOut?: () => void;
   onLongPress?: () => void;
   accessibilityLabel?: string;
 }
@@ -127,6 +125,9 @@ interface CarouselPageProps {
  * detail screen while a horizontal drag is consumed by the parent scroller —
  * React Native's responder system hands the gesture to the scroll view once it
  * travels horizontally, so the press only fires on a genuine tap.
+ *
+ * The photo zooms inside the page's rounded mask on hover (web, owned by
+ * `ZoomableImage`) / press (native) — the Airbnb move; the card never scales.
  *
  * Uses React Native's `Image` (not `expo-image`): `expo-image` fails to paint
  * remote photos on web here, leaving the page blank while the chrome renders
@@ -141,27 +142,36 @@ const CarouselPage: React.FC<CarouselPageProps> = ({
   fillWhenUnmeasured = false,
   onPress,
   onPressIn,
-  onPressOut,
   onLongPress,
   accessibilityLabel,
-}) => (
-  <Pressable
-    onPress={onPress}
-    onPressIn={onPressIn}
-    onPressOut={onPressOut}
-    onLongPress={onLongPress}
-    accessibilityRole="button"
-    accessibilityLabel={accessibilityLabel}
-    style={[
-      styles.page,
-      fillWhenUnmeasured && (width <= 0 || height <= 0)
-        ? styles.pageFill
-        : { width, height },
-    ]}
-  >
-    <Image source={source} style={styles.image} resizeMode="cover" />
-  </Pressable>
-);
+}) => {
+  // Local press state drives the native press-zoom (`ZoomableImage` owns web
+  // hover itself). Static-array style + state, never function-form `style`.
+  const [pressed, setPressed] = useState(false);
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={() => {
+        setPressed(true);
+        onPressIn?.();
+      }}
+      onPressOut={() => setPressed(false)}
+      onLongPress={onLongPress}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      style={[
+        styles.page,
+        fillWhenUnmeasured && (width <= 0 || height <= 0)
+          ? styles.pageFill
+          : { width, height },
+      ]}
+    >
+      <ZoomableImage active={pressed} style={styles.pageZoom}>
+        <Image source={source} style={styles.image} resizeMode="cover" />
+      </ZoomableImage>
+    </Pressable>
+  );
+};
 
 interface NavArrowProps {
   direction: 'prev' | 'next';
@@ -265,7 +275,6 @@ export const PropertyImageCarousel: React.FC<PropertyImageCarouselProps> = ({
   borderRadius,
   onPress,
   onPressIn,
-  onPressOut,
   onLongPress,
   onIndexChange,
   accessibilityLabel,
@@ -359,12 +368,11 @@ export const PropertyImageCarousel: React.FC<PropertyImageCarouselProps> = ({
         height={pageHeight}
         onPress={onPress}
         onPressIn={onPressIn}
-        onPressOut={onPressOut}
         onLongPress={onLongPress}
         accessibilityLabel={accessibilityLabel}
       />
     ),
-    [containerWidth, pageHeight, onPress, onPressIn, onPressOut, onLongPress, accessibilityLabel],
+    [containerWidth, pageHeight, onPress, onPressIn, onLongPress, accessibilityLabel],
   );
 
   const isMultiPage = sources.length > 1;
@@ -415,7 +423,6 @@ export const PropertyImageCarousel: React.FC<PropertyImageCarouselProps> = ({
           fillWhenUnmeasured
           onPress={onPress}
           onPressIn={onPressIn}
-          onPressOut={onPressOut}
           onLongPress={onLongPress}
           accessibilityLabel={accessibilityLabel}
         />
@@ -456,6 +463,15 @@ const styles = StyleSheet.create({
   pageFill: {
     width: '100%',
     height: '100%',
+  },
+  // The masked zoom wrapper fills the page so the photo scales inside the page
+  // bounds (and the carousel's rounded container) without moving the layout.
+  pageZoom: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
   },
   image: {
     width: '100%',

--- a/packages/frontend/components/ui/CardSurface.tsx
+++ b/packages/frontend/components/ui/CardSurface.tsx
@@ -1,10 +1,11 @@
 /**
- * CardSurface — Airbnb-2026 lifted card primitive.
+ * CardSurface — Airbnb-2026 flat card primitive.
  *
- * Wraps section content in a white surface with the small Homiio shadow
- * (`withShadow('sm')`), the standard card radius, and zero border. Personal
- * screens compose these instead of hand-rolling `style={{ backgroundColor:
- * colors.white, borderRadius: …, shadow*: … }}` everywhere.
+ * Wraps section content in a white surface with the standard card radius and no
+ * border or shadow (Airbnb-flat, image-forward). Personal screens compose these
+ * instead of hand-rolling `style={{ backgroundColor: colors.white, borderRadius:
+ * … }}` everywhere. The card is FLAT by default; pass `flat={false}` only for the
+ * rare floating surface that genuinely needs the small elevation shadow.
  *
  * Usage:
  *   <CardSurface>
@@ -24,7 +25,7 @@ export interface CardSurfaceProps {
   style?: StyleProp<ViewStyle>;
   /** Override inner padding. Defaults to `spacing.xl` (20). */
   padding?: number;
-  /** Skip the elevation shadow (useful when the parent already provides one). */
+  /** Add the small elevation shadow. Defaults to `true` (flat). */
   flat?: boolean;
 }
 
@@ -32,7 +33,7 @@ export const CardSurface: React.FC<CardSurfaceProps> = ({
   children,
   style,
   padding = spacing.xl,
-  flat = false,
+  flat = true,
 }) => (
   <View
     style={[

--- a/packages/frontend/components/ui/SectionCard.tsx
+++ b/packages/frontend/components/ui/SectionCard.tsx
@@ -31,8 +31,8 @@ interface SectionCardProps {
     titleStyle?: ViewStyle;
 
     /**
-     * Whether to show the card shadow/elevation
-     * @default true
+     * Whether to show the card shadow/elevation. Defaults to `false`
+     * (Airbnb-flat) — the card's hairline border provides its separation.
      */
     showShadow?: boolean;
 
@@ -61,7 +61,7 @@ export const SectionCard: React.FC<SectionCardProps> = ({
     containerStyle,
     cardStyle,
     titleStyle,
-    showShadow = true,
+    showShadow = false,
     padding = 16,
     borderRadius = 12,
     marginBottom = 20,

--- a/packages/frontend/components/ui/ThumbnailCard.tsx
+++ b/packages/frontend/components/ui/ThumbnailCard.tsx
@@ -2,10 +2,10 @@
  * ThumbnailCard — the horizontal "thumbnail + body" list card.
  *
  * The application, reservation, and exchange-request cards all rendered the
- * same lifted white surface (radius `lg`, `withShadow('sm')`, clipped corners,
- * `spacing.md` bottom margin) wrapping a fixed-size thumbnail next to a flexible
- * body, with an optional action row beneath. This owns that shell so the three
- * cards can't drift; each one supplies its own thumbnail node, body, press
+ * same flat white surface (radius `lg`, a hairline `colors.border`, clipped
+ * corners, `spacing.md` bottom margin) wrapping a fixed-size thumbnail next to a
+ * flexible body, with an optional action row beneath. This owns that shell so the
+ * three cards can't drift; each one supplies its own thumbnail node, body, press
  * handler, and optional actions.
  *
  * Layout:
@@ -23,7 +23,7 @@ import React from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 
 import { colors } from '@/styles/colors';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { CardActionsFooter } from './CardActionsFooter';
 
 /** Edge length of the square thumbnail slot. */
@@ -69,7 +69,8 @@ const styles = StyleSheet.create({
     borderRadius: radius.lg,
     overflow: 'hidden',
     marginBottom: spacing.md,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   row: {
     flexDirection: 'row',

--- a/packages/frontend/components/ui/ZoomableImage.tsx
+++ b/packages/frontend/components/ui/ZoomableImage.tsx
@@ -1,0 +1,115 @@
+/**
+ * ZoomableImage — the shared Airbnb-2026 masked image-zoom primitive.
+ *
+ * A rounded mask (`overflow: 'hidden'`) wrapping an inner wrapper that scales the
+ * image on hover (web) / press (native) while the mask — and therefore the card —
+ * stays perfectly still. This is the app-wide REPLACEMENT for whole-card hover/
+ * press `scale`: the photo zooms inside its rounded corners, the layout never
+ * moves. Every photo tile drops this in so the interaction reads identically.
+ *
+ * Interaction state is owned internally (web hover via pointer enter/leave) and
+ * can be augmented by an external `active` signal (a parent Pressable's press, or
+ * a carousel's shared hover), OR-ed together. Static style arrays + `useState`,
+ * per the NativeWind function-form-`style` constraint (AGENTS.md §NativeWind
+ * Pressable); it's its own component, so there are never hooks inside a `.map`.
+ */
+import React, { useState } from 'react';
+import {
+  Platform,
+  StyleSheet,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+
+const IS_WEB = Platform.OS === 'web';
+
+/** Image scale while active — a subtle Airbnb-style zoom inside the mask. */
+const ZOOM = 1.05;
+
+/**
+ * Web-only CSS transition so the zoom eases instead of snapping. `transition*`
+ * are web CSS values RN's `ViewStyle` lacks, so this block is web-cast (the
+ * sanctioned pattern for web-only CSS in this codebase).
+ */
+const WEB_ZOOM_TRANSITION: ViewStyle | null = IS_WEB
+  ? ({
+      transitionProperty: 'transform',
+      transitionDuration: '400ms',
+      transitionTimingFunction: 'cubic-bezier(0.2, 0, 0.2, 1)',
+    } as unknown as ViewStyle)
+  : null;
+
+/**
+ * `will-change: transform` on the MASK fixes a Safari bug where the rounded
+ * corners stop clipping the scaling child mid-transform. Web-only CSS → web-cast.
+ */
+const WEB_MASK_HINT: ViewStyle | null = IS_WEB
+  ? ({ willChange: 'transform' } as unknown as ViewStyle)
+  : null;
+
+interface ZoomableImageProps {
+  /** The image (or media) to zoom — rendered inside the scaling inner wrapper. */
+  children: React.ReactNode;
+  /** Corner radius of the mask, so the zoom clips to the card. */
+  borderRadius?: number;
+  /** Width / height ratio of the mask (e.g. `1` square, `4 / 3`). */
+  aspectRatio?: number;
+  /**
+   * External active signal OR-ed with the internal web hover — e.g. a parent
+   * Pressable's press state (native zoom) or a carousel's shared hover.
+   */
+  active?: boolean;
+  /** Extra style for the mask (e.g. fill the parent, background). */
+  style?: StyleProp<ViewStyle>;
+}
+
+export const ZoomableImage: React.FC<ZoomableImageProps> = ({
+  children,
+  borderRadius,
+  aspectRatio,
+  active = false,
+  style,
+}) => {
+  const [hovered, setHovered] = useState(false);
+  const isActive = active || hovered;
+
+  return (
+    <View
+      // Pointer enter/leave (not Pressable-only onHoverIn/Out) so a plain layout
+      // View hosts the hover state; they fire on the mask's own boundary and map
+      // to mouseenter/mouseleave on RN-Web. No-op on native — touch has no hover.
+      onPointerEnter={IS_WEB ? () => setHovered(true) : undefined}
+      onPointerLeave={IS_WEB ? () => setHovered(false) : undefined}
+      style={[
+        styles.mask,
+        borderRadius !== undefined ? { borderRadius } : null,
+        aspectRatio !== undefined ? { aspectRatio } : null,
+        WEB_MASK_HINT,
+        style,
+      ]}
+    >
+      <View
+        style={[
+          styles.inner,
+          WEB_ZOOM_TRANSITION,
+          { transform: [{ scale: isActive ? ZOOM : 1 }] },
+        ]}
+      >
+        {children}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  mask: {
+    overflow: 'hidden',
+  },
+  inner: {
+    width: '100%',
+    height: '100%',
+  },
+});
+
+export default ZoomableImage;

--- a/packages/frontend/components/ui/skeletons/PropertyListSkeleton.tsx
+++ b/packages/frontend/components/ui/skeletons/PropertyListSkeleton.tsx
@@ -3,7 +3,6 @@ import { View, StyleSheet, ScrollView } from 'react-native';
 import { Skeleton } from '@oxyhq/bloom';
 import { TextLines } from './TextLines';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 
 interface PropertyListSkeletonProps {
   viewMode?: 'list' | 'grid';
@@ -80,7 +79,6 @@ const styles = StyleSheet.create({
     backgroundColor: colors.white,
     borderRadius: 12,
     overflow: 'hidden',
-    ...shadowToken({ y: 1, blur: 4, color: colors.COLOR_BLACK, opacity: 0.1, elevation: 2 }),
   },
   gridImage: {
     backgroundColor: colors.COLOR_BLACK_LIGHT_6,
@@ -110,7 +108,6 @@ const styles = StyleSheet.create({
     padding: 12,
     flexDirection: 'row',
     gap: 12,
-    ...shadowToken({ y: 1, blur: 4, color: colors.COLOR_BLACK, opacity: 0.1, elevation: 2 }),
   },
   listImage: {
     backgroundColor: colors.COLOR_BLACK_LIGHT_6,

--- a/packages/frontend/components/ui/skeletons/SearchSkeleton.tsx
+++ b/packages/frontend/components/ui/skeletons/SearchSkeleton.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { View, ScrollView } from 'react-native';
 import { Skeleton } from '@oxyhq/bloom';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 
 interface SearchSkeletonProps {
   showFilters?: boolean;
@@ -56,7 +55,6 @@ function SearchResultSkeleton() {
         borderRadius: 12,
         marginBottom: 16,
         overflow: 'hidden',
-        ...shadowToken({ y: 2, blur: 4, color: colors.COLOR_BLACK, opacity: 0.1, elevation: 3 }),
       }}>
       {/* Image */}
       <Skeleton.Box width="100%" height={200} borderRadius={0} />

--- a/packages/frontend/components/ui/skeletons/TipsSkeleton.tsx
+++ b/packages/frontend/components/ui/skeletons/TipsSkeleton.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 import { Skeleton } from '@oxyhq/bloom';
 import { TextLines } from './TextLines';
 import { colors } from '@/styles/colors';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 
 interface TipsSkeletonProps {
   itemCount?: number;
@@ -30,7 +30,6 @@ function FeaturedTipCardSkeleton() {
         backgroundColor: colors.surfaceElevated,
         borderRadius: radius.xl,
         overflow: 'hidden',
-        ...withShadow('sm'),
       }}
     >
       <Skeleton.Box width="100%" height={260} borderRadius={0} />
@@ -53,7 +52,6 @@ function TipCardSkeleton() {
         backgroundColor: colors.surfaceElevated,
         borderRadius: radius.lg,
         overflow: 'hidden',
-        ...withShadow('sm'),
       }}
     >
       <Skeleton.Box width="100%" height={180} borderRadius={0} />

--- a/packages/frontend/components/widgets/RecentlyViewedWidget.tsx
+++ b/packages/frontend/components/widgets/RecentlyViewedWidget.tsx
@@ -10,7 +10,6 @@ import { useOxy } from '@oxyhq/services';
 import { BaseWidget } from './BaseWidget';
 import { PropertyCard } from '@/components/PropertyCard';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 
 
 export function RecentlyViewedWidget() {
@@ -191,7 +190,6 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(255, 255, 255, 0.95)',
     justifyContent: 'center',
     alignItems: 'center',
-    ...shadowToken({ y: 2, blur: 4, color: colors.COLOR_BLACK, opacity: 0.15, elevation: 3 }),
     transform: [{ translateY: -18 }],
     borderWidth: 1,
     borderColor: 'rgba(0, 0, 0, 0.1)',


### PR DESCRIPTION
## Summary
- **No card-level scale on hover/press.** Removed `transform:[{scale}]` from PropertyCard, PropertyImageCarousel, HomeCategoryStrip, CityShowcaseSection, HostCtaBanner, AgentCtaBanner, AgentHero CTA — cards stay put; only the photo now zooms inside its mask.
- **New shared primitive `ZoomableImage`** (`packages/frontend/components/ui/ZoomableImage.tsx`): image scales inside a rounded `overflow:hidden` mask; card never scales. Web hover owned internally; optional `active` prop for native press. Wired into PropertyImageCarousel, PropertyCard, CityShowcaseSection, Host/AgentCtaBanner, tips TipCard, RoomList.
- **Compact frosted "new" chip** on PropertyCard: `rgba(255,255,255,0.95)` pill, black text, height 20, no shadow (was a larger colored/shadowed badge).
- **Flattened card shadows** across CardSurface, SectionCard, ThumbnailCard, MediaChip, CityShowcaseSection, Host/AgentCtaBanner, RewardsTeaser, ReviewCard, RoomList, RecentlyViewedWidget, tips screens, and skeletons — added a hairline `colors.border` where a same-background card would otherwise vanish. KEEP-list elevation (FABs, MapMarkerPopover, Header, search pills, carousel chevrons) is untouched.
- Documented the new `ZoomableImage` primitive in `AGENTS.md` under "Masked Image Zoom (ZoomableImage)".

Scope: `packages/frontend` only — no backend/shared-types/listing-providers changes.

## Test plan
- [x] `bunx tsc --noEmit` in packages/frontend — 11 pre-existing baseline errors only, none new, none in touched files beyond the known PropertyCard.tsx OfferingSummary.fallback error
- [x] `bun run build` (root) — shared-types, listing-providers, backend, frontend (expo export web) all exit 0
- [x] `bun run test` (root) — frontend 32/32, backend 510/510, listing-providers 380/380, all green
- [x] `bun install --frozen-lockfile` — no lockfile drift
- [x] `grep -rnE "transform.*scale" components app` — only ZoomableImage + pre-existing Reanimated worklets
- [x] `grep -rn "style=({" app components` — no function-form Pressable style regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)