### PR TITLE
fix(home): center hero search pill segment text

### DIFF
--- a/packages/frontend/components/search/SearchSummaryBar.tsx
+++ b/packages/frontend/components/search/SearchSummaryBar.tsx
@@ -85,8 +85,6 @@ const SEGMENT_FONT = 14;
  */
 const COLUMN_PAD_X_WIDE = spacing.lg;
 const COLUMN_PAD_X_NARROW = spacing.md;
-const COLUMN_FIRST_PAD_LEFT_WIDE = spacing.xl;
-const COLUMN_FIRST_PAD_LEFT_NARROW = spacing.lg;
 
 /** Single-line (compact) pill leading search-icon size. */
 const COMPACT_ICON_SIZE = 16;
@@ -186,7 +184,6 @@ const PillColumn: React.FC<PillColumnProps> = ({
         styles.column,
         isNarrow && styles.columnNarrow,
         isFirst && styles.columnFirst,
-        isFirst && isNarrow && styles.columnFirstNarrow,
         pressed && styles.columnPressed,
       ]}
     >
@@ -500,6 +497,11 @@ const styles = StyleSheet.create({
     flex: 1,
     minWidth: 0,
     height: '100%',
+    // Center the one-line segment vertically. The Text keeps the default
+    // cross-axis stretch (full segment width) so `textAlign: 'center'` centers
+    // it horizontally while `numberOfLines`/`ellipsizeMode` can still tail-
+    // truncate a long value — an `alignItems: 'center'` here would shrink the
+    // Text to content width and defeat that truncation.
     justifyContent: 'center',
     paddingHorizontal: COLUMN_PAD_X_WIDE,
   },
@@ -508,29 +510,30 @@ const styles = StyleSheet.create({
     // the full-size button on a phone. Height/type/divider are unchanged.
     paddingHorizontal: COLUMN_PAD_X_NARROW,
   },
+  // The first segment keeps the rounded-left corners but the SAME symmetric
+  // horizontal padding as the others (no extra left inset) so its centered text
+  // lines up with segments 2 and 3.
   columnFirst: {
-    paddingLeft: COLUMN_FIRST_PAD_LEFT_WIDE,
     borderTopLeftRadius: radius.pill,
     borderBottomLeftRadius: radius.pill,
-  },
-  columnFirstNarrow: {
-    paddingLeft: COLUMN_FIRST_PAD_LEFT_NARROW,
   },
   columnPressed: {
     backgroundColor: colors.COLOR_BLACK_LIGHT_8,
   },
-  // Filled segment: bold foreground value.
+  // Filled segment: bold foreground value, centered.
   columnValue: {
     fontSize: SEGMENT_FONT,
     fontWeight: '600',
     color: colors.COLOR_BLACK,
     letterSpacing: tracker.wide,
+    textAlign: 'center',
   },
-  // Empty segment: muted-gray placeholder (Airbnb's `text-gray-400`).
+  // Empty segment: muted-gray placeholder (Airbnb's `text-gray-400`), centered.
   columnPlaceholder: {
     fontSize: SEGMENT_FONT,
     fontWeight: '400',
     color: colors.COLOR_BLACK_LIGHT_4,
+    textAlign: 'center',
   },
   divider: {
     width: hairline.width,


### PR DESCRIPTION
## Summary
- Follow-up alignment fix to #188 (slim single-line hero search pill).
- Centers the three segment texts (`textAlign: 'center'` on `columnValue`/`columnPlaceholder`).
- Removes the first segment's extra left padding (`COLUMN_FIRST_PAD_LEFT_*` + `columnFirstNarrow`) so its centered text now lines up with segments 2 and 3.
- Truncation, mode labels, guests step, and the `bg-primary` circle are all unchanged.

## Test plan
- [x] `grep -rn "style={({" app components --include=*.tsx` = 0
- [x] `bunx tsc --noEmit` = 11 errors, identical to pre-existing baseline, none in `SearchSummaryBar`
- [x] `bun run test` (full monorepo) — shared-types, frontend (32), listing-providers (393), backend (537) all pass
- [x] `bun run build:frontend` (expo web export) exit 0
- [x] Web smoke (Playwright): both modes render each segment centered; long-term "Anywhere | Any price | Any type", vacation "Anywhere | Any week | Add guests"; guests step opens; zero page errors