### PR TITLE
fix(frontend): one compact icon-size system for header/bar buttons

### DIFF
--- a/packages/frontend/app/properties/[id]/index.tsx
+++ b/packages/frontend/app/properties/[id]/index.tsx
@@ -97,7 +97,7 @@ import { BookingCard } from '@/components/property/BookingCard';
 
 import { resolveBookingMode } from '@/utils/bookingMode';
 import { colors } from '@/styles/colors';
-import { barIconButton, hairline, spacing } from '@/constants/styles';
+import { barIconButton, barIconSize, hairline, spacing } from '@/constants/styles';
 
 interface PropertyDetailViewModel {
   id: string;
@@ -637,7 +637,7 @@ export default function PropertyDetailPage() {
                       accessibilityRole="button"
                       accessibilityLabel="Open host profile"
                     >
-                      <Ionicons name="person-circle-outline" size={24} color={colors.COLOR_BLACK} />
+                      <Ionicons name="person-circle-outline" size={barIconSize} color={colors.COLOR_BLACK} />
                     </Pressable>
                   ) : null,
                   <Pressable
@@ -647,7 +647,7 @@ export default function PropertyDetailPage() {
                     accessibilityRole="button"
                     accessibilityLabel="Share property"
                   >
-                    <Ionicons name="share-outline" size={24} color={colors.COLOR_BLACK} />
+                    <Ionicons name="share-outline" size={barIconSize} color={colors.COLOR_BLACK} />
                   </Pressable>,
                   <Pressable
                     key="viewings"
@@ -659,7 +659,7 @@ export default function PropertyDetailPage() {
                     <View style={styles.viewingIconContainer}>
                       <Ionicons
                         name="calendar-outline"
-                        size={24}
+                        size={barIconSize}
                         color={colors.COLOR_BLACK}
                       />
                       {hasActiveViewing ? (

--- a/packages/frontend/components/Header.tsx
+++ b/packages/frontend/components/Header.tsx
@@ -14,7 +14,7 @@ import { colorChannels } from '@/styles/shadows';
 import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { PANEL_TOP_INSET } from '@oxyhq/bloom/content-panel';
-import { barContent, barIconButton, barIconButtonPressed, spacing } from '@/constants/styles';
+import { barBackIconSize, barContent, barIconButton, barIconButtonPressed, spacing } from '@/constants/styles';
 import { useIsScreenNotMobile } from '@/hooks/useOptimizedMediaQuery';
 
 /**
@@ -186,7 +186,7 @@ export const Header: React.FC<Props> = ({ options, scrollY: externalScrollY }) =
               accessibilityRole="button"
               style={[barIconButton, backPressed && barIconButtonPressed]}
             >
-              <Ionicons name="arrow-back" size={24} color={colors.COLOR_BLACK} />
+              <Ionicons name="arrow-back" size={barBackIconSize} color={colors.COLOR_BLACK} />
             </Pressable>
           )}
           {options?.leftComponents?.map((component, index) => (

--- a/packages/frontend/components/property/StickyPropertyHeader.tsx
+++ b/packages/frontend/components/property/StickyPropertyHeader.tsx
@@ -31,7 +31,7 @@ import { Text as BloomText } from '@oxyhq/bloom/typography';
 import { SaveButton } from '@/components/SaveButton';
 import { useIsScreenNotMobile } from '@/hooks/useOptimizedMediaQuery';
 import { colors } from '@/styles/colors';
-import { barContent, barIconButton, barIconButtonPressed, hairline, spacing } from '@/constants/styles';
+import { barBackIconSize, barContent, barIconButton, barIconButtonPressed, barIconSize, hairline, spacing } from '@/constants/styles';
 import type { Property } from '@homiio/shared-types';
 
 interface StickyPropertyHeaderProps {
@@ -94,7 +94,7 @@ export const StickyPropertyHeader: React.FC<StickyPropertyHeaderProps> = ({
           accessibilityRole="button"
           accessibilityLabel={t('goBack')}
         >
-          <Ionicons name="arrow-back" size={22} color={colors.COLOR_BLACK} />
+          <Ionicons name="arrow-back" size={barBackIconSize} color={colors.COLOR_BLACK} />
         </Pressable>
         <View style={styles.titleBlock}>
           <BloomText style={styles.title} numberOfLines={1}>
@@ -113,7 +113,7 @@ export const StickyPropertyHeader: React.FC<StickyPropertyHeaderProps> = ({
             accessibilityRole="button"
             accessibilityLabel={t('common.share')}
           >
-            <Ionicons name="share-outline" size={20} color={colors.COLOR_BLACK} />
+            <Ionicons name="share-outline" size={barIconSize} color={colors.COLOR_BLACK} />
           </Pressable>
           {property ? (
             <SaveButton

--- a/packages/frontend/constants/styles.ts
+++ b/packages/frontend/constants/styles.ts
@@ -365,6 +365,9 @@ export const BANNER_FILL_MIN_HEIGHT = 200;
  *   back button and every left/right icon action. Pair the two via a `pressed`
  *   `useState` + a static style array — never the NativeWind-incompatible
  *   function-form `style` (§NativeWind Pressable).
+ * - `barIconSize` / `barBackIconSize`: ONE compact glyph scale for bar icons —
+ *   actions `20`, the back chevron `22` — matching the property sticky bar (the
+ *   gold reference) so the top header buttons never read chunkier than it.
  */
 export const barContent: ViewStyle = {
   maxWidth: contentClamp.page,
@@ -380,3 +383,8 @@ export const barIconButton: ViewStyle = {
 export const barIconButtonPressed: ViewStyle = {
   backgroundColor: colors.mutedSubtle,
 };
+
+/** Glyph size for bar action icons (share, save, host, …). */
+export const barIconSize = 20;
+/** Glyph size for the bar back chevron — a touch larger than the actions. */
+export const barBackIconSize = 22;


### PR DESCRIPTION
Follow-up to #182. The shared `barIconButton` chrome (padding + `radius.pill`) was unified, but the icon **glyph sizes** still diverged: `Header.tsx` back + the property floating-header actions were **24px**, while the property sticky bar (the gold reference) uses back **22** / actions **20**. Same button box + bigger glyphs → the top header buttons read chunkier than the sticky bar. This unifies the sizes.

## Changes
- **`constants/styles.ts`** — new shared `barIconSize = 20` (actions) and `barBackIconSize = 22` (back chevron), next to `barIconButton`, matching the sticky bar's reference values.
- **`components/Header.tsx`** — back chevron `24` → `barBackIconSize` (22).
- **`app/properties/[id]/index.tsx`** — the 3 floating-header action icons (host / share / viewings) `24` → `barIconSize` (20). The tiny checkmark sub-badge (12) and the `SaveButton` component are untouched.
- **`components/property/StickyPropertyHeader.tsx`** — its back (22) / share (20) now read from the shared constants (values unchanged — it's the reference) so nothing drifts again.

Every header/bar icon is now one compact size system.

## Verification
- `bun run build` exit 0 (frontend web export + backend).
- `bunx tsc --noEmit` → 11 pre-existing baseline errors, none in the 4 touched files.
- `grep -rn "style={({" app components` → ZERO (only the pre-existing SearchSummaryBar doc comment). No new `as any`/`@ts-ignore`/`!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)