### PR TITLE
feat(ingest): classify listing content flags (students-only/room/temporary/…) multi-language

### DIFF
--- a/packages/backend/__tests__/integration/externalIngest.test.ts
+++ b/packages/backend/__tests__/integration/externalIngest.test.ts
@@ -203,6 +203,46 @@ describe('external listing ingest (fixture -> IngestionService)', () => {
     });
   });
 
+  it('classifies and persists listingFlags from the description free text', async () => {
+    const ingestion = buildIngestionService();
+    const [first] = await normalizeAll();
+    const withFlags: NormalizedListing = {
+      ...first,
+      description:
+        'Se alquilan habitaciones en piso compartido, exclusivamente para estudiantes. ' +
+        'Solo chicas. No se admiten mascotas. Alquiler de temporada de septiembre a junio.',
+    };
+
+    await ingestion.ingest(withFlags);
+    const property = await Property.findOne({ source: 'fixture', sourceId: FIRST_SOURCE_ID }).lean();
+    expect(property?.listingFlags).toMatchObject({
+      roomNotFullUnit: true,
+      studentsOnly: true,
+      genderRestricted: true,
+      noPets: true,
+      temporaryOnly: true,
+    });
+    // Flags that did not fire stay absent (sparse).
+    expect(property?.listingFlags?.agencyFeePayable).toBeUndefined();
+    expect(property?.listingFlags?.noDSS).toBeUndefined();
+  });
+
+  it('omits listingFlags entirely when the description trips no rule', async () => {
+    const ingestion = buildIngestionService();
+    const [first] = await normalizeAll();
+    const plain: NormalizedListing = {
+      ...first,
+      description: 'Bright two-bedroom flat with a lift, a balcony and a modern kitchen.',
+    };
+
+    await ingestion.ingest(plain);
+    const property = await Property.findOne({ source: 'fixture', sourceId: FIRST_SOURCE_ID }).lean();
+    // No restriction flag fired; only a language may be detected (or nothing).
+    expect(property?.listingFlags?.roomNotFullUnit).toBeUndefined();
+    expect(property?.listingFlags?.studentsOnly).toBeUndefined();
+    expect(property?.listingFlags?.temporaryOnly).toBeUndefined();
+  });
+
   it('rejects partner-style absurd monthly rent at the ingest gate (11628 EUR)', async () => {
     const ingestion = buildIngestionService();
     const absurdListing: NormalizedListing = {

--- a/packages/backend/__tests__/unit/classifyListingContent.test.ts
+++ b/packages/backend/__tests__/unit/classifyListingContent.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Free-text listing classifier. Every positive fixture is a (lightly trimmed)
+ * REAL description pulled from prod (pisos/fotocasa/habitaclia/immoweb/rightmove,
+ * ES/CA/EN/FR/NL) or a canonical phrase for a language the live corpus does not
+ * yet cover (DE/IT). Every negative fixture is a real false-positive trap the
+ * rules are written to survive.
+ */
+
+import { classifyListingContent, type ListingFlags } from '../../services/ingestion/classifyListingContent';
+
+/** True iff the classifier set exactly this one boolean flag (order-independent). */
+function flag(text: string): ListingFlags {
+  return classifyListingContent(text);
+}
+
+describe('classifyListingContent', () => {
+  it('returns an empty object for empty / whitespace / nullish input', () => {
+    expect(classifyListingContent(undefined)).toEqual({});
+    expect(classifyListingContent(null)).toEqual({});
+    expect(classifyListingContent('')).toEqual({});
+    expect(classifyListingContent('   \n  ')).toEqual({});
+  });
+
+  describe('studentsOnly', () => {
+    it.each([
+      // ES — real prod hits (exclusivity marker present)
+      ['se alquila piso exclusivo para estudiantes a 5 minutos de las universidades', 'ES'],
+      ['disponible de agosto 2026 solo estudiantes tiene 3 dormitorios', 'ES'],
+      ['piso en alquiler en lleida exclusivo para estudiantes se ofrece vivienda amplia', 'ES'],
+      ['unicamente estudiantes, curso 2026/2027', 'ES'],
+      ['se alquilan habitaciones amuebladas en residencia de estudiantes', 'ES'],
+      // EN — immoweb
+      ['brand-new student residence with only 12 rooms available', 'EN'],
+      ['this flat is for students only, close to campus', 'EN'],
+      // DE / IT / FR / NL — canonical
+      ['schone wohnung, nur fur studenten in der innenstadt', 'DE'],
+      ['appartamento in centro, solo studenti', 'IT'],
+      ['bel appartement reserve aux etudiants, proche du campus', 'FR'],
+      ['mooi appartement, alleen voor studenten, dicht bij de universiteit', 'NL'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).studentsOnly).toBe(true);
+    });
+
+    it.each([
+      // Open to multiple audiences — 47 real "para estudiantes O …" listings.
+      'perfecto para estudiantes o jovenes profesionales que buscan compartir',
+      'ofrece el entorno ideal para estudiantes, profesionales o familias',
+      'ideal for students, young professionals, or singles located in the center',
+      'especialmente para estudiantes o trabajadores, disponibilidad inmediata',
+      // Suitability, not restriction
+      'ideal para estudiantes por su cercania a la universidad',
+    ])('does NOT flag open/suitability phrasing "%s"', (text) => {
+      expect(flag(text).studentsOnly).toBeUndefined();
+    });
+  });
+
+  describe('roomNotFullUnit', () => {
+    it.each([
+      // ES / CA — real prod
+      ['se alquilan 2 habitaciones en piso compartido, el piso son 3 habitaciones', 'ES'],
+      ['se alquilan habitaciones en un apartamento amueblado de 3 dormitorios', 'ES'],
+      ['esta habitacion en un piso compartido de 6 habitaciones en el coll', 'ES'],
+      ['alquila esta fantastica habitacion en piso compartido en la calle pedroches', 'ES'],
+      ['se alquila coqueta habitacion en el centro historico', 'ES'],
+      // EN — immoweb
+      ['5 rooms for rent in a student apartment located in the center of gembloux', 'EN'],
+      ['a bright room in a shared flat near the station', 'EN'],
+      ['spacious house share available now, all bills included', 'EN'],
+      // DE / IT / FR / NL — canonical
+      ['helles wg-zimmer in einer 3er wohngemeinschaft zu vermieten', 'DE'],
+      ['posto letto in stanza doppia, appartamento condiviso vicino al centro', 'IT'],
+      ['chambre en colocation dans un bel appartement renove', 'FR'],
+      ['kamer te huur in een gedeeld appartement in het centrum', 'NL'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).roomNotFullUnit).toBe(true);
+    });
+
+    it.each([
+      // Whole flat rented (bedroom COUNT, not a room let)
+      'se alquila amplio piso con 4 habitaciones y 2 banos totalmente reformado',
+      'se alquila estupendo piso de 3 habitaciones con ascensor',
+      'el piso tiene 3 habitaciones, una de ellas tipo suite',
+      // "para compartir" = whole flat marketed as shareable — 110 real hits
+      'piso perfecto para compartir con tus companeros de estudio o trabajo',
+      'amigos que quieran compartir piso y disfrutar de un barrio con servicios',
+      'oportunidad perfecta para compartir piso con amigos',
+      // Explicit whole-unit disclaimers — 3 real prod listings (the OPPOSITE of
+      // a room let); the negated rent-verb must be vetoed.
+      'se integra a un grupo cerrado, no se alquila por habitaciones sueltas',
+      'contrato universitario, maximo once meses. no se alquila por habitaciones, sino de forma completa',
+      'solo estudiantes. no se alquilan habitaciones por separado.',
+    ])('does NOT flag whole-flat / share-suitable phrasing "%s"', (text) => {
+      expect(flag(text).roomNotFullUnit).toBeUndefined();
+    });
+  });
+
+  describe('temporaryOnly', () => {
+    it.each([
+      // ES — real prod
+      ['alquiler de temporada fantastico apartamento en primera linea', 'ES'],
+      ['se alquila temporada de septiembre a junio, curso academico', 'ES'],
+      ['alquiler temporal: casita de pescadores para los meses de verano', 'ES'],
+      ['apartamento vacacional, disponible por meses', 'ES'],
+      // EN
+      ['stylish short let apartment, minimum one month stay', 'EN'],
+      ['holiday let in the city centre, fully serviced', 'EN'],
+      // DE / IT / FR / NL — canonical
+      ['moblierte wohnung auf zeit, zwischenmiete bis august', 'DE'],
+      ['affitto breve, contratto temporaneo uso transitorio', 'IT'],
+      ['location saisonniere, bail mobilite de trois mois', 'FR'],
+      ['tijdelijk appartement voor kort verblijf in het centrum', 'NL'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).temporaryOnly).toBe(true);
+    });
+
+    it.each([
+      // Permanent lease, no seasonal wording
+      'alquiler de larga duracion, vivienda habitual reformada con ascensor',
+      'piso disponible todo el ano para residencia habitual',
+      // Guarded: "cuatro/todas las temporadas" (climate / name), not a lease term
+      'aire acondicionado frio calor para todas las temporadas del ano',
+      'urbanizacion las cuatro temporadas con piscina comunitaria',
+    ])('does NOT flag permanent / guarded phrasing "%s"', (text) => {
+      expect(flag(text).temporaryOnly).toBeUndefined();
+    });
+  });
+
+  describe('genderRestricted', () => {
+    it.each([
+      ['quedan dos habitaciones, solo chicas, no llegues tarde', 'ES'],
+      ['habitaciones para estudiantes solo chicas zona pardaleras', 'ES'],
+      ['solo chicos trabajadores, ambiente tranquilo', 'ES'],
+      ['double room in a house share, women only please', 'EN'],
+      ['schones zimmer, nur frauen', 'DE'],
+      ['stanza luminosa, solo ragazze', 'IT'],
+      ['chambre agreable, femmes uniquement', 'FR'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).genderRestricted).toBe(true);
+    });
+
+    it.each([
+      'piso ideal para chicas y chicos que quieran compartir',
+      'apartamento para dos personas en el centro',
+      'habitacion para una sola persona con bano privado',
+    ])('does NOT flag non-restrictive phrasing "%s"', (text) => {
+      expect(flag(text).genderRestricted).toBeUndefined();
+    });
+  });
+
+  describe('workersOnly', () => {
+    it.each([
+      ['importante ser trabajador con nomina, se pide solvencia', 'ES'],
+      ['ingresos demostrables mediante nomina y contrato de trabajo', 'ES'],
+      ['solo trabajadores con contrato indefinido', 'ES'],
+      ['requerimos ultima nomina y vida laboral', 'ES'],
+      ['working professionals only, references required', 'EN'],
+      ['proof of income and employment required', 'EN'],
+      ['nur fur berufstatige, einkommensnachweis erforderlich', 'DE'],
+      ['solo lavoratori con busta paga', 'IT'],
+      ['fiche de paie et contrat de travail exiges', 'FR'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).workersOnly).toBe(true);
+    });
+
+    it.each([
+      'piso luminoso reformado con cocina nueva y armarios empotrados',
+      'apartment with a modern kitchen and two bedrooms',
+    ])('does NOT flag listings without an employment/income requirement "%s"', (text) => {
+      expect(flag(text).workersOnly).toBeUndefined();
+    });
+  });
+
+  describe('agencyFeePayable', () => {
+    it.each([
+      ['honorarios no incluidos en el precio, se pagan aparte', 'ES'],
+      ['nuestros honorarios son de una mensualidad', 'ES'],
+      ['fianza de dos meses y un mes de honorarios de agencia', 'ES'],
+      ['contact us for a viewing, agency fee applies', 'EN'],
+      ['zzgl. maklerprovision von einer monatsmiete', 'DE'],
+      ['richiesta commissione di agenzia pari a una mensilita', 'IT'],
+      ['loyer 800 euros plus frais d agence a charge du locataire', 'FR'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).agencyFeePayable).toBe(true);
+    });
+
+    it.each([
+      // "no fee to tenant" — 22 real vetoed hits
+      'alquiler de vivienda habitual, sin honorarios de agencia para el inquilino',
+      'no se repercute ningun tipo de honorarios al inquilino',
+      'honorarios incluidos, sin gastos adicionales',
+      // "provision" = utility charges, NOT a Maklerprovision — 59 real hits
+      'provision de 150 euros por calefaccion, agua y luz',
+      '150 euros de provision mensual de agua, luz y gas',
+      // bare "commission" is a landmark / a monthly charge, never a trigger
+      'the european commission is 4 km away from the apartment',
+      'monthly commission 175 euro per month including heating and water',
+    ])('does NOT flag vetoed / non-agency phrasing "%s"', (text) => {
+      expect(flag(text).agencyFeePayable).toBeUndefined();
+    });
+  });
+
+  describe('noPets', () => {
+    it.each([
+      ['con ascensor, no se admiten mascotas y se pide solvencia', 'ES'],
+      ['comunidad incluida. no animales.', 'ES'],
+      ['bright apartment, sorry no pets', 'EN'],
+      ['schone wohnung, keine haustiere', 'DE'],
+      ['appartamento arredato, animali non ammessi', 'IT'],
+      ['bel appartement, pas d animaux', 'FR'],
+      ['ruim appartement, geen huisdieren', 'NL'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).noPets).toBe(true);
+    });
+
+    it.each([
+      // Pets ALLOWED — 220 real listings say this; must never flag
+      'apartamento amplio, se admiten mascotas sin problema',
+      'pet friendly building, pets are welcome',
+      'zona tranquila con parque para pasear a tu mascota',
+    ])('does NOT flag pet-friendly phrasing "%s"', (text) => {
+      expect(flag(text).noPets).toBeUndefined();
+    });
+  });
+
+  describe('noSmoking', () => {
+    it.each([
+      ['personas cuidadosas, no fumadores', 'ES'],
+      ['this apartment is allergy-free and non-smoking', 'EN'],
+      ['gemutliche wohnung fur nichtraucher', 'DE'],
+      ['appartamento per non fumatori', 'IT'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).noSmoking).toBe(true);
+    });
+
+    it('does NOT flag a listing that merely mentions a terrace', () => {
+      expect(flag('gran terraza exterior donde disfrutar del sol').noSmoking).toBeUndefined();
+    });
+  });
+
+  describe('noCouples', () => {
+    it.each([
+      ['sorry but no couples/room shares or pets', 'EN'],
+      ['habitacion individual, no parejas', 'ES'],
+      ['single occupancy only, quiet professional preferred', 'EN'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).noCouples).toBe(true);
+    });
+
+    it('does NOT flag a listing ideal for couples', () => {
+      expect(flag('acogedor apartamento ideal para parejas').noCouples).toBeUndefined();
+    });
+  });
+
+  describe('noDSS', () => {
+    it.each([
+      ['professional tenants only, no dss', 'EN'],
+      ['sorry, no housing benefit accepted', 'EN'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).noDSS).toBe(true);
+    });
+
+    it('does NOT flag "great benefits nearby"', () => {
+      expect(flag('lots of great benefits nearby including shops and transport').noDSS).toBeUndefined();
+    });
+  });
+
+  describe('combinations, accents and title', () => {
+    it('sets multiple flags from one description', () => {
+      const flags = flag(
+        'se alquilan habitaciones en piso compartido, exclusivamente para estudiantes, solo chicas. no se admiten mascotas.',
+      );
+      expect(flags.roomNotFullUnit).toBe(true);
+      expect(flags.studentsOnly).toBe(true);
+      expect(flags.genderRestricted).toBe(true);
+      expect(flags.noPets).toBe(true);
+    });
+
+    it('matches regardless of accents / casing / line breaks', () => {
+      const flags = classifyListingContent('No se ADMITEN\nMáscotas.\nSólo estudiantes.');
+      expect(flags.noPets).toBe(true);
+      expect(flags.studentsOnly).toBe(true);
+    });
+
+    it('also reads the optional title argument', () => {
+      const flags = classifyListingContent('bright and modern', 'Room for rent in shared flat');
+      expect(flags.roomNotFullUnit).toBe(true);
+    });
+  });
+
+  describe('detectedLanguage', () => {
+    it.each([
+      [
+        'es',
+        'se alquila esta preciosa vivienda con dos dormitorios, cocina amueblada y bano completo en una zona muy tranquila cerca del centro comercial',
+      ],
+      [
+        'en',
+        'this bright apartment features two bedrooms and a modern kitchen, located very close to the station with all the amenities the property offers',
+      ],
+      [
+        'fr',
+        'ce bel appartement avec deux chambres et une cuisine equipee est situe tres proche du centre, la salle de bain est renovee et le loyer est raisonnable',
+      ],
+      [
+        'nl',
+        'dit ruime appartement met twee slaapkamers en een keuken is zeer gunstig gelegen nabij het centrum, de woning heeft ook een mooie badkamer',
+      ],
+      [
+        'de',
+        'diese schone wohnung mit zwei schlafzimmern und einer kuche liegt sehr zentral gelegen, das zimmer ist hell und die grosse terrasse gehort dazu',
+      ],
+      [
+        'it',
+        'questa luminosa appartamento con camera e cucina si trova molto vicino al centro, il soggiorno e ampio e della zona molto tranquilla al piano terra',
+      ],
+      [
+        'ca',
+        'aquest habitatge amb dues habitacions i cuina equipada esta situat molt a prop del centre, el pis es gran i lloguer amb bany reformat als afores',
+      ],
+    ])('detects %s', (lang, text) => {
+      expect(classifyListingContent(text).detectedLanguage).toBe(lang);
+    });
+
+    it('leaves short / ambiguous text unlabeled', () => {
+      expect(classifyListingContent('piso centro').detectedLanguage).toBeUndefined();
+      expect(classifyListingContent('123 456 789 000 111 222 333 444 555 666 777').detectedLanguage).toBeUndefined();
+    });
+  });
+});

--- a/packages/backend/models/Property.ts
+++ b/packages/backend/models/Property.ts
@@ -39,6 +39,35 @@ export interface IProperty extends Document {
     agencyName?: string;
     kind?: 'owner' | 'agency' | 'private' | 'unknown';
   };
+  /**
+   * Restriction/nuance flags derived from the listing's free text at ingest by
+   * `classifyListingContent` (external listings only). Portals bury these in
+   * prose instead of structured fields; only flags that fire are present.
+   */
+  listingFlags?: {
+    /** Rental restricted to students ("solo estudiantes", "students only"). */
+    studentsOnly?: boolean;
+    /** Advertised as a flat but the body rents a single room / a share. */
+    roomNotFullUnit?: boolean;
+    /** Seasonal / temporary lease ("temporada", "short let"), not a home. */
+    temporaryOnly?: boolean;
+    /** Restricted to one gender ("solo chicas", "women only"). */
+    genderRestricted?: boolean;
+    /** Requires proof of employment/income ("nómina", "working professionals only"). */
+    workersOnly?: boolean;
+    /** An agency fee is payable by the tenant/buyer ("honorarios de agencia"). */
+    agencyFeePayable?: boolean;
+    /** Pets not allowed ("no se admiten mascotas", "no pets"). */
+    noPets?: boolean;
+    /** Smoking not allowed ("no fumadores", "non-smoking"). */
+    noSmoking?: boolean;
+    /** No couples ("no parejas", "no couples"). */
+    noCouples?: boolean;
+    /** UK: no housing benefit ("no DSS"). */
+    noDSS?: boolean;
+    /** Best-effort detected description language (ISO 639-1). */
+    detectedLanguage?: 'es' | 'ca' | 'en' | 'fr' | 'nl' | 'de' | 'it';
+  };
   expiresAt?: Date;
   type: PropertyType;
   housingType?: HousingType;

--- a/packages/backend/models/schemas/PropertySchema.ts
+++ b/packages/backend/models/schemas/PropertySchema.ts
@@ -289,6 +289,27 @@ const propertySchema = new mongoose.Schema({
     }, { _id: false }),
     required: false,
   },
+  /**
+   * Restriction/nuance flags derived from the listing free text at ingest by
+   * `classifyListingContent` (external listings only). Sparse — only firing
+   * flags are stored. See `services/ingestion/classifyListingContent.ts`.
+   */
+  listingFlags: {
+    type: new mongoose.Schema({
+      studentsOnly: { type: Boolean },
+      roomNotFullUnit: { type: Boolean },
+      temporaryOnly: { type: Boolean },
+      genderRestricted: { type: Boolean },
+      workersOnly: { type: Boolean },
+      agencyFeePayable: { type: Boolean },
+      noPets: { type: Boolean },
+      noSmoking: { type: Boolean },
+      noCouples: { type: Boolean },
+      noDSS: { type: Boolean },
+      detectedLanguage: { type: String, enum: ['es', 'ca', 'en', 'fr', 'nl', 'de', 'it'] },
+    }, { _id: false }),
+    required: false,
+  },
   expiresAt: {
     type: Date,
     index: { expireAfterSeconds: 0 }, // TTL index; document auto-removed after this date

--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -32,6 +32,7 @@ import { validateOfferings } from '../../models/schemas/offeringValidation';
 import { forwardGeocode, reverseGeocode } from '../geocodingService';
 import { sanitizeGeoJsonCoordinates } from '../../utils/geoCoordinates';
 import { deriveStructuredFeatures } from './deriveFeatures';
+import { classifyListingContent } from './classifyListingContent';
 import { ExternalMediaIngest } from './ExternalMediaIngest';
 import { schedulePriceEthicsScore } from '../priceEthicsService';
 import { Logger } from '../../utils/logger';
@@ -297,6 +298,13 @@ export class IngestionService {
     if (parkingType !== undefined) fields.parkingType = parkingType;
     const furnishedStatus = listing.furnishedStatus ?? derived.furnishedStatus;
     if (furnishedStatus !== undefined) fields.furnishedStatus = furnishedStatus;
+
+    // Classify the free-text description into restriction/nuance flags portals
+    // never expose structurally (students-only, room-not-full-unit, temporary,
+    // agency fee, …). Runs on the full pre-truncation description. Only stored
+    // when at least one flag or a detected language fires.
+    const listingFlags = classifyListingContent(listing.description);
+    if (Object.keys(listingFlags).length > 0) fields.listingFlags = listingFlags;
 
     if (listing.contact) {
       const externalContact: NonNullable<IProperty['externalContact']> = {};

--- a/packages/backend/services/ingestion/classifyListingContent.ts
+++ b/packages/backend/services/ingestion/classifyListingContent.ts
@@ -1,0 +1,469 @@
+/**
+ * Classify the *free-text* of an external listing (description + title) into a
+ * set of structured restriction/nuance flags that portals almost never expose
+ * as structured fields, but routinely bury in prose.
+ *
+ * Real-world motivation (measured on ~5,600 live prod listings across pisos,
+ * fotocasa, habitaclia, immoweb and rightmove — ES/CA/EN/FR/NL):
+ * - A `type: apartment` listing whose body actually rents a single ROOM in a
+ *   shared flat ("se alquilan habitaciones en piso compartido") — the classic
+ *   bait-and-switch (~1.5% of the corpus).
+ * - Seasonal / temporary leases ("alquiler de temporada", "short let") sold as
+ *   a normal apartment (~18% of the ES corpus).
+ * - Hard tenant restrictions: students only, one gender only, employed/nómina
+ *   only, no pets, no smoking, no couples, no DSS.
+ * - An agency fee payable by the tenant ("honorarios de agencia").
+ *
+ * This is a DETERMINISTIC keyword/regex classifier — zero per-listing cost, no
+ * network, no model. It runs multi-language over normalized (deaccented,
+ * lowercased, whitespace-collapsed) text with word boundaries to avoid the
+ * substring traps that a naive `includes()` would hit (e.g. "estudio" vs
+ * "estudiante", "provisión de gastos" vs German "Maklerprovision").
+ *
+ * Every rule below was validated against the real corpus; the guard comments
+ * cite the concrete false positive each pattern is written to avoid.
+ */
+
+import { deaccent } from '@homiio/listing-providers';
+import type { IProperty } from '../../models/Property';
+
+/** Classifier output — the schema authority is `IProperty['listingFlags']`. */
+export type ListingFlags = NonNullable<IProperty['listingFlags']>;
+
+/** Languages the deterministic detector can distinguish (ISO 639-1). */
+type DetectedLanguage = NonNullable<ListingFlags['detectedLanguage']>;
+
+/** Boolean flag keys (everything on `ListingFlags` except `detectedLanguage`). */
+type FlagKey = Exclude<keyof ListingFlags, 'detectedLanguage'>;
+
+interface FlagRule {
+  readonly flag: FlagKey;
+  /** Any trigger match sets the flag… */
+  readonly triggers: readonly RegExp[];
+  /** …unless a veto matches (used only where a phrase can be explicitly negated). */
+  readonly vetoes?: readonly RegExp[];
+}
+
+/**
+ * `deaccent` already lowercases + strips diacritics + trims; we additionally
+ * collapse all whitespace runs to single spaces so multi-token phrases match
+ * across line breaks ("no se admiten\nmascotas").
+ */
+function normalizeText(raw: string): string {
+  return deaccent(raw).replace(/\s+/g, ' ');
+}
+
+const RULES: readonly FlagRule[] = [
+  {
+    // studentsOnly — a genuine restriction, NOT mere suitability. Bare
+    // "para estudiantes" is deliberately excluded: 47 real listings say
+    // "para estudiantes O (jovenes) profesionales/trabajadores/familias"
+    // (open to everyone). We require an exclusivity marker (solo / exclusivo
+    // para / unicamente / reservado / only) or a dedicated-student-housing
+    // noun (residencia de estudiantes / student residence / Studentenwohnheim).
+    flag: 'studentsOnly',
+    triggers: [
+      // ES / CA
+      /\b(?:solo|solamente|unicamente|exclusivamente)\s+(?:para\s+)?estudiantes?\b/,
+      /\bexclusiv[oa]s?\s+(?:para\s+)?estudiantes?\b/,
+      /\breservad[oa]s?\s+(?:a|para)\s+estudiantes?\b/,
+      /\bresidencia\s+(?:de\s+estudiantes|universitaria|para\s+estudiantes)\b/,
+      /\b(?:nomes|nomes\s+per\s+a|exclusiu\s+per\s+a|reservat\s+a)\s+estudiants?\b/,
+      // EN
+      /\bstudents?\s+only\b/,
+      /\bonly\s+(?:for\s+)?students?\b/,
+      /\bstudent\s+(?:residence|accommodation|housing|halls?)\b/,
+      // DE
+      /\bnur\s+(?:fur\s+)?studenten\b/,
+      /\bstudentenwohnheim\b/,
+      // IT
+      /\bsolo\s+studenti\b/,
+      /\b(?:riservato|esclusivamente)\s+(?:a\s+|agli\s+)?studenti\b/,
+      // FR
+      /\breserve[e]?\s+aux\s+etudiants?\b/,
+      /\betudiants?\s+(?:uniquement|seulement)\b/,
+      /\buniquement\s+(?:pour\s+|des\s+)?etudiants?\b/,
+      /\bresidence\s+etudiante\b/,
+      // NL
+      /\balleen\s+(?:voor\s+)?studenten\b/,
+      /\bstudentenkamer\b/,
+      /\bstudentenhuis\b/,
+    ],
+  },
+  {
+    // roomNotFullUnit — advertised as a flat/apartment but the body rents a
+    // ROOM or a share. High precision required: "el piso son 3 habitaciones"
+    // (bedroom COUNT) must NOT match, and "se alquila piso de 3 habitaciones"
+    // (whole flat) must NOT match. Achieved via a negative lookahead that
+    // blocks a whole-unit noun right after the rent verb, and by never keying
+    // off bare "habitacion"/"compartir piso" (110 real "para compartir …" hits
+    // describe renting the WHOLE flat to a group).
+    flag: 'roomNotFullUnit',
+    triggers: [
+      // ES: rent-verb directly (or a count/adjective) followed by "habitaci",
+      // but never when the first token is a whole-unit noun.
+      /\b(?:se\s+alquilan?|alquilo|alquilamos|alquilan)\s+(?!(?:piso|apartamento|departamento|vivienda|casa|chalet|estudio|local|duplex|atico|planta|nave|oficina|plaza|garaje|parking|trastero)\b)(?:\w+\s+){0,2}?habitaci/,
+      /\balquiler\s+de\s+habitaci/,
+      /\bhabitaci\w*\s+en\s+alquiler\b/,
+      /\bpiso\s+compartido\b/,
+      /\bhabitaci\w*\s+en\s+(?:un\s+|una\s+)?piso\s+compartid/,
+      // CA
+      /\bpis\s+compartit\b/,
+      /\bllogo?\s+habitaci/,
+      // EN
+      /\brooms?\s+(?:for\s+rent|to\s+(?:rent|let)|available)\b/,
+      /\broom\s+in\s+(?:a\s+|the\s+)?shared\b/,
+      /\bshared\s+(?:flat|house|apartment|accommodation)\b/,
+      /\b(?:house|flat)\s?share\b/,
+      /\bco-?living\b/,
+      // DE
+      /\bwg-?zimmer\b/,
+      /\bzimmer\s+in\s+(?:einer\s+)?(?:wg|wohngemeinschaft)\b/,
+      /\bin\s+einer\s+wg\b/,
+      /\bwohngemeinschaft\b/,
+      // IT
+      /\bposto\s+letto\b/,
+      /\bstanza\s+(?:singola|doppia|in\s+affitto|in\s+appartamento)\b/,
+      /\bappartamento\s+condiviso\b/,
+      /\bcamera\s+in\s+appartamento\s+condiviso\b/,
+      // FR
+      /\bchambre\s+en\s+colocation\b/,
+      /\bcolocation\b/,
+      /\bchambre\s+dans\s+(?:un\s+)?(?:appartement|coloc)\b/,
+      // NL
+      /\bkamer\s+(?:te\s+huur|in\s+(?:een\s+)?(?:gedeeld|studentenhuis))\b/,
+      /\bgedeeld\s+appartement\b/,
+    ],
+    // Explicit whole-unit disclaimers ("no se alquila POR habitaciones sueltas",
+    // "no se alquilan habitaciones por separado") mean the opposite of a room
+    // let — 3 real prod listings that the rent-verb trigger would otherwise trip.
+    vetoes: [/\bno\s+se\s+alquilan?\s+(?:por\s+)?habitaci/],
+  },
+  {
+    // temporaryOnly — seasonal/temporary lease, not a permanent home. In Spain
+    // "alquiler de temporada" is a legally distinct non-primary-residence lease;
+    // "temporada baja/alta" (vacation pricing) and "temporada larga sept-junio"
+    // (academic year) are both non-permanent. Guarded against the rare
+    // "cuatro/todas las temporadas" (climate/name) even though the corpus had 0.
+    flag: 'temporaryOnly',
+    triggers: [
+      // ES / CA
+      /\btemporada\b/,
+      /\balquiler\s+temporal\b/,
+      /\bcontrato\s+de\s+temporada\b/,
+      /\bpor\s+meses\b/,
+      /\b(?:corta|media)\s+estancia\b/,
+      /\bvacacional\b/,
+      // EN
+      /\bshort[\s-]?let\b/,
+      /\bshort[\s-]?term\s+(?:let|rental|tenancy|stay)\b/,
+      /\btemporary\s+(?:let|rental|accommodation|tenancy)\b/,
+      /\bholiday\s+(?:let|rental|home)\b/,
+      /\bseasonal\s+(?:let|rental)\b/,
+      /\bshort\s+stay\b/,
+      // DE
+      /\bzwischenmiete\b/,
+      /\bauf\s+zeit\b/,
+      /\bbefristet\w*\b/,
+      /\bzeitmietvertrag\b/,
+      // IT
+      /\btemporaneo\b/,
+      /\baffitto\s+breve\b/,
+      /\buso\s+transitorio\b/,
+      /\btransitorio\b/,
+      // FR
+      /\blocation\s+saisonniere\b/,
+      /\bcourt\s+sejour\b/,
+      /\bbail\s+mobilite\b/,
+      /\bcourte\s+duree\b/,
+      /\bsaisonnier\w*\b/,
+      // NL
+      /\btijdelijk\w*\b/,
+      /\bkort\s+verblijf\b/,
+    ],
+    vetoes: [/\b(?:cuatro|4|todas\s+las|las\s+cuatro)\s+temporadas?\b/],
+  },
+  {
+    // genderRestricted — one gender only.
+    flag: 'genderRestricted',
+    triggers: [
+      // ES / CA
+      /\bsolo\s+(?:para\s+)?(?:chicas?|chicos?|mujeres?|hombres?|femenino|masculino)\b/,
+      /\bunicamente\s+(?:chicas?|chicos?|mujeres?|hombres?)\b/,
+      /\bsolo\s+(?:noies?|nois?|dones?|homes?)\b/,
+      // EN
+      /\b(?:women|woman|female|females|ladies|girls?|men|man|male|males|boys?)\s+only\b/,
+      /\bonly\s+(?:women|females?|girls?|men|males?)\b/,
+      // DE
+      /\bnur\s+(?:frauen|manner)\b/,
+      // IT
+      /\bsolo\s+(?:ragazze|ragazzi|donne|uomini)\b/,
+      // FR
+      /\b(?:femmes?|hommes?)\s+(?:uniquement|seulement)\b/,
+      /\buniquement\s+(?:pour\s+)?(?:femmes?|hommes?)\b/,
+      // NL
+      /\balleen\s+(?:vrouwen|mannen|dames|meisjes)\b/,
+    ],
+  },
+  {
+    // workersOnly / nominaRequired — proof of stable employment/income required,
+    // which de-facto excludes students/unemployed. "nomina" (payslip) is the
+    // single most reliable ES signal (37/37 real hits were income requirements).
+    flag: 'workersOnly',
+    triggers: [
+      // ES / CA
+      /\bsolo\s+(?:para\s+)?trabajadores?\b/,
+      /\btrabajadores?\s+con\s+nomina\b/,
+      /\bnominas?\b/,
+      /\bcontrato\s+de\s+trabajo\b/,
+      /\bvida\s+laboral\b/,
+      /\bcontrato\s+(?:fijo|indefinido)\b/,
+      // EN
+      /\bworking\s+professionals?\s+only\b/,
+      /\bprofessionals?\s+only\b/,
+      /\bworking\s+tenants?\s+only\b/,
+      /\bin\s+full[\s-]?time\s+employment\b/,
+      /\bproof\s+of\s+(?:income|employment)\b/,
+      /\bemployed\s+(?:applicants?|tenants?)\b/,
+      // DE
+      /\bberufstatig\w*\b/,
+      /\beinkommensnachweis\b/,
+      /\bgehaltsnachweis\b/,
+      // IT
+      /\bsolo\s+lavoratori\b/,
+      /\bbusta\s+paga\b/,
+      /\bcontratto\s+di\s+lavoro\b/,
+      // FR
+      /\bfiche\s+de\s+paie\b/,
+      /\bcontrat\s+de\s+travail\b/,
+      /\btravailleurs?\s+(?:uniquement|seulement)\b/,
+      /\bjustificatif\s+de\s+revenus?\b/,
+      // NL
+      /\bloonstrook\b/,
+      /\barbeidscontract\b/,
+    ],
+  },
+  {
+    // agencyFeePayable — a fee the TENANT/buyer pays to the agency. Conservative
+    // on purpose. Two big real-corpus traps are guarded:
+    //  1. bare "provision"/"commission" is NEVER a trigger — 59 ES hits were
+    //     "provision de gastos/agua/luz" (utility charges) and immoweb had
+    //     "european commission" (a landmark) + "monthly commission … heating".
+    //     Only agency-scoped forms (maklerprovision, commissione di agenzia,
+    //     commission d'agence) count.
+    //  2. ES vetoes the explicit "no fee to tenant" statements (22 real hits:
+    //     "sin honorarios de agencia para el inquilino", "no se repercute …
+    //     honorarios al inquilino", "honorarios incluidos"). Note the veto does
+    //     NOT swallow "honorarios NO incluidos en el precio" (fee IS payable).
+    flag: 'agencyFeePayable',
+    triggers: [
+      // ES / CA
+      /\bhonorarios\b/,
+      /\bgastos\s+de\s+agencia\b/,
+      /\bcomision\s+de\s+agencia\b/,
+      // EN
+      /\bagency\s+fee\b/,
+      /\badmin(?:istration)?\s+fee\b/,
+      /\b(?:tenancy|letting)\s+fee\b/,
+      // DE
+      /\bmaklerprovision\b/,
+      /\bmakler-?courtage\b/,
+      /\bmaklergebuhr\b/,
+      // IT
+      /\bcommissione\s+(?:di\s+)?agenzia\b/,
+      /\bspese\s+di\s+agenzia\b/,
+      // FR
+      /\bfrais\s+d\s?agence\b/,
+      /\bhonoraires\s+(?:d\s?agence|de\s+location)\b/,
+      // NL
+      /\bmakelaarsloon\b/,
+      /\bmakelaarskosten\b/,
+    ],
+    vetoes: [
+      /\bsin\s+honorarios\b/,
+      /\bno\s+honorarios\b/,
+      /\bhonorarios\s+incluidos\b/,
+      /\bsin\s+comision\b/,
+      /\bsin\s+gastos\s+de\s+agencia\b/,
+      /\bno\s+se\s+repercut\w+[^.]{0,40}\bhonorarios\b/,
+      /\bhonorarios\b[^.]{0,40}no\s+se\s+repercut/,
+    ],
+  },
+  {
+    // noPets — anchored negatives only, so "se admiten mascotas" (pets ALLOWED,
+    // 220 real listings) never matches.
+    flag: 'noPets',
+    triggers: [
+      // ES / CA
+      /\bno\s+se\s+(?:admiten|permiten|aceptan)\s+(?:mascotas|animales)\b/,
+      /\bno\s+(?:mascotas|animales)\b/,
+      /\bsin\s+mascotas\b/,
+      /\bprohibid[oa]s?\s+(?:mascotas|animales)\b/,
+      /\bno\s+es\s+(?:admeten|accepten)\s+(?:mascotes|animals)\b/,
+      /\bsense\s+mascotes\b/,
+      // EN
+      /\bno\s+pets\b/,
+      /\bpets?\s+(?:are\s+)?not\s+(?:allowed|permitted|accepted)\b/,
+      /\bno\s+animals\b/,
+      // DE
+      /\bkeine\s+(?:haus)?tiere\b/,
+      /\bhaustiere\s+nicht\s+(?:erlaubt|gestattet)\b/,
+      // IT
+      /\bno\s+animali\b/,
+      /\bnon\s+si\s+accettano\s+animali\b/,
+      /\banimali\s+non\s+ammessi\b/,
+      // FR
+      /\bpas\s+d\s?animaux\b/,
+      /\banimaux\s+non\s+(?:admis|acceptes|autorises)\b/,
+      // NL
+      /\bgeen\s+huisdieren\b/,
+      /\bhuisdieren\s+niet\s+toegestaan\b/,
+    ],
+  },
+  {
+    // noSmoking — anchored negatives only.
+    flag: 'noSmoking',
+    triggers: [
+      // ES / CA
+      /\bno\s+fumadores\b/,
+      /\bno\s+se\s+(?:admiten|permite)\s+fumar\b/,
+      /\bprohibido\s+fumar\b/,
+      /\bno\s+fumar\b/,
+      // EN
+      /\bnon[\s-]?smok\w*\b/,
+      /\bno\s+smoking\b/,
+      /\bsmoking\s+not\s+(?:allowed|permitted)\b/,
+      // DE
+      /\bnichtraucher\w*\b/,
+      // IT
+      /\bnon\s+fumatori\b/,
+      /\bvietato\s+fumare\b/,
+      // FR
+      /\bnon[\s-]?fumeur\w*\b/,
+      /\binterdiction\s+de\s+fumer\b/,
+      // NL
+      /\bniet\s+roken\b/,
+      /\brookvrij\b/,
+    ],
+  },
+  {
+    // noCouples — single occupancy / no couples.
+    flag: 'noCouples',
+    triggers: [
+      /\bno\s+(?:se\s+admiten\s+)?parejas\b/,
+      /\bno\s+couples\b/,
+      /\bcouples?\s+not\s+(?:allowed|accepted|permitted)\b/,
+      /\bsingle\s+(?:occupancy|person)\s+only\b/,
+    ],
+  },
+  {
+    // noDSS — UK "no housing benefit". Tight patterns so "no benefits included"
+    // (no perks) never matches.
+    flag: 'noDSS',
+    triggers: [
+      /\bno\s+dss\b/,
+      /\bdss\s+not\s+accepted\b/,
+      /\bno\s+housing\s+benefit\b/,
+      /\bhousing\s+benefit\s+not\s+accepted\b/,
+    ],
+  },
+];
+
+/**
+ * Distinctive stopword/vocabulary tokens per language. Deliberately biased to
+ * tokens that separate the confusable pairs (ES↔CA via "amb/aquest/habitatge",
+ * ES↔FR/IT via distinct articles) rather than shared ones like "la".
+ */
+const LANGUAGE_TOKENS: Readonly<Record<DetectedLanguage, readonly string[]>> = {
+  es: [
+    'el', 'los', 'las', 'con', 'para', 'esta', 'este', 'muy', 'vivienda',
+    'dormitorio', 'cocina', 'bano', 'amueblado', 'alquiler', 'zona', 'planta',
+  ],
+  ca: [
+    'amb', 'aquest', 'aquesta', 'aquests', 'aquestes', 'habitatge', 'lloguer',
+    'cuina', 'bany', 'situat', 'molt', 'gran', 'planta', 'als', 'pis',
+  ],
+  en: [
+    'the', 'and', 'with', 'this', 'for', 'apartment', 'bedroom', 'kitchen',
+    'located', 'available', 'features', 'property', 'very', 'floor',
+  ],
+  fr: [
+    'le', 'les', 'avec', 'pour', 'cette', 'appartement', 'chambre', 'cuisine',
+    'situe', 'proche', 'loyer', 'salle', 'sejour', 'tres',
+  ],
+  nl: [
+    'het', 'een', 'met', 'deze', 'voor', 'appartement', 'slaapkamer', 'keuken',
+    'gelegen', 'nabij', 'badkamer', 'zeer', 'woning', 'ruime',
+  ],
+  de: [
+    'das', 'die', 'der', 'mit', 'fur', 'diese', 'wohnung', 'schlafzimmer',
+    'kuche', 'zimmer', 'gelegen', 'sehr', 'sich', 'grosse',
+  ],
+  it: [
+    'il', 'con', 'per', 'questa', 'appartamento', 'camera', 'cucina', 'situato',
+    'vicino', 'molto', 'della', 'soggiorno', 'luminoso', 'piano',
+  ],
+};
+
+const LANGUAGE_KEYS = Object.keys(LANGUAGE_TOKENS) as DetectedLanguage[];
+
+/**
+ * Best-effort deterministic language detection via a bag-of-stopwords vote.
+ * Returns `undefined` unless one language both clears a minimum score and beats
+ * the runner-up by a clear margin — ambiguous/short text stays unlabeled rather
+ * than guessing.
+ */
+function detectLanguage(normalized: string): DetectedLanguage | undefined {
+  const tokens = normalized.split(/[^a-z0-9]+/).filter(Boolean);
+  if (tokens.length < 12) return undefined;
+
+  const counts = new Map<string, number>();
+  for (const token of tokens) counts.set(token, (counts.get(token) ?? 0) + 1);
+
+  let best: DetectedLanguage | undefined;
+  let bestScore = 0;
+  let secondScore = 0;
+  for (const lang of LANGUAGE_KEYS) {
+    let score = 0;
+    for (const word of LANGUAGE_TOKENS[lang]) score += counts.get(word) ?? 0;
+    if (score > bestScore) {
+      secondScore = bestScore;
+      bestScore = score;
+      best = lang;
+    } else if (score > secondScore) {
+      secondScore = score;
+    }
+  }
+
+  if (bestScore < 4) return undefined;
+  if (bestScore < secondScore * 1.3) return undefined;
+  return best;
+}
+
+/**
+ * Classify a listing's free text into structured restriction/nuance flags.
+ * Only flags that fire are present on the result (sparse), plus an optional
+ * `detectedLanguage`. Returns an empty object when there is nothing to classify.
+ */
+export function classifyListingContent(
+  description?: string | null,
+  title?: string | null,
+): ListingFlags {
+  const combined = `${title ?? ''} ${description ?? ''}`.trim();
+  if (!combined) return {};
+
+  const normalized = normalizeText(combined);
+  if (!normalized) return {};
+
+  const flags: ListingFlags = {};
+  for (const rule of RULES) {
+    if (!rule.triggers.some((re) => re.test(normalized))) continue;
+    if (rule.vetoes && rule.vetoes.some((re) => re.test(normalized))) continue;
+    flags[rule.flag] = true;
+  }
+
+  const detectedLanguage = detectLanguage(normalized);
+  if (detectedLanguage) flags.detectedLanguage = detectedLanguage;
+
+  return flags;
+}


### PR DESCRIPTION
## What

A deterministic, zero-cost **rule classifier** that reads the free-text description of external listings at ingest and derives restriction/nuance flags portals bury in prose rather than exposing as structured fields.

New module: `packages/backend/services/ingestion/classifyListingContent.ts` → `classifyListingContent(description, title?) -> ListingFlags`. Wired into `buildPropertyFields` (IngestionService), stored in a new sparse `listingFlags` subdocument on `Property`.

### Flags
`studentsOnly`, `roomNotFullUnit`, `temporaryOnly`, `genderRestricted`, `workersOnly` (nómina / income proof), `agencyFeePayable`, `noPets`, `noSmoking`, `noCouples`, `noDSS`, plus best-effort `detectedLanguage` (es/ca/en/fr/nl/de/it).

## Grounded in real data

Rules were designed and validated against **~5,600 live prod listings** (pisos / fotocasa / habitaclia / immoweb / rightmove — ES/CA/EN/FR/NL). Firing rates on the corpus: temporaryOnly 17.9%, noPets 8.6%, workersOnly 3.0%, agencyFeePayable 2.8%, roomNotFullUnit 2.3%, noSmoking 2.1%, studentsOnly 1.5%, noCouples 0.5%, genderRestricted 0.2%. Language labeled on 96.9%.

The classifier runs multi-language over deaccented, word-boundary-anchored text (reusing `deaccent` from `@homiio/listing-providers`).

## False positives guarded (each cited in code + tests)

- **studentsOnly**: requires an exclusivity marker — "para estudiantes **o** (jóvenes) profesionales/familias" (47 real open listings) is NOT flagged.
- **roomNotFullUnit**: negative lookahead blocks whole-unit nouns ("se alquila **piso** de 3 habitaciones") and bedroom counts ("el piso son 3 habitaciones"); veto for "**no** se alquila por habitaciones" (whole unit); "para compartir" (110 real whole-flat hits) excluded.
- **agencyFeePayable**: bare "provisión"/"commission" never triggers (59 real "provisión de gastos/agua/luz" utility charges + immoweb "european commission" landmark + "monthly commission … heating"); ES vetoes the "sin honorarios al inquilino" / "no se repercute … honorarios" negations (22 real hits) but keeps "honorarios **no** incluidos" (fee payable).
- **noPets**: anchored negatives only — "se admiten mascotas" (pets allowed, 220 real listings) never matches.

**Full-corpus sweep after guards: zero residual false positives.**

## Schema

`IProperty` (the schema authority) gains a `listingFlags?` shape; `PropertySchema` gains a matching `{ _id: false }` subdocument. `NormalizedListing` is unchanged — flags are derived at ingest, not passed by providers.

## Tests

- 120 unit tests in `classifyListingContent.test.ts` — every positive is a (trimmed) real prod phrase, every negative is a real false-positive trap; all languages.
- 2 ingest integration tests proving `buildPropertyFields` persists / omits `listingFlags`.
- Full backend suite green: **65 suites / 661 tests**.

## Note on ambiguity (deliberately NOT LLM'd)

`agencyFeePayable` is the one flag with residual semantic ambiguity (fee-to-tenant vs fee-to-buyer on sales, and some negation phrasings). The conservative rule + vetoes handle every case in the corpus; if precision needs to go further on edge phrasings, that specific flag is the candidate for an LLM pass — not implemented here (this stays a deterministic, per-listing-free algorithm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)