### PR TITLE
fix(pisos): drop watermarked cover duplicate first photo

### DIFF
--- a/packages/backend/__tests__/unit/pisosProvider.test.ts
+++ b/packages/backend/__tests__/unit/pisosProvider.test.ts
@@ -9,8 +9,11 @@ import {
   parsePisosContactPhone,
   mergePisosContact,
   pisosSourceIdFromUrl,
+  readPisosImageUrls,
   PISOS_FIXTURE_DETAIL_HTML,
   PISOS_FIXTURE_DETAIL_VALLADOLID_HTML,
+  PISOS_FIXTURE_DETAIL_IMAGES_HTML,
+  PISOS_FIXTURE_DETAIL_IMAGES_EXPECTED,
   PISOS_FIXTURE_SEARCH_HTML,
   PISOS_FIXTURE_CONTACT_JSON,
 } from '@homiio/listing-providers';
@@ -95,6 +98,44 @@ describe('PisosProvider.normalize', () => {
     expect(listing.floor).toBeUndefined();
     expect(listing.yearBuilt).toBeUndefined();
     expect(listing.parkingSpaces).toBeUndefined();
+  });
+
+  it('drops the pisos.com-watermarked cover duplicate and agency logo, keeping one clean copy per photo', () => {
+    // Live listings serve each photo under several size prefixes: `xl-wp` /
+    // `fch-wp` covers and `appswm-wp` carry the burned-in pisos.com watermark,
+    // while `apps-wp` + `fchm-wp` are clean and `prof-wp/logos/…` is the agency
+    // logo. The parser must ingest only the clean, de-duplicated gallery.
+    const urls = readPisosImageUrls(PISOS_FIXTURE_DETAIL_IMAGES_HTML);
+
+    expect(urls).toEqual(PISOS_FIXTURE_DETAIL_IMAGES_EXPECTED);
+    // The clean `apps-wp` copy of the first photo leads (its watermarked
+    // `xl-wp` og:image twin, which appears first in the HTML, is discarded).
+    expect(urls[0]).toContain('/apps-wp/');
+    // No watermarked or logo rendition survives.
+    expect(urls.some((url) => /\/(?:xl-wp|fch-wp|appswm-wp)\//.test(url))).toBe(false);
+    expect(urls.some((url) => url.includes('/logos/'))).toBe(false);
+    // Each underlying photo appears exactly once (no size-variant duplicates).
+    const photoKeys = urls.map((url) => url.replace(/^https:\/\/[^/]+\/[^/]+\//, ''));
+    expect(new Set(photoKeys).size).toBe(photoKeys.length);
+  });
+
+  it('normalizes the images fixture into watermark-free remoteImages with a clean primary', () => {
+    const payload = parsePisosDetail(
+      PISOS_FIXTURE_DETAIL_IMAGES_HTML,
+      'https://www.pisos.com/alquilar/piso-alboraia_alboraya_centro_urbano-65023401382_106400/',
+    );
+    const listing = provider.normalize({
+      ref: { provider: 'pisos', sourceId: payload.sourceId, url: payload.url },
+      payload,
+    });
+
+    expect(listing.remoteImages).toHaveLength(PISOS_FIXTURE_DETAIL_IMAGES_EXPECTED.length);
+    expect(listing.remoteImages[0]?.isPrimary).toBe(true);
+    expect(listing.remoteImages[0]?.url).toContain('/apps-wp/');
+    expect(
+      listing.remoteImages.some((image) => /\/(?:xl-wp|fch-wp|appswm-wp)\//.test(image.url)),
+    ).toBe(false);
+    expect(listing.remoteImages.some((image) => image.url.includes('/logos/'))).toBe(false);
   });
 
   it('parses contact AJAX JSON', () => {

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -471,6 +471,7 @@ export {
   parsePisosDetail,
   parsePisosSearch,
   mergePisosContact,
+  readPisosImageUrls,
   readPisosLocationMapCoordinates,
   readPisosAscendingGeo,
   postalCodeFromPisosUrl,
@@ -480,6 +481,8 @@ export {
   PISOS_BASE_URL,
   PISOS_FIXTURE_DETAIL_HTML,
   PISOS_FIXTURE_DETAIL_VALLADOLID_HTML,
+  PISOS_FIXTURE_DETAIL_IMAGES_HTML,
+  PISOS_FIXTURE_DETAIL_IMAGES_EXPECTED,
   PISOS_FIXTURE_SEARCH_HTML,
   PISOS_FIXTURE_CONTACT_JSON,
 } from './providers/pisos/fixtures';

--- a/packages/listing-providers/src/providers/pisos/fixtures.ts
+++ b/packages/listing-providers/src/providers/pisos/fixtures.ts
@@ -63,5 +63,55 @@ export const PISOS_FIXTURE_DETAIL_VALLADOLID_HTML = `<!doctype html>
 <p class="description">Loft con encanto en el casco histórico de valladolid.</p>
 </body></html>`;
 
+/**
+ * Recorded image block from a live Alboraya (Valencia) detail page. pisos serves
+ * every photo under several `fotos.imghs.net` size prefixes: the `xl-wp` /
+ * `fch-wp` cover renditions and the `appswm-wp` ("apps watermark") rendition
+ * carry the burned-in pisos.com watermark, while `apps-wp` and the gallery
+ * `fchm-wp` thumbnails are clean. `prof-wp/logos/…` is the agency logo, not a
+ * property photo. The URLs, ordering, and duplication mirror the real markup:
+ * the watermarked `xl-wp` cover appears first (it is also the `og:image`), the
+ * clean `apps-wp` copy of the same photo second, then the clean `fchm-wp`
+ * gallery, with watermarked `appswm-wp` duplicates and the agency logo mixed in.
+ */
+export const PISOS_FIXTURE_DETAIL_IMAGES_HTML = `<!doctype html>
+<html lang="es"><head><title>Piso en alquiler en Avinguda Mare Nostrum</title>
+<meta property="og:image" content="https://fotos.imghs.net/xl-wp/1064/3230323630363137/d1e479cd-09f2-4e87-b0ea-5a232c242428.jpg" />
+</head><body>
+<input id="hdnIdPiso" name="hdnIdPiso" type="hidden" value="65023401382.106400" />
+<h1>Piso en alquiler en Avinguda Mare Nostrum</h1>
+<div class="ascending-geo__row" data-zone="P00000000000046" data-ga-geoLevelName='provincia' property="itemListElement" typeof="ListItem">
+<a href="/alquiler/piso-valencia/" class="ascending-geo__result" property="item" typeof="WebPage"><span property="name">València</span></a>
+</div>
+<div class="ascending-geo__row" data-zone="M00000000046013" data-ga-geoLevelName='municipio' property="itemListElement" typeof="ListItem">
+<a href="/alquiler/piso-alboraya/" class="ascending-geo__result" property="item" typeof="WebPage"><span property="name">Alboraia - Alboraya</span></a>
+</div>
+<div data-var='{"telefono":"960365571","caracteristicasInmueble":"ascensor,balcon,terraza","nHabitaciones":"2","nBanios":"1","superficieInmueble":"80"}'></div>
+<div class="locationmap" data-params="latitude=39.4915&amp;longitude=-0.325534&amp;zoom=17&amp;showMarker=True"></div>
+<script>var precio = 1400;</script>
+<div class="gallery">
+<img src="https://fotos.imghs.net/xl-wp/1064/3230323630363137/d1e479cd-09f2-4e87-b0ea-5a232c242428.jpg" />
+<img src="https://fotos.imghs.net/apps-wp/1064/3230323630363137/d1e479cd-09f2-4e87-b0ea-5a232c242428.jpg" />
+<img src="https://fotos.imghs.net/fch-wp/1064/3230323630363137/d1e479cd-09f2-4e87-b0ea-5a232c242428.jpg" />
+<img src="https://fotos.imghs.net/fchm-wp/1064/3230323630363137/8cb66161-4444-4287-a7cc-efaa714ea86e.jpg" />
+<img src="https://fotos.imghs.net/fchm-wp/1064/3230323630363137/5ef76e58-1754-4ad6-9c48-ad35fcbcc5a2.jpg" />
+<img src="https://fotos.imghs.net/fchm-wp/1064/3230323630363137/634ed073-0c83-4d9f-8e6a-8c7c46102b06.jpg" />
+<img src="https://fotos.imghs.net/appswm-wp/1064/3230323630363137/d1e479cd-09f2-4e87-b0ea-5a232c242428.jpg" />
+<img src="https://fotos.imghs.net/appswm-wp/1064/3230323630363137/8cb66161-4444-4287-a7cc-efaa714ea86e.jpg" />
+<img src="https://fotos.imghs.net/prof-wp/logos/Logo_518562_20200728111844.jpg" />
+<img src="https://fotos.imghs.net/fchm-wp/1064/3230323630363137/8cb66161-4444-4287-a7cc-efaa714ea86e.jpg" />
+<img src="https://fotos.imghs.net/apps-wp/1064/3230323630363137/d1e479cd-09f2-4e87-b0ea-5a232c242428.jpg" />
+</div>
+<p class="description">Piso reformado con terraza y vistas al mar en Alboraya.</p>
+</body></html>`;
+
+/** Clean gallery the parser must keep from {@link PISOS_FIXTURE_DETAIL_IMAGES_HTML}. */
+export const PISOS_FIXTURE_DETAIL_IMAGES_EXPECTED = [
+  'https://fotos.imghs.net/apps-wp/1064/3230323630363137/d1e479cd-09f2-4e87-b0ea-5a232c242428.jpg',
+  'https://fotos.imghs.net/fchm-wp/1064/3230323630363137/8cb66161-4444-4287-a7cc-efaa714ea86e.jpg',
+  'https://fotos.imghs.net/fchm-wp/1064/3230323630363137/5ef76e58-1754-4ad6-9c48-ad35fcbcc5a2.jpg',
+  'https://fotos.imghs.net/fchm-wp/1064/3230323630363137/634ed073-0c83-4d9f-8e6a-8c7c46102b06.jpg',
+] as const;
+
 /** Recorded contact AJAX body from `/WebsiteUserInfo/GetNormalizedPhone`. */
 export const PISOS_FIXTURE_CONTACT_JSON = `{"phone":"919376345","normalizedPhone":"+34919376345"}`;

--- a/packages/listing-providers/src/providers/pisos/parse.ts
+++ b/packages/listing-providers/src/providers/pisos/parse.ts
@@ -86,8 +86,63 @@ function readDescriptionText(html: string): string | undefined {
   return raw.length > 0 ? stripTags(raw) : undefined;
 }
 
-function readPisosImageUrls(html: string): string[] {
-  const urls: string[] = [];
+/**
+ * pisos serves every property photo under several `fotos.imghs.net` size
+ * prefixes (the first path segment). The large "cover"/hero renditions
+ * (`xl-wp`, `fch-wp`) and the explicit `appswm-wp` ("apps watermark") rendition
+ * have the **pisos.com watermark** — and sometimes a decorative frame — burned
+ * into the pixels; the `apps-wp` and gallery-thumbnail `fchm-wp` renditions are
+ * clean. `prof-wp/logos/…` is the agency logo, not a property photo. The pair
+ * `apps-wp` (clean) / `appswm-wp` (watermarked) proves `apps-wp` is the
+ * watermark-free copy of the same image. Verified against live listings.
+ */
+
+/** Size prefixes whose rendition has the pisos.com watermark burned in. */
+const PISOS_WATERMARK_VARIANTS = new Set(['xl', 'fch']);
+
+/**
+ * Clean renditions ranked largest-first so the best watermark-free copy of a
+ * photo wins. Unknown prefixes fall back to rank 0 — kept (never silently drop
+ * a real photo) but always superseded by a known clean rendition of the same
+ * image.
+ */
+const PISOS_CLEAN_VARIANT_RANK: Record<string, number> = {
+  apps: 2, // 640×480, no watermark — the clean cover
+  fchm: 1, // gallery thumbnail, no watermark
+};
+
+interface PisosImageRendition {
+  url: string;
+  /** Underlying photo identity: the path after the size/variant segment. */
+  photoKey: string;
+  rank: number;
+}
+
+/**
+ * Classify a `fotos.imghs.net` URL into its underlying photo + clean-rendition
+ * rank. Watermarked size prefixes (`xl-wp`, `fch-wp`, any `*wm` such as
+ * `appswm-wp`) and agency logos (`prof-wp/logos/…`) are rejected outright.
+ */
+function classifyPisosImage(url: string): PisosImageRendition | undefined {
+  const path = url.slice(PISOS_IMG_HOST.length);
+  const slash = path.indexOf('/');
+  if (slash < 0) return undefined;
+  const photoKey = path.slice(slash + 1);
+  if (photoKey.startsWith('logos/')) return undefined; // agency logo, not a property photo
+  const variant = path.slice(0, slash).replace(/-wp$/i, '').toLowerCase();
+  if (variant.endsWith('wm') || PISOS_WATERMARK_VARIANTS.has(variant)) return undefined; // watermarked
+  return { url, photoKey, rank: PISOS_CLEAN_VARIANT_RANK[variant] ?? 0 };
+}
+
+/**
+ * Extract the clean, de-duplicated gallery from a detail page, in first-seen
+ * order. Watermarked cover/hero renditions and the agency logo are dropped, and
+ * each underlying photo keeps only its highest-ranked clean rendition — so the
+ * portal-watermarked duplicate of the first photo is never ingested.
+ */
+export function readPisosImageUrls(html: string): string[] {
+  const bestByPhoto = new Map<string, PisosImageRendition>();
+  const order: string[] = [];
   let cursor = 0;
   while (cursor < html.length) {
     const idx = html.indexOf(PISOS_IMG_HOST, cursor);
@@ -102,10 +157,21 @@ function readPisosImageUrls(html: string): string[] {
       break;
     }
     const candidate = html.slice(idx, end);
-    if (/\.(?:jpg|jpeg|webp|png)$/i.test(candidate)) urls.push(candidate);
     cursor = end;
+    if (!/\.(?:jpg|jpeg|webp|png)$/i.test(candidate)) continue;
+    const rendition = classifyPisosImage(candidate);
+    if (!rendition) continue;
+    const existing = bestByPhoto.get(rendition.photoKey);
+    if (!existing) {
+      bestByPhoto.set(rendition.photoKey, rendition);
+      order.push(rendition.photoKey);
+    } else if (rendition.rank > existing.rank) {
+      bestByPhoto.set(rendition.photoKey, rendition);
+    }
   }
-  return urls;
+  return order
+    .map((key) => bestByPhoto.get(key)?.url)
+    .filter((url): url is string => url !== undefined);
 }
 
 function readHiddenPisoId(html: string): string | undefined {
@@ -344,7 +410,7 @@ export function parsePisosDetail(html: string, url: string): PisosRaw {
   const h1 = readFirstH1Text(html);
   const description = readDescriptionText(html) ?? h1;
 
-  const images = [...new Set(readPisosImageUrls(html))];
+  const images = readPisosImageUrls(html);
   const ld = extractEsSchemaListings(html)[0];
   const geo = readPisosAscendingGeo(html);
   const mapCoords = readPisosLocationMapCoordinates(html);


### PR DESCRIPTION
## Problem

Reported: on pisos.com listings the **first (featured) photo is the same as the second but with the pisos.com watermark** — and in some listings a decorative frame too.

## Root cause (confirmed with real HTML + downloaded renditions)

pisos serves every property photo under several `fotos.imghs.net` **size-variant prefixes** (the first path segment). Downloading the renditions of the same photo across four live listings (Valencia / Madrid / Sevilla) shows:

| variant | watermark? | note |
|---|---|---|
| `xl-wp` | **YES** (pisos.com) | the cover / `og:image` — this was `urls[0]`, the featured photo |
| `fch-wp` | **YES** | large "ficha" rendition |
| `appswm-wp` | **YES** (`wm` = watermark) | apps-size watermarked copy |
| `apps-wp` | no | clean cover copy — this was `urls[1]` |
| `fchm-wp` | no | clean gallery thumbnails |
| `prof-wp/logos/…` | n/a | agency **logo**, not a property photo |

`readPisosImageUrls` scanned every imghs URL and de-duplicated only by exact string, so each listing ingested the watermarked `xl-wp` cover **and** its watermarked `appswm` duplicates **and** the agency logo. The existence of the `apps-wp` (clean) / `appswm-wp` (watermarked) pair proves `apps-wp` is the watermark-free copy of the same image — exactly the user's "first = second but watermarked".

## Fix

- `classifyPisosImage` rejects watermarked size prefixes (`xl-wp`, `fch-wp`, any `*wm` such as `appswm-wp`) and agency logos (`prof-wp/logos/…`).
- `readPisosImageUrls` keeps **one clean rendition per underlying photo** (`apps-wp` preferred over `fchm-wp`) in first-seen order, so the clean cover leads and no size-variant duplicates survive. Unknown future prefixes fall back to a deduped last resort so a real photo is never silently dropped.

## Verification

Real HTML from four live listings (through the ES residential proxy, session-warmed):

| listing | before (mixed) | after (clean) | watermark/logo leaked |
|---|---|---|---|
| Valencia | 14 | 10 | 0 |
| Madrid | 26 | 21 | 0 |
| Sevilla | 35 | 30 | 0 |
| Valencia (Cabañal) | 17 | 12 | 0 |

Primary in every case is now the clean `apps-wp` cover (not the watermarked `xl-wp`).

New fixture `PISOS_FIXTURE_DETAIL_IMAGES_HTML` (recorded from a live Alboraya listing, real URLs + ordering) + tests assert the watermarked cover duplicate and agency logo are dropped and the clean gallery is kept in order. `shared-types` → `listing-providers` → `backend` build clean; pisos + ingestion suites green (16/16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)