### PR TITLE
fix(otodom): activate enabled provider — repair discover URLs + detail price

### DIFF
--- a/packages/backend/__tests__/unit/ceuProviders.test.ts
+++ b/packages/backend/__tests__/unit/ceuProviders.test.ts
@@ -18,6 +18,7 @@ import {
   parseOtodomDetail,
   parseOtodomSearch,
   OTODOM_FIXTURE_DETAIL_HTML,
+  OTODOM_FIXTURE_DETAIL_UNIFIED_HTML,
   OTODOM_FIXTURE_SEARCH_HTML,
   FundaProvider,
   parseFundaDetail,
@@ -97,6 +98,19 @@ describe('OtodomProvider (PL)', () => {
     expect(refs[0].sourceId).toBe('67155161');
   });
 
+  it('rebuilds canonical /pl/oferta/<slug> URLs from `[lang]/ad/` hrefs', () => {
+    const refs = parseOtodomSearch(OTODOM_FIXTURE_SEARCH_HTML);
+    // The portal `href` is a `[lang]/ad/<slug>` template whose path 404s; the
+    // discover ref must point at the canonical detail URL that actually resolves.
+    expect(refs[0].url).toBe(
+      'https://www.otodom.pl/pl/oferta/bez-prowizji-2-pokoje-ul-bunscha-ID4xM7L',
+    );
+    for (const ref of refs) {
+      expect(ref.url).toMatch(/^https:\/\/www\.otodom\.pl\/pl\/oferta\/[^/]+$/);
+      expect(ref.url).not.toContain('/ad/');
+    }
+  });
+
   it('normalizes detail with contact phones', () => {
     const payload = parseOtodomDetail(
       OTODOM_FIXTURE_DETAIL_HTML,
@@ -111,6 +125,27 @@ describe('OtodomProvider (PL)', () => {
     expect(listing.contact?.phone).toContain('48698089999');
     expect(listing.longTermRent?.monthlyAmount).toBe(2900);
     expect(listing.bedrooms).toBe(2);
+  });
+
+  it('resolves price from unifiedAd/characteristics (current markup, no ad.totalPrice)', () => {
+    const payload = parseOtodomDetail(
+      OTODOM_FIXTURE_DETAIL_UNIFIED_HTML,
+      'https://www.otodom.pl/pl/oferta/mieszkanie-2-pokojowe-skorosze-ID4CamF',
+    );
+    const listing = otodom.normalize({
+      ref: { provider: 'otodom', sourceId: payload.sourceId, url: payload.url },
+      payload,
+    });
+    expect(listing.source).toBe('otodom');
+    expect(listing.offerings).toContain(OfferingType.LONG_TERM_RENT);
+    expect(listing.longTermRent?.monthlyAmount).toBe(3650);
+    expect(listing.longTermRent?.currency).toBe('PLN');
+    expect(listing.bedrooms).toBe(2);
+    expect(listing.squareFootage).toBe(38);
+    expect(listing.address.city).toBe('Warszawa');
+    expect(listing.address.coordinates?.lat).toBeCloseTo(52.188404, 4);
+    expect(listing.remoteImages.length).toBe(2);
+    expect(listing.contact?.phone).toContain('48733806496');
   });
 });
 

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -1070,6 +1070,7 @@ export {
 export {
   OTODOM_BASE_URL,
   OTODOM_FIXTURE_DETAIL_HTML,
+  OTODOM_FIXTURE_DETAIL_UNIFIED_HTML,
   OTODOM_FIXTURE_SEARCH_HTML,
 } from './providers/pl/otodom/fixtures';
 

--- a/packages/listing-providers/src/providers/pl/otodom/fixtures.ts
+++ b/packages/listing-providers/src/providers/pl/otodom/fixtures.ts
@@ -31,7 +31,7 @@ export const OTODOM_FIXTURE_SEARCH_HTML = `<!doctype html>
               "id": 67155161,
               "title": "Bez prowizji - 2 pokoje - ul. Bunscha",
               "slug": "bez-prowizji-2-pokoje-ul-bunscha-ID4xM7L",
-              "href": "/pl/oferta/bez-prowizji-2-pokoje-ul-bunscha-ID4xM7L",
+              "href": "[lang]/ad/bez-prowizji-2-pokoje-ul-bunscha-ID4xM7L",
               "estate": "FLAT",
               "transaction": "RENT",
               "totalPrice": { "value": 2900, "currency": "PLN" },
@@ -50,7 +50,7 @@ export const OTODOM_FIXTURE_SEARCH_HTML = `<!doctype html>
               "id": 67155162,
               "title": "Mieszkanie na sprzedaż",
               "slug": "mieszkanie-krakow-ID4xM7M",
-              "href": "/pl/oferta/mieszkanie-krakow-ID4xM7M",
+              "href": "[lang]/ad/mieszkanie-krakow-ID4xM7M",
               "estate": "FLAT",
               "transaction": "SELL",
               "totalPrice": { "value": 650000, "currency": "PLN" },
@@ -103,6 +103,75 @@ export const OTODOM_FIXTURE_DETAIL_HTML = `<!doctype html>
         "images": [
           { "large": "https://ireland.apollo.olxcdn.com/v1/files/example-67155161.jpg" }
         ]
+      }
+    }
+  }
+}
+</script>
+</body>
+</html>`;
+
+/**
+ * Current Otodom detail markup: the headline price lives in
+ * `unifiedAd.price.rentalPrice` / `ad.characteristics`, the operation in
+ * `ad.adCategory.type`, and there is no `ad.totalPrice`. This is the shape the
+ * live portal serves today — the legacy fixture above keeps the old-shape path
+ * covered.
+ */
+export const OTODOM_FIXTURE_DETAIL_UNIFIED_HTML = `<!doctype html>
+<html lang="pl">
+<head><title>Mieszkanie 2- pokojowe Skorosze | Otodom.pl</title></head>
+<body>
+<script id="__NEXT_DATA__" type="application/json">
+{
+  "props": {
+    "pageProps": {
+      "id": "68201653",
+      "contactDetails": {
+        "name": "Marcin",
+        "type": "private",
+        "phones": ["+48733806496"]
+      },
+      "ad": {
+        "id": 68201653,
+        "title": "Mieszkanie 2- pokojowe, Skorosze przy Alejach Jerozolimskich",
+        "slug": "mieszkanie-2-pokojowe-skorosze-ID4CamF",
+        "url": "https://www.otodom.pl/pl/oferta/mieszkanie-2-pokojowe-skorosze-ID4CamF",
+        "description": "Przytulne mieszkanie na Skoroszach.",
+        "price": { "type": "VISIBLE" },
+        "adCategory": { "id": 102, "name": "FLAT", "type": "RENT" },
+        "target": { "OfferType": "wynajem", "Price": 3650, "Rooms_num": ["2"], "Area": 38 },
+        "attributes": { "rooms_num": "2", "m": "38", "building_type": "apartment" },
+        "characteristics": [
+          { "key": "price", "value": "3650", "currency": "PLN", "localizedValue": "3650 zł" },
+          { "key": "rent", "value": "950", "currency": "PLN", "localizedValue": "950 zł" },
+          { "key": "m", "value": "38", "localizedValue": "38 m²", "currency": "" },
+          { "key": "rooms_num", "value": "2", "localizedValue": "2", "currency": "" }
+        ],
+        "location": {
+          "address": { "street": { "name": "al. Aleje Jerozolimskie", "number": null } },
+          "reverseGeocoding": {
+            "locations": [
+              { "name": "mazowieckie", "locationLevel": "voivodeship" },
+              { "name": "Warszawa", "locationLevel": "city_or_village" },
+              { "name": "Skorosze", "locationLevel": "residential" }
+            ]
+          },
+          "coordinates": { "latitude": 52.188404, "longitude": 20.912094 }
+        },
+        "images": [
+          { "large": "https://ireland.apollo.olxcdn.com/v1/files/example-68201653-1.jpg" },
+          { "large": "https://ireland.apollo.olxcdn.com/v1/files/example-68201653-2.jpg" }
+        ]
+      },
+      "unifiedAd": {
+        "id": 68201653,
+        "title": "Mieszkanie 2- pokojowe, Skorosze przy Alejach Jerozolimskich",
+        "attributes": { "rooms_num": "2", "m": "38" },
+        "price": {
+          "__typename": "RentalPrice",
+          "rentalPrice": { "value": 3650, "currency": "PLN", "__typename": "Money" }
+        }
       }
     }
   }

--- a/packages/listing-providers/src/providers/pl/otodom/parse.ts
+++ b/packages/listing-providers/src/providers/pl/otodom/parse.ts
@@ -63,11 +63,21 @@ export function otodomSearchUrl(city: string, kind: 'rent' | 'sale', page = 1): 
   return page <= 1 ? base : `${base}?page=${page}`;
 }
 
+/**
+ * Build a canonical Otodom detail URL. Search results expose a clean `slug`
+ * plus an `href` template of the form `[lang]/ad/<slug>`; the canonical detail
+ * path is `/pl/oferta/<slug>` (the `[lang]/ad/` template path 404s). Reduce
+ * whatever we get to its slug and rebuild against the canonical path.
+ */
 function absoluteOfferUrl(hrefOrSlug: string): string {
-  const normalized = hrefOrSlug.replace('[lang]', 'pl');
-  if (normalized.startsWith('http')) return normalized.split('?')[0] ?? normalized;
-  const path = normalized.startsWith('/') ? normalized : `/pl/oferta/${normalized}`;
-  return `${OTODOM_BASE_URL}${path.split('?')[0]}`;
+  const value = hrefOrSlug.trim();
+  if (value.startsWith('http')) return value.split('?')[0] ?? value;
+  const slug = value
+    .split('?')[0]
+    .replace(/^\[lang\]/, '')
+    .replace(/^\/+/, '')
+    .replace(/^(?:pl\/)?(?:oferta|ad)\//, '');
+  return `${OTODOM_BASE_URL}/pl/oferta/${slug}`;
 }
 
 function operationFromTransaction(value: unknown): 'rent' | 'sale' {
@@ -145,6 +155,80 @@ function moneyFromItem(item: Record<string, unknown>): { value: number; currency
   return undefined;
 }
 
+/** Read a `{ value, currency }` Money node (Otodom unifiedAd nested price). */
+function moneyFromObject(value: unknown): { value: number; currency: string } | undefined {
+  if (!isRecord(value)) return undefined;
+  const amount = asNumber(value.value);
+  if (amount === undefined || amount <= 0) return undefined;
+  return { value: amount, currency: asString(value.currency) ?? 'PLN' };
+}
+
+/** Resolve rent/sale for a detail ad from category / price typename / offer type. */
+function detailOperation(
+  ad: Record<string, unknown> | undefined,
+  unified: Record<string, unknown> | undefined,
+): 'rent' | 'sale' {
+  const categoryType = ad && isRecord(ad.adCategory) ? asString(ad.adCategory.type) : undefined;
+  if (categoryType) {
+    if (/sell|sale/i.test(categoryType)) return 'sale';
+    if (/rent/i.test(categoryType)) return 'rent';
+  }
+  const priceType = unified && isRecord(unified.price) ? asString(unified.price.__typename) : undefined;
+  if (priceType) {
+    if (/sell|sale/i.test(priceType)) return 'sale';
+    if (/rent/i.test(priceType)) return 'rent';
+  }
+  const offerType = ad && isRecord(ad.target) ? asString(ad.target.OfferType) : undefined;
+  if (offerType) {
+    if (/sprzeda/i.test(offerType)) return 'sale';
+    if (/wynaj/i.test(offerType)) return 'rent';
+  }
+  return operationFromTransaction(ad?.transaction ?? unified?.transaction);
+}
+
+/** Headline price from `ad.characteristics` (`[{ key: 'price', value, currency }]`). */
+function characteristicPrice(
+  ad: Record<string, unknown> | undefined,
+): { value: number; currency: string } | undefined {
+  if (!ad || !Array.isArray(ad.characteristics)) return undefined;
+  for (const entry of ad.characteristics) {
+    if (!isRecord(entry) || asString(entry.key) !== 'price') continue;
+    const amount = asNumber(entry.value);
+    if (amount !== undefined && amount > 0) {
+      return { value: amount, currency: asString(entry.currency) ?? 'PLN' };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the headline price + currency + operation from a detail ad/unifiedAd.
+ * Detail pages no longer carry `ad.price.value` / `ad.transaction`; the amount
+ * lives in `unifiedAd.price.{rentalPrice,sellingPrice,price}`, in
+ * `ad.characteristics`, or in `ad.target.Price`.
+ */
+function detailMoney(
+  ad: Record<string, unknown> | undefined,
+  unified: Record<string, unknown> | undefined,
+): { value: number; currency: string; operation: 'rent' | 'sale' } | undefined {
+  const operation = detailOperation(ad, unified);
+  const unifiedPrice = unified && isRecord(unified.price) ? unified.price : undefined;
+  const fromUnified =
+    moneyFromObject(unifiedPrice?.rentalPrice) ??
+    moneyFromObject(unifiedPrice?.sellingPrice) ??
+    moneyFromObject(unifiedPrice?.price) ??
+    moneyFromObject(unifiedPrice);
+  if (fromUnified) return { ...fromUnified, operation };
+  const fromCharacteristics = characteristicPrice(ad);
+  if (fromCharacteristics) return { ...fromCharacteristics, operation };
+  const fromTarget = ad && isRecord(ad.target) ? asNumber(ad.target.Price) : undefined;
+  if (fromTarget !== undefined && fromTarget > 0) return { value: fromTarget, currency: 'PLN', operation };
+  // Legacy markup: `ad.totalPrice` / `ad.price.value` (kept for older payloads).
+  const legacy = (ad ? moneyFromItem(ad) : undefined) ?? (unified ? moneyFromItem(unified) : undefined);
+  if (legacy) return legacy;
+  return undefined;
+}
+
 function parseContact(details: unknown): NormalizedListingContact | undefined {
   if (!isRecord(details)) return undefined;
   const name = asString(details.name);
@@ -205,7 +289,9 @@ export function parseOtodomSearch(htmlOrJson: string): OtodomSearchRef[] {
   for (const item of items) {
     if (!isRecord(item)) continue;
     const id = asString(item.id) ?? (typeof item.id === 'number' ? String(item.id) : undefined);
-    const href = asString(item.href) ?? asString(item.slug) ?? asString(item.url);
+    // Prefer the clean `slug`; `href` is a `[lang]/ad/<slug>` template whose
+    // path segment 404s — `absoluteOfferUrl` rebuilds the canonical URL either way.
+    const href = asString(item.slug) ?? asString(item.href) ?? asString(item.url);
     if (!id || !href) continue;
     const money = moneyFromItem(item);
     if (!money || money.value <= 0) continue;
@@ -239,15 +325,7 @@ export function parseOtodomDetail(html: string, url: string): OtodomRawListing {
     throw new Error('otodom: could not resolve sourceId');
   }
 
-  const priceInfo =
-    (ad ? moneyFromItem(ad) : undefined) ??
-    (unified
-      ? moneyFromItem({
-          ...unified,
-          transaction: unified.transaction ?? ad?.transaction,
-          totalPrice: unified.totalPrice ?? unified.price,
-        })
-      : undefined);
+  const priceInfo = detailMoney(ad, unified);
   if (!priceInfo) {
     throw new Error(`otodom: listing ${sourceId} has no resolvable price`);
   }
@@ -285,7 +363,15 @@ export function parseOtodomDetail(html: string, url: string): OtodomRawListing {
   const squareMeters = asNumber(attrs.m) ?? asNumber(ad?.areaInSquareMeters);
   if (squareMeters !== undefined) result.squareMeters = squareMeters;
   if (place.coordinates) result.coordinates = place.coordinates;
-  const estate = asString(ad?.estate) ?? asString(unified?.estate);
+  // `ad.estate` is gone from current markup; derive the dwelling kind from the
+  // OLX category name (`FLAT`/`HOUSE`) or the `building_type` attribute so houses
+  // are not all misclassified as apartments.
+  const adCategoryName = ad && isRecord(ad.adCategory) ? asString(ad.adCategory.name) : undefined;
+  const estate =
+    asString(ad?.estate) ??
+    asString(unified?.estate) ??
+    adCategoryName ??
+    asString(attrs.building_type);
   if (estate) result.estate = estate;
 
   const contact = parseContact(props.contactDetails);


### PR DESCRIPTION
## Summary
Part of activating listing providers that are enabled in prod but produce no inventory (daft, otodom, onthemarket, openrent, apartments_com, zillow). This PR fixes the one provider with a real, verifiable code bug: **Otodom (PL)**.

## Otodom fixes (verified against live otodom.pl)
- **Discover URLs were 404s.** Search `href` is a `[lang]/ad/<slug>` template; the parser emitted `/pl/oferta/pl/ad/<slug>` (404). Now rebuilds the canonical `/pl/oferta/<slug>` (verified 200) from the clean `slug`.
- **Detail price/operation broke on current markup.** `ad.price.value`/`ad.transaction` are gone; the amount now lives in `unifiedAd.price.rentalPrice` / `ad.characteristics` / `ad.target.Price`, operation in `ad.adCategory.type`. New `detailMoney`/`detailOperation` resolver with a legacy fallback; `estate` derived from `adCategory.name`/`building_type`.
- New `OTODOM_FIXTURE_DETAIL_UNIFIED_HTML` (current markup) + 2 tests (canonical URL rebuild, unifiedAd/characteristics price path). End-to-end verified on a live listing: price 3650 PLN, 2 rooms, 38 m², 20 images, contact + coordinates.

## Viability of the other 5 (no code change in this PR)
- **onthemarket (GB)** and **openrent (GB)**: cold-HTTP works end-to-end from an AWS datacenter IP (28 / 20 discover refs, full normalize with price/beds/images/contact). No parser bug — their prod count=0 was discover scheduling (idealista was hogging the queue), now unblocked.
- **daft (IE)**: Cloudflare "Just a moment" + DataDome — 403 on cold HTTP, geo-correct residential proxy, AND headless Playwright+residential. Needs managed anti-bot fetch; not fixable in parser code.
- **apartments_com (US)**: Akamai Bot Manager (`errors.edgesuite.net`) — 403 on all of the above. Needs managed fetch.
- **zillow (US)**: PerimeterX — 403 on all of the above. Needs managed fetch.

Prod worker currently has `LISTING_HTTP_USE_PROXY`, `LISTING_BROWSER_ENABLED`, and `LISTING_MANAGED_FETCH_URL` all unset, so every provider gets only a direct datacenter-IP GET — the three hard-anti-bot portals will stay at 0 until a managed-fetch tier is provisioned (infra, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)