### PR TITLE
fix(search): show real result count + 'properties' copy in results header

### DIFF
--- a/packages/frontend/components/search/SearchResultsView.tsx
+++ b/packages/frontend/components/search/SearchResultsView.tsx
@@ -399,15 +399,15 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
 
   const resultsHeading = useMemo(() => {
     if (isLoading) {
-      return t('search.header.loading', 'Searching homes...') || 'Searching homes...';
+      return t('search.header.loading', 'Searching properties...') || 'Searching properties...';
     }
     if (total === 0) {
-      return t('search.header.noResults', 'No homes match this search') ||
-        'No homes match this search';
+      return t('search.header.noResults', 'No properties match this search') ||
+        'No properties match this search';
     }
-    return (
-      t('search.header.count', `${total} homes`) || `${total} homes`
-    );
+    // Pass `count` as interpolation options so i18next selects the pluralized
+    // `search.header.count_one`/`_other` variant and fills `{{count}}`.
+    return t('search.header.count', { count: total }) || `${total} properties`;
   }, [t, isLoading, total]);
 
   // --- shared sub-renders ---
@@ -488,7 +488,7 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
     if (isError) {
       return (
         <ErrorState
-          title={t('search.error.title', 'Could not load homes') || 'Could not load homes'}
+          title={t('search.error.title', 'Could not load properties') || 'Could not load properties'}
           description={error?.message}
           retryLabel={t('common.tryAgain', 'Try again') || 'Try again'}
           onRetry={() => void refetch()}
@@ -500,8 +500,8 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
         <EmptyState
           icon="home-outline"
           title={
-            t('search.empty.title', 'No homes match this search') ||
-            'No homes match this search'
+            t('search.empty.title', 'No properties match this search') ||
+            'No properties match this search'
           }
           description={
             t('search.empty.description', 'Try widening your area or relaxing your filters.') ||

--- a/packages/frontend/locales/ca-ES.json
+++ b/packages/frontend/locales/ca-ES.json
@@ -405,7 +405,7 @@
     "notificationsDescription": "Rep notificacions quan noves propietats coincideixin amb aquesta cerca",
     "withFilters": "Amb filtres",
     "error": {
-      "title": "Could not load homes"
+      "title": "No s'han pogut carregar les propietats"
     },
     "enterSearchQuery": "Si us plau introdueix una consulta de cerca primer",
     "deleteSearch": "Eliminar Cerca",
@@ -647,9 +647,10 @@
     },
     "header": {
       "geocoding": "Looking up location...",
-      "noResults": "No homes match this search",
-      "loading": "Searching homes...",
-      "count": "{{count}} homes"
+      "noResults": "Cap propietat coincideix amb aquesta cerca",
+      "loading": "Cercant propietats...",
+      "count_one": "{{count}} propietat",
+      "count_other": "{{count}} propietats"
     },
     "recent": {
       "title": "Recent searches"
@@ -667,7 +668,7 @@
     "empty": {
       "action": "Edit search",
       "description": "Try widening your area or relaxing your filters.",
-      "title": "No homes match this search"
+      "title": "Cap propietat coincideix amb aquesta cerca"
     },
     "sort": {
       "title": "Ordenar per",

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -415,7 +415,7 @@
     "disableNotifications": "Disable notifications",
     "withFilters": "With filters",
     "error": {
-      "title": "Could not load homes"
+      "title": "Could not load properties"
     },
     "enterSearchQuery": "Please enter a search query first",
     "deleteSearch": "Delete Search",
@@ -650,9 +650,10 @@
     },
     "header": {
       "geocoding": "Looking up location...",
-      "noResults": "No homes match this search",
-      "loading": "Searching homes...",
-      "count": "{{count}} homes"
+      "noResults": "No properties match this search",
+      "loading": "Searching properties...",
+      "count_one": "{{count}} property",
+      "count_other": "{{count}} properties"
     },
     "recent": {
       "title": "Recent searches"
@@ -670,7 +671,7 @@
     "empty": {
       "action": "Edit search",
       "description": "Try widening your area or relaxing your filters.",
-      "title": "No homes match this search"
+      "title": "No properties match this search"
     },
     "sort": {
       "title": "Sort by",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -384,7 +384,7 @@
     "notificationsDescription": "Recibe notificaciones cuando nuevas propiedades coincidan con esta búsqueda",
     "withFilters": "Con filtros",
     "error": {
-      "title": "Could not load homes"
+      "title": "No se pudieron cargar las propiedades"
     },
     "enterSearchQuery": "Por favor ingresa una consulta de búsqueda primero",
     "deleteSearch": "Eliminar Búsqueda",
@@ -626,9 +626,10 @@
     },
     "header": {
       "geocoding": "Looking up location...",
-      "noResults": "No homes match this search",
-      "loading": "Searching homes...",
-      "count": "{{count}} homes"
+      "noResults": "Ninguna propiedad coincide con esta búsqueda",
+      "loading": "Buscando propiedades...",
+      "count_one": "{{count}} propiedad",
+      "count_other": "{{count}} propiedades"
     },
     "recent": {
       "title": "Recent searches"
@@ -646,7 +647,7 @@
     "empty": {
       "action": "Edit search",
       "description": "Try widening your area or relaxing your filters.",
-      "title": "No homes match this search"
+      "title": "Ninguna propiedad coincide con esta búsqueda"
     },
     "sort": {
       "title": "Ordenar por",

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -723,7 +723,7 @@
     "disableNotifications": "Disable notifications",
     "withFilters": "With filters",
     "error": {
-      "title": "Could not load homes"
+      "title": "Impossibile caricare gli immobili"
     },
     "enterSearchQuery": "Please enter a search query first",
     "deleteSearch": "Delete Search",
@@ -794,9 +794,10 @@
     },
     "header": {
       "geocoding": "Looking up location...",
-      "noResults": "No homes match this search",
-      "loading": "Searching homes...",
-      "count": "{{count}} homes"
+      "noResults": "Nessun immobile corrisponde a questa ricerca",
+      "loading": "Ricerca immobili...",
+      "count_one": "{{count}} immobile",
+      "count_other": "{{count}} immobili"
     },
     "recent": {
       "title": "Recent searches"
@@ -814,7 +815,7 @@
     "empty": {
       "action": "Edit search",
       "description": "Try widening your area or relaxing your filters.",
-      "title": "No homes match this search"
+      "title": "Nessun immobile corrisponde a questa ricerca"
     },
     "sort": {
       "title": "Ordina per",


### PR DESCRIPTION
## Summary
- Fixes the results header showing a literal `{{count}} homes` — `t('search.header.count', \`${total} homes\`)` passed the count as a string, which i18next treats as a defaultValue rather than an interpolation value, so `{{count}}` never filled. Now calls `t('search.header.count', { count: total })`.
- Switches search-results copy from "homes" to "properties": `search.header.count` is pluralized (`count_one`/`count_other`, old `count` key removed), plus `header.loading`, `header.noResults`, `error.title`, `empty.title` and their hardcoded English fallbacks. Translated across all 4 locales (es "propiedades", it "immobili", ca "propietats"). Home-screen brand copy ("Recommended homes" etc.) is intentionally unchanged.

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] `bun run check:i18n` (locale parity)
- [x] `bunx tsc --noEmit` — 11 pre-existing baseline errors only, none in touched files
- [x] `bun run test` (full monorepo) — frontend 32/32, backend 539/539, listing-providers 395/395
- [x] `bun run build:frontend` — exit 0