### PR TITLE
fix(frontend): sweep remaining pointerEvents:'box-none'-in-style bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,6 +382,14 @@ const [pressed, setPressed] = useState(false);
 - Canonical template: `packages/frontend/components/search/SearchSummaryBar.tsx`
 - Audit: `grep -rn "style={({" app components --include=*.tsx` must return ZERO.
 
+## `pointerEvents: 'box-none'` / `'box-only'` in a STYLE is BROKEN on web
+
+`box-none`/`box-only` are React Native-ONLY values — they are NOT valid CSS `pointer-events`. Put them in a `style` object (`style={{ pointerEvents: 'box-none' }}`) and RN-Web **silently drops** them, leaving the element at `pointer-events: auto` — so a transparent, full-size overlay (a save layer, a scrim wrapper, a padded popover) **swallows every tap/hover beneath it** with no error. This hid the property-card carousel arrows and would freeze the whole mobile-web screen behind the closed sidebar drawer (PR #202 / the box-none sweep).
+
+- **Fix / correct pattern:** split into a pass-through container `pointerEvents: 'none'` (valid CSS) + genuinely-interactive children that re-enable themselves with `pointerEvents: 'auto'` (valid CSS: a child `auto` inside a parent `none` IS hittable). That reproduces box-none semantics with values RN-Web actually applies.
+- The RN `pointerEvents` **PROP** (`<View pointerEvents="box-none">`) is fine — RN-Web maps it correctly. Only the STYLE form is broken. Prefer the none/auto split.
+- Audit: `grep -rn "pointerEvents: 'box-none'\|pointerEvents: 'box-only'" app components` should stay ZERO in style objects.
+
 ## Masked Image Zoom (ZoomableImage)
 
 Cards NEVER scale on hover/press ("cutrada"). The app-wide Airbnb-2026 move is the **image zooming inside the card's rounded mask** — the photo scales, the card stays put, corners stay clipped. There is **one** primitive: `components/ui/ZoomableImage.tsx`.

--- a/packages/frontend/components/SideBar/index.tsx
+++ b/packages/frontend/components/SideBar/index.tsx
@@ -813,12 +813,16 @@ export function SideBar() {
     // app's `front` drawer overlays the entire screen. The Portal host stays
     // mounted while on mobile so Reanimated can play the exit (slide-out +
     // fade) when `mobileDrawerOpen` flips to false; only the scrim + panel
-    // mount/unmount. `box-none` lets touches pass through when closed.
+    // mount/unmount. The full-screen wrapper is `pointerEvents:'none'` so that
+    // WHEN CLOSED (no children) it passes every touch through to the app beneath
+    // (the RN-only `'box-none'` is invalid CSS — RN-Web drops it, leaving the
+    // wrapper `auto` and freezing the whole mobile-web screen). The scrim + drawer
+    // re-enable themselves with `'auto'` so they stay interactive when open.
     return (
       <Portal>
         <View
           className="flex-row"
-          style={[StyleSheet.absoluteFill, { pointerEvents: 'box-none' }]}
+          style={[StyleSheet.absoluteFill, { pointerEvents: 'none' }]}
         >
           {mobileDrawerOpen && (
             <>
@@ -830,13 +834,13 @@ export function SideBar() {
                 onPress={closeMobileDrawer}
                 style={[
                   StyleSheet.absoluteFill,
-                  { backgroundColor: MOBILE_DRAWER_SCRIM },
+                  { backgroundColor: MOBILE_DRAWER_SCRIM, pointerEvents: 'auto' },
                 ]}
               />
               <Animated.View
                 entering={slideIn}
                 exiting={slideOut}
-                style={{ width: drawerWidth }}
+                style={{ width: drawerWidth, pointerEvents: 'auto' }}
                 className="h-full bg-background"
               >
                 <BaseSidebar header={header} footer={footer}>

--- a/packages/frontend/components/sindi/SindiPanel.tsx
+++ b/packages/frontend/components/sindi/SindiPanel.tsx
@@ -466,9 +466,14 @@ export function SindiPanel() {
   // the sidebar so the sidebar itself stays interactive while the panel is open.
   return (
     <Portal>
+      {/* Wrapper is `pointerEvents:'none'` so the strip left of the scrim (the
+          sidebar column) passes touches through and stays interactive while the
+          panel is open — the RN-only `'box-none'` is invalid CSS that RN-Web
+          drops, which would leave the wrapper `auto` and block the sidebar. The
+          scrim + panel re-enable themselves with `'auto'`. */}
       <View
         className="flex-row"
-        style={[StyleSheet.absoluteFill, { pointerEvents: 'box-none' }]}
+        style={[StyleSheet.absoluteFill, { pointerEvents: 'none' }]}
       >
         <AnimatedPressable
           entering={FadeIn.duration(SCRIM_FADE_DURATION)}
@@ -478,7 +483,7 @@ export function SindiPanel() {
           onPress={closeSindiPanel}
           style={[
             StyleSheet.absoluteFill,
-            { left: sidebarWidth, backgroundColor: PANEL_SCRIM },
+            { left: sidebarWidth, backgroundColor: PANEL_SCRIM, pointerEvents: 'auto' },
           ]}
         />
         <Animated.View
@@ -487,7 +492,7 @@ export function SindiPanel() {
           className="bg-background"
           style={[
             styles.panel,
-            { width: panelWidth },
+            { width: panelWidth, pointerEvents: 'auto' },
             panelBorders.railEdge,
             overlayPanelPinnedStyle(sidebarWidth),
           ]}

--- a/packages/frontend/components/ui/MapMarkerPopover.tsx
+++ b/packages/frontend/components/ui/MapMarkerPopover.tsx
@@ -47,8 +47,12 @@ export const MapMarkerPopover: React.FC<MapMarkerPopoverProps> = ({
   }, [onPress]);
 
   return (
-    <View style={[styles.container, style, { pointerEvents: 'box-none' }]}>
-      <View style={[styles.card, cardShadow.lg]}>
+    // `pointerEvents:'none'` (NOT the RN-only `'box-none'`, which is invalid CSS
+    // that RN-Web drops → the padded container stays `auto` and blocks the map
+    // under its side gutters). The card re-enables itself with `'auto'`, so only
+    // the popover is interactive and the gutters pass taps through to the map.
+    <View style={[styles.container, style, { pointerEvents: 'none' }]}>
+      <View style={[styles.card, cardShadow.lg, { pointerEvents: 'auto' }]}>
         <View style={styles.dismissAnchor}>
           <Button
             onPress={onDismiss}


### PR DESCRIPTION
Follow-up to #202. `box-none`/`box-only` are React Native-ONLY `pointer-events` values — **invalid as CSS** — so RN-Web silently drops them from a `style` object, leaving the element at `pointer-events:auto` and swallowing taps/hover beneath a transparent overlay. Swept the three remaining STYLE occurrences.

## Classification (all 3 were REAL bugs; no valid-prop usages, no `box-only` anywhere)
- **`components/ui/MapMarkerPopover.tsx`** — the padded container was `auto`, so the map under its left/right gutters wasn't tappable. → container `pointerEvents:'none'` + card `'auto'`.
- **`components/SideBar/index.tsx`** — the mobile-drawer Portal's full-screen `absoluteFill` wrapper was `auto` **even when closed (empty)**, so it covered and froze the entire mobile-web screen. → wrapper `'none'` + scrim + drawer `'auto'`.
- **`components/sindi/SindiPanel.tsx`** — the overlay wrapper was `auto`, blocking the sidebar strip the panel is explicitly meant to leave interactive. → wrapper `'none'` + scrim + panel `'auto'`.

Each keeps the intended behavior: the pass-through container no longer intercepts, and the genuinely-interactive children (card / scrim / drawer / panel) re-enable themselves with valid-CSS `pointer-events:'auto'`.

## Verified in a real browser (Playwright @390)
The full-viewport wrappers are now `pointer-events: none` and `document.elementFromPoint` at the screen centre/upper zones returns real interactive content (`IMG`, `pe:auto`) **through** them (they were `auto`/blocking before). Confirms the SideBar "freezes the screen" bug is fixed and the app stays interactive with the wrapper mounted.

## Docs
Added a durable gotcha to the frontend AGENTS.md (NativeWind/RN-Web notes) citing #202: box-none/box-only in a `style` are invalid CSS → dropped → use the `pointerEvents` prop, or split into parent `none` + interactive children `auto`. Audit grep included.

## Gates
`bun run build` exit 0; tsc → 11 pre-existing baseline (none in touched files); `grep "style={({"` = ZERO; `grep "pointerEvents: 'box-none'/'box-only'"` in style = ZERO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)