### PR TITLE
feat(habitaclia): extract floor/yearBuilt/parkingSpaces from detail

### DIFF
--- a/packages/backend/__tests__/unit/habitacliaProvider.test.ts
+++ b/packages/backend/__tests__/unit/habitacliaProvider.test.ts
@@ -55,6 +55,11 @@ describe('HabitacliaProvider', () => {
     expect(raw.squareMeters).toBe(95);
     expect(raw.furnished).toBe(true);
     expect(raw.amenities).toEqual(['elevator', 'air_conditioning']);
+    // Floor / construction year / parking count live in the detail markup, not
+    // the JSON-LD — the shared enrich step fills them on the JSON-LD path too.
+    expect(raw.floor).toBe(5);
+    expect(raw.yearBuilt).toBe(2005);
+    expect(raw.parkingSpaces).toBe(1);
     expect(raw.images).toHaveLength(2);
     expect(raw.images[0]?.isPrimary).toBe(true);
   });
@@ -74,7 +79,22 @@ describe('HabitacliaProvider', () => {
     expect(raw.bedrooms).toBe(3);
     expect(raw.bathrooms).toBe(2);
     expect(raw.squareMeters).toBe(95);
+    // "Planta 4ª" / "Año construcción 1998" / "2 plazas de garaje" become
+    // structured numerics — not junk amenity slugs.
+    expect(raw.floor).toBe(4);
+    expect(raw.yearBuilt).toBe(1998);
+    expect(raw.parkingSpaces).toBe(2);
     expect(raw.amenities).toEqual(['elevator', 'terrace']);
+  });
+
+  it('ignores fuzzy characteristics that carry no reliable number', () => {
+    const html = HABITACLIA_FIXTURE_DETAIL_HTML_LIVE.replace('Planta 4ª', 'Planta baja')
+      .replace('Año construcción 1998', 'Antigüedad: entre 30 y 50 años')
+      .replace('2 plazas de garaje', 'Plaza de garaje');
+    const raw = parseHabitacliaDetail(html, DETAIL_URL);
+    expect(raw.floor).toBeUndefined();
+    expect(raw.yearBuilt).toBeUndefined();
+    expect(raw.parkingSpaces).toBeUndefined();
   });
 
   it('extracts listainmuebles form fields and parses AJAX fragments', () => {
@@ -107,6 +127,9 @@ describe('HabitacliaProvider', () => {
     expect(listing.address.countryCode).toBe('ES');
     expect(listing.address.coordinates).toEqual({ lat: 41.3959, lng: 2.1631 });
     expect(listing.furnishedStatus).toBe('furnished');
+    expect(listing.floor).toBe(5);
+    expect(listing.yearBuilt).toBe(2005);
+    expect(listing.parkingSpaces).toBe(1);
     expect(listing.remoteImages).toHaveLength(2);
     expect(listing.remoteImages.filter((image) => image.isPrimary)).toHaveLength(1);
   });

--- a/packages/listing-providers/src/providers/habitaclia/fixtures.ts
+++ b/packages/listing-providers/src/providers/habitaclia/fixtures.ts
@@ -45,7 +45,12 @@ export interface HabitacliaRawListing {
   bedrooms?: number;
   bathrooms?: number;
   squareMeters?: number;
+  /** Floor level, from a "Planta N" detail characteristic. */
   floor?: number;
+  /** Construction year, from an "Año construcción: YYYY" detail characteristic. */
+  yearBuilt?: number;
+  /** Parking-space count, from an "N plazas de parking" detail characteristic. */
+  parkingSpaces?: number;
   furnished?: boolean;
   amenities?: string[];
   images: HabitacliaRawImage[];
@@ -101,7 +106,14 @@ export const HABITACLIA_FIXTURE_DETAIL_HTML = `<!doctype html>
 }
 </script>
 </head>
-<body><h1>Piso en alquiler en Carrer de Provença</h1></body>
+<body>
+<h1>Piso en alquiler en Carrer de Provença</h1>
+<ul class="feature-list">
+  <li>Planta 5ª</li>
+  <li>Año construcción 2005</li>
+  <li>1 plaza de parking</li>
+</ul>
+</body>
 </html>`;
 
 /**
@@ -138,7 +150,7 @@ export const HABITACLIA_FIXTURE_DETAIL_HTML_LIVE = `<!doctype html>
   </ul>
 </section>
 <p id="js-detail-description" class="detail-description">Luminoso piso reformado en Gràcia.</p>
-<ul><li>Ascensor </li><li>Terraza </li></ul>
+<ul class="feature-list"><li>Ascensor </li><li>Terraza </li><li>Planta 4ª</li><li>Año construcción 1998</li><li>2 plazas de garaje</li></ul>
 <img itemprop="image" src="//images.habimg.com/imgh/55551-4519/sample-g.jpg" />
 </body></html>`;
 

--- a/packages/listing-providers/src/providers/habitaclia/index.ts
+++ b/packages/listing-providers/src/providers/habitaclia/index.ts
@@ -487,6 +487,8 @@ export class HabitacliaProvider implements ListingProvider {
       bathrooms: listing.bathrooms,
       squareFootage: listing.squareMeters,
       floor: listing.floor,
+      yearBuilt: listing.yearBuilt,
+      parkingSpaces: listing.parkingSpaces,
       amenities: listing.amenities,
       furnishedStatus: resolveFurnished(listing.furnished),
       remoteImages: toRemoteImages(listing),

--- a/packages/listing-providers/src/providers/habitaclia/parse.ts
+++ b/packages/listing-providers/src/providers/habitaclia/parse.ts
@@ -175,10 +175,30 @@ function resolvePropertyType(node: Record<string, unknown>): string {
  */
 export function parseHabitacliaDetail(html: string, url: string): HabitacliaRawListing {
   const node = extractJsonLdNodes(html).find(isListingNode);
-  if (node) {
-    return parseHabitacliaDetailFromJsonLd(node, url);
+  const raw = node ? parseHabitacliaDetailFromJsonLd(node, url) : parseHabitacliaDetailHtml(html, url);
+  return applyDetailCharacteristics(raw, html);
+}
+
+/**
+ * Merge the numeric characteristics Habitaclia prints only in the detail markup
+ * — floor level, construction year and the parking-space count — onto the raw
+ * listing, regardless of whether the base fields came from JSON-LD or microdata
+ * (neither source carries these reliably). A value already set by the base
+ * parser always wins; the HTML characteristics only fill the gaps.
+ */
+function applyDetailCharacteristics(raw: HabitacliaRawListing, html: string): HabitacliaRawListing {
+  const floor = raw.floor ?? parseFloorLevel(html);
+  const yearBuilt = raw.yearBuilt ?? parseYearBuilt(html);
+  const parkingSpaces = raw.parkingSpaces ?? parseParkingSpaces(html);
+  if (floor === undefined && yearBuilt === undefined && parkingSpaces === undefined) {
+    return raw;
   }
-  return parseHabitacliaDetailHtml(html, url);
+  return {
+    ...raw,
+    ...(floor !== undefined ? { floor } : {}),
+    ...(yearBuilt !== undefined ? { yearBuilt } : {}),
+    ...(parkingSpaces !== undefined ? { parkingSpaces } : {}),
+  };
 }
 
 function parseHabitacliaDetailFromJsonLd(node: Record<string, unknown>, url: string): HabitacliaRawListing {
@@ -305,6 +325,42 @@ function firstMatch(html: string, re: RegExp): string | undefined {
   return match?.[1] ? decodeHtmlEntities(match[1].trim()) : undefined;
 }
 
+/**
+ * Floor level from a "Planta N" / "Planta Nª" characteristic. Returns `undefined`
+ * for the label-only forms Habitaclia also uses ("Planta baja", "Ático"), which
+ * carry no reliable number.
+ */
+function parseFloorLevel(html: string): number | undefined {
+  const floor = asNumber(firstMatch(html, /\bPlanta\s+(\d{1,2})\s*(?:[ªº°]|\b)/i));
+  return floor !== undefined && floor >= 0 && floor <= 60 ? floor : undefined;
+}
+
+/**
+ * Construction year from an "Año (de) construcción: YYYY" / "Construido en YYYY"
+ * characteristic. Habitaclia often states age as a fuzzy range instead
+ * ("Antigüedad: entre 30 y 50 años") — those carry no exact year and are ignored.
+ */
+function parseYearBuilt(html: string): number | undefined {
+  const year = asNumber(
+    firstMatch(html, /A[ñn]o\s+(?:de\s+)?construcci[óo]n\s*[:\s]\s*(\d{4})/i) ??
+      firstMatch(html, /\bconstruid[oa]\s+en\s+(?:el\s+a[ñn]o\s+)?(\d{4})/i),
+  );
+  const maxYear = new Date().getFullYear() + 2;
+  return year !== undefined && year >= 1800 && year <= maxYear ? year : undefined;
+}
+
+/**
+ * Parking-space count from an "N plazas de parking/garaje/aparcamiento"
+ * characteristic. The label-only "Plaza de parking" boolean carries no count and
+ * is left to the amenity → parking-type derivation instead.
+ */
+function parseParkingSpaces(html: string): number | undefined {
+  const spaces = asNumber(
+    firstMatch(html, /(\d{1,2})\s*plazas?\s+de\s+(?:parking|garaje|aparcamiento)/i),
+  );
+  return spaces !== undefined && spaces >= 1 && spaces <= 20 ? spaces : undefined;
+}
+
 function collectItempropImages(html: string): HabitacliaRawImage[] {
   const urls: string[] = [];
   for (const match of html.matchAll(/itemprop=["']image["'][^>]*src=["']([^"']+)["']/gi)) {
@@ -370,7 +426,13 @@ export function parseHabitacliaDetailHtml(html: string, url: string): Habitaclia
   let furnished: boolean | undefined;
   for (const match of html.matchAll(/<li>([^<]{2,60})<\/li>/gi)) {
     const label = match[1]?.trim();
-    if (!label || /habitacion|baño|ba\u00F1o|m2|€\/m/i.test(label)) continue;
+    if (
+      !label ||
+      /habitacion|baño|ba\u00F1o|m2|€\/m|planta\s+\d|construcci|antig[üu]edad|\d+\s*plazas?\s+de\s+(?:parking|garaje|aparcamiento)/i.test(
+        label,
+      )
+    )
+      continue;
     const key = normalizeAmenity(label);
     if (key === 'furnished') {
       furnished = true;


### PR DESCRIPTION
## What

Widen the `habitaclia` provider's detail parse + `normalize()` to extract three numeric characteristics it was dropping: **floor level**, **construction year**, and **parking-space count**.

These live as plain text in Habitaclia's detail markup (e.g. `Planta 4ª`, `Año construcción 1998`, `2 plazas de garaje`) — outside both the schema.org JSON-LD and the summary `.feature-container`. Previously `normalize()` never set them, and the `<li>` amenity loop slugged them into junk amenity keys (`planta_4a`, …).

## How

- New label-anchored extractors in `parse.ts` (`parseFloorLevel` / `parseYearBuilt` / `parseParkingSpaces`), built on the existing `firstMatch` + `asNumber` helpers — no new parse machinery.
- Applied on **both** parse paths (JSON-LD and microdata) via a shared `applyDetailCharacteristics` enrich step, since neither source carries these reliably. A base-parser value always wins; the HTML characteristics only fill gaps.
- **Conservative:** only clean numeric forms are accepted. Fuzzy variants Habitaclia also uses — `Planta baja`, `Antigüedad: entre 30 y 50 años`, `Plaza de parking` (no count) — carry no reliable number and are ignored (guarded by range checks + a dedicated test).
- The `<li>` amenity loop now skips these numeric characteristic lines so they no longer pollute `amenities`.
- `normalize()` emits `floor` / `yearBuilt` / `parkingSpaces` onto `NormalizedListing`; the ingest already maps all three onto the `Property` (`IngestionService`).

## Scope

Only the `habitaclia` provider (`parse.ts`, `fixtures.ts`, `index.ts`) + its unit test. The shared `NormalizedListing` contract and the ingest are untouched (fields already existed there).

## Tests

`packages/backend/__tests__/unit/habitacliaProvider.test.ts` — 12/12 green. Extended the JSON-LD, microdata and normalize fixtures/assertions; added a conservative test proving fuzzy characteristics yield `undefined`. Builds green for `shared-types` → `listing-providers` → `backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)