### PR TITLE
feat(providers): activate DE + MercadoLibre AR/MX + otodom (cold-HTTP fixes)

### DIFF
--- a/packages/backend/__tests__/unit/arProviders.test.ts
+++ b/packages/backend/__tests__/unit/arProviders.test.ts
@@ -20,6 +20,7 @@ import {
   parseMercadolibreArDetail,
   parseMercadolibreArSearch,
   parseMercadolibreArSearchJson,
+  isMercadolibreArChallenge,
   isMercadolibreArHousingCategory,
   mercadolibreArHousingSearchUrl,
   MERCADOLIBRE_AR_FIXTURE_DETAIL_HTML,
@@ -118,7 +119,15 @@ describe('MercadolibreArProvider', () => {
     expect(isMercadolibreArHousingCategory(undefined, 'CARS_AND_VANS')).toBe(false);
   });
 
-  it('normalizes detail HTML with VIP city fields', () => {
+  it('does not flag a valid VIP detail page (invisible reCAPTCHA v3) as a challenge', () => {
+    // The contact form embeds reCAPTCHA; a bare `captcha` marker used to false-positive
+    // and make the cold-HTTP ladder discard a perfectly good listing.
+    expect(isMercadolibreArChallenge(MERCADOLIBRE_AR_FIXTURE_DETAIL_HTML)).toBe(false);
+    expect(isMercadolibreArChallenge('<html>datadome captcha-delivery</html>')).toBe(true);
+    expect(isMercadolibreArChallenge('go=account-verification suspicious-traffic')).toBe(true);
+  });
+
+  it('normalizes cold-HTTP detail HTML with specs, region and gallery', () => {
     const refs = parseMercadolibreArSearch(MERCADOLIBRE_AR_FIXTURE_SEARCH_HTML);
     expect(refs.length).toBeGreaterThanOrEqual(1);
     const payload = parseMercadolibreArDetail(
@@ -133,6 +142,14 @@ describe('MercadolibreArProvider', () => {
     expect(listing.address.city).toBe('Capital Federal');
     expect(listing.address.neighborhood).toBe('Belgrano');
     expect(listing.contact?.phone).toBeTruthy();
+    // Highlighted-specs block (`BED → "2 dorm."`, `BATHROOM → "1 baño"`, `SCALE_UP → "55 m² totales"`).
+    expect(listing.bedrooms).toBe(2);
+    expect(listing.bathrooms).toBe(1);
+    expect(listing.squareFootage).toBe(55);
+    // Region resolves to the address-adjacent state, not the UI `"state":"VISIBLE"` flag.
+    expect(listing.address.state).toBe('Capital Federal');
+    // Full server-rendered gallery, not the single JSON-LD image.
+    expect(listing.remoteImages.length).toBeGreaterThanOrEqual(2);
   });
 
   it('throws NonHousingListingError for car item JSON', () => {

--- a/packages/backend/__tests__/unit/ceuProviders.test.ts
+++ b/packages/backend/__tests__/unit/ceuProviders.test.ts
@@ -18,6 +18,7 @@ import {
   parseOtodomDetail,
   parseOtodomSearch,
   OTODOM_FIXTURE_DETAIL_HTML,
+  OTODOM_FIXTURE_DETAIL_UNIFIED_HTML,
   OTODOM_FIXTURE_SEARCH_HTML,
   FundaProvider,
   parseFundaDetail,
@@ -97,6 +98,19 @@ describe('OtodomProvider (PL)', () => {
     expect(refs[0].sourceId).toBe('67155161');
   });
 
+  it('rebuilds canonical /pl/oferta/<slug> URLs from `[lang]/ad/` hrefs', () => {
+    const refs = parseOtodomSearch(OTODOM_FIXTURE_SEARCH_HTML);
+    // The portal `href` is a `[lang]/ad/<slug>` template whose path 404s; the
+    // discover ref must point at the canonical detail URL that actually resolves.
+    expect(refs[0].url).toBe(
+      'https://www.otodom.pl/pl/oferta/bez-prowizji-2-pokoje-ul-bunscha-ID4xM7L',
+    );
+    for (const ref of refs) {
+      expect(ref.url).toMatch(/^https:\/\/www\.otodom\.pl\/pl\/oferta\/[^/]+$/);
+      expect(ref.url).not.toContain('/ad/');
+    }
+  });
+
   it('normalizes detail with contact phones', () => {
     const payload = parseOtodomDetail(
       OTODOM_FIXTURE_DETAIL_HTML,
@@ -111,6 +125,27 @@ describe('OtodomProvider (PL)', () => {
     expect(listing.contact?.phone).toContain('48698089999');
     expect(listing.longTermRent?.monthlyAmount).toBe(2900);
     expect(listing.bedrooms).toBe(2);
+  });
+
+  it('resolves price from unifiedAd/characteristics (current markup, no ad.totalPrice)', () => {
+    const payload = parseOtodomDetail(
+      OTODOM_FIXTURE_DETAIL_UNIFIED_HTML,
+      'https://www.otodom.pl/pl/oferta/mieszkanie-2-pokojowe-skorosze-ID4CamF',
+    );
+    const listing = otodom.normalize({
+      ref: { provider: 'otodom', sourceId: payload.sourceId, url: payload.url },
+      payload,
+    });
+    expect(listing.source).toBe('otodom');
+    expect(listing.offerings).toContain(OfferingType.LONG_TERM_RENT);
+    expect(listing.longTermRent?.monthlyAmount).toBe(3650);
+    expect(listing.longTermRent?.currency).toBe('PLN');
+    expect(listing.bedrooms).toBe(2);
+    expect(listing.squareFootage).toBe(38);
+    expect(listing.address.city).toBe('Warszawa');
+    expect(listing.address.coordinates?.lat).toBeCloseTo(52.188404, 4);
+    expect(listing.remoteImages.length).toBe(2);
+    expect(listing.contact?.phone).toContain('48733806496');
   });
 });
 

--- a/packages/backend/__tests__/unit/immobilienscout24Provider.test.ts
+++ b/packages/backend/__tests__/unit/immobilienscout24Provider.test.ts
@@ -44,6 +44,10 @@ describe('ImmobilienScout24Provider', () => {
     expect(listing.remoteImages.length).toBe(2);
     expect(listing.contact?.phone).toMatch(/493012345678/);
     expect(listing.contact?.agencyName).toMatch(/Mitte Homes/i);
+    // Description comes from the 'Objektbeschreibung' TEXT_AREA block (the real
+    // mobile expose shape), not the 'Lage' block that precedes it.
+    expect(listing.description).toMatch(/Balkon/i);
+    expect(listing.description).not.toMatch(/Rosenthaler Platz/i);
   });
 
   it('derives source id and public URL helpers', () => {

--- a/packages/backend/__tests__/unit/kleinanzeigenProvider.test.ts
+++ b/packages/backend/__tests__/unit/kleinanzeigenProvider.test.ts
@@ -44,6 +44,14 @@ describe('KleinanzeigenProvider housing filter', () => {
     expect(listing.address.countryCode).toBe('DE');
     expect(listing.contact?.phone).toMatch(/493098765432/);
     expect(listing.contact?.whatsapp).toMatch(/493098765432/);
+    // Full gallery is captured (not just og:image), deduped by base id,
+    // normalized to the largest `$_57.AUTO` variant, og:image primary.
+    expect(listing.remoteImages).toHaveLength(3);
+    expect(listing.remoteImages[0]?.url).toBe(
+      'https://img.kleinanzeigen.de/api/v1/prod-ads/images/aa/example-1?rule=$_57.AUTO',
+    );
+    expect(listing.remoteImages[0]?.isPrimary).toBe(true);
+    expect(listing.remoteImages.every((image) => image.url.endsWith('?rule=$_57.AUTO'))).toBe(true);
   });
 
   it('rejects non-housing detail HTML', () => {
@@ -58,5 +66,16 @@ describe('KleinanzeigenProvider housing filter', () => {
     expect(url).toContain('/c203');
     expect(url).toContain('wohnung-mieten');
     expect(() => kleinanzeigenHousingSearchUrl('berlin', 1, '216')).toThrow(/not a housing category/);
+  });
+
+  it('paginates with `seite:N` before the category code (keeps the category filter)', () => {
+    // Appending `/seite:N` AFTER the `c203l…` code drops the category filter and
+    // returns a site-wide page; the page segment must sit before the code.
+    expect(kleinanzeigenHousingSearchUrl('berlin', 2, '203')).toBe(
+      'https://www.kleinanzeigen.de/s-wohnung-mieten/berlin/seite:2/c203l3331',
+    );
+    expect(kleinanzeigenHousingSearchUrl('muenchen', 3, '205')).toBe(
+      'https://www.kleinanzeigen.de/s-haus-mieten/muenchen/seite:3/c205l6411',
+    );
   });
 });

--- a/packages/backend/__tests__/unit/latamProviders.test.ts
+++ b/packages/backend/__tests__/unit/latamProviders.test.ts
@@ -64,7 +64,7 @@ describe('MercadolibreCoProvider', () => {
     expect(provider.markets).toEqual(['CO']);
     const url = mercadolibreCoHousingSearchUrl('bogota-dc');
     expect(isHousingCategoryUrl(url, MERCADOLIBRE_CO_HOUSING_SLUGS)).toBe(true);
-    expect(url).toContain('/departamentos/alquiler/');
+    expect(url).toContain('/departamentos/arriendo/');
   });
 
   it('parses housing search JSON and rejects cars', () => {
@@ -218,7 +218,7 @@ describe('MercadolibreMxProvider', () => {
     expect(isMercadolibreMxHousingCategory(undefined, 'CARS_AND_VANS')).toBe(false);
   });
 
-  it('normalizes detail HTML with contact', () => {
+  it('normalizes cold-HTTP detail HTML with specs, region and gallery', () => {
     const refs = parseMercadolibreMxSearch(MERCADOLIBRE_MX_FIXTURE_SEARCH_HTML);
     expect(refs.length).toBeGreaterThanOrEqual(1);
     const payload = parseMercadolibreMxDetail(
@@ -232,5 +232,14 @@ describe('MercadolibreMxProvider', () => {
     expect(listing.longTermRent?.currency).toBe('MXN');
     expect(listing.address.countryCode).toBe('MX');
     expect(listing.contact?.phone).toBeTruthy();
+    // Highlighted-specs block (`BED → "2 rec."`, `BATHROOM → "2 baños"`, `SCALE_UP → "72 m² totales"`).
+    expect(listing.bedrooms).toBe(2);
+    expect(listing.bathrooms).toBe(2);
+    expect(listing.squareFootage).toBe(72);
+    // Region is the address-adjacent state, never the UI `"state":"VISIBLE"` flag.
+    expect(listing.address.state).toBe('Ciudad de México');
+    // Full gallery, not the single JSON-LD image.
+    expect(listing.remoteImages.length).toBeGreaterThanOrEqual(2);
+    expect(listing.remoteImages[0]?.url).toContain('http2.mlstatic.com');
   });
 });

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -1070,6 +1070,7 @@ export {
 export {
   OTODOM_BASE_URL,
   OTODOM_FIXTURE_DETAIL_HTML,
+  OTODOM_FIXTURE_DETAIL_UNIFIED_HTML,
   OTODOM_FIXTURE_SEARCH_HTML,
 } from './providers/pl/otodom/fixtures';
 

--- a/packages/listing-providers/src/mercadolibre.ts
+++ b/packages/listing-providers/src/mercadolibre.ts
@@ -393,7 +393,7 @@ function extractHighlightedSpecs(html: string): {
 function extractGalleryImages(html: string): string[] {
   const out: string[] = [];
   const seen = new Set<string>();
-  const re = /class="gallery-image__link"[^>]*>\s*<img[^>]*\bsrc="(https:\/\/[^"]+)"/g;
+  const re = /class="gallery-image__link"[^>]{0,400}>\s{0,20}<img[^>]{0,400}\bsrc="(https:\/\/[^"]{0,2000})"/g;
   for (const match of html.matchAll(re)) {
     const url = match[1];
     if (seen.has(url)) continue;

--- a/packages/listing-providers/src/mercadolibre.ts
+++ b/packages/listing-providers/src/mercadolibre.ts
@@ -93,7 +93,13 @@ function asNumber(value: unknown): number | undefined {
 
 export function isMercadolibreChallenge(body: string): boolean {
   if (body.trim().length < 128) return true;
-  return /suspicious-traffic|captcha|datadome|access denied|just a moment|PA_UNAUTHORIZED/i.test(
+  // Narrow, anti-bot-specific markers only. A bare `captcha` false-positives on
+  // every VALID VIP detail page — MercadoLibre embeds an invisible reCAPTCHA v3
+  // (`recaptchaSiteKey`, `ui-pdp-recaptcha-v3`) in the contact form — which would
+  // make the cold-HTTP ladder treat a perfectly good listing as a challenge.
+  // The real walls are DataDome (`datadome` / `captcha-delivery` / `px-captcha`)
+  // and MercadoLibre's own `account-verification` / `suspicious-traffic` gate.
+  return /suspicious-traffic|account-verification|captcha-delivery|px-captcha|datadome|access denied|just a moment|PA_UNAUTHORIZED/i.test(
     body,
   );
 }
@@ -306,18 +312,95 @@ export function parseMercadolibreSearch(
   return out;
 }
 
-/** Pull VIP-embedded city/neighborhood/domain from detail HTML. */
+/** Pull VIP-embedded city/neighborhood/state/domain from detail HTML. */
 function extractVipFields(html: string): {
   city?: string;
   neighborhood?: string;
   state?: string;
   domainId?: string;
 } {
-  const city = html.match(/"city"\s*:\s*"([^"]+)"/)?.[1];
-  const neighborhood = html.match(/"neighborhood"\s*:\s*"([^"]+)"/)?.[1];
-  const state = html.match(/"state"\s*:\s*"([^"]+)"/)?.[1];
+  // The VIP tracking block renders the location fields adjacently:
+  // `"city":"…","neighborhood":"…","state":"…"`. Anchoring `state` to that
+  // adjacency avoids the earlier `"state":"VISIBLE"` UI-component flag, which is
+  // the FIRST bare `"state"` on the page and previously polluted the region.
+  const loc = html.match(
+    /"city"\s*:\s*"([^"]+)"\s*,\s*"neighborhood"\s*:\s*"([^"]*)"\s*,\s*"state"\s*:\s*"([^"]+)"/,
+  );
+  const city = loc?.[1] ?? html.match(/"city"\s*:\s*"([^"]+)"/)?.[1];
+  const neighborhood = (loc?.[2]?.trim() || undefined) ?? html.match(/"neighborhood"\s*:\s*"([^"]+)"/)?.[1];
+  const state = loc?.[3];
   const domainId = html.match(/"domain_id"\s*:\s*"([^"]+)"/)?.[1];
   return { city, neighborhood, state, domainId };
+}
+
+/** First integer in a highlighted-specs label such as "2 dorm." / "1 baño". */
+function labelInt(text: string): number | undefined {
+  const match = text.match(/(\d+)/);
+  return match ? Number.parseInt(match[1], 10) : undefined;
+}
+
+/** First number in an area label such as "138 m² totales" / "30,5 m²". */
+function labelArea(text: string): number | undefined {
+  const match = text.match(/(\d+(?:[.,]\d+)?)/);
+  if (!match) return undefined;
+  const parsed = Number.parseFloat(match[1].replace(',', '.'));
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Bedrooms / bathrooms / covered area from the VIP highlighted-specs block —
+ * the only reliable cold-HTTP source now that the public items API is
+ * OAuth-gated. It is the first `"attributes":[…]` array carrying a `BATHROOM`
+ * or `SCALE_UP` icon; each entry is an `{icon:{id},label:{text}}` pair
+ * (`BED → "2 dorm."/"2 rec."`, `BATHROOM → "1 baño"`, `SCALE_UP → "75 m² totales"`).
+ */
+function extractHighlightedSpecs(html: string): {
+  bedrooms?: number;
+  bathrooms?: number;
+  squareMeters?: number;
+} {
+  const marker = '"attributes":[';
+  let from = 0;
+  for (;;) {
+    const start = html.indexOf(marker, from);
+    if (start < 0) break;
+    const open = start + marker.length - 1;
+    const end = html.indexOf(']', open);
+    if (end < 0) break;
+    const block = html.slice(open, end + 1);
+    from = end + 1;
+    if (!/"id":"(?:BATHROOM|SCALE_UP|BED|BEDROOM)"/.test(block)) continue;
+
+    const result: { bedrooms?: number; bathrooms?: number; squareMeters?: number } = {};
+    const pairRe = /"id":"([A-Z_]+)"[^}]*\}\s*,\s*"label":\{"text":"([^"]+)"/g;
+    for (const match of block.matchAll(pairRe)) {
+      const icon = match[1];
+      const text = match[2];
+      if (/^BED(?:ROOM)?$/.test(icon) && result.bedrooms === undefined) {
+        result.bedrooms = labelInt(text);
+      } else if (icon === 'BATHROOM' && result.bathrooms === undefined) {
+        result.bathrooms = labelInt(text);
+      } else if (icon === 'SCALE_UP' && result.squareMeters === undefined) {
+        result.squareMeters = labelArea(text);
+      }
+    }
+    return result;
+  }
+  return {};
+}
+
+/** Main-gallery image URLs from the server-rendered `gallery-image__link` anchors. */
+function extractGalleryImages(html: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const re = /class="gallery-image__link"[^>]*>\s*<img[^>]*\bsrc="(https:\/\/[^"]+)"/g;
+  for (const match of html.matchAll(re)) {
+    const url = match[1];
+    if (seen.has(url)) continue;
+    seen.add(url);
+    out.push(url);
+  }
+  return out;
 }
 
 export function parseMercadolibreDetail(
@@ -373,23 +456,41 @@ export function parseMercadolibreDetail(
     throw new NonHousingListingError(config.provider, sourceId, `domain ${domainId}`);
   }
 
-  const images: string[] = [];
-  const imageVal = product.image;
-  if (typeof imageVal === 'string') images.push(imageVal);
-  else if (Array.isArray(imageVal)) {
-    for (const entry of imageVal) {
-      if (typeof entry === 'string') images.push(entry);
+  // Prefer the full server-rendered gallery; the JSON-LD `image` is a single URL.
+  const images: string[] = extractGalleryImages(html);
+  if (images.length === 0) {
+    const imageVal = product.image;
+    if (typeof imageVal === 'string') images.push(imageVal);
+    else if (Array.isArray(imageVal)) {
+      for (const entry of imageVal) {
+        if (typeof entry === 'string') images.push(entry);
+      }
     }
   }
+
+  // Operation from the domain id (`…_FOR_SALE` / `…_FOR_RENT`) when present, since
+  // the URL slug is not always decisive; fall back to the URL.
+  const operation: 'rent' | 'sale' = /FOR_SALE|_SALE\b|VENTA/i.test(domainId)
+    ? 'sale'
+    : /FOR_RENT|_RENT\b|ALQUILER|ARRIENDO|RENTA/i.test(domainId)
+      ? 'rent'
+      : /venta/i.test(url)
+        ? 'sale'
+        : 'rent';
+
+  const specs = extractHighlightedSpecs(html);
 
   const raw: MercadolibreRawListing = {
     sourceId,
     url: asString(product.url) ?? url,
     title: asString(product.name),
     description: asString(product.description),
-    operation: /venta/i.test(url) ? 'sale' : 'rent',
+    operation,
     price,
     currency: asString(offer?.priceCurrency) ?? config.defaultCurrency,
+    bedrooms: specs.bedrooms,
+    bathrooms: specs.bathrooms,
+    squareMeters: specs.squareMeters,
     address: {
       street: asString(address?.streetAddress),
       city,
@@ -406,6 +507,9 @@ export function parseMercadolibreDetail(
   assertHousingListing(config.provider, sourceId, {
     category: 'inmuebles',
     typology: domainId,
+    squareMeters: raw.squareMeters,
+    bedrooms: raw.bedrooms,
+    bathrooms: raw.bathrooms,
     hasAddressLike: true,
     hasPrice: true,
   });

--- a/packages/listing-providers/src/providers/ar/mercadolibre/fixtures.ts
+++ b/packages/listing-providers/src/providers/ar/mercadolibre/fixtures.ts
@@ -66,8 +66,15 @@ export const MERCADOLIBRE_AR_FIXTURE_DETAIL_HTML = `<!DOCTYPE html><html><head>
 {"name":"Alquiler Departamento 2 Ambientes Belgrano","image":"https://http2.mlstatic.com/fixture-ml-ar-1.jpg","offers":{"price":650000,"availability":"https://schema.org/InStock","url":"https://departamento.mercadolibre.com.ar/MLA-3557653074-alquiler-departamento-2-ambientes-belgrano-_JM","@type":"Offer","priceCurrency":"ARS"},"sku":"MLA3557653074","@context":"https://schema.org","@type":"Product","productID":"MLA3557653074"}
 </script>
 </head><body>
-<script>var x={"domain_id":"MLA-APARTMENTS_FOR_RENT","city":"Capital Federal","neighborhood":"Belgrano","state":"Capital Federal","whatsapp_available":true};</script>
+<script>var seller={"id":"seller_profile","type":"seller_profile","state":"VISIBLE"};</script>
+<script>var vip={"domain_id":"MLA-APARTMENTS_FOR_RENT","description_type":"plain_text","city":"Capital Federal","neighborhood":"Belgrano","state":"Capital Federal","whatsapp_available":true};</script>
+<script>var specs={"attributes":[{"icon":{"id":"BED","color":"BLACK","size":"XXSMALL"},"label":{"text":"2 dorm.","color":"BLACK"}},{"icon":{"id":"BATHROOM","color":"BLACK","size":"XXSMALL"},"label":{"text":"1 baño","color":"BLACK"}},{"icon":{"id":"SCALE_UP","color":"BLACK","size":"XXSMALL"},"label":{"text":"55 m² totales","color":"BLACK"}}]};</script>
 <a href="tel:+5491155667788">Llamar</a>
+<div class="ui-pdp-gallery">
+<a class="gallery-image__link" href="#"><img src="https://http2.mlstatic.com/D_NQ_NP_621054-MLA109844438740_042026-F-null.webp"/></a>
+<a class="gallery-image__link" href="#"><img src="https://http2.mlstatic.com/D_NQ_NP_984582-MLA109844438786_042026-F-null.webp"/></a>
+<a class="gallery-image__link" href="#"><img src="https://http2.mlstatic.com/D_NQ_NP_919980-MLA109844438792_042026-F-null.webp"/></a>
+</div>
 <h1>Alquiler departamento</h1>
 </body></html>`;
 

--- a/packages/listing-providers/src/providers/co/mercadolibre/index.ts
+++ b/packages/listing-providers/src/providers/co/mercadolibre/index.ts
@@ -31,6 +31,8 @@ export const MERCADOLIBRE_CO_SITE: MercadolibreSiteConfig = {
   defaultCurrency: 'COP',
   inmueblesBaseUrl: MERCADOLIBRE_CO_BASE_URL,
   housingSlugs: MERCADOLIBRE_CO_HOUSING_SLUGS,
+  // Colombia rents are advertised as "arriendo" (not "alquiler").
+  rentSegment: 'arriendo',
   hrefRe:
     /href="(https:\/\/(?:departamento|casa|inmueble|ph|monoambiente)[^"]*mercadolibre\.com\.co\/MCO-?\d+[^"]*)"/i,
 };

--- a/packages/listing-providers/src/providers/de/immobilienscout24/fixtures.ts
+++ b/packages/listing-providers/src/providers/de/immobilienscout24/fixtures.ts
@@ -85,7 +85,7 @@ export const IS24_FIXTURE_EXPOSE_JSON = `{
     {
       "type": "TOP_ATTRIBUTES",
       "attributes": [
-        { "label": "Kaltmiete", "text": "1.250 €", "type": "TEXT", "highlighted": true },
+        { "label": "Kaltmiete 19,23 €/m²", "text": "1.250 €", "type": "TEXT", "highlighted": true },
         { "label": "Zimmer", "text": "2", "type": "TEXT" },
         { "label": "Wohnfläche", "text": "65 m²", "type": "TEXT" },
         { "label": "Warmmiete", "text": "1.450 €", "type": "TEXT" }
@@ -100,7 +100,12 @@ export const IS24_FIXTURE_EXPOSE_JSON = `{
       "addressLine2": "10119 Mitte, Berlin"
     },
     {
-      "type": "DESCRIPTION",
+      "type": "TEXT_AREA",
+      "title": "Lage",
+      "text": "Zentrale Lage in Berlin-Mitte, nahe U-Bahn Rosenthaler Platz."
+    },
+    {
+      "type": "TEXT_AREA",
       "title": "Objektbeschreibung",
       "text": "Lichtdurchflutete Wohnung mit Balkon und Einbauküche in Berlin-Mitte."
     }

--- a/packages/listing-providers/src/providers/de/immobilienscout24/parse.ts
+++ b/packages/listing-providers/src/providers/de/immobilienscout24/parse.ts
@@ -176,8 +176,13 @@ export function parseIs24Expose(body: string, fallbackUrl?: string): Is24RawList
     const type = asString(record.type);
     if (type === 'TITLE') {
       title = asString(record.title) ?? title;
-    } else if (type === 'DESCRIPTION') {
-      description = asString(record.text) ?? asString(record.description) ?? description;
+    } else if (type === 'TEXT_AREA') {
+      // The mobile expose splits free text into titled TEXT_AREA blocks
+      // ('Objektbeschreibung', 'Lage', 'Sonstiges'). Only the object
+      // description is a real listing description; keep the first one.
+      if (description === undefined && asString(record.title)?.toLowerCase() === 'objektbeschreibung') {
+        description = asString(record.text);
+      }
     } else if (type === 'TOP_ATTRIBUTES' || type === 'ATTRIBUTES') {
       attrs = attrMap(record.attributes);
     } else if (type === 'MAP') {

--- a/packages/listing-providers/src/providers/de/immowelt/index.ts
+++ b/packages/listing-providers/src/providers/de/immowelt/index.ts
@@ -144,10 +144,12 @@ export class ImmoweltProvider implements ListingProvider {
                 // skip
               }
             }
+            let newRefs = 0;
             for (const ref of refs) {
               if (yielded >= limit) return;
               if (seen.has(ref.sourceId)) continue;
               seen.add(ref.sourceId);
+              newRefs += 1;
               const card = byLegacy.get(ref.sourceId);
               yield {
                 provider: this.id,
@@ -157,7 +159,12 @@ export class ImmoweltProvider implements ListingProvider {
               };
               yielded += 1;
             }
-            if (refs.length === 0) break;
+            // The legacy `/liste/…?page=N` URL 301-redirects to a page-1
+            // snapshot that ignores the page param over plain HTTP, so a page
+            // that adds no new refs means pagination is exhausted — stop before
+            // re-fetching the same ~1 MB SERP. (Real pagination needs the
+            // DataDome-gated classified-search AJAX via a browser session.)
+            if (newRefs === 0) break;
             continue;
           } catch (error) {
             if (error instanceof ChallengeError) return;
@@ -166,13 +173,16 @@ export class ImmoweltProvider implements ListingProvider {
         }
 
         if (refs.length === 0) break;
+        let newRefs = 0;
         for (const ref of refs) {
           if (yielded >= limit) return;
           if (seen.has(ref.sourceId)) continue;
           seen.add(ref.sourceId);
+          newRefs += 1;
           yield { provider: this.id, sourceId: ref.sourceId, url: ref.url };
           yielded += 1;
         }
+        if (newRefs === 0) break;
       }
     }
   }

--- a/packages/listing-providers/src/providers/de/kleinanzeigen/fixtures.ts
+++ b/packages/listing-providers/src/providers/de/kleinanzeigen/fixtures.ts
@@ -32,7 +32,7 @@ export const KLEINANZEIGEN_FIXTURE_DETAIL_HTML = `<!doctype html>
 <meta property="og:title" content="Helle 2-Zimmer-Wohnung in Mitte" />
 <meta property="og:description" content="Schöne Wohnung mit Balkon in Berlin-Mitte." />
 <meta property="og:url" content="https://www.kleinanzeigen.de/s-anzeige/helle-2-zimmer-wohnung-in-mitte/3367000001-203-3331" />
-<meta property="og:image" content="https://img.kleinanzeigen.de/api/v1/prod-ads/images/aa/bb/example-1.jpg" />
+<meta property="og:image" content="https://img.kleinanzeigen.de/api/v1/prod-ads/images/aa/example-1?rule=$_59.JPG" />
 <meta property="og:latitude" content="52.531" />
 <meta property="og:longitude" content="13.401" />
 <meta property="og:locality" content="Mitte" />
@@ -41,6 +41,11 @@ export const KLEINANZEIGEN_FIXTURE_DETAIL_HTML = `<!doctype html>
 <title>Helle 2-Zimmer-Wohnung in Mitte | Wohnung mieten</title>
 </head>
 <body>
+<div class="galleryimage-large">
+  <img id="viewad-image" class="galleryimage-element current" data-imgsrc="https://img.kleinanzeigen.de/api/v1/prod-ads/images/aa/example-1?rule=$_57.AUTO" />
+  <img id="viewad-image" class="galleryimage-element" data-imgsrc="https://img.kleinanzeigen.de/api/v1/prod-ads/images/bb/example-2?rule=$_57.AUTO" />
+  <img id="viewad-image" class="galleryimage-element" data-imgsrc="https://img.kleinanzeigen.de/api/v1/prod-ads/images/cc/example-3?rule=$_59.AUTO" />
+</div>
 <div class="boxedarticle--price" id="viewad-price">1.250 €</div>
 <ul>
   <li class="addetailslist--detail">Wohnfläche<span class="addetailslist--detail--value">65 m²</span></li>

--- a/packages/listing-providers/src/providers/de/kleinanzeigen/parse.ts
+++ b/packages/listing-providers/src/providers/de/kleinanzeigen/parse.ts
@@ -64,6 +64,15 @@ export function isKleinanzeigenHousingCategory(categoryId: string | undefined): 
   return !!categoryId && KLEINANZEIGEN_HOUSING_CATEGORY_IDS.has(categoryId);
 }
 
+/** Housing category id → Kleinanzeigen SEO path segment (e.g. `s-wohnung-mieten`). */
+const CATEGORY_SEGMENTS: Readonly<Record<string, string>> = {
+  '203': 's-wohnung-mieten',
+  '205': 's-haus-mieten',
+  '208': 's-wohnung-kaufen',
+  '207': 's-haus-kaufen',
+  '199': 's-wg-zimmer',
+};
+
 export function kleinanzeigenHousingSearchUrl(
   city: string,
   page = 1,
@@ -74,18 +83,12 @@ export function kleinanzeigenHousingSearchUrl(
   }
   const slug = citySlugDe(city);
   const locationId = CITY_LOCATION_IDS[slug] ?? '0';
-  const path =
-    categoryId === '203'
-      ? `/s-wohnung-mieten/${slug}/c203l${locationId}`
-      : categoryId === '205'
-        ? `/s-haus-mieten/${slug}/c205l${locationId}`
-        : categoryId === '208'
-          ? `/s-wohnung-kaufen/${slug}/c208l${locationId}`
-          : categoryId === '207'
-            ? `/s-haus-kaufen/${slug}/c207l${locationId}`
-            : `/s-wg-zimmer/${slug}/c199l${locationId}`;
-  const base = `${KLEINANZEIGEN_BASE_URL}${path}`;
-  return page <= 1 ? base : `${base}/seite:${page}`;
+  const segment = CATEGORY_SEGMENTS[categoryId] ?? 's-wg-zimmer';
+  // Kleinanzeigen paginates with `seite:N` BETWEEN the city slug and the
+  // category code — appending it after the code drops the category filter and
+  // returns a site-wide (non-housing) page.
+  const pageSegment = page > 1 ? `/seite:${page}` : '';
+  return `${KLEINANZEIGEN_BASE_URL}/${segment}/${slug}${pageSegment}/c${categoryId}l${locationId}`;
 }
 
 export function kleinanzeigenSourceIdFromUrl(url: string): string | undefined {
@@ -123,6 +126,33 @@ export function parseKleinanzeigenSearch(html: string): KleinanzeigenSearchRef[]
   return refs;
 }
 
+/**
+ * Kleinanzeigen serves each ad photo from `img.kleinanzeigen.de` with a `rule`
+ * size suffix; the detail gallery lists them via `data-imgsrc`. `$_57.AUTO`
+ * is the largest variant (1200x1600), so every URL is normalized to it and
+ * deduped by base image id, with the `og:image` kept as the primary.
+ */
+const GALLERY_IMG_RE = /data-imgsrc=["'](https:\/\/img\.kleinanzeigen\.de\/[^"']+)["']/gi;
+const IMAGE_RULE_RE = /\?rule=\$_\d+\.[A-Za-z]+$/i;
+
+function largestImageVariant(url: string): string {
+  return url.replace(IMAGE_RULE_RE, '') + '?rule=$_57.AUTO';
+}
+
+function extractGalleryImages(html: string, ogImage: string | undefined): string[] {
+  const byBase = new Map<string, string>();
+  const add = (raw: string): void => {
+    const normalized = largestImageVariant(raw);
+    const base = normalized.split('?')[0] ?? normalized;
+    if (!byBase.has(base)) byBase.set(base, normalized);
+  };
+  if (ogImage) add(ogImage);
+  for (const match of html.matchAll(GALLERY_IMG_RE)) {
+    if (match[1]) add(match[1]);
+  }
+  return [...byBase.values()];
+}
+
 function detailValue(html: string, label: string): string | undefined {
   const re = new RegExp(
     `addetailslist--detail[^>]*>\\s*${label}\\s*<span[^>]*class=["']addetailslist--detail--value["'][^>]*>\\s*([^<]+)`,
@@ -151,8 +181,7 @@ export function parseKleinanzeigenDetail(html: string, url: string): Kleinanzeig
   const neighborhood = meta.get('og:locality');
   const region = meta.get('og:region');
   const city = region ?? neighborhood ?? '';
-  const image = meta.get('og:image');
-  const images = image ? [image] : [];
+  const images = extractGalleryImages(html, meta.get('og:image'));
 
   return {
     sourceId,

--- a/packages/listing-providers/src/providers/ec/mercadolibre/index.ts
+++ b/packages/listing-providers/src/providers/ec/mercadolibre/index.ts
@@ -31,6 +31,8 @@ export const MERCADOLIBRE_EC_SITE: MercadolibreSiteConfig = {
   defaultCurrency: 'USD',
   inmueblesBaseUrl: MERCADOLIBRE_EC_BASE_URL,
   housingSlugs: MERCADOLIBRE_EC_HOUSING_SLUGS,
+  // Ecuador rents are advertised as "arriendo" (not "alquiler").
+  rentSegment: 'arriendo',
   hrefRe:
     /href="(https:\/\/(?:departamento|casa|inmueble|ph|monoambiente)[^"]*mercadolibre\.com\.ec\/MEC-?\d+[^"]*)"/i,
 };

--- a/packages/listing-providers/src/providers/mx/mercadolibre/fixtures.ts
+++ b/packages/listing-providers/src/providers/mx/mercadolibre/fixtures.ts
@@ -66,8 +66,14 @@ export const MERCADOLIBRE_MX_FIXTURE_DETAIL_HTML = `<!DOCTYPE html><html><head>
 {"name":"Renta departamento 2 recámaras Roma","image":"https://http2.mlstatic.com/fixture-ml-mx-1.jpg","offers":{"price":28000,"availability":"https://schema.org/InStock","url":"https://departamento.mercadolibre.com.mx/MLM-3847653074-renta-departamento-2-recamaras-roma-_JM","@type":"Offer","priceCurrency":"MXN"},"sku":"MLM3847653074","@context":"https://schema.org","@type":"Product","productID":"MLM3847653074"}
 </script>
 </head><body>
-<script>var x={"domain_id":"MLM-APARTMENTS_FOR_RENT","city":"Ciudad de México","neighborhood":"Roma Norte","state":"Ciudad de México"};</script>
+<script>var seller={"id":"seller_profile","type":"seller_profile","state":"VISIBLE"};</script>
+<script>var vip={"domain_id":"MLM-APARTMENTS_FOR_RENT","description_type":"plain_text","city":"Benito Juárez","neighborhood":"Roma Norte","state":"Ciudad de México"};</script>
+<script>var specs={"attributes":[{"icon":{"id":"BED","color":"BLACK","size":"XXSMALL"},"label":{"text":"2 rec.","color":"BLACK"}},{"icon":{"id":"BATHROOM","color":"BLACK","size":"XXSMALL"},"label":{"text":"2 baños","color":"BLACK"}},{"icon":{"id":"SCALE_UP","color":"BLACK","size":"XXSMALL"},"label":{"text":"72 m² totales","color":"BLACK"}}]};</script>
 <a href="tel:+525555667788">Llamar</a>
+<div class="ui-pdp-gallery">
+<a class="gallery-image__link" href="#"><img src="https://http2.mlstatic.com/D_NQ_NP_620729-MLM112636094885_062026-F.webp"/></a>
+<a class="gallery-image__link" href="#"><img src="https://http2.mlstatic.com/D_NQ_NP_708821-MLM112636094891_062026-F.webp"/></a>
+</div>
 <h1>Renta departamento</h1>
 </body></html>`;
 

--- a/packages/listing-providers/src/providers/mx/mercadolibre/index.ts
+++ b/packages/listing-providers/src/providers/mx/mercadolibre/index.ts
@@ -2,8 +2,9 @@
  * MercadoLibre Mexico inmuebles — classifieds, HOUSING ONLY.
  *
  * Thin wrapper over shared {@link ../../../mercadolibre} + {@link ../../../mercadolibreProvider}.
- * Bot/suspicious-traffic gated; keep OFF until live Playwright + residential proxy probe.
- * Registered OFF by default (`PROVIDER_MERCADOLIBRE_MX_ENABLED`).
+ * Cold HTTP works for search + detail HTML (verified — no account-verification wall
+ * from datacenter IPs, unlike CO/CL/PE/EC); item API is OAuth-gated. Registered OFF
+ * by default (`PROVIDER_MERCADOLIBRE_MX_ENABLED`) — enable after live probe.
  */
 
 import type { ProviderId } from '@homiio/shared-types';
@@ -64,7 +65,7 @@ export class MercadolibreMxProvider implements ListingProvider {
       locale: 'es-MX',
       acceptLanguage: 'es-MX,es;q=0.9,en;q=0.8',
       countryName: 'Mexico',
-      requireBrowserSession: true,
+      requireBrowserSession: false,
       runtime: options.runtime,
       cities: options.cities,
       metrics: options.metrics,

--- a/packages/listing-providers/src/providers/pl/otodom/fixtures.ts
+++ b/packages/listing-providers/src/providers/pl/otodom/fixtures.ts
@@ -31,7 +31,7 @@ export const OTODOM_FIXTURE_SEARCH_HTML = `<!doctype html>
               "id": 67155161,
               "title": "Bez prowizji - 2 pokoje - ul. Bunscha",
               "slug": "bez-prowizji-2-pokoje-ul-bunscha-ID4xM7L",
-              "href": "/pl/oferta/bez-prowizji-2-pokoje-ul-bunscha-ID4xM7L",
+              "href": "[lang]/ad/bez-prowizji-2-pokoje-ul-bunscha-ID4xM7L",
               "estate": "FLAT",
               "transaction": "RENT",
               "totalPrice": { "value": 2900, "currency": "PLN" },
@@ -50,7 +50,7 @@ export const OTODOM_FIXTURE_SEARCH_HTML = `<!doctype html>
               "id": 67155162,
               "title": "Mieszkanie na sprzedaż",
               "slug": "mieszkanie-krakow-ID4xM7M",
-              "href": "/pl/oferta/mieszkanie-krakow-ID4xM7M",
+              "href": "[lang]/ad/mieszkanie-krakow-ID4xM7M",
               "estate": "FLAT",
               "transaction": "SELL",
               "totalPrice": { "value": 650000, "currency": "PLN" },
@@ -103,6 +103,75 @@ export const OTODOM_FIXTURE_DETAIL_HTML = `<!doctype html>
         "images": [
           { "large": "https://ireland.apollo.olxcdn.com/v1/files/example-67155161.jpg" }
         ]
+      }
+    }
+  }
+}
+</script>
+</body>
+</html>`;
+
+/**
+ * Current Otodom detail markup: the headline price lives in
+ * `unifiedAd.price.rentalPrice` / `ad.characteristics`, the operation in
+ * `ad.adCategory.type`, and there is no `ad.totalPrice`. This is the shape the
+ * live portal serves today — the legacy fixture above keeps the old-shape path
+ * covered.
+ */
+export const OTODOM_FIXTURE_DETAIL_UNIFIED_HTML = `<!doctype html>
+<html lang="pl">
+<head><title>Mieszkanie 2- pokojowe Skorosze | Otodom.pl</title></head>
+<body>
+<script id="__NEXT_DATA__" type="application/json">
+{
+  "props": {
+    "pageProps": {
+      "id": "68201653",
+      "contactDetails": {
+        "name": "Marcin",
+        "type": "private",
+        "phones": ["+48733806496"]
+      },
+      "ad": {
+        "id": 68201653,
+        "title": "Mieszkanie 2- pokojowe, Skorosze przy Alejach Jerozolimskich",
+        "slug": "mieszkanie-2-pokojowe-skorosze-ID4CamF",
+        "url": "https://www.otodom.pl/pl/oferta/mieszkanie-2-pokojowe-skorosze-ID4CamF",
+        "description": "Przytulne mieszkanie na Skoroszach.",
+        "price": { "type": "VISIBLE" },
+        "adCategory": { "id": 102, "name": "FLAT", "type": "RENT" },
+        "target": { "OfferType": "wynajem", "Price": 3650, "Rooms_num": ["2"], "Area": 38 },
+        "attributes": { "rooms_num": "2", "m": "38", "building_type": "apartment" },
+        "characteristics": [
+          { "key": "price", "value": "3650", "currency": "PLN", "localizedValue": "3650 zł" },
+          { "key": "rent", "value": "950", "currency": "PLN", "localizedValue": "950 zł" },
+          { "key": "m", "value": "38", "localizedValue": "38 m²", "currency": "" },
+          { "key": "rooms_num", "value": "2", "localizedValue": "2", "currency": "" }
+        ],
+        "location": {
+          "address": { "street": { "name": "al. Aleje Jerozolimskie", "number": null } },
+          "reverseGeocoding": {
+            "locations": [
+              { "name": "mazowieckie", "locationLevel": "voivodeship" },
+              { "name": "Warszawa", "locationLevel": "city_or_village" },
+              { "name": "Skorosze", "locationLevel": "residential" }
+            ]
+          },
+          "coordinates": { "latitude": 52.188404, "longitude": 20.912094 }
+        },
+        "images": [
+          { "large": "https://ireland.apollo.olxcdn.com/v1/files/example-68201653-1.jpg" },
+          { "large": "https://ireland.apollo.olxcdn.com/v1/files/example-68201653-2.jpg" }
+        ]
+      },
+      "unifiedAd": {
+        "id": 68201653,
+        "title": "Mieszkanie 2- pokojowe, Skorosze przy Alejach Jerozolimskich",
+        "attributes": { "rooms_num": "2", "m": "38" },
+        "price": {
+          "__typename": "RentalPrice",
+          "rentalPrice": { "value": 3650, "currency": "PLN", "__typename": "Money" }
+        }
       }
     }
   }

--- a/packages/listing-providers/src/providers/pl/otodom/parse.ts
+++ b/packages/listing-providers/src/providers/pl/otodom/parse.ts
@@ -63,11 +63,21 @@ export function otodomSearchUrl(city: string, kind: 'rent' | 'sale', page = 1): 
   return page <= 1 ? base : `${base}?page=${page}`;
 }
 
+/**
+ * Build a canonical Otodom detail URL. Search results expose a clean `slug`
+ * plus an `href` template of the form `[lang]/ad/<slug>`; the canonical detail
+ * path is `/pl/oferta/<slug>` (the `[lang]/ad/` template path 404s). Reduce
+ * whatever we get to its slug and rebuild against the canonical path.
+ */
 function absoluteOfferUrl(hrefOrSlug: string): string {
-  const normalized = hrefOrSlug.replace('[lang]', 'pl');
-  if (normalized.startsWith('http')) return normalized.split('?')[0] ?? normalized;
-  const path = normalized.startsWith('/') ? normalized : `/pl/oferta/${normalized}`;
-  return `${OTODOM_BASE_URL}${path.split('?')[0]}`;
+  const value = hrefOrSlug.trim();
+  if (value.startsWith('http')) return value.split('?')[0] ?? value;
+  const slug = value
+    .split('?')[0]
+    .replace(/^\[lang\]/, '')
+    .replace(/^\/+/, '')
+    .replace(/^(?:pl\/)?(?:oferta|ad)\//, '');
+  return `${OTODOM_BASE_URL}/pl/oferta/${slug}`;
 }
 
 function operationFromTransaction(value: unknown): 'rent' | 'sale' {
@@ -145,6 +155,80 @@ function moneyFromItem(item: Record<string, unknown>): { value: number; currency
   return undefined;
 }
 
+/** Read a `{ value, currency }` Money node (Otodom unifiedAd nested price). */
+function moneyFromObject(value: unknown): { value: number; currency: string } | undefined {
+  if (!isRecord(value)) return undefined;
+  const amount = asNumber(value.value);
+  if (amount === undefined || amount <= 0) return undefined;
+  return { value: amount, currency: asString(value.currency) ?? 'PLN' };
+}
+
+/** Resolve rent/sale for a detail ad from category / price typename / offer type. */
+function detailOperation(
+  ad: Record<string, unknown> | undefined,
+  unified: Record<string, unknown> | undefined,
+): 'rent' | 'sale' {
+  const categoryType = ad && isRecord(ad.adCategory) ? asString(ad.adCategory.type) : undefined;
+  if (categoryType) {
+    if (/sell|sale/i.test(categoryType)) return 'sale';
+    if (/rent/i.test(categoryType)) return 'rent';
+  }
+  const priceType = unified && isRecord(unified.price) ? asString(unified.price.__typename) : undefined;
+  if (priceType) {
+    if (/sell|sale/i.test(priceType)) return 'sale';
+    if (/rent/i.test(priceType)) return 'rent';
+  }
+  const offerType = ad && isRecord(ad.target) ? asString(ad.target.OfferType) : undefined;
+  if (offerType) {
+    if (/sprzeda/i.test(offerType)) return 'sale';
+    if (/wynaj/i.test(offerType)) return 'rent';
+  }
+  return operationFromTransaction(ad?.transaction ?? unified?.transaction);
+}
+
+/** Headline price from `ad.characteristics` (`[{ key: 'price', value, currency }]`). */
+function characteristicPrice(
+  ad: Record<string, unknown> | undefined,
+): { value: number; currency: string } | undefined {
+  if (!ad || !Array.isArray(ad.characteristics)) return undefined;
+  for (const entry of ad.characteristics) {
+    if (!isRecord(entry) || asString(entry.key) !== 'price') continue;
+    const amount = asNumber(entry.value);
+    if (amount !== undefined && amount > 0) {
+      return { value: amount, currency: asString(entry.currency) ?? 'PLN' };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the headline price + currency + operation from a detail ad/unifiedAd.
+ * Detail pages no longer carry `ad.price.value` / `ad.transaction`; the amount
+ * lives in `unifiedAd.price.{rentalPrice,sellingPrice,price}`, in
+ * `ad.characteristics`, or in `ad.target.Price`.
+ */
+function detailMoney(
+  ad: Record<string, unknown> | undefined,
+  unified: Record<string, unknown> | undefined,
+): { value: number; currency: string; operation: 'rent' | 'sale' } | undefined {
+  const operation = detailOperation(ad, unified);
+  const unifiedPrice = unified && isRecord(unified.price) ? unified.price : undefined;
+  const fromUnified =
+    moneyFromObject(unifiedPrice?.rentalPrice) ??
+    moneyFromObject(unifiedPrice?.sellingPrice) ??
+    moneyFromObject(unifiedPrice?.price) ??
+    moneyFromObject(unifiedPrice);
+  if (fromUnified) return { ...fromUnified, operation };
+  const fromCharacteristics = characteristicPrice(ad);
+  if (fromCharacteristics) return { ...fromCharacteristics, operation };
+  const fromTarget = ad && isRecord(ad.target) ? asNumber(ad.target.Price) : undefined;
+  if (fromTarget !== undefined && fromTarget > 0) return { value: fromTarget, currency: 'PLN', operation };
+  // Legacy markup: `ad.totalPrice` / `ad.price.value` (kept for older payloads).
+  const legacy = (ad ? moneyFromItem(ad) : undefined) ?? (unified ? moneyFromItem(unified) : undefined);
+  if (legacy) return legacy;
+  return undefined;
+}
+
 function parseContact(details: unknown): NormalizedListingContact | undefined {
   if (!isRecord(details)) return undefined;
   const name = asString(details.name);
@@ -205,7 +289,9 @@ export function parseOtodomSearch(htmlOrJson: string): OtodomSearchRef[] {
   for (const item of items) {
     if (!isRecord(item)) continue;
     const id = asString(item.id) ?? (typeof item.id === 'number' ? String(item.id) : undefined);
-    const href = asString(item.href) ?? asString(item.slug) ?? asString(item.url);
+    // Prefer the clean `slug`; `href` is a `[lang]/ad/<slug>` template whose
+    // path segment 404s — `absoluteOfferUrl` rebuilds the canonical URL either way.
+    const href = asString(item.slug) ?? asString(item.href) ?? asString(item.url);
     if (!id || !href) continue;
     const money = moneyFromItem(item);
     if (!money || money.value <= 0) continue;
@@ -239,15 +325,7 @@ export function parseOtodomDetail(html: string, url: string): OtodomRawListing {
     throw new Error('otodom: could not resolve sourceId');
   }
 
-  const priceInfo =
-    (ad ? moneyFromItem(ad) : undefined) ??
-    (unified
-      ? moneyFromItem({
-          ...unified,
-          transaction: unified.transaction ?? ad?.transaction,
-          totalPrice: unified.totalPrice ?? unified.price,
-        })
-      : undefined);
+  const priceInfo = detailMoney(ad, unified);
   if (!priceInfo) {
     throw new Error(`otodom: listing ${sourceId} has no resolvable price`);
   }
@@ -285,7 +363,15 @@ export function parseOtodomDetail(html: string, url: string): OtodomRawListing {
   const squareMeters = asNumber(attrs.m) ?? asNumber(ad?.areaInSquareMeters);
   if (squareMeters !== undefined) result.squareMeters = squareMeters;
   if (place.coordinates) result.coordinates = place.coordinates;
-  const estate = asString(ad?.estate) ?? asString(unified?.estate);
+  // `ad.estate` is gone from current markup; derive the dwelling kind from the
+  // OLX category name (`FLAT`/`HOUSE`) or the `building_type` attribute so houses
+  // are not all misclassified as apartments.
+  const adCategoryName = ad && isRecord(ad.adCategory) ? asString(ad.adCategory.name) : undefined;
+  const estate =
+    asString(ad?.estate) ??
+    asString(unified?.estate) ??
+    adCategoryName ??
+    asString(attrs.building_type);
   if (estate) result.estate = estate;
 
   const contact = parseContact(props.contactDetails);


### PR DESCRIPTION
Consolida los fixes de código verificados contra portal real para activar más providers por cold-HTTP (los flags se encienden aparte en terraform):

- **DE (#181)**: immobilienscout24 (descripción real), immowelt (paginación), kleinanzeigen (categoría housing + galería) — los 3 cold-HTTP.
- **MercadoLibre (#183)**: arregla un bug compartido (falso challenge por reCAPTCHA v3 invisible) que rompía AR/MX/todos; region/specs/galería. AR + MX cold-HTTP viables.
- **otodom (#184)**: URL de discover (404→200) + precio del markup nuevo. Cold-HTTP.

Verificado contra markup real de cada portal. 282 tests provider/parse verdes.

Cierra #181 #183 #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)