### PR TITLE
feat(listing-providers): activate MercadoLibre AR/MX cold-HTTP + fix shared detail parser

### DIFF
--- a/packages/backend/__tests__/unit/arProviders.test.ts
+++ b/packages/backend/__tests__/unit/arProviders.test.ts
@@ -20,6 +20,7 @@ import {
   parseMercadolibreArDetail,
   parseMercadolibreArSearch,
   parseMercadolibreArSearchJson,
+  isMercadolibreArChallenge,
   isMercadolibreArHousingCategory,
   mercadolibreArHousingSearchUrl,
   MERCADOLIBRE_AR_FIXTURE_DETAIL_HTML,
@@ -118,7 +119,15 @@ describe('MercadolibreArProvider', () => {
     expect(isMercadolibreArHousingCategory(undefined, 'CARS_AND_VANS')).toBe(false);
   });
 
-  it('normalizes detail HTML with VIP city fields', () => {
+  it('does not flag a valid VIP detail page (invisible reCAPTCHA v3) as a challenge', () => {
+    // The contact form embeds reCAPTCHA; a bare `captcha` marker used to false-positive
+    // and make the cold-HTTP ladder discard a perfectly good listing.
+    expect(isMercadolibreArChallenge(MERCADOLIBRE_AR_FIXTURE_DETAIL_HTML)).toBe(false);
+    expect(isMercadolibreArChallenge('<html>datadome captcha-delivery</html>')).toBe(true);
+    expect(isMercadolibreArChallenge('go=account-verification suspicious-traffic')).toBe(true);
+  });
+
+  it('normalizes cold-HTTP detail HTML with specs, region and gallery', () => {
     const refs = parseMercadolibreArSearch(MERCADOLIBRE_AR_FIXTURE_SEARCH_HTML);
     expect(refs.length).toBeGreaterThanOrEqual(1);
     const payload = parseMercadolibreArDetail(
@@ -133,6 +142,14 @@ describe('MercadolibreArProvider', () => {
     expect(listing.address.city).toBe('Capital Federal');
     expect(listing.address.neighborhood).toBe('Belgrano');
     expect(listing.contact?.phone).toBeTruthy();
+    // Highlighted-specs block (`BED → "2 dorm."`, `BATHROOM → "1 baño"`, `SCALE_UP → "55 m² totales"`).
+    expect(listing.bedrooms).toBe(2);
+    expect(listing.bathrooms).toBe(1);
+    expect(listing.squareFootage).toBe(55);
+    // Region resolves to the address-adjacent state, not the UI `"state":"VISIBLE"` flag.
+    expect(listing.address.state).toBe('Capital Federal');
+    // Full server-rendered gallery, not the single JSON-LD image.
+    expect(listing.remoteImages.length).toBeGreaterThanOrEqual(2);
   });
 
   it('throws NonHousingListingError for car item JSON', () => {

--- a/packages/backend/__tests__/unit/latamProviders.test.ts
+++ b/packages/backend/__tests__/unit/latamProviders.test.ts
@@ -64,7 +64,7 @@ describe('MercadolibreCoProvider', () => {
     expect(provider.markets).toEqual(['CO']);
     const url = mercadolibreCoHousingSearchUrl('bogota-dc');
     expect(isHousingCategoryUrl(url, MERCADOLIBRE_CO_HOUSING_SLUGS)).toBe(true);
-    expect(url).toContain('/departamentos/alquiler/');
+    expect(url).toContain('/departamentos/arriendo/');
   });
 
   it('parses housing search JSON and rejects cars', () => {
@@ -218,7 +218,7 @@ describe('MercadolibreMxProvider', () => {
     expect(isMercadolibreMxHousingCategory(undefined, 'CARS_AND_VANS')).toBe(false);
   });
 
-  it('normalizes detail HTML with contact', () => {
+  it('normalizes cold-HTTP detail HTML with specs, region and gallery', () => {
     const refs = parseMercadolibreMxSearch(MERCADOLIBRE_MX_FIXTURE_SEARCH_HTML);
     expect(refs.length).toBeGreaterThanOrEqual(1);
     const payload = parseMercadolibreMxDetail(
@@ -232,5 +232,14 @@ describe('MercadolibreMxProvider', () => {
     expect(listing.longTermRent?.currency).toBe('MXN');
     expect(listing.address.countryCode).toBe('MX');
     expect(listing.contact?.phone).toBeTruthy();
+    // Highlighted-specs block (`BED → "2 rec."`, `BATHROOM → "2 baños"`, `SCALE_UP → "72 m² totales"`).
+    expect(listing.bedrooms).toBe(2);
+    expect(listing.bathrooms).toBe(2);
+    expect(listing.squareFootage).toBe(72);
+    // Region is the address-adjacent state, never the UI `"state":"VISIBLE"` flag.
+    expect(listing.address.state).toBe('Ciudad de México');
+    // Full gallery, not the single JSON-LD image.
+    expect(listing.remoteImages.length).toBeGreaterThanOrEqual(2);
+    expect(listing.remoteImages[0]?.url).toContain('http2.mlstatic.com');
   });
 });

--- a/packages/listing-providers/src/mercadolibre.ts
+++ b/packages/listing-providers/src/mercadolibre.ts
@@ -93,7 +93,13 @@ function asNumber(value: unknown): number | undefined {
 
 export function isMercadolibreChallenge(body: string): boolean {
   if (body.trim().length < 128) return true;
-  return /suspicious-traffic|captcha|datadome|access denied|just a moment|PA_UNAUTHORIZED/i.test(
+  // Narrow, anti-bot-specific markers only. A bare `captcha` false-positives on
+  // every VALID VIP detail page — MercadoLibre embeds an invisible reCAPTCHA v3
+  // (`recaptchaSiteKey`, `ui-pdp-recaptcha-v3`) in the contact form — which would
+  // make the cold-HTTP ladder treat a perfectly good listing as a challenge.
+  // The real walls are DataDome (`datadome` / `captcha-delivery` / `px-captcha`)
+  // and MercadoLibre's own `account-verification` / `suspicious-traffic` gate.
+  return /suspicious-traffic|account-verification|captcha-delivery|px-captcha|datadome|access denied|just a moment|PA_UNAUTHORIZED/i.test(
     body,
   );
 }
@@ -306,18 +312,95 @@ export function parseMercadolibreSearch(
   return out;
 }
 
-/** Pull VIP-embedded city/neighborhood/domain from detail HTML. */
+/** Pull VIP-embedded city/neighborhood/state/domain from detail HTML. */
 function extractVipFields(html: string): {
   city?: string;
   neighborhood?: string;
   state?: string;
   domainId?: string;
 } {
-  const city = html.match(/"city"\s*:\s*"([^"]+)"/)?.[1];
-  const neighborhood = html.match(/"neighborhood"\s*:\s*"([^"]+)"/)?.[1];
-  const state = html.match(/"state"\s*:\s*"([^"]+)"/)?.[1];
+  // The VIP tracking block renders the location fields adjacently:
+  // `"city":"…","neighborhood":"…","state":"…"`. Anchoring `state` to that
+  // adjacency avoids the earlier `"state":"VISIBLE"` UI-component flag, which is
+  // the FIRST bare `"state"` on the page and previously polluted the region.
+  const loc = html.match(
+    /"city"\s*:\s*"([^"]+)"\s*,\s*"neighborhood"\s*:\s*"([^"]*)"\s*,\s*"state"\s*:\s*"([^"]+)"/,
+  );
+  const city = loc?.[1] ?? html.match(/"city"\s*:\s*"([^"]+)"/)?.[1];
+  const neighborhood = (loc?.[2]?.trim() || undefined) ?? html.match(/"neighborhood"\s*:\s*"([^"]+)"/)?.[1];
+  const state = loc?.[3];
   const domainId = html.match(/"domain_id"\s*:\s*"([^"]+)"/)?.[1];
   return { city, neighborhood, state, domainId };
+}
+
+/** First integer in a highlighted-specs label such as "2 dorm." / "1 baño". */
+function labelInt(text: string): number | undefined {
+  const match = text.match(/(\d+)/);
+  return match ? Number.parseInt(match[1], 10) : undefined;
+}
+
+/** First number in an area label such as "138 m² totales" / "30,5 m²". */
+function labelArea(text: string): number | undefined {
+  const match = text.match(/(\d+(?:[.,]\d+)?)/);
+  if (!match) return undefined;
+  const parsed = Number.parseFloat(match[1].replace(',', '.'));
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Bedrooms / bathrooms / covered area from the VIP highlighted-specs block —
+ * the only reliable cold-HTTP source now that the public items API is
+ * OAuth-gated. It is the first `"attributes":[…]` array carrying a `BATHROOM`
+ * or `SCALE_UP` icon; each entry is an `{icon:{id},label:{text}}` pair
+ * (`BED → "2 dorm."/"2 rec."`, `BATHROOM → "1 baño"`, `SCALE_UP → "75 m² totales"`).
+ */
+function extractHighlightedSpecs(html: string): {
+  bedrooms?: number;
+  bathrooms?: number;
+  squareMeters?: number;
+} {
+  const marker = '"attributes":[';
+  let from = 0;
+  for (;;) {
+    const start = html.indexOf(marker, from);
+    if (start < 0) break;
+    const open = start + marker.length - 1;
+    const end = html.indexOf(']', open);
+    if (end < 0) break;
+    const block = html.slice(open, end + 1);
+    from = end + 1;
+    if (!/"id":"(?:BATHROOM|SCALE_UP|BED|BEDROOM)"/.test(block)) continue;
+
+    const result: { bedrooms?: number; bathrooms?: number; squareMeters?: number } = {};
+    const pairRe = /"id":"([A-Z_]+)"[^}]*\}\s*,\s*"label":\{"text":"([^"]+)"/g;
+    for (const match of block.matchAll(pairRe)) {
+      const icon = match[1];
+      const text = match[2];
+      if (/^BED(?:ROOM)?$/.test(icon) && result.bedrooms === undefined) {
+        result.bedrooms = labelInt(text);
+      } else if (icon === 'BATHROOM' && result.bathrooms === undefined) {
+        result.bathrooms = labelInt(text);
+      } else if (icon === 'SCALE_UP' && result.squareMeters === undefined) {
+        result.squareMeters = labelArea(text);
+      }
+    }
+    return result;
+  }
+  return {};
+}
+
+/** Main-gallery image URLs from the server-rendered `gallery-image__link` anchors. */
+function extractGalleryImages(html: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const re = /class="gallery-image__link"[^>]*>\s*<img[^>]*\bsrc="(https:\/\/[^"]+)"/g;
+  for (const match of html.matchAll(re)) {
+    const url = match[1];
+    if (seen.has(url)) continue;
+    seen.add(url);
+    out.push(url);
+  }
+  return out;
 }
 
 export function parseMercadolibreDetail(
@@ -373,23 +456,41 @@ export function parseMercadolibreDetail(
     throw new NonHousingListingError(config.provider, sourceId, `domain ${domainId}`);
   }
 
-  const images: string[] = [];
-  const imageVal = product.image;
-  if (typeof imageVal === 'string') images.push(imageVal);
-  else if (Array.isArray(imageVal)) {
-    for (const entry of imageVal) {
-      if (typeof entry === 'string') images.push(entry);
+  // Prefer the full server-rendered gallery; the JSON-LD `image` is a single URL.
+  const images: string[] = extractGalleryImages(html);
+  if (images.length === 0) {
+    const imageVal = product.image;
+    if (typeof imageVal === 'string') images.push(imageVal);
+    else if (Array.isArray(imageVal)) {
+      for (const entry of imageVal) {
+        if (typeof entry === 'string') images.push(entry);
+      }
     }
   }
+
+  // Operation from the domain id (`…_FOR_SALE` / `…_FOR_RENT`) when present, since
+  // the URL slug is not always decisive; fall back to the URL.
+  const operation: 'rent' | 'sale' = /FOR_SALE|_SALE\b|VENTA/i.test(domainId)
+    ? 'sale'
+    : /FOR_RENT|_RENT\b|ALQUILER|ARRIENDO|RENTA/i.test(domainId)
+      ? 'rent'
+      : /venta/i.test(url)
+        ? 'sale'
+        : 'rent';
+
+  const specs = extractHighlightedSpecs(html);
 
   const raw: MercadolibreRawListing = {
     sourceId,
     url: asString(product.url) ?? url,
     title: asString(product.name),
     description: asString(product.description),
-    operation: /venta/i.test(url) ? 'sale' : 'rent',
+    operation,
     price,
     currency: asString(offer?.priceCurrency) ?? config.defaultCurrency,
+    bedrooms: specs.bedrooms,
+    bathrooms: specs.bathrooms,
+    squareMeters: specs.squareMeters,
     address: {
       street: asString(address?.streetAddress),
       city,
@@ -406,6 +507,9 @@ export function parseMercadolibreDetail(
   assertHousingListing(config.provider, sourceId, {
     category: 'inmuebles',
     typology: domainId,
+    squareMeters: raw.squareMeters,
+    bedrooms: raw.bedrooms,
+    bathrooms: raw.bathrooms,
     hasAddressLike: true,
     hasPrice: true,
   });

--- a/packages/listing-providers/src/providers/ar/mercadolibre/fixtures.ts
+++ b/packages/listing-providers/src/providers/ar/mercadolibre/fixtures.ts
@@ -66,8 +66,15 @@ export const MERCADOLIBRE_AR_FIXTURE_DETAIL_HTML = `<!DOCTYPE html><html><head>
 {"name":"Alquiler Departamento 2 Ambientes Belgrano","image":"https://http2.mlstatic.com/fixture-ml-ar-1.jpg","offers":{"price":650000,"availability":"https://schema.org/InStock","url":"https://departamento.mercadolibre.com.ar/MLA-3557653074-alquiler-departamento-2-ambientes-belgrano-_JM","@type":"Offer","priceCurrency":"ARS"},"sku":"MLA3557653074","@context":"https://schema.org","@type":"Product","productID":"MLA3557653074"}
 </script>
 </head><body>
-<script>var x={"domain_id":"MLA-APARTMENTS_FOR_RENT","city":"Capital Federal","neighborhood":"Belgrano","state":"Capital Federal","whatsapp_available":true};</script>
+<script>var seller={"id":"seller_profile","type":"seller_profile","state":"VISIBLE"};</script>
+<script>var vip={"domain_id":"MLA-APARTMENTS_FOR_RENT","description_type":"plain_text","city":"Capital Federal","neighborhood":"Belgrano","state":"Capital Federal","whatsapp_available":true};</script>
+<script>var specs={"attributes":[{"icon":{"id":"BED","color":"BLACK","size":"XXSMALL"},"label":{"text":"2 dorm.","color":"BLACK"}},{"icon":{"id":"BATHROOM","color":"BLACK","size":"XXSMALL"},"label":{"text":"1 baño","color":"BLACK"}},{"icon":{"id":"SCALE_UP","color":"BLACK","size":"XXSMALL"},"label":{"text":"55 m² totales","color":"BLACK"}}]};</script>
 <a href="tel:+5491155667788">Llamar</a>
+<div class="ui-pdp-gallery">
+<a class="gallery-image__link" href="#"><img src="https://http2.mlstatic.com/D_NQ_NP_621054-MLA109844438740_042026-F-null.webp"/></a>
+<a class="gallery-image__link" href="#"><img src="https://http2.mlstatic.com/D_NQ_NP_984582-MLA109844438786_042026-F-null.webp"/></a>
+<a class="gallery-image__link" href="#"><img src="https://http2.mlstatic.com/D_NQ_NP_919980-MLA109844438792_042026-F-null.webp"/></a>
+</div>
 <h1>Alquiler departamento</h1>
 </body></html>`;
 

--- a/packages/listing-providers/src/providers/co/mercadolibre/index.ts
+++ b/packages/listing-providers/src/providers/co/mercadolibre/index.ts
@@ -31,6 +31,8 @@ export const MERCADOLIBRE_CO_SITE: MercadolibreSiteConfig = {
   defaultCurrency: 'COP',
   inmueblesBaseUrl: MERCADOLIBRE_CO_BASE_URL,
   housingSlugs: MERCADOLIBRE_CO_HOUSING_SLUGS,
+  // Colombia rents are advertised as "arriendo" (not "alquiler").
+  rentSegment: 'arriendo',
   hrefRe:
     /href="(https:\/\/(?:departamento|casa|inmueble|ph|monoambiente)[^"]*mercadolibre\.com\.co\/MCO-?\d+[^"]*)"/i,
 };

--- a/packages/listing-providers/src/providers/ec/mercadolibre/index.ts
+++ b/packages/listing-providers/src/providers/ec/mercadolibre/index.ts
@@ -31,6 +31,8 @@ export const MERCADOLIBRE_EC_SITE: MercadolibreSiteConfig = {
   defaultCurrency: 'USD',
   inmueblesBaseUrl: MERCADOLIBRE_EC_BASE_URL,
   housingSlugs: MERCADOLIBRE_EC_HOUSING_SLUGS,
+  // Ecuador rents are advertised as "arriendo" (not "alquiler").
+  rentSegment: 'arriendo',
   hrefRe:
     /href="(https:\/\/(?:departamento|casa|inmueble|ph|monoambiente)[^"]*mercadolibre\.com\.ec\/MEC-?\d+[^"]*)"/i,
 };

--- a/packages/listing-providers/src/providers/mx/mercadolibre/fixtures.ts
+++ b/packages/listing-providers/src/providers/mx/mercadolibre/fixtures.ts
@@ -66,8 +66,14 @@ export const MERCADOLIBRE_MX_FIXTURE_DETAIL_HTML = `<!DOCTYPE html><html><head>
 {"name":"Renta departamento 2 recámaras Roma","image":"https://http2.mlstatic.com/fixture-ml-mx-1.jpg","offers":{"price":28000,"availability":"https://schema.org/InStock","url":"https://departamento.mercadolibre.com.mx/MLM-3847653074-renta-departamento-2-recamaras-roma-_JM","@type":"Offer","priceCurrency":"MXN"},"sku":"MLM3847653074","@context":"https://schema.org","@type":"Product","productID":"MLM3847653074"}
 </script>
 </head><body>
-<script>var x={"domain_id":"MLM-APARTMENTS_FOR_RENT","city":"Ciudad de México","neighborhood":"Roma Norte","state":"Ciudad de México"};</script>
+<script>var seller={"id":"seller_profile","type":"seller_profile","state":"VISIBLE"};</script>
+<script>var vip={"domain_id":"MLM-APARTMENTS_FOR_RENT","description_type":"plain_text","city":"Benito Juárez","neighborhood":"Roma Norte","state":"Ciudad de México"};</script>
+<script>var specs={"attributes":[{"icon":{"id":"BED","color":"BLACK","size":"XXSMALL"},"label":{"text":"2 rec.","color":"BLACK"}},{"icon":{"id":"BATHROOM","color":"BLACK","size":"XXSMALL"},"label":{"text":"2 baños","color":"BLACK"}},{"icon":{"id":"SCALE_UP","color":"BLACK","size":"XXSMALL"},"label":{"text":"72 m² totales","color":"BLACK"}}]};</script>
 <a href="tel:+525555667788">Llamar</a>
+<div class="ui-pdp-gallery">
+<a class="gallery-image__link" href="#"><img src="https://http2.mlstatic.com/D_NQ_NP_620729-MLM112636094885_062026-F.webp"/></a>
+<a class="gallery-image__link" href="#"><img src="https://http2.mlstatic.com/D_NQ_NP_708821-MLM112636094891_062026-F.webp"/></a>
+</div>
 <h1>Renta departamento</h1>
 </body></html>`;
 

--- a/packages/listing-providers/src/providers/mx/mercadolibre/index.ts
+++ b/packages/listing-providers/src/providers/mx/mercadolibre/index.ts
@@ -2,8 +2,9 @@
  * MercadoLibre Mexico inmuebles — classifieds, HOUSING ONLY.
  *
  * Thin wrapper over shared {@link ../../../mercadolibre} + {@link ../../../mercadolibreProvider}.
- * Bot/suspicious-traffic gated; keep OFF until live Playwright + residential proxy probe.
- * Registered OFF by default (`PROVIDER_MERCADOLIBRE_MX_ENABLED`).
+ * Cold HTTP works for search + detail HTML (verified — no account-verification wall
+ * from datacenter IPs, unlike CO/CL/PE/EC); item API is OAuth-gated. Registered OFF
+ * by default (`PROVIDER_MERCADOLIBRE_MX_ENABLED`) — enable after live probe.
  */
 
 import type { ProviderId } from '@homiio/shared-types';
@@ -64,7 +65,7 @@ export class MercadolibreMxProvider implements ListingProvider {
       locale: 'es-MX',
       acceptLanguage: 'es-MX,es;q=0.9,en;q=0.8',
       countryName: 'Mexico',
-      requireBrowserSession: true,
+      requireBrowserSession: false,
       runtime: options.runtime,
       cities: options.cities,
       metrics: options.metrics,


### PR DESCRIPTION
## Summary

Verified and fixed the LATAM MercadoLibre / Navent providers for cold-HTTP publishing, probing each portal's **real** housing search + detail from a datacenter IP (and, where blocked, confirming the anti-bot gate). All fixes are against real markup, not fixtures.

### Root-cause fixes (shared `mercadolibre.ts` — benefits all 6 ML countries)
- **`isMercadolibreChallenge` false-positive (the big one).** Every valid VIP detail page embeds an invisible reCAPTCHA v3 (`recaptchaSiteKey`, `ui-pdp-recaptcha-v3`). The bare `captcha` marker made the ladder's `classifyOutcome` treat good listings as challenges → `ChallengeError` → **every cold detail fetch failed**, including AR (which was marked "cold verified" but was actually broken). Narrowed to the real walls: `datadome`/`captcha-delivery`/`px-captcha` + ML's `account-verification`/`suspicious-traffic` gate.
- **Region = `"VISIBLE"`.** `extractVipFields` grabbed the first bare `"state"`, which is the `"state":"VISIBLE"` UI-component flag. Now anchored to the `city/neighborhood/state` address block.
- **No bedrooms/baths/m².** New `extractHighlightedSpecs` reads the VIP highlighted-specs array (`BED → "2 dorm."/"2 rec."`, `BATHROOM → "1 baño"`, `SCALE_UP → "75 m² totales"`) — the only reliable cold source now the public items API is OAuth-gated (403 `PA_UNAUTHORIZED`).
- **1 image instead of the gallery.** New `extractGalleryImages` reads the full `gallery-image__link` gallery.
- Operation derived from the domain id (`…_FOR_SALE`/`…_FOR_RENT`) with a URL fallback.

### Provider config
- **MX**: `requireBrowserSession` `true → false` — cold search + detail verified (no `account-verification` wall from datacenter IPs, unlike CO/CL/PE/EC).
- **CO / EC**: `rentSegment → 'arriendo'` (regional Spanish; was defaulting to `alquiler`, which finds nothing).

### Viability (probed live, datacenter IP)
| Provider | Country | Cold reachable | Housing filter | Class |
|---|---|---|---|---|
| mercadolibre_ar | AR | ✅ search+detail | ✅ | ✅ **cold-HTTP** |
| mercadolibre_mx | MX | ✅ search+detail | ✅ | ✅ **cold-HTTP** |
| mercadolibre_co | CO | ❌ `/gz/account-verification` | ✅ | 🟠 browser+residential |
| mercadolibre_cl | CL | ❌ `/gz/account-verification` | ✅ | 🟠 browser+residential |
| mercadolibre_pe | PE | ❌ `/gz/account-verification` | ✅ | 🟠 browser+residential |
| mercadolibre_ec | EC | ❌ `/gz/account-verification` | ✅ | 🟠 browser+residential |
| zonaprop | AR | ❌ 403 Cloudflare | n/a | 🟠 browser+residential |
| argenprop | AR | ⚠️ reachable now, CF IP-reputation risk | n/a | 🟠 browser+residential |
| properati | AR | ⚠️ JSON-LD reachable now, CF IP-reputation risk | n/a | 🟠 browser+residential |

Navent/Properati stay browser-tier by design (shared factory with the CF-blocked Zonaprop; prod ECS IP reputation unverified). The residential proxy (DataImpulse) could not be exercised from this environment (407 auth) — those rows are classified from the observed anti-bot gates.

### Tests
354 provider tests green. Fixtures updated to the real cold structure (highlighted-specs array, gallery anchors, a decoy `"state":"VISIBLE"`); new assertions cover beds/baths/m²/region/gallery and the reCAPTCHA-is-not-a-challenge regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)