### PR TITLE
feat(ingest): fetch priority + content classifier + canonical vocab/i18n

### DIFF
--- a/packages/backend/__tests__/integration/externalIngest.test.ts
+++ b/packages/backend/__tests__/integration/externalIngest.test.ts
@@ -203,6 +203,46 @@ describe('external listing ingest (fixture -> IngestionService)', () => {
     });
   });
 
+  it('classifies and persists listingFlags from the description free text', async () => {
+    const ingestion = buildIngestionService();
+    const [first] = await normalizeAll();
+    const withFlags: NormalizedListing = {
+      ...first,
+      description:
+        'Se alquilan habitaciones en piso compartido, exclusivamente para estudiantes. ' +
+        'Solo chicas. No se admiten mascotas. Alquiler de temporada de septiembre a junio.',
+    };
+
+    await ingestion.ingest(withFlags);
+    const property = await Property.findOne({ source: 'fixture', sourceId: FIRST_SOURCE_ID }).lean();
+    expect(property?.listingFlags).toMatchObject({
+      roomNotFullUnit: true,
+      studentsOnly: true,
+      genderRestricted: true,
+      noPets: true,
+      temporaryOnly: true,
+    });
+    // Flags that did not fire stay absent (sparse).
+    expect(property?.listingFlags?.agencyFeePayable).toBeUndefined();
+    expect(property?.listingFlags?.noDSS).toBeUndefined();
+  });
+
+  it('omits listingFlags entirely when the description trips no rule', async () => {
+    const ingestion = buildIngestionService();
+    const [first] = await normalizeAll();
+    const plain: NormalizedListing = {
+      ...first,
+      description: 'Bright two-bedroom flat with a lift, a balcony and a modern kitchen.',
+    };
+
+    await ingestion.ingest(plain);
+    const property = await Property.findOne({ source: 'fixture', sourceId: FIRST_SOURCE_ID }).lean();
+    // No restriction flag fired; only a language may be detected (or nothing).
+    expect(property?.listingFlags?.roomNotFullUnit).toBeUndefined();
+    expect(property?.listingFlags?.studentsOnly).toBeUndefined();
+    expect(property?.listingFlags?.temporaryOnly).toBeUndefined();
+  });
+
   it('rejects partner-style absurd monthly rent at the ingest gate (11628 EUR)', async () => {
     const ingestion = buildIngestionService();
     const absurdListing: NormalizedListing = {

--- a/packages/backend/__tests__/unit/bluegroundParse.test.ts
+++ b/packages/backend/__tests__/unit/bluegroundParse.test.ts
@@ -82,9 +82,11 @@ describe('Blueground parse', () => {
 
   it('extracts available amenities as canonical slugs, excluding struck-through ones', () => {
     const { amenities, floor } = readBluegroundAmenities(FIRST_PARTY_DETAIL_HTML);
-    // Available apartment/building amenities, canonicalized and deduped.
+    // Available apartment/building amenities, canonicalized onto the shared fixed
+    // vocabulary (`washerUnit`→washing_machine); non-canonical `coffeeMachine` is
+    // dropped rather than stored as a bespoke slug.
     expect(amenities.sort()).toEqual(
-      ['air_conditioning', 'balcony', 'coffee_machine', 'elevator', 'washer'].sort(),
+      ['air_conditioning', 'balcony', 'elevator', 'washing_machine'].sort(),
     );
     // Struck-through amenities (parking, doorman, bathtub) must NOT appear.
     expect(amenities).not.toContain('parking');
@@ -101,7 +103,7 @@ describe('Blueground parse', () => {
     const listing = parseBluegroundDetail(FIRST_PARTY_DETAIL_HTML, ref);
     expect(listing.floor).toBe(2);
     expect(listing.amenities).toContain('elevator');
-    expect(listing.amenities).toContain('washer');
+    expect(listing.amenities).toContain('washing_machine');
     expect(listing.amenities).not.toContain('parking');
   });
 

--- a/packages/backend/__tests__/unit/canonicalAmenities.test.ts
+++ b/packages/backend/__tests__/unit/canonicalAmenities.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Canonical amenity vocabulary — the single source of truth every provider maps
+ * onto. These tests lock the contract: different portal dialects (localized
+ * ES/IT labels, English feature slugs, camelCase keys, boolean-flag targets, raw
+ * slugs, free-text marketing copy) all collapse onto the SAME fixed canonical
+ * key, non-amenities are dropped, and `furnished` is hoisted out of the list.
+ */
+
+import {
+  CANONICAL_AMENITIES,
+  canonicalAmenity,
+  canonicalizeAmenities,
+  isCanonicalAmenity,
+  slugifyAmenityToken,
+} from '@homiio/listing-providers';
+
+describe('canonicalAmenity', () => {
+  it('maps every portal dialect for the same amenity to one canonical key', () => {
+    // elevator: ES / IT / EN feature slug / camelCase (blueground) / free text
+    for (const input of ['ascensor', 'ascensore', 'Lift', 'elevatorInTheBuilding', 'elevator']) {
+      expect(canonicalAmenity(input)).toBe('elevator');
+    }
+    // parking: ES slug / IT / EN / camelCase / free-text marketing copy
+    for (const input of ['garaje', 'posto_auto', 'garage', 'parkingSpace', 'Off street parking']) {
+      expect(canonicalAmenity(input)).toBe('parking');
+    }
+    // pool
+    for (const input of ['piscina', 'swimming_pool', 'community_pool']) {
+      expect(canonicalAmenity(input)).toBe('pool');
+    }
+    // air conditioning (localized + EN + camelCase)
+    for (const input of ['aire acondicionado', 'aria condizionata', 'air_conditioner', 'airConditioning']) {
+      expect(canonicalAmenity(input)).toBe('air_conditioning');
+    }
+    // washing machine (blueground washerUnit / laundryRoomUnit / raw washer)
+    for (const input of ['washer', 'washerUnit', 'laundryRoomUnit', 'lavadora']) {
+      expect(canonicalAmenity(input)).toBe('washing_machine');
+    }
+    // connectivity: immoweb `internet` and search `wifi` unify
+    for (const input of ['internet', 'wifi', 'wi-fi']) {
+      expect(canonicalAmenity(input)).toBe('wifi');
+    }
+    // terrace (ES/IT) and intercom (immoweb visiophone)
+    expect(canonicalAmenity('terraza')).toBe('terrace');
+    expect(canonicalAmenity('terrazzo')).toBe('terrace');
+    expect(canonicalAmenity('visiophone')).toBe('intercom');
+  });
+
+  it('hoists furnished tokens to the sentinel, never an amenity', () => {
+    for (const input of ['amueblado', 'arredato', 'furnished', 'meublee']) {
+      expect(canonicalAmenity(input)).toBe('furnished');
+    }
+  });
+
+  it('drops non-amenity words (condition, orientation, marketing copy)', () => {
+    for (const input of ['soleado', 'exterior', 'reformado', 'Double glazing', 'coffeeMachine', '']) {
+      expect(canonicalAmenity(input)).toBeUndefined();
+    }
+  });
+
+  it('only ever resolves to a key in the fixed canonical set', () => {
+    for (const key of CANONICAL_AMENITIES) {
+      expect(isCanonicalAmenity(key)).toBe(true);
+    }
+    expect(isCanonicalAmenity('coffee_machine')).toBe(false);
+  });
+});
+
+describe('slugifyAmenityToken', () => {
+  it('deaccents, splits camelCase, and snake-cases', () => {
+    expect(slugifyAmenityToken('airConditioning')).toBe('air_conditioning');
+    expect(slugifyAmenityToken('Aire Acondicionado')).toBe('aire_acondicionado');
+    expect(slugifyAmenityToken('Off street parking')).toBe('off_street_parking');
+  });
+});
+
+describe('canonicalizeAmenities', () => {
+  it('canonicalizes, dedupes, and hoists furnished out of the list', () => {
+    const result = canonicalizeAmenities([
+      'ascensor', // elevator
+      'Lift', // elevator (dedupe)
+      'piscina', // pool
+      'amueblado', // furnished → hoisted
+      'soleado', // dropped
+      'garaje', // parking
+    ]);
+    expect(result.amenities).toEqual(['elevator', 'pool', 'parking']);
+    expect(result.furnished).toBe(true);
+  });
+
+  it('omits furnished when no furnished token is present', () => {
+    expect(canonicalizeAmenities(['piscina', 'jardin'])).toEqual({
+      amenities: ['pool', 'garden'],
+    });
+  });
+});

--- a/packages/backend/__tests__/unit/ceuProviders.test.ts
+++ b/packages/backend/__tests__/unit/ceuProviders.test.ts
@@ -84,10 +84,11 @@ describe('ImmowebProvider (BE)', () => {
     expect(listing.bathrooms).toBe(2);
     // constructionYear lives on property.building, not the unit
     expect(listing.yearBuilt).toBe(1965);
-    // amenities built from the true `has*` flags, mapped to canonical slugs
+    // amenities built from the true `has*` flags, mapped to the shared canonical
+    // vocabulary (`laundry_room`, `wifi` — not bespoke `laundry`/`internet`).
     expect(listing.amenities).toBeDefined();
     expect(listing.amenities).toEqual(
-      expect.arrayContaining(['elevator', 'terrace', 'garden', 'storage', 'laundry', 'internet']),
+      expect.arrayContaining(['elevator', 'terrace', 'garden', 'storage', 'laundry_room', 'wifi']),
     );
     expect(listing.hasElevator).toBe(true);
     expect(listing.hasGarden).toBe(true);

--- a/packages/backend/__tests__/unit/classifyListingContent.test.ts
+++ b/packages/backend/__tests__/unit/classifyListingContent.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Free-text listing classifier. Every positive fixture is a (lightly trimmed)
+ * REAL description pulled from prod (pisos/fotocasa/habitaclia/immoweb/rightmove,
+ * ES/CA/EN/FR/NL) or a canonical phrase for a language the live corpus does not
+ * yet cover (DE/IT). Every negative fixture is a real false-positive trap the
+ * rules are written to survive.
+ */
+
+import { classifyListingContent, type ListingFlags } from '../../services/ingestion/classifyListingContent';
+
+/** True iff the classifier set exactly this one boolean flag (order-independent). */
+function flag(text: string): ListingFlags {
+  return classifyListingContent(text);
+}
+
+describe('classifyListingContent', () => {
+  it('returns an empty object for empty / whitespace / nullish input', () => {
+    expect(classifyListingContent(undefined)).toEqual({});
+    expect(classifyListingContent(null)).toEqual({});
+    expect(classifyListingContent('')).toEqual({});
+    expect(classifyListingContent('   \n  ')).toEqual({});
+  });
+
+  describe('studentsOnly', () => {
+    it.each([
+      // ES — real prod hits (exclusivity marker present)
+      ['se alquila piso exclusivo para estudiantes a 5 minutos de las universidades', 'ES'],
+      ['disponible de agosto 2026 solo estudiantes tiene 3 dormitorios', 'ES'],
+      ['piso en alquiler en lleida exclusivo para estudiantes se ofrece vivienda amplia', 'ES'],
+      ['unicamente estudiantes, curso 2026/2027', 'ES'],
+      ['se alquilan habitaciones amuebladas en residencia de estudiantes', 'ES'],
+      // EN — immoweb
+      ['brand-new student residence with only 12 rooms available', 'EN'],
+      ['this flat is for students only, close to campus', 'EN'],
+      // DE / IT / FR / NL — canonical
+      ['schone wohnung, nur fur studenten in der innenstadt', 'DE'],
+      ['appartamento in centro, solo studenti', 'IT'],
+      ['bel appartement reserve aux etudiants, proche du campus', 'FR'],
+      ['mooi appartement, alleen voor studenten, dicht bij de universiteit', 'NL'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).studentsOnly).toBe(true);
+    });
+
+    it.each([
+      // Open to multiple audiences — 47 real "para estudiantes O …" listings.
+      'perfecto para estudiantes o jovenes profesionales que buscan compartir',
+      'ofrece el entorno ideal para estudiantes, profesionales o familias',
+      'ideal for students, young professionals, or singles located in the center',
+      'especialmente para estudiantes o trabajadores, disponibilidad inmediata',
+      // Suitability, not restriction
+      'ideal para estudiantes por su cercania a la universidad',
+    ])('does NOT flag open/suitability phrasing "%s"', (text) => {
+      expect(flag(text).studentsOnly).toBeUndefined();
+    });
+  });
+
+  describe('roomNotFullUnit', () => {
+    it.each([
+      // ES / CA — real prod
+      ['se alquilan 2 habitaciones en piso compartido, el piso son 3 habitaciones', 'ES'],
+      ['se alquilan habitaciones en un apartamento amueblado de 3 dormitorios', 'ES'],
+      ['esta habitacion en un piso compartido de 6 habitaciones en el coll', 'ES'],
+      ['alquila esta fantastica habitacion en piso compartido en la calle pedroches', 'ES'],
+      ['se alquila coqueta habitacion en el centro historico', 'ES'],
+      // EN — immoweb
+      ['5 rooms for rent in a student apartment located in the center of gembloux', 'EN'],
+      ['a bright room in a shared flat near the station', 'EN'],
+      ['spacious house share available now, all bills included', 'EN'],
+      // DE / IT / FR / NL — canonical
+      ['helles wg-zimmer in einer 3er wohngemeinschaft zu vermieten', 'DE'],
+      ['posto letto in stanza doppia, appartamento condiviso vicino al centro', 'IT'],
+      ['chambre en colocation dans un bel appartement renove', 'FR'],
+      ['kamer te huur in een gedeeld appartement in het centrum', 'NL'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).roomNotFullUnit).toBe(true);
+    });
+
+    it.each([
+      // Whole flat rented (bedroom COUNT, not a room let)
+      'se alquila amplio piso con 4 habitaciones y 2 banos totalmente reformado',
+      'se alquila estupendo piso de 3 habitaciones con ascensor',
+      'el piso tiene 3 habitaciones, una de ellas tipo suite',
+      // "para compartir" = whole flat marketed as shareable — 110 real hits
+      'piso perfecto para compartir con tus companeros de estudio o trabajo',
+      'amigos que quieran compartir piso y disfrutar de un barrio con servicios',
+      'oportunidad perfecta para compartir piso con amigos',
+      // Explicit whole-unit disclaimers — 3 real prod listings (the OPPOSITE of
+      // a room let); the negated rent-verb must be vetoed.
+      'se integra a un grupo cerrado, no se alquila por habitaciones sueltas',
+      'contrato universitario, maximo once meses. no se alquila por habitaciones, sino de forma completa',
+      'solo estudiantes. no se alquilan habitaciones por separado.',
+    ])('does NOT flag whole-flat / share-suitable phrasing "%s"', (text) => {
+      expect(flag(text).roomNotFullUnit).toBeUndefined();
+    });
+  });
+
+  describe('temporaryOnly', () => {
+    it.each([
+      // ES — real prod
+      ['alquiler de temporada fantastico apartamento en primera linea', 'ES'],
+      ['se alquila temporada de septiembre a junio, curso academico', 'ES'],
+      ['alquiler temporal: casita de pescadores para los meses de verano', 'ES'],
+      ['apartamento vacacional, disponible por meses', 'ES'],
+      // EN
+      ['stylish short let apartment, minimum one month stay', 'EN'],
+      ['holiday let in the city centre, fully serviced', 'EN'],
+      // DE / IT / FR / NL — canonical
+      ['moblierte wohnung auf zeit, zwischenmiete bis august', 'DE'],
+      ['affitto breve, contratto temporaneo uso transitorio', 'IT'],
+      ['location saisonniere, bail mobilite de trois mois', 'FR'],
+      ['tijdelijk appartement voor kort verblijf in het centrum', 'NL'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).temporaryOnly).toBe(true);
+    });
+
+    it.each([
+      // Permanent lease, no seasonal wording
+      'alquiler de larga duracion, vivienda habitual reformada con ascensor',
+      'piso disponible todo el ano para residencia habitual',
+      // Guarded: "cuatro/todas las temporadas" (climate / name), not a lease term
+      'aire acondicionado frio calor para todas las temporadas del ano',
+      'urbanizacion las cuatro temporadas con piscina comunitaria',
+    ])('does NOT flag permanent / guarded phrasing "%s"', (text) => {
+      expect(flag(text).temporaryOnly).toBeUndefined();
+    });
+  });
+
+  describe('genderRestricted', () => {
+    it.each([
+      ['quedan dos habitaciones, solo chicas, no llegues tarde', 'ES'],
+      ['habitaciones para estudiantes solo chicas zona pardaleras', 'ES'],
+      ['solo chicos trabajadores, ambiente tranquilo', 'ES'],
+      ['double room in a house share, women only please', 'EN'],
+      ['schones zimmer, nur frauen', 'DE'],
+      ['stanza luminosa, solo ragazze', 'IT'],
+      ['chambre agreable, femmes uniquement', 'FR'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).genderRestricted).toBe(true);
+    });
+
+    it.each([
+      'piso ideal para chicas y chicos que quieran compartir',
+      'apartamento para dos personas en el centro',
+      'habitacion para una sola persona con bano privado',
+    ])('does NOT flag non-restrictive phrasing "%s"', (text) => {
+      expect(flag(text).genderRestricted).toBeUndefined();
+    });
+  });
+
+  describe('workersOnly', () => {
+    it.each([
+      ['importante ser trabajador con nomina, se pide solvencia', 'ES'],
+      ['ingresos demostrables mediante nomina y contrato de trabajo', 'ES'],
+      ['solo trabajadores con contrato indefinido', 'ES'],
+      ['requerimos ultima nomina y vida laboral', 'ES'],
+      ['working professionals only, references required', 'EN'],
+      ['proof of income and employment required', 'EN'],
+      ['nur fur berufstatige, einkommensnachweis erforderlich', 'DE'],
+      ['solo lavoratori con busta paga', 'IT'],
+      ['fiche de paie et contrat de travail exiges', 'FR'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).workersOnly).toBe(true);
+    });
+
+    it.each([
+      'piso luminoso reformado con cocina nueva y armarios empotrados',
+      'apartment with a modern kitchen and two bedrooms',
+    ])('does NOT flag listings without an employment/income requirement "%s"', (text) => {
+      expect(flag(text).workersOnly).toBeUndefined();
+    });
+  });
+
+  describe('agencyFeePayable', () => {
+    it.each([
+      ['honorarios no incluidos en el precio, se pagan aparte', 'ES'],
+      ['nuestros honorarios son de una mensualidad', 'ES'],
+      ['fianza de dos meses y un mes de honorarios de agencia', 'ES'],
+      ['contact us for a viewing, agency fee applies', 'EN'],
+      ['zzgl. maklerprovision von einer monatsmiete', 'DE'],
+      ['richiesta commissione di agenzia pari a una mensilita', 'IT'],
+      ['loyer 800 euros plus frais d agence a charge du locataire', 'FR'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).agencyFeePayable).toBe(true);
+    });
+
+    it.each([
+      // "no fee to tenant" — 22 real vetoed hits
+      'alquiler de vivienda habitual, sin honorarios de agencia para el inquilino',
+      'no se repercute ningun tipo de honorarios al inquilino',
+      'honorarios incluidos, sin gastos adicionales',
+      // "provision" = utility charges, NOT a Maklerprovision — 59 real hits
+      'provision de 150 euros por calefaccion, agua y luz',
+      '150 euros de provision mensual de agua, luz y gas',
+      // bare "commission" is a landmark / a monthly charge, never a trigger
+      'the european commission is 4 km away from the apartment',
+      'monthly commission 175 euro per month including heating and water',
+    ])('does NOT flag vetoed / non-agency phrasing "%s"', (text) => {
+      expect(flag(text).agencyFeePayable).toBeUndefined();
+    });
+  });
+
+  describe('noPets', () => {
+    it.each([
+      ['con ascensor, no se admiten mascotas y se pide solvencia', 'ES'],
+      ['comunidad incluida. no animales.', 'ES'],
+      ['bright apartment, sorry no pets', 'EN'],
+      ['schone wohnung, keine haustiere', 'DE'],
+      ['appartamento arredato, animali non ammessi', 'IT'],
+      ['bel appartement, pas d animaux', 'FR'],
+      ['ruim appartement, geen huisdieren', 'NL'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).noPets).toBe(true);
+    });
+
+    it.each([
+      // Pets ALLOWED — 220 real listings say this; must never flag
+      'apartamento amplio, se admiten mascotas sin problema',
+      'pet friendly building, pets are welcome',
+      'zona tranquila con parque para pasear a tu mascota',
+    ])('does NOT flag pet-friendly phrasing "%s"', (text) => {
+      expect(flag(text).noPets).toBeUndefined();
+    });
+  });
+
+  describe('noSmoking', () => {
+    it.each([
+      ['personas cuidadosas, no fumadores', 'ES'],
+      ['this apartment is allergy-free and non-smoking', 'EN'],
+      ['gemutliche wohnung fur nichtraucher', 'DE'],
+      ['appartamento per non fumatori', 'IT'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).noSmoking).toBe(true);
+    });
+
+    it('does NOT flag a listing that merely mentions a terrace', () => {
+      expect(flag('gran terraza exterior donde disfrutar del sol').noSmoking).toBeUndefined();
+    });
+  });
+
+  describe('noCouples', () => {
+    it.each([
+      ['sorry but no couples/room shares or pets', 'EN'],
+      ['habitacion individual, no parejas', 'ES'],
+      ['single occupancy only, quiet professional preferred', 'EN'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).noCouples).toBe(true);
+    });
+
+    it('does NOT flag a listing ideal for couples', () => {
+      expect(flag('acogedor apartamento ideal para parejas').noCouples).toBeUndefined();
+    });
+  });
+
+  describe('noDSS', () => {
+    it.each([
+      ['professional tenants only, no dss', 'EN'],
+      ['sorry, no housing benefit accepted', 'EN'],
+    ])('flags "%s" (%s)', (text) => {
+      expect(flag(text).noDSS).toBe(true);
+    });
+
+    it('does NOT flag "great benefits nearby"', () => {
+      expect(flag('lots of great benefits nearby including shops and transport').noDSS).toBeUndefined();
+    });
+  });
+
+  describe('combinations, accents and title', () => {
+    it('sets multiple flags from one description', () => {
+      const flags = flag(
+        'se alquilan habitaciones en piso compartido, exclusivamente para estudiantes, solo chicas. no se admiten mascotas.',
+      );
+      expect(flags.roomNotFullUnit).toBe(true);
+      expect(flags.studentsOnly).toBe(true);
+      expect(flags.genderRestricted).toBe(true);
+      expect(flags.noPets).toBe(true);
+    });
+
+    it('matches regardless of accents / casing / line breaks', () => {
+      const flags = classifyListingContent('No se ADMITEN\nMáscotas.\nSólo estudiantes.');
+      expect(flags.noPets).toBe(true);
+      expect(flags.studentsOnly).toBe(true);
+    });
+
+    it('also reads the optional title argument', () => {
+      const flags = classifyListingContent('bright and modern', 'Room for rent in shared flat');
+      expect(flags.roomNotFullUnit).toBe(true);
+    });
+  });
+
+  describe('detectedLanguage', () => {
+    it.each([
+      [
+        'es',
+        'se alquila esta preciosa vivienda con dos dormitorios, cocina amueblada y bano completo en una zona muy tranquila cerca del centro comercial',
+      ],
+      [
+        'en',
+        'this bright apartment features two bedrooms and a modern kitchen, located very close to the station with all the amenities the property offers',
+      ],
+      [
+        'fr',
+        'ce bel appartement avec deux chambres et une cuisine equipee est situe tres proche du centre, la salle de bain est renovee et le loyer est raisonnable',
+      ],
+      [
+        'nl',
+        'dit ruime appartement met twee slaapkamers en een keuken is zeer gunstig gelegen nabij het centrum, de woning heeft ook een mooie badkamer',
+      ],
+      [
+        'de',
+        'diese schone wohnung mit zwei schlafzimmern und einer kuche liegt sehr zentral gelegen, das zimmer ist hell und die grosse terrasse gehort dazu',
+      ],
+      [
+        'it',
+        'questa luminosa appartamento con camera e cucina si trova molto vicino al centro, il soggiorno e ampio e della zona molto tranquilla al piano terra',
+      ],
+      [
+        'ca',
+        'aquest habitatge amb dues habitacions i cuina equipada esta situat molt a prop del centre, el pis es gran i lloguer amb bany reformat als afores',
+      ],
+    ])('detects %s', (lang, text) => {
+      expect(classifyListingContent(text).detectedLanguage).toBe(lang);
+    });
+
+    it('leaves short / ambiguous text unlabeled', () => {
+      expect(classifyListingContent('piso centro').detectedLanguage).toBeUndefined();
+      expect(classifyListingContent('123 456 789 000 111 222 333 444 555 666 777').detectedLanguage).toBeUndefined();
+    });
+  });
+});

--- a/packages/backend/__tests__/unit/gbProviders.test.ts
+++ b/packages/backend/__tests__/unit/gbProviders.test.ts
@@ -95,8 +95,8 @@ describe('RightmoveProvider', () => {
     expect(listing.remoteImages.length).toBeGreaterThan(0);
     // sizings[] → squareFootage in m² (prefers the native sqm entry).
     expect(listing.squareFootage).toBe(79);
-    // keyFeatures[] → amenities (ingest derives hasGarden/hasBalcony/hasElevator/parking).
-    expect(listing.amenities).toEqual(['Garden', 'Off street parking', 'Balcony', 'Lift']);
+    // keyFeatures[] → canonical amenities (ingest derives hasGarden/hasBalcony/hasElevator/parking).
+    expect(listing.amenities).toEqual(['garden', 'parking', 'balcony', 'elevator']);
     // letting.furnishType → furnishedStatus.
     expect(listing.furnishedStatus).toBe('furnished');
   });

--- a/packages/backend/__tests__/unit/htmlText.test.ts
+++ b/packages/backend/__tests__/unit/htmlText.test.ts
@@ -68,7 +68,8 @@ describe('sanitizeNormalizedListingTextFields', () => {
     sanitizeNormalizedListingTextFields(listing);
 
     expect(listing.description).toBe('Council Tax Band: E\n\nGuidance only');
-    expect(listing.amenities).toEqual(['Garden', 'Parking']);
+    // HTML-stripped, then canonicalized onto the shared amenity vocabulary.
+    expect(listing.amenities).toEqual(['garden', 'parking']);
     expect(listing.contact?.name).toBe('Jane Doe');
     expect(listing.contact?.agencyName).toBe('Savills & Co');
     expect(listing.remoteImages[0]?.caption).toBe('Living room');

--- a/packages/backend/__tests__/unit/pisosProvider.test.ts
+++ b/packages/backend/__tests__/unit/pisosProvider.test.ts
@@ -47,7 +47,9 @@ describe('PisosProvider.normalize', () => {
     expect(listing.contact?.phone).toBe('919376345');
     expect(listing.contact?.kind).toBe('agency');
     expect(listing.remoteImages.length).toBeGreaterThan(0);
-    expect(listing.amenities).toEqual(expect.arrayContaining(['ascensor', 'balcon', 'soleado']));
+    // Raw ES slugs canonicalized (`ascensor`→elevator, `balcon`→balcony); the
+    // non-amenity `soleado` is dropped.
+    expect(listing.amenities).toEqual(['elevator', 'balcony']);
     expect(listing.address.city).toBe('Madrid Capital');
     expect(listing.address.coordinates).toEqual({ lat: 40.41593545782718, lng: -3.7083892232908435 });
   });

--- a/packages/backend/models/Property.ts
+++ b/packages/backend/models/Property.ts
@@ -39,6 +39,35 @@ export interface IProperty extends Document {
     agencyName?: string;
     kind?: 'owner' | 'agency' | 'private' | 'unknown';
   };
+  /**
+   * Restriction/nuance flags derived from the listing's free text at ingest by
+   * `classifyListingContent` (external listings only). Portals bury these in
+   * prose instead of structured fields; only flags that fire are present.
+   */
+  listingFlags?: {
+    /** Rental restricted to students ("solo estudiantes", "students only"). */
+    studentsOnly?: boolean;
+    /** Advertised as a flat but the body rents a single room / a share. */
+    roomNotFullUnit?: boolean;
+    /** Seasonal / temporary lease ("temporada", "short let"), not a home. */
+    temporaryOnly?: boolean;
+    /** Restricted to one gender ("solo chicas", "women only"). */
+    genderRestricted?: boolean;
+    /** Requires proof of employment/income ("nómina", "working professionals only"). */
+    workersOnly?: boolean;
+    /** An agency fee is payable by the tenant/buyer ("honorarios de agencia"). */
+    agencyFeePayable?: boolean;
+    /** Pets not allowed ("no se admiten mascotas", "no pets"). */
+    noPets?: boolean;
+    /** Smoking not allowed ("no fumadores", "non-smoking"). */
+    noSmoking?: boolean;
+    /** No couples ("no parejas", "no couples"). */
+    noCouples?: boolean;
+    /** UK: no housing benefit ("no DSS"). */
+    noDSS?: boolean;
+    /** Best-effort detected description language (ISO 639-1). */
+    detectedLanguage?: 'es' | 'ca' | 'en' | 'fr' | 'nl' | 'de' | 'it';
+  };
   expiresAt?: Date;
   type: PropertyType;
   housingType?: HousingType;

--- a/packages/backend/models/schemas/PropertySchema.ts
+++ b/packages/backend/models/schemas/PropertySchema.ts
@@ -289,6 +289,27 @@ const propertySchema = new mongoose.Schema({
     }, { _id: false }),
     required: false,
   },
+  /**
+   * Restriction/nuance flags derived from the listing free text at ingest by
+   * `classifyListingContent` (external listings only). Sparse — only firing
+   * flags are stored. See `services/ingestion/classifyListingContent.ts`.
+   */
+  listingFlags: {
+    type: new mongoose.Schema({
+      studentsOnly: { type: Boolean },
+      roomNotFullUnit: { type: Boolean },
+      temporaryOnly: { type: Boolean },
+      genderRestricted: { type: Boolean },
+      workersOnly: { type: Boolean },
+      agencyFeePayable: { type: Boolean },
+      noPets: { type: Boolean },
+      noSmoking: { type: Boolean },
+      noCouples: { type: Boolean },
+      noDSS: { type: Boolean },
+      detectedLanguage: { type: String, enum: ['es', 'ca', 'en', 'fr', 'nl', 'de', 'it'] },
+    }, { _id: false }),
+    required: false,
+  },
   expiresAt: {
     type: Date,
     index: { expireAfterSeconds: 0 }, // TTL index; document auto-removed after this date

--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -32,6 +32,7 @@ import { validateOfferings } from '../../models/schemas/offeringValidation';
 import { forwardGeocode, reverseGeocode } from '../geocodingService';
 import { sanitizeGeoJsonCoordinates } from '../../utils/geoCoordinates';
 import { deriveStructuredFeatures } from './deriveFeatures';
+import { classifyListingContent } from './classifyListingContent';
 import { ExternalMediaIngest } from './ExternalMediaIngest';
 import { schedulePriceEthicsScore } from '../priceEthicsService';
 import { Logger } from '../../utils/logger';
@@ -297,6 +298,13 @@ export class IngestionService {
     if (parkingType !== undefined) fields.parkingType = parkingType;
     const furnishedStatus = listing.furnishedStatus ?? derived.furnishedStatus;
     if (furnishedStatus !== undefined) fields.furnishedStatus = furnishedStatus;
+
+    // Classify the free-text description into restriction/nuance flags portals
+    // never expose structurally (students-only, room-not-full-unit, temporary,
+    // agency fee, …). Runs on the full pre-truncation description. Only stored
+    // when at least one flag or a detected language fires.
+    const listingFlags = classifyListingContent(listing.description);
+    if (Object.keys(listingFlags).length > 0) fields.listingFlags = listingFlags;
 
     if (listing.contact) {
       const externalContact: NonNullable<IProperty['externalContact']> = {};

--- a/packages/backend/services/ingestion/classifyListingContent.ts
+++ b/packages/backend/services/ingestion/classifyListingContent.ts
@@ -1,0 +1,469 @@
+/**
+ * Classify the *free-text* of an external listing (description + title) into a
+ * set of structured restriction/nuance flags that portals almost never expose
+ * as structured fields, but routinely bury in prose.
+ *
+ * Real-world motivation (measured on ~5,600 live prod listings across pisos,
+ * fotocasa, habitaclia, immoweb and rightmove — ES/CA/EN/FR/NL):
+ * - A `type: apartment` listing whose body actually rents a single ROOM in a
+ *   shared flat ("se alquilan habitaciones en piso compartido") — the classic
+ *   bait-and-switch (~1.5% of the corpus).
+ * - Seasonal / temporary leases ("alquiler de temporada", "short let") sold as
+ *   a normal apartment (~18% of the ES corpus).
+ * - Hard tenant restrictions: students only, one gender only, employed/nómina
+ *   only, no pets, no smoking, no couples, no DSS.
+ * - An agency fee payable by the tenant ("honorarios de agencia").
+ *
+ * This is a DETERMINISTIC keyword/regex classifier — zero per-listing cost, no
+ * network, no model. It runs multi-language over normalized (deaccented,
+ * lowercased, whitespace-collapsed) text with word boundaries to avoid the
+ * substring traps that a naive `includes()` would hit (e.g. "estudio" vs
+ * "estudiante", "provisión de gastos" vs German "Maklerprovision").
+ *
+ * Every rule below was validated against the real corpus; the guard comments
+ * cite the concrete false positive each pattern is written to avoid.
+ */
+
+import { deaccent } from '@homiio/listing-providers';
+import type { IProperty } from '../../models/Property';
+
+/** Classifier output — the schema authority is `IProperty['listingFlags']`. */
+export type ListingFlags = NonNullable<IProperty['listingFlags']>;
+
+/** Languages the deterministic detector can distinguish (ISO 639-1). */
+type DetectedLanguage = NonNullable<ListingFlags['detectedLanguage']>;
+
+/** Boolean flag keys (everything on `ListingFlags` except `detectedLanguage`). */
+type FlagKey = Exclude<keyof ListingFlags, 'detectedLanguage'>;
+
+interface FlagRule {
+  readonly flag: FlagKey;
+  /** Any trigger match sets the flag… */
+  readonly triggers: readonly RegExp[];
+  /** …unless a veto matches (used only where a phrase can be explicitly negated). */
+  readonly vetoes?: readonly RegExp[];
+}
+
+/**
+ * `deaccent` already lowercases + strips diacritics + trims; we additionally
+ * collapse all whitespace runs to single spaces so multi-token phrases match
+ * across line breaks ("no se admiten\nmascotas").
+ */
+function normalizeText(raw: string): string {
+  return deaccent(raw).replace(/\s+/g, ' ');
+}
+
+const RULES: readonly FlagRule[] = [
+  {
+    // studentsOnly — a genuine restriction, NOT mere suitability. Bare
+    // "para estudiantes" is deliberately excluded: 47 real listings say
+    // "para estudiantes O (jovenes) profesionales/trabajadores/familias"
+    // (open to everyone). We require an exclusivity marker (solo / exclusivo
+    // para / unicamente / reservado / only) or a dedicated-student-housing
+    // noun (residencia de estudiantes / student residence / Studentenwohnheim).
+    flag: 'studentsOnly',
+    triggers: [
+      // ES / CA
+      /\b(?:solo|solamente|unicamente|exclusivamente)\s+(?:para\s+)?estudiantes?\b/,
+      /\bexclusiv[oa]s?\s+(?:para\s+)?estudiantes?\b/,
+      /\breservad[oa]s?\s+(?:a|para)\s+estudiantes?\b/,
+      /\bresidencia\s+(?:de\s+estudiantes|universitaria|para\s+estudiantes)\b/,
+      /\b(?:nomes|nomes\s+per\s+a|exclusiu\s+per\s+a|reservat\s+a)\s+estudiants?\b/,
+      // EN
+      /\bstudents?\s+only\b/,
+      /\bonly\s+(?:for\s+)?students?\b/,
+      /\bstudent\s+(?:residence|accommodation|housing|halls?)\b/,
+      // DE
+      /\bnur\s+(?:fur\s+)?studenten\b/,
+      /\bstudentenwohnheim\b/,
+      // IT
+      /\bsolo\s+studenti\b/,
+      /\b(?:riservato|esclusivamente)\s+(?:a\s+|agli\s+)?studenti\b/,
+      // FR
+      /\breserve[e]?\s+aux\s+etudiants?\b/,
+      /\betudiants?\s+(?:uniquement|seulement)\b/,
+      /\buniquement\s+(?:pour\s+|des\s+)?etudiants?\b/,
+      /\bresidence\s+etudiante\b/,
+      // NL
+      /\balleen\s+(?:voor\s+)?studenten\b/,
+      /\bstudentenkamer\b/,
+      /\bstudentenhuis\b/,
+    ],
+  },
+  {
+    // roomNotFullUnit — advertised as a flat/apartment but the body rents a
+    // ROOM or a share. High precision required: "el piso son 3 habitaciones"
+    // (bedroom COUNT) must NOT match, and "se alquila piso de 3 habitaciones"
+    // (whole flat) must NOT match. Achieved via a negative lookahead that
+    // blocks a whole-unit noun right after the rent verb, and by never keying
+    // off bare "habitacion"/"compartir piso" (110 real "para compartir …" hits
+    // describe renting the WHOLE flat to a group).
+    flag: 'roomNotFullUnit',
+    triggers: [
+      // ES: rent-verb directly (or a count/adjective) followed by "habitaci",
+      // but never when the first token is a whole-unit noun.
+      /\b(?:se\s+alquilan?|alquilo|alquilamos|alquilan)\s+(?!(?:piso|apartamento|departamento|vivienda|casa|chalet|estudio|local|duplex|atico|planta|nave|oficina|plaza|garaje|parking|trastero)\b)(?:\w+\s+){0,2}?habitaci/,
+      /\balquiler\s+de\s+habitaci/,
+      /\bhabitaci\w*\s+en\s+alquiler\b/,
+      /\bpiso\s+compartido\b/,
+      /\bhabitaci\w*\s+en\s+(?:un\s+|una\s+)?piso\s+compartid/,
+      // CA
+      /\bpis\s+compartit\b/,
+      /\bllogo?\s+habitaci/,
+      // EN
+      /\brooms?\s+(?:for\s+rent|to\s+(?:rent|let)|available)\b/,
+      /\broom\s+in\s+(?:a\s+|the\s+)?shared\b/,
+      /\bshared\s+(?:flat|house|apartment|accommodation)\b/,
+      /\b(?:house|flat)\s?share\b/,
+      /\bco-?living\b/,
+      // DE
+      /\bwg-?zimmer\b/,
+      /\bzimmer\s+in\s+(?:einer\s+)?(?:wg|wohngemeinschaft)\b/,
+      /\bin\s+einer\s+wg\b/,
+      /\bwohngemeinschaft\b/,
+      // IT
+      /\bposto\s+letto\b/,
+      /\bstanza\s+(?:singola|doppia|in\s+affitto|in\s+appartamento)\b/,
+      /\bappartamento\s+condiviso\b/,
+      /\bcamera\s+in\s+appartamento\s+condiviso\b/,
+      // FR
+      /\bchambre\s+en\s+colocation\b/,
+      /\bcolocation\b/,
+      /\bchambre\s+dans\s+(?:un\s+)?(?:appartement|coloc)\b/,
+      // NL
+      /\bkamer\s+(?:te\s+huur|in\s+(?:een\s+)?(?:gedeeld|studentenhuis))\b/,
+      /\bgedeeld\s+appartement\b/,
+    ],
+    // Explicit whole-unit disclaimers ("no se alquila POR habitaciones sueltas",
+    // "no se alquilan habitaciones por separado") mean the opposite of a room
+    // let — 3 real prod listings that the rent-verb trigger would otherwise trip.
+    vetoes: [/\bno\s+se\s+alquilan?\s+(?:por\s+)?habitaci/],
+  },
+  {
+    // temporaryOnly — seasonal/temporary lease, not a permanent home. In Spain
+    // "alquiler de temporada" is a legally distinct non-primary-residence lease;
+    // "temporada baja/alta" (vacation pricing) and "temporada larga sept-junio"
+    // (academic year) are both non-permanent. Guarded against the rare
+    // "cuatro/todas las temporadas" (climate/name) even though the corpus had 0.
+    flag: 'temporaryOnly',
+    triggers: [
+      // ES / CA
+      /\btemporada\b/,
+      /\balquiler\s+temporal\b/,
+      /\bcontrato\s+de\s+temporada\b/,
+      /\bpor\s+meses\b/,
+      /\b(?:corta|media)\s+estancia\b/,
+      /\bvacacional\b/,
+      // EN
+      /\bshort[\s-]?let\b/,
+      /\bshort[\s-]?term\s+(?:let|rental|tenancy|stay)\b/,
+      /\btemporary\s+(?:let|rental|accommodation|tenancy)\b/,
+      /\bholiday\s+(?:let|rental|home)\b/,
+      /\bseasonal\s+(?:let|rental)\b/,
+      /\bshort\s+stay\b/,
+      // DE
+      /\bzwischenmiete\b/,
+      /\bauf\s+zeit\b/,
+      /\bbefristet\w*\b/,
+      /\bzeitmietvertrag\b/,
+      // IT
+      /\btemporaneo\b/,
+      /\baffitto\s+breve\b/,
+      /\buso\s+transitorio\b/,
+      /\btransitorio\b/,
+      // FR
+      /\blocation\s+saisonniere\b/,
+      /\bcourt\s+sejour\b/,
+      /\bbail\s+mobilite\b/,
+      /\bcourte\s+duree\b/,
+      /\bsaisonnier\w*\b/,
+      // NL
+      /\btijdelijk\w*\b/,
+      /\bkort\s+verblijf\b/,
+    ],
+    vetoes: [/\b(?:cuatro|4|todas\s+las|las\s+cuatro)\s+temporadas?\b/],
+  },
+  {
+    // genderRestricted — one gender only.
+    flag: 'genderRestricted',
+    triggers: [
+      // ES / CA
+      /\bsolo\s+(?:para\s+)?(?:chicas?|chicos?|mujeres?|hombres?|femenino|masculino)\b/,
+      /\bunicamente\s+(?:chicas?|chicos?|mujeres?|hombres?)\b/,
+      /\bsolo\s+(?:noies?|nois?|dones?|homes?)\b/,
+      // EN
+      /\b(?:women|woman|female|females|ladies|girls?|men|man|male|males|boys?)\s+only\b/,
+      /\bonly\s+(?:women|females?|girls?|men|males?)\b/,
+      // DE
+      /\bnur\s+(?:frauen|manner)\b/,
+      // IT
+      /\bsolo\s+(?:ragazze|ragazzi|donne|uomini)\b/,
+      // FR
+      /\b(?:femmes?|hommes?)\s+(?:uniquement|seulement)\b/,
+      /\buniquement\s+(?:pour\s+)?(?:femmes?|hommes?)\b/,
+      // NL
+      /\balleen\s+(?:vrouwen|mannen|dames|meisjes)\b/,
+    ],
+  },
+  {
+    // workersOnly / nominaRequired — proof of stable employment/income required,
+    // which de-facto excludes students/unemployed. "nomina" (payslip) is the
+    // single most reliable ES signal (37/37 real hits were income requirements).
+    flag: 'workersOnly',
+    triggers: [
+      // ES / CA
+      /\bsolo\s+(?:para\s+)?trabajadores?\b/,
+      /\btrabajadores?\s+con\s+nomina\b/,
+      /\bnominas?\b/,
+      /\bcontrato\s+de\s+trabajo\b/,
+      /\bvida\s+laboral\b/,
+      /\bcontrato\s+(?:fijo|indefinido)\b/,
+      // EN
+      /\bworking\s+professionals?\s+only\b/,
+      /\bprofessionals?\s+only\b/,
+      /\bworking\s+tenants?\s+only\b/,
+      /\bin\s+full[\s-]?time\s+employment\b/,
+      /\bproof\s+of\s+(?:income|employment)\b/,
+      /\bemployed\s+(?:applicants?|tenants?)\b/,
+      // DE
+      /\bberufstatig\w*\b/,
+      /\beinkommensnachweis\b/,
+      /\bgehaltsnachweis\b/,
+      // IT
+      /\bsolo\s+lavoratori\b/,
+      /\bbusta\s+paga\b/,
+      /\bcontratto\s+di\s+lavoro\b/,
+      // FR
+      /\bfiche\s+de\s+paie\b/,
+      /\bcontrat\s+de\s+travail\b/,
+      /\btravailleurs?\s+(?:uniquement|seulement)\b/,
+      /\bjustificatif\s+de\s+revenus?\b/,
+      // NL
+      /\bloonstrook\b/,
+      /\barbeidscontract\b/,
+    ],
+  },
+  {
+    // agencyFeePayable — a fee the TENANT/buyer pays to the agency. Conservative
+    // on purpose. Two big real-corpus traps are guarded:
+    //  1. bare "provision"/"commission" is NEVER a trigger — 59 ES hits were
+    //     "provision de gastos/agua/luz" (utility charges) and immoweb had
+    //     "european commission" (a landmark) + "monthly commission … heating".
+    //     Only agency-scoped forms (maklerprovision, commissione di agenzia,
+    //     commission d'agence) count.
+    //  2. ES vetoes the explicit "no fee to tenant" statements (22 real hits:
+    //     "sin honorarios de agencia para el inquilino", "no se repercute …
+    //     honorarios al inquilino", "honorarios incluidos"). Note the veto does
+    //     NOT swallow "honorarios NO incluidos en el precio" (fee IS payable).
+    flag: 'agencyFeePayable',
+    triggers: [
+      // ES / CA
+      /\bhonorarios\b/,
+      /\bgastos\s+de\s+agencia\b/,
+      /\bcomision\s+de\s+agencia\b/,
+      // EN
+      /\bagency\s+fee\b/,
+      /\badmin(?:istration)?\s+fee\b/,
+      /\b(?:tenancy|letting)\s+fee\b/,
+      // DE
+      /\bmaklerprovision\b/,
+      /\bmakler-?courtage\b/,
+      /\bmaklergebuhr\b/,
+      // IT
+      /\bcommissione\s+(?:di\s+)?agenzia\b/,
+      /\bspese\s+di\s+agenzia\b/,
+      // FR
+      /\bfrais\s+d\s?agence\b/,
+      /\bhonoraires\s+(?:d\s?agence|de\s+location)\b/,
+      // NL
+      /\bmakelaarsloon\b/,
+      /\bmakelaarskosten\b/,
+    ],
+    vetoes: [
+      /\bsin\s+honorarios\b/,
+      /\bno\s+honorarios\b/,
+      /\bhonorarios\s+incluidos\b/,
+      /\bsin\s+comision\b/,
+      /\bsin\s+gastos\s+de\s+agencia\b/,
+      /\bno\s+se\s+repercut\w+[^.]{0,40}\bhonorarios\b/,
+      /\bhonorarios\b[^.]{0,40}no\s+se\s+repercut/,
+    ],
+  },
+  {
+    // noPets — anchored negatives only, so "se admiten mascotas" (pets ALLOWED,
+    // 220 real listings) never matches.
+    flag: 'noPets',
+    triggers: [
+      // ES / CA
+      /\bno\s+se\s+(?:admiten|permiten|aceptan)\s+(?:mascotas|animales)\b/,
+      /\bno\s+(?:mascotas|animales)\b/,
+      /\bsin\s+mascotas\b/,
+      /\bprohibid[oa]s?\s+(?:mascotas|animales)\b/,
+      /\bno\s+es\s+(?:admeten|accepten)\s+(?:mascotes|animals)\b/,
+      /\bsense\s+mascotes\b/,
+      // EN
+      /\bno\s+pets\b/,
+      /\bpets?\s+(?:are\s+)?not\s+(?:allowed|permitted|accepted)\b/,
+      /\bno\s+animals\b/,
+      // DE
+      /\bkeine\s+(?:haus)?tiere\b/,
+      /\bhaustiere\s+nicht\s+(?:erlaubt|gestattet)\b/,
+      // IT
+      /\bno\s+animali\b/,
+      /\bnon\s+si\s+accettano\s+animali\b/,
+      /\banimali\s+non\s+ammessi\b/,
+      // FR
+      /\bpas\s+d\s?animaux\b/,
+      /\banimaux\s+non\s+(?:admis|acceptes|autorises)\b/,
+      // NL
+      /\bgeen\s+huisdieren\b/,
+      /\bhuisdieren\s+niet\s+toegestaan\b/,
+    ],
+  },
+  {
+    // noSmoking — anchored negatives only.
+    flag: 'noSmoking',
+    triggers: [
+      // ES / CA
+      /\bno\s+fumadores\b/,
+      /\bno\s+se\s+(?:admiten|permite)\s+fumar\b/,
+      /\bprohibido\s+fumar\b/,
+      /\bno\s+fumar\b/,
+      // EN
+      /\bnon[\s-]?smok\w*\b/,
+      /\bno\s+smoking\b/,
+      /\bsmoking\s+not\s+(?:allowed|permitted)\b/,
+      // DE
+      /\bnichtraucher\w*\b/,
+      // IT
+      /\bnon\s+fumatori\b/,
+      /\bvietato\s+fumare\b/,
+      // FR
+      /\bnon[\s-]?fumeur\w*\b/,
+      /\binterdiction\s+de\s+fumer\b/,
+      // NL
+      /\bniet\s+roken\b/,
+      /\brookvrij\b/,
+    ],
+  },
+  {
+    // noCouples — single occupancy / no couples.
+    flag: 'noCouples',
+    triggers: [
+      /\bno\s+(?:se\s+admiten\s+)?parejas\b/,
+      /\bno\s+couples\b/,
+      /\bcouples?\s+not\s+(?:allowed|accepted|permitted)\b/,
+      /\bsingle\s+(?:occupancy|person)\s+only\b/,
+    ],
+  },
+  {
+    // noDSS — UK "no housing benefit". Tight patterns so "no benefits included"
+    // (no perks) never matches.
+    flag: 'noDSS',
+    triggers: [
+      /\bno\s+dss\b/,
+      /\bdss\s+not\s+accepted\b/,
+      /\bno\s+housing\s+benefit\b/,
+      /\bhousing\s+benefit\s+not\s+accepted\b/,
+    ],
+  },
+];
+
+/**
+ * Distinctive stopword/vocabulary tokens per language. Deliberately biased to
+ * tokens that separate the confusable pairs (ES↔CA via "amb/aquest/habitatge",
+ * ES↔FR/IT via distinct articles) rather than shared ones like "la".
+ */
+const LANGUAGE_TOKENS: Readonly<Record<DetectedLanguage, readonly string[]>> = {
+  es: [
+    'el', 'los', 'las', 'con', 'para', 'esta', 'este', 'muy', 'vivienda',
+    'dormitorio', 'cocina', 'bano', 'amueblado', 'alquiler', 'zona', 'planta',
+  ],
+  ca: [
+    'amb', 'aquest', 'aquesta', 'aquests', 'aquestes', 'habitatge', 'lloguer',
+    'cuina', 'bany', 'situat', 'molt', 'gran', 'planta', 'als', 'pis',
+  ],
+  en: [
+    'the', 'and', 'with', 'this', 'for', 'apartment', 'bedroom', 'kitchen',
+    'located', 'available', 'features', 'property', 'very', 'floor',
+  ],
+  fr: [
+    'le', 'les', 'avec', 'pour', 'cette', 'appartement', 'chambre', 'cuisine',
+    'situe', 'proche', 'loyer', 'salle', 'sejour', 'tres',
+  ],
+  nl: [
+    'het', 'een', 'met', 'deze', 'voor', 'appartement', 'slaapkamer', 'keuken',
+    'gelegen', 'nabij', 'badkamer', 'zeer', 'woning', 'ruime',
+  ],
+  de: [
+    'das', 'die', 'der', 'mit', 'fur', 'diese', 'wohnung', 'schlafzimmer',
+    'kuche', 'zimmer', 'gelegen', 'sehr', 'sich', 'grosse',
+  ],
+  it: [
+    'il', 'con', 'per', 'questa', 'appartamento', 'camera', 'cucina', 'situato',
+    'vicino', 'molto', 'della', 'soggiorno', 'luminoso', 'piano',
+  ],
+};
+
+const LANGUAGE_KEYS = Object.keys(LANGUAGE_TOKENS) as DetectedLanguage[];
+
+/**
+ * Best-effort deterministic language detection via a bag-of-stopwords vote.
+ * Returns `undefined` unless one language both clears a minimum score and beats
+ * the runner-up by a clear margin — ambiguous/short text stays unlabeled rather
+ * than guessing.
+ */
+function detectLanguage(normalized: string): DetectedLanguage | undefined {
+  const tokens = normalized.split(/[^a-z0-9]+/).filter(Boolean);
+  if (tokens.length < 12) return undefined;
+
+  const counts = new Map<string, number>();
+  for (const token of tokens) counts.set(token, (counts.get(token) ?? 0) + 1);
+
+  let best: DetectedLanguage | undefined;
+  let bestScore = 0;
+  let secondScore = 0;
+  for (const lang of LANGUAGE_KEYS) {
+    let score = 0;
+    for (const word of LANGUAGE_TOKENS[lang]) score += counts.get(word) ?? 0;
+    if (score > bestScore) {
+      secondScore = bestScore;
+      bestScore = score;
+      best = lang;
+    } else if (score > secondScore) {
+      secondScore = score;
+    }
+  }
+
+  if (bestScore < 4) return undefined;
+  if (bestScore < secondScore * 1.3) return undefined;
+  return best;
+}
+
+/**
+ * Classify a listing's free text into structured restriction/nuance flags.
+ * Only flags that fire are present on the result (sparse), plus an optional
+ * `detectedLanguage`. Returns an empty object when there is nothing to classify.
+ */
+export function classifyListingContent(
+  description?: string | null,
+  title?: string | null,
+): ListingFlags {
+  const combined = `${title ?? ''} ${description ?? ''}`.trim();
+  if (!combined) return {};
+
+  const normalized = normalizeText(combined);
+  if (!normalized) return {};
+
+  const flags: ListingFlags = {};
+  for (const rule of RULES) {
+    if (!rule.triggers.some((re) => re.test(normalized))) continue;
+    if (rule.vetoes && rule.vetoes.some((re) => re.test(normalized))) continue;
+    flags[rule.flag] = true;
+  }
+
+  const detectedLanguage = detectLanguage(normalized);
+  if (detectedLanguage) flags.detectedLanguage = detectedLanguage;
+
+  return flags;
+}

--- a/packages/backend/worker.ts
+++ b/packages/backend/worker.ts
@@ -65,6 +65,19 @@ const FETCH_CONCURRENCY = parseInt(process.env.LISTING_FETCH_CONCURRENCY || '6',
  */
 const DISCOVER_CONCURRENCY = parseInt(process.env.LISTING_DISCOVER_CONCURRENCY || '3', 10);
 
+/**
+ * Per-city ES portals emit thousands of fetch jobs per pass. Give their fetch a
+ * LOWER priority so the handful of jobs from a smaller provider (immobilienscout24,
+ * mercadolibre, otodom, …) isn't stuck behind that backlog — every provider makes
+ * progress instead of the big three starving the rest. BullMQ: lower number = higher
+ * priority; both are >0 so neither falls into the unprioritised (top) lane.
+ */
+const HIGH_VOLUME_PROVIDERS = new Set(['fotocasa', 'habitaclia', 'pisos']);
+const FETCH_PRIORITY_HIGH = 10;
+const FETCH_PRIORITY_LOW = 100;
+const fetchPriorityFor = (provider: string): number =>
+  HIGH_VOLUME_PROVIDERS.has(provider) ? FETCH_PRIORITY_LOW : FETCH_PRIORITY_HIGH;
+
 /** Discover jobs may hold a browser session across many cities — match worker lockDuration. */
 const DISCOVER_LOCK_MS = 600_000;
 
@@ -359,6 +372,7 @@ async function startBullMq(): Promise<() => Promise<void>> {
         }
         await fetchQueue.add(QUEUE_NAMES.fetch, { ref }, {
           jobId,
+          priority: fetchPriorityFor(ref.provider),
           attempts: 3,
           backoff: { type: 'exponential', delay: 60_000 },
         });

--- a/packages/frontend/components/PropertyCard.tsx
+++ b/packages/frontend/components/PropertyCard.tsx
@@ -556,10 +556,10 @@ export function PropertyCard({
               </View>
             </>
           )}
-          {variant === 'compact' && propertyData.type && (
+          {variant === 'compact' && typeMeta && (
             <>
               <ThemedText style={styles.featureSeparator}>•</ThemedText>
-              <ThemedText style={styles.featureText}>{propertyData.type}</ThemedText>
+              <ThemedText style={styles.featureText}>{typeMeta.label}</ThemedText>
             </>
           )}
         </View>

--- a/packages/frontend/components/SearchFiltersBottomSheet.tsx
+++ b/packages/frontend/components/SearchFiltersBottomSheet.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FiltersBottomSheet, FilterSection, FilterValue } from '@/components/FiltersBar/FiltersBottomSheet';
 import { useRentalMode } from '@/context/RentalModeContext';
+import { getAmenityById } from '@/constants/amenities';
 import { CancellationPolicy } from '@homiio/shared-types';
 
 /**
@@ -235,11 +236,14 @@ export function SearchFiltersBottomSheet({
             id: 'amenities',
             title: t('Amenities'),
             type: 'chips',
-            options: AMENITIES.map((amenity) => ({
-                id: amenity,
-                label: t(amenity.replace('_', ' ')),
-                value: amenity,
-            })),
+            options: AMENITIES.map((amenity) => {
+                const nameKey = getAmenityById(amenity)?.nameKey;
+                return {
+                    id: amenity,
+                    label: nameKey ? t(nameKey) : amenity,
+                    value: amenity,
+                };
+            }),
             value: filters.amenities,
         });
 

--- a/packages/frontend/components/property/AmenitiesGrid.tsx
+++ b/packages/frontend/components/property/AmenitiesGrid.tsx
@@ -55,12 +55,21 @@ interface AmenitiesGridProps {
   maxVisible?: number;
 }
 
+/** Title-case a snake_case slug so an unmapped id never renders as a raw slug. */
+function humanizeAmenityId(id: string): string {
+  return id
+    .split('_')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
 /** Resolve the localized, human label for a resolved amenity. */
 function useAmenityLabel(): (entry: ResolvedAmenity) => string {
   const { t } = useTranslation();
   return useCallback(
     ({ id, amenity }: ResolvedAmenity): string => {
-      if (!amenity?.nameKey) return id;
+      if (!amenity?.nameKey) return humanizeAmenityId(id);
       return t(amenity.nameKey);
     },
     [t],

--- a/packages/frontend/components/property/PropertyFeatures.tsx
+++ b/packages/frontend/components/property/PropertyFeatures.tsx
@@ -14,6 +14,11 @@
  *   - Garden      shown only when `hasGarden`. Ionicons `leaf` (no PNG yet).
  *   - Elevator    shown only when `hasElevator`. PNG `elevator`, fallback
  *                 `arrow-up-circle`.
+ *   - Parking     shown when `parkingType` is set and not `none` (label varies
+ *                 by kind: garage / assigned / street). PNG `parking`, fallback `car`.
+ *   - Pets        shown when `petPolicy` is set (allowed / not_allowed / case_by_case).
+ *                 Ionicons `paw`.
+ * All labels come from the shared `parkingType.*` / `petPolicy.*` enum vocab.
  * No rows → renders nothing.
  */
 import React, { useMemo } from 'react';
@@ -30,6 +35,8 @@ import {
 import { getIconArt } from '@/constants/iconArt';
 
 type FurnishedStatus = 'furnished' | 'partially_furnished' | 'unfurnished';
+type ParkingType = 'none' | 'street' | 'assigned' | 'garage';
+type PetPolicy = 'allowed' | 'not_allowed' | 'case_by_case';
 
 interface Props {
     property?: {
@@ -37,6 +44,8 @@ interface Props {
         hasBalcony?: boolean;
         hasGarden?: boolean;
         hasElevator?: boolean;
+        parkingType?: ParkingType;
+        petPolicy?: PetPolicy;
     } | null;
 }
 
@@ -73,6 +82,8 @@ export const PropertyFeatures: React.FC<Props> = ({ property }) => {
     const hasBalcony = property?.hasBalcony;
     const hasGarden = property?.hasGarden;
     const hasElevator = property?.hasElevator;
+    const parkingType = property?.parkingType;
+    const petPolicy = property?.petPolicy;
 
     const rows = useMemo<FeatureRow[]>(() => {
         const next: FeatureRow[] = [];
@@ -100,9 +111,20 @@ export const PropertyFeatures: React.FC<Props> = ({ property }) => {
                 icon: 'arrow-up-circle',
             });
         }
+        if (parkingType !== undefined && parkingType !== 'none') {
+            next.push({
+                key: 'parking',
+                label: t(`parkingType.${parkingType}`),
+                imageId: 'parking',
+                icon: 'car',
+            });
+        }
+        if (petPolicy !== undefined) {
+            next.push({ key: 'petPolicy', label: t(`petPolicy.${petPolicy}`), icon: 'paw' });
+        }
 
         return next;
-    }, [furnishedStatus, hasBalcony, hasGarden, hasElevator, t]);
+    }, [furnishedStatus, hasBalcony, hasGarden, hasElevator, parkingType, petPolicy, t]);
 
     if (rows.length === 0) return null;
 

--- a/packages/frontend/constants/amenities.tsx
+++ b/packages/frontend/constants/amenities.tsx
@@ -67,7 +67,6 @@ export const AMENITY_CATEGORIES: AmenityCategory[] = [
   {
     id: 'kitchen',
     name: 'Kitchen & dining',
-    nameKey: 'amenities.kitchen',
     nameKey: 'amenities.categories.kitchen',
     icon: 'restaurant',
     color: '#ea580c',
@@ -574,6 +573,17 @@ export const AMENITIES: Amenity[] = [
     environmental: 'neutral',
   },
   {
+    id: 'attic',
+    name: 'Attic',
+    nameKey: 'amenities.attic',
+    icon: 'cube',
+    category: 'storage',
+    description: 'Attic storage space',
+    maxFairValue: 15,
+    ethicalNotes: 'Extra storage should be priced fairly based on space provided',
+    environmental: 'neutral',
+  },
+  {
     id: 'walk_in_closet',
     name: 'Walk-in Closet',
     nameKey: 'amenities.walkInCloset',
@@ -675,6 +685,17 @@ export const AMENITIES: Amenity[] = [
     category: 'outdoor',
     description: 'Private outdoor balcony space',
     maxFairValue: 25, // Reasonable value for private outdoor space
+    ethicalNotes: 'Outdoor space improves mental health and quality of life',
+    environmental: 'positive',
+  },
+  {
+    id: 'terrace',
+    name: 'Terrace',
+    nameKey: 'amenities.terrace',
+    icon: 'sunny',
+    category: 'outdoor',
+    description: 'Private or shared terrace',
+    maxFairValue: 25,
     ethicalNotes: 'Outdoor space improves mental health and quality of life',
     environmental: 'positive',
   },
@@ -1128,6 +1149,17 @@ export const AMENITIES: Amenity[] = [
     ethicalNotes: 'Wellness amenity for relaxation and community',
     environmental: 'neutral',
   },
+  {
+    id: 'sauna',
+    name: 'Sauna',
+    nameKey: 'amenities.sauna',
+    icon: 'flame',
+    category: 'wellness',
+    description: 'Private or shared sauna',
+    maxFairValue: 25,
+    ethicalNotes: 'Wellness amenity for relaxation and community',
+    environmental: 'neutral',
+  },
 
   // Family & Children Amenities
   {
@@ -1235,9 +1267,37 @@ export const AMENITIES: Amenity[] = [
   },
 ];
 
+/**
+ * Ingest canonical amenity slug (from `@homiio/listing-providers`
+ * `parse/amenities.ts`) → catalog amenity id. External listings store the
+ * fixed canonical vocabulary (`pool`, `parking`, `garden`, …); a few of those
+ * keys differ from the catalog id used by internally-created listings
+ * (`swimming_pool`, `parking_space`, `garden_space`, …). Resolving through this
+ * map means external + internal listings share one icon + one translation.
+ * Canonical keys that already match a catalog id (`elevator`, `heating`,
+ * `air_conditioning`, `wifi`, `terrace`, `sauna`, `attic`, …) are absent here
+ * and pass through unchanged.
+ */
+export const CANONICAL_AMENITY_ALIASES: Readonly<Record<string, string>> = {
+  pool: 'swimming_pool',
+  parking: 'parking_space',
+  garden: 'garden_space',
+  storage: 'storage_unit',
+  laundry: 'laundry_room',
+  washer: 'washing_machine',
+  jacuzzi: 'hot_tub',
+  armored_door: 'secure_entry',
+  disabled_access: 'wheelchair_accessible',
+  intercom_system: 'intercom',
+};
+
+/** Resolve a stored amenity slug to its catalog id (identity when not aliased). */
+export const resolveAmenityId = (id: string): string => CANONICAL_AMENITY_ALIASES[id] ?? id;
+
 // Helper functions for ethical amenity management
 export const getAmenityById = (id: string): Amenity | undefined => {
-  return AMENITIES.find((amenity) => amenity.id === id);
+  const resolvedId = resolveAmenityId(id);
+  return AMENITIES.find((amenity) => amenity.id === resolvedId);
 };
 
 /**
@@ -1274,16 +1334,17 @@ export const groupAmenitiesByCategory = (ids: string[]): AmenityGroup[] => {
   const byCategory = new Map<string, ResolvedAmenity[]>();
 
   for (const id of ids) {
-    const amenity = getAmenityById(id);
+    const resolvedId = resolveAmenityId(id);
+    const amenity = getAmenityById(resolvedId);
     const categoryId =
       amenity && getCategoryById(amenity.category)
         ? amenity.category
         : UNCATEGORIZED_AMENITY_ID;
     const bucket = byCategory.get(categoryId);
     if (bucket) {
-      bucket.push({ id, amenity });
+      bucket.push({ id: resolvedId, amenity });
     } else {
-      byCategory.set(categoryId, [{ id, amenity }]);
+      byCategory.set(categoryId, [{ id: resolvedId, amenity }]);
     }
   }
 

--- a/packages/frontend/locales/ca-ES.json
+++ b/packages/frontend/locales/ca-ES.json
@@ -102,7 +102,10 @@
     "wholeHouseFan": "Ventilador de tota la casa",
     "wideDoorways": "Portes amples",
     "wifi": "Internet d'alta velocitat",
-    "wineFridge": "Nevera per a vins"
+    "wineFridge": "Nevera per a vins",
+    "terrace": "Terrassa",
+    "sauna": "Sauna",
+    "attic": "Golfa"
   },
   "home": {
     "hero": {
@@ -1109,7 +1112,17 @@
         "room": "Habitació",
         "studio": "Estudi",
         "duplex": "Dúplex",
-        "penthouse": "Àtic"
+        "penthouse": "Àtic",
+        "couchsurfing": "Couchsurfing",
+        "roommates": "Companys de pis",
+        "coliving": "Coliving",
+        "hostel": "Alberg",
+        "guesthouse": "Casa d'hostes",
+        "campsite": "Càmping",
+        "boat": "Vaixell",
+        "treehouse": "Casa de l'arbre",
+        "yurt": "Iurta",
+        "other": "Altre"
       }
     },
     "type": {
@@ -3506,5 +3519,15 @@
   },
   "inbox": {
     "title": "Bústia"
+  },
+  "parkingType": {
+    "street": "Aparcament al carrer",
+    "assigned": "Plaça assignada",
+    "garage": "Garatge"
+  },
+  "petPolicy": {
+    "allowed": "S'admeten mascotes",
+    "not_allowed": "No s'admeten mascotes",
+    "case_by_case": "Mascotes segons el cas"
   }
 }

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -115,7 +115,10 @@
     "wholeHouseFan": "Whole House Fan",
     "wideDoorways": "Wide Doorways",
     "wifi": "High-Speed Internet",
-    "wineFridge": "Wine Refrigerator"
+    "wineFridge": "Wine Refrigerator",
+    "terrace": "Terrace",
+    "sauna": "Sauna",
+    "attic": "Attic"
   },
   "home": {
     "insights": {
@@ -1132,7 +1135,17 @@
         "room": "Room",
         "studio": "Studio",
         "duplex": "Duplex",
-        "penthouse": "Penthouse"
+        "penthouse": "Penthouse",
+        "couchsurfing": "Couchsurfing",
+        "roommates": "Roommates",
+        "coliving": "Co-living",
+        "hostel": "Hostel",
+        "guesthouse": "Guesthouse",
+        "campsite": "Campsite",
+        "boat": "Boat",
+        "treehouse": "Treehouse",
+        "yurt": "Yurt",
+        "other": "Other"
       }
     },
     "actions": {
@@ -3441,5 +3454,15 @@
   },
   "inbox": {
     "title": "Inbox"
+  },
+  "parkingType": {
+    "street": "Street Parking",
+    "assigned": "Assigned Parking",
+    "garage": "Garage"
+  },
+  "petPolicy": {
+    "allowed": "Pets Allowed",
+    "not_allowed": "No Pets",
+    "case_by_case": "Pets Case by Case"
   }
 }

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -102,7 +102,10 @@
     "wholeHouseFan": "Ventilador de toda la casa",
     "wideDoorways": "Puertas anchas",
     "wifi": "Internet de alta velocidad",
-    "wineFridge": "Nevera para vinos"
+    "wineFridge": "Nevera para vinos",
+    "terrace": "Terraza",
+    "sauna": "Sauna",
+    "attic": "Buhardilla"
   },
   "home": {
     "insights": {
@@ -1088,7 +1091,17 @@
         "room": "Habitación",
         "studio": "Estudio",
         "duplex": "Dúplex",
-        "penthouse": "Ático"
+        "penthouse": "Ático",
+        "couchsurfing": "Couchsurfing",
+        "roommates": "Compañeros de piso",
+        "coliving": "Coliving",
+        "hostel": "Hostal",
+        "guesthouse": "Casa de huéspedes",
+        "campsite": "Camping",
+        "boat": "Barco",
+        "treehouse": "Casa del árbol",
+        "yurt": "Yurta",
+        "other": "Otro"
       }
     },
     "type": {
@@ -3485,5 +3498,15 @@
   },
   "inbox": {
     "title": "Buzón"
+  },
+  "parkingType": {
+    "street": "Aparcamiento en la calle",
+    "assigned": "Plaza asignada",
+    "garage": "Garaje"
+  },
+  "petPolicy": {
+    "allowed": "Se admiten mascotas",
+    "not_allowed": "No se admiten mascotas",
+    "case_by_case": "Mascotas según el caso"
   }
 }

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -102,7 +102,10 @@
     "wholeHouseFan": "Ventilatore per tutta la casa",
     "wideDoorways": "Porte larghe",
     "wifi": "Internet ad alta velocità",
-    "wineFridge": "Frigo per vini"
+    "wineFridge": "Frigo per vini",
+    "terrace": "Terrazza",
+    "sauna": "Sauna",
+    "attic": "Mansarda"
   },
   "settings": {
     "title": "Impostazioni",
@@ -1256,7 +1259,17 @@
         "room": "Stanza",
         "studio": "Monolocale",
         "duplex": "Duplex",
-        "penthouse": "Attico"
+        "penthouse": "Attico",
+        "couchsurfing": "Couchsurfing",
+        "roommates": "Coinquilini",
+        "coliving": "Coliving",
+        "hostel": "Ostello",
+        "guesthouse": "Pensione",
+        "campsite": "Campeggio",
+        "boat": "Barca",
+        "treehouse": "Casa sull'albero",
+        "yurt": "Yurta",
+        "other": "Altro"
       }
     },
     "type": {
@@ -3490,5 +3503,15 @@
   },
   "inbox": {
     "title": "Posta"
+  },
+  "parkingType": {
+    "street": "Parcheggio su strada",
+    "assigned": "Posto auto assegnato",
+    "garage": "Garage"
+  },
+  "petPolicy": {
+    "allowed": "Animali ammessi",
+    "not_allowed": "Animali non ammessi",
+    "case_by_case": "Animali caso per caso"
   }
 }

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -47,6 +47,16 @@ export {
 } from './parse/listing';
 export { stripHtmlToPlainText } from './parse/htmlText';
 export {
+  CANONICAL_AMENITIES,
+  FURNISHED_TOKEN,
+  slugifyAmenityToken,
+  canonicalAmenity,
+  isCanonicalAmenity,
+  canonicalizeAmenities,
+  type CanonicalAmenity,
+  type CanonicalizeAmenitiesResult,
+} from './parse/amenities';
+export {
   assertHousingListing,
   isHousingCategory,
   isHousingCategoryUrl,

--- a/packages/listing-providers/src/parse/amenities.ts
+++ b/packages/listing-providers/src/parse/amenities.ts
@@ -1,0 +1,237 @@
+/**
+ * Canonical amenity vocabulary — ONE source of truth for every provider.
+ *
+ * Portals speak wildly different amenity dialects: localized labels
+ * (`ascensor`, `ascensore`, `aria condizionata`), internal English feature
+ * slugs (`air_conditioner`, `storage_room`), camelCase keys
+ * (`elevatorInTheBuilding`, `parkingSpace`), boolean flag names (`hasLift`) and
+ * free-form marketing copy (`Off street parking`). Left unmapped, the same
+ * amenity would be stored under a dozen different keys, breaking cross-portal
+ * search (`amenities: { $in }`) and forcing the app to render raw slugs.
+ *
+ * This module collapses ALL of those inputs onto a single fixed, documented set
+ * of canonical EN snake_case keys. Every provider (and the ingest chokepoint in
+ * {@link ./listing.ts sanitizeNormalizedListingTextFields}) canonicalizes
+ * through {@link canonicalAmenity} / {@link canonicalizeAmenities} — there are
+ * NO per-portal alias tables anymore. The frontend has a matching translation
+ * for each canonical key, so structured amenities always render localized.
+ */
+
+/**
+ * The fixed, documented canonical amenity vocabulary (EN snake_case). Every key
+ * here has a frontend translation under `amenities.*`. Anything a provider emits
+ * that does not resolve to one of these (or {@link FURNISHED_TOKEN}) is dropped
+ * rather than stored as an untranslatable slug.
+ *
+ * Keep this in sync with the frontend catalog aliases in
+ * `packages/frontend/constants/amenities.tsx` (`CANONICAL_AMENITY_TO_CATALOG_ID`).
+ */
+export const CANONICAL_AMENITIES = [
+  'air_conditioning',
+  'heating',
+  'elevator',
+  'balcony',
+  'terrace',
+  'garden',
+  'parking',
+  'pool',
+  'storage',
+  'wifi',
+  'cable_tv',
+  'dishwasher',
+  'washing_machine',
+  'dryer',
+  'laundry_room',
+  'gym',
+  'sauna',
+  'jacuzzi',
+  'intercom',
+  'armored_door',
+  'attic',
+  'disabled_access',
+] as const;
+
+export type CanonicalAmenity = (typeof CANONICAL_AMENITIES)[number];
+
+/**
+ * Special sentinel: `furnished` is a first-class structured field
+ * (`furnishedStatus`), never stored as an amenity tag. Providers/ingest hoist it
+ * out of the amenity list — see {@link canonicalizeAmenities}.
+ */
+export const FURNISHED_TOKEN = 'furnished';
+
+const CANONICAL_SET: ReadonlySet<string> = new Set(CANONICAL_AMENITIES);
+
+/**
+ * Normalize an arbitrary amenity token/label to a comparable slug: strip
+ * accents, split camelCase (`airConditioning` → `air_conditioning`), lowercase,
+ * and collapse every non-alphanumeric run to a single `_`.
+ */
+export function slugifyAmenityToken(raw: string): string {
+  return raw
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/**
+ * Every recognized input slug → canonical key (or {@link FURNISHED_TOKEN}).
+ * Inputs are already {@link slugifyAmenityToken}-normalized. Covers Spanish and
+ * Italian localized labels, English portal feature slugs, camelCase/boolean-flag
+ * derived slugs and common free-text phrases. Keys not present here fall back to
+ * a direct canonical-set membership check in {@link canonicalAmenity}.
+ */
+const AMENITY_ALIASES: Readonly<Record<string, CanonicalAmenity | typeof FURNISHED_TOKEN>> = {
+  // elevator
+  ascensor: 'elevator',
+  ascensore: 'elevator',
+  ascenseur: 'elevator',
+  lift: 'elevator',
+  elevator_in_the_building: 'elevator',
+  // air conditioning
+  aire_acondicionado: 'air_conditioning',
+  climatizacion: 'air_conditioning',
+  aria_condizionata: 'air_conditioning',
+  climatizzazione: 'air_conditioning',
+  air_conditioner: 'air_conditioning',
+  air_conditioned: 'air_conditioning',
+  // heating
+  calefaccion: 'heating',
+  riscaldamento: 'heating',
+  central_heating: 'heating',
+  gas_central_heating: 'heating',
+  // terrace
+  terraza: 'terrace',
+  terrazzo: 'terrace',
+  terrazza: 'terrace',
+  terrace_private: 'terrace',
+  // balcony
+  balcon: 'balcony',
+  balcone: 'balcony',
+  // parking
+  garaje: 'parking',
+  garage: 'parking',
+  parcheggio: 'parking',
+  posto_auto: 'parking',
+  parking_space: 'parking',
+  plaza_de_garaje: 'parking',
+  plaza_garaje: 'parking',
+  off_street_parking: 'parking',
+  // pool
+  piscina: 'pool',
+  swimming_pool: 'pool',
+  community_pool: 'pool',
+  private_pool: 'pool',
+  // garden
+  jardin: 'garden',
+  giardino: 'garden',
+  jardim: 'garden',
+  private_garden: 'garden',
+  communal_garden: 'garden',
+  // storage
+  trastero: 'storage',
+  cantina: 'storage',
+  storage_room: 'storage',
+  basement: 'storage',
+  // washing machine / laundry
+  lavadora: 'washing_machine',
+  lavatrice: 'washing_machine',
+  washer: 'washing_machine',
+  washer_unit: 'washing_machine',
+  laundry_room_unit: 'washing_machine',
+  laundry: 'laundry_room',
+  // dryer / dishwasher
+  secadora: 'dryer',
+  tumble_dryer: 'dryer',
+  lavavajillas: 'dishwasher',
+  lavastoviglie: 'dishwasher',
+  dish_washer: 'dishwasher',
+  // gym / wellness
+  gimnasio: 'gym',
+  fitness_room: 'gym',
+  fitness: 'gym',
+  hot_tub: 'jacuzzi',
+  // connectivity
+  internet: 'wifi',
+  wi_fi: 'wifi',
+  fiber: 'wifi',
+  // intercom / security
+  portero: 'intercom',
+  portero_automatico: 'intercom',
+  visiophone: 'intercom',
+  video_intercom: 'intercom',
+  puerta_blindada: 'armored_door',
+  buhardilla: 'attic',
+  acceso_minusvalidos: 'disabled_access',
+  wheelchair_access: 'disabled_access',
+  disabled_access: 'disabled_access',
+  // furnished (hoisted into furnishedStatus, never stored as an amenity)
+  amueblado: FURNISHED_TOKEN,
+  amoblado: FURNISHED_TOKEN,
+  arredato: FURNISHED_TOKEN,
+  arredata: FURNISHED_TOKEN,
+  meuble: FURNISHED_TOKEN,
+  meublee: FURNISHED_TOKEN,
+  furnished: FURNISHED_TOKEN,
+};
+
+/**
+ * Resolve any portal amenity token/label to its canonical key,
+ * {@link FURNISHED_TOKEN}, or `undefined` when it is not a recognized amenity
+ * (dimensions, condition, orientation, marketing fluff, …). Never falls back to
+ * a raw slug — unrecognized inputs are intentionally dropped so only the fixed,
+ * translatable vocabulary is ever stored.
+ */
+export function canonicalAmenity(
+  input: string,
+): CanonicalAmenity | typeof FURNISHED_TOKEN | undefined {
+  const slug = slugifyAmenityToken(input);
+  if (!slug) return undefined;
+  const aliased = AMENITY_ALIASES[slug];
+  if (aliased) return aliased;
+  if (CANONICAL_SET.has(slug)) return slug as CanonicalAmenity;
+  return undefined;
+}
+
+/** Whether a slug is one of the fixed canonical amenity keys. */
+export function isCanonicalAmenity(slug: string): slug is CanonicalAmenity {
+  return CANONICAL_SET.has(slug);
+}
+
+export interface CanonicalizeAmenitiesResult {
+  /** Deduped canonical amenity keys, in first-seen order. */
+  amenities: string[];
+  /** `true` when a `furnished` token was seen (hoist into `furnishedStatus`). */
+  furnished?: boolean;
+}
+
+/**
+ * Canonicalize a list of raw amenity tokens/labels: map each through
+ * {@link canonicalAmenity}, drop unrecognized entries, dedupe, and hoist any
+ * `furnished` token into the returned {@link CanonicalizeAmenitiesResult.furnished}
+ * flag instead of the amenity list.
+ */
+export function canonicalizeAmenities(
+  inputs: Iterable<string>,
+): CanonicalizeAmenitiesResult {
+  const seen = new Set<string>();
+  const amenities: string[] = [];
+  let furnished: boolean | undefined;
+  for (const input of inputs) {
+    const canonical = canonicalAmenity(input);
+    if (!canonical) continue;
+    if (canonical === FURNISHED_TOKEN) {
+      furnished = true;
+      continue;
+    }
+    if (!seen.has(canonical)) {
+      seen.add(canonical);
+      amenities.push(canonical);
+    }
+  }
+  return furnished === undefined ? { amenities } : { amenities, furnished };
+}

--- a/packages/listing-providers/src/parse/jsonLd.ts
+++ b/packages/listing-providers/src/parse/jsonLd.ts
@@ -5,7 +5,8 @@
  * {@link SchemaOrgListing}. Portal markup changes are fixed here.
  */
 
-import { asCoordinate, asNumberEu, asNumberUs, asString, deaccent, isRecord } from './guards';
+import { canonicalAmenity, FURNISHED_TOKEN } from './amenities';
+import { asCoordinate, asNumberEu, asNumberUs, asString, isRecord } from './guards';
 
 const LD_JSON_TYPE = 'application/ld+json';
 
@@ -60,104 +61,32 @@ export interface EurSchemaListing {
 export type EsSchemaListing = EurSchemaListing;
 export type ItSchemaListing = EurSchemaListing;
 
-const ES_AMENITY_ALIASES: Readonly<Record<string, string>> = {
-  ascensor: 'elevator',
-  'aire acondicionado': 'air_conditioning',
-  climatizacion: 'air_conditioning',
-  calefaccion: 'heating',
-  terraza: 'terrace',
-  balcon: 'balcony',
-  parking: 'parking',
-  garaje: 'parking',
-  piscina: 'pool',
-  jardin: 'garden',
-  trastero: 'storage',
-  amueblado: 'furnished',
-};
-
-/**
- * Canonical amenity for a portal English feature-SLUG key (e.g. Fotocasa
- * `features[].key`: `air_conditioner`, `elevator`, `storage_room`, …). These
- * are internal snake_case keys, NOT the localized Spanish labels handled by
- * {@link ES_AMENITY_ALIASES} — but they resolve to the SAME canonical vocabulary
- * so external listings share one amenity slug set across parse paths. Keys that
- * are dimensions (`rooms`/`bathrooms`/`surface`/`floor`) or non-amenity metadata
- * (`conservationStatus`, `antiquity`, …) are intentionally absent → dropped.
- */
-const FEATURE_KEY_AMENITY_ALIASES: Readonly<Record<string, string>> = {
-  elevator: 'elevator',
-  lift: 'elevator',
-  air_conditioner: 'air_conditioning',
-  air_conditioning: 'air_conditioning',
-  air_conditioned: 'air_conditioning',
-  heating: 'heating',
-  terrace: 'terrace',
-  balcony: 'balcony',
-  parking: 'parking',
-  garage: 'parking',
-  storage_room: 'storage',
-  storage: 'storage',
-  pool: 'pool',
-  swimming_pool: 'pool',
-  community_pool: 'pool',
-  private_pool: 'pool',
-  garden: 'garden',
-  private_garden: 'garden',
-  communal_garden: 'garden',
-  furnished: 'furnished',
-};
-
-const IT_AMENITY_ALIASES: Readonly<Record<string, string>> = {
-  ascensore: 'elevator',
-  'aria condizionata': 'air_conditioning',
-  climatizzazione: 'air_conditioning',
-  riscaldamento: 'heating',
-  terrazzo: 'terrace',
-  terrazza: 'terrace',
-  balcone: 'balcony',
-  posto_auto: 'parking',
-  garage: 'parking',
-  parcheggio: 'parking',
-  piscina: 'pool',
-  giardino: 'garden',
-  cantina: 'storage',
-  arredato: 'furnished',
-  arredata: 'furnished',
-};
-
 interface EurJsonLdConfig {
   defaultCountryCode: string;
-  amenityAliases: Readonly<Record<string, string>>;
 }
 
-const ES_JSON_LD_CONFIG: EurJsonLdConfig = { defaultCountryCode: 'ES', amenityAliases: ES_AMENITY_ALIASES };
-const IT_JSON_LD_CONFIG: EurJsonLdConfig = { defaultCountryCode: 'IT', amenityAliases: IT_AMENITY_ALIASES };
-
-function normalizeAmenity(name: string, aliases: Readonly<Record<string, string>>): string {
-  const key = deaccent(name);
-  return aliases[key] ?? key.replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
-}
+const ES_JSON_LD_CONFIG: EurJsonLdConfig = { defaultCountryCode: 'ES' };
+const IT_JSON_LD_CONFIG: EurJsonLdConfig = { defaultCountryCode: 'IT' };
 
 /**
- * Canonical ES amenity key for a free-form label (e.g. a portal property-JSON
+ * Canonical amenity key for a free-form label (e.g. a portal property-JSON
  * `features`/`extras` entry), or `undefined` when the label is not a recognized
- * amenity. Reuses the shared ES alias table — never duplicate it per portal.
- * `amueblado` resolves to `furnished`; callers hoist that into `furnishedStatus`.
- * Unlike {@link normalizeAmenity} it does NOT fall back to a snake_case slug, so
- * mixed "características" arrays (condition, orientation, …) don't leak as amenities.
+ * amenity. Delegates to the shared {@link canonicalAmenity} vocabulary — never a
+ * per-portal alias table. `amueblado`/`arredato`/… resolve to `furnished`;
+ * callers hoist that into `furnishedStatus`. Non-amenity entries (condition,
+ * orientation, …) return `undefined` so they don't leak as amenities.
  */
 export function matchEsAmenityKey(label: string): string | undefined {
-  return ES_AMENITY_ALIASES[deaccent(label)];
+  return canonicalAmenity(label);
 }
 
 /**
  * Canonical amenity slug for a portal English feature-slug key (Fotocasa
  * `features[].key`, …), or `undefined` when the key is not a recognized amenity.
- * Reuses the shared canonical vocabulary — resolves to the same slugs as
- * {@link matchEsAmenityKey} without duplicating the Spanish alias table.
+ * Same shared {@link canonicalAmenity} vocabulary as {@link matchEsAmenityKey}.
  */
 export function matchFeatureKeyAmenity(key: string): string | undefined {
-  return FEATURE_KEY_AMENITY_ALIASES[key.trim().toLowerCase()];
+  return canonicalAmenity(key);
 }
 
 function readTypes(value: unknown): string[] {
@@ -238,11 +167,9 @@ function readEurOffer(value: unknown): { price?: number; currency?: string; oper
   return {};
 }
 
-function readAmenities(
-  value: unknown,
-  aliases: Readonly<Record<string, string>>,
-): { amenities: string[]; furnished?: boolean } {
+function readAmenities(value: unknown): { amenities: string[]; furnished?: boolean } {
   const amenities: string[] = [];
+  const seen = new Set<string>();
   let furnished: boolean | undefined;
   const entries = Array.isArray(value) ? value : value === undefined ? [] : [value];
   for (const entry of entries) {
@@ -250,12 +177,16 @@ function readAmenities(
     const name = asString(entry.name);
     if (!name) continue;
     if (entry.value === false) continue;
-    const key = normalizeAmenity(name, aliases);
-    if (key === 'furnished') {
+    const key = canonicalAmenity(name);
+    if (!key) continue;
+    if (key === FURNISHED_TOKEN) {
       furnished = true;
       continue;
     }
-    if (key) amenities.push(key);
+    if (!seen.has(key)) {
+      seen.add(key);
+      amenities.push(key);
+    }
   }
   return { amenities, furnished };
 }
@@ -269,10 +200,7 @@ function toEurListing(node: Record<string, unknown>, config: EurJsonLdConfig): E
   const subject = readSubject(node);
   const offer = readEurOffer(node.offers ?? subject.offers);
   const topLevelPrice = asNumberEu(node.price);
-  const { amenities, furnished } = readAmenities(
-    subject.amenityFeature ?? node.amenityFeature,
-    config.amenityAliases,
-  );
+  const { amenities, furnished } = readAmenities(subject.amenityFeature ?? node.amenityFeature);
   const types = [...readTypes(node['@type']), ...readTypes(subject['@type'])];
   return {
     types,

--- a/packages/listing-providers/src/parse/listing.ts
+++ b/packages/listing-providers/src/parse/listing.ts
@@ -3,6 +3,7 @@
  */
 
 import { OfferingType, type NormalizedListing } from '@homiio/shared-types';
+import { canonicalizeAmenities } from './amenities';
 import { stripHtmlToPlainText } from './htmlText';
 import { validateOfferingPrices } from './price';
 
@@ -42,11 +43,21 @@ export function sanitizeNormalizedListingTextFields(listing: NormalizedListing):
   }
 
   if (listing.amenities) {
-    listing.amenities = listing.amenities
+    // Strip portal HTML, then collapse every provider's amenity dialect onto the
+    // fixed canonical vocabulary (the single guarantee point — a provider that
+    // forgets to canonicalize still ends up consistent + translatable). A
+    // `furnished` token is hoisted into `furnishedStatus` rather than stored.
+    const cleaned = listing.amenities
       .map((item) => stripHtmlToPlainText(item) ?? '')
       .filter((item) => item.length > 0);
-    if (listing.amenities.length === 0) {
+    const { amenities, furnished } = canonicalizeAmenities(cleaned);
+    if (amenities.length > 0) {
+      listing.amenities = amenities;
+    } else {
       delete listing.amenities;
+    }
+    if (furnished && listing.furnishedStatus === undefined) {
+      listing.furnishedStatus = 'furnished';
     }
   }
 

--- a/packages/listing-providers/src/providers/be/immoweb/parse.ts
+++ b/packages/listing-providers/src/providers/be/immoweb/parse.ts
@@ -183,22 +183,22 @@ function featurePresent(flag: unknown, surface: unknown): boolean | undefined {
 
 /**
  * Immoweb detail JSON exposes ~30 boolean amenity flags on `property.has*`.
- * Map the ones we recognize to the canonical amenity slugs the rest of the
- * pipeline speaks (matching `parse/jsonLd.ts` aliases + ingest `deriveFeatures`
- * keywords: `elevator`/`terrace`/`garden`/`pool`/`storage`/`air_conditioning`).
- * The ingest promotes `elevator`→hasElevator, `terrace`→hasBalcony,
- * `garden`→hasGarden from this array; other slugs surface as amenity tags.
+ * Map the ones we recognize directly to the shared canonical amenity vocabulary
+ * (`parse/amenities.ts`) — this is a portal-specific INPUT adapter (Immoweb's
+ * boolean flag names), and every target is a fixed canonical key, so the ingest
+ * promotes `elevator`→hasElevator, `terrace`→hasBalcony, `garden`→hasGarden and
+ * the app renders each translated.
  */
 const IMMOWEB_AMENITY_FLAGS: Readonly<Record<string, string>> = {
   hasLift: 'elevator',
   hasTerrace: 'terrace',
   hasGarden: 'garden',
   hasBasement: 'storage',
-  hasLaundryRoom: 'laundry',
+  hasLaundryRoom: 'laundry_room',
   hasArmoredDoor: 'armored_door',
   hasAttic: 'attic',
-  hasInternet: 'internet',
-  hasVisiophone: 'visiophone',
+  hasInternet: 'wifi',
+  hasVisiophone: 'intercom',
   hasAirConditioning: 'air_conditioning',
   hasSwimmingPool: 'pool',
   hasFitnessRoom: 'gym',

--- a/packages/listing-providers/src/providers/blueground/parse.ts
+++ b/packages/listing-providers/src/providers/blueground/parse.ts
@@ -12,6 +12,7 @@
  */
 
 import type { ExternalListingRef } from '../../types';
+import { canonicalAmenity, FURNISHED_TOKEN } from '../../parse/amenities';
 import { asRecord, asString } from '../../parse/guards';
 import { extractBalancedJsonAfter } from '../../parse/nextData';
 import type { BluegroundRawListing, BluegroundRawPhoto } from './fixtures';
@@ -135,37 +136,18 @@ function readPhotos(html: string): BluegroundRawPhoto[] {
  * We normalize the stable `key` — never the localized caption — so extraction is
  * market-agnostic.
  *
- * Only the handful of keys whose generic slug would diverge from the canonical
- * vocabulary the ingest/search read (`elevator`, `parking`, `terrace`,
- * `washer`, `air_conditioning`) are aliased; everything else is slugified
- * generically. This is Blueground's OWN camelCase vocabulary, not a duplicate of
- * the shared ES/IT free-text amenity table in `parse/jsonLd.ts`.
+ * The stable `key` is run through the shared {@link canonicalAmenity} vocabulary
+ * (which slugifies camelCase, so `elevatorInTheBuilding`→`elevator`,
+ * `parkingSpace`→`parking`, `washerUnit`→`washing_machine`); keys that don't map
+ * to the fixed canonical set (e.g. `coffeeMachine`) are dropped rather than
+ * stored as a bespoke slug. No per-portal alias table.
  */
-const BLUEGROUND_AMENITY_ALIASES: Readonly<Record<string, string>> = {
-  airConditioning: 'air_conditioning',
-  elevatorInTheBuilding: 'elevator',
-  parkingSpace: 'parking',
-  terracePrivate: 'terrace',
-  laundryRoomUnit: 'washer',
-  washerUnit: 'washer',
-};
 
 /** Categories that list amenities the unit does NOT have (struck through in UI). */
 const BLUEGROUND_STRUCKTHROUGH_PREFIX = 'struckthrough';
 /** Category holding structured facts (bedrooms/bathrooms/lotSize/floor), not amenities. */
 const BLUEGROUND_FACTS_CATEGORY = 'main';
 const BLUEGROUND_FLOOR_KEY = 'floor';
-
-/** Canonicalize a Blueground amenity `key`; unknown keys → generic snake_case slug. */
-function bluegroundAmenitySlug(key: string): string {
-  const alias = BLUEGROUND_AMENITY_ALIASES[key];
-  if (alias) return alias;
-  return key
-    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '');
-}
 
 /** Read the `main.floor` structured value (string like `"2"` or a number). */
 function readBluegroundFloor(entries: readonly unknown[]): number | undefined {
@@ -217,8 +199,8 @@ export function readBluegroundAmenities(html: string): { amenities: string[]; fl
     for (const entry of entries) {
       const key = asString(asRecord(entry)?.['key']);
       if (!key) continue;
-      const slug = bluegroundAmenitySlug(key);
-      if (slug) amenities.add(slug);
+      const canonical = canonicalAmenity(key);
+      if (canonical && canonical !== FURNISHED_TOKEN) amenities.add(canonical);
     }
   }
 

--- a/packages/listing-providers/src/providers/gb/rightmove/parse.ts
+++ b/packages/listing-providers/src/providers/gb/rightmove/parse.ts
@@ -7,6 +7,7 @@
  */
 
 import type { NormalizedListingContact } from '@homiio/shared-types';
+import { canonicalizeAmenities } from '../../../parse/amenities';
 import { buildContact } from '../../../parse/contact';
 import { asNumberUs as asNumber, asString, isRecord } from '../../../parse/guards';
 import { parseNextData } from '../../../parse/nextData';
@@ -266,15 +267,21 @@ function squareMetersFromDetail(prop: Record<string, unknown>): number | undefin
   return squareMetersFromSizings(prop) ?? squareMetersFromDisplaySize(prop);
 }
 
-/** Portal `keyFeatures[]` strings — passed to ingest as amenities for derivation. */
+/**
+ * Portal `keyFeatures[]` are free-form marketing copy ("Off street parking",
+ * "Gas central heating", "Double glazing"). Collapse them onto the shared
+ * canonical amenity vocabulary so they match every other portal + render
+ * translated; unrecognized copy is dropped and `Furnished` is hoisted into
+ * `furnishedStatus` (letting.furnishType already sets it).
+ */
 function keyFeaturesFromDetail(prop: Record<string, unknown>): string[] {
   if (!Array.isArray(prop.keyFeatures)) return [];
-  const out: string[] = [];
+  const labels: string[] = [];
   for (const feature of prop.keyFeatures) {
     const value = asString(feature);
-    if (value) out.push(value);
+    if (value) labels.push(value);
   }
-  return out;
+  return canonicalizeAmenities(labels).amenities;
 }
 
 /** Map `propertyData.letting.furnishType` to the normalized furnished status. */

--- a/packages/listing-providers/src/providers/habitaclia/parse.ts
+++ b/packages/listing-providers/src/providers/habitaclia/parse.ts
@@ -12,6 +12,7 @@
  */
 
 import { HABITACLIA_BASE_URL, type HabitacliaRawImage, type HabitacliaRawListing } from './fixtures';
+import { canonicalAmenity, FURNISHED_TOKEN } from '../../parse/amenities';
 import { asCoordinate, asNumber, asString } from '../../parse/guards';
 
 /** Match every `<script type="application/ld+json">…</script>` block. */
@@ -25,21 +26,6 @@ const DETAIL_DATA_HREF_RE =
   /data-href=["']([^"']*-i(\d+)\.htm(?:\?[^"']*)?)["']/gi;
 /** Fallback when anchors omit the `-i` prefix but keep the trailing id segment. */
 const DETAIL_LINK_FALLBACK_RE = /href=["']([^"']*\/alquiler-[^"']*-(\d{6,})\.htm)["']/gi;
-
-/** Spanish → canonical amenity keys; unknown names fall back to a slug. */
-const AMENITY_ALIASES: Readonly<Record<string, string>> = {
-  ascensor: 'elevator',
-  'aire acondicionado': 'air_conditioning',
-  calefaccion: 'heating',
-  terraza: 'terrace',
-  balcon: 'balcony',
-  parking: 'parking',
-  garaje: 'parking',
-  piscina: 'pool',
-  jardin: 'garden',
-  trastero: 'storage',
-  amueblado: 'furnished',
-};
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -91,16 +77,6 @@ function htmlFragmentToText(html: string): string {
   return text.replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim();
 }
 
-/** Strip accents and lowercase for alias lookup / slugging. */
-function deaccent(value: string): string {
-  return value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().trim();
-}
-
-function normalizeAmenity(name: string): string {
-  const key = deaccent(name);
-  return AMENITY_ALIASES[key] ?? key.replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
-}
-
 /** Parse every JSON-LD block in the page, ignoring malformed ones. */
 function extractJsonLdNodes(html: string): Record<string, unknown>[] {
   const nodes: Record<string, unknown>[] = [];
@@ -146,18 +122,23 @@ function toImages(node: Record<string, unknown>): HabitacliaRawImage[] {
 
 function toAmenities(node: Record<string, unknown>): { amenities: string[]; furnished?: boolean } {
   const amenities: string[] = [];
+  const seen = new Set<string>();
   let furnished: boolean | undefined;
   for (const entry of asArray(node['amenityFeature'])) {
     const record = asRecord(entry);
     const name = asString(record?.['name']);
     if (!name) continue;
     if (record?.['value'] === false) continue;
-    const key = normalizeAmenity(name);
-    if (key === 'furnished') {
+    const key = canonicalAmenity(name);
+    if (!key) continue;
+    if (key === FURNISHED_TOKEN) {
       furnished = true;
       continue;
     }
-    if (key) amenities.push(key);
+    if (!seen.has(key)) {
+      seen.add(key);
+      amenities.push(key);
+    }
   }
   return { amenities, furnished };
 }
@@ -480,6 +461,7 @@ export function parseHabitacliaDetailHtml(html: string, url: string): Habitaclia
   );
 
   const amenities: string[] = [];
+  const seen = new Set<string>();
   let furnished: boolean | undefined;
   for (const match of html.matchAll(/<li>([^<]{2,60})<\/li>/gi)) {
     const label = match[1]?.trim();
@@ -490,12 +472,16 @@ export function parseHabitacliaDetailHtml(html: string, url: string): Habitaclia
       )
     )
       continue;
-    const key = normalizeAmenity(label);
-    if (key === 'furnished') {
+    const key = canonicalAmenity(label);
+    if (!key) continue;
+    if (key === FURNISHED_TOKEN) {
       furnished = true;
       continue;
     }
-    if (key) amenities.push(key);
+    if (!seen.has(key)) {
+      seen.add(key);
+      amenities.push(key);
+    }
   }
 
   return {

--- a/packages/listing-providers/src/providers/pisos/index.ts
+++ b/packages/listing-providers/src/providers/pisos/index.ts
@@ -454,6 +454,7 @@ export class PisosProvider implements ListingProvider {
     if (yearBuilt !== undefined) result.yearBuilt = yearBuilt;
     if (parkingSpaces !== undefined) result.parkingSpaces = parkingSpaces;
     if (listing.amenities.length > 0) result.amenities = listing.amenities;
+    if (listing.furnished === true) result.furnishedStatus = 'furnished';
     if (contact && (contact.phone || contact.email || contact.whatsapp || contact.agencyName)) {
       result.contact = contact;
     }

--- a/packages/listing-providers/src/providers/pisos/parse.ts
+++ b/packages/listing-providers/src/providers/pisos/parse.ts
@@ -8,6 +8,7 @@
 
 import type { NormalizedListingContact } from '@homiio/shared-types';
 import { ldJsonScriptBodies } from '../../html';
+import { canonicalizeAmenities } from '../../parse/amenities';
 import { extractEsSchemaListings, type EsSchemaListing } from '../../parse/jsonLd';
 import { PISOS_BASE_URL } from './fixtures';
 import { asCoordinate, asNumber } from '../../parse/guards';
@@ -329,20 +330,15 @@ export function postalCodeFromPisosUrl(url: string): string | undefined {
   return url.match(/(\d{5})-\d+[._]\d+/)?.[1];
 }
 
-function amenityList(raw: unknown): string[] {
-  if (typeof raw !== 'string' || raw.trim().length === 0) return [];
-  return raw
-    .split(',')
-    .map((part) =>
-      part
-        .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, '')
-        .toLowerCase()
-        .trim()
-        .replace(/[^a-z0-9]+/g, '_')
-        .replace(/^_+|_+$/g, ''),
-    )
-    .filter(Boolean);
+/**
+ * Pisos' `caracteristicasInmueble` is a comma-separated list of raw Spanish
+ * feature slugs (`ascensor,balcon,soleado,amueblado`). Collapse it onto the
+ * shared canonical amenity vocabulary \u2014 non-amenity words (`soleado`, \u2026) drop
+ * and `amueblado` is hoisted into the returned `furnished` flag.
+ */
+function amenityList(raw: unknown): { amenities: string[]; furnished?: boolean } {
+  if (typeof raw !== 'string' || raw.trim().length === 0) return { amenities: [] };
+  return canonicalizeAmenities(raw.split(','));
 }
 
 /**
@@ -421,6 +417,8 @@ export function parsePisosDetail(html: string, url: string): PisosRaw {
   const street = ld?.address?.street ?? h1 ?? city;
   const postalCode = ld?.address?.postalCode ?? postalCodeFromPisosUrl(url);
 
+  const { amenities, furnished } = amenityList(dataVar?.caracteristicasInmueble);
+
   const listing: EsSchemaListing = {
     types,
     name: h1 ?? ld?.name,
@@ -443,8 +441,9 @@ export function parsePisosDetail(html: string, url: string): PisosRaw {
     price,
     priceCurrency: 'EUR',
     operation,
-    amenities: amenityList(dataVar?.caracteristicasInmueble),
+    amenities,
   };
+  if (furnished) listing.furnished = true;
 
   const phone =
     typeof dataVar?.telefono === 'string' && dataVar.telefono.trim()


### PR DESCRIPTION
Consolida 3 mejoras del ingest en un deploy:

- **fetch-priority**: los portales ES per-city (fotocasa/habitaclia/pisos) encolan miles de fetch jobs y ahogaban a los providers pequeños (immobilienscout24/ML/otodom) en la cola FIFO. Ahora los 3 grandes tienen prioridad baja y el resto alta → todos avanzan. (Requiere un one-off de purga del backlog sin-prioridad para efecto inmediato.)
- **clasificador de contenido (#203)**: detecta trampas de la descripción multi-idioma (temporaryOnly 17.9%, roomNotFullUnit, studentsOnly, noPets, workersOnly, agencyFee…) → `Property.listingFlags`. Verificado sobre 5.588 anuncios reales, cero falsos positivos.
- **vocabulario canónico + i18n (#206)**: unifica los amenities de TODOS los providers a un set canónico único (borra tablas duplicadas), añade traducciones faltantes (es/en/ca/it) para amenities/parkingType/petPolicy/tipos, y arregla 4 componentes del frontend que mostraban slugs crudos.

Build verde; suite Provider/Parse/ingest/classify/canonical/worker: 434 pass.

Cierra #203 #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)