### PR TITLE
feat(ingest): derive structured Property features from amenities

### DIFF
--- a/packages/backend/__tests__/unit/deriveFeatures.test.ts
+++ b/packages/backend/__tests__/unit/deriveFeatures.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Amenity → structured feature derivation. Covers both provider vocabularies:
+ * raw ES slugs (pisos) and canonical EN keys (fotocasa/habitaclia/IT aliases).
+ */
+
+import { deriveStructuredFeatures } from '../../services/ingestion/deriveFeatures';
+
+describe('deriveStructuredFeatures', () => {
+  it('returns empty for no amenities', () => {
+    expect(deriveStructuredFeatures(undefined)).toEqual({});
+    expect(deriveStructuredFeatures([])).toEqual({});
+    expect(deriveStructuredFeatures(['soleado', 'exterior', 'reformado'])).toEqual({});
+  });
+
+  it('derives from raw ES slugs (pisos vocabulary)', () => {
+    expect(
+      deriveStructuredFeatures(['ascensor', 'balcon', 'jardin', 'garaje', 'amueblado']),
+    ).toEqual({
+      hasElevator: true,
+      hasBalcony: true,
+      hasGarden: true,
+      parkingType: 'garage',
+      furnishedStatus: 'furnished',
+    });
+  });
+
+  it('derives from canonical EN keys (fotocasa/habitaclia vocabulary)', () => {
+    expect(
+      deriveStructuredFeatures(['elevator', 'terrace', 'garden', 'parking', 'furnished']),
+    ).toEqual({
+      hasElevator: true,
+      hasBalcony: true,
+      hasGarden: true,
+      parkingType: 'garage',
+      furnishedStatus: 'furnished',
+    });
+  });
+
+  it('treats terrace and balcony as the same hasBalcony flag', () => {
+    expect(deriveStructuredFeatures(['terraza'])).toEqual({ hasBalcony: true });
+    expect(deriveStructuredFeatures(['balcony'])).toEqual({ hasBalcony: true });
+    expect(deriveStructuredFeatures(['terrazzo'])).toEqual({ hasBalcony: true });
+  });
+
+  it('matches multi-token slugs and phrases without false positives', () => {
+    expect(deriveStructuredFeatures(['plaza_de_garaje'])).toEqual({ parkingType: 'garage' });
+    expect(deriveStructuredFeatures(['posto_auto'])).toEqual({ parkingType: 'garage' });
+    expect(deriveStructuredFeatures(['terraza_20m2'])).toEqual({ hasBalcony: true });
+    // 'trastero' (storage) must not trip terrace/garden/parking
+    expect(deriveStructuredFeatures(['trastero', 'piscina'])).toEqual({});
+  });
+
+  it('normalizes accents and casing before matching', () => {
+    expect(deriveStructuredFeatures(['Ascensor', 'JARDÍN', 'Garaje'])).toEqual({
+      hasElevator: true,
+      hasGarden: true,
+      parkingType: 'garage',
+    });
+  });
+
+  it('only sets fields whose tags are present', () => {
+    expect(deriveStructuredFeatures(['ascensor'])).toEqual({ hasElevator: true });
+  });
+});

--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -31,6 +31,7 @@ import type { AddressCanonicalInput } from '../../models/Address';
 import { validateOfferings } from '../../models/schemas/offeringValidation';
 import { forwardGeocode, reverseGeocode } from '../geocodingService';
 import { sanitizeGeoJsonCoordinates } from '../../utils/geoCoordinates';
+import { deriveStructuredFeatures } from './deriveFeatures';
 import { ExternalMediaIngest } from './ExternalMediaIngest';
 import { schedulePriceEthicsScore } from '../priceEthicsService';
 import { Logger } from '../../utils/logger';
@@ -279,8 +280,24 @@ export class IngestionService {
     if (listing.bathrooms !== undefined) fields.bathrooms = listing.bathrooms;
     if (listing.squareFootage !== undefined) fields.squareFootage = listing.squareFootage;
     if (listing.floor !== undefined) fields.floor = listing.floor;
+    if (listing.yearBuilt !== undefined) fields.yearBuilt = listing.yearBuilt;
     if (listing.amenities !== undefined) fields.amenities = listing.amenities;
-    if (listing.furnishedStatus !== undefined) fields.furnishedStatus = listing.furnishedStatus;
+    if (listing.parkingSpaces !== undefined) fields.parkingSpaces = listing.parkingSpaces;
+
+    // Promote amenity tags to the structured feature columns the search filters
+    // and UI read. A provider-explicit value always wins over derivation.
+    const derived = deriveStructuredFeatures(listing.amenities);
+    const hasElevator = listing.hasElevator ?? derived.hasElevator;
+    if (hasElevator !== undefined) fields.hasElevator = hasElevator;
+    const hasBalcony = listing.hasBalcony ?? derived.hasBalcony;
+    if (hasBalcony !== undefined) fields.hasBalcony = hasBalcony;
+    const hasGarden = listing.hasGarden ?? derived.hasGarden;
+    if (hasGarden !== undefined) fields.hasGarden = hasGarden;
+    const parkingType = listing.parkingType ?? derived.parkingType;
+    if (parkingType !== undefined) fields.parkingType = parkingType;
+    const furnishedStatus = listing.furnishedStatus ?? derived.furnishedStatus;
+    if (furnishedStatus !== undefined) fields.furnishedStatus = furnishedStatus;
+
     if (listing.contact) {
       const externalContact: NonNullable<IProperty['externalContact']> = {};
       if (listing.contact.phone) externalContact.phone = listing.contact.phone;

--- a/packages/backend/services/ingestion/deriveFeatures.ts
+++ b/packages/backend/services/ingestion/deriveFeatures.ts
@@ -1,0 +1,101 @@
+/**
+ * Derive structured Property feature fields from a listing's free-form
+ * `amenities` list.
+ *
+ * Providers already parse portal feature tags (ascensor, terraza, garaje, …)
+ * but only ever store them as amenity strings — the structured Property columns
+ * the search filters and UI read (`hasElevator`, `hasBalcony`, `hasGarden`,
+ * `parkingType`, `furnishedStatus`) stay at their defaults. This is the single
+ * ingest chokepoint that promotes those tags to the structured fields, so every
+ * provider benefits without per-provider parsing.
+ *
+ * Two vocabularies coexist and are both handled:
+ * - raw ES slugs from pisos (`ascensor`, `balcon`, `terraza`, `garaje`, …)
+ * - canonical EN keys from fotocasa/habitaclia/IT aliases (`elevator`,
+ *   `terrace`, `balcony`, `parking`, `garden`, `furnished`).
+ *
+ * A provider that sets a structured field explicitly (e.g. immoweb `hasLift`)
+ * always wins — this only fills the gaps.
+ */
+
+/** Structured feature fields derivable from amenity tags. */
+export interface DerivedFeatures {
+  hasElevator?: boolean;
+  hasBalcony?: boolean;
+  hasGarden?: boolean;
+  parkingType?: 'garage';
+  furnishedStatus?: 'furnished';
+}
+
+/** Single-token keywords (deaccented, lowercased) that activate each feature. */
+const KEYWORDS = {
+  elevator: ['elevator', 'ascensor', 'ascensore', 'ascenseur', 'lift'],
+  balcony: [
+    'balcony',
+    'balcon',
+    'balcone',
+    'terrace',
+    'terraza',
+    'terrazza',
+    'terrazzo',
+    'terrasse',
+  ],
+  garden: ['garden', 'jardin', 'giardino', 'jardim'],
+  parking: ['parking', 'garaje', 'garage', 'parcheggio', 'estacionamiento', 'cochera'],
+  furnished: ['furnished', 'amueblado', 'amoblado', 'arredato', 'arredata', 'meuble', 'meublee'],
+} as const;
+
+/** Multi-token phrases (already normalized with `_` separators). */
+const PHRASES = {
+  parking: ['posto_auto', 'plaza_de_garaje', 'plaza_garaje', 'parking_space'],
+} as const;
+
+/** Match pisos' amenity normalization so both vocabularies compare equal. */
+function normalizeToken(raw: string): string {
+  return raw
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/**
+ * True when any amenity token equals a keyword, contains one as an underscore
+ * sub-token (`plaza_de_garaje` → `garaje`), or equals a known phrase.
+ */
+function hasFeature(
+  tokens: readonly string[],
+  keywords: readonly string[],
+  phrases: readonly string[] = [],
+): boolean {
+  const keywordSet = new Set(keywords);
+  const phraseSet = new Set(phrases);
+  for (const token of tokens) {
+    if (phraseSet.has(token)) return true;
+    if (keywordSet.has(token)) return true;
+    for (const part of token.split('_')) {
+      if (keywordSet.has(part)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Promote amenity tags to structured feature fields. Only sets a field when the
+ * corresponding tag is present — absent tags are left undefined so the caller
+ * keeps provider-explicit values and schema defaults.
+ */
+export function deriveStructuredFeatures(amenities: readonly string[] | undefined): DerivedFeatures {
+  if (!amenities || amenities.length === 0) return {};
+  const tokens = amenities.map(normalizeToken).filter(Boolean);
+  if (tokens.length === 0) return {};
+
+  const features: DerivedFeatures = {};
+  if (hasFeature(tokens, KEYWORDS.elevator)) features.hasElevator = true;
+  if (hasFeature(tokens, KEYWORDS.balcony)) features.hasBalcony = true;
+  if (hasFeature(tokens, KEYWORDS.garden)) features.hasGarden = true;
+  if (hasFeature(tokens, KEYWORDS.parking, PHRASES.parking)) features.parkingType = 'garage';
+  if (hasFeature(tokens, KEYWORDS.furnished)) features.furnishedStatus = 'furnished';
+  return features;
+}

--- a/packages/shared-types/src/listing.ts
+++ b/packages/shared-types/src/listing.ts
@@ -187,8 +187,23 @@ export interface NormalizedListing {
   bathrooms?: number;
   squareFootage?: number;
   floor?: number;
+  /** Construction year, when the portal exposes it (e.g. immoweb `constructionYear`). */
+  yearBuilt?: number;
   amenities?: string[];
   furnishedStatus?: 'furnished' | 'unfurnished' | 'partially_furnished' | 'not_specified';
+  /**
+   * Structured feature booleans. When a portal exposes these explicitly (e.g.
+   * immoweb `hasLift`/`hasGarden`/`hasTerrace`) the provider sets them directly;
+   * otherwise the ingest derives them from {@link amenities}. A provider-set
+   * value always wins over derivation.
+   */
+  hasElevator?: boolean;
+  hasBalcony?: boolean;
+  hasGarden?: boolean;
+  /** Parking kind, matching the Property schema enum. */
+  parkingType?: 'none' | 'street' | 'assigned' | 'garage';
+  /** Number of parking spaces, when the portal exposes a count. */
+  parkingSpaces?: number;
   /** Source images fetched once at ingest and re-hosted; never hotlinked. */
   remoteImages: NormalizedRemoteImage[];
   /**


### PR DESCRIPTION
## Por qué
Los listings externos con tags de ascensor/terraza/jardín/garaje/amueblado solo los guardaban como `amenities` strings — las columnas estructuradas que usan los **filtros de búsqueda y la UI** (`hasElevator`, `hasBalcony`, `hasGarden`, `parkingType`, `furnishedStatus`) quedaban en default en los ~2.200 listings publicados.

## Qué
- **Un chokepoint** en el ingest (`deriveStructuredFeatures`) que promueve los tags de amenity → columnas estructuradas. Cubre los **dos vocabularios**: slugs ES crudos (pisos) y claves canónicas EN (fotocasa/habitaclia/IT). Cero duplicación por-provider — todos se benefician gratis.
- `NormalizedListing` ampliado con `hasElevator/hasBalcony/hasGarden/parkingType/parkingSpaces/yearBuilt` para que un portal que los exponga explícitos (immoweb `hasLift`/`constructionYear`/`parkingCount`) gane sobre la derivación.
- `buildPropertyFields` copia los nuevos campos y aplica el derivador (provider-explícito > derivado).

Es la **base reutilizable**: sobre ella, cada provider amplía su `normalize()` para rellenar los campos numéricos que hoy descarta (bathrooms, m², yearBuilt, floor) reusando los parsers compartidos.

## Test
- Build `tsc` verde (shared-types + listing-providers + backend).
- `deriveFeatures.test.ts`: cubre ambos vocabularios, frases multi-token, sin falsos positivos (trastero/piscina no disparan), normalización de acentos.
- Suite ingest: 21 pass / 4 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)