### PR TITLE
refactor(frontend): reusable BarIconButton + bar-chrome Save for header/bar

### DIFF
--- a/packages/frontend/app/properties/[id]/index.tsx
+++ b/packages/frontend/app/properties/[id]/index.tsx
@@ -94,10 +94,11 @@ import { PropertyActionBar } from '@/components/property/PropertyActionBar';
 import { StickyPropertyHeader } from '@/components/property/StickyPropertyHeader';
 import { Section, SECTION_GUTTER } from '@/components/property/Section';
 import { BookingCard } from '@/components/property/BookingCard';
+import { BarIconButton } from '@/components/ui/BarIconButton';
 
 import { resolveBookingMode } from '@/utils/bookingMode';
 import { colors } from '@/styles/colors';
-import { barIconButton, barIconSize, hairline, spacing } from '@/constants/styles';
+import { hairline, spacing } from '@/constants/styles';
 
 interface PropertyDetailViewModel {
   id: string;
@@ -630,49 +631,37 @@ export default function PropertyDetailPage() {
               ? []
               : [
                   landlordOxyUserId ? (
-                    <Pressable
+                    <BarIconButton
                       key="profile"
-                      style={barIconButton}
+                      icon="person-circle-outline"
                       onPress={() => router.push(`/roommates/${landlordOxyUserId}`)}
-                      accessibilityRole="button"
                       accessibilityLabel="Open host profile"
-                    >
-                      <Ionicons name="person-circle-outline" size={barIconSize} color={colors.COLOR_BLACK} />
-                    </Pressable>
+                    />
                   ) : null,
-                  <Pressable
+                  <BarIconButton
                     key="share"
-                    style={barIconButton}
+                    icon="share-outline"
                     onPress={handleShare}
-                    accessibilityRole="button"
                     accessibilityLabel="Share property"
-                  >
-                    <Ionicons name="share-outline" size={barIconSize} color={colors.COLOR_BLACK} />
-                  </Pressable>,
-                  <Pressable
+                  />,
+                  <BarIconButton
                     key="viewings"
-                    style={barIconButton}
+                    icon="calendar-outline"
                     onPress={() => router.push('/viewings')}
-                    accessibilityRole="button"
                     accessibilityLabel="View bookings"
-                  >
-                    <View style={styles.viewingIconContainer}>
-                      <Ionicons
-                        name="calendar-outline"
-                        size={barIconSize}
-                        color={colors.COLOR_BLACK}
-                      />
-                      {hasActiveViewing ? (
+                    badge={
+                      hasActiveViewing ? (
                         <View style={styles.viewingBadge}>
                           <Ionicons name="checkmark" size={12} color={colors.primaryForeground} />
                         </View>
-                      ) : null}
-                    </View>
-                  </Pressable>,
+                      ) : undefined
+                    }
+                  />,
                   <View key="save" style={styles.headerSaveWrap}>
                     <SaveButton
                       property={apiProperty as Property}
                       variant="heart"
+                      chrome="bar"
                       color={colors.COLOR_BLACK}
                       activeColor={colors.error}
                       showCount
@@ -1017,7 +1006,6 @@ const styles = StyleSheet.create({
     right: 0,
     zIndex: 1000,
   },
-  viewingIconContainer: { position: 'relative' },
   viewingBadge: {
     position: 'absolute',
     top: -4,

--- a/packages/frontend/components/Header.tsx
+++ b/packages/frontend/components/Header.tsx
@@ -1,12 +1,12 @@
-import React, { useEffect, useState, ReactNode } from 'react';
-import { View, Platform, Pressable, StyleSheet, type ViewStyle } from 'react-native';
+import React, { useEffect, ReactNode } from 'react';
+import { View, Platform, StyleSheet, type ViewStyle } from 'react-native';
 import Animated, {
   interpolate,
   useAnimatedStyle,
   useSharedValue,
   type SharedValue,
 } from 'react-native-reanimated';
-import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { Text as BloomText } from '@oxyhq/bloom/typography';
 import { colors } from '@/styles/colors';
@@ -14,7 +14,8 @@ import { colorChannels } from '@/styles/shadows';
 import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { PANEL_TOP_INSET } from '@oxyhq/bloom/content-panel';
-import { barBackIconSize, barContent, barIconButton, barIconButtonPressed, spacing } from '@/constants/styles';
+import { barBackIconSize, barContent, spacing } from '@/constants/styles';
+import { BarIconButton } from '@/components/ui/BarIconButton';
 import { useIsScreenNotMobile } from '@/hooks/useOptimizedMediaQuery';
 
 /**
@@ -45,6 +46,7 @@ interface Props {
 
 export const Header: React.FC<Props> = ({ options, scrollY: externalScrollY }) => {
   const router = useRouter();
+  const { t } = useTranslation();
   const { colors: themeColors } = useTheme();
   // Derived directly from the router rather than synced via an effect — this is
   // a pure read of navigation state and avoids cascading renders.
@@ -53,7 +55,6 @@ export const Header: React.FC<Props> = ({ options, scrollY: externalScrollY }) =
   const isScreenNotMobile = useIsScreenNotMobile();
   const internalScrollY = useSharedValue(0);
   const scrollY = externalScrollY ?? internalScrollY;
-  const [backPressed, setBackPressed] = useState(false);
 
   // On web the DOCUMENT is the scroll owner and the shell frames content in a
   // rounded `ContentPanel` at `PANEL_TOP_INSET` (8px) on wide screens, so a
@@ -179,15 +180,12 @@ export const Header: React.FC<Props> = ({ options, scrollY: externalScrollY }) =
       >
         <View style={styles.leftSlot}>
           {options?.showBackButton && canGoBack && (
-            <Pressable
+            <BarIconButton
+              icon="arrow-back"
+              size={barBackIconSize}
               onPress={() => router.back()}
-              onPressIn={() => setBackPressed(true)}
-              onPressOut={() => setBackPressed(false)}
-              accessibilityRole="button"
-              style={[barIconButton, backPressed && barIconButtonPressed]}
-            >
-              <Ionicons name="arrow-back" size={barBackIconSize} color={colors.COLOR_BLACK} />
-            </Pressable>
+              accessibilityLabel={t('goBack')}
+            />
           )}
           {options?.leftComponents?.map((component, index) => (
             <React.Fragment key={index}>{component}</React.Fragment>

--- a/packages/frontend/components/SaveButton.tsx
+++ b/packages/frontend/components/SaveButton.tsx
@@ -37,6 +37,7 @@ import { TouchableOpacity, StyleSheet, ViewStyle, View, StyleProp } from 'react-
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '@/styles/colors';
 import { shadowToken } from '@/styles/shadows';
+import { barIconButton, barIconSize } from '@/constants/styles';
 import { Loading } from '@oxyhq/bloom/loading';
 import { SaveToFolderBottomSheet } from './SaveToFolderBottomSheet';
 import { BottomSheetContext } from '@/context/BottomSheetContext';
@@ -63,6 +64,16 @@ interface SaveButtonProps {
   showCount?: boolean;
   countBadgeStyle?: StyleProp<ViewStyle>;
   countDisplayMode?: 'badge' | 'inline';
+  /**
+   * Chrome variant. `'default'` keeps the cream-filled, soft-shadowed pill used
+   * as a standalone control. `'bar'` renders the SAME flat, transparent circular
+   * chrome as `BarIconButton` (shared `barIconButton` token, heart at
+   * `barIconSize`, no background/shadow) so it sits inside a header/bar next to
+   * the other bar buttons. Save LOGIC is identical in both. NOTE: the on-card
+   * frosted-white overlay is a separate context — it overrides chrome via `style`
+   * and must NOT use `'bar'`.
+   */
+  chrome?: 'default' | 'bar';
 }
 
 export function SaveButton({
@@ -82,10 +93,14 @@ export function SaveButton({
   showCount = false,
   countBadgeStyle,
   countDisplayMode = 'badge',
+  chrome = 'default',
 }: SaveButtonProps) {
   const [isPressed, setIsPressed] = useState(false);
   const bottomSheetContext = useContext(BottomSheetContext);
-  const sizeAll = Math.max(10, size * 1);
+  // In `'bar'` chrome the heart matches the shared bar icon size; otherwise it
+  // scales with the caller's `size`.
+  const isBar = chrome === 'bar';
+  const sizeAll = isBar ? barIconSize : Math.max(10, size * 1);
 
   // Use SavedPropertiesContext for all state management
   const {
@@ -252,13 +267,17 @@ export function SaveButton({
       activeOpacity={0.7}
       disabled={isButtonDisabled}
       style={[
-        styles.saveButton,
+        isBar ? barIconButton : styles.saveButton,
         isButtonDisabled && styles.disabledButton,
         style,
-        {
-          paddingHorizontal: sizeAll / (countDisplayMode === 'inline' ? 6 : 3),
-          paddingVertical: sizeAll / (countDisplayMode === 'inline' ? 2 : 3),
-        },
+        // `'bar'` chrome uses the shared circular button's own padding; only the
+        // default cream pill takes the size-derived padding.
+        isBar
+          ? null
+          : {
+              paddingHorizontal: sizeAll / (countDisplayMode === 'inline' ? 6 : 3),
+              paddingVertical: sizeAll / (countDisplayMode === 'inline' ? 2 : 3),
+            },
       ]}
     >
       <View

--- a/packages/frontend/components/property/StickyPropertyHeader.tsx
+++ b/packages/frontend/components/property/StickyPropertyHeader.tsx
@@ -12,26 +12,25 @@
  * device safe-area inset (`insets.top`). On framed web it pins at
  * `PANEL_TOP_INSET` so the ContentPanel bleed-mask does not clip it.
  */
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import {
   Platform,
-  Pressable,
   StyleSheet,
   View,
   type ViewStyle,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Ionicons } from '@expo/vector-icons';
 
 import { Button } from '@oxyhq/bloom/button';
 import { PANEL_TOP_INSET } from '@oxyhq/bloom/content-panel';
 import { Text as BloomText } from '@oxyhq/bloom/typography';
 
 import { SaveButton } from '@/components/SaveButton';
+import { BarIconButton } from '@/components/ui/BarIconButton';
 import { useIsScreenNotMobile } from '@/hooks/useOptimizedMediaQuery';
 import { colors } from '@/styles/colors';
-import { barBackIconSize, barContent, barIconButton, barIconButtonPressed, barIconSize, hairline, spacing } from '@/constants/styles';
+import { barBackIconSize, barContent, hairline, spacing } from '@/constants/styles';
 import type { Property } from '@homiio/shared-types';
 
 interface StickyPropertyHeaderProps {
@@ -59,9 +58,6 @@ export const StickyPropertyHeader: React.FC<StickyPropertyHeaderProps> = ({
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const isScreenNotMobile = useIsScreenNotMobile();
-  const [backPressed, setBackPressed] = useState(false);
-  const [sharePressed, setSharePressed] = useState(false);
-
   const handleShare = useCallback(() => onShare(), [onShare]);
 
   if (!visible) return null;
@@ -86,16 +82,12 @@ export const StickyPropertyHeader: React.FC<StickyPropertyHeaderProps> = ({
   return (
     <View style={[styles.bar, containerStyle, { paddingTop: insets.top }]}>
       <View style={styles.content}>
-        <Pressable
+        <BarIconButton
+          icon="arrow-back"
+          size={barBackIconSize}
           onPress={onBack}
-          onPressIn={() => setBackPressed(true)}
-          onPressOut={() => setBackPressed(false)}
-          style={[barIconButton, backPressed && barIconButtonPressed]}
-          accessibilityRole="button"
           accessibilityLabel={t('goBack')}
-        >
-          <Ionicons name="arrow-back" size={barBackIconSize} color={colors.COLOR_BLACK} />
-        </Pressable>
+        />
         <View style={styles.titleBlock}>
           <BloomText style={styles.title} numberOfLines={1}>
             {title}
@@ -105,20 +97,16 @@ export const StickyPropertyHeader: React.FC<StickyPropertyHeaderProps> = ({
           </BloomText>
         </View>
         <View style={styles.actions}>
-          <Pressable
+          <BarIconButton
+            icon="share-outline"
             onPress={handleShare}
-            onPressIn={() => setSharePressed(true)}
-            onPressOut={() => setSharePressed(false)}
-            style={[barIconButton, sharePressed && barIconButtonPressed]}
-            accessibilityRole="button"
             accessibilityLabel={t('common.share')}
-          >
-            <Ionicons name="share-outline" size={barIconSize} color={colors.COLOR_BLACK} />
-          </Pressable>
+          />
           {property ? (
             <SaveButton
               property={property as Property & { _id: string }}
               variant="heart"
+              chrome="bar"
               color={colors.COLOR_BLACK}
               activeColor={colors.error}
             />

--- a/packages/frontend/components/ui/BarIconButton.tsx
+++ b/packages/frontend/components/ui/BarIconButton.tsx
@@ -1,0 +1,79 @@
+/**
+ * BarIconButton — the ONE reusable circular header/bar icon button (back, share,
+ * viewings, host, …). Flat + transparent with a pressed/hover tint, matching the
+ * property sticky bar. Consumes the shared `barIconButton` / `barIconButtonPressed`
+ * / `barIconSize` tokens so no screen hand-rolls this chrome again.
+ *
+ * Owns its own pressed + web-hover state via a STATIC style array — never the
+ * NativeWind-incompatible function-form `style` (AGENTS.md §NativeWind Pressable).
+ * It's a standalone component, so it is safe to render inside a `.map` / a
+ * component array (each instance owns its own hooks).
+ */
+import React, { useState } from 'react';
+import { Platform, Pressable, StyleSheet, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import { colors } from '@/styles/colors';
+import { barIconButton, barIconButtonPressed, barIconSize } from '@/constants/styles';
+
+type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
+
+const IS_WEB = Platform.OS === 'web';
+
+interface BarIconButtonProps {
+  icon: IoniconName;
+  onPress: () => void;
+  accessibilityLabel: string;
+  /** Glyph size. Defaults to the shared `barIconSize` (20). */
+  size?: number;
+  /** Glyph colour. Defaults to the standard bar icon black. */
+  color?: string;
+  disabled?: boolean;
+  /** Optional overlay pinned over the icon (e.g. a status checkmark badge). */
+  badge?: React.ReactNode;
+}
+
+export const BarIconButton: React.FC<BarIconButtonProps> = ({
+  icon,
+  onPress,
+  accessibilityLabel,
+  size = barIconSize,
+  color = colors.COLOR_BLACK,
+  disabled = false,
+  badge,
+}) => {
+  const [pressed, setPressed] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const active = pressed || hovered;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      onHoverIn={IS_WEB ? () => setHovered(true) : undefined}
+      onHoverOut={IS_WEB ? () => setHovered(false) : undefined}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      style={[barIconButton, active && barIconButtonPressed]}
+    >
+      {badge ? (
+        <View style={styles.badgeWrap}>
+          <Ionicons name={icon} size={size} color={color} />
+          {badge}
+        </View>
+      ) : (
+        <Ionicons name={icon} size={size} color={color} />
+      )}
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  badgeWrap: {
+    position: 'relative',
+  },
+});
+
+export default BarIconButton;


### PR DESCRIPTION
Follow-up to #182/#187. The shared `barIconButton` *style* was unified, but it was still hand-rolled as `<Pressable style={[barIconButton, pressed && barIconButtonPressed]}><Ionicons/></Pressable>` in 3 places, and `SaveButton` rendered completely different chrome (cream `primaryLight` bg + `webShadow` + `borderRadius:25`). So in a header, the Save button showed a cream shadowed pill next to flat transparent circle siblings. This makes them **one reusable component** and aligns Save.

## Changes
- **New `components/ui/BarIconButton.tsx`** — the ONE reusable flat circular header/bar icon button. Props: `icon`, `onPress`, `accessibilityLabel`, `size?=barIconSize`, `color?=COLOR_BLACK`, `disabled?`, `badge?`. Owns its own pressed + web-hover state via a static style array (no function-form `style`, per AGENTS.md). Optional absolutely-positioned `badge` slot (the viewings checkmark). Standalone component → safe inside a component array.
- **Replaced the hand-rolled Pressables** with `<BarIconButton>`: `Header.tsx` back (size `barBackIconSize`), `StickyPropertyHeader.tsx` back + share, `app/properties/[id]/index.tsx` floating-header host/share/viewings (viewings passes its checkmark `badge`). Header gains `useTranslation` for the back label (`t('goBack')`).
- **`SaveButton` gains `chrome?: 'default' | 'bar'`** — `'bar'` renders the SAME flat `barIconButton` chrome (transparent, `radius.pill`, `spacing.sm` padding, **no** cream bg / `webShadow` / elevation), heart at `barIconSize`, all Save LOGIC intact (toggle, red `activeColor`, count). Wired `chrome="bar"` in `StickyPropertyHeader` + the property floating header. The **on-card frosted-white overlay Save** (`rgba(255,255,255,0.95)`) is untouched — it overrides chrome via `style` and stays `'default'`.

Net: every header/bar button — back, share, viewings, AND save — is one reusable, flat, compact circular button.

## Verification
- `bun run build` exit 0 (frontend web export + backend).
- `bunx tsc --noEmit` → 11 pre-existing baseline errors, none in the new/edited files.
- `grep -rn "style={({" app components` → ZERO (only the pre-existing SearchSummaryBar doc comment). No new `as any`/`@ts-ignore`/`!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)