### PR TITLE
chore(frontend): whole-app flat cards sweep

### DIFF
--- a/packages/frontend/app/(tabs)/saved/notes.tsx
+++ b/packages/frontend/app/(tabs)/saved/notes.tsx
@@ -17,7 +17,6 @@ import { useTranslation } from 'react-i18next';
 import { Header } from '@/components/Header';
 import { Button } from '@oxyhq/bloom/button';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 import { useSavedPropertiesContext } from '@/context/SavedPropertiesContext';
 import {
   parseNotesString,
@@ -383,7 +382,6 @@ const styles = StyleSheet.create({
     marginBottom: 12,
     flex: 1,
     marginHorizontal: 4,
-    ...shadowToken({ y: 1, blur: 3, color: colors.COLOR_BLACK, opacity: 0.06, elevation: 2 }),
   },
   archivedCard: {
     opacity: 0.6,

--- a/packages/frontend/app/(tabs)/sindi/index.tsx
+++ b/packages/frontend/app/(tabs)/sindi/index.tsx
@@ -6,7 +6,7 @@
  *   - Bloom Typography (H1/H2/H3/Text) everywhere, no raw <Text>.
  *   - Bloom Button replaces every TouchableOpacity CTA.
  *   - Bloom SearchInput replaces hand-rolled search bar.
- *   - withShadow('sm') cards with radius.lg, no borders, semantic tokens.
+ *   - Flat cards with radius.lg + hairline borders, semantic tokens.
  *   - Skeleton.Box rows during load; EmptyState shared.
  */
 import React, {
@@ -43,7 +43,7 @@ import { useSindiAuthenticatedFetch } from '@/hooks/useSindiAuthenticatedFetch';
 import { BottomSheetContext } from '@/context/BottomSheetContext';
 import { SindiExplanationBottomSheet } from '@/components/SindiExplanationBottomSheet';
 import { useConversationStore } from '@/store/conversationStore';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
 const SindiSkeleton: React.FC = () => (
@@ -296,7 +296,8 @@ const styles = StyleSheet.create({
     borderRadius: radius.xl,
     alignItems: 'center',
     gap: spacing.sm,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   heroIcon: {
     width: 88,
@@ -330,7 +331,8 @@ const styles = StyleSheet.create({
     borderRadius: radius.md,
     alignItems: 'center',
     gap: spacing.xs,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   featureLabel: {
     fontSize: 12,
@@ -357,7 +359,8 @@ const styles = StyleSheet.create({
     backgroundColor: colors.surfaceElevated,
     padding: spacing.lg,
     borderRadius: radius.lg,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   skeletonBody: {
     flex: 1,

--- a/packages/frontend/app/addresses/[id].tsx
+++ b/packages/frontend/app/addresses/[id].tsx
@@ -5,7 +5,7 @@
  *   - Bloom Typography (H2/H3/Text) everywhere, no raw <Text>.
  *   - Bloom Button replaces TouchableOpacity CTAs (Write review, Helpful,
  *     Report, Reply, Switch).
- *   - withShadow('sm') cards with radius.lg, no border accents.
+ *   - Flat cards with radius.lg + hairline borders.
  *   - Shared EmptyState / ErrorState / SectionEyebrow.
  *   - Skeleton via PropertyListSkeleton for properties, Skeleton.Box rows
  *     for reviews while loading.
@@ -36,7 +36,7 @@ import { SectionEyebrow } from '@/components/ui/SectionEyebrow';
 import { NeighborhoodRatingWidget } from '@/components/widgets/NeighborhoodRatingWidget';
 import { api } from '@/utils/api';
 import { Property } from '@homiio/shared-types';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
@@ -782,7 +782,8 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     borderRadius: radius.lg,
     gap: spacing.md,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   cardHeading: {
     letterSpacing: -0.3,
@@ -889,7 +890,8 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     borderRadius: radius.lg,
     gap: spacing.sm,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   reviewHeader: {
     flexDirection: 'row',

--- a/packages/frontend/app/applications/[id].tsx
+++ b/packages/frontend/app/applications/[id].tsx
@@ -8,8 +8,8 @@
  *
  * Documents are linked via signed S3 URLs returned by the API.
  *
- * Stream P polish: each block is a `CardSurface` with `withShadow('sm')` and
- * no border. Status is rendered with the existing Bloom Badge wrapper.
+ * Stream P polish: each block is a flat `CardSurface` with no border. Status is
+ * rendered with the existing Bloom Badge wrapper.
  * Spinner and ad-hoc error text were replaced with Bloom Loading +
  * the shared ErrorState component.
  */

--- a/packages/frontend/app/contracts/index.tsx
+++ b/packages/frontend/app/contracts/index.tsx
@@ -3,7 +3,7 @@
  *
  * Stream Q polish:
  *   - Bloom Chip filter row, Bloom Button "New contract" CTA in the header.
- *   - withShadow('sm') ContractCard list with radius.lg.
+ *   - Flat ContractCard list with radius.lg + hairline borders.
  *   - Bloom Skeleton + shared EmptyState / ErrorState.
  *   - Bloom Typography (H2, Text) and SectionEyebrow for hierarchy.
  */
@@ -26,7 +26,7 @@ import { useUserLeases, useHasRentalProperties } from '@/hooks/useLeaseQueries';
 import type { Lease } from '@/services/leaseService';
 import type { Profile } from '@homiio/shared-types';
 import { generatePropertyTitle } from '@/utils/propertyTitleGenerator';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
 /**
@@ -287,7 +287,8 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     borderRadius: radius.lg,
     gap: spacing.sm,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   skeletonHeader: {
     flexDirection: 'row',
@@ -297,7 +298,8 @@ const styles = StyleSheet.create({
   footer: {
     padding: spacing.lg,
     backgroundColor: colors.surfaceElevated,
-    ...withShadow('sm'),
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
   },
   footerButton: {
     alignSelf: 'stretch',

--- a/packages/frontend/app/horizon/index.tsx
+++ b/packages/frontend/app/horizon/index.tsx
@@ -3,7 +3,6 @@ import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-nati
 import { useTranslation } from 'react-i18next';
 import * as Linking from 'expo-linking';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Header } from '@/components/Header';
@@ -338,7 +337,8 @@ const styles = StyleSheet.create({
     borderRadius: 15,
     padding: 20,
     marginBottom: 15,
-    ...shadowToken({ y: 2, blur: 4, color: colors.shadow, opacity: 0.1, elevation: 3 }),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   testimonialHeader: {
     flexDirection: 'row',

--- a/packages/frontend/app/host/calendar.tsx
+++ b/packages/frontend/app/host/calendar.tsx
@@ -4,7 +4,7 @@
  * Stream Q polish (Airbnb-2026):
  *   - Bloom primitives only (Typography, Button, Chip, Menu, Skeleton, Loading).
  *   - Property picker uses Bloom Menu (dropdown) instead of a horizontal chip row.
- *   - Cards rendered on white surfaces with `withShadow('sm')`, `radius.lg`.
+ *   - Flat cards on white surfaces with hairline borders, `radius.lg`.
  *   - All copy lives in Bloom Typography, no raw RN <Text>.
  *   - Block-dates flow now reuses ConfirmDialog + Bloom TextField.
  */
@@ -52,7 +52,7 @@ import {
 import { useUserProperties } from '@/hooks/usePropertyQueries';
 import { propertyService } from '@/services/propertyService';
 import { getPropertyTitle } from '@/utils/propertyUtils';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
 interface BlockDialogState {
@@ -463,7 +463,8 @@ const styles = StyleSheet.create({
     backgroundColor: colors.surfaceElevated,
     padding: spacing.lg,
     borderRadius: radius.lg,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   pickerButton: {
     justifyContent: 'space-between',
@@ -506,6 +507,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.surfaceElevated,
     padding: spacing.lg,
     borderRadius: radius.lg,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
 });

--- a/packages/frontend/app/host/reservations.tsx
+++ b/packages/frontend/app/host/reservations.tsx
@@ -30,7 +30,7 @@ import {
   useReservationsQuery,
   useUpdateReservation,
 } from '@/hooks/useReservationQueries';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
 type StatusFilter = 'all' | ReservationStatus;
@@ -292,7 +292,8 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     borderRadius: radius.lg,
     gap: spacing.sm,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   skeletonHeader: {
     flexDirection: 'row',

--- a/packages/frontend/app/insights/index.tsx
+++ b/packages/frontend/app/insights/index.tsx
@@ -3,7 +3,6 @@ import { View, ScrollView, StyleSheet, Dimensions, LayoutChangeEvent } from 'rea
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 import { ThemedText } from '@/components/ThemedText';
 import { LinearGradient } from 'expo-linear-gradient';
 import Svg, { Rect, Text as SvgText } from 'react-native-svg';
@@ -323,7 +322,8 @@ const styles = StyleSheet.create({
         minWidth: 160,
         borderRadius: 16,
         overflow: 'hidden',
-        ...shadowToken({ y: 1, blur: 8, color: colors.COLOR_BLACK, opacity: 0.08, elevation: 3 }),
+        borderWidth: 1,
+        borderColor: colors.border,
     },
     kpiInner: {
         padding: 16,
@@ -365,7 +365,8 @@ const styles = StyleSheet.create({
         borderRadius: 20,
         paddingHorizontal: 16,
         paddingVertical: 12,
-        ...shadowToken({ y: 1, blur: 8, color: colors.COLOR_BLACK, opacity: 0.08, elevation: 3 }),
+        borderWidth: 1,
+        borderColor: colors.border,
     },
     cardTitle: {
         fontSize: 22,
@@ -388,7 +389,8 @@ const styles = StyleSheet.create({
         backgroundColor: colors.white,
         borderRadius: 16,
         padding: 12,
-        ...shadowToken({ y: 1, blur: 8, color: colors.COLOR_BLACK, opacity: 0.08, elevation: 3 }),
+        borderWidth: 1,
+        borderColor: colors.border,
     },
     chart: {
         borderRadius: 16,
@@ -408,7 +410,8 @@ const styles = StyleSheet.create({
         padding: 12,
         flexGrow: 1,
         minWidth: 160,
-        ...shadowToken({ y: 1, blur: 8, color: colors.COLOR_BLACK, opacity: 0.08, elevation: 3 }),
+        borderWidth: 1,
+        borderColor: colors.border,
     },
     cityHeaderRow: {
         flexDirection: 'row',

--- a/packages/frontend/app/landlord/applications/[id].tsx
+++ b/packages/frontend/app/landlord/applications/[id].tsx
@@ -3,7 +3,7 @@
  *
  * Stream Q polish:
  *   - Bloom Typography (H2 / Text), Bloom Avatar, Bloom Button, Divider.
- *   - withShadow('sm') cards with radius.lg.
+ *   - Flat cards with radius.lg + hairline borders.
  *   - All Pressables replaced by Bloom Button.
  *   - Shared EmptyState / ErrorState components.
  */
@@ -53,7 +53,7 @@ import {
   getPropertyImageSource,
   getPropertyTitle,
 } from '@/utils/propertyUtils';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
@@ -614,7 +614,6 @@ const styles = StyleSheet.create({
     borderRadius: radius.xl,
     overflow: 'hidden',
     backgroundColor: colors.mutedSubtle,
-    ...withShadow('sm'),
   },
   thumb: {
     width: '100%',
@@ -628,7 +627,8 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     borderRadius: radius.lg,
     gap: spacing.sm,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   cardHeading: {
     letterSpacing: -0.3,

--- a/packages/frontend/app/landlord/applications/index.tsx
+++ b/packages/frontend/app/landlord/applications/index.tsx
@@ -32,7 +32,7 @@ import { useProperty } from '@/hooks';
 import { useOxyAvatars } from '@/hooks/useOxyAvatars';
 import profileService from '@/services/profileService';
 import { getPropertyTitle } from '@/utils/propertyUtils';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
 type StatusFilter = 'all' | TenantApplicationStatus;
@@ -408,7 +408,8 @@ const styles = StyleSheet.create({
     backgroundColor: colors.surfaceElevated,
     padding: spacing.lg,
     borderRadius: radius.lg,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   skeletonBody: {
     flex: 1,

--- a/packages/frontend/app/properties/[id]/book-viewing.tsx
+++ b/packages/frontend/app/properties/[id]/book-viewing.tsx
@@ -11,7 +11,6 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Header } from '@/components/Header';
@@ -423,7 +422,8 @@ const styles = StyleSheet.create({
     borderRadius: 15,
     padding: 15,
     marginBottom: 20,
-    ...shadowToken({ y: 2, blur: 4, color: colors.shadow, opacity: 0.1, elevation: 2 }),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   propertyTitle: {
     fontSize: 18,
@@ -495,7 +495,8 @@ const styles = StyleSheet.create({
     marginRight: 10,
     alignItems: 'center',
     justifyContent: 'center',
-    ...shadowToken({ y: 1, blur: 2, color: colors.shadow, opacity: 0.1, elevation: 1 }),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   activeDateCard: {
     backgroundColor: colors.primaryColor,
@@ -531,7 +532,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     flexDirection: 'row',
-    ...shadowToken({ y: 1, blur: 2, color: colors.shadow, opacity: 0.1, elevation: 1 }),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   selectedSlot: {
     backgroundColor: colors.primaryColor,

--- a/packages/frontend/app/properties/city/[id].tsx
+++ b/packages/frontend/app/properties/city/[id].tsx
@@ -12,7 +12,6 @@ import { Image } from 'expo-image';
 import { useTranslation } from 'react-i18next';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 import { spacing } from '@/constants/styles';
 
 import { Header } from '@/components/Header';
@@ -495,7 +494,8 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     padding: 20,
     alignItems: 'center',
-    ...shadowToken({ y: 2, blur: 8, color: colors.shadow, opacity: 0.08, elevation: 3 }),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   statNumber: {
     fontSize: 24,

--- a/packages/frontend/app/properties/drafts.tsx
+++ b/packages/frontend/app/properties/drafts.tsx
@@ -35,7 +35,7 @@ import { EmptyState } from '@/components/ui/EmptyState';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { toast } from '@/lib/sonner';
 import { colors } from '@/styles/colors';
-import { contentClamp, radius, spacing, withShadow } from '@/constants/styles';
+import { contentClamp, radius, spacing } from '@/constants/styles';
 import { logger } from '@/utils/logger';
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
@@ -143,7 +143,7 @@ function DraftCard({
   onDelete: () => void;
 }) {
   return (
-    <View style={[styles.draftCard, withShadow('sm')]}>
+    <View style={styles.draftCard}>
       <View style={styles.draftHeader}>
         <View style={styles.draftTypeContainer}>
           <Ionicons name={getPropertyTypeIcon(draft.type)} size={20} color={colors.primaryColor} />
@@ -361,6 +361,8 @@ const styles = StyleSheet.create({
     backgroundColor: colors.white,
     borderRadius: radius.lg,
     padding: spacing.xl,
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   draftHeader: {
     flexDirection: 'row',

--- a/packages/frontend/app/reservations/[id].tsx
+++ b/packages/frontend/app/reservations/[id].tsx
@@ -2,7 +2,7 @@
  * Reservation detail (guest + host view).
  *
  * Stream P polish:
- * - Each section becomes a `CardSurface` with `withShadow('sm')`, no border.
+ * - Each section becomes a `CardSurface` (flat surface, no border).
  * - Bloom Loading + ErrorState replace the ad-hoc spinner/error views.
  * - Bloom Button for every CTA; the inline modal was replaced by the
  *   shared `ConfirmDialog` (Modal + Bloom Button).

--- a/packages/frontend/app/reviews/write.tsx
+++ b/packages/frontend/app/reviews/write.tsx
@@ -4,7 +4,7 @@
  * Stream Q polish:
  *   - Bloom TextField for every input (no raw TextInput / inline styles).
  *   - Bloom Button for submit + recommendation choice + retry.
- *   - withShadow('sm') section cards with radius.lg.
+ *   - Flat section cards with radius.lg + hairline borders.
  *   - Bloom Skeleton + shared EmptyState / ErrorState while loading.
  *   - Stars now use Bloom Typography for the count label, semantic
  *     ratingStar token instead of hex literals.
@@ -32,7 +32,7 @@ import { ErrorState } from '@/components/ui/ErrorState';
 import { SectionEyebrow } from '@/components/ui/SectionEyebrow';
 import reviewService from '@/services/reviewService';
 import { api } from '@/utils/api';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
 interface ReviewFormData {
@@ -633,7 +633,8 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     borderRadius: radius.lg,
     gap: spacing.md,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   sectionTitle: {
     letterSpacing: -0.3,

--- a/packages/frontend/app/roommates/[id].tsx
+++ b/packages/frontend/app/roommates/[id].tsx
@@ -19,7 +19,7 @@ import { SectionEyebrow } from '@/components/ui/SectionEyebrow';
 import { useRoommate } from '@/hooks/useRoommate';
 import profileService from '@/services/profileService';
 import { roommateService } from '@/services/roommateService';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
 export default function RoommateProfilePage() {
@@ -217,7 +217,8 @@ const styles = StyleSheet.create({
     borderRadius: radius.lg,
     padding: spacing.xl,
     gap: spacing.xs,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   avatar: {
     width: 72,
@@ -264,7 +265,8 @@ const styles = StyleSheet.create({
     borderRadius: radius.lg,
     padding: spacing.lg,
     gap: spacing.sm,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   cardTitle: {
     letterSpacing: -0.3,

--- a/packages/frontend/app/roommates/index.tsx
+++ b/packages/frontend/app/roommates/index.tsx
@@ -8,7 +8,7 @@
  *   - Tab bar uses semantic tokens + Pressable + Bloom Text instead of
  *     raw TouchableOpacity.
  *   - Shared EmptyState + Loading (Bloom) component.
- *   - withShadow('sm') wrappers around list content.
+ *   - Flat wrappers (hairline border) around list content.
  */
 import React, { useCallback, useEffect, useState } from 'react';
 import {
@@ -40,7 +40,7 @@ import { useRoommate } from '@/hooks/useRoommate';
 import { roommateService } from '@/services/roommateService';
 import { type PropertyFilters } from '@/services/propertyService';
 import { useProfileStore } from '@/store/profileStore';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
@@ -565,7 +565,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingBottom: spacing.md,
     gap: spacing.md,
-    ...withShadow('sm'),
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
   },
   headerInner: {
     flexDirection: 'row',

--- a/packages/frontend/app/roommates/preferences.tsx
+++ b/packages/frontend/app/roommates/preferences.tsx
@@ -22,7 +22,7 @@ import { SectionEyebrow } from '@/components/ui/SectionEyebrow';
 import { useProfile } from '@/context/ProfileContext';
 import { roommateService, type RoommateMatchingPreferences } from '@/services/roommateService';
 import { useProfileStore } from '@/store/profileStore';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
 type LifestyleChoice = 'yes' | 'no' | 'prefer_not';
@@ -459,7 +459,8 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     borderRadius: radius.lg,
     gap: spacing.md,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   cardTitle: {
     letterSpacing: -0.3,

--- a/packages/frontend/app/viewings/index.tsx
+++ b/packages/frontend/app/viewings/index.tsx
@@ -4,7 +4,7 @@
  * Stream Q polish:
  *   - Bloom Button for modify/cancel, Bloom Chip filter row, Bloom Skeleton
  *     while loading, Bloom Typography throughout.
- *   - withShadow('sm') cards with radius.lg, no borders.
+ *   - Flat cards with radius.lg + hairline borders.
  *   - Shared EmptyState / ErrorState components.
  *   - Confirm cancel via ConfirmDialog (Bloom Modal-based).
  */
@@ -28,7 +28,7 @@ import { ErrorState } from '@/components/ui/ErrorState';
 import { SectionEyebrow } from '@/components/ui/SectionEyebrow';
 import { viewingService, ViewingRequest } from '@/services/viewingService';
 import { ApiError } from '@/utils/api';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
@@ -404,7 +404,8 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     borderRadius: radius.lg,
     gap: spacing.sm,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   headerRow: {
     flexDirection: 'row',
@@ -451,7 +452,8 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     borderRadius: radius.lg,
     gap: spacing.sm,
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   skeletonHeader: {
     flexDirection: 'row',

--- a/packages/frontend/components/AddressDisplay.tsx
+++ b/packages/frontend/components/AddressDisplay.tsx
@@ -3,7 +3,6 @@ import { View, StyleSheet, TouchableOpacity, Platform, Linking, StyleProp, ViewS
 import { ThemedText } from './ThemedText';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 import { useTranslation } from 'react-i18next';
 import * as Clipboard from 'expo-clipboard';
 import { toast } from '@/lib/sonner';
@@ -186,7 +185,8 @@ const styles = StyleSheet.create({
     padding: 16,
     borderRadius: 12,
     backgroundColor: colors.COLOR_BLACK_LIGHT_9,
-    ...shadowToken({ y: 2, blur: 4, color: colors.shadow, opacity: 0.1, elevation: 3 }),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   cardHeader: {
     flexDirection: 'row',

--- a/packages/frontend/components/ContractCard.tsx
+++ b/packages/frontend/components/ContractCard.tsx
@@ -2,7 +2,7 @@
  * ContractCard — lease summary used by `/contracts` and shared list views.
  *
  * Stream Q polish:
- *   - CardSurface (surfaceElevated, withShadow('sm'), radius.lg) container.
+ *   - CardSurface (surfaceElevated, flat, radius.lg) container.
  *   - Bloom Typography for every label / value, no raw <Text>.
  *   - Inline Bloom Button actions for share / download (when provided), laid
  *     out by the shared CardActionsFooter.

--- a/packages/frontend/components/ErrorBoundary.tsx
+++ b/packages/frontend/components/ErrorBoundary.tsx
@@ -27,7 +27,7 @@ import { H2, P, Text as BloomText } from '@oxyhq/bloom/typography';
 import { toast } from '@/lib/sonner';
 
 import { colors } from '@/styles/colors';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 
 interface Props {
   children: ReactNode;
@@ -206,7 +206,7 @@ function ErrorFallback({
       keyboardShouldPersistTaps="handled">
       <View
         {...a11yAlertProps}
-        style={[styles.card, isWide && styles.cardWide, isWide && withShadow('lg')]}>
+        style={[styles.card, isWide && styles.cardWide]}>
         <Pressable
           onPress={handleBadgePress}
           onPressIn={() => setBadgePressed(true)}
@@ -429,6 +429,8 @@ const styles = StyleSheet.create({
     maxWidth: CARD_MAX_WIDTH,
     paddingHorizontal: spacing['3xl'],
     paddingVertical: spacing['5xl'],
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   iconBadge: {
     width: ICON_BADGE_SIZE,

--- a/packages/frontend/components/RoommateMatch.tsx
+++ b/packages/frontend/components/RoommateMatch.tsx
@@ -10,7 +10,6 @@ import {
 import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 import type { RoommateProfile } from '@/hooks/useRoommate';
 import { ActionButton } from '@/components/ui/ActionButton';
 import { FollowButton } from '@oxyhq/services';
@@ -173,7 +172,8 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     padding: 16,
     marginBottom: 16,
-    ...shadowToken({ y: 2, blur: 4, color: colors.COLOR_BLACK, opacity: 0.1, elevation: 3 }),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   header: {
     flexDirection: 'row',

--- a/packages/frontend/components/RoommateRelationship.tsx
+++ b/packages/frontend/components/RoommateRelationship.tsx
@@ -3,7 +3,6 @@ import { View, Text, StyleSheet, TouchableOpacity, Alert } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 import type { RoommateRelationship, RoommateProfile } from '@/hooks/useRoommate';
 import { ActionButton } from '@/components/ui/ActionButton';
 import { getDateLocale } from '@/utils/dateLocale';
@@ -191,7 +190,8 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     padding: 16,
     marginBottom: 16,
-    ...shadowToken({ y: 2, blur: 4, color: colors.COLOR_BLACK, opacity: 0.1, elevation: 3 }),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   header: {
     flexDirection: 'row',

--- a/packages/frontend/components/RoommateRequest.tsx
+++ b/packages/frontend/components/RoommateRequest.tsx
@@ -3,7 +3,6 @@ import { View, StyleSheet, TouchableOpacity, Alert, TextInput } from 'react-nati
 import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 import type { RoommateRequest, RoommateProfile } from '@/hooks/useRoommate';
 import { ActionButton } from '@/components/ui/ActionButton';
 import { ThemedText } from './ThemedText';
@@ -214,7 +213,8 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     padding: 16,
     marginBottom: 16,
-    ...shadowToken({ y: 2, blur: 4, color: colors.COLOR_BLACK, opacity: 0.1, elevation: 3 }),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   header: {
     flexDirection: 'row',

--- a/packages/frontend/components/sindi/ConversationItem.tsx
+++ b/packages/frontend/components/sindi/ConversationItem.tsx
@@ -2,7 +2,7 @@ import React, { memo, useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Text as BloomText } from '@oxyhq/bloom/typography';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 import type { Conversation } from '@/store/conversationStore';
 
@@ -135,6 +135,7 @@ export const conversationListStyles = StyleSheet.create({
     backgroundColor: colors.surfaceElevated,
     borderRadius: radius.lg,
     overflow: 'hidden',
-    ...withShadow('sm'),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
 });

--- a/packages/frontend/components/ui/CardSurface.tsx
+++ b/packages/frontend/components/ui/CardSurface.tsx
@@ -1,11 +1,12 @@
 /**
  * CardSurface — Airbnb-2026 flat card primitive.
  *
- * Wraps section content in a white surface with the standard card radius and no
- * border or shadow (Airbnb-flat, image-forward). Personal screens compose these
- * instead of hand-rolling `style={{ backgroundColor: colors.white, borderRadius:
- * … }}` everywhere. The card is FLAT by default; pass `flat={false}` only for the
- * rare floating surface that genuinely needs the small elevation shadow.
+ * Wraps section content in a surface with the standard card radius and a 1px
+ * hairline border (no shadow — Airbnb-flat, image-forward). The hairline is what
+ * separates the card from the page: `surfaceElevated` resolves to the same value
+ * as the page `background`, so a borderless flat card would be invisible.
+ * Personal screens compose these instead of hand-rolling
+ * `style={{ backgroundColor: …, borderRadius: …, borderWidth: … }}` everywhere.
  *
  * Usage:
  *   <CardSurface>
@@ -17,7 +18,7 @@ import React from 'react';
 import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
 
 import { colors } from '@/styles/colors';
-import { radius, spacing, withShadow } from '@/constants/styles';
+import { radius, spacing } from '@/constants/styles';
 
 export interface CardSurfaceProps {
   children: React.ReactNode;
@@ -25,24 +26,14 @@ export interface CardSurfaceProps {
   style?: StyleProp<ViewStyle>;
   /** Override inner padding. Defaults to `spacing.xl` (20). */
   padding?: number;
-  /** Add the small elevation shadow. Defaults to `true` (flat). */
-  flat?: boolean;
 }
 
 export const CardSurface: React.FC<CardSurfaceProps> = ({
   children,
   style,
   padding = spacing.xl,
-  flat = true,
 }) => (
-  <View
-    style={[
-      styles.card,
-      { padding },
-      flat ? null : withShadow('sm'),
-      style,
-    ]}
-  >
+  <View style={[styles.card, { padding }, style]}>
     {children}
   </View>
 );
@@ -51,6 +42,8 @@ const styles = StyleSheet.create({
   card: {
     backgroundColor: colors.surfaceElevated,
     borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
   },
 });
 

--- a/packages/frontend/components/ui/SectionCard.tsx
+++ b/packages/frontend/components/ui/SectionCard.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { View, StyleSheet, ViewStyle } from 'react-native';
 import { ThemedText } from '@/components/ThemedText';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 
 interface SectionCardProps {
     /**
@@ -31,12 +30,6 @@ interface SectionCardProps {
     titleStyle?: ViewStyle;
 
     /**
-     * Whether to show the card shadow/elevation. Defaults to `false`
-     * (Airbnb-flat) — the card's hairline border provides its separation.
-     */
-    showShadow?: boolean;
-
-    /**
      * Custom padding for the card content
      * @default 16
      */
@@ -61,7 +54,6 @@ export const SectionCard: React.FC<SectionCardProps> = ({
     containerStyle,
     cardStyle,
     titleStyle,
-    showShadow = false,
     padding = 16,
     borderRadius = 12,
     marginBottom = 20,
@@ -71,7 +63,6 @@ export const SectionCard: React.FC<SectionCardProps> = ({
         {
             padding,
             borderRadius,
-            ...(showShadow ? shadowStyles : {}),
         },
         cardStyle,
     ];
@@ -95,14 +86,6 @@ export const SectionCard: React.FC<SectionCardProps> = ({
         </View>
     );
 };
-
-const shadowStyles = shadowToken({
-    y: 1,
-    blur: 4,
-    color: colors.COLOR_BLACK,
-    opacity: 0.05,
-    elevation: 1,
-});
 
 const styles = StyleSheet.create({
     container: {

--- a/packages/frontend/components/ui/skeletons/InsightsSkeleton.tsx
+++ b/packages/frontend/components/ui/skeletons/InsightsSkeleton.tsx
@@ -3,7 +3,6 @@ import { View, ScrollView } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Skeleton } from '@oxyhq/bloom';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 
 export function InsightsSkeleton() {
   const insets = useSafeAreaInsets();
@@ -27,7 +26,8 @@ export function InsightsSkeleton() {
               backgroundColor: colors.white,
               padding: 16,
               borderRadius: 12,
-              ...shadowToken({ y: 2, blur: 4, color: colors.COLOR_BLACK, opacity: 0.1, elevation: 3 }),
+              borderWidth: 1,
+              borderColor: colors.border,
             }}>
             <Skeleton.Box width={40} height={40} borderRadius={20} style={{ marginBottom: 12 }} />
             <Skeleton.Box width={60} height={24} style={{ marginBottom: 8 }} />
@@ -43,7 +43,8 @@ export function InsightsSkeleton() {
             backgroundColor: colors.white,
             padding: 20,
             borderRadius: 12,
-            ...shadowToken({ y: 2, blur: 4, color: colors.COLOR_BLACK, opacity: 0.1, elevation: 3 }),
+            borderWidth: 1,
+            borderColor: colors.border,
           }}>
           <Skeleton.Box width={150} height={20} style={{ marginBottom: 16 }} />
           <Skeleton.Box width="100%" height={200} borderRadius={8} />
@@ -62,7 +63,8 @@ export function InsightsSkeleton() {
               borderRadius: 12,
               marginBottom: 12,
               overflow: 'hidden',
-              ...shadowToken({ y: 2, blur: 4, color: colors.COLOR_BLACK, opacity: 0.1, elevation: 3 }),
+              borderWidth: 1,
+              borderColor: colors.border,
             }}>
             <View style={{ flexDirection: 'row' }}>
               <Skeleton.Box width={100} height={80} borderRadius={0} />

--- a/packages/frontend/components/ui/skeletons/ProfileSkeleton.tsx
+++ b/packages/frontend/components/ui/skeletons/ProfileSkeleton.tsx
@@ -3,7 +3,6 @@ import { View, ScrollView } from 'react-native';
 import { Skeleton } from '@oxyhq/bloom';
 import { TextLines } from './TextLines';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 
 interface ProfileSkeletonProps {
   showHeader?: boolean;
@@ -91,7 +90,8 @@ export function ProfileSkeleton({ showHeader = true, showActions = true }: Profi
                 padding: 16,
                 borderRadius: 8,
                 marginBottom: 12,
-                ...shadowToken({ y: 1, blur: 3, color: colors.COLOR_BLACK, opacity: 0.1, elevation: 2 }),
+                borderWidth: 1,
+                borderColor: colors.border,
               }}>
               <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
                 <Skeleton.Box width={40} height={40} borderRadius={20} />

--- a/packages/frontend/components/ui/skeletons/PropertyDetailSkeleton.tsx
+++ b/packages/frontend/components/ui/skeletons/PropertyDetailSkeleton.tsx
@@ -3,7 +3,6 @@ import { View, StyleSheet, ScrollView } from 'react-native';
 import { Skeleton } from '@oxyhq/bloom';
 import { TextLines } from './TextLines';
 import { colors } from '@/styles/colors';
-import { shadowToken } from '@/styles/shadows';
 
 export const PropertyDetailSkeleton: React.FC = () => {
   return (
@@ -181,7 +180,8 @@ const styles = StyleSheet.create({
     backgroundColor: colors.white,
     borderRadius: 12,
     padding: 16,
-    ...shadowToken({ y: 1, blur: 4, color: colors.COLOR_BLACK, opacity: 0.1, elevation: 2 }),
+    borderWidth: 1,
+    borderColor: colors.border,
   },
   cardTitle: {
     marginBottom: 16,


### PR DESCRIPTION
## Summary
- Follow-up to #164: flattens the deep-screen cards/tiles/list-items/badges that PR #164 left untouched (components: AddressDisplay, RoommateMatch/Relationship/Request, sindi ConversationItem, ErrorBoundary, Insights/Profile/PropertyDetail skeletons; app screens: horizon, roommates, sindi, host reservations/calendar, viewings, properties/city/[id], book-viewing date/time tiles, insights, landlord applications, reviews/write, contracts, drafts, addresses/[id]).
- Adds a 1px `colors.border` hairline wherever a same-background card would otherwise vanish — `colors.surfaceElevated`, `colors.primaryLight`, and `colors.COLOR_BLACK_LIGHT_9` all resolve to the same value as `colors.background`.
- Removes dead opt-ins with no remaining callers: `CardSurface` drops its `flat` prop (now always flat, and gains its own hairline border — fixes a post-#164 invisible-card regression); `SectionCard` drops its unused `showShadow` prop (it already had a border).

## Verification
- `bun run build` — exit 0 across all packages (shared-types, listing-providers, frontend web export, backend).
- `bun run test` — all green (backend 523 tests / 63 suites, listing-providers 386 tests / 42 suites, frontend 32 tests / 3 suites, shared-types).
- `bunx tsc --noEmit` in packages/frontend — 11 errors, identical to the pre-existing baseline (none in the touched files).
- Shadow grep confirms only the intentional KEEP list remains (SaveButton heart, HomeCarouselSection/CityShowcaseSection scroll arrows, SearchActionPill, MapMarkerPopover, Header, SearchPanel, RangeSlider knob, SearchBar/SearchSummaryBar pills, MapFab, SearchResultsView search FAB, PropertyImageCarousel chevron, properties/index FAB):
  \`\`\`
  grep -rnE "cardShadow|withShadow\(|shadowToken\(|boxShadow|elevation|cardBoxShadowWeb" components app --include=*.tsx | grep -vE "styles/shadows|constants/styles"
  \`\`\`

## Test plan
- [x] `bun run build`
- [x] `bun run test`
- [x] `bunx tsc --noEmit` (baseline unchanged)
- [x] Shadow grep shows only KEEP list

🤖 Generated with [Claude Code](https://claude.com/claude-code)