### PR TITLE
feat(blueground): extract real amenities + floor from detail JSON

### DIFF
--- a/packages/backend/__tests__/unit/bluegroundParse.test.ts
+++ b/packages/backend/__tests__/unit/bluegroundParse.test.ts
@@ -2,6 +2,7 @@ import {
   BluegroundPartnerListingError,
   parseBluegroundDetail,
   parseBluegroundSearch,
+  readBluegroundAmenities,
   readBluegroundLowestRent,
 } from '@homiio/listing-providers';
 
@@ -10,12 +11,42 @@ const SEARCH_HTML = `
   <a href="https://www.theblueground.com/p/furnished-apartments/mad-1461670p">B</a>
 `;
 
+/**
+ * Mirrors the real Blueground detail markup: the `"amenities"` object is keyed
+ * by category (`apartment`/`building`/`important`/`main`/`struckthrough*`), each
+ * entry carrying a language-independent camelCase `key`. `struckthrough*`
+ * categories list amenities the unit does NOT have (elevator here is available,
+ * but parking + doorman are struck through) and `main.floor` carries the floor.
+ */
+const AMENITIES_JSON =
+  '"amenities":{' +
+  '"apartment":[' +
+  '{"key":"airConditioning","caption":"amenities.all.airConditioning","iconUrl":"AirConditioning.svg"},' +
+  '{"key":"laundryRoomUnit","price":{"charged":false},"caption":"amenities.all.laundryRoomUnit","iconUrl":"WashingMachine.svg"},' +
+  '{"key":"balcony","caption":"amenities.all.balcony","iconUrl":"Balcony.svg"},' +
+  '{"key":"coffeeMachine","caption":"amenities.all.coffeeMachine","iconUrl":"Coffee.svg"}' +
+  '],' +
+  '"blueground":[],' +
+  '"building":[{"key":"elevatorInTheBuilding","caption":"amenities.all.elevatorInTheBuilding","iconUrl":"Elevator.svg"}],' +
+  '"important":[{"key":"airConditioning","caption":"amenities.all.airConditioning","iconUrl":"AirConditioning.svg"}],' +
+  '"main":[' +
+  '{"key":"bedrooms","value":"1","caption":"amenities.all.bedrooms","iconUrl":"QueenBed.svg"},' +
+  '{"key":"bathrooms","value":"1","caption":"amenities.all.bathrooms","iconUrl":"Bathtub.svg"},' +
+  '{"key":"floor","value":"2","caption":"amenities.all.floor","iconUrl":"Floor.svg"}' +
+  '],' +
+  '"struckthroughApartment":[{"key":"bathtub","caption":"amenities.all.bathtub","iconUrl":"Bathtub.svg"}],' +
+  '"struckthroughBuilding":[' +
+  '{"key":"parkingSpace","caption":"amenities.all.parkingSpace","iconUrl":"Parking.svg"},' +
+  '{"key":"doorman","caption":"amenities.all.doorman","iconUrl":"Doorman.svg"}' +
+  ']}';
+
 const FIRST_PARTY_DETAIL_HTML = `
   <meta property="og:title" content="Calle de San Bartolomé - Apartment for Rent in Chueca Justicia, Madrid | Blueground">
   <meta property="og:description" content="Rent a fully furnished apartment in Chueca Justicia, Madrid.">
   <meta property="og:url" content="https://www.theblueground.com/p/furnished-apartments/mad-1490341p">
   "amount":99999,"currency":"USD"
   "businessModel":"CORE","cityCode":"MAD","bedrooms":1,"bathrooms":1
+  ${AMENITIES_JSON}
   "lowestRent":{"amount":3473,"currency":"EUR"}
   https://photos2.theblueground.com/736/sample/living-room.jpg
   https://photos2.theblueground.com/736/sample/bedroom.jpg
@@ -47,6 +78,36 @@ describe('Blueground parse', () => {
       amount: 3473,
       currency: 'EUR',
     });
+  });
+
+  it('extracts available amenities as canonical slugs, excluding struck-through ones', () => {
+    const { amenities, floor } = readBluegroundAmenities(FIRST_PARTY_DETAIL_HTML);
+    // Available apartment/building amenities, canonicalized and deduped.
+    expect(amenities.sort()).toEqual(
+      ['air_conditioning', 'balcony', 'coffee_machine', 'elevator', 'washer'].sort(),
+    );
+    // Struck-through amenities (parking, doorman, bathtub) must NOT appear.
+    expect(amenities).not.toContain('parking');
+    expect(amenities).not.toContain('doorman');
+    expect(amenities).not.toContain('bathtub');
+    // `main` structured facts (bedrooms/bathrooms/floor) are not amenities.
+    expect(amenities).not.toContain('bedrooms');
+    expect(amenities).not.toContain('floor');
+    expect(floor).toBe(2);
+  });
+
+  it('carries amenities + floor through parseBluegroundDetail', () => {
+    const ref = { provider: 'blueground' as const, sourceId: 'mad-1490341p', url: 'https://x' };
+    const listing = parseBluegroundDetail(FIRST_PARTY_DETAIL_HTML, ref);
+    expect(listing.floor).toBe(2);
+    expect(listing.amenities).toContain('elevator');
+    expect(listing.amenities).toContain('washer');
+    expect(listing.amenities).not.toContain('parking');
+  });
+
+  it('degrades to empty amenities when no amenities object is present', () => {
+    const html = '<meta property="og:title" content="x"> "lowestRent":{"amount":3473,"currency":"EUR"}';
+    expect(readBluegroundAmenities(html)).toEqual({ amenities: [] });
   });
 
   it('skips PARTNERS_NETWORK listings instead of publishing lowestRent as monthly', () => {

--- a/packages/backend/__tests__/unit/bluegroundProvider.test.ts
+++ b/packages/backend/__tests__/unit/bluegroundProvider.test.ts
@@ -46,6 +46,8 @@ describe('BluegroundProvider', () => {
     expect(listing.address.countryCode).toBe('ES');
     expect(listing.address.neighborhood).toBe('Chueca Justicia');
     expect(listing.furnishedStatus).toBe('furnished');
+    expect(listing.floor).toBe(2);
+    expect(listing.amenities).toEqual(['air_conditioning', 'wifi', 'elevator', 'washer', 'heating']);
     expect(listing.remoteImages).toHaveLength(2);
     expect(listing.remoteImages.filter((image) => image.isPrimary)).toHaveLength(1);
   });
@@ -58,6 +60,7 @@ describe('BluegroundProvider', () => {
     expect(listing.address.city).toBe('New York');
     expect(listing.address.countryCode).toBe('US');
     expect(listing.furnishedStatus).toBe('furnished');
+    expect(listing.floor).toBe(12);
   });
 
   it('rejects partner-network payloads in normalize (no false monthly from lowestRent)', () => {

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -92,6 +92,7 @@ export {
   coerceBluegroundListing,
   BluegroundPartnerListingError,
   isBluegroundPartnerListing,
+  readBluegroundAmenities,
   readBluegroundLowestRent,
   readBluegroundPartnerSignals,
 } from './providers/blueground';

--- a/packages/listing-providers/src/parse/nextData.ts
+++ b/packages/listing-providers/src/parse/nextData.ts
@@ -22,7 +22,13 @@ function extractScriptBodyById(html: string, scriptId: string): string | undefin
   return undefined;
 }
 
-function extractBalancedJsonAfter(html: string, marker: string): string | undefined {
+/**
+ * Slice the first brace-balanced JSON object that follows `marker` in `html`.
+ * Shared with providers that read an embedded object by key (e.g. Blueground's
+ * `"amenities":{…}`). Depth counting only — a malformed slice is caught by the
+ * caller's `JSON.parse`, so the failure mode is a safe `undefined`.
+ */
+export function extractBalancedJsonAfter(html: string, marker: string): string | undefined {
   const idx = html.indexOf(marker);
   if (idx < 0) return undefined;
   const braceStart = html.indexOf('{', idx + marker.length);

--- a/packages/listing-providers/src/providers/blueground/fixtures.ts
+++ b/packages/listing-providers/src/providers/blueground/fixtures.ts
@@ -72,6 +72,7 @@ export const BLUEGROUND_FIXTURES: readonly BluegroundRawListing[] = [
     monthlyRent: { amount: 3473, currency: 'EUR' },
     bedrooms: 1,
     bathrooms: 1,
+    floor: 2,
     furnished: true,
     amenities: ['air_conditioning', 'wifi', 'elevator', 'washer', 'heating'],
     address: {
@@ -105,6 +106,7 @@ export const BLUEGROUND_FIXTURES: readonly BluegroundRawListing[] = [
     monthlyRent: { amount: 4200, currency: 'USD' },
     bedrooms: 1,
     bathrooms: 1,
+    floor: 12,
     furnished: true,
     amenities: ['air_conditioning', 'wifi', 'doorman', 'washer', 'gym'],
     address: {

--- a/packages/listing-providers/src/providers/blueground/index.ts
+++ b/packages/listing-providers/src/providers/blueground/index.ts
@@ -46,6 +46,7 @@ import {
 export {
   BluegroundPartnerListingError,
   isBluegroundPartnerListing,
+  readBluegroundAmenities,
   readBluegroundLowestRent,
   readBluegroundPartnerSignals,
 } from './parse';

--- a/packages/listing-providers/src/providers/blueground/parse.ts
+++ b/packages/listing-providers/src/providers/blueground/parse.ts
@@ -12,6 +12,8 @@
  */
 
 import type { ExternalListingRef } from '../../types';
+import { asRecord, asString } from '../../parse/guards';
+import { extractBalancedJsonAfter } from '../../parse/nextData';
 import type { BluegroundRawListing, BluegroundRawPhoto } from './fixtures';
 
 const BASE_HOST = 'https://www.theblueground.com';
@@ -125,6 +127,104 @@ function readPhotos(html: string): BluegroundRawPhoto[] {
   }));
 }
 
+/**
+ * Blueground exposes in-unit/building amenities as an object keyed by category
+ * (`apartment`, `building`, `blueground`, `important`, `main`, plus
+ * `struckthrough*`). Each entry carries a language-independent camelCase `key`
+ * (`airConditioning`, `elevatorInTheBuilding`, …) alongside an i18n `caption`.
+ * We normalize the stable `key` — never the localized caption — so extraction is
+ * market-agnostic.
+ *
+ * Only the handful of keys whose generic slug would diverge from the canonical
+ * vocabulary the ingest/search read (`elevator`, `parking`, `terrace`,
+ * `washer`, `air_conditioning`) are aliased; everything else is slugified
+ * generically. This is Blueground's OWN camelCase vocabulary, not a duplicate of
+ * the shared ES/IT free-text amenity table in `parse/jsonLd.ts`.
+ */
+const BLUEGROUND_AMENITY_ALIASES: Readonly<Record<string, string>> = {
+  airConditioning: 'air_conditioning',
+  elevatorInTheBuilding: 'elevator',
+  parkingSpace: 'parking',
+  terracePrivate: 'terrace',
+  laundryRoomUnit: 'washer',
+  washerUnit: 'washer',
+};
+
+/** Categories that list amenities the unit does NOT have (struck through in UI). */
+const BLUEGROUND_STRUCKTHROUGH_PREFIX = 'struckthrough';
+/** Category holding structured facts (bedrooms/bathrooms/lotSize/floor), not amenities. */
+const BLUEGROUND_FACTS_CATEGORY = 'main';
+const BLUEGROUND_FLOOR_KEY = 'floor';
+
+/** Canonicalize a Blueground amenity `key`; unknown keys → generic snake_case slug. */
+function bluegroundAmenitySlug(key: string): string {
+  const alias = BLUEGROUND_AMENITY_ALIASES[key];
+  if (alias) return alias;
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/** Read the `main.floor` structured value (string like `"2"` or a number). */
+function readBluegroundFloor(entries: readonly unknown[]): number | undefined {
+  for (const entry of entries) {
+    const record = asRecord(entry);
+    if (asString(record?.['key']) !== BLUEGROUND_FLOOR_KEY) continue;
+    const value = record?.['value'];
+    const numeric =
+      typeof value === 'number'
+        ? value
+        : typeof value === 'string'
+          ? Number.parseInt(value, 10)
+          : Number.NaN;
+    if (Number.isInteger(numeric)) return numeric;
+  }
+  return undefined;
+}
+
+/**
+ * Extract available in-unit/building amenities (as canonical slugs) plus the
+ * building floor from a detail page's embedded `"amenities":{…}` object.
+ * Struck-through (unavailable) amenities are excluded; the `main` facts block
+ * contributes only the floor. Missing/malformed data degrades to `{ amenities: [] }`.
+ */
+export function readBluegroundAmenities(html: string): { amenities: string[]; floor?: number } {
+  const body = extractBalancedJsonAfter(html, '"amenities":');
+  if (!body) return { amenities: [] };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return { amenities: [] };
+  }
+
+  const categories = asRecord(parsed);
+  if (!categories) return { amenities: [] };
+
+  const amenities = new Set<string>();
+  let floor: number | undefined;
+
+  for (const [category, entries] of Object.entries(categories)) {
+    if (!Array.isArray(entries)) continue;
+    if (category.startsWith(BLUEGROUND_STRUCKTHROUGH_PREFIX)) continue;
+    if (category === BLUEGROUND_FACTS_CATEGORY) {
+      floor = floor ?? readBluegroundFloor(entries);
+      continue;
+    }
+    for (const entry of entries) {
+      const key = asString(asRecord(entry)?.['key']);
+      if (!key) continue;
+      const slug = bluegroundAmenitySlug(key);
+      if (slug) amenities.add(slug);
+    }
+  }
+
+  return { amenities: [...amenities], floor };
+}
+
 /** Derive a stable source id from a detail URL's final slug segment. */
 export function bluegroundSourceIdFromUrl(url: string): string {
   const pathname = new URL(url).pathname.replace(/\/+$/, '');
@@ -193,6 +293,7 @@ export function parseBluegroundDetail(html: string, ref: ExternalListingRef): Bl
   const bathrooms = readJsonField(html, 'bathrooms');
   const sizeSqm = readJsonField(html, 'sizeSqm');
   const description = readMeta(html, 'og:description') ?? readJsonField(html, 'description');
+  const { amenities, floor } = readBluegroundAmenities(html);
 
   const city = ogLocation.city ?? cityMeta?.city ?? '';
   const region =
@@ -211,8 +312,9 @@ export function parseBluegroundDetail(html: string, ref: ExternalListingRef): Bl
     bedrooms: bedrooms ? Number.parseInt(bedrooms, 10) : undefined,
     bathrooms: bathrooms ? Number.parseInt(bathrooms, 10) : undefined,
     sizeSqm: sizeSqm ? Number.parseInt(sizeSqm, 10) : undefined,
+    floor,
     furnished: true,
-    amenities: [],
+    amenities,
     address: {
       line1: ogLocation.street,
       neighborhood: ogLocation.neighborhood,


### PR DESCRIPTION
## What

Blueground's `normalize()` previously shipped **every** unit with `amenities: []` and no `floor` — the in-unit/building features embedded in each detail page were parsed and discarded. This wires them through.

## Evidence (verified against 4 live ES listings)

Blueground detail pages embed an `"amenities"` object keyed by category:

```json
"amenities":{
  "apartment":[{"key":"airConditioning","caption":"amenities.all.airConditioning","iconUrl":"…"}, …],
  "building":[{"key":"elevatorInTheBuilding", …}],
  "blueground":[…], "important":[…],
  "main":[{"key":"floor","value":"2", …}, {"key":"bedrooms","value":"1", …}, …],
  "struckthroughApartment":[…], "struckthroughBuilding":[{"key":"parkingSpace", …},{"key":"doorman", …}]
}
```

Each entry carries a language-independent camelCase `key` (normalized instead of the localized `caption`, so extraction is market-agnostic). `struckthrough*` categories list amenities the unit does **not** have.

## Changes

- **`readBluegroundAmenities()`** in `providers/blueground/parse.ts`: slices the embedded object via the shared `extractBalancedJsonAfter` helper (now `export`ed from `parse/nextData.ts`), then:
  - Normalizes each `key` to a canonical slug — aliases the ones the ingest/search read (`airConditioning`→`air_conditioning`, `elevatorInTheBuilding`→`elevator`, `parkingSpace`→`parking`, `terracePrivate`→`terrace`, `laundryRoomUnit`/`washerUnit`→`washer`); unknown keys → generic `snake_case`. No duplication of the shared ES/IT amenity table — this is Blueground's own camelCase vocabulary.
  - **Excludes `struckthrough*`** (prevents falsely reporting elevator/parking/doorman).
  - Reads `floor` from `main.floor` only (bedrooms/bathrooms/lotSize stay facts, not amenities).
- Wires `amenities` + `floor` through `parseBluegroundDetail` (replacing `amenities: []`). `normalize()` already forwards both, so the ingest's `deriveStructuredFeatures` now promotes `hasElevator`/`hasBalcony`/`parkingType` for Blueground units.
- `furnishedStatus` stays `furnished` (Blueground is always furnished — correct).
- Failure mode is safe: missing/malformed object → `{ amenities: [] }` (no throw, no regression).

## What the JSON does NOT expose
- No `wifi`, `gym`, or year-built for the sampled ES units (amenity coverage varies per listing; gym/doorman appear only when the building has them).
- `floor` is optional (present in ~half the sampled listings) and comes as a **string** in `main.floor`; parsed to int, omitted when absent.
- Only in-unit/building amenities are modeled — no `hasGarden`/`yearBuilt`/`parkingSpaces` source fields on Blueground.

## Tests
- `bluegroundParse.test.ts`: real-shaped amenities object → asserts canonical slugs, struck-through exclusion, `main` facts excluded, `floor: 2`, and safe degradation with no amenities object.
- `bluegroundProvider.test.ts`: `floor` + `amenities` flow through `normalize()`.
- Full `Provider|Parse|deriveFeatures` sweep: **279 passed / 32 suites**. shared-types + listing-providers + backend build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)