### PR TITLE
style(frontend): align profile hero to sticky-bar recipe

### DIFF
--- a/packages/frontend/app/(tabs)/profile/index.tsx
+++ b/packages/frontend/app/(tabs)/profile/index.tsx
@@ -30,7 +30,7 @@ import { useMyApplications } from '@/hooks/useApplicationQueries';
 import { useReservationsQuery } from '@/hooks/useReservationQueries';
 import { useSavedPropertiesContext } from '@/context/SavedPropertiesContext';
 import { colors } from '@/styles/colors';
-import { spacing, tracker } from '@/constants/styles';
+import { contentClamp, spacing } from '@/constants/styles';
 import { logger } from '@/utils/logger';
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
@@ -142,16 +142,18 @@ export default function ProfileScreen() {
       {header}
       <ScrollView contentContainerStyle={styles.scroll}>
         <View style={styles.heroWrap}>
-          <CardSurface padding={spacing['2xl']}>
+          <View style={styles.heroContent}>
             <View style={styles.heroRow}>
               <Avatar size={88} shape="squircle" uri={avatarUri} name={displayName} />
               <View style={styles.heroBody}>
-                <H1 style={styles.heroName}>{displayName}</H1>
-                <BloomText style={styles.heroSubtitle}>
-                  {user?.username ? `@${user.username}` : ''}
-                </BloomText>
+                <H1 className="text-2xl font-bold text-foreground">{displayName}</H1>
+                {user?.username ? (
+                  <BloomText className="text-sm text-muted-foreground">
+                    {`@${user.username}`}
+                  </BloomText>
+                ) : null}
                 {bio ? (
-                  <BloomText style={styles.heroBio} numberOfLines={3}>
+                  <BloomText className="text-sm text-muted-foreground" numberOfLines={3}>
                     {bio}
                   </BloomText>
                 ) : null}
@@ -181,7 +183,7 @@ export default function ProfileScreen() {
                 {t('profile.actions.editProfile')}
               </Button>
             </View>
-          </CardSurface>
+          </View>
         </View>
 
         <View style={styles.statsWrap}>
@@ -346,38 +348,32 @@ const styles = StyleSheet.create({
     marginBottom: spacing.lg,
   },
   heroWrap: {
-    paddingHorizontal: spacing.lg,
     marginBottom: spacing.lg,
   },
+  // Mirrors `StickyPropertyHeader.content` so the flat hero lines up with the
+  // pinned header on wide web: ONE width clamp + ONE horizontal padding + ONE
+  // uniform vertical gap between the identity row, badges, and action.
+  heroContent: {
+    maxWidth: contentClamp.page,
+    width: '100%',
+    alignSelf: 'center',
+    paddingHorizontal: spacing.lg,
+    gap: spacing.lg,
+  },
+  // Top-align the name/handle/bio to the avatar's top edge (not its mid-height).
   heroRow: {
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     gap: spacing.lg,
-    marginBottom: spacing.md,
   },
   heroBody: {
     flex: 1,
     gap: spacing.xs,
   },
-  heroName: {
-    fontSize: 24,
-    fontWeight: '700',
-    letterSpacing: tracker.tight,
-  },
-  heroSubtitle: {
-    fontSize: 13,
-    color: colors.muted,
-  },
-  heroBio: {
-    fontSize: 14,
-    color: colors.muted,
-    lineHeight: 20,
-  },
   badgesRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: spacing.xs,
-    marginBottom: spacing.md,
   },
   heroActions: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- Drop the `CardSurface` wrapper — the hero is now a flat block, matching the flat design language elsewhere in the app.
- Adopt the `StickyPropertyHeader.content` recipe for the hero container (`maxWidth: contentClamp.page`, centered, `paddingHorizontal: spacing.lg`) so on wide web the hero lines up with the pinned header.
- Top-align name/handle/bio to the avatar's top edge (`alignItems: 'flex-start'`) instead of mid-height.
- Switch typography from hardcoded inline styles to Bloom `className` tokens (`H1` → `text-2xl font-bold text-foreground`, handle/bio → `BloomText text-sm text-muted-foreground`), dropping the unused `heroName`/`heroSubtitle`/`heroBio` styles and the `tracker` import.
- Unify spacing rhythm: `spacing.lg` between blocks and avatar/text, `spacing.xs` within the name/handle/bio stack, replacing mixed 24/16/12/4px values and per-block margins.

All hero content is preserved: avatar squircle (88px), name, @handle, 3-line bio, verified badges row, Edit button. The shared `components/Header.tsx` sticky header was not touched.

Build, tests (945 total across shared-types/frontend/listing-providers/backend), tsc (baseline unchanged at 11 pre-existing errors, none in this file), and the lockfile gate (`--frozen-lockfile`) were all verified green before this PR.

## Test plan
- [x] Local build passed
- [x] Full test suite passed (945 tests)
- [x] tsc baseline unchanged, no new errors in this file
- [x] `bun install --frozen-lockfile` passed
- [ ] Visual check of profile hero on wide web + native

🤖 Generated with [Claude Code](https://claude.com/claude-code)