### PR TITLE
feat(fotocasa): extract amenities+contact from property-JSON path

### DIFF
--- a/packages/backend/__tests__/unit/fotocasaProvider.test.ts
+++ b/packages/backend/__tests__/unit/fotocasaProvider.test.ts
@@ -86,7 +86,33 @@ describe('FotocasaProvider.normalize', () => {
     expect(listing.bedrooms).toBe(3);
     expect(listing.bathrooms).toBe(2);
     expect(listing.squareFootage).toBe(95);
+    expect(listing.floor).toBe(3);
     expect(listing.remoteImages).toHaveLength(2);
+  });
+
+  it('extracts amenities, furnished, and contact from the property-JSON features', () => {
+    const payload = parseFotocasaPropertyJson(
+      FOTOCASA_FIXTURE_PROPERTY_JSON,
+      'https://www.fotocasa.es/es/alquiler/vivienda/madrid-capital/x/187654321/d',
+    );
+    const ref: ExternalListingRef = { provider: 'fotocasa', sourceId: payload.sourceId, url: payload.url };
+    const listing = provider.normalize({ ref, payload });
+
+    // Recognized equipment labels normalize to the SAME canonical keys as JSON-LD.
+    expect(listing.amenities).toEqual(
+      expect.arrayContaining(['elevator', 'air_conditioning', 'heating', 'terrace', 'pool']),
+    );
+    // `value: false` and unrecognized "características" never leak as amenities.
+    expect(listing.amenities).not.toContain('parking');
+    expect(listing.amenities).toEqual(expect.not.arrayContaining(['buen_estado']));
+    // `amueblado` is hoisted into furnishedStatus, not left as a raw amenity.
+    expect(listing.amenities).not.toContain('furnished');
+    expect(listing.furnishedStatus).toBe('furnished');
+
+    expect(listing.contact?.phone).toBe('911234567');
+    expect(listing.contact?.email).toBe('agente@example-inmobiliaria.es');
+    expect(listing.contact?.agencyName).toBe('Inmobiliaria Almagro');
+    expect(listing.contact?.name).toBe('Agente Almagro');
   });
 
   it('parses RealEstateListing JSON-LD with a nested about node', () => {
@@ -599,7 +625,13 @@ describe('FotocasaProvider.fetch property JSON path', () => {
             rooms: 3,
             baths: 2,
             surface: 95,
+            floor: 2,
             address: { municipality: 'Madrid' },
+            features: [
+              { name: 'Ascensor', value: true },
+              { name: 'Parking', value: true },
+            ],
+            contactInfo: { phone: '911234567', agencyName: 'Inmobiliaria Almagro' },
           },
         },
       },
@@ -609,6 +641,10 @@ describe('FotocasaProvider.fetch property JSON path', () => {
     const listing = local.normalize(raw);
     expect(listing.sourceId).toBe('187654321');
     expect(listing.longTermRent?.monthlyAmount).toBe(1850);
+    expect(listing.floor).toBe(2);
+    expect(listing.amenities).toEqual(expect.arrayContaining(['elevator', 'parking']));
+    expect(listing.contact?.phone).toBe('911234567');
+    expect(listing.contact?.agencyName).toBe('Inmobiliaria Almagro');
   });
 
   it('throws ChallengeError when property JSON and detail HTML stay blocked', async () => {

--- a/packages/listing-providers/src/parse/jsonLd.ts
+++ b/packages/listing-providers/src/parse/jsonLd.ts
@@ -106,6 +106,18 @@ function normalizeAmenity(name: string, aliases: Readonly<Record<string, string>
   return aliases[key] ?? key.replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
 }
 
+/**
+ * Canonical ES amenity key for a free-form label (e.g. a portal property-JSON
+ * `features`/`extras` entry), or `undefined` when the label is not a recognized
+ * amenity. Reuses the shared ES alias table — never duplicate it per portal.
+ * `amueblado` resolves to `furnished`; callers hoist that into `furnishedStatus`.
+ * Unlike {@link normalizeAmenity} it does NOT fall back to a snake_case slug, so
+ * mixed "características" arrays (condition, orientation, …) don't leak as amenities.
+ */
+export function matchEsAmenityKey(label: string): string | undefined {
+  return ES_AMENITY_ALIASES[deaccent(label)];
+}
+
 function readTypes(value: unknown): string[] {
   if (typeof value === 'string') return [value];
   if (Array.isArray(value)) return value.filter((entry): entry is string => typeof entry === 'string');

--- a/packages/listing-providers/src/providers/fotocasa/fixtures.ts
+++ b/packages/listing-providers/src/providers/fotocasa/fixtures.ts
@@ -189,7 +189,12 @@ export const FOTOCASA_FIXTURE_LOCATION_SEGMENTS_JSON = JSON.stringify({
 export const FOTOCASA_FIXTURE_SEARCHADS_CHALLENGE =
   '<!DOCTYPE html><html><body><div id="px-captcha">Verifica que eres una persona</div></body></html>';
 
-/** Property detail JSON from `web.gw.fotocasa.es/.../property`. */
+/**
+ * Property detail JSON from `web.gw.fotocasa.es/.../property` (called with
+ * `language=es`, so `features` labels are localized). Models the `features`
+ * equipment array, structured `floor`, and the advertiser `contactInfo` node the
+ * detail payload carries so the parser exercises amenity/floor/contact extraction.
+ */
 export const FOTOCASA_FIXTURE_PROPERTY_JSON = JSON.stringify({
   propertyId: '187654321',
   title: 'Piso en alquiler en Calle de Almagro',
@@ -199,6 +204,7 @@ export const FOTOCASA_FIXTURE_PROPERTY_JSON = JSON.stringify({
   rooms: 3,
   baths: 2,
   surface: 95,
+  floor: 3,
   street: 'Calle de Almagro',
   number: '30',
   address: {
@@ -208,6 +214,22 @@ export const FOTOCASA_FIXTURE_PROPERTY_JSON = JSON.stringify({
     province: 'Madrid',
   },
   location: { latitude: '40.4318', longitude: '-3.6931' },
+  features: [
+    { name: 'Ascensor', value: true },
+    { name: 'Aire acondicionado', value: true },
+    { name: 'Calefacción', value: true },
+    { name: 'Terraza', value: true },
+    { name: 'Amueblado', value: true },
+    { name: 'Parking', value: false },
+    { name: 'Buen estado', value: true },
+    'Piscina',
+  ],
+  contactInfo: {
+    phone: '911234567',
+    email: 'agente@example-inmobiliaria.es',
+    contactName: 'Agente Almagro',
+    agencyName: 'Inmobiliaria Almagro',
+  },
   multimedia: [
     { url: 'https://static.fotocasa.es/images/anuncios/187654321/1.jpg', type: 'image' },
     { url: 'https://static.fotocasa.es/images/anuncios/187654321/2.jpg', type: 'image' },

--- a/packages/listing-providers/src/providers/fotocasa/index.ts
+++ b/packages/listing-providers/src/providers/fotocasa/index.ts
@@ -603,7 +603,7 @@ export class FotocasaProvider implements ListingProvider {
   }
 
   normalize(raw: RawListing): NormalizedListing {
-    const { sourceId, url, listing } = asFotocasaRaw(raw.payload);
+    const { sourceId, url, listing, floor, contact } = asFotocasaRaw(raw.payload);
     if (listing.price === undefined) {
       throw new Error(`fotocasa: listing ${sourceId} has no resolvable price`);
     }
@@ -637,9 +637,11 @@ export class FotocasaProvider implements ListingProvider {
     if (listing.bedrooms !== undefined) result.bedrooms = listing.bedrooms;
     if (listing.bathrooms !== undefined) result.bathrooms = listing.bathrooms;
     if (listing.squareMeters !== undefined) result.squareFootage = listing.squareMeters;
+    if (floor !== undefined) result.floor = floor;
     if (listing.amenities.length > 0) result.amenities = listing.amenities;
     const furnished = resolveFurnished(listing.furnished);
     if (furnished !== 'not_specified') result.furnishedStatus = furnished;
+    if (contact) result.contact = contact;
 
     return result;
   }

--- a/packages/listing-providers/src/providers/fotocasa/parse.ts
+++ b/packages/listing-providers/src/providers/fotocasa/parse.ts
@@ -5,6 +5,7 @@
  * JSON-LD and Next hydration parsing delegate to shared `src/parse/*` modules.
  */
 
+import type { NormalizedListingContact } from '@homiio/shared-types';
 import { extractEurListingFromNextData } from '../../parse/nextData';
 import { extractEsSchemaListings, pickEsListing, type EsSchemaListing } from '../../parse/jsonLd';
 import { FOTOCASA_BASE_URL } from './fixtures';
@@ -15,6 +16,10 @@ export interface FotocasaRaw {
   sourceId: string;
   url: string;
   listing: EsSchemaListing;
+  /** Floor number when the property-JSON record exposes it (searchads cards rarely do). */
+  floor?: number;
+  /** Advertiser contact captured from the property-JSON record, when present. */
+  contact?: NormalizedListingContact;
 }
 
 /** Match Fotocasa detail links (`…/<id>/d`) and capture the numeric id. */

--- a/packages/listing-providers/src/providers/fotocasa/property.ts
+++ b/packages/listing-providers/src/providers/fotocasa/property.ts
@@ -6,8 +6,10 @@
  * parse JSON-LD from those bodies.
  */
 
-import type { EsSchemaListing } from '../../parse/jsonLd';
+import type { NormalizedListingContact } from '@homiio/shared-types';
+import { matchEsAmenityKey, type EsSchemaListing } from '../../parse/jsonLd';
 import { asCoordinate, asNumberEu, asString, isRecord } from '../../parse/guards';
+import { contactFromUnknown, mergeContact } from '../../parse/contact';
 import {
   collectNestedImages,
   eurListingFromNextDataCandidate,
@@ -55,6 +57,78 @@ function resolveOperation(record: Record<string, unknown>, url: string): 'rent' 
   return url.includes('/comprar') || url.includes('/venta') ? 'sale' : 'rent';
 }
 
+/** Feature/equipment arrays a Fotocasa property-JSON (`language=es`) record may carry. */
+const FOTOCASA_FEATURE_FIELDS = ['features', 'otherFeatures', 'equipment', 'extras'] as const;
+
+/**
+ * Extract canonical amenities + the furnished flag from a Fotocasa property-JSON
+ * record. Reads localized feature labels (the property API is called with
+ * `language=es`) from any of {@link FOTOCASA_FEATURE_FIELDS}, skipping entries the
+ * portal marks absent (`value: false`/`0`). Labels are normalized through the
+ * shared {@link matchEsAmenityKey} alias table, so unrecognized "características"
+ * (condition, orientation, …) are dropped rather than leaked as junk amenities.
+ */
+function readFotocasaAmenities(record: Record<string, unknown>): {
+  amenities: string[];
+  furnished?: boolean;
+} {
+  const amenities: string[] = [];
+  const seen = new Set<string>();
+  let furnished: boolean | undefined;
+
+  const consider = (label: unknown, present: unknown): void => {
+    if (present === false || present === 0) return;
+    const text = asString(label);
+    if (!text) return;
+    const key = matchEsAmenityKey(text);
+    if (!key) return;
+    if (key === 'furnished') {
+      furnished = true;
+      return;
+    }
+    if (!seen.has(key)) {
+      seen.add(key);
+      amenities.push(key);
+    }
+  };
+
+  for (const field of FOTOCASA_FEATURE_FIELDS) {
+    const value = record[field];
+    if (!Array.isArray(value)) continue;
+    for (const entry of value) {
+      if (typeof entry === 'string') {
+        consider(entry, true);
+      } else if (isRecord(entry)) {
+        const label =
+          asString(entry.name) ?? asString(entry.label) ?? asString(entry.key) ?? asString(entry.type);
+        consider(label, 'value' in entry ? entry.value : true);
+      }
+    }
+  }
+
+  return { amenities, furnished };
+}
+
+/** Floor number from a Fotocasa property-JSON record, when numerically resolvable. */
+function readFotocasaFloor(record: Record<string, unknown>): number | undefined {
+  return asNumberEu(record.floor) ?? asNumberEu(record.floorNumber) ?? asNumberEu(record.planta);
+}
+
+/**
+ * Advertiser contact from a Fotocasa property-JSON record (phone/email/agency).
+ * Probes the wrapper nodes Fotocasa uses and delegates parsing to the shared
+ * contact chokepoint — never invents a contact when the record omits one.
+ */
+function readFotocasaContact(record: Record<string, unknown>): NormalizedListingContact | undefined {
+  return mergeContact(
+    contactFromUnknown(record.contactInfo),
+    contactFromUnknown(record.advertiser),
+    contactFromUnknown(record.contact),
+    contactFromUnknown(record.agency),
+    contactFromUnknown(record.client),
+  );
+}
+
 function fotocasaRecordToListing(
   record: Record<string, unknown>,
   url: string,
@@ -85,6 +159,7 @@ function fotocasaRecordToListing(
     : url;
   const streetParts = [asString(record.street), asString(record.number)].filter(Boolean).join(' ').trim();
   const images = collectNestedImages(record);
+  const { amenities, furnished } = readFotocasaAmenities(record);
 
   return {
     types: [asString(record.buildingType) ?? 'Apartment'],
@@ -107,7 +182,8 @@ function fotocasaRecordToListing(
     price,
     priceCurrency: 'EUR',
     operation,
-    amenities: [],
+    amenities,
+    furnished,
   };
 }
 
@@ -161,11 +237,16 @@ export function parseFotocasaSearchCardRecord(
     throw new Error(`fotocasa: cannot derive a source id from searchads card at ${url}`);
   }
 
-  return {
+  const raw: FotocasaRaw = {
     sourceId,
     url: listing.url ?? url,
     listing,
   };
+  const floor = readFotocasaFloor(enriched);
+  if (floor !== undefined) raw.floor = floor;
+  const contact = readFotocasaContact(enriched);
+  if (contact) raw.contact = contact;
+  return raw;
 }
 
 /**
@@ -204,9 +285,14 @@ export function parseFotocasaPropertyJson(body: string, url: string): FotocasaRa
     throw new Error(`fotocasa: cannot derive a source id from property API at ${url}`);
   }
 
-  return {
+  const raw: FotocasaRaw = {
     sourceId,
     url: listing.url ?? url,
     listing,
   };
+  const floor = readFotocasaFloor(record);
+  if (floor !== undefined) raw.floor = floor;
+  const contact = readFotocasaContact(record);
+  if (contact) raw.contact = contact;
+  return raw;
 }


### PR DESCRIPTION
## What

The Fotocasa property-JSON parser (`web.gw.fotocasa.es/.../property`) hardcoded `amenities: []`, discarding the equipment/features the record carries — only the JSON-LD HTML fallback ever recovered amenities. It also never populated `contact` or `floor`. Since the ingest now derives `hasElevator`/`hasBalcony`/`parkingType`/`furnishedStatus` from `amenities` (`deriveStructuredFeatures`), the property-JSON path was silently losing all of that.

## Changes (fotocasa only — no shared contract / ingest changes)

- **Amenities**: `fotocasaRecordToListing` reads the localized `features`/`otherFeatures`/`equipment`/`extras` arrays (the property API is called with `language=es`, so labels are Spanish). Labels normalize through a new **shared** `matchEsAmenityKey` in `parse/jsonLd.ts` that reuses the existing `ES_AMENITY_ALIASES` table — **no duplicated alias table**. It is alias-strict (no snake_case slug fallback), so mixed "características" (condition, orientation, …) are dropped instead of leaking as junk amenity keys. `value: false`/`0` entries are skipped; `amueblado` is hoisted into `furnishedStatus`.
- **Contact**: advertiser phone/email/whatsapp/agency captured via the shared `parse/contact.ts` chokepoint (`contactFromUnknown` + `mergeContact`) — **never invents a contact** when the record omits one.
- **Floor**: extracted when numerically resolvable.
- Both the property-JSON path (`parseFotocasaPropertyJson`) and the searchads-card path (`parseFotocasaSearchCardRecord`) benefit — they share `fotocasaRecordToListing` and now the extras extraction.

## Not extracted
`yearBuilt` — `NormalizedListing` has no such field and the shared contract is out of scope.

## Tests
Fixtures extended (`features` array with recognized + `value:false` + unrecognized + string entries, `contactInfo`, `floor`). `fotocasaProvider.test.ts` asserts amenity normalization (incl. dropping `parking:false`, junk `buen_estado`, and hoisting `amueblado`→furnished), floor, and contact on both the property-JSON and searchads-card paths. All 27 fotocasa tests green; shared jsonLd/contact and other ES/IT provider suites unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)