### PR TITLE
fix(listing-providers): verify + fix Germany providers (is24, immowelt, kleinanzeigen)

### DIFF
--- a/packages/backend/__tests__/unit/immobilienscout24Provider.test.ts
+++ b/packages/backend/__tests__/unit/immobilienscout24Provider.test.ts
@@ -44,6 +44,10 @@ describe('ImmobilienScout24Provider', () => {
     expect(listing.remoteImages.length).toBe(2);
     expect(listing.contact?.phone).toMatch(/493012345678/);
     expect(listing.contact?.agencyName).toMatch(/Mitte Homes/i);
+    // Description comes from the 'Objektbeschreibung' TEXT_AREA block (the real
+    // mobile expose shape), not the 'Lage' block that precedes it.
+    expect(listing.description).toMatch(/Balkon/i);
+    expect(listing.description).not.toMatch(/Rosenthaler Platz/i);
   });
 
   it('derives source id and public URL helpers', () => {

--- a/packages/backend/__tests__/unit/kleinanzeigenProvider.test.ts
+++ b/packages/backend/__tests__/unit/kleinanzeigenProvider.test.ts
@@ -44,6 +44,14 @@ describe('KleinanzeigenProvider housing filter', () => {
     expect(listing.address.countryCode).toBe('DE');
     expect(listing.contact?.phone).toMatch(/493098765432/);
     expect(listing.contact?.whatsapp).toMatch(/493098765432/);
+    // Full gallery is captured (not just og:image), deduped by base id,
+    // normalized to the largest `$_57.AUTO` variant, og:image primary.
+    expect(listing.remoteImages).toHaveLength(3);
+    expect(listing.remoteImages[0]?.url).toBe(
+      'https://img.kleinanzeigen.de/api/v1/prod-ads/images/aa/example-1?rule=$_57.AUTO',
+    );
+    expect(listing.remoteImages[0]?.isPrimary).toBe(true);
+    expect(listing.remoteImages.every((image) => image.url.endsWith('?rule=$_57.AUTO'))).toBe(true);
   });
 
   it('rejects non-housing detail HTML', () => {
@@ -58,5 +66,16 @@ describe('KleinanzeigenProvider housing filter', () => {
     expect(url).toContain('/c203');
     expect(url).toContain('wohnung-mieten');
     expect(() => kleinanzeigenHousingSearchUrl('berlin', 1, '216')).toThrow(/not a housing category/);
+  });
+
+  it('paginates with `seite:N` before the category code (keeps the category filter)', () => {
+    // Appending `/seite:N` AFTER the `c203l…` code drops the category filter and
+    // returns a site-wide page; the page segment must sit before the code.
+    expect(kleinanzeigenHousingSearchUrl('berlin', 2, '203')).toBe(
+      'https://www.kleinanzeigen.de/s-wohnung-mieten/berlin/seite:2/c203l3331',
+    );
+    expect(kleinanzeigenHousingSearchUrl('muenchen', 3, '205')).toBe(
+      'https://www.kleinanzeigen.de/s-haus-mieten/muenchen/seite:3/c205l6411',
+    );
   });
 });

--- a/packages/listing-providers/src/providers/de/immobilienscout24/fixtures.ts
+++ b/packages/listing-providers/src/providers/de/immobilienscout24/fixtures.ts
@@ -85,7 +85,7 @@ export const IS24_FIXTURE_EXPOSE_JSON = `{
     {
       "type": "TOP_ATTRIBUTES",
       "attributes": [
-        { "label": "Kaltmiete", "text": "1.250 €", "type": "TEXT", "highlighted": true },
+        { "label": "Kaltmiete 19,23 €/m²", "text": "1.250 €", "type": "TEXT", "highlighted": true },
         { "label": "Zimmer", "text": "2", "type": "TEXT" },
         { "label": "Wohnfläche", "text": "65 m²", "type": "TEXT" },
         { "label": "Warmmiete", "text": "1.450 €", "type": "TEXT" }
@@ -100,7 +100,12 @@ export const IS24_FIXTURE_EXPOSE_JSON = `{
       "addressLine2": "10119 Mitte, Berlin"
     },
     {
-      "type": "DESCRIPTION",
+      "type": "TEXT_AREA",
+      "title": "Lage",
+      "text": "Zentrale Lage in Berlin-Mitte, nahe U-Bahn Rosenthaler Platz."
+    },
+    {
+      "type": "TEXT_AREA",
       "title": "Objektbeschreibung",
       "text": "Lichtdurchflutete Wohnung mit Balkon und Einbauküche in Berlin-Mitte."
     }

--- a/packages/listing-providers/src/providers/de/immobilienscout24/parse.ts
+++ b/packages/listing-providers/src/providers/de/immobilienscout24/parse.ts
@@ -176,8 +176,13 @@ export function parseIs24Expose(body: string, fallbackUrl?: string): Is24RawList
     const type = asString(record.type);
     if (type === 'TITLE') {
       title = asString(record.title) ?? title;
-    } else if (type === 'DESCRIPTION') {
-      description = asString(record.text) ?? asString(record.description) ?? description;
+    } else if (type === 'TEXT_AREA') {
+      // The mobile expose splits free text into titled TEXT_AREA blocks
+      // ('Objektbeschreibung', 'Lage', 'Sonstiges'). Only the object
+      // description is a real listing description; keep the first one.
+      if (description === undefined && asString(record.title)?.toLowerCase() === 'objektbeschreibung') {
+        description = asString(record.text);
+      }
     } else if (type === 'TOP_ATTRIBUTES' || type === 'ATTRIBUTES') {
       attrs = attrMap(record.attributes);
     } else if (type === 'MAP') {

--- a/packages/listing-providers/src/providers/de/immowelt/index.ts
+++ b/packages/listing-providers/src/providers/de/immowelt/index.ts
@@ -144,10 +144,12 @@ export class ImmoweltProvider implements ListingProvider {
                 // skip
               }
             }
+            let newRefs = 0;
             for (const ref of refs) {
               if (yielded >= limit) return;
               if (seen.has(ref.sourceId)) continue;
               seen.add(ref.sourceId);
+              newRefs += 1;
               const card = byLegacy.get(ref.sourceId);
               yield {
                 provider: this.id,
@@ -157,7 +159,12 @@ export class ImmoweltProvider implements ListingProvider {
               };
               yielded += 1;
             }
-            if (refs.length === 0) break;
+            // The legacy `/liste/…?page=N` URL 301-redirects to a page-1
+            // snapshot that ignores the page param over plain HTTP, so a page
+            // that adds no new refs means pagination is exhausted — stop before
+            // re-fetching the same ~1 MB SERP. (Real pagination needs the
+            // DataDome-gated classified-search AJAX via a browser session.)
+            if (newRefs === 0) break;
             continue;
           } catch (error) {
             if (error instanceof ChallengeError) return;
@@ -166,13 +173,16 @@ export class ImmoweltProvider implements ListingProvider {
         }
 
         if (refs.length === 0) break;
+        let newRefs = 0;
         for (const ref of refs) {
           if (yielded >= limit) return;
           if (seen.has(ref.sourceId)) continue;
           seen.add(ref.sourceId);
+          newRefs += 1;
           yield { provider: this.id, sourceId: ref.sourceId, url: ref.url };
           yielded += 1;
         }
+        if (newRefs === 0) break;
       }
     }
   }

--- a/packages/listing-providers/src/providers/de/kleinanzeigen/fixtures.ts
+++ b/packages/listing-providers/src/providers/de/kleinanzeigen/fixtures.ts
@@ -32,7 +32,7 @@ export const KLEINANZEIGEN_FIXTURE_DETAIL_HTML = `<!doctype html>
 <meta property="og:title" content="Helle 2-Zimmer-Wohnung in Mitte" />
 <meta property="og:description" content="Schöne Wohnung mit Balkon in Berlin-Mitte." />
 <meta property="og:url" content="https://www.kleinanzeigen.de/s-anzeige/helle-2-zimmer-wohnung-in-mitte/3367000001-203-3331" />
-<meta property="og:image" content="https://img.kleinanzeigen.de/api/v1/prod-ads/images/aa/bb/example-1.jpg" />
+<meta property="og:image" content="https://img.kleinanzeigen.de/api/v1/prod-ads/images/aa/example-1?rule=$_59.JPG" />
 <meta property="og:latitude" content="52.531" />
 <meta property="og:longitude" content="13.401" />
 <meta property="og:locality" content="Mitte" />
@@ -41,6 +41,11 @@ export const KLEINANZEIGEN_FIXTURE_DETAIL_HTML = `<!doctype html>
 <title>Helle 2-Zimmer-Wohnung in Mitte | Wohnung mieten</title>
 </head>
 <body>
+<div class="galleryimage-large">
+  <img id="viewad-image" class="galleryimage-element current" data-imgsrc="https://img.kleinanzeigen.de/api/v1/prod-ads/images/aa/example-1?rule=$_57.AUTO" />
+  <img id="viewad-image" class="galleryimage-element" data-imgsrc="https://img.kleinanzeigen.de/api/v1/prod-ads/images/bb/example-2?rule=$_57.AUTO" />
+  <img id="viewad-image" class="galleryimage-element" data-imgsrc="https://img.kleinanzeigen.de/api/v1/prod-ads/images/cc/example-3?rule=$_59.AUTO" />
+</div>
 <div class="boxedarticle--price" id="viewad-price">1.250 €</div>
 <ul>
   <li class="addetailslist--detail">Wohnfläche<span class="addetailslist--detail--value">65 m²</span></li>

--- a/packages/listing-providers/src/providers/de/kleinanzeigen/parse.ts
+++ b/packages/listing-providers/src/providers/de/kleinanzeigen/parse.ts
@@ -64,6 +64,15 @@ export function isKleinanzeigenHousingCategory(categoryId: string | undefined): 
   return !!categoryId && KLEINANZEIGEN_HOUSING_CATEGORY_IDS.has(categoryId);
 }
 
+/** Housing category id → Kleinanzeigen SEO path segment (e.g. `s-wohnung-mieten`). */
+const CATEGORY_SEGMENTS: Readonly<Record<string, string>> = {
+  '203': 's-wohnung-mieten',
+  '205': 's-haus-mieten',
+  '208': 's-wohnung-kaufen',
+  '207': 's-haus-kaufen',
+  '199': 's-wg-zimmer',
+};
+
 export function kleinanzeigenHousingSearchUrl(
   city: string,
   page = 1,
@@ -74,18 +83,12 @@ export function kleinanzeigenHousingSearchUrl(
   }
   const slug = citySlugDe(city);
   const locationId = CITY_LOCATION_IDS[slug] ?? '0';
-  const path =
-    categoryId === '203'
-      ? `/s-wohnung-mieten/${slug}/c203l${locationId}`
-      : categoryId === '205'
-        ? `/s-haus-mieten/${slug}/c205l${locationId}`
-        : categoryId === '208'
-          ? `/s-wohnung-kaufen/${slug}/c208l${locationId}`
-          : categoryId === '207'
-            ? `/s-haus-kaufen/${slug}/c207l${locationId}`
-            : `/s-wg-zimmer/${slug}/c199l${locationId}`;
-  const base = `${KLEINANZEIGEN_BASE_URL}${path}`;
-  return page <= 1 ? base : `${base}/seite:${page}`;
+  const segment = CATEGORY_SEGMENTS[categoryId] ?? 's-wg-zimmer';
+  // Kleinanzeigen paginates with `seite:N` BETWEEN the city slug and the
+  // category code — appending it after the code drops the category filter and
+  // returns a site-wide (non-housing) page.
+  const pageSegment = page > 1 ? `/seite:${page}` : '';
+  return `${KLEINANZEIGEN_BASE_URL}/${segment}/${slug}${pageSegment}/c${categoryId}l${locationId}`;
 }
 
 export function kleinanzeigenSourceIdFromUrl(url: string): string | undefined {
@@ -123,6 +126,33 @@ export function parseKleinanzeigenSearch(html: string): KleinanzeigenSearchRef[]
   return refs;
 }
 
+/**
+ * Kleinanzeigen serves each ad photo from `img.kleinanzeigen.de` with a `rule`
+ * size suffix; the detail gallery lists them via `data-imgsrc`. `$_57.AUTO`
+ * is the largest variant (1200x1600), so every URL is normalized to it and
+ * deduped by base image id, with the `og:image` kept as the primary.
+ */
+const GALLERY_IMG_RE = /data-imgsrc=["'](https:\/\/img\.kleinanzeigen\.de\/[^"']+)["']/gi;
+const IMAGE_RULE_RE = /\?rule=\$_\d+\.[A-Za-z]+$/i;
+
+function largestImageVariant(url: string): string {
+  return url.replace(IMAGE_RULE_RE, '') + '?rule=$_57.AUTO';
+}
+
+function extractGalleryImages(html: string, ogImage: string | undefined): string[] {
+  const byBase = new Map<string, string>();
+  const add = (raw: string): void => {
+    const normalized = largestImageVariant(raw);
+    const base = normalized.split('?')[0] ?? normalized;
+    if (!byBase.has(base)) byBase.set(base, normalized);
+  };
+  if (ogImage) add(ogImage);
+  for (const match of html.matchAll(GALLERY_IMG_RE)) {
+    if (match[1]) add(match[1]);
+  }
+  return [...byBase.values()];
+}
+
 function detailValue(html: string, label: string): string | undefined {
   const re = new RegExp(
     `addetailslist--detail[^>]*>\\s*${label}\\s*<span[^>]*class=["']addetailslist--detail--value["'][^>]*>\\s*([^<]+)`,
@@ -151,8 +181,7 @@ export function parseKleinanzeigenDetail(html: string, url: string): Kleinanzeig
   const neighborhood = meta.get('og:locality');
   const region = meta.get('og:region');
   const city = region ?? neighborhood ?? '';
-  const image = meta.get('og:image');
-  const images = image ? [image] : [];
+  const images = extractGalleryImages(html, meta.get('og:image'));
 
   return {
     sourceId,


### PR DESCRIPTION
## Summary

Verified and fixed the three Germany listing providers against **live portal markup**. All three were probed from an AWS datacenter IP (same class as the Fargate worker) and from an Evomi `_country-de` residential proxy — **cold HTTP works for all three; no proxy is required to activate them**. Full `discover → fetch → normalize` confirmed on real listings.

| Provider | Real status | Classification |
|----------|-------------|----------------|
| ImmobilienScout24 | mobile JSON API 200 cold (search POST + expose GET); 3/3 normalized | ✅ cold-HTTP |
| Immowelt | SERP LZ JSON 200 cold (after 301 redirect-follow); 3/3 normalized | ✅ cold-HTTP |
| Kleinanzeigen | housing search + detail 200 cold; gesuche correctly rejected | ✅ cold-HTTP |

## Fixes (against real markup)

**ImmobilienScout24** — the mobile expose returns the object description in a `TEXT_AREA` block titled `Objektbeschreibung`, not a `DESCRIPTION` section (that type does not exist in the real API). Parse the titled `TEXT_AREA` so listings keep a real description instead of always falling back to the title. Fixture updated to the real API shape.

**Immowelt** — the legacy `/liste/…?page=N` URL 301-redirects to a `/suche/<token>` page-1 snapshot that ignores the page param over plain HTTP, so pages 2/3 re-fetched the same ~1 MB SERP and yielded only duplicates. Discover now breaks when a page adds zero new refs (real pagination needs the DataDome-gated classified-search AJAX via a browser session).

**Kleinanzeigen**
- Pagination URL bug: `seite:N` was appended **after** the `c203l…` category code, which drops the category filter and returns a **site-wide, non-housing** page. Kleinanzeigen requires `seite:N` **between** the city slug and the category code — fixed and verified live (page 2 stays scoped to Wohnung mieten).
- Capture the full detail gallery from `data-imgsrc` (normalized to the largest `$_57.AUTO` variant, deduped by base id, og:image primary) instead of only the single og:image.
- Seeking-ads (`Gesuch`, no price) are correctly rejected — no bad data ingested.

## Validation
- `bun run build` (listing-providers) exit 0
- 469 backend unit tests green (added description, gallery, and pagination assertions)
- Live e2e: IS24 3/3, Immowelt 3/3, Kleinanzeigen 2/3 (the 1 skip is a legitimate seeking-ad rejection)

Providers stay **OFF by default** behind `PROVIDER_IMMOBILIENSCOUT24_ENABLED` / `PROVIDER_IMMOWELT_ENABLED` / `PROVIDER_KLEINANZEIGEN_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)