### PR TITLE
feat(listings): canonical amenity vocabulary + i18n for all structured values

### DIFF
--- a/packages/backend/__tests__/unit/bluegroundParse.test.ts
+++ b/packages/backend/__tests__/unit/bluegroundParse.test.ts
@@ -82,9 +82,11 @@ describe('Blueground parse', () => {
 
   it('extracts available amenities as canonical slugs, excluding struck-through ones', () => {
     const { amenities, floor } = readBluegroundAmenities(FIRST_PARTY_DETAIL_HTML);
-    // Available apartment/building amenities, canonicalized and deduped.
+    // Available apartment/building amenities, canonicalized onto the shared fixed
+    // vocabulary (`washerUnit`→washing_machine); non-canonical `coffeeMachine` is
+    // dropped rather than stored as a bespoke slug.
     expect(amenities.sort()).toEqual(
-      ['air_conditioning', 'balcony', 'coffee_machine', 'elevator', 'washer'].sort(),
+      ['air_conditioning', 'balcony', 'elevator', 'washing_machine'].sort(),
     );
     // Struck-through amenities (parking, doorman, bathtub) must NOT appear.
     expect(amenities).not.toContain('parking');
@@ -101,7 +103,7 @@ describe('Blueground parse', () => {
     const listing = parseBluegroundDetail(FIRST_PARTY_DETAIL_HTML, ref);
     expect(listing.floor).toBe(2);
     expect(listing.amenities).toContain('elevator');
-    expect(listing.amenities).toContain('washer');
+    expect(listing.amenities).toContain('washing_machine');
     expect(listing.amenities).not.toContain('parking');
   });
 

--- a/packages/backend/__tests__/unit/canonicalAmenities.test.ts
+++ b/packages/backend/__tests__/unit/canonicalAmenities.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Canonical amenity vocabulary — the single source of truth every provider maps
+ * onto. These tests lock the contract: different portal dialects (localized
+ * ES/IT labels, English feature slugs, camelCase keys, boolean-flag targets, raw
+ * slugs, free-text marketing copy) all collapse onto the SAME fixed canonical
+ * key, non-amenities are dropped, and `furnished` is hoisted out of the list.
+ */
+
+import {
+  CANONICAL_AMENITIES,
+  canonicalAmenity,
+  canonicalizeAmenities,
+  isCanonicalAmenity,
+  slugifyAmenityToken,
+} from '@homiio/listing-providers';
+
+describe('canonicalAmenity', () => {
+  it('maps every portal dialect for the same amenity to one canonical key', () => {
+    // elevator: ES / IT / EN feature slug / camelCase (blueground) / free text
+    for (const input of ['ascensor', 'ascensore', 'Lift', 'elevatorInTheBuilding', 'elevator']) {
+      expect(canonicalAmenity(input)).toBe('elevator');
+    }
+    // parking: ES slug / IT / EN / camelCase / free-text marketing copy
+    for (const input of ['garaje', 'posto_auto', 'garage', 'parkingSpace', 'Off street parking']) {
+      expect(canonicalAmenity(input)).toBe('parking');
+    }
+    // pool
+    for (const input of ['piscina', 'swimming_pool', 'community_pool']) {
+      expect(canonicalAmenity(input)).toBe('pool');
+    }
+    // air conditioning (localized + EN + camelCase)
+    for (const input of ['aire acondicionado', 'aria condizionata', 'air_conditioner', 'airConditioning']) {
+      expect(canonicalAmenity(input)).toBe('air_conditioning');
+    }
+    // washing machine (blueground washerUnit / laundryRoomUnit / raw washer)
+    for (const input of ['washer', 'washerUnit', 'laundryRoomUnit', 'lavadora']) {
+      expect(canonicalAmenity(input)).toBe('washing_machine');
+    }
+    // connectivity: immoweb `internet` and search `wifi` unify
+    for (const input of ['internet', 'wifi', 'wi-fi']) {
+      expect(canonicalAmenity(input)).toBe('wifi');
+    }
+    // terrace (ES/IT) and intercom (immoweb visiophone)
+    expect(canonicalAmenity('terraza')).toBe('terrace');
+    expect(canonicalAmenity('terrazzo')).toBe('terrace');
+    expect(canonicalAmenity('visiophone')).toBe('intercom');
+  });
+
+  it('hoists furnished tokens to the sentinel, never an amenity', () => {
+    for (const input of ['amueblado', 'arredato', 'furnished', 'meublee']) {
+      expect(canonicalAmenity(input)).toBe('furnished');
+    }
+  });
+
+  it('drops non-amenity words (condition, orientation, marketing copy)', () => {
+    for (const input of ['soleado', 'exterior', 'reformado', 'Double glazing', 'coffeeMachine', '']) {
+      expect(canonicalAmenity(input)).toBeUndefined();
+    }
+  });
+
+  it('only ever resolves to a key in the fixed canonical set', () => {
+    for (const key of CANONICAL_AMENITIES) {
+      expect(isCanonicalAmenity(key)).toBe(true);
+    }
+    expect(isCanonicalAmenity('coffee_machine')).toBe(false);
+  });
+});
+
+describe('slugifyAmenityToken', () => {
+  it('deaccents, splits camelCase, and snake-cases', () => {
+    expect(slugifyAmenityToken('airConditioning')).toBe('air_conditioning');
+    expect(slugifyAmenityToken('Aire Acondicionado')).toBe('aire_acondicionado');
+    expect(slugifyAmenityToken('Off street parking')).toBe('off_street_parking');
+  });
+});
+
+describe('canonicalizeAmenities', () => {
+  it('canonicalizes, dedupes, and hoists furnished out of the list', () => {
+    const result = canonicalizeAmenities([
+      'ascensor', // elevator
+      'Lift', // elevator (dedupe)
+      'piscina', // pool
+      'amueblado', // furnished → hoisted
+      'soleado', // dropped
+      'garaje', // parking
+    ]);
+    expect(result.amenities).toEqual(['elevator', 'pool', 'parking']);
+    expect(result.furnished).toBe(true);
+  });
+
+  it('omits furnished when no furnished token is present', () => {
+    expect(canonicalizeAmenities(['piscina', 'jardin'])).toEqual({
+      amenities: ['pool', 'garden'],
+    });
+  });
+});

--- a/packages/backend/__tests__/unit/ceuProviders.test.ts
+++ b/packages/backend/__tests__/unit/ceuProviders.test.ts
@@ -84,10 +84,11 @@ describe('ImmowebProvider (BE)', () => {
     expect(listing.bathrooms).toBe(2);
     // constructionYear lives on property.building, not the unit
     expect(listing.yearBuilt).toBe(1965);
-    // amenities built from the true `has*` flags, mapped to canonical slugs
+    // amenities built from the true `has*` flags, mapped to the shared canonical
+    // vocabulary (`laundry_room`, `wifi` — not bespoke `laundry`/`internet`).
     expect(listing.amenities).toBeDefined();
     expect(listing.amenities).toEqual(
-      expect.arrayContaining(['elevator', 'terrace', 'garden', 'storage', 'laundry', 'internet']),
+      expect.arrayContaining(['elevator', 'terrace', 'garden', 'storage', 'laundry_room', 'wifi']),
     );
     expect(listing.hasElevator).toBe(true);
     expect(listing.hasGarden).toBe(true);

--- a/packages/backend/__tests__/unit/gbProviders.test.ts
+++ b/packages/backend/__tests__/unit/gbProviders.test.ts
@@ -95,8 +95,8 @@ describe('RightmoveProvider', () => {
     expect(listing.remoteImages.length).toBeGreaterThan(0);
     // sizings[] → squareFootage in m² (prefers the native sqm entry).
     expect(listing.squareFootage).toBe(79);
-    // keyFeatures[] → amenities (ingest derives hasGarden/hasBalcony/hasElevator/parking).
-    expect(listing.amenities).toEqual(['Garden', 'Off street parking', 'Balcony', 'Lift']);
+    // keyFeatures[] → canonical amenities (ingest derives hasGarden/hasBalcony/hasElevator/parking).
+    expect(listing.amenities).toEqual(['garden', 'parking', 'balcony', 'elevator']);
     // letting.furnishType → furnishedStatus.
     expect(listing.furnishedStatus).toBe('furnished');
   });

--- a/packages/backend/__tests__/unit/htmlText.test.ts
+++ b/packages/backend/__tests__/unit/htmlText.test.ts
@@ -68,7 +68,8 @@ describe('sanitizeNormalizedListingTextFields', () => {
     sanitizeNormalizedListingTextFields(listing);
 
     expect(listing.description).toBe('Council Tax Band: E\n\nGuidance only');
-    expect(listing.amenities).toEqual(['Garden', 'Parking']);
+    // HTML-stripped, then canonicalized onto the shared amenity vocabulary.
+    expect(listing.amenities).toEqual(['garden', 'parking']);
     expect(listing.contact?.name).toBe('Jane Doe');
     expect(listing.contact?.agencyName).toBe('Savills & Co');
     expect(listing.remoteImages[0]?.caption).toBe('Living room');

--- a/packages/backend/__tests__/unit/pisosProvider.test.ts
+++ b/packages/backend/__tests__/unit/pisosProvider.test.ts
@@ -47,7 +47,9 @@ describe('PisosProvider.normalize', () => {
     expect(listing.contact?.phone).toBe('919376345');
     expect(listing.contact?.kind).toBe('agency');
     expect(listing.remoteImages.length).toBeGreaterThan(0);
-    expect(listing.amenities).toEqual(expect.arrayContaining(['ascensor', 'balcon', 'soleado']));
+    // Raw ES slugs canonicalized (`ascensor`→elevator, `balcon`→balcony); the
+    // non-amenity `soleado` is dropped.
+    expect(listing.amenities).toEqual(['elevator', 'balcony']);
     expect(listing.address.city).toBe('Madrid Capital');
     expect(listing.address.coordinates).toEqual({ lat: 40.41593545782718, lng: -3.7083892232908435 });
   });

--- a/packages/frontend/components/PropertyCard.tsx
+++ b/packages/frontend/components/PropertyCard.tsx
@@ -556,10 +556,10 @@ export function PropertyCard({
               </View>
             </>
           )}
-          {variant === 'compact' && propertyData.type && (
+          {variant === 'compact' && typeMeta && (
             <>
               <ThemedText style={styles.featureSeparator}>•</ThemedText>
-              <ThemedText style={styles.featureText}>{propertyData.type}</ThemedText>
+              <ThemedText style={styles.featureText}>{typeMeta.label}</ThemedText>
             </>
           )}
         </View>

--- a/packages/frontend/components/SearchFiltersBottomSheet.tsx
+++ b/packages/frontend/components/SearchFiltersBottomSheet.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FiltersBottomSheet, FilterSection, FilterValue } from '@/components/FiltersBar/FiltersBottomSheet';
 import { useRentalMode } from '@/context/RentalModeContext';
+import { getAmenityById } from '@/constants/amenities';
 import { CancellationPolicy } from '@homiio/shared-types';
 
 /**
@@ -235,11 +236,14 @@ export function SearchFiltersBottomSheet({
             id: 'amenities',
             title: t('Amenities'),
             type: 'chips',
-            options: AMENITIES.map((amenity) => ({
-                id: amenity,
-                label: t(amenity.replace('_', ' ')),
-                value: amenity,
-            })),
+            options: AMENITIES.map((amenity) => {
+                const nameKey = getAmenityById(amenity)?.nameKey;
+                return {
+                    id: amenity,
+                    label: nameKey ? t(nameKey) : amenity,
+                    value: amenity,
+                };
+            }),
             value: filters.amenities,
         });
 

--- a/packages/frontend/components/property/AmenitiesGrid.tsx
+++ b/packages/frontend/components/property/AmenitiesGrid.tsx
@@ -55,12 +55,21 @@ interface AmenitiesGridProps {
   maxVisible?: number;
 }
 
+/** Title-case a snake_case slug so an unmapped id never renders as a raw slug. */
+function humanizeAmenityId(id: string): string {
+  return id
+    .split('_')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
 /** Resolve the localized, human label for a resolved amenity. */
 function useAmenityLabel(): (entry: ResolvedAmenity) => string {
   const { t } = useTranslation();
   return useCallback(
     ({ id, amenity }: ResolvedAmenity): string => {
-      if (!amenity?.nameKey) return id;
+      if (!amenity?.nameKey) return humanizeAmenityId(id);
       return t(amenity.nameKey);
     },
     [t],

--- a/packages/frontend/components/property/PropertyFeatures.tsx
+++ b/packages/frontend/components/property/PropertyFeatures.tsx
@@ -14,6 +14,11 @@
  *   - Garden      shown only when `hasGarden`. Ionicons `leaf` (no PNG yet).
  *   - Elevator    shown only when `hasElevator`. PNG `elevator`, fallback
  *                 `arrow-up-circle`.
+ *   - Parking     shown when `parkingType` is set and not `none` (label varies
+ *                 by kind: garage / assigned / street). PNG `parking`, fallback `car`.
+ *   - Pets        shown when `petPolicy` is set (allowed / not_allowed / case_by_case).
+ *                 Ionicons `paw`.
+ * All labels come from the shared `parkingType.*` / `petPolicy.*` enum vocab.
  * No rows → renders nothing.
  */
 import React, { useMemo } from 'react';
@@ -30,6 +35,8 @@ import {
 import { getIconArt } from '@/constants/iconArt';
 
 type FurnishedStatus = 'furnished' | 'partially_furnished' | 'unfurnished';
+type ParkingType = 'none' | 'street' | 'assigned' | 'garage';
+type PetPolicy = 'allowed' | 'not_allowed' | 'case_by_case';
 
 interface Props {
     property?: {
@@ -37,6 +44,8 @@ interface Props {
         hasBalcony?: boolean;
         hasGarden?: boolean;
         hasElevator?: boolean;
+        parkingType?: ParkingType;
+        petPolicy?: PetPolicy;
     } | null;
 }
 
@@ -73,6 +82,8 @@ export const PropertyFeatures: React.FC<Props> = ({ property }) => {
     const hasBalcony = property?.hasBalcony;
     const hasGarden = property?.hasGarden;
     const hasElevator = property?.hasElevator;
+    const parkingType = property?.parkingType;
+    const petPolicy = property?.petPolicy;
 
     const rows = useMemo<FeatureRow[]>(() => {
         const next: FeatureRow[] = [];
@@ -100,9 +111,20 @@ export const PropertyFeatures: React.FC<Props> = ({ property }) => {
                 icon: 'arrow-up-circle',
             });
         }
+        if (parkingType !== undefined && parkingType !== 'none') {
+            next.push({
+                key: 'parking',
+                label: t(`parkingType.${parkingType}`),
+                imageId: 'parking',
+                icon: 'car',
+            });
+        }
+        if (petPolicy !== undefined) {
+            next.push({ key: 'petPolicy', label: t(`petPolicy.${petPolicy}`), icon: 'paw' });
+        }
 
         return next;
-    }, [furnishedStatus, hasBalcony, hasGarden, hasElevator, t]);
+    }, [furnishedStatus, hasBalcony, hasGarden, hasElevator, parkingType, petPolicy, t]);
 
     if (rows.length === 0) return null;
 

--- a/packages/frontend/constants/amenities.tsx
+++ b/packages/frontend/constants/amenities.tsx
@@ -67,7 +67,6 @@ export const AMENITY_CATEGORIES: AmenityCategory[] = [
   {
     id: 'kitchen',
     name: 'Kitchen & dining',
-    nameKey: 'amenities.kitchen',
     nameKey: 'amenities.categories.kitchen',
     icon: 'restaurant',
     color: '#ea580c',
@@ -574,6 +573,17 @@ export const AMENITIES: Amenity[] = [
     environmental: 'neutral',
   },
   {
+    id: 'attic',
+    name: 'Attic',
+    nameKey: 'amenities.attic',
+    icon: 'cube',
+    category: 'storage',
+    description: 'Attic storage space',
+    maxFairValue: 15,
+    ethicalNotes: 'Extra storage should be priced fairly based on space provided',
+    environmental: 'neutral',
+  },
+  {
     id: 'walk_in_closet',
     name: 'Walk-in Closet',
     nameKey: 'amenities.walkInCloset',
@@ -675,6 +685,17 @@ export const AMENITIES: Amenity[] = [
     category: 'outdoor',
     description: 'Private outdoor balcony space',
     maxFairValue: 25, // Reasonable value for private outdoor space
+    ethicalNotes: 'Outdoor space improves mental health and quality of life',
+    environmental: 'positive',
+  },
+  {
+    id: 'terrace',
+    name: 'Terrace',
+    nameKey: 'amenities.terrace',
+    icon: 'sunny',
+    category: 'outdoor',
+    description: 'Private or shared terrace',
+    maxFairValue: 25,
     ethicalNotes: 'Outdoor space improves mental health and quality of life',
     environmental: 'positive',
   },
@@ -1128,6 +1149,17 @@ export const AMENITIES: Amenity[] = [
     ethicalNotes: 'Wellness amenity for relaxation and community',
     environmental: 'neutral',
   },
+  {
+    id: 'sauna',
+    name: 'Sauna',
+    nameKey: 'amenities.sauna',
+    icon: 'flame',
+    category: 'wellness',
+    description: 'Private or shared sauna',
+    maxFairValue: 25,
+    ethicalNotes: 'Wellness amenity for relaxation and community',
+    environmental: 'neutral',
+  },
 
   // Family & Children Amenities
   {
@@ -1235,9 +1267,37 @@ export const AMENITIES: Amenity[] = [
   },
 ];
 
+/**
+ * Ingest canonical amenity slug (from `@homiio/listing-providers`
+ * `parse/amenities.ts`) → catalog amenity id. External listings store the
+ * fixed canonical vocabulary (`pool`, `parking`, `garden`, …); a few of those
+ * keys differ from the catalog id used by internally-created listings
+ * (`swimming_pool`, `parking_space`, `garden_space`, …). Resolving through this
+ * map means external + internal listings share one icon + one translation.
+ * Canonical keys that already match a catalog id (`elevator`, `heating`,
+ * `air_conditioning`, `wifi`, `terrace`, `sauna`, `attic`, …) are absent here
+ * and pass through unchanged.
+ */
+export const CANONICAL_AMENITY_ALIASES: Readonly<Record<string, string>> = {
+  pool: 'swimming_pool',
+  parking: 'parking_space',
+  garden: 'garden_space',
+  storage: 'storage_unit',
+  laundry: 'laundry_room',
+  washer: 'washing_machine',
+  jacuzzi: 'hot_tub',
+  armored_door: 'secure_entry',
+  disabled_access: 'wheelchair_accessible',
+  intercom_system: 'intercom',
+};
+
+/** Resolve a stored amenity slug to its catalog id (identity when not aliased). */
+export const resolveAmenityId = (id: string): string => CANONICAL_AMENITY_ALIASES[id] ?? id;
+
 // Helper functions for ethical amenity management
 export const getAmenityById = (id: string): Amenity | undefined => {
-  return AMENITIES.find((amenity) => amenity.id === id);
+  const resolvedId = resolveAmenityId(id);
+  return AMENITIES.find((amenity) => amenity.id === resolvedId);
 };
 
 /**
@@ -1274,16 +1334,17 @@ export const groupAmenitiesByCategory = (ids: string[]): AmenityGroup[] => {
   const byCategory = new Map<string, ResolvedAmenity[]>();
 
   for (const id of ids) {
-    const amenity = getAmenityById(id);
+    const resolvedId = resolveAmenityId(id);
+    const amenity = getAmenityById(resolvedId);
     const categoryId =
       amenity && getCategoryById(amenity.category)
         ? amenity.category
         : UNCATEGORIZED_AMENITY_ID;
     const bucket = byCategory.get(categoryId);
     if (bucket) {
-      bucket.push({ id, amenity });
+      bucket.push({ id: resolvedId, amenity });
     } else {
-      byCategory.set(categoryId, [{ id, amenity }]);
+      byCategory.set(categoryId, [{ id: resolvedId, amenity }]);
     }
   }
 

--- a/packages/frontend/locales/ca-ES.json
+++ b/packages/frontend/locales/ca-ES.json
@@ -102,7 +102,10 @@
     "wholeHouseFan": "Ventilador de tota la casa",
     "wideDoorways": "Portes amples",
     "wifi": "Internet d'alta velocitat",
-    "wineFridge": "Nevera per a vins"
+    "wineFridge": "Nevera per a vins",
+    "terrace": "Terrassa",
+    "sauna": "Sauna",
+    "attic": "Golfa"
   },
   "home": {
     "hero": {
@@ -1109,7 +1112,17 @@
         "room": "Habitació",
         "studio": "Estudi",
         "duplex": "Dúplex",
-        "penthouse": "Àtic"
+        "penthouse": "Àtic",
+        "couchsurfing": "Couchsurfing",
+        "roommates": "Companys de pis",
+        "coliving": "Coliving",
+        "hostel": "Alberg",
+        "guesthouse": "Casa d'hostes",
+        "campsite": "Càmping",
+        "boat": "Vaixell",
+        "treehouse": "Casa de l'arbre",
+        "yurt": "Iurta",
+        "other": "Altre"
       }
     },
     "type": {
@@ -3506,5 +3519,15 @@
   },
   "inbox": {
     "title": "Bústia"
+  },
+  "parkingType": {
+    "street": "Aparcament al carrer",
+    "assigned": "Plaça assignada",
+    "garage": "Garatge"
+  },
+  "petPolicy": {
+    "allowed": "S'admeten mascotes",
+    "not_allowed": "No s'admeten mascotes",
+    "case_by_case": "Mascotes segons el cas"
   }
 }

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -115,7 +115,10 @@
     "wholeHouseFan": "Whole House Fan",
     "wideDoorways": "Wide Doorways",
     "wifi": "High-Speed Internet",
-    "wineFridge": "Wine Refrigerator"
+    "wineFridge": "Wine Refrigerator",
+    "terrace": "Terrace",
+    "sauna": "Sauna",
+    "attic": "Attic"
   },
   "home": {
     "insights": {
@@ -1132,7 +1135,17 @@
         "room": "Room",
         "studio": "Studio",
         "duplex": "Duplex",
-        "penthouse": "Penthouse"
+        "penthouse": "Penthouse",
+        "couchsurfing": "Couchsurfing",
+        "roommates": "Roommates",
+        "coliving": "Co-living",
+        "hostel": "Hostel",
+        "guesthouse": "Guesthouse",
+        "campsite": "Campsite",
+        "boat": "Boat",
+        "treehouse": "Treehouse",
+        "yurt": "Yurt",
+        "other": "Other"
       }
     },
     "actions": {
@@ -3441,5 +3454,15 @@
   },
   "inbox": {
     "title": "Inbox"
+  },
+  "parkingType": {
+    "street": "Street Parking",
+    "assigned": "Assigned Parking",
+    "garage": "Garage"
+  },
+  "petPolicy": {
+    "allowed": "Pets Allowed",
+    "not_allowed": "No Pets",
+    "case_by_case": "Pets Case by Case"
   }
 }

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -102,7 +102,10 @@
     "wholeHouseFan": "Ventilador de toda la casa",
     "wideDoorways": "Puertas anchas",
     "wifi": "Internet de alta velocidad",
-    "wineFridge": "Nevera para vinos"
+    "wineFridge": "Nevera para vinos",
+    "terrace": "Terraza",
+    "sauna": "Sauna",
+    "attic": "Buhardilla"
   },
   "home": {
     "insights": {
@@ -1088,7 +1091,17 @@
         "room": "Habitación",
         "studio": "Estudio",
         "duplex": "Dúplex",
-        "penthouse": "Ático"
+        "penthouse": "Ático",
+        "couchsurfing": "Couchsurfing",
+        "roommates": "Compañeros de piso",
+        "coliving": "Coliving",
+        "hostel": "Hostal",
+        "guesthouse": "Casa de huéspedes",
+        "campsite": "Camping",
+        "boat": "Barco",
+        "treehouse": "Casa del árbol",
+        "yurt": "Yurta",
+        "other": "Otro"
       }
     },
     "type": {
@@ -3485,5 +3498,15 @@
   },
   "inbox": {
     "title": "Buzón"
+  },
+  "parkingType": {
+    "street": "Aparcamiento en la calle",
+    "assigned": "Plaza asignada",
+    "garage": "Garaje"
+  },
+  "petPolicy": {
+    "allowed": "Se admiten mascotas",
+    "not_allowed": "No se admiten mascotas",
+    "case_by_case": "Mascotas según el caso"
   }
 }

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -102,7 +102,10 @@
     "wholeHouseFan": "Ventilatore per tutta la casa",
     "wideDoorways": "Porte larghe",
     "wifi": "Internet ad alta velocità",
-    "wineFridge": "Frigo per vini"
+    "wineFridge": "Frigo per vini",
+    "terrace": "Terrazza",
+    "sauna": "Sauna",
+    "attic": "Mansarda"
   },
   "settings": {
     "title": "Impostazioni",
@@ -1256,7 +1259,17 @@
         "room": "Stanza",
         "studio": "Monolocale",
         "duplex": "Duplex",
-        "penthouse": "Attico"
+        "penthouse": "Attico",
+        "couchsurfing": "Couchsurfing",
+        "roommates": "Coinquilini",
+        "coliving": "Coliving",
+        "hostel": "Ostello",
+        "guesthouse": "Pensione",
+        "campsite": "Campeggio",
+        "boat": "Barca",
+        "treehouse": "Casa sull'albero",
+        "yurt": "Yurta",
+        "other": "Altro"
       }
     },
     "type": {
@@ -3490,5 +3503,15 @@
   },
   "inbox": {
     "title": "Posta"
+  },
+  "parkingType": {
+    "street": "Parcheggio su strada",
+    "assigned": "Posto auto assegnato",
+    "garage": "Garage"
+  },
+  "petPolicy": {
+    "allowed": "Animali ammessi",
+    "not_allowed": "Animali non ammessi",
+    "case_by_case": "Animali caso per caso"
   }
 }

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -47,6 +47,16 @@ export {
 } from './parse/listing';
 export { stripHtmlToPlainText } from './parse/htmlText';
 export {
+  CANONICAL_AMENITIES,
+  FURNISHED_TOKEN,
+  slugifyAmenityToken,
+  canonicalAmenity,
+  isCanonicalAmenity,
+  canonicalizeAmenities,
+  type CanonicalAmenity,
+  type CanonicalizeAmenitiesResult,
+} from './parse/amenities';
+export {
   assertHousingListing,
   isHousingCategory,
   isHousingCategoryUrl,

--- a/packages/listing-providers/src/parse/amenities.ts
+++ b/packages/listing-providers/src/parse/amenities.ts
@@ -1,0 +1,237 @@
+/**
+ * Canonical amenity vocabulary — ONE source of truth for every provider.
+ *
+ * Portals speak wildly different amenity dialects: localized labels
+ * (`ascensor`, `ascensore`, `aria condizionata`), internal English feature
+ * slugs (`air_conditioner`, `storage_room`), camelCase keys
+ * (`elevatorInTheBuilding`, `parkingSpace`), boolean flag names (`hasLift`) and
+ * free-form marketing copy (`Off street parking`). Left unmapped, the same
+ * amenity would be stored under a dozen different keys, breaking cross-portal
+ * search (`amenities: { $in }`) and forcing the app to render raw slugs.
+ *
+ * This module collapses ALL of those inputs onto a single fixed, documented set
+ * of canonical EN snake_case keys. Every provider (and the ingest chokepoint in
+ * {@link ./listing.ts sanitizeNormalizedListingTextFields}) canonicalizes
+ * through {@link canonicalAmenity} / {@link canonicalizeAmenities} — there are
+ * NO per-portal alias tables anymore. The frontend has a matching translation
+ * for each canonical key, so structured amenities always render localized.
+ */
+
+/**
+ * The fixed, documented canonical amenity vocabulary (EN snake_case). Every key
+ * here has a frontend translation under `amenities.*`. Anything a provider emits
+ * that does not resolve to one of these (or {@link FURNISHED_TOKEN}) is dropped
+ * rather than stored as an untranslatable slug.
+ *
+ * Keep this in sync with the frontend catalog aliases in
+ * `packages/frontend/constants/amenities.tsx` (`CANONICAL_AMENITY_TO_CATALOG_ID`).
+ */
+export const CANONICAL_AMENITIES = [
+  'air_conditioning',
+  'heating',
+  'elevator',
+  'balcony',
+  'terrace',
+  'garden',
+  'parking',
+  'pool',
+  'storage',
+  'wifi',
+  'cable_tv',
+  'dishwasher',
+  'washing_machine',
+  'dryer',
+  'laundry_room',
+  'gym',
+  'sauna',
+  'jacuzzi',
+  'intercom',
+  'armored_door',
+  'attic',
+  'disabled_access',
+] as const;
+
+export type CanonicalAmenity = (typeof CANONICAL_AMENITIES)[number];
+
+/**
+ * Special sentinel: `furnished` is a first-class structured field
+ * (`furnishedStatus`), never stored as an amenity tag. Providers/ingest hoist it
+ * out of the amenity list — see {@link canonicalizeAmenities}.
+ */
+export const FURNISHED_TOKEN = 'furnished';
+
+const CANONICAL_SET: ReadonlySet<string> = new Set(CANONICAL_AMENITIES);
+
+/**
+ * Normalize an arbitrary amenity token/label to a comparable slug: strip
+ * accents, split camelCase (`airConditioning` → `air_conditioning`), lowercase,
+ * and collapse every non-alphanumeric run to a single `_`.
+ */
+export function slugifyAmenityToken(raw: string): string {
+  return raw
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/**
+ * Every recognized input slug → canonical key (or {@link FURNISHED_TOKEN}).
+ * Inputs are already {@link slugifyAmenityToken}-normalized. Covers Spanish and
+ * Italian localized labels, English portal feature slugs, camelCase/boolean-flag
+ * derived slugs and common free-text phrases. Keys not present here fall back to
+ * a direct canonical-set membership check in {@link canonicalAmenity}.
+ */
+const AMENITY_ALIASES: Readonly<Record<string, CanonicalAmenity | typeof FURNISHED_TOKEN>> = {
+  // elevator
+  ascensor: 'elevator',
+  ascensore: 'elevator',
+  ascenseur: 'elevator',
+  lift: 'elevator',
+  elevator_in_the_building: 'elevator',
+  // air conditioning
+  aire_acondicionado: 'air_conditioning',
+  climatizacion: 'air_conditioning',
+  aria_condizionata: 'air_conditioning',
+  climatizzazione: 'air_conditioning',
+  air_conditioner: 'air_conditioning',
+  air_conditioned: 'air_conditioning',
+  // heating
+  calefaccion: 'heating',
+  riscaldamento: 'heating',
+  central_heating: 'heating',
+  gas_central_heating: 'heating',
+  // terrace
+  terraza: 'terrace',
+  terrazzo: 'terrace',
+  terrazza: 'terrace',
+  terrace_private: 'terrace',
+  // balcony
+  balcon: 'balcony',
+  balcone: 'balcony',
+  // parking
+  garaje: 'parking',
+  garage: 'parking',
+  parcheggio: 'parking',
+  posto_auto: 'parking',
+  parking_space: 'parking',
+  plaza_de_garaje: 'parking',
+  plaza_garaje: 'parking',
+  off_street_parking: 'parking',
+  // pool
+  piscina: 'pool',
+  swimming_pool: 'pool',
+  community_pool: 'pool',
+  private_pool: 'pool',
+  // garden
+  jardin: 'garden',
+  giardino: 'garden',
+  jardim: 'garden',
+  private_garden: 'garden',
+  communal_garden: 'garden',
+  // storage
+  trastero: 'storage',
+  cantina: 'storage',
+  storage_room: 'storage',
+  basement: 'storage',
+  // washing machine / laundry
+  lavadora: 'washing_machine',
+  lavatrice: 'washing_machine',
+  washer: 'washing_machine',
+  washer_unit: 'washing_machine',
+  laundry_room_unit: 'washing_machine',
+  laundry: 'laundry_room',
+  // dryer / dishwasher
+  secadora: 'dryer',
+  tumble_dryer: 'dryer',
+  lavavajillas: 'dishwasher',
+  lavastoviglie: 'dishwasher',
+  dish_washer: 'dishwasher',
+  // gym / wellness
+  gimnasio: 'gym',
+  fitness_room: 'gym',
+  fitness: 'gym',
+  hot_tub: 'jacuzzi',
+  // connectivity
+  internet: 'wifi',
+  wi_fi: 'wifi',
+  fiber: 'wifi',
+  // intercom / security
+  portero: 'intercom',
+  portero_automatico: 'intercom',
+  visiophone: 'intercom',
+  video_intercom: 'intercom',
+  puerta_blindada: 'armored_door',
+  buhardilla: 'attic',
+  acceso_minusvalidos: 'disabled_access',
+  wheelchair_access: 'disabled_access',
+  disabled_access: 'disabled_access',
+  // furnished (hoisted into furnishedStatus, never stored as an amenity)
+  amueblado: FURNISHED_TOKEN,
+  amoblado: FURNISHED_TOKEN,
+  arredato: FURNISHED_TOKEN,
+  arredata: FURNISHED_TOKEN,
+  meuble: FURNISHED_TOKEN,
+  meublee: FURNISHED_TOKEN,
+  furnished: FURNISHED_TOKEN,
+};
+
+/**
+ * Resolve any portal amenity token/label to its canonical key,
+ * {@link FURNISHED_TOKEN}, or `undefined` when it is not a recognized amenity
+ * (dimensions, condition, orientation, marketing fluff, …). Never falls back to
+ * a raw slug — unrecognized inputs are intentionally dropped so only the fixed,
+ * translatable vocabulary is ever stored.
+ */
+export function canonicalAmenity(
+  input: string,
+): CanonicalAmenity | typeof FURNISHED_TOKEN | undefined {
+  const slug = slugifyAmenityToken(input);
+  if (!slug) return undefined;
+  const aliased = AMENITY_ALIASES[slug];
+  if (aliased) return aliased;
+  if (CANONICAL_SET.has(slug)) return slug as CanonicalAmenity;
+  return undefined;
+}
+
+/** Whether a slug is one of the fixed canonical amenity keys. */
+export function isCanonicalAmenity(slug: string): slug is CanonicalAmenity {
+  return CANONICAL_SET.has(slug);
+}
+
+export interface CanonicalizeAmenitiesResult {
+  /** Deduped canonical amenity keys, in first-seen order. */
+  amenities: string[];
+  /** `true` when a `furnished` token was seen (hoist into `furnishedStatus`). */
+  furnished?: boolean;
+}
+
+/**
+ * Canonicalize a list of raw amenity tokens/labels: map each through
+ * {@link canonicalAmenity}, drop unrecognized entries, dedupe, and hoist any
+ * `furnished` token into the returned {@link CanonicalizeAmenitiesResult.furnished}
+ * flag instead of the amenity list.
+ */
+export function canonicalizeAmenities(
+  inputs: Iterable<string>,
+): CanonicalizeAmenitiesResult {
+  const seen = new Set<string>();
+  const amenities: string[] = [];
+  let furnished: boolean | undefined;
+  for (const input of inputs) {
+    const canonical = canonicalAmenity(input);
+    if (!canonical) continue;
+    if (canonical === FURNISHED_TOKEN) {
+      furnished = true;
+      continue;
+    }
+    if (!seen.has(canonical)) {
+      seen.add(canonical);
+      amenities.push(canonical);
+    }
+  }
+  return furnished === undefined ? { amenities } : { amenities, furnished };
+}

--- a/packages/listing-providers/src/parse/jsonLd.ts
+++ b/packages/listing-providers/src/parse/jsonLd.ts
@@ -5,7 +5,8 @@
  * {@link SchemaOrgListing}. Portal markup changes are fixed here.
  */
 
-import { asCoordinate, asNumberEu, asNumberUs, asString, deaccent, isRecord } from './guards';
+import { canonicalAmenity, FURNISHED_TOKEN } from './amenities';
+import { asCoordinate, asNumberEu, asNumberUs, asString, isRecord } from './guards';
 
 const LD_JSON_TYPE = 'application/ld+json';
 
@@ -60,104 +61,32 @@ export interface EurSchemaListing {
 export type EsSchemaListing = EurSchemaListing;
 export type ItSchemaListing = EurSchemaListing;
 
-const ES_AMENITY_ALIASES: Readonly<Record<string, string>> = {
-  ascensor: 'elevator',
-  'aire acondicionado': 'air_conditioning',
-  climatizacion: 'air_conditioning',
-  calefaccion: 'heating',
-  terraza: 'terrace',
-  balcon: 'balcony',
-  parking: 'parking',
-  garaje: 'parking',
-  piscina: 'pool',
-  jardin: 'garden',
-  trastero: 'storage',
-  amueblado: 'furnished',
-};
-
-/**
- * Canonical amenity for a portal English feature-SLUG key (e.g. Fotocasa
- * `features[].key`: `air_conditioner`, `elevator`, `storage_room`, …). These
- * are internal snake_case keys, NOT the localized Spanish labels handled by
- * {@link ES_AMENITY_ALIASES} — but they resolve to the SAME canonical vocabulary
- * so external listings share one amenity slug set across parse paths. Keys that
- * are dimensions (`rooms`/`bathrooms`/`surface`/`floor`) or non-amenity metadata
- * (`conservationStatus`, `antiquity`, …) are intentionally absent → dropped.
- */
-const FEATURE_KEY_AMENITY_ALIASES: Readonly<Record<string, string>> = {
-  elevator: 'elevator',
-  lift: 'elevator',
-  air_conditioner: 'air_conditioning',
-  air_conditioning: 'air_conditioning',
-  air_conditioned: 'air_conditioning',
-  heating: 'heating',
-  terrace: 'terrace',
-  balcony: 'balcony',
-  parking: 'parking',
-  garage: 'parking',
-  storage_room: 'storage',
-  storage: 'storage',
-  pool: 'pool',
-  swimming_pool: 'pool',
-  community_pool: 'pool',
-  private_pool: 'pool',
-  garden: 'garden',
-  private_garden: 'garden',
-  communal_garden: 'garden',
-  furnished: 'furnished',
-};
-
-const IT_AMENITY_ALIASES: Readonly<Record<string, string>> = {
-  ascensore: 'elevator',
-  'aria condizionata': 'air_conditioning',
-  climatizzazione: 'air_conditioning',
-  riscaldamento: 'heating',
-  terrazzo: 'terrace',
-  terrazza: 'terrace',
-  balcone: 'balcony',
-  posto_auto: 'parking',
-  garage: 'parking',
-  parcheggio: 'parking',
-  piscina: 'pool',
-  giardino: 'garden',
-  cantina: 'storage',
-  arredato: 'furnished',
-  arredata: 'furnished',
-};
-
 interface EurJsonLdConfig {
   defaultCountryCode: string;
-  amenityAliases: Readonly<Record<string, string>>;
 }
 
-const ES_JSON_LD_CONFIG: EurJsonLdConfig = { defaultCountryCode: 'ES', amenityAliases: ES_AMENITY_ALIASES };
-const IT_JSON_LD_CONFIG: EurJsonLdConfig = { defaultCountryCode: 'IT', amenityAliases: IT_AMENITY_ALIASES };
-
-function normalizeAmenity(name: string, aliases: Readonly<Record<string, string>>): string {
-  const key = deaccent(name);
-  return aliases[key] ?? key.replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
-}
+const ES_JSON_LD_CONFIG: EurJsonLdConfig = { defaultCountryCode: 'ES' };
+const IT_JSON_LD_CONFIG: EurJsonLdConfig = { defaultCountryCode: 'IT' };
 
 /**
- * Canonical ES amenity key for a free-form label (e.g. a portal property-JSON
+ * Canonical amenity key for a free-form label (e.g. a portal property-JSON
  * `features`/`extras` entry), or `undefined` when the label is not a recognized
- * amenity. Reuses the shared ES alias table — never duplicate it per portal.
- * `amueblado` resolves to `furnished`; callers hoist that into `furnishedStatus`.
- * Unlike {@link normalizeAmenity} it does NOT fall back to a snake_case slug, so
- * mixed "características" arrays (condition, orientation, …) don't leak as amenities.
+ * amenity. Delegates to the shared {@link canonicalAmenity} vocabulary — never a
+ * per-portal alias table. `amueblado`/`arredato`/… resolve to `furnished`;
+ * callers hoist that into `furnishedStatus`. Non-amenity entries (condition,
+ * orientation, …) return `undefined` so they don't leak as amenities.
  */
 export function matchEsAmenityKey(label: string): string | undefined {
-  return ES_AMENITY_ALIASES[deaccent(label)];
+  return canonicalAmenity(label);
 }
 
 /**
  * Canonical amenity slug for a portal English feature-slug key (Fotocasa
  * `features[].key`, …), or `undefined` when the key is not a recognized amenity.
- * Reuses the shared canonical vocabulary — resolves to the same slugs as
- * {@link matchEsAmenityKey} without duplicating the Spanish alias table.
+ * Same shared {@link canonicalAmenity} vocabulary as {@link matchEsAmenityKey}.
  */
 export function matchFeatureKeyAmenity(key: string): string | undefined {
-  return FEATURE_KEY_AMENITY_ALIASES[key.trim().toLowerCase()];
+  return canonicalAmenity(key);
 }
 
 function readTypes(value: unknown): string[] {
@@ -238,11 +167,9 @@ function readEurOffer(value: unknown): { price?: number; currency?: string; oper
   return {};
 }
 
-function readAmenities(
-  value: unknown,
-  aliases: Readonly<Record<string, string>>,
-): { amenities: string[]; furnished?: boolean } {
+function readAmenities(value: unknown): { amenities: string[]; furnished?: boolean } {
   const amenities: string[] = [];
+  const seen = new Set<string>();
   let furnished: boolean | undefined;
   const entries = Array.isArray(value) ? value : value === undefined ? [] : [value];
   for (const entry of entries) {
@@ -250,12 +177,16 @@ function readAmenities(
     const name = asString(entry.name);
     if (!name) continue;
     if (entry.value === false) continue;
-    const key = normalizeAmenity(name, aliases);
-    if (key === 'furnished') {
+    const key = canonicalAmenity(name);
+    if (!key) continue;
+    if (key === FURNISHED_TOKEN) {
       furnished = true;
       continue;
     }
-    if (key) amenities.push(key);
+    if (!seen.has(key)) {
+      seen.add(key);
+      amenities.push(key);
+    }
   }
   return { amenities, furnished };
 }
@@ -269,10 +200,7 @@ function toEurListing(node: Record<string, unknown>, config: EurJsonLdConfig): E
   const subject = readSubject(node);
   const offer = readEurOffer(node.offers ?? subject.offers);
   const topLevelPrice = asNumberEu(node.price);
-  const { amenities, furnished } = readAmenities(
-    subject.amenityFeature ?? node.amenityFeature,
-    config.amenityAliases,
-  );
+  const { amenities, furnished } = readAmenities(subject.amenityFeature ?? node.amenityFeature);
   const types = [...readTypes(node['@type']), ...readTypes(subject['@type'])];
   return {
     types,

--- a/packages/listing-providers/src/parse/listing.ts
+++ b/packages/listing-providers/src/parse/listing.ts
@@ -3,6 +3,7 @@
  */
 
 import { OfferingType, type NormalizedListing } from '@homiio/shared-types';
+import { canonicalizeAmenities } from './amenities';
 import { stripHtmlToPlainText } from './htmlText';
 import { validateOfferingPrices } from './price';
 
@@ -42,11 +43,21 @@ export function sanitizeNormalizedListingTextFields(listing: NormalizedListing):
   }
 
   if (listing.amenities) {
-    listing.amenities = listing.amenities
+    // Strip portal HTML, then collapse every provider's amenity dialect onto the
+    // fixed canonical vocabulary (the single guarantee point — a provider that
+    // forgets to canonicalize still ends up consistent + translatable). A
+    // `furnished` token is hoisted into `furnishedStatus` rather than stored.
+    const cleaned = listing.amenities
       .map((item) => stripHtmlToPlainText(item) ?? '')
       .filter((item) => item.length > 0);
-    if (listing.amenities.length === 0) {
+    const { amenities, furnished } = canonicalizeAmenities(cleaned);
+    if (amenities.length > 0) {
+      listing.amenities = amenities;
+    } else {
       delete listing.amenities;
+    }
+    if (furnished && listing.furnishedStatus === undefined) {
+      listing.furnishedStatus = 'furnished';
     }
   }
 

--- a/packages/listing-providers/src/providers/be/immoweb/parse.ts
+++ b/packages/listing-providers/src/providers/be/immoweb/parse.ts
@@ -183,22 +183,22 @@ function featurePresent(flag: unknown, surface: unknown): boolean | undefined {
 
 /**
  * Immoweb detail JSON exposes ~30 boolean amenity flags on `property.has*`.
- * Map the ones we recognize to the canonical amenity slugs the rest of the
- * pipeline speaks (matching `parse/jsonLd.ts` aliases + ingest `deriveFeatures`
- * keywords: `elevator`/`terrace`/`garden`/`pool`/`storage`/`air_conditioning`).
- * The ingest promotes `elevator`→hasElevator, `terrace`→hasBalcony,
- * `garden`→hasGarden from this array; other slugs surface as amenity tags.
+ * Map the ones we recognize directly to the shared canonical amenity vocabulary
+ * (`parse/amenities.ts`) — this is a portal-specific INPUT adapter (Immoweb's
+ * boolean flag names), and every target is a fixed canonical key, so the ingest
+ * promotes `elevator`→hasElevator, `terrace`→hasBalcony, `garden`→hasGarden and
+ * the app renders each translated.
  */
 const IMMOWEB_AMENITY_FLAGS: Readonly<Record<string, string>> = {
   hasLift: 'elevator',
   hasTerrace: 'terrace',
   hasGarden: 'garden',
   hasBasement: 'storage',
-  hasLaundryRoom: 'laundry',
+  hasLaundryRoom: 'laundry_room',
   hasArmoredDoor: 'armored_door',
   hasAttic: 'attic',
-  hasInternet: 'internet',
-  hasVisiophone: 'visiophone',
+  hasInternet: 'wifi',
+  hasVisiophone: 'intercom',
   hasAirConditioning: 'air_conditioning',
   hasSwimmingPool: 'pool',
   hasFitnessRoom: 'gym',

--- a/packages/listing-providers/src/providers/blueground/parse.ts
+++ b/packages/listing-providers/src/providers/blueground/parse.ts
@@ -12,6 +12,7 @@
  */
 
 import type { ExternalListingRef } from '../../types';
+import { canonicalAmenity, FURNISHED_TOKEN } from '../../parse/amenities';
 import { asRecord, asString } from '../../parse/guards';
 import { extractBalancedJsonAfter } from '../../parse/nextData';
 import type { BluegroundRawListing, BluegroundRawPhoto } from './fixtures';
@@ -135,37 +136,18 @@ function readPhotos(html: string): BluegroundRawPhoto[] {
  * We normalize the stable `key` — never the localized caption — so extraction is
  * market-agnostic.
  *
- * Only the handful of keys whose generic slug would diverge from the canonical
- * vocabulary the ingest/search read (`elevator`, `parking`, `terrace`,
- * `washer`, `air_conditioning`) are aliased; everything else is slugified
- * generically. This is Blueground's OWN camelCase vocabulary, not a duplicate of
- * the shared ES/IT free-text amenity table in `parse/jsonLd.ts`.
+ * The stable `key` is run through the shared {@link canonicalAmenity} vocabulary
+ * (which slugifies camelCase, so `elevatorInTheBuilding`→`elevator`,
+ * `parkingSpace`→`parking`, `washerUnit`→`washing_machine`); keys that don't map
+ * to the fixed canonical set (e.g. `coffeeMachine`) are dropped rather than
+ * stored as a bespoke slug. No per-portal alias table.
  */
-const BLUEGROUND_AMENITY_ALIASES: Readonly<Record<string, string>> = {
-  airConditioning: 'air_conditioning',
-  elevatorInTheBuilding: 'elevator',
-  parkingSpace: 'parking',
-  terracePrivate: 'terrace',
-  laundryRoomUnit: 'washer',
-  washerUnit: 'washer',
-};
 
 /** Categories that list amenities the unit does NOT have (struck through in UI). */
 const BLUEGROUND_STRUCKTHROUGH_PREFIX = 'struckthrough';
 /** Category holding structured facts (bedrooms/bathrooms/lotSize/floor), not amenities. */
 const BLUEGROUND_FACTS_CATEGORY = 'main';
 const BLUEGROUND_FLOOR_KEY = 'floor';
-
-/** Canonicalize a Blueground amenity `key`; unknown keys → generic snake_case slug. */
-function bluegroundAmenitySlug(key: string): string {
-  const alias = BLUEGROUND_AMENITY_ALIASES[key];
-  if (alias) return alias;
-  return key
-    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '');
-}
 
 /** Read the `main.floor` structured value (string like `"2"` or a number). */
 function readBluegroundFloor(entries: readonly unknown[]): number | undefined {
@@ -217,8 +199,8 @@ export function readBluegroundAmenities(html: string): { amenities: string[]; fl
     for (const entry of entries) {
       const key = asString(asRecord(entry)?.['key']);
       if (!key) continue;
-      const slug = bluegroundAmenitySlug(key);
-      if (slug) amenities.add(slug);
+      const canonical = canonicalAmenity(key);
+      if (canonical && canonical !== FURNISHED_TOKEN) amenities.add(canonical);
     }
   }
 

--- a/packages/listing-providers/src/providers/gb/rightmove/parse.ts
+++ b/packages/listing-providers/src/providers/gb/rightmove/parse.ts
@@ -7,6 +7,7 @@
  */
 
 import type { NormalizedListingContact } from '@homiio/shared-types';
+import { canonicalizeAmenities } from '../../../parse/amenities';
 import { buildContact } from '../../../parse/contact';
 import { asNumberUs as asNumber, asString, isRecord } from '../../../parse/guards';
 import { parseNextData } from '../../../parse/nextData';
@@ -266,15 +267,21 @@ function squareMetersFromDetail(prop: Record<string, unknown>): number | undefin
   return squareMetersFromSizings(prop) ?? squareMetersFromDisplaySize(prop);
 }
 
-/** Portal `keyFeatures[]` strings — passed to ingest as amenities for derivation. */
+/**
+ * Portal `keyFeatures[]` are free-form marketing copy ("Off street parking",
+ * "Gas central heating", "Double glazing"). Collapse them onto the shared
+ * canonical amenity vocabulary so they match every other portal + render
+ * translated; unrecognized copy is dropped and `Furnished` is hoisted into
+ * `furnishedStatus` (letting.furnishType already sets it).
+ */
 function keyFeaturesFromDetail(prop: Record<string, unknown>): string[] {
   if (!Array.isArray(prop.keyFeatures)) return [];
-  const out: string[] = [];
+  const labels: string[] = [];
   for (const feature of prop.keyFeatures) {
     const value = asString(feature);
-    if (value) out.push(value);
+    if (value) labels.push(value);
   }
-  return out;
+  return canonicalizeAmenities(labels).amenities;
 }
 
 /** Map `propertyData.letting.furnishType` to the normalized furnished status. */

--- a/packages/listing-providers/src/providers/habitaclia/parse.ts
+++ b/packages/listing-providers/src/providers/habitaclia/parse.ts
@@ -12,6 +12,7 @@
  */
 
 import { HABITACLIA_BASE_URL, type HabitacliaRawImage, type HabitacliaRawListing } from './fixtures';
+import { canonicalAmenity, FURNISHED_TOKEN } from '../../parse/amenities';
 import { asCoordinate, asNumber, asString } from '../../parse/guards';
 
 /** Match every `<script type="application/ld+json">…</script>` block. */
@@ -25,21 +26,6 @@ const DETAIL_DATA_HREF_RE =
   /data-href=["']([^"']*-i(\d+)\.htm(?:\?[^"']*)?)["']/gi;
 /** Fallback when anchors omit the `-i` prefix but keep the trailing id segment. */
 const DETAIL_LINK_FALLBACK_RE = /href=["']([^"']*\/alquiler-[^"']*-(\d{6,})\.htm)["']/gi;
-
-/** Spanish → canonical amenity keys; unknown names fall back to a slug. */
-const AMENITY_ALIASES: Readonly<Record<string, string>> = {
-  ascensor: 'elevator',
-  'aire acondicionado': 'air_conditioning',
-  calefaccion: 'heating',
-  terraza: 'terrace',
-  balcon: 'balcony',
-  parking: 'parking',
-  garaje: 'parking',
-  piscina: 'pool',
-  jardin: 'garden',
-  trastero: 'storage',
-  amueblado: 'furnished',
-};
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -91,16 +77,6 @@ function htmlFragmentToText(html: string): string {
   return text.replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim();
 }
 
-/** Strip accents and lowercase for alias lookup / slugging. */
-function deaccent(value: string): string {
-  return value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().trim();
-}
-
-function normalizeAmenity(name: string): string {
-  const key = deaccent(name);
-  return AMENITY_ALIASES[key] ?? key.replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
-}
-
 /** Parse every JSON-LD block in the page, ignoring malformed ones. */
 function extractJsonLdNodes(html: string): Record<string, unknown>[] {
   const nodes: Record<string, unknown>[] = [];
@@ -146,18 +122,23 @@ function toImages(node: Record<string, unknown>): HabitacliaRawImage[] {
 
 function toAmenities(node: Record<string, unknown>): { amenities: string[]; furnished?: boolean } {
   const amenities: string[] = [];
+  const seen = new Set<string>();
   let furnished: boolean | undefined;
   for (const entry of asArray(node['amenityFeature'])) {
     const record = asRecord(entry);
     const name = asString(record?.['name']);
     if (!name) continue;
     if (record?.['value'] === false) continue;
-    const key = normalizeAmenity(name);
-    if (key === 'furnished') {
+    const key = canonicalAmenity(name);
+    if (!key) continue;
+    if (key === FURNISHED_TOKEN) {
       furnished = true;
       continue;
     }
-    if (key) amenities.push(key);
+    if (!seen.has(key)) {
+      seen.add(key);
+      amenities.push(key);
+    }
   }
   return { amenities, furnished };
 }
@@ -480,6 +461,7 @@ export function parseHabitacliaDetailHtml(html: string, url: string): Habitaclia
   );
 
   const amenities: string[] = [];
+  const seen = new Set<string>();
   let furnished: boolean | undefined;
   for (const match of html.matchAll(/<li>([^<]{2,60})<\/li>/gi)) {
     const label = match[1]?.trim();
@@ -490,12 +472,16 @@ export function parseHabitacliaDetailHtml(html: string, url: string): Habitaclia
       )
     )
       continue;
-    const key = normalizeAmenity(label);
-    if (key === 'furnished') {
+    const key = canonicalAmenity(label);
+    if (!key) continue;
+    if (key === FURNISHED_TOKEN) {
       furnished = true;
       continue;
     }
-    if (key) amenities.push(key);
+    if (!seen.has(key)) {
+      seen.add(key);
+      amenities.push(key);
+    }
   }
 
   return {

--- a/packages/listing-providers/src/providers/pisos/index.ts
+++ b/packages/listing-providers/src/providers/pisos/index.ts
@@ -454,6 +454,7 @@ export class PisosProvider implements ListingProvider {
     if (yearBuilt !== undefined) result.yearBuilt = yearBuilt;
     if (parkingSpaces !== undefined) result.parkingSpaces = parkingSpaces;
     if (listing.amenities.length > 0) result.amenities = listing.amenities;
+    if (listing.furnished === true) result.furnishedStatus = 'furnished';
     if (contact && (contact.phone || contact.email || contact.whatsapp || contact.agencyName)) {
       result.contact = contact;
     }

--- a/packages/listing-providers/src/providers/pisos/parse.ts
+++ b/packages/listing-providers/src/providers/pisos/parse.ts
@@ -8,6 +8,7 @@
 
 import type { NormalizedListingContact } from '@homiio/shared-types';
 import { ldJsonScriptBodies } from '../../html';
+import { canonicalizeAmenities } from '../../parse/amenities';
 import { extractEsSchemaListings, type EsSchemaListing } from '../../parse/jsonLd';
 import { PISOS_BASE_URL } from './fixtures';
 import { asCoordinate, asNumber } from '../../parse/guards';
@@ -329,20 +330,15 @@ export function postalCodeFromPisosUrl(url: string): string | undefined {
   return url.match(/(\d{5})-\d+[._]\d+/)?.[1];
 }
 
-function amenityList(raw: unknown): string[] {
-  if (typeof raw !== 'string' || raw.trim().length === 0) return [];
-  return raw
-    .split(',')
-    .map((part) =>
-      part
-        .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, '')
-        .toLowerCase()
-        .trim()
-        .replace(/[^a-z0-9]+/g, '_')
-        .replace(/^_+|_+$/g, ''),
-    )
-    .filter(Boolean);
+/**
+ * Pisos' `caracteristicasInmueble` is a comma-separated list of raw Spanish
+ * feature slugs (`ascensor,balcon,soleado,amueblado`). Collapse it onto the
+ * shared canonical amenity vocabulary \u2014 non-amenity words (`soleado`, \u2026) drop
+ * and `amueblado` is hoisted into the returned `furnished` flag.
+ */
+function amenityList(raw: unknown): { amenities: string[]; furnished?: boolean } {
+  if (typeof raw !== 'string' || raw.trim().length === 0) return { amenities: [] };
+  return canonicalizeAmenities(raw.split(','));
 }
 
 /**
@@ -421,6 +417,8 @@ export function parsePisosDetail(html: string, url: string): PisosRaw {
   const street = ld?.address?.street ?? h1 ?? city;
   const postalCode = ld?.address?.postalCode ?? postalCodeFromPisosUrl(url);
 
+  const { amenities, furnished } = amenityList(dataVar?.caracteristicasInmueble);
+
   const listing: EsSchemaListing = {
     types,
     name: h1 ?? ld?.name,
@@ -443,8 +441,9 @@ export function parsePisosDetail(html: string, url: string): PisosRaw {
     price,
     priceCurrency: 'EUR',
     operation,
-    amenities: amenityList(dataVar?.caracteristicasInmueble),
+    amenities,
   };
+  if (furnished) listing.furnished = true;
 
   const phone =
     typeof dataVar?.telefono === 'string' && dataVar.telefono.trim()


### PR DESCRIPTION
## Summary
- New canonical amenity vocabulary module (`packages/listing-providers/src/parse/amenities.ts`) as the single source of truth for structured listing values across all providers.
- Ingest chokepoint `sanitizeNormalizedListingTextFields` in `packages/listing-providers/src/parse/listing.ts` canonicalizes every listing and hoists `furnished` into `furnishedStatus`.
- Providers (jsonLd, habitaclia, blueground, immoweb, pisos, rightmove) mapped to the shared canonical EN keys, removing duplicate per-portal alias tables.
- Frontend renders canonical slugs/enums translated via new locale keys (en/es/ca-ES/it).

## Test plan
- [x] `shared-types` build passes
- [x] `listing-providers` build passes
- [x] Backend Jest unit tests: 56 suites / 489 tests pass (`NODE_OPTIONS='--max-old-space-size=6144' npx jest __tests__/unit` from `packages/backend`)
- [x] Lockfile gate (`bun install --frozen-lockfile`) passes clean

### Known pre-existing issues (not introduced by this PR)
- `packages/listing-providers` `bun run lint` has 15 pre-existing errors in untouched files (`src/providers/fr/seloger/parse.ts`, `src/proxy.ts`, `src/runtime.ts`, `src/session.ts`).
- Frontend tsc/eslint have pre-existing errors in `PropertyCard.tsx` (`Date.now()` purity at line ~256, `summary.fallback` on `OfferingSummary` at line ~336) that are not part of this diff's edited lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)