### PR TITLE
fix(frontend): unblock property card carousel nav arrows (RN-Web box-none is invalid CSS)

### DIFF
--- a/packages/frontend/components/PropertyCard.tsx
+++ b/packages/frontend/components/PropertyCard.tsx
@@ -706,9 +706,14 @@ export function PropertyCard({
         // Only the vertical / grid geometry — `finalShowSaveButton` is false for
         // the horizontal thumbnail, so the heart never renders there.
         <View
+          // `pointerEvents:'none'` (NOT the RN-only `'box-none'`, which is an
+          // INVALID CSS `pointer-events` value that RN-Web silently drops → the
+          // full-photo overlay stays `auto` and swallows every hover/tap on the
+          // carousel, hiding the nav arrows). The save heart re-enables itself
+          // with `pointerEvents:'auto'` (valid CSS) so only it stays interactive.
           style={[
             styles.mediaOverlay,
-            { pointerEvents: 'box-none' },
+            { pointerEvents: 'none' },
             { left: 0, right: 0, aspectRatio: isGrid ? gridAspectRatio : 1 },
           ]}
         >
@@ -890,12 +895,14 @@ const styles = StyleSheet.create({
     zIndex: 2,
   },
   // Positioning only — the frosted-white chrome comes from `SaveButton`'s
-  // `chrome="overlay"` variant.
+  // `chrome="overlay"` variant. `pointerEvents:'auto'` re-enables just the heart
+  // inside the `pointerEvents:'none'` media overlay (valid-CSS box-none).
   saveButton: {
     position: 'absolute',
     top: spacing.sm,
     right: spacing.sm,
     zIndex: 2,
+    pointerEvents: 'auto',
   },
   /**
    * The single photo-overlay chip stack. Absolutely pinned to the top-left at a

--- a/packages/frontend/components/property/PropertyImageCarousel.tsx
+++ b/packages/frontend/components/property/PropertyImageCarousel.tsx
@@ -442,20 +442,24 @@ export const PropertyImageCarousel: React.FC<PropertyImageCarouselProps> = ({
         />
       )}
 
+      {/* Caller chrome (heart, badges, price) — rendered UNDER the dots + arrows
+          so it can never paint over or intercept the nav arrows. Its own
+          absolutely-positioned bits sit in the corners, clear of the arrows. */}
+      {children}
+
       {isMultiPage ? (
         <PaginationDots count={sources.length} activeIndex={activeIndex} />
       ) : null}
 
-      {/* Web hover arrows — siblings of the FlatList, so each is its own press
-          target and never bubbles to the page tap that opens the detail. */}
+      {/* Web hover arrows — the TOPMOST interactive layer over the photo, and
+          siblings of the FlatList so each is its own press target that never
+          bubbles to the page tap that opens the detail. */}
       {showPrevArrow ? (
         <NavArrow direction="prev" onPress={goPrev} accessibilityLabel="Previous photo" />
       ) : null}
       {showNextArrow ? (
         <NavArrow direction="next" onPress={goNext} accessibilityLabel="Next photo" />
       ) : null}
-
-      {children}
     </View>
   );
 };


### PR DESCRIPTION
User: on the property card image carousel, "hay algo por encima que bloquea poder VER/usar las arrows."

## Root cause (found via Playwright `document.elementFromPoint`, not guessed)
`PropertyCard`'s full-photo `mediaOverlay` save layer set `pointerEvents:'box-none'` as a **style**. `box-none` is an RN-only value — **not a valid CSS `pointer-events` value** — so RN-Web silently drops it and the layer stays `pointer-events:auto`. That transparent, photo-spanning, `zIndex:2` overlay then swallowed every hover/tap over the carousel:
- `elementFromPoint` at the arrow position returned that overlay div (computed `pointer-events:auto`, `z:2`), not the arrow.
- The carousel's `onPointerEnter` never fired → `hovered` stayed false → **the nav arrows never rendered** (`Next arrow present: false`).
- Photo taps didn't reach the carousel's `onPress` (`taps:0`).

## Fix (2 files)
- `PropertyCard.tsx` `mediaOverlay` → `pointerEvents:'none'` (valid CSS; passes hover + taps through); the save heart re-enables itself with `pointerEvents:'auto'` — the valid-CSS equivalent of box-none, so only the heart stays interactive.
- `PropertyImageCarousel.tsx` renders `{children}` (caller chrome) UNDER the dots + arrows, so the nav arrows are the **topmost interactive layer** and no chrome can paint over/intercept them.

`ZoomableImage.tsx` needed no change (the masked zoom is untouched and still works).

## Verified in a real browser (Playwright)
Reproduced the exact PropertyCard media stacking (real carousel + a faithful replica of the `mediaOverlay` save layer + a chip badge). Before → `Next arrow present on hover: false` (blocked). After → arrows appear on hover, `elementFromPoint` at each arrow returns the arrow `BUTTON`, clicking Next pages the photo (red→green) + advances the dots, the arrow click does NOT leak to the photo tap (`taps:0`), and tapping the photo opens detail (`taps:1`). Screenshots in scratchpad: `carousel_broken_hover.png` (before), `carousel_hover.png` + `carousel_after_next.png` (after).

Note: the live home/explore feed needs a backend the static export lacks, so verification used a faithful component harness of the exact layering (then deleted).

## Gates
`bun run build` exit 0; tsc → 11 pre-existing baseline (none in touched files); `grep "style={({"` = ZERO.

## Follow-up (out of scope)
The same latent `pointerEvents:'box-none'`-as-style bug exists in `components/ui/MapMarkerPopover.tsx`, `components/SideBar/index.tsx`, `components/sindi/SindiPanel.tsx` — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)