### PR TITLE
feat(pisos): extract floor/yearBuilt/parkingSpaces from dataVar

### DIFF
--- a/packages/backend/__tests__/unit/pisosProvider.test.ts
+++ b/packages/backend/__tests__/unit/pisosProvider.test.ts
@@ -38,6 +38,9 @@ describe('PisosProvider.normalize', () => {
     expect(listing.bedrooms).toBe(2);
     expect(listing.bathrooms).toBe(2);
     expect(listing.squareFootage).toBe(107);
+    expect(listing.floor).toBe(3);
+    expect(listing.yearBuilt).toBe(1998);
+    expect(listing.parkingSpaces).toBe(1);
     expect(listing.contact?.phone).toBe('919376345');
     expect(listing.contact?.kind).toBe('agency');
     expect(listing.remoteImages.length).toBeGreaterThan(0);
@@ -69,6 +72,29 @@ describe('PisosProvider.normalize', () => {
     expect(madrid.address.coordinates).toEqual({ lat: 40.41593545782718, lng: -3.7083892232908435 });
     expect(valladolid.address.coordinates).toEqual({ lat: 41.6531628, lng: -4.7216201 });
     expect(madrid.address.coordinates).not.toEqual(valladolid.address.coordinates);
+    // Valladolid's trimmed `data-var` omits planta / año / plazas — stay undefined.
+    expect(valladolid.floor).toBeUndefined();
+    expect(valladolid.yearBuilt).toBeUndefined();
+    expect(valladolid.parkingSpaces).toBeUndefined();
+  });
+
+  it('rejects non-numeric floor and age-encoded antiguedad instead of fabricating values', () => {
+    const bogusHtml = PISOS_FIXTURE_DETAIL_HTML.replace(
+      '"planta":"3","anioConstruccion":"1998","nPlazasGaraje":"1"',
+      '"planta":"Bajo","anioConstruccion":"antigua","antiguedad":"30 años"',
+    );
+    const payload = parsePisosDetail(
+      bogusHtml,
+      'https://www.pisos.com/alquilar/piso-sol_barrio28012-20026385030_992099/',
+    );
+    const listing = provider.normalize({
+      ref: { provider: 'pisos', sourceId: payload.sourceId, url: payload.url },
+      payload,
+    });
+
+    expect(listing.floor).toBeUndefined();
+    expect(listing.yearBuilt).toBeUndefined();
+    expect(listing.parkingSpaces).toBeUndefined();
   });
 
   it('parses contact AJAX JSON', () => {

--- a/packages/listing-providers/src/providers/pisos/fixtures.ts
+++ b/packages/listing-providers/src/providers/pisos/fixtures.ts
@@ -2,7 +2,8 @@
  * Recorded pisos.com fixtures (portal-shaped, hand-authored).
  *
  * Search pages ship schema.org JSON-LD for each card; detail pages embed a
- * `data-var` JSON blob (rooms/baths/m²/phone) plus a tracking JSON object with
+ * `data-var` JSON blob (rooms/baths/m²/phone plus optional planta / año de
+ * construcción / plazas de garaje) plus a tracking JSON object with
  * price/operation. Image URLs point at example CDN hosts and are re-hosted at
  * ingest — never hotlinked at runtime.
  */
@@ -34,7 +35,7 @@ export const PISOS_FIXTURE_DETAIL_HTML = `<!doctype html>
 <div class="ascending-geo__row" data-zone="M00000000028079" data-ga-geoLevelName='municipio' property="itemListElement" typeof="ListItem">
 <a href="/alquiler/piso-madrid_capital/" class="ascending-geo__result" property="item" typeof="WebPage"><span property="name">Madrid Capital</span></a>
 </div>
-<div data-var='{"fechaModificacion":"17/06/2026","fechaPrimeraPublicacion":"04/05/2026","telefono":"919376345","caracteristicasInmueble":"ascensor,balcon,soleado","nHabitaciones":"2","nBanios":"2","superficieInmueble":"107","descuentoAplicado":"8"}'></div>
+<div data-var='{"fechaModificacion":"17/06/2026","fechaPrimeraPublicacion":"04/05/2026","telefono":"919376345","caracteristicasInmueble":"ascensor,balcon,soleado","nHabitaciones":"2","nBanios":"2","superficieInmueble":"107","planta":"3","anioConstruccion":"1998","nPlazasGaraje":"1","descuentoAplicado":"8"}'></div>
 <div class="locationmap" data-params="latitude=40.41593545782718&amp;longitude=-3.7083892232908435&amp;zoom=17&amp;showMarker=True"></div>
 <script>
 window.__pisosTrack = {"tipoContenido":"detalle","tipoOperacion":"alquiler","seccion":"alquiler","idioma":"ES","subseccion1":"casas-pisos","tipoContenidoA":"detalle-casas-pisos","provincia":"P00000000000028","municipio":"M00000000028079","distrito":"G00000002807901","precioInmueble":"2550","precio":"2550","tipoVendedor":"profesional","referenciaInmueble":"","marca":"196080","tipoInmueble":"casas-pisos","subTipoInmueble":"piso-apartamento"};

--- a/packages/listing-providers/src/providers/pisos/index.ts
+++ b/packages/listing-providers/src/providers/pisos/index.ts
@@ -416,7 +416,7 @@ export class PisosProvider implements ListingProvider {
   }
 
   normalize(raw: RawListing): NormalizedListing {
-    const { sourceId, url, listing, contact } = asPisosRaw(raw.payload);
+    const { sourceId, url, listing, contact, floor, yearBuilt, parkingSpaces } = asPisosRaw(raw.payload);
     if (listing.price === undefined) {
       throw new Error(`pisos: listing ${sourceId} has no resolvable price`);
     }
@@ -450,6 +450,9 @@ export class PisosProvider implements ListingProvider {
     if (listing.bedrooms !== undefined) result.bedrooms = listing.bedrooms;
     if (listing.bathrooms !== undefined) result.bathrooms = listing.bathrooms;
     if (listing.squareMeters !== undefined) result.squareFootage = listing.squareMeters;
+    if (floor !== undefined) result.floor = floor;
+    if (yearBuilt !== undefined) result.yearBuilt = yearBuilt;
+    if (parkingSpaces !== undefined) result.parkingSpaces = parkingSpaces;
     if (listing.amenities.length > 0) result.amenities = listing.amenities;
     if (contact && (contact.phone || contact.email || contact.whatsapp || contact.agencyName)) {
       result.contact = contact;

--- a/packages/listing-providers/src/providers/pisos/parse.ts
+++ b/packages/listing-providers/src/providers/pisos/parse.ts
@@ -18,6 +18,12 @@ export interface PisosRaw {
   url: string;
   listing: EsSchemaListing;
   contact?: NormalizedListingContact;
+  /** Floor number from the `data-var` `planta` field (numeric floors only). */
+  floor?: number;
+  /** Construction year from `data-var` `anioConstruccion` / `antiguedad`. */
+  yearBuilt?: number;
+  /** Garage spaces from the `data-var` `nPlazasGaraje` field. */
+  parkingSpaces?: number;
 }
 
 const DETAIL_PATH_RE = /\/(?:alquilar|comprar)\/[^"'?\s]*?-(\d+[._]\d+|\d+)\/?/i;
@@ -274,6 +280,38 @@ function amenityList(raw: unknown): string[] {
 }
 
 /**
+ * Floor number from the `data-var` `planta` field. Only numeric floors are
+ * kept (`asNumber` strips the ordinal suffix in `"3ª"`); textual floors such
+ * as "Bajo" / "Entreplanta" yield `undefined` rather than a fabricated number.
+ * A year accidentally landing in this field is rejected by the range guard.
+ */
+function readPisosFloor(dataVar: Record<string, unknown> | undefined): number | undefined {
+  const floor = asNumber(dataVar?.planta);
+  if (floor === undefined || !Number.isInteger(floor) || floor < 0 || floor > 200) return undefined;
+  return floor;
+}
+
+/**
+ * Construction year from the `data-var` `anioConstruccion` (preferred) or
+ * `antiguedad`. The plausible-year range guard rejects `antiguedad` values that
+ * encode an age in years ("30") or a bucket ("Menos de 5 años") rather than a
+ * real four-digit year, so only a genuine construction year is emitted.
+ */
+function readPisosYearBuilt(dataVar: Record<string, unknown> | undefined): number | undefined {
+  const year = asNumber(dataVar?.anioConstruccion) ?? asNumber(dataVar?.antiguedad);
+  const maxYear = new Date().getFullYear() + 2;
+  if (year === undefined || !Number.isInteger(year) || year < 1800 || year > maxYear) return undefined;
+  return year;
+}
+
+/** Garage spaces from the `data-var` `nPlazasGaraje` field (non-negative int). */
+function readPisosParkingSpaces(dataVar: Record<string, unknown> | undefined): number | undefined {
+  const spaces = asNumber(dataVar?.nPlazasGaraje);
+  if (spaces === undefined || !Number.isInteger(spaces) || spaces < 0 || spaces > 50) return undefined;
+  return spaces;
+}
+
+/**
  * Parse a detail page into {@link PisosRaw}. Prefers embedded JSON blobs;
  * falls back to JSON-LD / light HTML for title, images, description.
  */
@@ -354,7 +392,15 @@ export function parsePisosDetail(html: string, url: string): PisosRaw {
       }
     : undefined;
 
-  return { sourceId: resolvedId, url, listing, contact };
+  const raw: PisosRaw = { sourceId: resolvedId, url, listing, contact };
+  const floor = readPisosFloor(dataVar);
+  if (floor !== undefined) raw.floor = floor;
+  const yearBuilt = readPisosYearBuilt(dataVar);
+  if (yearBuilt !== undefined) raw.yearBuilt = yearBuilt;
+  const parkingSpaces = readPisosParkingSpaces(dataVar);
+  if (parkingSpaces !== undefined) raw.parkingSpaces = parkingSpaces;
+
+  return raw;
 }
 
 /** Merge best-effort contact AJAX phone into an existing raw payload. */


### PR DESCRIPTION
## What

Widen the pisos.com (ES) `normalize()` to fill numeric `NormalizedListing` fields the detail `data-var` blob exposes but the provider previously discarded:

- **`floor`** ← `data-var.planta` — numeric floors only. `asNumber` strips the ordinal suffix in `"3ª"`; textual floors like `"Bajo"` / `"Entreplanta"` yield `undefined` rather than a fabricated number.
- **`yearBuilt`** ← `data-var.anioConstruccion` (preferred), falling back to `antiguedad` **only** when it parses to a plausible four-digit year. Age-in-years (`"30"`) or bucket (`"Menos de 5 años"`) values are rejected by the `[1800, currentYear+2]` range guard.
- **`parkingSpaces`** ← `data-var.nPlazasGaraje` — non-negative integer (`[0, 50]`).

Every read is range-guarded so an out-of-band value (a year landing in `planta`, an age in `antiguedad`) never fabricates a field.

## Scope / non-goals

- Structured booleans (`hasElevator` / `hasBalcony` / `hasGarden` / `parkingType` / `furnishedStatus`) stay **derived at ingest** from pisos' raw ES amenity slugs (`ascensor` / `balcon` / `garaje` / …) via `deriveStructuredFeatures` — this PR only adds the numeric/explicit fields.
- No changes to the shared `NormalizedListing` contract or the ingest path (both already merged on main). No shared `jsonLd.ts` change (pisos detail LD is search-only; `EurSchemaListing` does not expose floor/year, and extending it would touch every EUR provider).

## Tests

`packages/backend/__tests__/unit/pisosProvider.test.ts` — Madrid fixture now carries `planta` / `anioConstruccion` / `nPlazasGaraje`:
- positive path asserts `floor: 3`, `yearBuilt: 1998`, `parkingSpaces: 1`
- trimmed Valladolid fixture asserts all three stay `undefined`
- new guard test replaces the blob with `planta: "Bajo"`, `anioConstruccion: "antigua"`, `antiguedad: "30 años"` and asserts none are fabricated

`shared-types` → `listing-providers` → `backend` build clean; 9/9 pisos tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)