### PR TITLE
feat(backend): reviucasa-parity reviews — Agency entity, dimensions, helpful/report, explore

### DIFF
--- a/packages/backend/__tests__/integration/reviewSystem.test.ts
+++ b/packages/backend/__tests__/integration/reviewSystem.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Reviucasa-parity review system: mass-assignment guards, helpful votes,
+ * reports, agency attribution + reads, and the review-explore aggregations.
+ *
+ * Uses real Mongoose models against in-memory Mongo. Geo resolution runs fully
+ * offline because every seeded address supplies a complete name set
+ * (city + state + countryCode) plus coordinates, so `resolveGeo` never calls the
+ * geocoder.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+
+import { createRentProperty } from '../helpers/factories';
+
+const reviewController = require('../../controllers/reviewController');
+const { Review, Agency, Address, Property } = require('../../models');
+const { clearResolutionCache } = require('../../services/geoResolutionService');
+
+// The geo-resolution cache is process-level and short-circuits geo id
+// resolution WITHOUT re-upserting the Country/Region/City/Neighborhood docs.
+// The global `afterEach` wipes those collections, so reset the cache between
+// tests or a later resolution returns an id for a deleted doc.
+beforeEach(() => {
+  clearResolutionCache();
+});
+
+// ---- Test app (auth shim mirrors the lease-ownership integration test) ----
+function buildApp(oxyUserId?: string): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (oxyUserId) {
+      const authed = req as unknown as { user: { id: string }; userId: string };
+      authed.user = { id: oxyUserId };
+      authed.userId = oxyUserId;
+    }
+    next();
+  });
+
+  app.post('/reviews', (req, res) => reviewController.createReview(req, res));
+  app.put('/reviews/:reviewId', (req, res) => reviewController.updateReview(req, res));
+  app.delete('/reviews/:reviewId', (req, res) => reviewController.deleteReview(req, res));
+  app.post('/reviews/:reviewId/helpful', (req, res) => reviewController.toggleHelpful(req, res));
+  app.post('/reviews/:reviewId/report', (req, res) => reviewController.reportReview(req, res));
+
+  app.get('/agencies/search', (req, res) => reviewController.searchAgencies(req, res));
+  app.get('/agencies/:slug', (req, res) => reviewController.getAgencyBySlug(req, res));
+  app.get('/agencies/:slug/reviews', (req, res) => reviewController.getAgencyReviews(req, res));
+  app.get('/agencies/:slug/properties', (req, res) => reviewController.getAgencyProperties(req, res));
+
+  app.get('/reviews/explore', (req, res) => reviewController.getExploreCities(req, res));
+  app.get('/reviews/explore/city/:cityId', (req, res) => reviewController.getExploreCity(req, res));
+  app.get('/reviews/explore/neighborhood/:neighborhoodId', (req, res) => reviewController.getExploreNeighborhood(req, res));
+
+  return app;
+}
+
+interface AddressOverrides {
+  street?: string;
+  number?: string;
+  city?: string;
+  state?: string;
+  neighborhood?: string;
+  coordinates?: [number, number];
+}
+
+async function makeBuildingAddress(overrides: AddressOverrides = {}) {
+  return Address.findOrCreateCanonical({
+    street: overrides.street ?? 'Carrer de Test',
+    number: overrides.number ?? '10',
+    city: overrides.city ?? 'Barcelona',
+    state: overrides.state ?? 'Catalonia',
+    country: 'Spain',
+    countryCode: 'ES',
+    postal_code: '08013',
+    neighborhood: overrides.neighborhood ?? 'Eixample',
+    coordinates: { type: 'Point', coordinates: overrides.coordinates ?? [2.17, 41.39] },
+  });
+}
+
+interface ReviewOverrides {
+  address?: AddressOverrides;
+  review?: Record<string, unknown>;
+}
+
+async function seedReview(oxyUserId: string, overrides: ReviewOverrides = {}) {
+  const address = await makeBuildingAddress(overrides.address);
+  const review = await Review.create({
+    addressId: address._id,
+    addressLevel: 'BUILDING',
+    streetLevelId: address._id,
+    buildingLevelId: address._id,
+    cityId: address.cityId,
+    neighborhoodId: address.neighborhoodId,
+    oxyUserId,
+    title: 'A perfectly reasonable title',
+    price: 1000,
+    currency: 'EUR',
+    livedFrom: new Date('2020-01-01'),
+    livedTo: new Date('2021-01-01'),
+    rating: 4,
+    recommendation: true,
+    opinion: 'Lived here a while — a reasonable opinion string.',
+    ...overrides.review,
+  });
+  return { address, review };
+}
+
+describe('createReview (allowlist + agency + geo)', () => {
+  it('creates a review, resolves the agency, sets cityId, and ignores injected server fields', async () => {
+    const res = await request(buildApp('oxy-reviewer'))
+      .post('/reviews')
+      .send({
+        address: {
+          street: 'Carrer Nou',
+          number: '22',
+          city: 'Barcelona',
+          state: 'Catalonia',
+          country: 'Spain',
+          countryCode: 'ES',
+          postal_code: '08010',
+          neighborhood: 'Eixample',
+          latitude: 41.39,
+          longitude: 2.17,
+        },
+        title: 'Great flat overall',
+        price: 1200,
+        currency: 'EUR',
+        livedFrom: '2020-01-01',
+        livedTo: '2021-06-01',
+        rating: 4,
+        recommendation: true,
+        opinion: 'Generally a very good experience living here.',
+        prosItems: ['Bright', 'Quiet'],
+        consItems: ['Cold in winter'],
+        noise: 'quiet',
+        depositReturned: 'full',
+        agencyName: 'Fincas García',
+        // Injected server-owned fields — must be ignored.
+        oxyUserId: 'attacker',
+        verified: true,
+        moderationStatus: 'removed',
+        helpfulVoters: ['x', 'y'],
+      });
+
+    expect(res.status).toBe(201);
+
+    const agency = await Agency.findOne({ normalizedName: 'fincas garcia' });
+    expect(agency).toBeTruthy();
+    expect(agency.slug).toBe('fincas-garcia');
+
+    const review = await Review.findOne({ title: 'Great flat overall' });
+    expect(review.oxyUserId).toBe('oxy-reviewer');
+    expect(review.verified).toBe(false);
+    expect(review.moderationStatus).toBe('active');
+    expect(review.helpfulVoters).toEqual([]);
+    expect(review.cityId).toBeTruthy();
+    expect(String(review.agencyId)).toBe(String(agency._id));
+    expect(review.depositReturned).toBe('full');
+
+    // DTO strips internal fields and derives helpful counters.
+    expect(res.body.review.helpfulVoters).toBeUndefined();
+    expect(res.body.review.reports).toBeUndefined();
+    expect(res.body.review.helpfulCount).toBe(0);
+    expect(res.body.review.agency).toMatchObject({ name: 'Fincas García', slug: 'fincas-garcia' });
+  });
+
+  it('rejects a review without a title', async () => {
+    const res = await request(buildApp('oxy-reviewer'))
+      .post('/reviews')
+      .send({
+        address: { street: 'X', number: '1', city: 'Barcelona', state: 'Catalonia', country: 'Spain', countryCode: 'ES', postal_code: '08010', latitude: 41.39, longitude: 2.17 },
+        price: 1000, currency: 'EUR', livedFrom: '2020-01-01', livedTo: '2021-01-01',
+        rating: 4, recommendation: true, opinion: 'A reasonable opinion string here.',
+      });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('updateReview (mass-assignment guard + ownership)', () => {
+  it('applies allowlisted edits and ignores injected server fields', async () => {
+    const { review } = await seedReview('oxy-owner');
+    const res = await request(buildApp('oxy-owner'))
+      .put(`/reviews/${review._id}`)
+      .send({
+        title: 'An edited review title',
+        oxyUserId: 'attacker',
+        verified: true,
+        helpfulVoters: ['a', 'b'],
+        moderationStatus: 'removed',
+        reports: [{ oxyUserId: 'a', reason: 'spam' }],
+      });
+
+    expect(res.status).toBe(200);
+    const persisted = await Review.findById(review._id);
+    expect(persisted.title).toBe('An edited review title');
+    expect(persisted.oxyUserId).toBe('oxy-owner');
+    expect(persisted.verified).toBe(false);
+    expect(persisted.helpfulVoters).toEqual([]);
+    expect(persisted.moderationStatus).toBe('active');
+    expect(persisted.reports).toEqual([]);
+  });
+
+  it('returns 404 for a non-owner PUT', async () => {
+    const { review } = await seedReview('oxy-owner');
+    const res = await request(buildApp('oxy-stranger'))
+      .put(`/reviews/${review._id}`)
+      .send({ title: 'Stranger edit attempt here' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for a non-owner DELETE and leaves the review intact', async () => {
+    const { review } = await seedReview('oxy-owner');
+    const res = await request(buildApp('oxy-stranger')).delete(`/reviews/${review._id}`);
+    expect(res.status).toBe(404);
+    expect(await Review.findById(review._id)).toBeTruthy();
+  });
+
+  it('lets the owner delete their review', async () => {
+    const { review } = await seedReview('oxy-owner');
+    const res = await request(buildApp('oxy-owner')).delete(`/reviews/${review._id}`);
+    expect(res.status).toBe(200);
+    expect(await Review.findById(review._id)).toBeNull();
+  });
+});
+
+describe('toggleHelpful', () => {
+  it('toggles on then off (1 → 0)', async () => {
+    const { review } = await seedReview('oxy-author');
+    const app = buildApp('oxy-voter');
+
+    const first = await request(app).post(`/reviews/${review._id}/helpful`);
+    expect(first.status).toBe(200);
+    expect(first.body.helpfulCount).toBe(1);
+    expect(first.body.viewerHasVotedHelpful).toBe(true);
+
+    const second = await request(app).post(`/reviews/${review._id}/helpful`);
+    expect(second.status).toBe(200);
+    expect(second.body.helpfulCount).toBe(0);
+    expect(second.body.viewerHasVotedHelpful).toBe(false);
+  });
+
+  it('rejects voting on your own review with 400', async () => {
+    const { review } = await seedReview('oxy-author');
+    const res = await request(buildApp('oxy-author')).post(`/reviews/${review._id}/helpful`);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('reportReview', () => {
+  it('dedupes repeat reports from the same reporter', async () => {
+    const { review } = await seedReview('oxy-author');
+    const app = buildApp('oxy-reporter');
+
+    const first = await request(app).post(`/reviews/${review._id}/report`).send({ reason: 'spam' });
+    expect(first.status).toBe(201);
+
+    const second = await request(app).post(`/reviews/${review._id}/report`).send({ reason: 'spam' });
+    expect(second.status).toBe(200);
+
+    const persisted = await Review.findById(review._id);
+    expect(persisted.reports).toHaveLength(1);
+  });
+
+  it('requires details when the reason is "other"', async () => {
+    const { review } = await seedReview('oxy-author');
+    const res = await request(buildApp('oxy-reporter')).post(`/reviews/${review._id}/report`).send({ reason: 'other' });
+    expect(res.status).toBe(400);
+  });
+
+  it('escalates to under_review after 3 distinct reporters', async () => {
+    const { review } = await seedReview('oxy-author');
+    for (const reporter of ['r1', 'r2', 'r3']) {
+      const res = await request(buildApp(reporter)).post(`/reviews/${review._id}/report`).send({ reason: 'fake' });
+      expect(res.status).toBe(201);
+    }
+    const persisted = await Review.findById(review._id);
+    expect(persisted.reports).toHaveLength(3);
+    expect(persisted.moderationStatus).toBe('under_review');
+  });
+
+  it('keeps under_review reviews visible in agency reads but hides removed ones', async () => {
+    const agency = await Agency.findOrCreateByName('Visible Agency');
+    await seedReview('oxy-a', { review: { agencyId: agency._id, moderationStatus: 'under_review' } });
+    await seedReview('oxy-b', { address: { number: '11' }, review: { agencyId: agency._id, moderationStatus: 'removed' } });
+
+    const res = await request(buildApp()).get(`/agencies/${agency.slug}/reviews`);
+    expect(res.status).toBe(200);
+    expect(res.body.reviews).toHaveLength(1);
+  });
+});
+
+describe('agency reads', () => {
+  it('returns agency stats + listings count', async () => {
+    const agency = await Agency.findOrCreateByName('Stats Agency');
+
+    // Create the property FIRST: the factory's `ensureGeo` uses `Country.create`
+    // (not upsert), so it must run before `resolveGeo` upserts the ES country.
+    const property = await createRentProperty({ oxyUserId: 'oxy-owner' });
+    await Property.updateOne({ _id: property._id }, { $set: { agencyId: agency._id } });
+
+    await seedReview('oxy-a', { review: { agencyId: agency._id, rating: 5, recommendation: true, depositReturned: 'full' } });
+    await seedReview('oxy-b', { address: { number: '12' }, review: { agencyId: agency._id, rating: 3, recommendation: false, depositReturned: 'no' } });
+
+    const res = await request(buildApp()).get(`/agencies/${agency.slug}`);
+    expect(res.status).toBe(200);
+    expect(res.body.agency).toMatchObject({ name: 'Stats Agency', slug: 'stats-agency' });
+    expect(res.body.stats.totalReviews).toBe(2);
+    expect(res.body.stats.averageRating).toBe(4);
+    expect(res.body.stats.recommendationPercentage).toBe(50);
+    expect(res.body.stats.depositFullPct).toBe(50);
+    expect(res.body.stats.listingsCount).toBe(1);
+  });
+
+  it('lists agency properties with flat pagination aliases', async () => {
+    const agency = await Agency.findOrCreateByName('Props Agency');
+    const property = await createRentProperty({ oxyUserId: 'oxy-owner' });
+    await Property.updateOne({ _id: property._id }, { $set: { agencyId: agency._id } });
+
+    const res = await request(buildApp()).get(`/agencies/${agency.slug}/properties`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.hasMore).toBe(false);
+    expect(res.body.totalPages).toBe(1);
+    expect(res.body.total).toBe(1);
+  });
+
+  it('prefix-searches agencies by normalized name', async () => {
+    await Agency.findOrCreateByName('Fincas García');
+    await Agency.findOrCreateByName('Other Realty');
+
+    const res = await request(buildApp()).get('/agencies/search').query({ q: 'fincas' });
+    expect(res.status).toBe(200);
+    expect(res.body.agencies).toHaveLength(1);
+    expect(res.body.agencies[0]).toMatchObject({ name: 'Fincas García', slug: 'fincas-garcia' });
+  });
+
+  it('returns 404 for an unknown agency slug', async () => {
+    const res = await request(buildApp()).get('/agencies/does-not-exist');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('review explore aggregations', () => {
+  it('summarizes cities → neighborhoods → buildings', async () => {
+    // Two buildings in the same Barcelona neighborhood, one in Madrid.
+    const { address: bcnA } = await seedReview('oxy-1', { address: { number: '10' }, review: { rating: 4, recommendation: true } });
+    await seedReview('oxy-2', { address: { number: '20' }, review: { rating: 2, recommendation: false } });
+    await seedReview('oxy-3', {
+      address: { street: 'Gran Via', number: '5', city: 'Madrid', state: 'Madrid', neighborhood: 'Centro', coordinates: [-3.7, 40.4] },
+      review: { rating: 5, recommendation: true },
+    });
+
+    const cities = await request(buildApp()).get('/reviews/explore');
+    expect(cities.status).toBe(200);
+    expect(cities.body.cities.length).toBe(2);
+    const barcelona = cities.body.cities.find((c: { name: string }) => c.name === 'Barcelona');
+    expect(barcelona).toBeTruthy();
+    expect(barcelona.reviewCount).toBe(2);
+
+    const neighborhoods = await request(buildApp()).get(`/reviews/explore/city/${barcelona.cityId}`);
+    expect(neighborhoods.status).toBe(200);
+    expect(neighborhoods.body.neighborhoods.length).toBe(1);
+    const eixample = neighborhoods.body.neighborhoods[0];
+    expect(eixample.name).toBe('Eixample');
+    expect(eixample.reviewCount).toBe(2);
+
+    const buildings = await request(buildApp()).get(`/reviews/explore/neighborhood/${eixample.neighborhoodId}`);
+    expect(buildings.status).toBe(200);
+    expect(buildings.body.buildings.length).toBe(2);
+    expect(buildings.body.hasMore).toBe(false);
+    // Building street/number come from the Address doc.
+    expect(buildings.body.buildings.every((b: { street: string }) => b.street === 'Carrer de Test')).toBe(true);
+    void bcnA;
+  });
+
+  it('excludes removed reviews from explore coverage', async () => {
+    await seedReview('oxy-1', { review: { moderationStatus: 'removed' } });
+    const cities = await request(buildApp()).get('/reviews/explore');
+    expect(cities.status).toBe(200);
+    expect(cities.body.cities).toHaveLength(0);
+  });
+});

--- a/packages/backend/controllers/review/editableFields.ts
+++ b/packages/backend/controllers/review/editableFields.ts
@@ -1,0 +1,73 @@
+/**
+ * Mass-assignment protection for review write endpoints.
+ *
+ * `createReview`/`updateReview` must NEVER spread `req.body` straight into the
+ * Review model. That would let a client set the address hierarchy ids, the
+ * author (`oxyUserId`), the moderation/verification state, the helpful voters,
+ * the report queue, or the relational `agencyId` — an IDOR / integrity hole.
+ * Instead the controllers pick ONLY the explicit, user-supplied fields listed
+ * here; every server-owned field is resolved and set explicitly.
+ *
+ * `agencyName` is a WRITE-ONLY input: the controller resolves it into a
+ * canonical `Agency` and sets `agencyId` server-side — the raw name is never
+ * persisted on the review. The address is handled separately (nested
+ * `address` object, create-only), so it is intentionally absent here.
+ *
+ * Keep this list in sync with the user-facing fields of the Review schema in
+ * `models/Review.ts`. Server/system fields are intentionally absent:
+ *   oxyUserId, verified, helpfulVoters, reports, moderationStatus,
+ *   addressId, addressLevel, streetLevelId, buildingLevelId, unitLevelId,
+ *   cityId, neighborhoodId, agencyId, livedForMonths, greenHouse,
+ *   positiveComment, negativeComment.
+ */
+
+/**
+ * Fields a user may set when CREATING a review. The address hierarchy,
+ * `cityId`/`neighborhoodId`, the resolved `agencyId`, `oxyUserId`,
+ * `livedForMonths` and every moderation field are resolved / derived
+ * server-side and are intentionally absent.
+ */
+export const CREATABLE_REVIEW_FIELDS: readonly string[] = [
+  // Core
+  'title',
+  'price',
+  'currency',
+  'livedFrom',
+  'livedTo',
+  'rating',
+  'recommendation',
+  'opinion',
+  'prosItems',
+  'consItems',
+  'adviceToAgency',
+  'adviceToLandlord',
+  // Write-only: resolved into agencyId server-side.
+  'agencyName',
+  'images',
+  // Deposit outcome (enum).
+  'depositReturned',
+  // Dimension ratings.
+  'summerTemperature',
+  'winterTemperature',
+  'noise',
+  'light',
+  'conditionAndMaintenance',
+  'services',
+  'landlordTreatment',
+  'problemResponse',
+  'staircaseNeighbors',
+  'touristApartments',
+  'neighborRelations',
+  'cleaning',
+  'areaTourists',
+  'areaSecurity',
+  'areaNoise',
+  'areaCleanliness',
+];
+
+/**
+ * Fields a user may change when UPDATING their review. Mirrors the creatable
+ * set — the address is create-only (a review can't be re-homed), so it is not
+ * editable; everything else the author supplied stays editable.
+ */
+export const EDITABLE_REVIEW_FIELDS: readonly string[] = [...CREATABLE_REVIEW_FIELDS];

--- a/packages/backend/controllers/review/toReviewDTO.ts
+++ b/packages/backend/controllers/review/toReviewDTO.ts
@@ -1,0 +1,119 @@
+/**
+ * Review DTO serializer — the single serialization chokepoint for every review
+ * read path.
+ *
+ * Converts a Review Mongoose document (optionally populated with its `agencyId`
+ * and `addressId`) into the flat DTO the frontend consumes:
+ *   - `_id` → `id`,
+ *   - `helpfulCount` derived from `helpfulVoters.length`,
+ *   - `viewerHasVotedHelpful` from the optional requesting viewer,
+ *   - an inline `agency { id, name, slug }` projection when `agencyId` is
+ *     populated,
+ *   - a `populatedAddress` projection when `addressId` is populated.
+ *
+ * CRITICAL: `helpfulVoters` and `reports` are STRIPPED — they are internal
+ * moderation/audit data and must never reach a client.
+ *
+ * The shape mirrors `ReviewDTO` in `@homiio/shared-types`, which treats the
+ * Mongoose schema as the single authority.
+ */
+
+const mongoose = require('mongoose');
+
+type Loose = Record<string, unknown>;
+
+interface HasToJSON {
+  toJSON(): Loose;
+}
+
+function hasToJSON(value: unknown): value is HasToJSON {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { toJSON?: unknown }).toJSON === 'function'
+  );
+}
+
+function plain(value: unknown): Loose {
+  if (hasToJSON(value)) {
+    return value.toJSON();
+  }
+  return (value ?? {}) as Loose;
+}
+
+function refToId(ref: unknown): string | undefined {
+  if (ref === null || ref === undefined) return undefined;
+  if (ref instanceof mongoose.Types.ObjectId) return ref.toString();
+  if (typeof ref === 'string') return ref;
+  if (typeof ref === 'object') {
+    const obj = ref as { _id?: unknown; id?: unknown };
+    if (obj._id !== undefined && obj._id !== null) return String(obj._id);
+    if (obj.id !== undefined && obj.id !== null) return String(obj.id);
+  }
+  return String(ref);
+}
+
+/** Build the inline agency summary, but only when `agencyId` is populated. */
+function agencySummary(ref: unknown): { id: string; name: string; slug: string } | undefined {
+  if (!ref || typeof ref !== 'object' || ref instanceof mongoose.Types.ObjectId) {
+    return undefined;
+  }
+  const obj = plain(ref);
+  if (typeof obj.name !== 'string' || typeof obj.slug !== 'string') {
+    return undefined;
+  }
+  const id = refToId(obj._id ?? obj.id);
+  if (!id) return undefined;
+  return { id, name: obj.name, slug: obj.slug };
+}
+
+/** Return the populated address as a plain object (with `id`), or undefined for a bare id ref. */
+function populatedAddress(ref: unknown): Loose | undefined {
+  if (!ref || typeof ref !== 'object' || ref instanceof mongoose.Types.ObjectId) {
+    return undefined;
+  }
+  const obj = plain(ref);
+  const id = refToId(obj._id ?? obj.id);
+  return id ? { ...obj, id } : { ...obj };
+}
+
+/**
+ * Serialize a review document/lean-object into a `ReviewDTO`.
+ *
+ * @param reviewDoc  a Review document, `.lean()` object, or `.toJSON()` output.
+ * @param viewerOxyUserId  the requesting user (optional) — drives `viewerHasVotedHelpful`.
+ */
+export function toReviewDTO(reviewDoc: unknown, viewerOxyUserId?: string | null): Loose {
+  const review = plain(reviewDoc);
+
+  const helpfulVoters = Array.isArray(review.helpfulVoters)
+    ? review.helpfulVoters.map((v) => String(v))
+    : [];
+  const helpfulCount = helpfulVoters.length;
+  const viewerHasVotedHelpful = viewerOxyUserId
+    ? helpfulVoters.includes(String(viewerOxyUserId))
+    : false;
+
+  const agency = agencySummary(review.agencyId);
+  const address = populatedAddress(review.addressId);
+
+  const dto: Loose = {
+    ...review,
+    id: refToId(review._id ?? review.id),
+    addressId: refToId(review.addressId),
+    agencyId: refToId(review.agencyId),
+    helpfulCount,
+    viewerHasVotedHelpful,
+  };
+
+  // Strip internal moderation/audit data — never exposed to clients.
+  delete dto.helpfulVoters;
+  delete dto.reports;
+
+  if (agency) dto.agency = agency;
+  if (address) dto.populatedAddress = address;
+
+  return dto;
+}
+
+export default toReviewDTO;

--- a/packages/backend/controllers/reviewController.ts
+++ b/packages/backend/controllers/reviewController.ts
@@ -1,15 +1,38 @@
 /**
  * Review Controller
- * Handles hierarchical address review operations (STREET → BUILDING → UNIT)
+ *
+ * Handles the reviucasa-style address review system: hierarchical address
+ * reviews (STREET → BUILDING → UNIT), agency attribution, helpful votes, trust
+ * & safety reports, and the review-explore aggregations (cities → neighborhoods
+ * → buildings).
+ *
+ * Security invariants (see AGENTS.md):
+ *   - WRITES never trust the client: `createReview`/`updateReview` pick an
+ *     explicit allowlist (`CREATABLE_REVIEW_FIELDS` / `EDITABLE_REVIEW_FIELDS`)
+ *     — never `...req.body`. `oxyUserId`, the address hierarchy, `cityId`,
+ *     `neighborhoodId`, `agencyId`, moderation and verification are all resolved
+ *     server-side.
+ *   - Update/delete resolve ownership with `Review.findOne({ _id, oxyUserId })`
+ *     → a non-owner gets a 404 (never a leaky 400).
+ *   - Every read serializes through `toReviewDTO`, which strips `helpfulVoters`
+ *     and `reports` and hides `moderationStatus === 'removed'` reviews.
  */
 
 import { Request, Response } from 'express';
 import { Types } from 'mongoose';
-import { Review } from '../models/Review';
+import { Review, Agency, Property, Address } from '../models';
 import { forwardGeocode } from '../services/geocodingService';
-import { Address } from '../models';
 import { getErrorName, getValidationMessages } from '../utils/errors';
-import { getRequiredOxyUserId } from '@oxyhq/core/server';
+import { getRequiredOxyUserId, getOxyUserId } from '@oxyhq/core/server';
+import { ReviewReportReason, ReviewModerationStatus } from '@homiio/shared-types';
+import { pickFields } from '../utils/pickFields';
+import { CREATABLE_REVIEW_FIELDS, EDITABLE_REVIEW_FIELDS } from './review/editableFields';
+import { toReviewDTO } from './review/toReviewDTO';
+import { notificationDispatchService } from '../services/notificationDispatchService';
+import { normalizeAgencyName, escapeRegex } from '../utils/agencyName';
+import { logger } from '../middlewares/logging';
+import { serializePropertyAddresses, ADDRESS_GEO_POPULATE } from '../services/propertyAddressSerializer';
+import { serializePropertyImages } from '../services/imageSerializer';
 
 const ok = (res: Response, data: Record<string, unknown>) => res.status(200).json({ success: true, ...data });
 const created = (res: Response, data: Record<string, unknown>) => res.status(201).json({ success: true, ...data });
@@ -17,15 +40,45 @@ const badRequest = (res: Response, data: Record<string, unknown>) => res.status(
 const notFound = (res: Response, data: Record<string, unknown>) => res.status(404).json({ success: false, ...data });
 const serverError = (res: Response, data: Record<string, unknown>) => res.status(500).json({ success: false, ...data });
 
-const logger = {
-  info: (_message: string, _data?: unknown) => {},
-  error: (_message: string, _error?: unknown) => {},
+const MIN_TITLE_LENGTH = 5;
+const MIN_OPINION_LENGTH = 10;
+const MAX_REPORT_DETAILS_LENGTH = 500;
+/** A review flips to 'under_review' once this many distinct users report it. */
+const REPORTS_TO_UNDER_REVIEW = 3;
+const DEFAULT_PAGE_SIZE = 10;
+const MAX_PAGE_SIZE = 50;
+
+const ALLOWED_REPORT_REASONS = new Set<string>(Object.values(ReviewReportReason));
+
+/** Parse `?page`/`?limit` with sane clamps. */
+function parsePageLimit(req: Request): { page: number; limit: number } {
+  const page = Math.max(1, parseInt(String(req.query.page ?? '1'), 10) || 1);
+  const rawLimit = parseInt(String(req.query.limit ?? DEFAULT_PAGE_SIZE), 10) || DEFAULT_PAGE_SIZE;
+  const limit = Math.min(MAX_PAGE_SIZE, Math.max(1, rawLimit));
+  return { page, limit };
+}
+
+/** Address populate used for review lists that surface an address label. */
+const REVIEW_ADDRESS_POPULATE = {
+  path: 'addressId',
+  select: 'street number postal_code countryCode cityId regionId countryId neighborhoodId coordinates',
+  populate: [
+    { path: 'cityId', select: 'name' },
+    { path: 'regionId', select: 'name' },
+    { path: 'countryId', select: 'name code' },
+    { path: 'neighborhoodId', select: 'name' },
+  ],
 };
+
+// ---------------------------------------------------------------------------
+// Hierarchical address reads (public, community-visible).
+// ---------------------------------------------------------------------------
 
 export const getReviewsByAddress = async (req: Request, res: Response) => {
   try {
     const { addressId } = req.params;
     const { page = 1, limit = 10 } = req.query;
+    const viewer = getOxyUserId(req);
 
     if (!Types.ObjectId.isValid(addressId)) {
       return badRequest(res, { message: 'Invalid address ID' });
@@ -39,6 +92,7 @@ export const getReviewsByAddress = async (req: Request, res: Response) => {
     const addressLevel = address.getAddressLevel();
     const pageNumber = parseInt(page as string, 10);
     const limitNumber = parseInt(limit as string, 10);
+    const toDto = (review: unknown) => toReviewDTO(review, viewer);
 
     let responseData: Record<string, unknown> = {};
 
@@ -47,7 +101,9 @@ export const getReviewsByAddress = async (req: Request, res: Response) => {
         const unitData = await Review.getUnitViewData(addressId);
         responseData = {
           level: 'UNIT',
-          unitReviews: unitData.unitReviews.slice((pageNumber - 1) * limitNumber, pageNumber * limitNumber),
+          unitReviews: unitData.unitReviews
+            .slice((pageNumber - 1) * limitNumber, pageNumber * limitNumber)
+            .map(toDto),
           buildingSummary: unitData.buildingSummary,
           totalReviews: unitData.unitReviews.length,
           pagination: {
@@ -63,8 +119,10 @@ export const getReviewsByAddress = async (req: Request, res: Response) => {
         const allReviews = [...buildingData.buildingReviews, ...buildingData.unitReviews];
         responseData = {
           level: 'BUILDING',
-          buildingReviews: buildingData.buildingReviews,
-          unitReviews: buildingData.unitReviews.slice((pageNumber - 1) * limitNumber, pageNumber * limitNumber),
+          buildingReviews: buildingData.buildingReviews.map(toDto),
+          unitReviews: buildingData.unitReviews
+            .slice((pageNumber - 1) * limitNumber, pageNumber * limitNumber)
+            .map(toDto),
           aggregatedStats: buildingData.aggregatedStats,
           totalReviews: allReviews.length,
           pagination: {
@@ -91,7 +149,7 @@ export const getReviewsByAddress = async (req: Request, res: Response) => {
 
     return ok(res, responseData);
   } catch (error) {
-    logger.error('Error fetching hierarchical reviews:', error);
+    logger.error('Error fetching hierarchical reviews', { error: error instanceof Error ? error.message : String(error) });
     return serverError(res, { message: 'Failed to fetch reviews' });
   }
 };
@@ -155,22 +213,78 @@ export const getAddressReviewStats = async (req: Request, res: Response) => {
 
     return ok(res, { stats: statsData });
   } catch (error) {
-    logger.error('Error fetching hierarchical review stats:', error);
+    logger.error('Error fetching hierarchical review stats', { error: error instanceof Error ? error.message : String(error) });
     return serverError(res, { message: 'Failed to fetch review statistics' });
   }
 };
 
+// ---------------------------------------------------------------------------
+// Create.
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort: notify every distinct property owner at the reviewed address /
+ * building (excluding the reviewer) that a new review landed. Swallow-and-log —
+ * the review must succeed even if notification dispatch fails.
+ */
+async function notifyAddressOwners(params: {
+  reviewerOxyUserId: string;
+  addressId: Types.ObjectId;
+  buildingLevelId?: Types.ObjectId;
+  reviewId: Types.ObjectId;
+}): Promise<void> {
+  try {
+    const addressIds = [params.addressId];
+    if (params.buildingLevelId && String(params.buildingLevelId) !== String(params.addressId)) {
+      addressIds.push(params.buildingLevelId);
+    }
+
+    const owners: string[] = await Property.distinct('oxyUserId', {
+      addressId: { $in: addressIds },
+      oxyUserId: { $nin: [null, ''] },
+    });
+
+    const recipients = Array.from(new Set(owners.filter((id) => id && id !== params.reviewerOxyUserId)));
+
+    await Promise.all(
+      recipients.map((recipientOxyUserId) =>
+        notificationDispatchService.createForUser(recipientOxyUserId, {
+          type: 'address_review_created',
+          title: 'New review at your property address',
+          message: 'Someone posted a review at an address where you have a listing.',
+          priority: 'low',
+          data: {
+            addressId: String(params.addressId),
+            reviewId: String(params.reviewId),
+          },
+        }),
+      ),
+    );
+  } catch (error) {
+    logger.error('Failed to dispatch address_review_created notifications', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 export const createReview = async (req: Request, res: Response) => {
   try {
-    const { address: addressData, ...reviewData } = req.body;
     const oxyUserId = getRequiredOxyUserId(req);
+    const addressData = (req.body || {}).address as Record<string, string> | undefined;
+    const picked = pickFields<Record<string, unknown>>(req.body, CREATABLE_REVIEW_FIELDS);
 
     if (!addressData || !addressData.street || !addressData.city || !addressData.postal_code || !addressData.country) {
       return badRequest(res, { message: 'Address information is required (street, city, postal_code, country)' });
     }
 
-    if (!reviewData.opinion || reviewData.opinion.trim().length < 10) {
-      return badRequest(res, { message: 'Opinion must be at least 10 characters long' });
+    const title = typeof picked.title === 'string' ? picked.title.trim() : '';
+    if (title.length < MIN_TITLE_LENGTH) {
+      return badRequest(res, { message: `Title must be at least ${MIN_TITLE_LENGTH} characters long` });
+    }
+
+    const opinion = typeof picked.opinion === 'string' ? picked.opinion.trim() : '';
+    if (opinion.length < MIN_OPINION_LENGTH) {
+      return badRequest(res, { message: `Opinion must be at least ${MIN_OPINION_LENGTH} characters long` });
     }
 
     let coordinates = addressData.latitude && addressData.longitude
@@ -209,16 +323,18 @@ export const createReview = async (req: Request, res: Response) => {
       return badRequest(res, { message: 'Reviews can only be created at BUILDING or UNIT level addresses' });
     }
 
-    const existingReview = await Review.findOne({
-      oxyUserId,
-      addressId: address._id,
-    });
-
+    const existingReview = await Review.findOne({ oxyUserId, addressId: address._id });
     if (existingReview) {
       return badRequest(res, { message: 'You have already reviewed this address' });
     }
 
-    const hierarchicalData: Record<string, unknown> = {
+    const hierarchicalData: {
+      addressLevel: string;
+      addressId: Types.ObjectId;
+      unitLevelId?: Types.ObjectId;
+      buildingLevelId?: Types.ObjectId;
+      streetLevelId?: Types.ObjectId;
+    } = {
       addressLevel,
       addressId: address._id,
     };
@@ -250,30 +366,42 @@ export const createReview = async (req: Request, res: Response) => {
       hierarchicalData.streetLevelId = streetLevel._id;
     }
 
+    // Resolve the submitted agency name into a canonical Agency (write-only
+    // input); the raw name is never persisted on the review.
+    const agencyName = typeof picked.agencyName === 'string' ? picked.agencyName : undefined;
+    delete picked.agencyName;
+    let agencyId: Types.ObjectId | undefined;
+    if (agencyName && agencyName.trim()) {
+      const agency = await Agency.findOrCreateByName(agencyName);
+      if (agency) agencyId = agency._id;
+    }
+
     const review = new Review({
-      ...reviewData,
+      ...picked,
       ...hierarchicalData,
       oxyUserId,
+      cityId: address.cityId,
+      neighborhoodId: address.neighborhoodId,
+      agencyId,
     });
 
     await review.save();
 
+    await notifyAddressOwners({
+      reviewerOxyUserId: oxyUserId,
+      addressId: address._id,
+      buildingLevelId: hierarchicalData.buildingLevelId,
+      reviewId: review._id,
+    });
+
     const populatedReview = await Review.findById(review._id)
-      .populate({
-        path: 'addressId',
-        select: 'street postal_code countryCode cityId regionId countryId neighborhoodId coordinates',
-        populate: [
-          { path: 'cityId', select: 'name' },
-          { path: 'regionId', select: 'name' },
-          { path: 'countryId', select: 'name code' },
-          { path: 'neighborhoodId', select: 'name' },
-        ],
-      })
+      .populate(REVIEW_ADDRESS_POPULATE)
+      .populate({ path: 'agencyId', select: 'name slug' })
       .lean();
 
-    return created(res, { review: populatedReview });
+    return created(res, { review: toReviewDTO(populatedReview, oxyUserId) });
   } catch (error) {
-    logger.error('Error creating review:', error);
+    logger.error('Error creating review', { error: error instanceof Error ? error.message : String(error) });
     if (getErrorName(error) === 'ValidationError') {
       return badRequest(res, {
         message: 'Validation error',
@@ -284,23 +412,36 @@ export const createReview = async (req: Request, res: Response) => {
   }
 };
 
+// ---------------------------------------------------------------------------
+// Single review read / update / delete.
+// ---------------------------------------------------------------------------
+
 export const getReviewById = async (req: Request, res: Response) => {
   try {
     const { reviewId } = req.params;
+    const viewer = getOxyUserId(req);
 
     if (!Types.ObjectId.isValid(reviewId)) {
       return badRequest(res, { message: 'Invalid review ID' });
     }
 
-    const review = await Review.findById(reviewId).populate('addressId');
+    const review = await Review.findById(reviewId)
+      .populate(REVIEW_ADDRESS_POPULATE)
+      .populate({ path: 'agencyId', select: 'name slug' })
+      .lean();
 
     if (!review) {
       return notFound(res, { message: 'Review not found' });
     }
 
-    return ok(res, { review });
+    // Hide removed reviews from everyone but their author.
+    if (review.moderationStatus === ReviewModerationStatus.REMOVED && (!viewer || String(review.oxyUserId) !== viewer)) {
+      return notFound(res, { message: 'Review not found' });
+    }
+
+    return ok(res, { review: toReviewDTO(review, viewer) });
   } catch (error) {
-    logger.error('Error fetching review:', error);
+    logger.error('Error fetching review', { error: error instanceof Error ? error.message : String(error) });
     return serverError(res, { message: 'Failed to fetch review' });
   }
 };
@@ -308,28 +449,42 @@ export const getReviewById = async (req: Request, res: Response) => {
 export const updateReview = async (req: Request, res: Response) => {
   try {
     const { reviewId } = req.params;
-    const updateData = req.body;
     const oxyUserId = getRequiredOxyUserId(req);
 
     if (!Types.ObjectId.isValid(reviewId)) {
       return badRequest(res, { message: 'Invalid review ID' });
     }
 
-    const review = await Review.findById(reviewId);
+    // Ownership + existence in one query: a non-owner (or missing) review is a
+    // 404, never a leaky 400 that reveals the review exists.
+    const review = await Review.findOne({ _id: reviewId, oxyUserId });
     if (!review) {
       return notFound(res, { message: 'Review not found' });
     }
 
-    if (review.oxyUserId !== oxyUserId) {
-      return badRequest(res, { message: 'You can only update your own reviews' });
+    const picked = pickFields<Record<string, unknown>>(req.body, EDITABLE_REVIEW_FIELDS);
+
+    // Re-resolve agency attribution when an agency name is (re)supplied.
+    if (Object.prototype.hasOwnProperty.call(picked, 'agencyName')) {
+      const agencyName = typeof picked.agencyName === 'string' ? picked.agencyName.trim() : '';
+      delete picked.agencyName;
+      if (agencyName) {
+        const agency = await Agency.findOrCreateByName(agencyName);
+        if (agency) review.agencyId = agency._id;
+      }
     }
 
-    Object.assign(review, updateData);
+    review.set(picked);
     await review.save();
 
-    return ok(res, { review });
+    const populatedReview = await Review.findById(review._id)
+      .populate(REVIEW_ADDRESS_POPULATE)
+      .populate({ path: 'agencyId', select: 'name slug' })
+      .lean();
+
+    return ok(res, { review: toReviewDTO(populatedReview, oxyUserId) });
   } catch (error) {
-    logger.error('Error updating review:', error);
+    logger.error('Error updating review', { error: error instanceof Error ? error.message : String(error) });
     if (getErrorName(error) === 'ValidationError') {
       return badRequest(res, {
         message: 'Validation error',
@@ -349,20 +504,14 @@ export const deleteReview = async (req: Request, res: Response) => {
       return badRequest(res, { message: 'Invalid review ID' });
     }
 
-    const review = await Review.findById(reviewId);
+    const review = await Review.findOneAndDelete({ _id: reviewId, oxyUserId });
     if (!review) {
       return notFound(res, { message: 'Review not found' });
     }
 
-    if (review.oxyUserId !== oxyUserId) {
-      return badRequest(res, { message: 'You can only delete your own reviews' });
-    }
-
-    await Review.findByIdAndDelete(reviewId);
-
     return ok(res, { message: 'Review deleted successfully' });
   } catch (error) {
-    logger.error('Error deleting review:', error);
+    logger.error('Error deleting review', { error: error instanceof Error ? error.message : String(error) });
     return serverError(res, { message: 'Failed to delete review' });
   }
 };
@@ -370,36 +519,332 @@ export const deleteReview = async (req: Request, res: Response) => {
 export const getUserReviews = async (req: Request, res: Response) => {
   try {
     const { oxyUserId } = req.params;
-    const { page = 1, limit = 10 } = req.query;
+    const viewer = getOxyUserId(req);
+    const { page, limit } = parsePageLimit(req);
 
     if (!oxyUserId) {
       return badRequest(res, { message: 'Oxy user id is required' });
     }
 
-    const pageNumber = parseInt(page as string, 10);
-    const limitNumber = parseInt(limit as string, 10);
-    const skip = (pageNumber - 1) * limitNumber;
+    const filter = { oxyUserId, moderationStatus: { $ne: ReviewModerationStatus.REMOVED } };
+    const skip = (page - 1) * limit;
 
-    const reviews = await Review.find({ oxyUserId })
-      .populate('addressId')
-      .sort({ createdAt: -1 })
-      .skip(skip)
-      .limit(limitNumber)
-      .lean();
+    const [reviews, totalReviews] = await Promise.all([
+      Review.find(filter)
+        .populate(REVIEW_ADDRESS_POPULATE)
+        .populate({ path: 'agencyId', select: 'name slug' })
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      Review.countDocuments(filter),
+    ]);
 
-    const totalReviews = await Review.countDocuments({ oxyUserId });
-
+    const totalPages = Math.ceil(totalReviews / limit);
     return ok(res, {
-      reviews,
-      pagination: {
-        currentPage: pageNumber,
-        totalPages: Math.ceil(totalReviews / limitNumber),
-        totalReviews,
-        limit: limitNumber,
-      },
+      reviews: reviews.map((review) => toReviewDTO(review, viewer)),
+      pagination: { currentPage: page, totalPages, totalReviews, limit },
+      hasMore: page < totalPages,
+      totalPages,
     });
   } catch (error) {
-    logger.error('Error fetching user reviews:', error);
+    logger.error('Error fetching user reviews', { error: error instanceof Error ? error.message : String(error) });
     return serverError(res, { message: 'Failed to fetch user reviews' });
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Helpful votes + reports.
+// ---------------------------------------------------------------------------
+
+export const toggleHelpful = async (req: Request, res: Response) => {
+  try {
+    const { reviewId } = req.params;
+    const oxyUserId = getRequiredOxyUserId(req);
+
+    if (!Types.ObjectId.isValid(reviewId)) {
+      return badRequest(res, { message: 'Invalid review ID' });
+    }
+
+    const review = await Review.findById(reviewId);
+    if (!review) {
+      return notFound(res, { message: 'Review not found' });
+    }
+
+    if (String(review.oxyUserId) === oxyUserId) {
+      return badRequest(res, { message: 'You cannot mark your own review as helpful' });
+    }
+
+    const alreadyVoted = (review.helpfulVoters || []).map(String).includes(oxyUserId);
+    const update = alreadyVoted
+      ? { $pull: { helpfulVoters: oxyUserId } }
+      : { $addToSet: { helpfulVoters: oxyUserId } };
+
+    const updated = await Review.findByIdAndUpdate(reviewId, update, { new: true });
+    const helpfulCount = updated?.helpfulVoters?.length ?? 0;
+    const viewerHasVotedHelpful = !alreadyVoted;
+
+    // Notify the author on a NEW helpful vote only (never on un-vote, never for
+    // one's own review — already rejected above). Best-effort.
+    if (!alreadyVoted) {
+      await notificationDispatchService.createForUser(String(review.oxyUserId), {
+        type: 'review_helpful',
+        title: 'Your review was marked helpful',
+        message: 'Someone found your address review helpful.',
+        priority: 'low',
+        data: { reviewId: String(review._id) },
+      });
+    }
+
+    return ok(res, { helpfulCount, viewerHasVotedHelpful });
+  } catch (error) {
+    logger.error('Error toggling helpful vote', { error: error instanceof Error ? error.message : String(error) });
+    return serverError(res, { message: 'Failed to toggle helpful vote' });
+  }
+};
+
+export const reportReview = async (req: Request, res: Response) => {
+  try {
+    const { reviewId } = req.params;
+    const oxyUserId = getRequiredOxyUserId(req);
+    const { reason, details } = req.body || {};
+
+    if (!Types.ObjectId.isValid(reviewId)) {
+      return badRequest(res, { message: 'Invalid review ID' });
+    }
+
+    if (!reason || !ALLOWED_REPORT_REASONS.has(reason)) {
+      return badRequest(res, { message: 'A valid report reason is required' });
+    }
+
+    const trimmedDetails = typeof details === 'string' ? details.trim() : '';
+    if (trimmedDetails.length > MAX_REPORT_DETAILS_LENGTH) {
+      return badRequest(res, { message: 'Report details are too long' });
+    }
+    if (reason === ReviewReportReason.OTHER && !trimmedDetails) {
+      return badRequest(res, { message: 'Details are required when the reason is "other"' });
+    }
+
+    const review = await Review.findById(reviewId);
+    if (!review) {
+      return notFound(res, { message: 'Review not found' });
+    }
+
+    // Dedup: one report per reporter. Re-filing is a no-op (200).
+    const alreadyReported = (review.reports || []).some((report) => String(report.oxyUserId) === oxyUserId);
+    if (alreadyReported) {
+      return ok(res, { message: 'Report already submitted', moderationStatus: review.moderationStatus });
+    }
+
+    review.reports.push({
+      oxyUserId,
+      reason,
+      details: trimmedDetails || undefined,
+      createdAt: new Date(),
+    });
+
+    // Escalate to moderation once enough distinct users have reported it.
+    if (review.reports.length >= REPORTS_TO_UNDER_REVIEW && review.moderationStatus === ReviewModerationStatus.ACTIVE) {
+      review.moderationStatus = ReviewModerationStatus.UNDER_REVIEW;
+    }
+
+    await review.save();
+
+    return created(res, { message: 'Report submitted', moderationStatus: review.moderationStatus });
+  } catch (error) {
+    logger.error('Error reporting review', { error: error instanceof Error ? error.message : String(error) });
+    return serverError(res, { message: 'Failed to report review' });
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Agencies (public reads).
+// ---------------------------------------------------------------------------
+
+interface AgencyLike {
+  _id: unknown;
+  name: string;
+  slug: string;
+}
+
+function toAgencySummary(agency: AgencyLike): { id: string; name: string; slug: string } {
+  return { id: String(agency._id), name: agency.name, slug: agency.slug };
+}
+
+export const searchAgencies = async (req: Request, res: Response) => {
+  try {
+    const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    if (!q) {
+      return ok(res, { agencies: [] });
+    }
+
+    const normalized = normalizeAgencyName(q);
+    if (!normalized) {
+      return ok(res, { agencies: [] });
+    }
+
+    const agencies = await Agency.find({ normalizedName: { $regex: `^${escapeRegex(normalized)}` } })
+      .sort({ normalizedName: 1 })
+      .limit(10)
+      .lean();
+
+    return ok(res, { agencies: agencies.map((agency) => toAgencySummary(agency as unknown as AgencyLike)) });
+  } catch (error) {
+    logger.error('Error searching agencies', { error: error instanceof Error ? error.message : String(error) });
+    return serverError(res, { message: 'Failed to search agencies' });
+  }
+};
+
+export const getAgencyBySlug = async (req: Request, res: Response) => {
+  try {
+    const agency = await Agency.findOne({ slug: req.params.slug }).lean();
+    if (!agency) {
+      return notFound(res, { message: 'Agency not found' });
+    }
+
+    const [stats, listingsCount] = await Promise.all([
+      Review.getAgencyStats(agency._id),
+      Property.countDocuments({ agencyId: agency._id, status: 'published', deletedAt: null }),
+    ]);
+
+    return ok(res, {
+      agency: toAgencySummary(agency as unknown as AgencyLike),
+      stats: { ...stats, listingsCount },
+    });
+  } catch (error) {
+    logger.error('Error fetching agency', { error: error instanceof Error ? error.message : String(error) });
+    return serverError(res, { message: 'Failed to fetch agency' });
+  }
+};
+
+export const getAgencyReviews = async (req: Request, res: Response) => {
+  try {
+    const viewer = getOxyUserId(req);
+    const { page, limit } = parsePageLimit(req);
+
+    const agency = await Agency.findOne({ slug: req.params.slug }).lean();
+    if (!agency) {
+      return notFound(res, { message: 'Agency not found' });
+    }
+
+    const filter = { agencyId: agency._id, moderationStatus: { $ne: ReviewModerationStatus.REMOVED } };
+    const skip = (page - 1) * limit;
+
+    const [reviews, totalReviews] = await Promise.all([
+      Review.find(filter)
+        .populate(REVIEW_ADDRESS_POPULATE)
+        .populate({ path: 'agencyId', select: 'name slug' })
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      Review.countDocuments(filter),
+    ]);
+
+    const totalPages = Math.ceil(totalReviews / limit);
+    return ok(res, {
+      agency: toAgencySummary(agency as unknown as AgencyLike),
+      reviews: reviews.map((review) => toReviewDTO(review, viewer)),
+      pagination: { currentPage: page, totalPages, totalReviews, limit },
+      hasMore: page < totalPages,
+      totalPages,
+    });
+  } catch (error) {
+    logger.error('Error fetching agency reviews', { error: error instanceof Error ? error.message : String(error) });
+    return serverError(res, { message: 'Failed to fetch agency reviews' });
+  }
+};
+
+export const getAgencyProperties = async (req: Request, res: Response) => {
+  try {
+    const { page, limit } = parsePageLimit(req);
+
+    const agency = await Agency.findOne({ slug: req.params.slug }).lean();
+    if (!agency) {
+      return notFound(res, { message: 'Agency not found' });
+    }
+
+    const filter = { agencyId: agency._id, status: 'published', deletedAt: null };
+    const skip = (page - 1) * limit;
+
+    const [properties, total] = await Promise.all([
+      Property.find(filter)
+        .populate(ADDRESS_GEO_POPULATE)
+        .sort({ hasImages: -1, createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      Property.countDocuments(filter),
+    ]);
+
+    serializePropertyAddresses(properties);
+    serializePropertyImages(properties);
+
+    const totalPages = Math.max(1, Math.ceil(total / limit));
+    return res.json({
+      success: true,
+      data: properties,
+      pagination: { page, limit, total, totalPages },
+      total,
+      page,
+      limit,
+      totalPages,
+      hasMore: (page - 1) * limit + properties.length < total,
+    });
+  } catch (error) {
+    logger.error('Error fetching agency properties', { error: error instanceof Error ? error.message : String(error) });
+    return serverError(res, { message: 'Failed to fetch agency properties' });
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Review-explore aggregations (public reads).
+// ---------------------------------------------------------------------------
+
+export const getExploreCities = async (_req: Request, res: Response) => {
+  try {
+    const cities = await Review.getCitiesWithReviews();
+    return ok(res, { cities });
+  } catch (error) {
+    logger.error('Error fetching explore cities', { error: error instanceof Error ? error.message : String(error) });
+    return serverError(res, { message: 'Failed to fetch explore cities' });
+  }
+};
+
+export const getExploreCity = async (req: Request, res: Response) => {
+  try {
+    const { cityId } = req.params;
+    if (!Types.ObjectId.isValid(cityId)) {
+      return badRequest(res, { message: 'Invalid city ID' });
+    }
+    const neighborhoods = await Review.getNeighborhoodSummaries(cityId);
+    return ok(res, { neighborhoods });
+  } catch (error) {
+    logger.error('Error fetching explore city', { error: error instanceof Error ? error.message : String(error) });
+    return serverError(res, { message: 'Failed to fetch explore city' });
+  }
+};
+
+export const getExploreNeighborhood = async (req: Request, res: Response) => {
+  try {
+    const { neighborhoodId } = req.params;
+    const { page, limit } = parsePageLimit(req);
+
+    if (!Types.ObjectId.isValid(neighborhoodId)) {
+      return badRequest(res, { message: 'Invalid neighborhood ID' });
+    }
+
+    const { buildings, total } = await Review.getBuildingSummaries(neighborhoodId, page, limit);
+    const totalPages = Math.max(1, Math.ceil(total / limit));
+
+    return ok(res, {
+      buildings,
+      pagination: { currentPage: page, totalPages, total, limit },
+      hasMore: page < totalPages,
+      totalPages,
+    });
+  } catch (error) {
+    logger.error('Error fetching explore neighborhood', { error: error instanceof Error ? error.message : String(error) });
+    return serverError(res, { message: 'Failed to fetch explore neighborhood' });
   }
 };

--- a/packages/backend/models/Property.ts
+++ b/packages/backend/models/Property.ts
@@ -160,6 +160,8 @@ export interface IProperty extends Document {
   sourcedByPartner?: Types.ObjectId;
   /** Audit copy of the referral code captured at create time (partners may rotate codes). */
   sourcedByReferralCode?: string;
+  /** Relational Agency link (resolved from portal contact agency name on external listings). */
+  agencyId?: Types.ObjectId;
   /** Server-computed ethical + market price score. */
   priceEthics?: Omit<PropertyPriceEthics, 'scoredAt'> & { scoredAt: Date };
   /** Populated runtime virtual added by the `toJSON`/`toObject` transform when `addressId` is populated. */

--- a/packages/backend/models/Review.ts
+++ b/packages/backend/models/Review.ts
@@ -17,6 +17,15 @@ import {
   TouristLevel,
   SecurityLevel,
   ServiceType,
+  DepositReturn,
+  ReviewModerationStatus,
+  ReviewReportReason,
+} from '@homiio/shared-types';
+import type {
+  AgencyStats,
+  ExploreCitySummary,
+  ExploreNeighborhoodSummary,
+  ExploreBuildingSummary,
 } from '@homiio/shared-types';
 
 // Define the Review interface
@@ -27,27 +36,42 @@ export interface IReview extends Document {
   
   // Hierarchical address references for aggregation
   streetLevelId: Types.ObjectId; // Reference to street-level address
-  buildingLevelId: Types.ObjectId; // Reference to building-level address  
+  buildingLevelId: Types.ObjectId; // Reference to building-level address
   unitLevelId?: Types.ObjectId; // Reference to unit-level address (only for UNIT level reviews)
-  
+
+  // Denormalized geo references for the review-explore aggregations. Set
+  // server-side at create time from the resolved canonical Address.
+  cityId?: Types.ObjectId;
+  neighborhoodId?: Types.ObjectId;
+
+  // Relational link to the managing Agency (resolved from the submitted agency
+  // name via `Agency.findOrCreateByName`). Never set from the raw request body.
+  agencyId?: Types.ObjectId;
+
   // Basic Information
+  title?: string;
   greenHouse: string;
   price: number;
   currency: string;
-  
+
   // Date Information
   livedFrom: Date;
   livedTo: Date;
   livedForMonths: number;
-  
+
   // Overall Review
   recommendation: boolean;
   opinion: string;
+  prosItems: string[];
+  consItems: string[];
+  adviceToAgency?: string;
+  adviceToLandlord?: string;
+  // Legacy free-text pros/cons (superseded by prosItems/consItems).
   positiveComment: string;
   negativeComment: string;
   images: string[];
   rating: number; // 1-5 stars
-  
+
   // Environmental Conditions
   summerTemperature: TemperatureRating;
   winterTemperature: TemperatureRating;
@@ -55,27 +79,44 @@ export interface IReview extends Document {
   light: LightLevel;
   conditionAndMaintenance: ConditionRating;
   services: ServiceType[];
-  
+
   // Management
   landlordTreatment: LandlordTreatment;
   problemResponse: ResponseRating;
-  depositReturned: boolean;
-  
+  depositReturned?: DepositReturn;
+
   // Neighbors / Community
   staircaseNeighbors: NeighborRating;
   touristApartments: boolean;
   neighborRelations: NeighborRelations;
   cleaning: CleaningRating;
-  
+
   // Area (300m radius)
   areaTourists: TouristLevel;
   areaSecurity: SecurityLevel;
-  
+  areaNoise?: NoiseLevel;
+  areaCleanliness?: CleaningRating;
+
+  // Community interaction — distinct oxyUserIds who marked the review helpful.
+  helpfulVoters: string[];
+  // Trust & safety reports filed against this review.
+  reports: IReviewReport[];
+  // Moderation lifecycle. 'removed' hides the review from every public read.
+  moderationStatus: ReviewModerationStatus;
+
   // Metadata
   oxyUserId: string;
   createdAt: Date;
   updatedAt: Date;
   verified: boolean;
+}
+
+/** A single trust & safety report embedded on a {@link IReview}. */
+export interface IReviewReport {
+  oxyUserId: string;
+  reason: ReviewReportReason;
+  details?: string;
+  createdAt: Date;
 }
 
 interface ReviewSummaryStats {
@@ -108,19 +149,45 @@ function createEmptyReviewSummary(): ReviewSummaryStats {
   };
 }
 
+/** Round a rating/average to one decimal place. */
+function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/** Round a percentage (0-100) to the nearest whole number. */
+function roundPct(value: number): number {
+  return Math.round(value);
+}
+
+/** Paginated building-summary result for the neighborhood explore view. */
+export interface BuildingSummariesResult {
+  buildings: ExploreBuildingSummary[];
+  total: number;
+}
+
 // Define static methods interface
 export interface IReviewModel extends Model<IReview> {
   // Hierarchical finder methods
   findByStreetLevel(streetLevelId: string | Types.ObjectId): Promise<IReview[]>;
   findByBuildingLevel(buildingLevelId: string | Types.ObjectId): Promise<IReview[]>;
   findByUnitLevel(unitLevelId: string | Types.ObjectId): Promise<IReview[]>;
-  
+
   // Aggregation methods for hierarchical views
   getUnitViewData(unitLevelId: string | Types.ObjectId): Promise<UnitViewData>;
-  
+
   getBuildingViewData(buildingLevelId: string | Types.ObjectId): Promise<BuildingViewData>;
-  
+
   getStreetViewData(streetLevelId: string | Types.ObjectId): Promise<StreetViewData>;
+
+  // Agency + explore aggregations (reviucasa parity).
+  getAgencyStats(agencyId: string | Types.ObjectId): Promise<AgencyStats>;
+  getCitiesWithReviews(): Promise<ExploreCitySummary[]>;
+  getNeighborhoodSummaries(cityId: string | Types.ObjectId): Promise<ExploreNeighborhoodSummary[]>;
+  getBuildingSummaries(
+    neighborhoodId: string | Types.ObjectId,
+    page: number,
+    limit: number,
+  ): Promise<BuildingSummariesResult>;
 }
 
 const ReviewSchema = new Schema<IReview, IReviewModel>({
@@ -174,6 +241,33 @@ const ReviewSchema = new Schema<IReview, IReviewModel>({
       message: 'Unit level address is required for UNIT level reviews and should be null for BUILDING level reviews'
     }
   },
+
+  // Denormalized geo references (set server-side from the canonical Address).
+  cityId: {
+    type: Schema.Types.ObjectId,
+    ref: 'City',
+    index: true
+  },
+  neighborhoodId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Neighborhood',
+    index: true
+  },
+  // Relational Agency link (resolved from the submitted agency name).
+  agencyId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Agency',
+    index: true
+  },
+
+  // Review headline. Optional at the schema level (legacy reviews predate it);
+  // the create controller requires it for new submissions.
+  title: {
+    type: String,
+    trim: true,
+    minlength: [5, 'Title must be at least 5 characters'],
+    maxlength: [120, 'Title cannot exceed 120 characters']
+  },
   greenHouse: {
     type: String,
     trim: true,
@@ -224,6 +318,34 @@ const ReviewSchema = new Schema<IReview, IReviewModel>({
     minlength: [10, 'Opinion must be at least 10 characters'],
     maxlength: [2000, 'Opinion cannot exceed 2000 characters']
   },
+  // Structured pros/cons (reviucasa parity) — each item capped, list capped.
+  prosItems: {
+    type: [{ type: String, trim: true, maxlength: [140, 'Each pro cannot exceed 140 characters'] }],
+    default: [],
+    validate: {
+      validator: (items: string[]) => !Array.isArray(items) || items.length <= 10,
+      message: 'A review can list at most 10 pros'
+    }
+  },
+  consItems: {
+    type: [{ type: String, trim: true, maxlength: [140, 'Each con cannot exceed 140 characters'] }],
+    default: [],
+    validate: {
+      validator: (items: string[]) => !Array.isArray(items) || items.length <= 10,
+      message: 'A review can list at most 10 cons'
+    }
+  },
+  adviceToAgency: {
+    type: String,
+    trim: true,
+    maxlength: [1000, 'Advice to agency cannot exceed 1000 characters']
+  },
+  adviceToLandlord: {
+    type: String,
+    trim: true,
+    maxlength: [1000, 'Advice to landlord cannot exceed 1000 characters']
+  },
+  // Legacy free-text pros/cons (read-only; superseded by prosItems/consItems).
   positiveComment: {
     type: String,
     trim: true,
@@ -238,7 +360,8 @@ const ReviewSchema = new Schema<IReview, IReviewModel>({
     type: String,
     validate: {
       validator: function(url: string) {
-        return /^https?:\/\/.+\.(jpg|jpeg|png|webp)$/i.test(url);
+        // Allow an optional query string (portal/CDN variant params).
+        return /^https?:\/\/.+\.(jpg|jpeg|png|webp)(\?.*)?$/i.test(url);
       },
       message: 'Invalid image URL format'
     }
@@ -297,7 +420,8 @@ const ReviewSchema = new Schema<IReview, IReviewModel>({
     required: false
   },
   depositReturned: {
-    type: Boolean,
+    type: String,
+    enum: Object.values(DepositReturn),
     required: false
   },
   
@@ -333,7 +457,47 @@ const ReviewSchema = new Schema<IReview, IReviewModel>({
     enum: Object.values(SecurityLevel),
     required: false
   },
-  
+  areaNoise: {
+    type: String,
+    enum: Object.values(NoiseLevel),
+    required: false
+  },
+  areaCleanliness: {
+    type: String,
+    enum: Object.values(CleaningRating),
+    required: false
+  },
+
+  // ---- Community interaction & moderation ----
+  // Distinct oxyUserIds who marked the review helpful. Length = helpful count;
+  // never exposed raw (the DTO derives helpfulCount + viewerHasVotedHelpful).
+  helpfulVoters: {
+    type: [String],
+    default: []
+  },
+  // Trust & safety reports. Stripped from every public DTO.
+  reports: {
+    type: [new Schema({
+      oxyUserId: { type: String, required: true },
+      reason: {
+        type: String,
+        enum: Object.values(ReviewReportReason),
+        required: true
+      },
+      details: { type: String, trim: true, maxlength: [500, 'Report details cannot exceed 500 characters'] },
+      createdAt: { type: Date, default: Date.now }
+    }, { _id: false })],
+    default: []
+  },
+  // Moderation lifecycle: 'active' (default), 'under_review' (>=3 reports),
+  // 'removed' (hidden from every public read).
+  moderationStatus: {
+    type: String,
+    enum: Object.values(ReviewModerationStatus),
+    default: ReviewModerationStatus.ACTIVE,
+    index: true
+  },
+
   // Metadata
   oxyUserId: {
     type: String,
@@ -363,6 +527,11 @@ ReviewSchema.index({ buildingLevelId: 1, addressLevel: 1, createdAt: -1 });
 ReviewSchema.index({ unitLevelId: 1, addressLevel: 1, createdAt: -1 });
 ReviewSchema.index({ addressLevel: 1, createdAt: -1 });
 
+// Agency profile + review-explore aggregations (newest-first per geo/agency).
+ReviewSchema.index({ agencyId: 1, createdAt: -1 });
+ReviewSchema.index({ cityId: 1, createdAt: -1 });
+ReviewSchema.index({ neighborhoodId: 1, createdAt: -1 });
+
 // Virtual for calculating lived duration
 ReviewSchema.virtual('livedDurationText').get(function(this: IReview) {
   const months = this.livedForMonths;
@@ -377,8 +546,11 @@ ReviewSchema.virtual('livedDurationText').get(function(this: IReview) {
   return `${years} year${years !== 1 ? 's' : ''} ${remainingMonths} month${remainingMonths !== 1 ? 's' : ''}`;
 });
 
-// Pre-save middleware to calculate lived duration
-ReviewSchema.pre('save', function(this: IReview, next) {
+// Derive the tenancy duration BEFORE validation. `livedForMonths` is a required
+// field that is ALWAYS server-computed from livedFrom/livedTo (the create
+// payload never supplies it), so this must run on `validate` — a `save` hook
+// would fire after the required-field check and reject every create.
+ReviewSchema.pre('validate', function(this: IReview, next) {
   if (this.livedFrom && this.livedTo) {
     const diffTime = Math.abs(this.livedTo.getTime() - this.livedFrom.getTime());
     const diffMonths = Math.ceil(diffTime / (1000 * 60 * 60 * 24 * 30.44)); // Average month length
@@ -387,12 +559,16 @@ ReviewSchema.pre('save', function(this: IReview, next) {
   next();
 });
 
+// Moderation filter shared by every public read/aggregation. 'removed' reviews
+// are hidden everywhere; 'under_review' stays visible.
+const VISIBLE_MODERATION = { $ne: ReviewModerationStatus.REMOVED } as const;
+
 // Static methods
 ReviewSchema.static('findByStreetLevel', function findByStreetLevel(
   this: IReviewModel,
   streetLevelId: string | Types.ObjectId
 ): Promise<IReview[]> {
-  return this.find({ streetLevelId })
+  return this.find({ streetLevelId, moderationStatus: VISIBLE_MODERATION })
     .sort({ createdAt: -1 })
     .exec();
 });
@@ -401,7 +577,7 @@ ReviewSchema.static('findByBuildingLevel', function findByBuildingLevel(
   this: IReviewModel,
   buildingLevelId: string | Types.ObjectId
 ): Promise<IReview[]> {
-  return this.find({ buildingLevelId })
+  return this.find({ buildingLevelId, moderationStatus: VISIBLE_MODERATION })
     .sort({ createdAt: -1 })
     .exec();
 });
@@ -410,7 +586,7 @@ ReviewSchema.static('findByUnitLevel', function findByUnitLevel(
   this: IReviewModel,
   unitLevelId: string | Types.ObjectId
 ): Promise<IReview[]> {
-  return this.find({ unitLevelId })
+  return this.find({ unitLevelId, moderationStatus: VISIBLE_MODERATION })
     .sort({ createdAt: -1 })
     .exec();
 });
@@ -421,18 +597,18 @@ ReviewSchema.static('getUnitViewData', async function getUnitViewData(
   unitLevelId: string | Types.ObjectId
 ): Promise<UnitViewData> {
   const unitReviews = await this.findByUnitLevel(unitLevelId);
-  
+
   // Get the building level from one of the unit reviews
-  const sampleReview = await this.findOne({ unitLevelId }).exec();
+  const sampleReview = await this.findOne({ unitLevelId, moderationStatus: VISIBLE_MODERATION }).exec();
   if (!sampleReview?.buildingLevelId) {
     return {
       unitReviews,
       buildingSummary: createEmptyReviewSummary()
     };
   }
-  
+
   const buildingSummaries = await this.aggregate<ReviewSummaryStats>([
-    { $match: { buildingLevelId: sampleReview.buildingLevelId, addressLevel: 'BUILDING' } },
+    { $match: { buildingLevelId: sampleReview.buildingLevelId, addressLevel: 'BUILDING', moderationStatus: VISIBLE_MODERATION } },
     {
       $group: {
         _id: null,
@@ -454,18 +630,20 @@ ReviewSchema.static('getBuildingViewData', async function getBuildingViewData(
   this: IReviewModel,
   buildingLevelId: string | Types.ObjectId
 ): Promise<BuildingViewData> {
-  const buildingReviews = await this.find({ 
-    buildingLevelId, 
-    addressLevel: 'BUILDING' 
+  const buildingReviews = await this.find({
+    buildingLevelId,
+    addressLevel: 'BUILDING',
+    moderationStatus: VISIBLE_MODERATION
   }).sort({ createdAt: -1 }).exec();
 
   const unitReviews = await this.find({
     buildingLevelId,
     addressLevel: 'UNIT',
+    moderationStatus: VISIBLE_MODERATION
   }).sort({ createdAt: -1 }).exec();
-  
+
   const aggregateResults = await this.aggregate<ReviewSummaryStats>([
-    { $match: { buildingLevelId: new Types.ObjectId(buildingLevelId.toString()) } },
+    { $match: { buildingLevelId: new Types.ObjectId(buildingLevelId.toString()), moderationStatus: VISIBLE_MODERATION } },
     {
       $group: {
         _id: null,
@@ -488,25 +666,204 @@ ReviewSchema.static('getStreetViewData', async function getStreetViewData(
   streetLevelId: string | Types.ObjectId
 ): Promise<StreetViewData> {
   const aggregateResults = await this.aggregate<ReviewSummaryStats>([
-    { $match: { streetLevelId: new Types.ObjectId(streetLevelId.toString()) } },
+    { $match: { streetLevelId: new Types.ObjectId(streetLevelId.toString()), moderationStatus: VISIBLE_MODERATION } },
     {
       $group: {
         _id: null,
         averageRating: { $avg: '$rating' },
         totalReviews: { $sum: 1 },
-        recommendationPercentage: { 
+        recommendationPercentage: {
           $avg: { $cond: [{ $eq: ['$recommendation', true] }, 100, 0] }
         }
       }
     }
   ]).exec();
   const aggregatedStats = aggregateResults[0] ?? createEmptyReviewSummary();
-  
-  const buildingCount = await this.distinct('buildingLevelId', { 
-    streetLevelId: new Types.ObjectId(streetLevelId.toString()) 
+
+  const buildingCount = await this.distinct('buildingLevelId', {
+    streetLevelId: new Types.ObjectId(streetLevelId.toString()),
+    moderationStatus: VISIBLE_MODERATION
   }).then((buildings: Types.ObjectId[]) => buildings.length);
-  
+
   return { aggregatedStats, buildingCount };
+});
+
+// ---------------------------------------------------------------------------
+// Agency + explore aggregations (reviucasa parity). Every pipeline excludes
+// 'removed' reviews via `VISIBLE_MODERATION`.
+// ---------------------------------------------------------------------------
+
+interface AgencyStatsRow {
+  averageRating: number;
+  totalReviews: number;
+  recommendCount: number;
+  depositFullCount: number;
+  depositKnownCount: number;
+}
+
+// AGENCY: average rating, total, recommendation %, deposit-full %.
+ReviewSchema.static('getAgencyStats', async function getAgencyStats(
+  this: IReviewModel,
+  agencyId: string | Types.ObjectId
+): Promise<AgencyStats> {
+  const rows = await this.aggregate<AgencyStatsRow>([
+    { $match: { agencyId: new Types.ObjectId(agencyId.toString()), moderationStatus: VISIBLE_MODERATION } },
+    {
+      $group: {
+        _id: null,
+        averageRating: { $avg: '$rating' },
+        totalReviews: { $sum: 1 },
+        recommendCount: { $sum: { $cond: [{ $eq: ['$recommendation', true] }, 1, 0] } },
+        depositFullCount: { $sum: { $cond: [{ $eq: ['$depositReturned', DepositReturn.FULL] }, 1, 0] } },
+        depositKnownCount: { $sum: { $cond: [{ $in: ['$depositReturned', Object.values(DepositReturn)] }, 1, 0] } }
+      }
+    }
+  ]).exec();
+
+  const row = rows[0];
+  if (!row || !row.totalReviews) {
+    return { averageRating: 0, totalReviews: 0, recommendationPercentage: 0, depositFullPct: 0 };
+  }
+  return {
+    averageRating: round1(row.averageRating),
+    totalReviews: row.totalReviews,
+    recommendationPercentage: roundPct((row.recommendCount / row.totalReviews) * 100),
+    depositFullPct: row.depositKnownCount > 0
+      ? roundPct((row.depositFullCount / row.depositKnownCount) * 100)
+      : 0
+  };
+});
+
+interface CityRow {
+  _id: Types.ObjectId;
+  reviewCount: number;
+  averageRating: number;
+  city: { name: string };
+}
+
+// EXPLORE (cities): coverage per city, newest coverage first by review count.
+ReviewSchema.static('getCitiesWithReviews', async function getCitiesWithReviews(
+  this: IReviewModel
+): Promise<ExploreCitySummary[]> {
+  const cityCollection = this.db.model('City').collection.collectionName;
+  const rows = await this.aggregate<CityRow>([
+    { $match: { cityId: { $ne: null }, moderationStatus: VISIBLE_MODERATION } },
+    { $group: { _id: '$cityId', reviewCount: { $sum: 1 }, averageRating: { $avg: '$rating' } } },
+    { $lookup: { from: cityCollection, localField: '_id', foreignField: '_id', as: 'city' } },
+    { $unwind: '$city' },
+    { $sort: { reviewCount: -1 } }
+  ]).exec();
+
+  return rows.map((row) => ({
+    cityId: String(row._id),
+    name: row.city.name,
+    reviewCount: row.reviewCount,
+    averageRating: round1(row.averageRating)
+  }));
+});
+
+interface NeighborhoodRow {
+  _id: Types.ObjectId;
+  reviewCount: number;
+  averageRating: number;
+  neighborhood: { name: string };
+}
+
+// EXPLORE (neighborhoods in a city): coverage per neighborhood.
+ReviewSchema.static('getNeighborhoodSummaries', async function getNeighborhoodSummaries(
+  this: IReviewModel,
+  cityId: string | Types.ObjectId
+): Promise<ExploreNeighborhoodSummary[]> {
+  const neighborhoodCollection = this.db.model('Neighborhood').collection.collectionName;
+  const rows = await this.aggregate<NeighborhoodRow>([
+    {
+      $match: {
+        cityId: new Types.ObjectId(cityId.toString()),
+        neighborhoodId: { $ne: null },
+        moderationStatus: VISIBLE_MODERATION
+      }
+    },
+    { $group: { _id: '$neighborhoodId', reviewCount: { $sum: 1 }, averageRating: { $avg: '$rating' } } },
+    { $lookup: { from: neighborhoodCollection, localField: '_id', foreignField: '_id', as: 'neighborhood' } },
+    { $unwind: '$neighborhood' },
+    { $sort: { reviewCount: -1 } }
+  ]).exec();
+
+  return rows.map((row) => ({
+    neighborhoodId: String(row._id),
+    name: row.neighborhood.name,
+    reviewCount: row.reviewCount,
+    averageRating: round1(row.averageRating)
+  }));
+});
+
+interface BuildingSummaryFacet {
+  buildings: Array<{
+    _id: Types.ObjectId;
+    reviewCount: number;
+    averageRating: number;
+    recommendCount: number;
+    address?: { street?: string; number?: string };
+  }>;
+  totalCount: Array<{ count: number }>;
+}
+
+// EXPLORE (buildings in a neighborhood): paginated building cards; street +
+// number come from the building-level Address doc.
+ReviewSchema.static('getBuildingSummaries', async function getBuildingSummaries(
+  this: IReviewModel,
+  neighborhoodId: string | Types.ObjectId,
+  page: number,
+  limit: number
+): Promise<BuildingSummariesResult> {
+  const addressCollection = this.db.model('Address').collection.collectionName;
+  const safePage = Math.max(1, page);
+  const safeLimit = Math.max(1, limit);
+  const skip = (safePage - 1) * safeLimit;
+
+  const facets = await this.aggregate<BuildingSummaryFacet>([
+    {
+      $match: {
+        neighborhoodId: new Types.ObjectId(neighborhoodId.toString()),
+        moderationStatus: VISIBLE_MODERATION
+      }
+    },
+    {
+      $group: {
+        _id: '$buildingLevelId',
+        reviewCount: { $sum: 1 },
+        averageRating: { $avg: '$rating' },
+        recommendCount: { $sum: { $cond: [{ $eq: ['$recommendation', true] }, 1, 0] } }
+      }
+    },
+    { $sort: { reviewCount: -1, _id: 1 } },
+    {
+      $facet: {
+        buildings: [
+          { $skip: skip },
+          { $limit: safeLimit },
+          { $lookup: { from: addressCollection, localField: '_id', foreignField: '_id', as: 'address' } },
+          { $unwind: { path: '$address', preserveNullAndEmptyArrays: true } }
+        ],
+        totalCount: [{ $count: 'count' }]
+      }
+    }
+  ]).exec();
+
+  const facet = facets[0];
+  const total = facet?.totalCount?.[0]?.count ?? 0;
+  const buildings: ExploreBuildingSummary[] = (facet?.buildings ?? []).map((row) => ({
+    buildingLevelId: String(row._id),
+    street: row.address?.street ?? '',
+    number: row.address?.number,
+    reviewCount: row.reviewCount,
+    averageRating: round1(row.averageRating),
+    recommendationPercentage: row.reviewCount > 0
+      ? roundPct((row.recommendCount / row.reviewCount) * 100)
+      : 0
+  }));
+
+  return { buildings, total };
 });
 
 // Create and export the model

--- a/packages/backend/models/documentTypes.ts
+++ b/packages/backend/models/documentTypes.ts
@@ -317,6 +317,26 @@ export type IExchangeReview = Document & {
   updatedAt: Date;
 } & Loose;
 
+// ---------- Agency ----------
+
+export type IAgency = Document & {
+  _id: Id;
+  name: string;
+  normalizedName: string;
+  slug: string;
+  createdAt: Date;
+  updatedAt: Date;
+} & Loose;
+
+export interface IAgencyModel extends Model<IAgency> {
+  /**
+   * Resolve a raw agency name to a persisted Agency, creating it on first
+   * sight. The SOLE write path for the collection. `null` when the name is
+   * too short to identify an agency.
+   */
+  findOrCreateByName(rawName: unknown): Promise<IAgency | null>;
+}
+
 // ---------- Reports ----------
 
 export type IListingReport = Document & {

--- a/packages/backend/models/index.ts
+++ b/packages/backend/models/index.ts
@@ -41,6 +41,8 @@ import type {
   IExchangeRequest,
   IExchangeReview,
   IListingReport,
+  IAgency,
+  IAgencyModel,
   IPartner,
   ICommission,
   IImage,
@@ -76,6 +78,7 @@ const NotificationModel = require('./schemas/NotificationSchema') as Model<INoti
 const ExchangeRequestModel = require('./schemas/ExchangeRequestSchema') as Model<IExchangeRequest>;
 const ExchangeReviewModel = require('./schemas/ExchangeReviewSchema') as Model<IExchangeReview>;
 const ListingReportModel = require('./schemas/ListingReportSchema') as Model<IListingReport>;
+const AgencyModel = require('./schemas/AgencySchema') as IAgencyModel;
 const PartnerModel = require('./schemas/PartnerSchema') as Model<IPartner>;
 const CommissionModel = require('./schemas/CommissionSchema') as Model<ICommission>;
 const ImageModel = require('./schemas/ImageSchema') as Model<IImage>;
@@ -109,6 +112,7 @@ export const Notification = NotificationModel;
 export const ExchangeRequest = ExchangeRequestModel;
 export const ExchangeReview = ExchangeReviewModel;
 export const ListingReport = ListingReportModel;
+export const Agency = AgencyModel;
 export const Partner = PartnerModel;
 export const Commission = CommissionModel;
 export const Image = ImageModel;
@@ -151,6 +155,8 @@ export type {
   IExchangeRequest,
   IExchangeReview,
   IListingReport,
+  IAgency,
+  IAgencyModel,
   IPartner,
   ICommission,
   IImage,
@@ -191,6 +197,7 @@ module.exports = {
   ExchangeRequest: ExchangeRequestModel,
   ExchangeReview: ExchangeReviewModel,
   ListingReport: ListingReportModel,
+  Agency: AgencyModel,
   Partner: PartnerModel,
   Commission: CommissionModel,
   Image: ImageModel,

--- a/packages/backend/models/schemas/AgencySchema.ts
+++ b/packages/backend/models/schemas/AgencySchema.ts
@@ -1,0 +1,102 @@
+/**
+ * Agency Schema
+ *
+ * A property-management / landlord agency that reviews (and external listings)
+ * can be attributed to, reviucasa-style. Agencies are DERIVED entities — they
+ * are never created by an authenticated write endpoint. The ONLY write path is
+ * the `findOrCreateByName` static, called when:
+ *   - a tenant submits a review naming their managing agency, or
+ *   - an external listing's portal contact AJAX exposes an agency name.
+ *
+ * Dedup is by `normalizedName` (diacritics-stripped, case-folded, whitespace-
+ * collapsed) so trivially different spellings resolve to one agency. Each
+ * agency is addressed publicly by a URL-safe, collision-suffixed `slug`.
+ */
+
+const mongoose = require('mongoose');
+const { normalizeAgencyName, slugifyAgencyName } = require('../../utils/agencyName');
+
+const MIN_NAME_LENGTH = 2;
+const MAX_NAME_LENGTH = 120;
+/** Bounded slug-suffix search before falling back to a timestamp suffix. */
+const MAX_SLUG_ATTEMPTS = 50;
+
+const agencySchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: [true, 'Agency name is required'],
+    trim: true,
+    minlength: [MIN_NAME_LENGTH, 'Agency name must be at least 2 characters'],
+    maxlength: [MAX_NAME_LENGTH, 'Agency name cannot exceed 120 characters']
+  },
+  // Canonical dedup key — one agency per normalized name. `unique` already
+  // creates the backing index.
+  normalizedName: {
+    type: String,
+    required: true,
+    unique: true
+  },
+  // URL-safe public identifier (collision-suffixed: base, base-2, base-3, …).
+  slug: {
+    type: String,
+    required: true,
+    unique: true
+  }
+}, {
+  timestamps: true,
+  toJSON: {
+    virtuals: true,
+    transform: function(_doc: unknown, ret: Record<string, unknown>): Record<string, unknown> {
+      ret.id = ret._id;
+      return ret;
+    }
+  },
+  toObject: { virtuals: true }
+});
+
+/** True for a MongoDB duplicate-key error (either unique index). */
+function isDuplicateKeyError(error: unknown): boolean {
+  const code = (error as { code?: number } | null)?.code;
+  return code === 11000 || code === 11001;
+}
+
+/**
+ * Resolve a raw agency name to a persisted Agency, creating it on first sight.
+ * The SOLE write path for the collection.
+ *
+ * Returns `null` when the name is empty / too short to identify an agency (the
+ * caller simply skips agency attribution). Concurrency-safe: a `normalizedName`
+ * race reuses the winner; a `slug` collision advances to the next suffix.
+ */
+agencySchema.statics.findOrCreateByName = async function findOrCreateByName(
+  rawName: unknown
+) {
+  if (typeof rawName !== 'string') return null;
+  const name = rawName.trim().slice(0, MAX_NAME_LENGTH);
+  const normalizedName = normalizeAgencyName(name);
+  if (normalizedName.length < MIN_NAME_LENGTH) return null;
+
+  const existing = await this.findOne({ normalizedName });
+  if (existing) return existing;
+
+  const baseSlug = slugifyAgencyName(name) || 'agency';
+
+  for (let attempt = 0; attempt < MAX_SLUG_ATTEMPTS; attempt++) {
+    const slug = attempt === 0 ? baseSlug : `${baseSlug}-${attempt + 1}`;
+    try {
+      return await this.create({ name, normalizedName, slug });
+    } catch (error) {
+      if (!isDuplicateKeyError(error)) throw error;
+      // A concurrent writer may have created the SAME agency (normalizedName
+      // race) — reuse it. Otherwise it was only a slug collision: try the next
+      // suffix.
+      const raced = await this.findOne({ normalizedName });
+      if (raced) return raced;
+    }
+  }
+
+  // Deterministic suffixes exhausted (pathological): last-resort unique slug.
+  return this.create({ name, normalizedName, slug: `${baseSlug}-${Date.now()}` });
+};
+
+module.exports = mongoose.model('Agency', agencySchema);

--- a/packages/backend/models/schemas/PropertySchema.ts
+++ b/packages/backend/models/schemas/PropertySchema.ts
@@ -307,6 +307,14 @@ const propertySchema = new mongoose.Schema({
     trim: true,
     lowercase: true
   },
+  // Relational link to the managing Agency. Resolved server-side from portal
+  // contact AJAX (external listings) via `Agency.findOrCreateByName`; optional.
+  agencyId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Agency',
+    index: true,
+    sparse: true
+  },
   description: {
     type: String,
     trim: true,

--- a/packages/backend/routes/public.ts
+++ b/packages/backend/routes/public.ts
@@ -67,6 +67,20 @@ export default function () {
   router.get('/reviews/address/:addressId', asyncHandler(reviewController.getReviewsByAddress));
   router.get('/reviews/address/:addressId/stats', asyncHandler(reviewController.getAddressReviewStats));
 
+  // Public review-explore aggregations (cities → neighborhoods → buildings).
+  // Coverage-only stats; no per-review reads here. Declared as distinct literal
+  // segments so they don't collide with `/reviews/address/...` above.
+  router.get('/reviews/explore', asyncHandler(reviewController.getExploreCities));
+  router.get('/reviews/explore/city/:cityId', asyncHandler(reviewController.getExploreCity));
+  router.get('/reviews/explore/neighborhood/:neighborhoodId', asyncHandler(reviewController.getExploreNeighborhood));
+
+  // Public agency profile reads. `/agencies/search` is declared BEFORE the
+  // `/agencies/:slug` catch so "search" is never captured as a slug.
+  router.get('/agencies/search', asyncHandler(reviewController.searchAgencies));
+  router.get('/agencies/:slug', asyncHandler(reviewController.getAgencyBySlug));
+  router.get('/agencies/:slug/reviews', asyncHandler(reviewController.getAgencyReviews));
+  router.get('/agencies/:slug/properties', asyncHandler(reviewController.getAgencyProperties));
+
   // Public self-hosted image store: serve a processed image's bytes by its
   // bucket-relative key (used when object storage is not configured). Images are
   // public assets — render-time photos must load without a token — so this lives

--- a/packages/backend/routes/reviews.ts
+++ b/packages/backend/routes/reviews.ts
@@ -9,18 +9,27 @@ import {
   getReviewById,
   updateReview,
   deleteReview,
-  getUserReviews
+  getUserReviews,
+  toggleHelpful,
+  reportReview
 } from '../controllers/reviewController';
 
 const router = Router();
 
 // NOTE: the address review READ routes (`GET /address/:addressId` and
-// `/address/:addressId/stats`) are served publicly from `routes/public.ts`
-// (community-visible reads, no auth). They are intentionally NOT declared here
-// so this authenticated router only owns mutations + owner-scoped reads.
+// `/address/:addressId/stats`), the agency reads, and the review-explore
+// aggregations are served publicly from `routes/public.ts` (community-visible
+// reads, no auth). They are intentionally NOT declared here so this
+// authenticated router only owns mutations + owner-scoped reads.
 
 // Review CRUD operations
 router.post('/', createReview);
+
+// Community interaction (authed). Declared before `/:reviewId` sub-routes so
+// the literal segments are unambiguous.
+router.post('/:reviewId/helpful', toggleHelpful);
+router.post('/:reviewId/report', reportReview);
+
 router.get('/:reviewId', getReviewById);
 router.put('/:reviewId', updateReview);
 router.delete('/:reviewId', deleteReview);

--- a/packages/backend/scripts/migrateReviewDepositReturned.ts
+++ b/packages/backend/scripts/migrateReviewDepositReturned.ts
@@ -1,0 +1,60 @@
+/**
+ * Migrate `Review.depositReturned` from the legacy Boolean to the
+ * {@link DepositReturn} string enum.
+ *
+ *   true  → 'full'   (deposit returned in full)
+ *   false → 'no'     (deposit not returned)
+ *
+ * Documents that predate the field, or that already hold an enum string, are
+ * left untouched. The reviucasa 'partial' outcome has no Boolean predecessor,
+ * so it is never produced by this migration.
+ *
+ * Usage:
+ *   bun run packages/backend/scripts/migrateReviewDepositReturned.ts          # dry run
+ *   bun run packages/backend/scripts/migrateReviewDepositReturned.ts --apply  # write
+ */
+
+require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
+
+import { DepositReturn } from '@homiio/shared-types';
+import database from '../database/connection';
+
+const { Review } = require('../models');
+
+const APPLY = process.argv.includes('--apply');
+
+async function main(): Promise<void> {
+  await database.connect();
+
+  // Match on the legacy BSON boolean type so already-migrated string values are
+  // never re-touched.
+  const trueFilter = { depositReturned: { $type: 'bool', $eq: true } };
+  const falseFilter = { depositReturned: { $type: 'bool', $eq: false } };
+
+  const [trueCount, falseCount] = await Promise.all([
+    Review.countDocuments(trueFilter),
+    Review.countDocuments(falseFilter),
+  ]);
+
+  console.log(
+    `${APPLY ? 'Migrating' : 'Would migrate'} depositReturned: ` +
+    `${trueCount} true → '${DepositReturn.FULL}', ${falseCount} false → '${DepositReturn.NO}'`,
+  );
+
+  if (APPLY) {
+    if (trueCount > 0) {
+      await Review.updateMany(trueFilter, { $set: { depositReturned: DepositReturn.FULL } });
+    }
+    if (falseCount > 0) {
+      await Review.updateMany(falseFilter, { $set: { depositReturned: DepositReturn.NO } });
+    }
+    console.log('Migration complete.');
+  }
+
+  await database.disconnect?.();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/backend/services/geoResolutionService.ts
+++ b/packages/backend/services/geoResolutionService.ts
@@ -122,6 +122,17 @@ function writeResolutionCache(key: string, value: ResolvedGeo): void {
   resolutionCache.set(key, value);
 }
 
+/**
+ * Drop every cached resolution. The cache short-circuits geo id resolution
+ * WITHOUT re-upserting the underlying Country/Region/City/Neighborhood docs, so
+ * a test that wipes those collections between cases must reset it — otherwise a
+ * later resolution returns an id for a now-deleted doc. Not used in production
+ * (geo docs are never deleted), so this is purely a test-support hook.
+ */
+export function clearResolutionCache(): void {
+  resolutionCache.clear();
+}
+
 /** A stable cache key for a resolution request. */
 function cacheKeyFor(input: ResolveGeoInput): string {
   const coordKey = input.coordinates

--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -25,7 +25,7 @@ import {
   ListingValidationError,
   validateNormalizedListing,
 } from '@homiio/listing-providers';
-import { Property, Address, type IProperty } from '../../models';
+import { Property, Address, Agency, type IProperty } from '../../models';
 import { ensureCover } from '../cityCoverSyncService';
 import type { AddressCanonicalInput } from '../../models/Address';
 import { validateOfferings } from '../../models/schemas/offeringValidation';
@@ -86,6 +86,14 @@ export class IngestionService {
 
     const addressId = await this.resolveAddress(listing.address);
     const fields = this.buildPropertyFields(listing, addressId);
+
+    // Attribute the listing to a canonical Agency when the portal contact AJAX
+    // exposed an agency name. `findOrCreateByName` is the sole Agency write path
+    // and dedupes by normalized name — the raw string stays on `externalContact`.
+    if (listing.contact?.agencyName) {
+      const agency = await Agency.findOrCreateByName(listing.contact.agencyName);
+      if (agency) fields.agencyId = agency._id;
+    }
 
     const existing = await Property.findOne({ source: listing.source, sourceId: listing.sourceId });
     const property = existing ?? new Property();

--- a/packages/backend/utils/agencyName.ts
+++ b/packages/backend/utils/agencyName.ts
@@ -1,0 +1,46 @@
+/**
+ * Agency name canonicalization helpers.
+ *
+ * An {@link Agency} is deduplicated by a diacritics-stripped, case-folded,
+ * whitespace-collapsed `normalizedName` and addressed publicly by a URL-safe
+ * `slug`. Both derivations live here so the model's `findOrCreateByName` write
+ * path and the read-side agency search apply the exact same rules — a portal
+ * that reports "Fincas García" and one that reports "FINCAS  garcia" must
+ * resolve to a single agency.
+ */
+
+/** Unicode combining diacritical marks (stripped after NFD decomposition). */
+const COMBINING_MARKS = /[̀-ͯ]/g;
+
+/**
+ * Fold a raw agency name to its canonical dedup key: NFD-decompose, strip
+ * combining diacritics, lowercase, collapse internal whitespace, trim.
+ */
+export function normalizeAgencyName(raw: string): string {
+  return raw
+    .normalize('NFD')
+    .replace(COMBINING_MARKS, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Derive a URL-safe slug from a raw agency name: diacritics-stripped,
+ * lowercased, non-alphanumeric runs replaced with a single hyphen, no leading
+ * or trailing hyphen. Returns an empty string when the name has no slug-able
+ * characters (callers must guard).
+ */
+export function slugifyAgencyName(raw: string): string {
+  return raw
+    .normalize('NFD')
+    .replace(COMBINING_MARKS, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Escape a string for safe use inside a `RegExp` (prefix search, etc.). */
+export function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## What & why
Upgrades the address-review system to reviucasa.com parity and adds a relational **Agency** entity. PR 2 of 3 — **backend + shared-types only, no frontend changes**. Builds on the shared-types contract merged in PR 1.

## Highlights
- **Review model**: `title`, `prosItems`/`consItems`, `adviceToAgency`/`adviceToLandlord`, `agencyId`, `areaNoise`/`areaCleanliness`, `cityId`/`neighborhoodId`, `helpfulVoters`, `reports[]`, `moderationStatus`; `depositReturned` Boolean→`DepositReturn` enum; image-URL validator relaxed to allow query strings; compound indexes on agency/city/neighborhood; new agency + explore aggregation statics. Hierarchical aggregations now exclude `moderationStatus: 'removed'`.
- **Agency entity**: dedup by diacritics/case/whitespace-folded `normalizedName` + unique, collision-suffixed `slug`; `findOrCreateByName` is the SOLE write path. External-listing ingest resolves `contact.agencyName` → `agencyId` (raw string contact kept).
- **Security fix (mass-assignment / IDOR)**: `updateReview`/`deleteReview` replaced `Object.assign(review, req.body)` + `findById`+compare→400 with `pickFields` allowlists + `Review.findOne({ _id, oxyUserId })` → **404 for a non-owner**. `createReview` picks `CREATABLE_REVIEW_FIELDS`, requires a title, resolves `agencyName`→`agencyId`, stamps `cityId`/`neighborhoodId`, and best-effort notifies address owners via `notificationDispatchService` (swallow-and-log).
- **`toReviewDTO`** — single read chokepoint: strips `helpfulVoters` + `reports`, derives `helpfulCount`/`viewerHasVotedHelpful`, inlines `agency` when populated.
- **Helpful votes + reports**: `toggleHelpful` (own-review → 400; atomic add/remove), `reportReview` (per-reporter dedup, escalate to `under_review` at 3 reports).
- **Bug fix**: `livedForMonths` now derived in `pre('validate')` (was `pre('save')`, which rejected every create now that the field is server-derived, not client-supplied).
- **Migration**: `scripts/migrateReviewDepositReturned.ts` (Boolean → `'full'`/`'no'`; ship-only, not run).

## Endpoints
- Authed (`/api/reviews`): `POST /:reviewId/helpful`, `POST /:reviewId/report` (existing CRUD unchanged).
- Public: `GET /api/reviews/explore`, `/api/reviews/explore/city/:cityId`, `/api/reviews/explore/neighborhood/:neighborhoodId`; `GET /api/agencies/search`, `/api/agencies/:slug`, `/api/agencies/:slug/reviews`, `/api/agencies/:slug/properties`.

## Tests
New `__tests__/integration/reviewSystem.test.ts`: allowlist guard (injected `oxyUserId`/`verified`/`helpfulVoters`/`moderationStatus` ignored), helpful toggle 1→0, own-review vote → 400, report dedup, 3-reporter → `under_review`, non-owner PUT/DELETE → 404, agency stats + reads, explore aggregations. Full backend suite green; backend `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)