### PR TITLE
fix(frontend): consolidated header — centered constant-size title, overlay on-photo icons, shared actions

### DIFF
--- a/packages/frontend/app/(tabs)/inbox/index.tsx
+++ b/packages/frontend/app/(tabs)/inbox/index.tsx
@@ -46,6 +46,7 @@ import { H3, Text as BloomText } from '@oxyhq/bloom/typography';
 import { useNotifications } from '@/context/NotificationContext';
 import { NotificationItem } from '@/components/NotificationItem';
 import { Header } from '@/components/Header';
+import { IconButton } from '@/components/ui/IconButton';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ErrorState } from '@/components/ui/ErrorState';
 import { ListSkeleton } from '@/components/ui/ListSkeleton';
@@ -231,20 +232,21 @@ export default function InboxScreen() {
     <Header
       options={{
         title: t('inbox.title'),
-        titlePosition: 'left',
         rightComponents: [
           unreadCount > 0 ? (
-            <HeaderIconButton
+            <IconButton
               key="mark-all"
               icon="checkmark-done"
+              variant="ghost"
               color={colors.primaryColor}
               accessibilityLabel={t('notification.markAllRead.action')}
               onPress={handleMarkAllAsRead}
             />
           ) : null,
-          <HeaderIconButton
+          <IconButton
             key="settings"
             icon="settings-outline"
+            variant="ghost"
             color={colors.COLOR_BLACK_LIGHT_2}
             accessibilityLabel={t('notification.settings.title')}
             onPress={() => router.push('/settings/notifications')}
@@ -413,41 +415,6 @@ export default function InboxScreen() {
   );
 }
 
-type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
-
-interface HeaderIconButtonProps {
-  icon: IoniconName;
-  color: string;
-  accessibilityLabel: string;
-  onPress: () => void;
-}
-
-/**
- * Round, tappable header action. Owns its pressed state (NativeWind v4 can't
- * use the function-form `style`), giving a subtle tint on press.
- */
-const HeaderIconButton: React.FC<HeaderIconButtonProps> = ({
-  icon,
-  color,
-  accessibilityLabel,
-  onPress,
-}) => {
-  const [pressed, setPressed] = useState(false);
-  return (
-    <Pressable
-      onPress={onPress}
-      onPressIn={() => setPressed(true)}
-      onPressOut={() => setPressed(false)}
-      accessibilityRole="button"
-      accessibilityLabel={accessibilityLabel}
-      hitSlop={6}
-      style={[styles.headerButton, pressed && styles.headerButtonPressed]}
-    >
-      <Ionicons name={icon} size={22} color={color} />
-    </Pressable>
-  );
-};
-
 interface ScheduledRowProps {
   request: Notifications.NotificationRequest;
   onCancel: () => void;
@@ -503,16 +470,6 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     backgroundColor: colors.background,
-  },
-  headerButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  headerButtonPressed: {
-    backgroundColor: colors.mutedSubtle,
   },
   controls: {
     paddingHorizontal: spacing.lg,

--- a/packages/frontend/app/(tabs)/profile/edit.tsx
+++ b/packages/frontend/app/(tabs)/profile/edit.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, ScrollView, TouchableOpacity } from 'react-native';
+import { View, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { Button } from '@oxyhq/bloom/button';
 import { Header } from '@/components/Header';
 import { ProfileSkeleton } from '@/components/ui/skeletons/ProfileSkeleton';
 import { ProfileEditTabBar } from '@/components/profile/edit/ProfileEditTabBar';
@@ -36,11 +37,15 @@ export default function ProfileEditScreen() {
         options={{
           title,
           rightComponents: [
-            <TouchableOpacity key="save" onPress={form.handleSave} disabled={form.isSaving}>
-              <Text style={styles.saveButtonText}>
-                {form.isSaving ? 'Saving…' : 'Save'}
-              </Text>
-            </TouchableOpacity>,
+            <Button
+              key="save"
+              variant="ghost"
+              size="small"
+              onPress={form.handleSave}
+              disabled={form.isSaving}
+            >
+              {form.isSaving ? 'Saving…' : 'Save'}
+            </Button>,
           ],
         }}
       />

--- a/packages/frontend/app/(tabs)/saved/index.tsx
+++ b/packages/frontend/app/(tabs)/saved/index.tsx
@@ -202,7 +202,6 @@ export default function SavedPropertiesScreen() {
     <Header
       options={{
         title: t('saved.header'),
-        titlePosition: 'left',
       }}
     />
   );

--- a/packages/frontend/app/(tabs)/sindi/[conversationId].tsx
+++ b/packages/frontend/app/(tabs)/sindi/[conversationId].tsx
@@ -3,7 +3,6 @@ import {
   KeyboardAvoidingView,
   Platform,
   Text,
-  TouchableOpacity,
   View,
   type ViewStyle,
 } from 'react-native';
@@ -15,6 +14,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
 import { useOxy, showSignInModal } from '@oxyhq/services';
 import { Header } from '@/components/Header';
+import { IconButton } from '@/components/ui/IconButton';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ChatContent } from '@/components/sindi/ChatContent';
 import { sindiStyles } from '@/components/sindi/styles';
@@ -148,14 +148,13 @@ export default function ConversationDetail() {
           subtitle: t('sindi.conversation.subtitle'),
           showBackButton: true,
           rightComponents: [
-            <TouchableOpacity
+            <IconButton
               key="share"
+              icon="share-outline"
+              variant="ghost"
               onPress={handleShare}
-              accessibilityRole="button"
               accessibilityLabel={t('common.share')}
-            >
-              <Ionicons name="share-outline" size={24} color={colors.COLOR_BLACK} />
-            </TouchableOpacity>,
+            />,
           ],
         }}
       />

--- a/packages/frontend/app/applications/[id].tsx
+++ b/packages/frontend/app/applications/[id].tsx
@@ -207,7 +207,6 @@ export default function ApplicationDetailScreen() {
       options={{
         showBackButton: true,
         title: 'Application',
-        titlePosition: 'center',
       }}
     />
   );

--- a/packages/frontend/app/applications/index.tsx
+++ b/packages/frontend/app/applications/index.tsx
@@ -134,7 +134,6 @@ export default function MyApplicationsScreen() {
       options={{
         showBackButton: true,
         title: t('applications.list.title'),
-        titlePosition: 'center',
       }}
     />
   );

--- a/packages/frontend/app/contracts/[id].tsx
+++ b/packages/frontend/app/contracts/[id].tsx
@@ -187,7 +187,6 @@ export default function ContractDetailScreen() {
       options={{
         showBackButton: true,
         title: t('contracts.detail.title'),
-        titlePosition: 'center',
       }}
     />
   );

--- a/packages/frontend/app/contracts/index.tsx
+++ b/packages/frontend/app/contracts/index.tsx
@@ -132,7 +132,6 @@ export default function ContractsScreen() {
         <Header
           options={{
             title: t('contracts.list.title'),
-            titlePosition: 'center',
           }}
         />
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
@@ -154,7 +153,6 @@ export default function ContractsScreen() {
       <Header
         options={{
           title: t('contracts.list.title'),
-          titlePosition: 'center',
         }}
       />
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>

--- a/packages/frontend/app/contracts/new.tsx
+++ b/packages/frontend/app/contracts/new.tsx
@@ -81,7 +81,6 @@ export default function NewContractScreen() {
       options={{
         showBackButton: true,
         title: t('contracts.new.title'),
-        titlePosition: 'center',
       }}
     />
   );

--- a/packages/frontend/app/exchange/[id].tsx
+++ b/packages/frontend/app/exchange/[id].tsx
@@ -126,7 +126,6 @@ export default function ExchangeRequestDetailScreen() {
       options={{
         showBackButton: true,
         title: t('listing.exchange.detailTitle'),
-        titlePosition: 'center',
       }}
     />
   );

--- a/packages/frontend/app/exchange/requests.tsx
+++ b/packages/frontend/app/exchange/requests.tsx
@@ -124,7 +124,6 @@ export default function ExchangeRequestsScreen() {
       options={{
         showBackButton: true,
         title: t('listing.exchange.requestsTitle'),
-        titlePosition: 'center',
       }}
     />
   );

--- a/packages/frontend/app/horizon/index.tsx
+++ b/packages/frontend/app/horizon/index.tsx
@@ -43,7 +43,6 @@ export default function HorizonPage() {
         options={{
           showBackButton: true,
           title: t('horizon.title'),
-          titlePosition: 'center',
         }}
       />
 

--- a/packages/frontend/app/host/calendar.tsx
+++ b/packages/frontend/app/host/calendar.tsx
@@ -185,7 +185,6 @@ export default function HostCalendarScreen() {
           options={{
             showBackButton: true,
             title: t('host.calendar.title'),
-            titlePosition: 'center',
           }}
         />
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
@@ -211,7 +210,6 @@ export default function HostCalendarScreen() {
           options={{
             showBackButton: true,
             title: t('host.calendar.title'),
-            titlePosition: 'center',
           }}
         />
         <ScrollView contentContainerStyle={styles.content}>
@@ -236,7 +234,6 @@ export default function HostCalendarScreen() {
           options={{
             showBackButton: true,
             title: t('host.calendar.title'),
-            titlePosition: 'center',
           }}
         />
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
@@ -262,7 +259,6 @@ export default function HostCalendarScreen() {
           options={{
             showBackButton: true,
             title: t('host.calendar.title'),
-            titlePosition: 'center',
           }}
         />
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
@@ -287,7 +283,6 @@ export default function HostCalendarScreen() {
         options={{
           showBackButton: true,
           title: t('host.calendar.title'),
-          titlePosition: 'center',
         }}
       />
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>

--- a/packages/frontend/app/host/reservations.tsx
+++ b/packages/frontend/app/host/reservations.tsx
@@ -153,7 +153,6 @@ export default function HostReservationsScreen() {
           options={{
             showBackButton: true,
             title: t('host.reservations.title'),
-            titlePosition: 'center',
           }}
         />
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
@@ -183,7 +182,6 @@ export default function HostReservationsScreen() {
         options={{
           showBackButton: true,
           title: t('host.reservations.title'),
-          titlePosition: 'center',
         }}
       />
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>

--- a/packages/frontend/app/landlord/applications/[id].tsx
+++ b/packages/frontend/app/landlord/applications/[id].tsx
@@ -303,7 +303,6 @@ export default function LandlordApplicationDetailScreen() {
           options={{
             showBackButton: true,
             title: 'Applicant',
-            titlePosition: 'center',
           }}
         />
         <ErrorState
@@ -324,7 +323,6 @@ export default function LandlordApplicationDetailScreen() {
           options={{
             showBackButton: true,
             title: 'Applicant',
-            titlePosition: 'center',
           }}
         />
         <ScrollView contentContainerStyle={styles.content}>
@@ -341,7 +339,6 @@ export default function LandlordApplicationDetailScreen() {
           options={{
             showBackButton: true,
             title: 'Applicant',
-            titlePosition: 'center',
           }}
         />
         <ErrorState
@@ -364,7 +361,6 @@ export default function LandlordApplicationDetailScreen() {
           options={{
             showBackButton: true,
             title: 'Applicant',
-            titlePosition: 'center',
           }}
         />
         <ErrorState
@@ -396,7 +392,6 @@ export default function LandlordApplicationDetailScreen() {
         options={{
           showBackButton: true,
           title: 'Applicant',
-          titlePosition: 'center',
         }}
       />
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>

--- a/packages/frontend/app/landlord/applications/index.tsx
+++ b/packages/frontend/app/landlord/applications/index.tsx
@@ -212,7 +212,6 @@ export default function LandlordApplicationsScreen() {
           options={{
             showBackButton: true,
             title: 'Applicant inbox',
-            titlePosition: 'center',
           }}
         />
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
@@ -238,7 +237,6 @@ export default function LandlordApplicationsScreen() {
           options={{
             showBackButton: true,
             title: 'Applicant inbox',
-            titlePosition: 'center',
           }}
         />
         <ScrollView contentContainerStyle={styles.content}>
@@ -255,7 +253,6 @@ export default function LandlordApplicationsScreen() {
           options={{
             showBackButton: true,
             title: 'Applicant inbox',
-            titlePosition: 'center',
           }}
         />
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
@@ -277,7 +274,6 @@ export default function LandlordApplicationsScreen() {
         options={{
           showBackButton: true,
           title: 'Applicant inbox',
-          titlePosition: 'center',
         }}
       />
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>

--- a/packages/frontend/app/properties/[id]/apply.tsx
+++ b/packages/frontend/app/properties/[id]/apply.tsx
@@ -360,7 +360,6 @@ export default function ApplyToRentScreen() {
         options={{
           showBackButton: true,
           title: t('applications.apply.title'),
-          titlePosition: 'center',
         }}
       />
       <SafeAreaView style={styles.scrollWrapper} edges={['bottom']}>

--- a/packages/frontend/app/properties/[id]/book-viewing.tsx
+++ b/packages/frontend/app/properties/[id]/book-viewing.tsx
@@ -263,7 +263,6 @@ export default function BookViewingPage() {
           options={{
             showBackButton: true,
             title: t('app.loading'),
-            titlePosition: 'center',
           }}
         />
         <View style={styles.loadingContainer}>
@@ -280,7 +279,6 @@ export default function BookViewingPage() {
         options={{
           showBackButton: true,
           title: isModifyMode ? t('viewings.actions.modify') : t('properties.bookViewing'),
-          titlePosition: 'center',
         }}
       />
 

--- a/packages/frontend/app/properties/[id]/index.tsx
+++ b/packages/frontend/app/properties/[id]/index.tsx
@@ -549,7 +549,6 @@ export default function PropertyDetailPage() {
           options={{
             showBackButton: true,
             title: t('property.error', 'Error') || 'Error',
-            titlePosition: 'center',
           }}
         />
         <SafeAreaView style={styles.errorBody} edges={['bottom']}>
@@ -621,7 +620,6 @@ export default function PropertyDetailPage() {
           options={{
             showBackButton: true,
             title: '',
-            titlePosition: 'center',
             transparent: true,
             scrollThreshold: 100,
             // Once the sticky property bar takes over the top, it owns
@@ -634,7 +632,7 @@ export default function PropertyDetailPage() {
                     <IconButton
                       key="profile"
                       icon="person-circle-outline"
-                      variant="ghost"
+                      variant="overlay"
                       onPress={() => router.push(`/roommates/${landlordOxyUserId}`)}
                       accessibilityLabel="Open host profile"
                     />
@@ -642,14 +640,14 @@ export default function PropertyDetailPage() {
                   <IconButton
                     key="share"
                     icon="share-outline"
-                    variant="ghost"
+                    variant="overlay"
                     onPress={handleShare}
                     accessibilityLabel="Share property"
                   />,
                   <IconButton
                     key="viewings"
                     icon="calendar-outline"
-                    variant="ghost"
+                    variant="overlay"
                     onPress={() => router.push('/viewings')}
                     accessibilityLabel="View bookings"
                     badge={
@@ -664,7 +662,7 @@ export default function PropertyDetailPage() {
                     <SaveButton
                       property={apiProperty as Property}
                       variant="heart"
-                      chrome="ghost"
+                      chrome="overlay"
                       color={colors.COLOR_BLACK}
                       activeColor={colors.error}
                       showCount

--- a/packages/frontend/app/properties/[id]/report.tsx
+++ b/packages/frontend/app/properties/[id]/report.tsx
@@ -158,7 +158,6 @@ export default function ReportListingScreen() {
         options={{
           showBackButton: true,
           title: t('property.report.title'),
-          titlePosition: 'center',
         }}
       />
       <SafeAreaView style={styles.scrollWrapper} edges={['bottom']}>

--- a/packages/frontend/app/properties/city/[id].tsx
+++ b/packages/frontend/app/properties/city/[id].tsx
@@ -238,7 +238,6 @@ export default function CityPropertiesPage() {
             options={{
               showBackButton: true,
               title: t('app.loading'),
-              titlePosition: 'center',
             }}
           />
         </View>
@@ -263,7 +262,6 @@ export default function CityPropertiesPage() {
             options={{
               showBackButton: true,
               title: t('common.error'),
-              titlePosition: 'center',
             }}
           />
         </View>
@@ -328,7 +326,6 @@ export default function CityPropertiesPage() {
           options={{
             showBackButton: true,
             title: city?.name || '',
-            titlePosition: 'center',
           }}
         />
       </View>

--- a/packages/frontend/app/reservations/[id].tsx
+++ b/packages/frontend/app/reservations/[id].tsx
@@ -129,7 +129,6 @@ export default function ReservationDetailScreen() {
       options={{
         showBackButton: true,
         title: t('reservations.detail.title'),
-        titlePosition: 'center',
       }}
     />
   );

--- a/packages/frontend/app/roommates/[id].tsx
+++ b/packages/frontend/app/roommates/[id].tsx
@@ -169,7 +169,6 @@ export default function RoommateProfilePage() {
         options={{
           title: t('roommates.profileDetail.title'),
           showBackButton: true,
-          titlePosition: 'center',
         }}
       />
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>

--- a/packages/frontend/app/roommates/preferences.tsx
+++ b/packages/frontend/app/roommates/preferences.tsx
@@ -256,7 +256,6 @@ export default function RoommatePreferencesPage() {
           options={{
             title: t('roommates.preferencesPage.title'),
             showBackButton: true,
-            titlePosition: 'center',
           }}
         />
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
@@ -281,7 +280,6 @@ export default function RoommatePreferencesPage() {
         options={{
           title: t('roommates.preferencesPage.title'),
           showBackButton: true,
-          titlePosition: 'center',
         }}
       />
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>

--- a/packages/frontend/app/settings/currency.tsx
+++ b/packages/frontend/app/settings/currency.tsx
@@ -46,7 +46,6 @@ export default function CurrencySettingsScreen() {
         options={{
           title: t('settings.currency.title'),
           showBackButton: true,
-          titlePosition: 'center',
         }}
       />
       <ScrollView contentContainerStyle={styles.scroll}>

--- a/packages/frontend/app/settings/language.tsx
+++ b/packages/frontend/app/settings/language.tsx
@@ -48,7 +48,6 @@ export default function LanguageSettingsScreen() {
         options={{
           title: t('settings.language.title'),
           showBackButton: true,
-          titlePosition: 'center',
         }}
       />
       <ScrollView contentContainerStyle={styles.scroll}>

--- a/packages/frontend/app/settings/notifications.tsx
+++ b/packages/frontend/app/settings/notifications.tsx
@@ -257,7 +257,6 @@ export default function NotificationSettingsScreen() {
         options={{
           title: t('notification.settings.title'),
           showBackButton: true,
-          titlePosition: 'center',
         }}
       />
       <ScrollView contentContainerStyle={styles.scroll}>

--- a/packages/frontend/app/settings/sindi.tsx
+++ b/packages/frontend/app/settings/sindi.tsx
@@ -55,7 +55,6 @@ export default function SindiSettingsScreen() {
         options={{
           title: t('sindi.settings.title'),
           showBackButton: true,
-          titlePosition: 'center',
           leftComponents: [
             <View key="logo" style={styles.headerIcon}>
               <SindiIcon size={20} color={colors.sindiColor} />

--- a/packages/frontend/app/stays/index.tsx
+++ b/packages/frontend/app/stays/index.tsx
@@ -124,7 +124,6 @@ export default function StaysScreen() {
       options={{
         showBackButton: true,
         title: t('stays.list.title'),
-        titlePosition: 'center',
       }}
     />
   );

--- a/packages/frontend/app/viewings/index.tsx
+++ b/packages/frontend/app/viewings/index.tsx
@@ -246,7 +246,6 @@ export default function ViewingsPage() {
           options={{
             showBackButton: true,
             title: t('viewings.title'),
-            titlePosition: 'center',
           }}
         />
         <SafeAreaView edges={['bottom']} style={styles.safeArea}>
@@ -271,7 +270,6 @@ export default function ViewingsPage() {
         options={{
           showBackButton: true,
           title: t('viewings.title'),
-          titlePosition: 'center',
         }}
       />
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>

--- a/packages/frontend/components/Header.tsx
+++ b/packages/frontend/components/Header.tsx
@@ -33,7 +33,6 @@ const HEADER_SHADOW_MAX_OPACITY = 0.1;
 interface Props {
   options?: {
     title?: string;
-    titlePosition?: 'left' | 'center';
     subtitle?: string;
     showBackButton?: boolean;
     leftComponents?: ReactNode[];
@@ -62,7 +61,6 @@ export const Header: React.FC<Props> = ({ options, scrollY: externalScrollY }) =
   // mask would clip it); it pins flush on narrow/full-bleed web.
   const framed = Platform.OS === 'web' && isScreenNotMobile;
 
-  const titlePosition = options?.titlePosition || 'left';
   const isTransparent = options?.transparent || false;
   const scrollThreshold = options?.scrollThreshold || 20;
 
@@ -127,25 +125,20 @@ export const Header: React.FC<Props> = ({ options, scrollY: externalScrollY }) =
     }),
   } as ViewStyle;
 
-  // Title + optional subtitle, via Bloom `Text`. Shared by the left and center
-  // title positions; each line truncates so a long title never shoves the
-  // actions off-screen (the enclosing block is `flex:1, minWidth:0`).
+  // Title + optional subtitle, via Bloom `Text`, ALWAYS centered. The title is a
+  // CONSTANT size (`text-xl`) — it never shrinks when a subtitle is present (that
+  // caused the live resize bug); the subtitle is a separate smaller muted line
+  // BELOW it. Each line truncates (`text-center` + `numberOfLines={1}`) inside the
+  // centered `flex:1` middle slot so a long title never shoves the actions off.
   const titleNode = (
     <>
       {options?.title ? (
-        <BloomText
-          numberOfLines={1}
-          className={
-            options?.subtitle
-              ? 'text-sm font-extrabold text-foreground'
-              : 'text-xl font-extrabold text-foreground'
-          }
-        >
+        <BloomText numberOfLines={1} className="text-center text-xl font-extrabold text-foreground">
           {options.title}
         </BloomText>
       ) : null}
       {options?.subtitle ? (
-        <BloomText numberOfLines={1} className="text-sm font-normal text-muted-foreground">
+        <BloomText numberOfLines={1} className="text-center text-sm font-normal text-muted-foreground">
           {options.subtitle}
         </BloomText>
       ) : null}
@@ -182,7 +175,10 @@ export const Header: React.FC<Props> = ({ options, scrollY: externalScrollY }) =
           {options?.showBackButton && canGoBack && (
             <IconButton
               icon="arrow-back"
-              variant="ghost"
+              // On a transparent (on-photo) header the bare dark chevron reads as
+              // unfinished — use the frosted-white overlay chip; a solid bar uses
+              // the flat ghost chrome.
+              variant={isTransparent ? 'overlay' : 'ghost'}
               size={barBackIconSize}
               onPress={() => router.back()}
               accessibilityLabel={t('goBack')}
@@ -191,13 +187,8 @@ export const Header: React.FC<Props> = ({ options, scrollY: externalScrollY }) =
           {options?.leftComponents?.map((component, index) => (
             <React.Fragment key={index}>{component}</React.Fragment>
           ))}
-          {titlePosition === 'left' && (
-            <View style={styles.titleBlock}>{titleNode}</View>
-          )}
         </View>
-        {titlePosition === 'center' && (
-          <View style={styles.centerSlot}>{titleNode}</View>
-        )}
+        <View style={styles.centerSlot}>{titleNode}</View>
         <View style={styles.rightSlot}>
           {options?.rightComponents?.map((component, index) => (
             <React.Fragment key={index}>{component}</React.Fragment>
@@ -226,9 +217,14 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: spacing.sm,
   },
+  // Centered middle title block. `minWidth:0` + stretched children (default
+  // alignItems) let the `text-center` title/subtitle truncate instead of pushing
+  // the side slots; sitting between two equal `flex:1` side slots keeps it
+  // centered in the bar regardless of how wide the left/right actions are.
   centerSlot: {
     flex: 1,
-    alignItems: 'center',
+    minWidth: 0,
+    justifyContent: 'center',
   },
   rightSlot: {
     flex: 1,
@@ -236,11 +232,5 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'flex-end',
     gap: spacing.sm,
-  },
-  // Truncating title/subtitle block — `flex:1, minWidth:0` lets a long title
-  // ellipsize inside the row instead of pushing the actions off-screen.
-  titleBlock: {
-    flex: 1,
-    minWidth: 0,
   },
 });


### PR DESCRIPTION
The header "feels completely broken" (user). Root causes fixed:

**A) Title CENTERED app-wide + CONSTANT size** (the "changes sizes" bug) — `Header.tsx` renders the title as a truly-centered middle block (`text-xl` extrabold, `text-center`, `numberOfLines={1}`) between equal `flex:1` side slots; it no longer jumps left↔center or shrinks when a subtitle exists. The subtitle is a separate smaller muted line BELOW. **Clean-cut removed the `titlePosition` prop + all 28 caller usages** (`grep titlePosition` = 0).

**B) Transparent (on-photo) Header → overlay back button** — frosted-white chip instead of a bare dark chevron over the hero; solid bars stay `ghost`.

**C) Property detail floating actions → overlay** — `properties/[id]/index.tsx` pre-scroll header host/share/viewings `IconButton`s + `SaveButton` → `variant`/`chrome="overlay"`. Scrolled `StickyPropertyHeader` stays `ghost`.

**D) Migrated 4 stray actions to shared components** — inbox (deleted local `HeaderIconButton`) + sindi/[conversationId] → `IconButton variant="ghost"`; profile/edit "Save" → Bloom `Button variant="ghost" size="small"` (matching saved/[folderId]'s "Edit").

## Verification
- `bun run build` exit 0; tsc → 11 pre-existing baseline (none in touched files); `grep "style={({"` = ZERO; `grep "titlePosition"` = ZERO.
- **Playwright screenshots (1280 + 390), saved to scratchpad:** `hfix_settings_*`, `hfix_contracts_*`, `hfix_saved_*`, `hfix_inbox_*`, `hfix_profile_*`, `hfix_language_*` — titles are **centered + identical size on all**, the migrated right actions render as flat ghost icons. ✅ consistent.
- ⚠️ **B/C not statically capturable:** `hfix_property_top_*` renders empty because the static serve has no backend (the property hero + floating header never load without a real property). The `overlay` variant is the exact frosted-white chrome already shipped/approved for the on-card save heart (#194), so it's low-risk — but the on-photo icons were **not** visually confirmed here.

**HELD FOR REVIEW** on the B/C point — not merging blind, per the "no blind merge" instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)