### PR TITLE
fix(frontend): hide the save button on the horizontal PropertyCard variant

### DIFF
--- a/packages/frontend/components/PropertyCard.tsx
+++ b/packages/frontend/components/PropertyCard.tsx
@@ -256,13 +256,19 @@ export function PropertyCard({
     return Number.isFinite(created) && Date.now() - created <= NEW_LISTING_WINDOW_MS;
   }, [property?.createdAt]);
 
+  // The horizontal (small single-cover thumbnail) variant is too tight for the
+  // save heart — suppress it there by either path (skeleton + real render).
+  // Vertical/grid/etc. keep it. Computed before the skeleton early-return so both
+  // branches share it.
+  const finalShowSaveButton = showSaveButton && orientation !== 'horizontal';
+
   // Show skeleton loading state
   if (isLoading) {
     return (
       <PropertyCardSkeleton
         variant={variant}
         orientation={orientation}
-        showSaveButton={showSaveButton}
+        showSaveButton={finalShowSaveButton}
         showRating={showRating}
         showPrice={showPrice}
         showFeatures={showFeatures}
@@ -696,14 +702,14 @@ export function PropertyCard({
           button (invalid HTML + hydration error on web). The overlay matches
           the image geometry per orientation so the heart stays pinned to the
           photo's top-right corner. */}
-      {showSaveButton && (
+      {finalShowSaveButton && (
+        // Only the vertical / grid geometry — `finalShowSaveButton` is false for
+        // the horizontal thumbnail, so the heart never renders there.
         <View
           style={[
             styles.mediaOverlay,
             { pointerEvents: 'box-none' },
-            orientation === 'horizontal'
-              ? { width: finalImageHeight, height: finalImageHeight }
-              : { left: 0, right: 0, aspectRatio: isGrid ? gridAspectRatio : 1 },
+            { left: 0, right: 0, aspectRatio: isGrid ? gridAspectRatio : 1 },
           ]}
         >
           <SaveButton


### PR DESCRIPTION
The user wants the horizontal small single-cover-thumbnail `PropertyCard` variant to NOT show the save heart (too tight).

## Change (`components/PropertyCard.tsx`)
- Derive `const finalShowSaveButton = showSaveButton && orientation !== 'horizontal';` before the skeleton early-return so both the skeleton and the real render share it.
- Use `finalShowSaveButton` for BOTH the overlay save render and the `showSaveButton` prop passed to `PropertyCardSkeleton` — a horizontal card never renders the heart by either path.
- The public `showSaveButton` prop default stays `true`; vertical/grid/featured/etc. are unchanged.
- Removed the now-unreachable `orientation === 'horizontal'` geometry branch inside the (non-horizontal-only) save overlay (TS flagged it as dead once `finalShowSaveButton` narrows the orientation).

## Verification
- `bun run build` exit 0; `bunx tsc --noEmit` → 11 pre-existing baseline errors (the PropertyCard `OfferingSummary.fallback` is pre-existing); `grep -rn "style={({"` → ZERO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)