### PR TITLE
feat(frontend): eviction solidarity board — tablón, RSVP, timeline, comentarios

### DIFF
--- a/packages/frontend/app/(tabs)/inbox/index.tsx
+++ b/packages/frontend/app/(tabs)/inbox/index.tsx
@@ -145,6 +145,8 @@ export default function InboxScreen() {
           notification.data?.propertyId
         ) {
           router.push(`/properties/${notification.data.propertyId}`);
+        } else if (notification.data?.evictionId) {
+          router.push(`/evictions/${notification.data.evictionId}`);
         } else if (notification.type === 'contract') {
           router.push('/contracts');
         } else if (notification.type === 'roommate') {

--- a/packages/frontend/app/evictions/[id].tsx
+++ b/packages/frontend/app/evictions/[id].tsx
@@ -1,0 +1,617 @@
+/**
+ * Eviction case detail (detalle) — the mobilisation page for a single desahucio.
+ *
+ * Cover → status + date/time → title → reporter → description → "Cómo ayudar"
+ * (tappable organiser contacts) → approximate-location map + disclaimer →
+ * timeline of owner updates → public comment thread (paginated). A sticky RSVP
+ * CTA drives "Asistiré/Asistiendo"; the header carries Share + Report. Owner-only
+ * controls (post update / edit / cancel) appear when the viewer owns the case.
+ */
+import React, { useCallback, useContext, useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Image } from 'expo-image';
+import { Ionicons } from '@expo/vector-icons';
+import { Avatar } from '@oxyhq/bloom/avatar';
+import { Button } from '@oxyhq/bloom/button';
+import { Divider } from '@oxyhq/bloom/divider';
+import * as Skeleton from '@oxyhq/bloom/skeleton';
+import { TextFieldInput } from '@oxyhq/bloom/text-field';
+import { H2, H3, Text as BloomText } from '@oxyhq/bloom/typography';
+import { useOxy, showSignInModal } from '@oxyhq/services';
+
+import { Header } from '@/components/Header';
+import Map from '@/components/Map';
+import { IconButton } from '@/components/ui/IconButton';
+import { ErrorState } from '@/components/ui/ErrorState';
+import { ZoomableImage } from '@/components/ui/ZoomableImage';
+import { LoadMoreSentinel } from '@/components/common/LoadMoreSentinel';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { useOxyAvatars } from '@/hooks/useOxyAvatars';
+import {
+  useCreateEvictionComment,
+  useDeleteEvictionComment,
+  useEvictionComments,
+  useEvictionDetail,
+  useToggleAttend,
+} from '@/hooks/useEvictionQueries';
+import { EvictionStatusBadge } from '@/components/evictions/EvictionStatusBadge';
+import { EvictionDateBlock } from '@/components/evictions/EvictionDateBlock';
+import { EvictionContactActions } from '@/components/evictions/EvictionContactActions';
+import { EvictionCommentRow } from '@/components/evictions/EvictionCommentRow';
+import { EvictionOwnerControls } from '@/components/evictions/EvictionOwnerControls';
+import { EvictionReportSheet } from '@/components/evictions/EvictionReportSheet';
+import {
+  formatEvictionFullDate,
+  EVICTION_STATUS_META,
+} from '@/components/evictions/evictionUtils';
+import { BottomSheetContext } from '@/context/BottomSheetContext';
+import { shareContent } from '@/utils/share';
+import { resolveBackendImageUrl } from '@/utils/imageUrl';
+import { formatRelativeTime } from '@/utils/dateLocale';
+import { webAlert } from '@/utils/api';
+import { toast } from '@/lib/sonner';
+import { colors } from '@/styles/colors';
+import { radius, spacing } from '@/constants/styles';
+
+const SectionCard: React.FC<React.PropsWithChildren<{ title?: string }>> = ({ title, children }) => (
+  <View style={styles.section}>
+    {title ? <H3 style={styles.sectionTitle}>{title}</H3> : null}
+    {children}
+  </View>
+);
+
+const DetailSkeleton: React.FC = () => (
+  <View style={styles.content}>
+    <Skeleton.Box width="100%" height={200} borderRadius={radius.lg} />
+    <Skeleton.Text style={{ width: 220, lineHeight: 24 }} />
+    <Skeleton.Text style={{ width: 160, lineHeight: 16 }} />
+    <Skeleton.Box width="100%" height={120} borderRadius={radius.lg} />
+  </View>
+);
+
+export default function EvictionDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const caseId = Array.isArray(id) ? id[0] : id ?? '';
+  const { t, i18n } = useTranslation();
+  const router = useRouter();
+  const bottomSheet = useContext(BottomSheetContext);
+  const { isAuthenticated, user } = useOxy();
+
+  const { data: eviction, isLoading, isError, error, refetch } = useEvictionDetail(caseId);
+
+  const {
+    comments,
+    total: commentTotal,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useEvictionComments(caseId);
+
+  const toggleAttend = useToggleAttend(caseId);
+  const createComment = useCreateEvictionComment(caseId);
+  const deleteComment = useDeleteEvictionComment(caseId);
+
+  const [commentText, setCommentText] = useState('');
+
+  const avatarIds = useMemo(
+    () => [eviction?.oxyUserId, ...comments.map((comment) => comment.oxyUserId)],
+    [eviction?.oxyUserId, comments],
+  );
+  const { usersById, getAvatarFileId } = useOxyAvatars(avatarIds);
+
+  const resolveName = useCallback(
+    (oxyUserId: string): string => {
+      const resolved = usersById.get(oxyUserId);
+      return (
+        resolved?.name?.displayName?.trim() ||
+        resolved?.username ||
+        t('evictions.detail.anonymous')
+      );
+    },
+    [usersById, t],
+  );
+
+  const handleEndReached = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) void fetchNextPage();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const { onScroll } = useInfiniteScroll({ onEndReached: handleEndReached, enabled: hasNextPage });
+
+  const handleShare = useCallback(async () => {
+    if (!eviction) return;
+    const url = `https://homiio.com/evictions/${caseId}`;
+    const outcome = await shareContent({
+      title: eviction.title,
+      message: `${eviction.title}\n${eviction.location.label}\n\n${url}`,
+      url,
+    });
+    if (outcome === 'copied') toast.success(t('evictions.detail.shareCopied'));
+    else if (outcome === 'failed') toast.error(t('evictions.detail.shareFailed'));
+  }, [eviction, caseId, t]);
+
+  const handleReport = useCallback(() => {
+    if (!isAuthenticated) {
+      showSignInModal();
+      return;
+    }
+    bottomSheet.openBottomSheet(
+      <EvictionReportSheet caseId={caseId} onClose={() => bottomSheet.closeBottomSheet()} />,
+    );
+  }, [isAuthenticated, bottomSheet, caseId]);
+
+  const handleRSVP = useCallback(() => {
+    if (!isAuthenticated) {
+      showSignInModal();
+      return;
+    }
+    toggleAttend.mutate();
+  }, [isAuthenticated, toggleAttend]);
+
+  const handleEdit = useCallback(() => {
+    router.push(`/evictions/new?edit=${caseId}`);
+  }, [router, caseId]);
+
+  const handlePostComment = useCallback(async () => {
+    const body = commentText.trim();
+    if (!body) return;
+    try {
+      await createComment.mutateAsync(body);
+      setCommentText('');
+    } catch {
+      toast.error(t('evictions.comments.postError'));
+    }
+  }, [commentText, createComment, t]);
+
+  const handleDeleteComment = useCallback(
+    (commentId: string) => {
+      webAlert(t('evictions.comments.deleteTitle'), t('evictions.comments.deleteMessage'), [
+        { text: t('common.cancel'), style: 'cancel' },
+        {
+          text: t('common.delete'),
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await deleteComment.mutateAsync(commentId);
+            } catch {
+              toast.error(t('evictions.comments.deleteError'));
+            }
+          },
+        },
+      ]);
+    },
+    [deleteComment, t],
+  );
+
+  const contactLabels = useMemo(
+    () => ({
+      phone: t('evictions.detail.contact.phone'),
+      whatsapp: t('evictions.detail.contact.whatsapp'),
+      telegram: t('evictions.detail.contact.telegram'),
+      email: t('evictions.detail.contact.email'),
+    }),
+    [t],
+  );
+
+  const shareButton = (
+    <IconButton
+      key="share"
+      icon="share-outline"
+      variant="ghost"
+      accessibilityLabel={t('evictions.detail.share')}
+      onPress={handleShare}
+    />
+  );
+  const reportButton = (
+    <IconButton
+      key="report"
+      icon="flag-outline"
+      variant="ghost"
+      accessibilityLabel={t('evictions.report.title')}
+      onPress={handleReport}
+    />
+  );
+
+  if (isLoading) {
+    return (
+      <View style={styles.root}>
+        <Header options={{ showBackButton: true, title: t('evictions.detail.title') }} />
+        <DetailSkeleton />
+      </View>
+    );
+  }
+
+  if (isError || !eviction) {
+    return (
+      <View style={styles.root}>
+        <Header options={{ showBackButton: true, title: t('evictions.detail.title') }} />
+        <ErrorState
+          icon="cloud-offline-outline"
+          title={t('evictions.loadError')}
+          description={error?.message ?? t('common.tryAgain')}
+          onRetry={() => void refetch()}
+        />
+      </View>
+    );
+  }
+
+  const coverUrl = eviction.coverImage?.url
+    ? resolveBackendImageUrl(eviction.coverImage.url)
+    : undefined;
+  const coords = eviction.location?.coordinates?.coordinates;
+  const hasPin =
+    Array.isArray(coords) &&
+    coords.length === 2 &&
+    typeof coords[0] === 'number' &&
+    typeof coords[1] === 'number' &&
+    !(coords[0] === 0 && coords[1] === 0);
+
+  return (
+    <View style={styles.root}>
+      <Header
+        options={{
+          showBackButton: true,
+          title: t('evictions.detail.title'),
+          rightComponents: [shareButton, reportButton],
+        }}
+      />
+      <SafeAreaView edges={['bottom']} style={styles.safeArea}>
+        <ScrollView
+          contentContainerStyle={styles.content}
+          onScroll={onScroll}
+          scrollEventThrottle={16}
+          showsVerticalScrollIndicator={false}
+        >
+          {coverUrl ? (
+            <ZoomableImage borderRadius={radius.lg} aspectRatio={16 / 9} style={styles.cover}>
+              <Image
+                source={{ uri: coverUrl }}
+                style={styles.coverImage}
+                contentFit="cover"
+                accessibilityIgnoresInvertColors
+              />
+            </ZoomableImage>
+          ) : null}
+
+          <View style={styles.heroRow}>
+            <EvictionDateBlock
+              scheduledAt={eviction.scheduledAt}
+              locale={i18n.language}
+              size="large"
+            />
+            <View style={styles.heroText}>
+              <EvictionStatusBadge status={eviction.status} />
+              <H2 style={styles.title}>{eviction.title}</H2>
+              <BloomText style={styles.when}>
+                {formatEvictionFullDate(eviction.scheduledAt, i18n.language)}
+              </BloomText>
+            </View>
+          </View>
+
+          <View style={styles.authorRow}>
+            <Avatar
+              size={36}
+              name={resolveName(eviction.oxyUserId)}
+              source={getAvatarFileId(eviction.oxyUserId) ?? null}
+              variant="thumb"
+            />
+            <View style={styles.authorText}>
+              <BloomText style={styles.authorLabel}>{t('evictions.detail.reportedBy')}</BloomText>
+              <BloomText style={styles.authorName} numberOfLines={1}>
+                {resolveName(eviction.oxyUserId)}
+              </BloomText>
+            </View>
+          </View>
+
+          <BloomText style={styles.description}>{eviction.description}</BloomText>
+
+          <SectionCard title={t('evictions.detail.howToHelp')}>
+            <EvictionContactActions
+              contact={eviction.contactInfo}
+              labels={contactLabels}
+              instructionsLabel={t('evictions.detail.instructions')}
+              openFailedLabel={t('evictions.detail.contactFailed')}
+            />
+            {!eviction.contactInfo ? (
+              <BloomText style={styles.muted}>{t('evictions.detail.noContact')}</BloomText>
+            ) : null}
+          </SectionCard>
+
+          {hasPin ? (
+            <SectionCard title={t('evictions.detail.where')}>
+              <View style={styles.mapWrap}>
+                <Map
+                  style={styles.mapInner}
+                  screenId={`eviction-${caseId}`}
+                  startFromCurrentLocation={false}
+                  initialCoordinates={[coords[0], coords[1]]}
+                  initialZoom={15}
+                  markers={[
+                    {
+                      id: eviction.id,
+                      coordinates: [coords[0], coords[1]],
+                      priceLabel: eviction.location.label,
+                    },
+                  ]}
+                />
+              </View>
+              <BloomText style={styles.locationLabel}>{eviction.location.label}</BloomText>
+              {eviction.location.precision === 'approximate' ? (
+                <View style={styles.disclaimerRow}>
+                  <Ionicons name="information-circle-outline" size={16} color={colors.info} />
+                  <BloomText style={styles.disclaimer}>
+                    {t('evictions.detail.approximateNotice')}
+                  </BloomText>
+                </View>
+              ) : null}
+            </SectionCard>
+          ) : null}
+
+          {eviction.updates.length > 0 ? (
+            <SectionCard title={t('evictions.detail.timeline')}>
+              <View style={styles.timeline}>
+                {eviction.updates
+                  .slice()
+                  .reverse()
+                  .map((update) => (
+                    <View key={update.id} style={styles.timelineItem}>
+                      <View style={styles.timelineDot} />
+                      <View style={styles.timelineBody}>
+                        <BloomText style={styles.timelineTime}>
+                          {formatRelativeTime(new Date(update.createdAt))}
+                        </BloomText>
+                        <BloomText style={styles.timelineMessage}>{update.message}</BloomText>
+                        {update.newStatus ? (
+                          <BloomText style={styles.timelineMeta}>
+                            {t(EVICTION_STATUS_META[update.newStatus].i18nKey)}
+                          </BloomText>
+                        ) : null}
+                      </View>
+                    </View>
+                  ))}
+              </View>
+            </SectionCard>
+          ) : null}
+
+          {eviction.isOwner ? (
+            <EvictionOwnerControls
+              caseId={caseId}
+              currentStatus={eviction.status}
+              onEdit={handleEdit}
+            />
+          ) : null}
+
+          <SectionCard
+            title={`${t('evictions.detail.comments')}${commentTotal > 0 ? ` · ${commentTotal}` : ''}`}
+          >
+            {comments.length === 0 ? (
+              <BloomText style={styles.muted}>{t('evictions.comments.empty')}</BloomText>
+            ) : (
+              <View>
+                {comments.map((comment, index) => {
+                  const canDelete =
+                    isAuthenticated &&
+                    (comment.oxyUserId === user?.id || Boolean(eviction.isOwner));
+                  return (
+                    <View key={comment.id}>
+                      {index > 0 ? <Divider /> : null}
+                      <EvictionCommentRow
+                        comment={comment}
+                        authorName={resolveName(comment.oxyUserId)}
+                        avatarFileId={getAvatarFileId(comment.oxyUserId)}
+                        time={formatRelativeTime(new Date(comment.createdAt))}
+                        canDelete={canDelete}
+                        onDelete={() => handleDeleteComment(comment.id)}
+                        deleteLabel={t('common.delete')}
+                      />
+                    </View>
+                  );
+                })}
+                {isFetchingNextPage ? (
+                  <BloomText style={styles.muted}>{t('common.loading')}</BloomText>
+                ) : null}
+                <LoadMoreSentinel enabled={hasNextPage} onLoadMore={handleEndReached} />
+              </View>
+            )}
+
+            {isAuthenticated ? (
+              <View style={styles.composer}>
+                <View style={styles.composerField}>
+                  <TextFieldInput
+                    label={t('evictions.comments.placeholder')}
+                    value={commentText}
+                    onChangeText={setCommentText}
+                    multiline
+                  />
+                </View>
+                <Button
+                  variant="primary"
+                  size="medium"
+                  onPress={handlePostComment}
+                  disabled={!commentText.trim() || createComment.isPending}
+                  loading={createComment.isPending}
+                >
+                  {t('evictions.comments.send')}
+                </Button>
+              </View>
+            ) : (
+              <Button variant="secondary" size="medium" onPress={() => showSignInModal()}>
+                {t('evictions.comments.signInToComment')}
+              </Button>
+            )}
+          </SectionCard>
+        </ScrollView>
+
+        <View style={styles.footer}>
+          <Button
+            variant={eviction.isAttending ? 'secondary' : 'primary'}
+            size="large"
+            onPress={handleRSVP}
+            loading={toggleAttend.isPending}
+            icon={
+              <Ionicons
+                name={eviction.isAttending ? 'checkmark-circle' : 'megaphone-outline'}
+                size={20}
+                color={eviction.isAttending ? colors.success : colors.primaryForeground}
+              />
+            }
+            iconPosition="left"
+            style={styles.footerButton}
+          >
+            {`${eviction.isAttending ? t('evictions.attending') : t('evictions.attend')} · ${t('evictions.attendeesCount', { count: eviction.attendeeCount })}`}
+          </Button>
+        </View>
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  safeArea: {
+    flex: 1,
+  },
+  content: {
+    padding: spacing.lg,
+    gap: spacing.lg,
+    paddingBottom: spacing['5xl'],
+  },
+  cover: {
+    width: '100%',
+  },
+  coverImage: {
+    width: '100%',
+    height: '100%',
+  },
+  heroRow: {
+    flexDirection: 'row',
+    gap: spacing.md,
+    alignItems: 'flex-start',
+  },
+  heroText: {
+    flex: 1,
+    minWidth: 0,
+    gap: spacing.xs,
+  },
+  title: {
+    letterSpacing: -0.5,
+  },
+  when: {
+    fontSize: 14,
+    color: colors.textSecondary,
+  },
+  authorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  authorText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  authorLabel: {
+    fontSize: 12,
+    color: colors.textSecondary,
+  },
+  authorName: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  description: {
+    fontSize: 15,
+    color: colors.text,
+    lineHeight: 22,
+  },
+  section: {
+    gap: spacing.md,
+    padding: spacing.lg,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surfaceElevated,
+  },
+  sectionTitle: {
+    letterSpacing: -0.3,
+  },
+  muted: {
+    fontSize: 14,
+    color: colors.textSecondary,
+  },
+  mapWrap: {
+    borderRadius: radius.md,
+    overflow: 'hidden',
+    backgroundColor: colors.mutedSubtle,
+  },
+  mapInner: {
+    height: 220,
+  },
+  locationLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  disclaimerRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+  },
+  disclaimer: {
+    flex: 1,
+    fontSize: 13,
+    color: colors.textSecondary,
+    lineHeight: 18,
+  },
+  timeline: {
+    gap: spacing.md,
+  },
+  timelineItem: {
+    flexDirection: 'row',
+    gap: spacing.md,
+  },
+  timelineDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    marginTop: 4,
+    backgroundColor: colors.primaryColor,
+  },
+  timelineBody: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  timelineTime: {
+    fontSize: 12,
+    color: colors.textTertiary,
+  },
+  timelineMessage: {
+    fontSize: 14,
+    color: colors.text,
+    lineHeight: 20,
+  },
+  timelineMeta: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.textSecondary,
+  },
+  composer: {
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  composerField: {
+    minWidth: 0,
+  },
+  footer: {
+    padding: spacing.lg,
+    backgroundColor: colors.surfaceElevated,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  footerButton: {
+    alignSelf: 'stretch',
+  },
+});

--- a/packages/frontend/app/evictions/index.tsx
+++ b/packages/frontend/app/evictions/index.tsx
@@ -1,0 +1,346 @@
+/**
+ * Eviction solidarity board (tablón) — the public list of upcoming evictions
+ * (desahucios) neighbours can show up to stop.
+ *
+ * Layout: Header (+ auth-gated "Publicar" CTA) → Bloom Chip status filter →
+ * flat `EvictionCard` list → floating map toggle (`MapFab`) revealing the pins.
+ * Paginates through BOTH infinite-scroll primitives (native `onScroll` +
+ * web `LoadMoreSentinel`). Public browse: no auth needed to read.
+ */
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  View,
+  type ImageSourcePropType,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { useRouter } from 'expo-router';
+import { Image } from 'expo-image';
+import { Ionicons } from '@expo/vector-icons';
+import { Button } from '@oxyhq/bloom/button';
+import { Chip } from '@oxyhq/bloom/chip';
+import * as Skeleton from '@oxyhq/bloom/skeleton';
+import { H2, H3, Text as BloomText } from '@oxyhq/bloom/typography';
+import { useOxy, showSignInModal } from '@oxyhq/services';
+
+import { EvictionCaseStatus } from '@homiio/shared-types';
+import { Header } from '@/components/Header';
+import Map from '@/components/Map';
+import { MapFab } from '@/components/ui/MapFab';
+import { ErrorState } from '@/components/ui/ErrorState';
+import { SectionEyebrow } from '@/components/ui/SectionEyebrow';
+import { LoadMoreSentinel } from '@/components/common/LoadMoreSentinel';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { useEvictions } from '@/hooks/useEvictionQueries';
+import { EvictionCard } from '@/components/evictions/EvictionCard';
+import { formatEvictionShortDate } from '@/components/evictions/evictionUtils';
+import { colors } from '@/styles/colors';
+import { radius, spacing } from '@/constants/styles';
+
+const EMPTY_ILLUSTRATION: ImageSourcePropType = require('@/assets/illustrations/empty-inbox.png');
+
+/** Board filters — one paginated server status per chip (no all-status feed). */
+const FILTERS: { status: EvictionCaseStatus; i18nKey: string }[] = [
+  { status: EvictionCaseStatus.UPCOMING, i18nKey: 'evictions.filter.upcoming' },
+  { status: EvictionCaseStatus.STOPPED, i18nKey: 'evictions.filter.stopped' },
+  { status: EvictionCaseStatus.POSTPONED, i18nKey: 'evictions.filter.postponed' },
+  { status: EvictionCaseStatus.EXECUTED, i18nKey: 'evictions.filter.executed' },
+];
+
+const BoardSkeleton: React.FC = () => (
+  <View style={styles.listWrap}>
+    {Array.from({ length: 4 }).map((_, idx) => (
+      <View key={idx} style={styles.skeletonCard}>
+        <Skeleton.Box width={60} height={60} borderRadius={radius.md} />
+        <View style={styles.skeletonBody}>
+          <Skeleton.Text style={{ width: 200, lineHeight: 18 }} />
+          <Skeleton.Text style={{ width: 140, lineHeight: 14 }} />
+          <Skeleton.Text style={{ width: 90, lineHeight: 14 }} />
+        </View>
+      </View>
+    ))}
+  </View>
+);
+
+export default function EvictionsBoardScreen() {
+  const { t, i18n } = useTranslation();
+  const router = useRouter();
+  const { isAuthenticated } = useOxy();
+
+  const [status, setStatus] = useState<EvictionCaseStatus>(EvictionCaseStatus.UPCOMING);
+  const [showMap, setShowMap] = useState(false);
+
+  const params = useMemo(() => ({ status }), [status]);
+  const {
+    cases,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useEvictions(params);
+
+  const handleEndReached = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) void fetchNextPage();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  const { onScroll } = useInfiniteScroll({ onEndReached: handleEndReached, enabled: hasNextPage });
+
+  const markers = useMemo(
+    () =>
+      cases
+        .map((eviction) => {
+          const coords = eviction.location?.coordinates?.coordinates;
+          if (
+            !coords ||
+            coords.length !== 2 ||
+            typeof coords[0] !== 'number' ||
+            typeof coords[1] !== 'number' ||
+            (coords[0] === 0 && coords[1] === 0)
+          ) {
+            return null;
+          }
+          return {
+            id: eviction.id,
+            coordinates: [coords[0], coords[1]] as [number, number],
+            priceLabel: formatEvictionShortDate(eviction.scheduledAt, i18n.language),
+          };
+        })
+        .filter(
+          (m): m is { id: string; coordinates: [number, number]; priceLabel: string } =>
+            m !== null,
+        ),
+    [cases, i18n.language],
+  );
+
+  const openDetail = useCallback(
+    (id: string) => router.push(`/evictions/${id}`),
+    [router],
+  );
+
+  const handlePublish = useCallback(() => {
+    if (!isAuthenticated) {
+      showSignInModal();
+      return;
+    }
+    router.push('/evictions/new');
+  }, [isAuthenticated, router]);
+
+  const publishButton = (
+    <Button
+      key="publish"
+      variant="primary"
+      size="small"
+      onPress={handlePublish}
+      icon={<Ionicons name="add" size={16} color={colors.primaryForeground} />}
+      iconPosition="left"
+      accessibilityLabel={t('evictions.publishCta')}
+    >
+      {t('evictions.publishCta')}
+    </Button>
+  );
+
+  const listBody = () => {
+    if (isLoading && cases.length === 0) return <BoardSkeleton />;
+    if (isError) {
+      return (
+        <ErrorState
+          icon="cloud-offline-outline"
+          title={t('evictions.loadError')}
+          description={error?.message ?? t('common.tryAgain')}
+          onRetry={() => void refetch()}
+        />
+      );
+    }
+    if (cases.length === 0) {
+      return (
+        <View style={styles.emptyWrap}>
+          <Image
+            source={EMPTY_ILLUSTRATION}
+            style={styles.emptyImage}
+            contentFit="contain"
+            accessibilityIgnoresInvertColors
+          />
+          <H3 style={styles.emptyTitle}>{t('evictions.empty.title')}</H3>
+          <BloomText style={styles.emptyMessage}>{t('evictions.empty.subtitle')}</BloomText>
+          <Button
+            variant="primary"
+            size="medium"
+            onPress={handlePublish}
+            icon={<Ionicons name="add" size={18} color={colors.primaryForeground} />}
+            iconPosition="left"
+            style={styles.emptyCta}
+          >
+            {t('evictions.publishCta')}
+          </Button>
+        </View>
+      );
+    }
+    return (
+      <View style={styles.listWrap}>
+        {cases.map((eviction) => (
+          <EvictionCard
+            key={eviction.id}
+            eviction={eviction}
+            locale={i18n.language}
+            onPress={() => openDetail(eviction.id)}
+          />
+        ))}
+        {isFetchingNextPage ? <BoardSkeleton /> : null}
+        <LoadMoreSentinel enabled={hasNextPage} onLoadMore={handleEndReached} />
+      </View>
+    );
+  };
+
+  return (
+    <View style={styles.root}>
+      <Header
+        options={{
+          title: t('evictions.title'),
+          rightComponents: [publishButton],
+        }}
+      />
+      <SafeAreaView edges={['bottom']} style={styles.safeArea}>
+        {showMap ? (
+          <View style={styles.mapPanel}>
+            <Map
+              style={styles.mapFill}
+              screenId="evictions-map"
+              markers={markers}
+              onMarkerPress={({ id }) => openDetail(id)}
+              cluster={{ enabled: true }}
+            />
+          </View>
+        ) : (
+          <ScrollView
+            contentContainerStyle={styles.content}
+            onScroll={onScroll}
+            scrollEventThrottle={16}
+            showsVerticalScrollIndicator={false}
+          >
+            <View style={styles.titleBlock}>
+              <SectionEyebrow>{t('evictions.eyebrow')}</SectionEyebrow>
+              <H2 style={styles.title}>{t('evictions.title')}</H2>
+              <BloomText style={styles.subtitle}>{t('evictions.subtitle')}</BloomText>
+            </View>
+
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.filterRow}
+            >
+              {FILTERS.map((entry) => {
+                const isActive = status === entry.status;
+                return (
+                  <Chip
+                    key={entry.status}
+                    onPress={() => setStatus(entry.status)}
+                    variant={isActive ? 'solid' : 'outlined'}
+                    color={isActive ? 'primary' : 'default'}
+                    selected={isActive}
+                  >
+                    {t(entry.i18nKey)}
+                  </Chip>
+                );
+              })}
+            </ScrollView>
+
+            {listBody()}
+          </ScrollView>
+        )}
+
+        <MapFab
+          onPress={() => setShowMap((prev) => !prev)}
+          label={showMap ? t('evictions.showList') : t('evictions.showMap')}
+          icon={showMap ? 'list' : 'map'}
+        />
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  safeArea: {
+    flex: 1,
+  },
+  content: {
+    padding: spacing.lg,
+    gap: spacing.lg,
+    paddingBottom: spacing['5xl'],
+  },
+  titleBlock: {
+    gap: spacing.xs,
+  },
+  title: {
+    letterSpacing: -0.5,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: colors.muted,
+  },
+  filterRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    paddingVertical: spacing.xs,
+  },
+  listWrap: {
+    gap: spacing.md,
+  },
+  skeletonCard: {
+    flexDirection: 'row',
+    gap: spacing.md,
+    padding: spacing.md,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surfaceElevated,
+  },
+  skeletonBody: {
+    flex: 1,
+    gap: spacing.sm,
+    justifyContent: 'center',
+  },
+  emptyWrap: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing['5xl'],
+    paddingHorizontal: spacing['2xl'],
+  },
+  emptyImage: {
+    width: 200,
+    height: 200,
+    marginBottom: spacing.xl,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.text,
+    textAlign: 'center',
+    marginBottom: spacing.sm,
+  },
+  emptyMessage: {
+    fontSize: 14,
+    color: colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 20,
+    maxWidth: 320,
+    marginBottom: spacing.lg,
+  },
+  emptyCta: {
+    alignSelf: 'center',
+  },
+  mapPanel: {
+    flex: 1,
+    position: 'relative',
+  },
+  mapFill: {
+    ...StyleSheet.absoluteFill,
+  },
+});

--- a/packages/frontend/app/evictions/new.tsx
+++ b/packages/frontend/app/evictions/new.tsx
@@ -1,0 +1,568 @@
+/**
+ * Publish / edit an eviction case (publicar).
+ *
+ * Sectioned form (mirrors `app/reviews/write.tsx`): 1) Qué pasa (title +
+ * description) · 2) Dónde (map address lookup → editable label + city + an
+ * approximate-location Switch that rounds the pin server-side) · 3) Cuándo (date
+ * + time) · 4) Cómo ayudar (phone/email/telegram/whatsapp + instructions) ·
+ * 5) Agencia/fondo ejecutor (free text) · 6) Foto opcional (single upload to the
+ * `evictions` folder). Submits through `useCreateEviction` / `useUpdateEviction`
+ * then `router.replace`s to the case. Edit mode prefills from the loaded case;
+ * the form initialises its state from that snapshot (no prefill `useEffect`).
+ */
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { Platform, ScrollView, StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { Image } from 'expo-image';
+import * as ImagePicker from 'expo-image-picker';
+import { Ionicons } from '@expo/vector-icons';
+import { Button } from '@oxyhq/bloom/button';
+import * as Skeleton from '@oxyhq/bloom/skeleton';
+import { Switch } from '@oxyhq/bloom/switch';
+import { TextFieldInput } from '@oxyhq/bloom/text-field';
+import { H2, H3, Text as BloomText } from '@oxyhq/bloom/typography';
+
+import { CreateEvictionCaseData, EvictionCase } from '@homiio/shared-types';
+import { Header } from '@/components/Header';
+import Map, { type MapApi, type AddressData, type LonLat } from '@/components/Map';
+import { ErrorState } from '@/components/ui/ErrorState';
+import { SectionEyebrow } from '@/components/ui/SectionEyebrow';
+import { useCreateEviction, useEvictionDetail, useUpdateEviction } from '@/hooks/useEvictionQueries';
+import { imageUploadService } from '@/services/imageUploadService';
+import { resolveBackendImageUrl } from '@/utils/imageUrl';
+import { toast } from '@/lib/sonner';
+import { colors } from '@/styles/colors';
+import { radius, spacing } from '@/constants/styles';
+
+interface EvictionFormState {
+  title: string;
+  description: string;
+  label: string;
+  city: string;
+  date: string;
+  time: string;
+  phone: string;
+  email: string;
+  telegram: string;
+  whatsapp: string;
+  instructions: string;
+  agencyName: string;
+}
+
+const EMPTY_STATE: EvictionFormState = {
+  title: '',
+  description: '',
+  label: '',
+  city: '',
+  date: '',
+  time: '',
+  phone: '',
+  email: '',
+  telegram: '',
+  whatsapp: '',
+  instructions: '',
+  agencyName: '',
+};
+
+/** Split an ISO date into the `YYYY-MM-DD` + `HH:mm` the form edits (local time). */
+const isoToParts = (iso: string): { date: string; time: string } => {
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return { date: '', time: '' };
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return {
+    date: `${parsed.getFullYear()}-${pad(parsed.getMonth() + 1)}-${pad(parsed.getDate())}`,
+    time: `${pad(parsed.getHours())}:${pad(parsed.getMinutes())}`,
+  };
+};
+
+const buildInitialState = (existing?: EvictionCase): EvictionFormState => {
+  if (!existing) return EMPTY_STATE;
+  const { date, time } = isoToParts(existing.scheduledAt);
+  return {
+    title: existing.title,
+    description: existing.description,
+    label: existing.location.label,
+    city: existing.location.city ?? '',
+    date,
+    time,
+    phone: existing.contactInfo?.phone ?? '',
+    email: existing.contactInfo?.email ?? '',
+    telegram: existing.contactInfo?.telegram ?? '',
+    whatsapp: existing.contactInfo?.whatsapp ?? '',
+    instructions: existing.contactInfo?.instructions ?? '',
+    agencyName: '',
+  };
+};
+
+/** Combine the `YYYY-MM-DD` + optional `HH:mm` fields into an ISO string. */
+const partsToIso = (date: string, time: string): string | undefined => {
+  const trimmed = date.trim();
+  if (!trimmed) return undefined;
+  const parsed = new Date(`${trimmed}T${time.trim() || '00:00'}`);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+};
+
+interface EvictionFormProps {
+  mode: 'create' | 'edit';
+  editId?: string;
+  existing?: EvictionCase;
+}
+
+const EvictionForm: React.FC<EvictionFormProps> = ({ mode, editId, existing }) => {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const mapRef = useRef<MapApi | null>(null);
+
+  // The case being edited is fixed for this form's lifetime, so its coordinates
+  // are a stable seed for the map center (later taps move the pin imperatively).
+  const initialCoords = useMemo<LonLat | null>(() => {
+    const c = existing?.location.coordinates?.coordinates;
+    return Array.isArray(c) && c.length === 2 ? [c[0], c[1]] : null;
+  }, [existing]);
+
+  const [form, setForm] = useState<EvictionFormState>(() => buildInitialState(existing));
+  const [approximate, setApproximate] = useState(existing?.location.precision !== 'exact');
+  const [coords, setCoords] = useState<LonLat | null>(initialCoords);
+  const [cover, setCover] = useState<{ imageId?: string; url?: string } | undefined>(
+    existing?.coverImage,
+  );
+  const [uploading, setUploading] = useState(false);
+
+  const createMutation = useCreateEviction();
+  const updateMutation = useUpdateEviction(editId ?? '');
+  const submitting = createMutation.isPending || updateMutation.isPending;
+
+  const initialCoordinates = initialCoords ?? undefined;
+
+  const update = useCallback(
+    <K extends keyof EvictionFormState>(key: K, value: EvictionFormState[K]) => {
+      setForm((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  const handleAddressSelect = useCallback((address: AddressData, coordinates: LonLat) => {
+    setCoords(coordinates);
+    const composed =
+      address.fullAddress ||
+      [address.street, address.houseNumber].filter(Boolean).join(' ') ||
+      address.neighborhood ||
+      address.city ||
+      '';
+    setForm((prev) => ({
+      ...prev,
+      label: composed || prev.label,
+      city: address.city || prev.city,
+    }));
+  }, []);
+
+  const handlePickCover = useCallback(async () => {
+    if (Platform.OS !== 'web') {
+      const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (permission.status !== 'granted') {
+        toast.error(t('evictions.form.photoPermission'));
+        return;
+      }
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.9,
+    });
+    if (result.canceled || result.assets.length === 0) return;
+    setUploading(true);
+    try {
+      const uploaded = await imageUploadService.uploadSingleImage(result.assets[0].uri, 'evictions');
+      setCover({ imageId: uploaded.imageId, url: uploaded.urls.medium ?? uploaded.urls.original });
+    } catch {
+      toast.error(t('evictions.form.photoFailed'));
+    } finally {
+      setUploading(false);
+    }
+  }, [t]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!form.title.trim()) {
+      toast.error(t('evictions.form.titleRequired'));
+      return;
+    }
+    if (!form.description.trim()) {
+      toast.error(t('evictions.form.descriptionRequired'));
+      return;
+    }
+    if (!coords) {
+      toast.error(t('evictions.form.locationRequired'));
+      return;
+    }
+    if (!form.label.trim()) {
+      toast.error(t('evictions.form.labelRequired'));
+      return;
+    }
+    const scheduledAt = partsToIso(form.date, form.time);
+    if (!scheduledAt) {
+      toast.error(t('evictions.form.dateRequired'));
+      return;
+    }
+
+    const contactInfo = {
+      phone: form.phone.trim() || undefined,
+      email: form.email.trim() || undefined,
+      telegram: form.telegram.trim() || undefined,
+      whatsapp: form.whatsapp.trim() || undefined,
+      instructions: form.instructions.trim() || undefined,
+    };
+    const hasContact = Object.values(contactInfo).some((value) => value !== undefined);
+
+    const payload: CreateEvictionCaseData = {
+      title: form.title.trim(),
+      description: form.description.trim(),
+      location: {
+        label: form.label.trim(),
+        coordinates: { type: 'Point', coordinates: [coords[0], coords[1]] },
+        precision: approximate ? 'approximate' : 'exact',
+        city: form.city.trim() || undefined,
+      },
+      scheduledAt,
+      contactInfo: hasContact ? contactInfo : undefined,
+      coverImage: cover?.imageId ? cover : undefined,
+      agencyName: form.agencyName.trim() || undefined,
+    };
+
+    try {
+      if (mode === 'edit' && editId) {
+        await updateMutation.mutateAsync(payload);
+        toast.success(t('evictions.form.updateSuccess'));
+        router.replace(`/evictions/${editId}`);
+      } else {
+        const created = await createMutation.mutateAsync(payload);
+        toast.success(t('evictions.form.createSuccess'));
+        router.replace(`/evictions/${created.id}`);
+      }
+    } catch (submitError) {
+      toast.error(
+        submitError instanceof Error ? submitError.message : t('evictions.form.submitError'),
+      );
+    }
+  }, [form, coords, approximate, cover, mode, editId, updateMutation, createMutation, router, t]);
+
+  const coverPreview = cover?.url ? resolveBackendImageUrl(cover.url) : undefined;
+
+  return (
+    <View style={styles.root}>
+      <Header
+        options={{
+          showBackButton: true,
+          title: mode === 'edit' ? t('evictions.form.editTitle') : t('evictions.form.title'),
+        }}
+      />
+      <SafeAreaView edges={['bottom']} style={styles.safeArea}>
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+          <View style={styles.titleBlock}>
+            <SectionEyebrow>{t('evictions.eyebrow')}</SectionEyebrow>
+            <H2 style={styles.pageTitle}>
+              {mode === 'edit' ? t('evictions.form.editTitle') : t('evictions.form.title')}
+            </H2>
+            <BloomText style={styles.subtitle}>{t('evictions.form.subtitle')}</BloomText>
+          </View>
+
+          <View style={styles.section}>
+            <H3 style={styles.sectionTitle}>{t('evictions.form.whatSection')}</H3>
+            <TextFieldInput
+              label={t('evictions.form.titleLabel')}
+              placeholder={t('evictions.form.titlePlaceholder')}
+              value={form.title}
+              onChangeText={(text) => update('title', text)}
+            />
+            <TextFieldInput
+              label={t('evictions.form.descriptionLabel')}
+              placeholder={t('evictions.form.descriptionPlaceholder')}
+              value={form.description}
+              onChangeText={(text) => update('description', text)}
+              multiline
+            />
+          </View>
+
+          <View style={styles.section}>
+            <H3 style={styles.sectionTitle}>{t('evictions.form.whereSection')}</H3>
+            <View style={styles.mapWrap}>
+              <Map
+                ref={mapRef}
+                style={styles.mapInner}
+                enableAddressLookup
+                showAddressInstructions
+                onAddressSelect={handleAddressSelect}
+                initialCoordinates={initialCoordinates}
+                startFromCurrentLocation={!initialCoordinates}
+                screenId="eviction-create"
+              />
+            </View>
+            <BloomText style={styles.hint}>{t('evictions.form.mapHint')}</BloomText>
+            <TextFieldInput
+              label={t('evictions.form.labelLabel')}
+              placeholder={t('evictions.form.labelPlaceholder')}
+              value={form.label}
+              onChangeText={(text) => update('label', text)}
+            />
+            <TextFieldInput
+              label={t('evictions.form.cityLabel')}
+              placeholder={t('evictions.form.cityPlaceholder')}
+              value={form.city}
+              onChangeText={(text) => update('city', text)}
+            />
+            <View style={styles.switchRow}>
+              <View style={styles.switchText}>
+                <BloomText style={styles.switchLabel}>
+                  {t('evictions.form.approximateLabel')}
+                </BloomText>
+                <BloomText style={styles.switchHint}>
+                  {t('evictions.form.approximateHint')}
+                </BloomText>
+              </View>
+              <Switch value={approximate} onValueChange={setApproximate} />
+            </View>
+          </View>
+
+          <View style={styles.section}>
+            <H3 style={styles.sectionTitle}>{t('evictions.form.whenSection')}</H3>
+            <View style={styles.row}>
+              <View style={styles.rowField}>
+                <TextFieldInput
+                  label={t('evictions.form.dateLabel')}
+                  placeholder="YYYY-MM-DD"
+                  value={form.date}
+                  onChangeText={(text) => update('date', text)}
+                />
+              </View>
+              <View style={styles.rowField}>
+                <TextFieldInput
+                  label={t('evictions.form.timeLabel')}
+                  placeholder="HH:MM"
+                  value={form.time}
+                  onChangeText={(text) => update('time', text)}
+                />
+              </View>
+            </View>
+          </View>
+
+          <View style={styles.section}>
+            <H3 style={styles.sectionTitle}>{t('evictions.form.helpSection')}</H3>
+            <TextFieldInput
+              label={t('evictions.detail.contact.phone')}
+              placeholder="+34 600 000 000"
+              value={form.phone}
+              onChangeText={(text) => update('phone', text)}
+              keyboardType="phone-pad"
+            />
+            <TextFieldInput
+              label={t('evictions.detail.contact.whatsapp')}
+              placeholder="+34 600 000 000"
+              value={form.whatsapp}
+              onChangeText={(text) => update('whatsapp', text)}
+            />
+            <TextFieldInput
+              label={t('evictions.detail.contact.telegram')}
+              placeholder="@canal"
+              value={form.telegram}
+              onChangeText={(text) => update('telegram', text)}
+              autoCapitalize="none"
+            />
+            <TextFieldInput
+              label={t('evictions.detail.contact.email')}
+              placeholder="solidaridad@example.org"
+              value={form.email}
+              onChangeText={(text) => update('email', text)}
+              keyboardType="email-address"
+              autoCapitalize="none"
+            />
+            <TextFieldInput
+              label={t('evictions.form.instructionsLabel')}
+              placeholder={t('evictions.form.instructionsPlaceholder')}
+              value={form.instructions}
+              onChangeText={(text) => update('instructions', text)}
+              multiline
+            />
+          </View>
+
+          <View style={styles.section}>
+            <H3 style={styles.sectionTitle}>{t('evictions.form.agencySection')}</H3>
+            <TextFieldInput
+              label={t('evictions.form.agencyLabel')}
+              placeholder={t('evictions.form.agencyPlaceholder')}
+              value={form.agencyName}
+              onChangeText={(text) => update('agencyName', text)}
+            />
+          </View>
+
+          <View style={styles.section}>
+            <H3 style={styles.sectionTitle}>{t('evictions.form.photoSection')}</H3>
+            {coverPreview ? (
+              <Image
+                source={{ uri: coverPreview }}
+                style={styles.coverPreview}
+                contentFit="cover"
+                accessibilityIgnoresInvertColors
+              />
+            ) : null}
+            <Button
+              variant="secondary"
+              size="medium"
+              onPress={handlePickCover}
+              loading={uploading}
+              disabled={uploading}
+              icon={<Ionicons name="image-outline" size={18} color={colors.text} />}
+              iconPosition="left"
+              style={styles.photoButton}
+            >
+              {cover?.imageId ? t('evictions.form.photoChange') : t('evictions.form.photoAdd')}
+            </Button>
+          </View>
+
+          <Button
+            variant="primary"
+            size="large"
+            onPress={handleSubmit}
+            loading={submitting}
+            disabled={submitting}
+            style={styles.submit}
+          >
+            {mode === 'edit' ? t('evictions.form.saveChanges') : t('evictions.form.publish')}
+          </Button>
+        </ScrollView>
+      </SafeAreaView>
+    </View>
+  );
+};
+
+export default function EvictionsFormScreen() {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const { edit } = useLocalSearchParams<{ edit?: string }>();
+  const editId = Array.isArray(edit) ? edit[0] : edit;
+  const isEdit = Boolean(editId);
+
+  const { data: existing, isLoading, isError } = useEvictionDetail(editId);
+
+  if (isEdit && isLoading) {
+    return (
+      <View style={styles.root}>
+        <Header options={{ showBackButton: true, title: t('evictions.form.editTitle') }} />
+        <View style={styles.content}>
+          <Skeleton.Box width="100%" height={48} borderRadius={radius.md} />
+          <Skeleton.Box width="100%" height={200} borderRadius={radius.lg} />
+          <Skeleton.Box width="100%" height={48} borderRadius={radius.md} />
+        </View>
+      </View>
+    );
+  }
+
+  if (isEdit && (isError || !existing)) {
+    return (
+      <View style={styles.root}>
+        <Header options={{ showBackButton: true, title: t('evictions.form.editTitle') }} />
+        <ErrorState
+          icon="cloud-offline-outline"
+          title={t('evictions.loadError')}
+          description={t('common.tryAgain')}
+          retryLabel={t('common.goBack')}
+          onRetry={() => router.back()}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <EvictionForm
+      mode={isEdit ? 'edit' : 'create'}
+      editId={editId}
+      existing={isEdit ? existing : undefined}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  safeArea: {
+    flex: 1,
+  },
+  content: {
+    padding: spacing.lg,
+    gap: spacing.lg,
+    paddingBottom: spacing['5xl'],
+  },
+  titleBlock: {
+    gap: spacing.xs,
+  },
+  pageTitle: {
+    letterSpacing: -0.5,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: colors.muted,
+  },
+  section: {
+    gap: spacing.md,
+    padding: spacing.lg,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surfaceElevated,
+  },
+  sectionTitle: {
+    letterSpacing: -0.3,
+  },
+  mapWrap: {
+    borderRadius: radius.md,
+    overflow: 'hidden',
+    backgroundColor: colors.mutedSubtle,
+  },
+  mapInner: {
+    height: 260,
+  },
+  hint: {
+    fontSize: 12,
+    color: colors.muted,
+    textAlign: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    gap: spacing.md,
+  },
+  rowField: {
+    flex: 1,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  switchText: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  switchLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  switchHint: {
+    fontSize: 12,
+    color: colors.textSecondary,
+    lineHeight: 16,
+  },
+  coverPreview: {
+    width: '100%',
+    height: 180,
+    borderRadius: radius.md,
+    backgroundColor: colors.mutedSubtle,
+  },
+  photoButton: {
+    alignSelf: 'flex-start',
+  },
+  submit: {
+    alignSelf: 'stretch',
+  },
+});

--- a/packages/frontend/components/NotificationItem.tsx
+++ b/packages/frontend/components/NotificationItem.tsx
@@ -65,6 +65,21 @@ const TYPE_VISUALS: Record<string, TypeVisual> = {
     color: colors.textSecondary,
     surface: colors.mutedSubtle,
   },
+  eviction_update: {
+    icon: 'megaphone',
+    color: colors.danger,
+    surface: colors.dangerSubtle,
+  },
+  eviction_comment: {
+    icon: 'chatbubbles',
+    color: colors.primaryColor,
+    surface: colors.infoSubtle,
+  },
+  eviction_rsvp: {
+    icon: 'people',
+    color: colors.success,
+    surface: colors.successSubtle,
+  },
 };
 
 const DEFAULT_VISUAL: TypeVisual = {

--- a/packages/frontend/components/SideBar/index.tsx
+++ b/packages/frontend/components/SideBar/index.tsx
@@ -24,6 +24,7 @@ import {
   BedDouble,
   User,
   Lightbulb,
+  Megaphone,
   Users,
   CalendarClock,
   Bookmark,
@@ -307,6 +308,14 @@ export function SideBar() {
       iconActive: Lightbulb,
       label: t('sidebar.navigation.tips'),
       route: '/tips',
+    });
+
+    entries.push({
+      key: 'evictions',
+      icon: Megaphone,
+      iconActive: Megaphone,
+      label: t('sidebar.navigation.evictions'),
+      route: '/evictions',
     });
 
     if (canAccessRoommates) {

--- a/packages/frontend/components/evictions/EvictionCard.tsx
+++ b/packages/frontend/components/evictions/EvictionCard.tsx
@@ -1,0 +1,161 @@
+/**
+ * EvictionCard — one flat row on the solidarity board.
+ *
+ * Layout: [ date block ] [ title · location · status + attendees ] [ cover ]
+ *
+ * The whole card owns ONE hover/press state and feeds `active` to the cover
+ * `ZoomableImage` so the photo zooms inside its rounded mask on hover anywhere
+ * on the card — the card itself never scales (AGENTS.md §ZoomableImage). Static
+ * style arrays + `onPressIn/Out` (never the NativeWind-incompatible function-form
+ * `style`); it's its own component, so no hooks run inside the board's `.map`.
+ */
+import React, { useState } from 'react';
+import { Platform, Pressable, StyleSheet, View } from 'react-native';
+import { Image } from 'expo-image';
+import { Ionicons } from '@expo/vector-icons';
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+import type { EvictionCase } from '@homiio/shared-types';
+
+import { ZoomableImage } from '@/components/ui/ZoomableImage';
+import { resolveBackendImageUrl } from '@/utils/imageUrl';
+import { colors } from '@/styles/colors';
+import { radius, spacing } from '@/constants/styles';
+import { EvictionStatusBadge } from './EvictionStatusBadge';
+import { EvictionDateBlock } from './EvictionDateBlock';
+
+const IS_WEB = Platform.OS === 'web';
+
+interface EvictionCardProps {
+  eviction: EvictionCase;
+  locale: string;
+  onPress: () => void;
+}
+
+export const EvictionCard: React.FC<EvictionCardProps> = ({ eviction, locale, onPress }) => {
+  const [pressed, setPressed] = useState(false);
+  const [hovered, setHovered] = useState(false);
+
+  const coverUrl = eviction.coverImage?.url
+    ? resolveBackendImageUrl(eviction.coverImage.url)
+    : undefined;
+
+  const locationLine = [eviction.location.label, eviction.location.city]
+    .filter((part): part is string => Boolean(part && part.trim()))
+    .join(' · ');
+
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      onHoverIn={IS_WEB ? () => setHovered(true) : undefined}
+      onHoverOut={IS_WEB ? () => setHovered(false) : undefined}
+      accessibilityRole="button"
+      accessibilityLabel={eviction.title}
+      style={[styles.card, pressed && styles.cardPressed]}
+    >
+      <EvictionDateBlock scheduledAt={eviction.scheduledAt} locale={locale} />
+
+      <View style={styles.body}>
+        <BloomText style={styles.title} numberOfLines={2} ellipsizeMode="tail">
+          {eviction.title}
+        </BloomText>
+        {locationLine ? (
+          <View style={styles.locationRow}>
+            <Ionicons name="location-outline" size={14} color={colors.textSecondary} />
+            <BloomText style={styles.location} numberOfLines={1} ellipsizeMode="tail">
+              {locationLine}
+            </BloomText>
+          </View>
+        ) : null}
+        <View style={styles.metaRow}>
+          <EvictionStatusBadge status={eviction.status} />
+          <View style={styles.attendees}>
+            <Ionicons name="people-outline" size={14} color={colors.textSecondary} />
+            <BloomText style={styles.attendeeCount}>{eviction.attendeeCount}</BloomText>
+          </View>
+        </View>
+      </View>
+
+      {coverUrl ? (
+        <ZoomableImage
+          borderRadius={radius.md}
+          aspectRatio={1}
+          active={hovered || pressed}
+          style={styles.cover}
+        >
+          <Image
+            source={{ uri: coverUrl }}
+            style={styles.coverImage}
+            contentFit="cover"
+            accessibilityIgnoresInvertColors
+          />
+        </ZoomableImage>
+      ) : null}
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    padding: spacing.md,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surfaceElevated,
+  },
+  cardPressed: {
+    backgroundColor: colors.mutedSubtle,
+  },
+  body: {
+    flex: 1,
+    minWidth: 0,
+    gap: spacing.xs,
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  locationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  location: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 13,
+    color: colors.textSecondary,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+    marginTop: spacing.xs,
+  },
+  attendees: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  attendeeCount: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.textSecondary,
+  },
+  cover: {
+    width: 72,
+    height: 72,
+  },
+  coverImage: {
+    width: '100%',
+    height: '100%',
+  },
+});
+
+export default EvictionCard;

--- a/packages/frontend/components/evictions/EvictionCommentRow.tsx
+++ b/packages/frontend/components/evictions/EvictionCommentRow.tsx
@@ -1,0 +1,96 @@
+/**
+ * One row in a case's public coordination thread: author avatar + name, a
+ * relative timestamp, the comment body, and a delete affordance shown only when
+ * the viewer may remove it (its author or the case owner). The delete button is
+ * the shared `IconButton` (which owns its own pressed state), so this row needs
+ * no interaction hooks and is safe inside the thread's `.map`.
+ */
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Avatar } from '@oxyhq/bloom/avatar';
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+import type { EvictionComment } from '@homiio/shared-types';
+
+import { IconButton } from '@/components/ui/IconButton';
+import { colors } from '@/styles/colors';
+import { spacing } from '@/constants/styles';
+
+interface EvictionCommentRowProps {
+  comment: EvictionComment;
+  authorName: string;
+  avatarFileId?: string;
+  time: string;
+  canDelete: boolean;
+  onDelete: () => void;
+  deleteLabel: string;
+}
+
+export const EvictionCommentRow: React.FC<EvictionCommentRowProps> = ({
+  comment,
+  authorName,
+  avatarFileId,
+  time,
+  canDelete,
+  onDelete,
+  deleteLabel,
+}) => (
+  <View style={styles.row}>
+    <Avatar size={40} name={authorName} source={avatarFileId ?? null} variant="thumb" />
+    <View style={styles.body}>
+      <View style={styles.headerRow}>
+        <BloomText style={styles.author} numberOfLines={1}>
+          {authorName}
+        </BloomText>
+        <BloomText style={styles.time}>{time}</BloomText>
+        {canDelete ? (
+          <IconButton
+            icon="trash-outline"
+            variant="ghost"
+            size={16}
+            color={colors.textTertiary}
+            accessibilityLabel={deleteLabel}
+            onPress={onDelete}
+          />
+        ) : null}
+      </View>
+      <BloomText style={styles.text}>{comment.body}</BloomText>
+    </View>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  body: {
+    flex: 1,
+    minWidth: 0,
+    gap: spacing.xs,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  author: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  time: {
+    fontSize: 12,
+    color: colors.textTertiary,
+  },
+  text: {
+    fontSize: 14,
+    color: colors.text,
+    lineHeight: 20,
+  },
+});
+
+export default EvictionCommentRow;

--- a/packages/frontend/components/evictions/EvictionContactActions.tsx
+++ b/packages/frontend/components/evictions/EvictionContactActions.tsx
@@ -1,0 +1,157 @@
+/**
+ * "Cómo ayudar" contact block for an eviction case: the organiser's tappable
+ * phone / WhatsApp / Telegram / email actions (only the fields the reporter
+ * provided — contacts are never invented) plus the free-text instructions.
+ *
+ * Each row owns its own pressed state via a static style array + `onPressIn/Out`
+ * (the NativeWind function-form `style` is unsupported), and the row is its own
+ * component so no hook runs inside the `.map`.
+ */
+import React, { useState } from 'react';
+import { Linking, Pressable, StyleSheet, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+import type { EvictionContactInfo } from '@homiio/shared-types';
+
+import { toast } from '@/lib/sonner';
+import { colors } from '@/styles/colors';
+import { radius, spacing } from '@/constants/styles';
+import { buildEvictionContactActions, type EvictionContactAction } from './evictionUtils';
+
+interface ContactRowProps {
+  action: EvictionContactAction;
+  label: string;
+  openFailedLabel: string;
+}
+
+const ContactRow: React.FC<ContactRowProps> = ({ action, label, openFailedLabel }) => {
+  const [pressed, setPressed] = useState(false);
+
+  const handlePress = async () => {
+    try {
+      await Linking.openURL(action.url);
+    } catch {
+      toast.error(openFailedLabel);
+    }
+  };
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      accessibilityRole="button"
+      accessibilityLabel={`${label}: ${action.value}`}
+      style={[styles.row, pressed && styles.rowPressed]}
+    >
+      <View style={styles.iconCircle}>
+        <Ionicons name={action.icon} size={18} color={colors.primaryColor} />
+      </View>
+      <View style={styles.rowText}>
+        <BloomText style={styles.rowLabel}>{label}</BloomText>
+        <BloomText style={styles.rowValue} numberOfLines={1} ellipsizeMode="middle">
+          {action.value}
+        </BloomText>
+      </View>
+      <Ionicons name="open-outline" size={16} color={colors.textTertiary} />
+    </Pressable>
+  );
+};
+
+interface EvictionContactActionsProps {
+  contact: EvictionContactInfo | undefined;
+  /** Localized labels keyed by contact kind. */
+  labels: Record<EvictionContactAction['kind'], string>;
+  instructionsLabel: string;
+  openFailedLabel: string;
+}
+
+export const EvictionContactActions: React.FC<EvictionContactActionsProps> = ({
+  contact,
+  labels,
+  instructionsLabel,
+  openFailedLabel,
+}) => {
+  const actions = buildEvictionContactActions(contact);
+  const instructions = contact?.instructions?.trim();
+
+  if (actions.length === 0 && !instructions) return null;
+
+  return (
+    <View style={styles.wrap}>
+      {actions.map((action) => (
+        <ContactRow
+          key={action.kind}
+          action={action}
+          label={labels[action.kind]}
+          openFailedLabel={openFailedLabel}
+        />
+      ))}
+      {instructions ? (
+        <View style={styles.instructions}>
+          <BloomText style={styles.instructionsLabel}>{instructionsLabel}</BloomText>
+          <BloomText style={styles.instructionsText}>{instructions}</BloomText>
+        </View>
+      ) : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrap: {
+    gap: spacing.sm,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    padding: spacing.sm,
+    borderRadius: radius.md,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  rowPressed: {
+    backgroundColor: colors.mutedSubtle,
+  },
+  iconCircle: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.infoSubtle,
+  },
+  rowText: {
+    flex: 1,
+    minWidth: 0,
+    gap: 2,
+  },
+  rowLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.textSecondary,
+  },
+  rowValue: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  instructions: {
+    gap: spacing.xs,
+    paddingHorizontal: spacing.xs,
+    paddingTop: spacing.xs,
+  },
+  instructionsLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.textSecondary,
+  },
+  instructionsText: {
+    fontSize: 14,
+    color: colors.text,
+    lineHeight: 20,
+  },
+});
+
+export default EvictionContactActions;

--- a/packages/frontend/components/evictions/EvictionDateBlock.tsx
+++ b/packages/frontend/components/evictions/EvictionDateBlock.tsx
@@ -1,0 +1,78 @@
+/**
+ * Calendar-style date block for an eviction case: the day big, the month above,
+ * the time below. Presentational only (no hooks beyond `useTranslation`'s locale
+ * read via the caller), so it drops into the board card and the detail hero.
+ */
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+
+import { colors } from '@/styles/colors';
+import { radius, spacing } from '@/constants/styles';
+import { formatEvictionDateParts } from './evictionUtils';
+
+interface EvictionDateBlockProps {
+  scheduledAt: string;
+  locale: string;
+  /** Larger variant for the detail hero. */
+  size?: 'compact' | 'large';
+}
+
+export const EvictionDateBlock: React.FC<EvictionDateBlockProps> = ({
+  scheduledAt,
+  locale,
+  size = 'compact',
+}) => {
+  const parts = formatEvictionDateParts(scheduledAt, locale);
+  const large = size === 'large';
+
+  return (
+    <View style={[styles.block, large ? styles.blockLarge : styles.blockCompact]}>
+      <BloomText style={styles.month}>{parts.month.toUpperCase()}</BloomText>
+      <BloomText style={[styles.day, large ? styles.dayLarge : null]}>{parts.day}</BloomText>
+      <BloomText style={styles.time}>{parts.time}</BloomText>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  block: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: radius.md,
+    backgroundColor: colors.mutedSubtle,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  blockCompact: {
+    width: 60,
+    paddingVertical: spacing.sm,
+  },
+  blockLarge: {
+    width: 76,
+    paddingVertical: spacing.md,
+  },
+  month: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    color: colors.danger,
+  },
+  day: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: colors.text,
+    lineHeight: 26,
+  },
+  dayLarge: {
+    fontSize: 28,
+    lineHeight: 32,
+  },
+  time: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: colors.textSecondary,
+  },
+});
+
+export default EvictionDateBlock;

--- a/packages/frontend/components/evictions/EvictionOwnerControls.tsx
+++ b/packages/frontend/components/evictions/EvictionOwnerControls.tsx
@@ -1,0 +1,225 @@
+/**
+ * Owner-only controls on the eviction detail screen: post a timeline update
+ * (message + optional reschedule + optional status change), jump to the
+ * prefilled edit form, and cancel the case (a confirmed status → `cancelled`).
+ *
+ * Owns its own form state + mutations (`useCreateEvictionUpdate`,
+ * `useUpdateEviction`) so the detail screen stays lean. Bloom controls only;
+ * status chips use static styles (no function-form `style`).
+ */
+import React, { useMemo, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@oxyhq/bloom/button';
+import { Chip } from '@oxyhq/bloom/chip';
+import { TextFieldInput } from '@oxyhq/bloom/text-field';
+import { H3, Text as BloomText } from '@oxyhq/bloom/typography';
+
+import { EvictionCaseStatus } from '@homiio/shared-types';
+import { useCreateEvictionUpdate, useUpdateEviction } from '@/hooks/useEvictionQueries';
+import { webAlert } from '@/utils/api';
+import { toast } from '@/lib/sonner';
+import { colors } from '@/styles/colors';
+import { radius, spacing } from '@/constants/styles';
+import { EVICTION_STATUS_META } from './evictionUtils';
+
+const STATUS_OPTIONS = Object.values(EvictionCaseStatus) as EvictionCaseStatus[];
+
+/** Combine a `YYYY-MM-DD` date + optional `HH:mm` time into an ISO string. */
+const toIso = (date: string, time: string): string | undefined => {
+  const trimmed = date.trim();
+  if (!trimmed) return undefined;
+  const parsed = new Date(`${trimmed}T${time.trim() || '00:00'}`);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+};
+
+interface EvictionOwnerControlsProps {
+  caseId: string;
+  currentStatus: EvictionCaseStatus;
+  onEdit: () => void;
+}
+
+export const EvictionOwnerControls: React.FC<EvictionOwnerControlsProps> = ({
+  caseId,
+  currentStatus,
+  onEdit,
+}) => {
+  const { t } = useTranslation();
+  const createUpdate = useCreateEvictionUpdate(caseId);
+  const updateCase = useUpdateEviction(caseId);
+
+  const [message, setMessage] = useState('');
+  const [newDate, setNewDate] = useState('');
+  const [newTime, setNewTime] = useState('');
+  const [newStatus, setNewStatus] = useState<EvictionCaseStatus | null>(null);
+
+  const dateInvalid = useMemo(
+    () => Boolean(newDate.trim()) && toIso(newDate, newTime) === undefined,
+    [newDate, newTime],
+  );
+
+  const canPost = message.trim().length > 0 && !dateInvalid && !createUpdate.isPending;
+
+  const handlePost = async () => {
+    if (!canPost) return;
+    try {
+      await createUpdate.mutateAsync({
+        message: message.trim(),
+        newScheduledAt: toIso(newDate, newTime),
+        newStatus: newStatus ?? undefined,
+      });
+      toast.success(t('evictions.update.success'));
+      setMessage('');
+      setNewDate('');
+      setNewTime('');
+      setNewStatus(null);
+    } catch {
+      toast.error(t('evictions.update.error'));
+    }
+  };
+
+  const handleCancelCase = () => {
+    webAlert(t('evictions.cancel.confirmTitle'), t('evictions.cancel.confirmMessage'), [
+      { text: t('common.cancel'), style: 'cancel' },
+      {
+        text: t('evictions.cancel.confirm'),
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await updateCase.mutateAsync({ status: EvictionCaseStatus.CANCELLED });
+            toast.success(t('evictions.cancel.success'));
+          } catch {
+            toast.error(t('evictions.cancel.error'));
+          }
+        },
+      },
+    ]);
+  };
+
+  return (
+    <View style={styles.wrap}>
+      <H3 style={styles.title}>{t('evictions.owner.title')}</H3>
+
+      <TextFieldInput
+        label={t('evictions.update.messageLabel')}
+        placeholder={t('evictions.update.messagePlaceholder')}
+        value={message}
+        onChangeText={setMessage}
+        multiline
+      />
+
+      <View style={styles.row}>
+        <View style={styles.rowField}>
+          <TextFieldInput
+            label={t('evictions.update.newDateLabel')}
+            placeholder="YYYY-MM-DD"
+            value={newDate}
+            onChangeText={setNewDate}
+          />
+        </View>
+        <View style={styles.rowField}>
+          <TextFieldInput
+            label={t('evictions.update.newTimeLabel')}
+            placeholder="HH:MM"
+            value={newTime}
+            onChangeText={setNewTime}
+          />
+        </View>
+      </View>
+      {dateInvalid ? (
+        <BloomText style={styles.error}>{t('evictions.form.invalidDate')}</BloomText>
+      ) : null}
+
+      <View>
+        <BloomText style={styles.fieldLabel}>{t('evictions.update.newStatusLabel')}</BloomText>
+        <View style={styles.chipRow}>
+          {STATUS_OPTIONS.map((option) => (
+            <Chip
+              key={option}
+              selected={newStatus === option}
+              onPress={() => setNewStatus((prev) => (prev === option ? null : option))}
+            >
+              {t(EVICTION_STATUS_META[option].i18nKey)}
+            </Chip>
+          ))}
+        </View>
+      </View>
+
+      <Button
+        variant="primary"
+        size="medium"
+        onPress={handlePost}
+        disabled={!canPost}
+        loading={createUpdate.isPending}
+        style={styles.action}
+      >
+        {t('evictions.update.post')}
+      </Button>
+
+      <View style={styles.ownerActions}>
+        <Button variant="secondary" size="medium" onPress={onEdit} style={styles.ownerAction}>
+          {t('evictions.owner.edit')}
+        </Button>
+        {currentStatus !== EvictionCaseStatus.CANCELLED ? (
+          <Button
+            variant="secondary"
+            size="medium"
+            onPress={handleCancelCase}
+            loading={updateCase.isPending}
+            style={styles.ownerAction}
+          >
+            {t('evictions.owner.cancelCase')}
+          </Button>
+        ) : null}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrap: {
+    gap: spacing.md,
+    padding: spacing.lg,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surfaceElevated,
+  },
+  title: {
+    letterSpacing: -0.3,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: spacing.md,
+  },
+  rowField: {
+    flex: 1,
+  },
+  error: {
+    fontSize: 12,
+    color: colors.danger,
+  },
+  fieldLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.textSecondary,
+    marginBottom: spacing.sm,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  action: {
+    alignSelf: 'stretch',
+  },
+  ownerActions: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  ownerAction: {
+    flex: 1,
+  },
+});
+
+export default EvictionOwnerControls;

--- a/packages/frontend/components/evictions/EvictionReportSheet.tsx
+++ b/packages/frontend/components/evictions/EvictionReportSheet.tsx
@@ -1,0 +1,128 @@
+/**
+ * Report-a-case reason sheet, opened from the detail overflow action via the
+ * app-wide `BottomSheetContext`. Reuses the property-report reason set + the
+ * same "details required when reason is other" rule, then files the report with
+ * `useReportEviction`. Bloom `Chip`/`Button`/`TextField` only.
+ */
+import React, { useMemo, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@oxyhq/bloom/button';
+import { Chip } from '@oxyhq/bloom/chip';
+import { TextFieldInput } from '@oxyhq/bloom/text-field';
+import { H3, Text as BloomText } from '@oxyhq/bloom/typography';
+import { ListingReportReason } from '@homiio/shared-types';
+
+import { useReportEviction } from '@/hooks/useEvictionQueries';
+import { toast } from '@/lib/sonner';
+import { colors } from '@/styles/colors';
+import { spacing } from '@/constants/styles';
+
+const REASON_OPTIONS: { value: ListingReportReason; labelKey: string }[] = [
+  { value: ListingReportReason.INACCURATE, labelKey: 'evictions.report.reason.inaccurate' },
+  { value: ListingReportReason.SCAM, labelKey: 'evictions.report.reason.scam' },
+  { value: ListingReportReason.INAPPROPRIATE, labelKey: 'evictions.report.reason.inappropriate' },
+  { value: ListingReportReason.OTHER, labelKey: 'evictions.report.reason.other' },
+];
+
+interface EvictionReportSheetProps {
+  caseId: string;
+  onClose: () => void;
+}
+
+export const EvictionReportSheet: React.FC<EvictionReportSheetProps> = ({ caseId, onClose }) => {
+  const { t } = useTranslation();
+  const reportMutation = useReportEviction(caseId);
+
+  const [reason, setReason] = useState<ListingReportReason | null>(null);
+  const [details, setDetails] = useState('');
+
+  const detailsRequired = reason === ListingReportReason.OTHER;
+  const isValid = useMemo(() => {
+    if (!reason) return false;
+    if (detailsRequired && !details.trim()) return false;
+    return true;
+  }, [reason, detailsRequired, details]);
+
+  const handleSubmit = async () => {
+    if (!reason || !isValid) return;
+    try {
+      await reportMutation.mutateAsync({
+        reason,
+        details: details.trim() || undefined,
+      });
+      toast.success(t('evictions.report.success'));
+      onClose();
+    } catch {
+      toast.error(t('evictions.report.error'));
+    }
+  };
+
+  return (
+    <View style={styles.wrap}>
+      <H3 style={styles.title}>{t('evictions.report.title')}</H3>
+      <BloomText style={styles.intro}>{t('evictions.report.intro')}</BloomText>
+
+      <View style={styles.chipRow}>
+        {REASON_OPTIONS.map((option) => (
+          <Chip
+            key={option.value}
+            selected={reason === option.value}
+            onPress={() => setReason(option.value)}
+          >
+            {t(option.labelKey)}
+          </Chip>
+        ))}
+      </View>
+
+      <TextFieldInput
+        label={
+          detailsRequired
+            ? t('evictions.report.detailsRequired')
+            : t('evictions.report.details')
+        }
+        placeholder={t('evictions.report.detailsPlaceholder')}
+        value={details}
+        onChangeText={setDetails}
+        multiline
+      />
+
+      <Button
+        variant="primary"
+        size="large"
+        onPress={handleSubmit}
+        disabled={!isValid || reportMutation.isPending}
+        loading={reportMutation.isPending}
+        style={styles.submit}
+      >
+        {t('evictions.report.submit')}
+      </Button>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrap: {
+    padding: spacing.lg,
+    gap: spacing.md,
+  },
+  title: {
+    letterSpacing: -0.3,
+  },
+  intro: {
+    fontSize: 14,
+    color: colors.textSecondary,
+    lineHeight: 20,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  submit: {
+    alignSelf: 'stretch',
+    marginTop: spacing.xs,
+  },
+});
+
+export default EvictionReportSheet;

--- a/packages/frontend/components/evictions/EvictionStatusBadge.tsx
+++ b/packages/frontend/components/evictions/EvictionStatusBadge.tsx
@@ -1,0 +1,23 @@
+/**
+ * Eviction lifecycle status badge. Built from the shared `createStatusBadge`
+ * factory so it renders identically to the applications/reservations/exchange
+ * badges — each status maps to a Bloom color + an i18n label key.
+ */
+import { EvictionCaseStatus } from '@homiio/shared-types';
+import { createStatusBadge, type StatusBadgeEntry } from '@/components/ui/createStatusBadge';
+import { EVICTION_STATUS_META } from './evictionUtils';
+
+const STATUS_MAP = Object.fromEntries(
+  (Object.values(EvictionCaseStatus) as EvictionCaseStatus[]).map((status) => [
+    status,
+    {
+      color: EVICTION_STATUS_META[status].color,
+      label: status,
+      i18nKey: EVICTION_STATUS_META[status].i18nKey,
+    } satisfies StatusBadgeEntry,
+  ]),
+) as Record<EvictionCaseStatus, StatusBadgeEntry>;
+
+export const EvictionStatusBadge = createStatusBadge<EvictionCaseStatus>(STATUS_MAP);
+
+export default EvictionStatusBadge;

--- a/packages/frontend/components/evictions/evictionUtils.ts
+++ b/packages/frontend/components/evictions/evictionUtils.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared, pure helpers for the eviction solidarity board — status → badge
+ * metadata, the day/month/time date block, short marker labels, and the
+ * tel:/mailto:/https://wa.me/https://t.me contact link builders. No JSX, no
+ * hooks, so both the board card and the detail screen import from here.
+ */
+import { EvictionCaseStatus, type EvictionContactInfo } from '@homiio/shared-types';
+import type { BadgeColor } from '@oxyhq/bloom/badge';
+
+/** Bloom badge color + i18n label key per lifecycle status. */
+export interface EvictionStatusMeta {
+  color: BadgeColor;
+  i18nKey: string;
+}
+
+export const EVICTION_STATUS_META: Record<EvictionCaseStatus, EvictionStatusMeta> = {
+  [EvictionCaseStatus.UPCOMING]: { color: 'warning', i18nKey: 'evictions.status.upcoming' },
+  [EvictionCaseStatus.STOPPED]: { color: 'success', i18nKey: 'evictions.status.stopped' },
+  [EvictionCaseStatus.POSTPONED]: { color: 'info', i18nKey: 'evictions.status.postponed' },
+  [EvictionCaseStatus.EXECUTED]: { color: 'error', i18nKey: 'evictions.status.executed' },
+  [EvictionCaseStatus.CANCELLED]: { color: 'default', i18nKey: 'evictions.status.cancelled' },
+};
+
+/** The day/month/time pieces rendered by the calendar-style date block. */
+export interface EvictionDateParts {
+  day: string;
+  month: string;
+  time: string;
+  weekday: string;
+}
+
+const safeDate = (iso: string): Date | null => {
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+/** Split an ISO date into the calendar block's day / month / time / weekday. */
+export function formatEvictionDateParts(iso: string, locale: string): EvictionDateParts {
+  const date = safeDate(iso);
+  if (!date) return { day: '--', month: '', time: '', weekday: '' };
+  return {
+    day: new Intl.DateTimeFormat(locale, { day: 'numeric' }).format(date),
+    month: new Intl.DateTimeFormat(locale, { month: 'short' }).format(date).replace('.', ''),
+    time: new Intl.DateTimeFormat(locale, { hour: '2-digit', minute: '2-digit' }).format(date),
+    weekday: new Intl.DateTimeFormat(locale, { weekday: 'long' }).format(date),
+  };
+}
+
+/** Full, human-readable date + time (detail "when" line). */
+export function formatEvictionFullDate(iso: string, locale: string): string {
+  const date = safeDate(iso);
+  if (!date) return '';
+  return new Intl.DateTimeFormat(locale, {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+/** Compact label for a map marker (e.g. "15 jul"). */
+export function formatEvictionShortDate(iso: string, locale: string): string {
+  const date = safeDate(iso);
+  if (!date) return '';
+  return new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'short' })
+    .format(date)
+    .replace('.', '');
+}
+
+/** A single tappable contact action derived from the case's `contactInfo`. */
+export interface EvictionContactAction {
+  kind: 'phone' | 'whatsapp' | 'email' | 'telegram';
+  icon: 'call-outline' | 'logo-whatsapp' | 'mail-outline' | 'paper-plane-outline';
+  /** Display value (the raw handle / number / address). */
+  value: string;
+  /** The `Linking.openURL` target. */
+  url: string;
+}
+
+const buildWhatsAppUrl = (value: string): string =>
+  /wa\.me\/|api\.whatsapp\.com/i.test(value)
+    ? value
+    : `https://wa.me/${value.replace(/\D/g, '')}`;
+
+const buildTelegramUrl = (value: string): string => {
+  const trimmed = value.trim();
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return `https://t.me/${trimmed.replace(/^@/, '')}`;
+};
+
+/**
+ * Build the ordered list of tappable contact actions from a case's contact
+ * info. Only fields the reporter actually provided appear — contacts are never
+ * invented. `instructions` is rendered separately by the caller.
+ */
+export function buildEvictionContactActions(
+  contact: EvictionContactInfo | undefined,
+): EvictionContactAction[] {
+  if (!contact) return [];
+  const actions: EvictionContactAction[] = [];
+  if (contact.phone?.trim()) {
+    actions.push({
+      kind: 'phone',
+      icon: 'call-outline',
+      value: contact.phone.trim(),
+      url: `tel:${contact.phone.trim()}`,
+    });
+  }
+  if (contact.whatsapp?.trim()) {
+    actions.push({
+      kind: 'whatsapp',
+      icon: 'logo-whatsapp',
+      value: contact.whatsapp.trim(),
+      url: buildWhatsAppUrl(contact.whatsapp.trim()),
+    });
+  }
+  if (contact.telegram?.trim()) {
+    actions.push({
+      kind: 'telegram',
+      icon: 'paper-plane-outline',
+      value: contact.telegram.trim(),
+      url: buildTelegramUrl(contact.telegram.trim()),
+    });
+  }
+  if (contact.email?.trim()) {
+    actions.push({
+      kind: 'email',
+      icon: 'mail-outline',
+      value: contact.email.trim(),
+      url: `mailto:${contact.email.trim()}`,
+    });
+  }
+  return actions;
+}

--- a/packages/frontend/hooks/useEvictionQueries.ts
+++ b/packages/frontend/hooks/useEvictionQueries.ts
@@ -1,0 +1,266 @@
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+  type UseMutationResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import { useMemo } from 'react';
+import {
+  CreateEvictionCaseData,
+  CreateEvictionReportInput,
+  CreateEvictionUpdateData,
+  EvictionCase,
+  EvictionComment,
+  UpdateEvictionCaseData,
+} from '@homiio/shared-types';
+import {
+  EvictionAttendResult,
+  EvictionCommentListResponse,
+  EvictionListResponse,
+  ListEvictionsParams,
+  evictionService,
+} from '@/services/evictionService';
+
+/** Page size for the board + comment infinite feeds. */
+const PAGE_SIZE = 20;
+
+const LIST_STALE_TIME = 1000 * 60;
+const DETAIL_STALE_TIME = 1000 * 30;
+const COMMENTS_STALE_TIME = 1000 * 30;
+
+const EVICTION_LIST_KEY = 'evictions';
+const EVICTION_DETAIL_KEY = 'eviction';
+const EVICTION_COMMENTS_KEY = 'eviction-comments';
+const EVICTION_ATTENDING_KEY = 'eviction-attending';
+
+export const evictionKeys = {
+  list: (params: ListEvictionsParams) => [EVICTION_LIST_KEY, params] as const,
+  detail: (id: string) => [EVICTION_DETAIL_KEY, id] as const,
+  comments: (id: string) => [EVICTION_COMMENTS_KEY, id] as const,
+  attending: () => [EVICTION_ATTENDING_KEY] as const,
+};
+
+export type EvictionsInfiniteResult = UseInfiniteQueryResult<
+  InfiniteData<EvictionListResponse>,
+  Error
+> & {
+  /** All loaded cases flattened across pages. */
+  cases: EvictionCase[];
+  /** Total match count reported by the server. */
+  total: number;
+};
+
+/**
+ * Paginated public board feed. Page-based `useInfiniteQuery` (mechanics mirror
+ * `usePropertySearch`): each `status`/`city` combination is its own cache entry
+ * and paging reuses it. Omitting `status` lets the backend serve `upcoming`.
+ */
+export function useEvictions(
+  params: ListEvictionsParams = {},
+  options: { enabled?: boolean } = {},
+): EvictionsInfiniteResult {
+  const key = useMemo(() => evictionKeys.list(params), [params]);
+
+  const result = useInfiniteQuery<EvictionListResponse, Error>({
+    queryKey: key,
+    initialPageParam: 1,
+    enabled: options.enabled ?? true,
+    staleTime: LIST_STALE_TIME,
+    queryFn: ({ pageParam }) =>
+      evictionService.list({ ...params, page: pageParam as number, limit: PAGE_SIZE }),
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore ? lastPage.pagination.page + 1 : undefined,
+  });
+
+  const cases = useMemo<EvictionCase[]>(
+    () => result.data?.pages.flatMap((page) => page.items) ?? [],
+    [result.data],
+  );
+  const total = result.data?.pages[0]?.pagination.total ?? 0;
+
+  return { ...result, cases, total };
+}
+
+/** Single case by id. Disabled until `id` is non-empty. */
+export function useEvictionDetail(
+  id: string | undefined,
+): UseQueryResult<EvictionCase, Error> {
+  return useQuery<EvictionCase, Error>({
+    queryKey: evictionKeys.detail(id ?? ''),
+    queryFn: () => {
+      if (!id) throw new Error('Eviction case id is required');
+      return evictionService.getById(id);
+    },
+    enabled: Boolean(id),
+    staleTime: DETAIL_STALE_TIME,
+  });
+}
+
+export type EvictionCommentsInfiniteResult = UseInfiniteQueryResult<
+  InfiniteData<EvictionCommentListResponse>,
+  Error
+> & {
+  comments: EvictionComment[];
+  total: number;
+};
+
+/** Paginated public comment thread for a case (newest-first). */
+export function useEvictionComments(
+  id: string | undefined,
+): EvictionCommentsInfiniteResult {
+  const result = useInfiniteQuery<EvictionCommentListResponse, Error>({
+    queryKey: evictionKeys.comments(id ?? ''),
+    initialPageParam: 1,
+    enabled: Boolean(id),
+    staleTime: COMMENTS_STALE_TIME,
+    queryFn: ({ pageParam }) => {
+      if (!id) throw new Error('Eviction case id is required');
+      return evictionService.listComments(id, pageParam as number, PAGE_SIZE);
+    },
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore ? lastPage.pagination.page + 1 : undefined,
+  });
+
+  const comments = useMemo<EvictionComment[]>(
+    () => result.data?.pages.flatMap((page) => page.items) ?? [],
+    [result.data],
+  );
+  const total = result.data?.pages[0]?.pagination.total ?? 0;
+
+  return { ...result, comments, total };
+}
+
+/** Cases the caller RSVP'd to. Only runs when authenticated. */
+export function useMyAttendingEvictions(
+  options: { enabled?: boolean } = {},
+): UseQueryResult<EvictionListResponse, Error> {
+  return useQuery<EvictionListResponse, Error>({
+    queryKey: evictionKeys.attending(),
+    queryFn: () => evictionService.myAttending(),
+    enabled: options.enabled ?? true,
+    staleTime: LIST_STALE_TIME,
+  });
+}
+
+export function useCreateEviction(): UseMutationResult<
+  EvictionCase,
+  Error,
+  CreateEvictionCaseData
+> {
+  const queryClient = useQueryClient();
+  return useMutation<EvictionCase, Error, CreateEvictionCaseData>({
+    mutationFn: (payload) => evictionService.create(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [EVICTION_LIST_KEY] });
+    },
+  });
+}
+
+export function useUpdateEviction(
+  id: string,
+): UseMutationResult<EvictionCase, Error, UpdateEvictionCaseData> {
+  const queryClient = useQueryClient();
+  return useMutation<EvictionCase, Error, UpdateEvictionCaseData>({
+    mutationFn: (payload) => evictionService.update(id, payload),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(evictionKeys.detail(id), updated);
+      queryClient.invalidateQueries({ queryKey: [EVICTION_LIST_KEY] });
+    },
+  });
+}
+
+/**
+ * Optimistic RSVP toggle. Flips `isAttending` and nudges `attendeeCount` on the
+ * cached detail immediately, rolls back on error, and reconciles with the
+ * server's authoritative count on success. Invalidates the board + attending
+ * lists so aggregate counts refresh.
+ */
+export function useToggleAttend(
+  id: string,
+): UseMutationResult<EvictionAttendResult, Error, void, { previous?: EvictionCase }> {
+  const queryClient = useQueryClient();
+  return useMutation<EvictionAttendResult, Error, void, { previous?: EvictionCase }>({
+    mutationFn: () => evictionService.toggleAttend(id),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: evictionKeys.detail(id) });
+      const previous = queryClient.getQueryData<EvictionCase>(evictionKeys.detail(id));
+      if (previous) {
+        const nextAttending = !previous.isAttending;
+        queryClient.setQueryData<EvictionCase>(evictionKeys.detail(id), {
+          ...previous,
+          isAttending: nextAttending,
+          attendeeCount: Math.max(0, previous.attendeeCount + (nextAttending ? 1 : -1)),
+        });
+      }
+      return { previous };
+    },
+    onError: (_error, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(evictionKeys.detail(id), context.previous);
+      }
+    },
+    onSuccess: (result) => {
+      const current = queryClient.getQueryData<EvictionCase>(evictionKeys.detail(id));
+      if (current) {
+        queryClient.setQueryData<EvictionCase>(evictionKeys.detail(id), {
+          ...current,
+          isAttending: result.attending,
+          attendeeCount: result.attendeeCount,
+        });
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: [EVICTION_LIST_KEY] });
+      queryClient.invalidateQueries({ queryKey: evictionKeys.attending() });
+    },
+  });
+}
+
+export function useCreateEvictionUpdate(
+  id: string,
+): UseMutationResult<EvictionCase, Error, CreateEvictionUpdateData> {
+  const queryClient = useQueryClient();
+  return useMutation<EvictionCase, Error, CreateEvictionUpdateData>({
+    mutationFn: (payload) => evictionService.createUpdate(id, payload),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(evictionKeys.detail(id), updated);
+      queryClient.invalidateQueries({ queryKey: [EVICTION_LIST_KEY] });
+    },
+  });
+}
+
+export function useCreateEvictionComment(
+  id: string,
+): UseMutationResult<EvictionComment, Error, string> {
+  const queryClient = useQueryClient();
+  return useMutation<EvictionComment, Error, string>({
+    mutationFn: (body) => evictionService.createComment(id, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: evictionKeys.comments(id) });
+    },
+  });
+}
+
+export function useDeleteEvictionComment(
+  id: string,
+): UseMutationResult<void, Error, string> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: (commentId) => evictionService.deleteComment(id, commentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: evictionKeys.comments(id) });
+    },
+  });
+}
+
+export function useReportEviction(
+  id: string,
+): UseMutationResult<void, Error, CreateEvictionReportInput> {
+  return useMutation<void, Error, CreateEvictionReportInput>({
+    mutationFn: (input) => evictionService.report(id, input),
+  });
+}

--- a/packages/frontend/locales/ca-ES.json
+++ b/packages/frontend/locales/ca-ES.json
@@ -2288,7 +2288,8 @@
       "hostCalendar": "Calendari d'amfitrió",
       "hostReservations": "Reserves d'amfitrió",
       "landlordApplications": "Safata de sol·licituds",
-      "insights": "Insights"
+      "insights": "Insights",
+      "evictions": "Desnonaments"
     },
     "actions": {
       "addProperty": "Afegir Propietat",
@@ -3529,5 +3530,148 @@
     "allowed": "S'admeten mascotes",
     "not_allowed": "No s'admeten mascotes",
     "case_by_case": "Mascotes segons el cas"
+  },
+  "evictions": {
+    "title": "Desnonaments",
+    "subtitle": "Fes costat a les teves veïnes. Segueix els desnonaments i organitza't per aturar-los.",
+    "eyebrow": "Tauler de solidaritat",
+    "publishCta": "Publicar",
+    "showMap": "Mapa",
+    "showList": "Llista",
+    "loadError": "No s'ha pogut carregar el tauler de desnonaments",
+    "attend": "Hi aniré",
+    "attending": "Hi assisteixo",
+    "attendeesCount_one": "{{count}} veïna",
+    "attendeesCount_other": "{{count}} veïnes",
+    "filter": {
+      "upcoming": "Propers",
+      "stopped": "Aturats",
+      "postponed": "Ajornats",
+      "executed": "Executats"
+    },
+    "status": {
+      "upcoming": "Proper",
+      "stopped": "Aturat!",
+      "postponed": "Ajornat",
+      "executed": "Executat",
+      "cancelled": "Cancel·lat"
+    },
+    "empty": {
+      "title": "Encara no hi ha desnonaments aquí",
+      "subtitle": "Quan algú avisa d'un desnonament, apareix aquí perquè el barri pugui organitzar-se."
+    },
+    "detail": {
+      "title": "Desnonament",
+      "reportedBy": "Avisat per",
+      "anonymous": "Una veïna",
+      "howToHelp": "Com ajudar",
+      "where": "On",
+      "timeline": "Novetats",
+      "comments": "Comentaris",
+      "approximateNotice": "L'adreça exacta està amagada: aquest punt és aproximat per protegir la família.",
+      "share": "Comparteix",
+      "shareCopied": "Enllaç copiat al porta-retalls",
+      "shareFailed": "No s'ha pogut compartir",
+      "instructions": "Instruccions",
+      "contactFailed": "No s'ha pogut obrir l'enllaç",
+      "noContact": "No s'han compartit dades de contacte per a aquest cas.",
+      "contact": {
+        "phone": "Trucar",
+        "whatsapp": "WhatsApp",
+        "telegram": "Telegram",
+        "email": "Correu"
+      }
+    },
+    "owner": {
+      "title": "Gestiona el cas",
+      "edit": "Edita el cas",
+      "cancelCase": "Cancel·la el cas"
+    },
+    "update": {
+      "messageLabel": "Novetat",
+      "messagePlaceholder": "Explica què està passant…",
+      "newDateLabel": "Nova data",
+      "newTimeLabel": "Nova hora",
+      "newStatusLabel": "Canvia l'estat",
+      "post": "Publica la novetat",
+      "success": "Novetat publicada",
+      "error": "No s'ha pogut publicar la novetat"
+    },
+    "cancel": {
+      "confirmTitle": "Vols cancel·lar aquest cas?",
+      "confirmMessage": "Es marcarà com a cancel·lat i s'avisarà qui hi havia d'assistir.",
+      "confirm": "Cancel·la el cas",
+      "success": "Cas cancel·lat",
+      "error": "No s'ha pogut cancel·lar el cas"
+    },
+    "comments": {
+      "empty": "Encara no hi ha comentaris. Obre la conversa.",
+      "placeholder": "Escriu un comentari…",
+      "send": "Envia",
+      "signInToComment": "Inicia la sessió per comentar",
+      "postError": "No s'ha pogut publicar el comentari",
+      "deleteTitle": "Vols eliminar el comentari?",
+      "deleteMessage": "Aquesta acció no es pot desfer.",
+      "deleteError": "No s'ha pogut eliminar el comentari"
+    },
+    "report": {
+      "title": "Denuncia aquest cas",
+      "intro": "Avisa'ns si un cas sembla fals, abusiu o inapropiat. El nostre equip revisa cada denúncia.",
+      "reason": {
+        "inaccurate": "Informació falsa",
+        "scam": "És fals",
+        "inappropriate": "Inapropiat",
+        "other": "Altres"
+      },
+      "details": "Detalls (opcional)",
+      "detailsRequired": "Detalls (obligatori)",
+      "detailsPlaceholder": "Explica'ns què passa…",
+      "submit": "Envia la denúncia",
+      "success": "Denúncia enviada",
+      "error": "No s'ha pogut enviar la denúncia"
+    },
+    "form": {
+      "title": "Publica un desnonament",
+      "editTitle": "Edita el cas",
+      "subtitle": "Dona a les veïnes el que necessiten per presentar-se i ajudar.",
+      "whatSection": "Què passa",
+      "titleLabel": "Títol",
+      "titlePlaceholder": "p. ex. Desnonament al Carrer de Sants 20",
+      "descriptionLabel": "Descripció",
+      "descriptionPlaceholder": "Què està passant i quin suport cal?",
+      "whereSection": "On",
+      "mapHint": "Toca el mapa per posar un punt i emplenar la zona.",
+      "labelLabel": "Ubicació",
+      "labelPlaceholder": "Carrer o zona (sense número de pis)",
+      "cityLabel": "Ciutat",
+      "cityPlaceholder": "p. ex. Barcelona",
+      "approximateLabel": "Mostra només la ubicació aproximada",
+      "approximateHint": "Arrodoneix el punt per no assenyalar l'habitatge exacte.",
+      "whenSection": "Quan",
+      "dateLabel": "Data",
+      "timeLabel": "Hora",
+      "helpSection": "Com ajudar",
+      "instructionsLabel": "Instruccions",
+      "instructionsPlaceholder": "p. ex. Concentració a les 7h, porteu pancartes…",
+      "agencySection": "Agència o fons (opcional)",
+      "agencyLabel": "Agència / propietari",
+      "agencyPlaceholder": "p. ex. Blackstone, Cerberus…",
+      "photoSection": "Foto (opcional)",
+      "photoAdd": "Afegeix foto",
+      "photoChange": "Canvia la foto",
+      "photoPermission": "Cal permís per a la galeria",
+      "photoFailed": "No s'ha pogut pujar la foto",
+      "titleRequired": "Afegeix un títol",
+      "descriptionRequired": "Afegeix una descripció",
+      "locationRequired": "Posa un punt al mapa",
+      "labelRequired": "Afegeix una etiqueta d'ubicació",
+      "dateRequired": "Afegeix una data i hora vàlides",
+      "invalidDate": "Aquesta data no és vàlida",
+      "publish": "Publica",
+      "saveChanges": "Desa els canvis",
+      "createSuccess": "Cas publicat",
+      "updateSuccess": "Canvis desats",
+      "submitError": "No s'ha pogut desar el cas"
+    }
   }
 }

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -1938,7 +1938,8 @@
       "tips": "Tips",
       "hostCalendar": "Host calendar",
       "hostReservations": "Host reservations",
-      "landlordApplications": "Applicant inbox"
+      "landlordApplications": "Applicant inbox",
+      "evictions": "Eviction watch"
     },
     "actions": {
       "addProperty": "Add Property",
@@ -3464,5 +3465,148 @@
     "allowed": "Pets Allowed",
     "not_allowed": "No Pets",
     "case_by_case": "Pets Case by Case"
+  },
+  "evictions": {
+    "title": "Eviction watch",
+    "subtitle": "Show up for your neighbours. Track upcoming evictions and stand together to stop them.",
+    "eyebrow": "Solidarity board",
+    "publishCta": "Post",
+    "showMap": "Map",
+    "showList": "List",
+    "loadError": "Couldn't load the eviction board",
+    "attend": "I'll show up",
+    "attending": "I'm going",
+    "attendeesCount_one": "{{count}} neighbour",
+    "attendeesCount_other": "{{count}} neighbours",
+    "filter": {
+      "upcoming": "Upcoming",
+      "stopped": "Stopped",
+      "postponed": "Postponed",
+      "executed": "Carried out"
+    },
+    "status": {
+      "upcoming": "Upcoming",
+      "stopped": "Stopped",
+      "postponed": "Postponed",
+      "executed": "Carried out",
+      "cancelled": "Cancelled"
+    },
+    "empty": {
+      "title": "No evictions here yet",
+      "subtitle": "When neighbours report an upcoming eviction, it shows up here so the community can organise."
+    },
+    "detail": {
+      "title": "Eviction",
+      "reportedBy": "Reported by",
+      "anonymous": "A neighbour",
+      "howToHelp": "How to help",
+      "where": "Where",
+      "timeline": "Updates",
+      "comments": "Comments",
+      "approximateNotice": "The exact address is hidden — this pin is approximate to protect the household.",
+      "share": "Share",
+      "shareCopied": "Link copied to clipboard",
+      "shareFailed": "Couldn't share this case",
+      "instructions": "Instructions",
+      "contactFailed": "Couldn't open that link",
+      "noContact": "No contact details were shared for this case.",
+      "contact": {
+        "phone": "Call",
+        "whatsapp": "WhatsApp",
+        "telegram": "Telegram",
+        "email": "Email"
+      }
+    },
+    "owner": {
+      "title": "Manage this case",
+      "edit": "Edit case",
+      "cancelCase": "Cancel case"
+    },
+    "update": {
+      "messageLabel": "Update",
+      "messagePlaceholder": "Share what's happening…",
+      "newDateLabel": "New date",
+      "newTimeLabel": "New time",
+      "newStatusLabel": "Change status",
+      "post": "Post update",
+      "success": "Update posted",
+      "error": "Couldn't post the update"
+    },
+    "cancel": {
+      "confirmTitle": "Cancel this case?",
+      "confirmMessage": "It will be marked as cancelled and attendees will be notified.",
+      "confirm": "Cancel case",
+      "success": "Case cancelled",
+      "error": "Couldn't cancel the case"
+    },
+    "comments": {
+      "empty": "No comments yet. Start the conversation.",
+      "placeholder": "Write a comment…",
+      "send": "Send",
+      "signInToComment": "Sign in to comment",
+      "postError": "Couldn't post your comment",
+      "deleteTitle": "Delete comment?",
+      "deleteMessage": "This can't be undone.",
+      "deleteError": "Couldn't delete the comment"
+    },
+    "report": {
+      "title": "Report this case",
+      "intro": "Flag a case that looks fake, abusive or inappropriate. Our team reviews every report.",
+      "reason": {
+        "inaccurate": "Inaccurate",
+        "scam": "Fake",
+        "inappropriate": "Inappropriate",
+        "other": "Other"
+      },
+      "details": "Details (optional)",
+      "detailsRequired": "Details (required)",
+      "detailsPlaceholder": "Tell us what's wrong…",
+      "submit": "Submit report",
+      "success": "Report submitted",
+      "error": "Couldn't submit the report"
+    },
+    "form": {
+      "title": "Post an eviction",
+      "editTitle": "Edit case",
+      "subtitle": "Give neighbours what they need to show up and help.",
+      "whatSection": "What's happening",
+      "titleLabel": "Title",
+      "titlePlaceholder": "e.g. Eviction at Carrer de Sants 20",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "What's going on, and what kind of support is needed?",
+      "whereSection": "Where",
+      "mapHint": "Tap the map to drop a pin and auto-fill the area.",
+      "labelLabel": "Location",
+      "labelPlaceholder": "Street or area (no unit number)",
+      "cityLabel": "City",
+      "cityPlaceholder": "e.g. Barcelona",
+      "approximateLabel": "Show only an approximate location",
+      "approximateHint": "Rounds the pin so the exact home is never pinpointed.",
+      "whenSection": "When",
+      "dateLabel": "Date",
+      "timeLabel": "Time",
+      "helpSection": "How to help",
+      "instructionsLabel": "Instructions",
+      "instructionsPlaceholder": "e.g. Gather at 7am, bring banners…",
+      "agencySection": "Agency or fund (optional)",
+      "agencyLabel": "Agency / landlord",
+      "agencyPlaceholder": "e.g. Blackstone, Cerberus…",
+      "photoSection": "Photo (optional)",
+      "photoAdd": "Add photo",
+      "photoChange": "Change photo",
+      "photoPermission": "Photo library permission is required",
+      "photoFailed": "Couldn't upload the photo",
+      "titleRequired": "Add a title",
+      "descriptionRequired": "Add a description",
+      "locationRequired": "Drop a pin on the map",
+      "labelRequired": "Add a location label",
+      "dateRequired": "Add a valid date and time",
+      "invalidDate": "That date isn't valid",
+      "publish": "Publish",
+      "saveChanges": "Save changes",
+      "createSuccess": "Case published",
+      "updateSuccess": "Changes saved",
+      "submitError": "Couldn't save the case"
+    }
   }
 }

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -2267,7 +2267,8 @@
       "hostCalendar": "Calendario de anfitrión",
       "hostReservations": "Reservas de anfitrión",
       "landlordApplications": "Bandeja de solicitudes",
-      "insights": "Insights"
+      "insights": "Insights",
+      "evictions": "Desahucios"
     },
     "actions": {
       "addProperty": "Agregar Propiedad",
@@ -3508,5 +3509,148 @@
     "allowed": "Se admiten mascotas",
     "not_allowed": "No se admiten mascotas",
     "case_by_case": "Mascotas según el caso"
+  },
+  "evictions": {
+    "title": "Desahucios",
+    "subtitle": "Planta cara junto a tus vecinas. Sigue los desahucios y organízate para pararlos.",
+    "eyebrow": "Tablón de solidaridad",
+    "publishCta": "Publicar",
+    "showMap": "Mapa",
+    "showList": "Lista",
+    "loadError": "No se pudo cargar el tablón de desahucios",
+    "attend": "Iré",
+    "attending": "Asistiendo",
+    "attendeesCount_one": "{{count}} vecina",
+    "attendeesCount_other": "{{count}} vecinas",
+    "filter": {
+      "upcoming": "Próximos",
+      "stopped": "Parados",
+      "postponed": "Aplazados",
+      "executed": "Ejecutados"
+    },
+    "status": {
+      "upcoming": "Próximo",
+      "stopped": "¡Lo paramos!",
+      "postponed": "Aplazado",
+      "executed": "Ejecutado",
+      "cancelled": "Cancelado"
+    },
+    "empty": {
+      "title": "Aún no hay desahucios aquí",
+      "subtitle": "Cuando alguien avisa de un desahucio, aparece aquí para que el barrio pueda organizarse."
+    },
+    "detail": {
+      "title": "Desahucio",
+      "reportedBy": "Avisado por",
+      "anonymous": "Una vecina",
+      "howToHelp": "Cómo ayudar",
+      "where": "Dónde",
+      "timeline": "Novedades",
+      "comments": "Comentarios",
+      "approximateNotice": "La dirección exacta está oculta: este punto es aproximado para proteger a la familia.",
+      "share": "Compartir",
+      "shareCopied": "Enlace copiado al portapapeles",
+      "shareFailed": "No se pudo compartir",
+      "instructions": "Instrucciones",
+      "contactFailed": "No se pudo abrir el enlace",
+      "noContact": "No se han compartido datos de contacto para este caso.",
+      "contact": {
+        "phone": "Llamar",
+        "whatsapp": "WhatsApp",
+        "telegram": "Telegram",
+        "email": "Correo"
+      }
+    },
+    "owner": {
+      "title": "Gestionar el caso",
+      "edit": "Editar caso",
+      "cancelCase": "Cancelar caso"
+    },
+    "update": {
+      "messageLabel": "Novedad",
+      "messagePlaceholder": "Cuenta qué está pasando…",
+      "newDateLabel": "Nueva fecha",
+      "newTimeLabel": "Nueva hora",
+      "newStatusLabel": "Cambiar estado",
+      "post": "Publicar novedad",
+      "success": "Novedad publicada",
+      "error": "No se pudo publicar la novedad"
+    },
+    "cancel": {
+      "confirmTitle": "¿Cancelar este caso?",
+      "confirmMessage": "Se marcará como cancelado y se avisará a quienes iban a asistir.",
+      "confirm": "Cancelar caso",
+      "success": "Caso cancelado",
+      "error": "No se pudo cancelar el caso"
+    },
+    "comments": {
+      "empty": "Aún no hay comentarios. Abre la conversación.",
+      "placeholder": "Escribe un comentario…",
+      "send": "Enviar",
+      "signInToComment": "Inicia sesión para comentar",
+      "postError": "No se pudo publicar tu comentario",
+      "deleteTitle": "¿Eliminar comentario?",
+      "deleteMessage": "Esta acción no se puede deshacer.",
+      "deleteError": "No se pudo eliminar el comentario"
+    },
+    "report": {
+      "title": "Reportar este caso",
+      "intro": "Avisa si un caso parece falso, abusivo o inapropiado. Nuestro equipo revisa cada reporte.",
+      "reason": {
+        "inaccurate": "Información falsa",
+        "scam": "Es falso",
+        "inappropriate": "Inapropiado",
+        "other": "Otro"
+      },
+      "details": "Detalles (opcional)",
+      "detailsRequired": "Detalles (obligatorio)",
+      "detailsPlaceholder": "Cuéntanos qué pasa…",
+      "submit": "Enviar reporte",
+      "success": "Reporte enviado",
+      "error": "No se pudo enviar el reporte"
+    },
+    "form": {
+      "title": "Publicar un desahucio",
+      "editTitle": "Editar caso",
+      "subtitle": "Da a las vecinas lo que necesitan para presentarse y ayudar.",
+      "whatSection": "Qué pasa",
+      "titleLabel": "Título",
+      "titlePlaceholder": "p. ej. Desahucio en Carrer de Sants 20",
+      "descriptionLabel": "Descripción",
+      "descriptionPlaceholder": "¿Qué está pasando y qué apoyo hace falta?",
+      "whereSection": "Dónde",
+      "mapHint": "Toca el mapa para poner un punto y rellenar la zona.",
+      "labelLabel": "Ubicación",
+      "labelPlaceholder": "Calle o zona (sin número de piso)",
+      "cityLabel": "Ciudad",
+      "cityPlaceholder": "p. ej. Barcelona",
+      "approximateLabel": "Mostrar solo la ubicación aproximada",
+      "approximateHint": "Redondea el punto para no señalar la vivienda exacta.",
+      "whenSection": "Cuándo",
+      "dateLabel": "Fecha",
+      "timeLabel": "Hora",
+      "helpSection": "Cómo ayudar",
+      "instructionsLabel": "Instrucciones",
+      "instructionsPlaceholder": "p. ej. Concentración a las 7h, traer pancartas…",
+      "agencySection": "Agencia o fondo (opcional)",
+      "agencyLabel": "Agencia / propietario",
+      "agencyPlaceholder": "p. ej. Blackstone, Cerberus…",
+      "photoSection": "Foto (opcional)",
+      "photoAdd": "Añadir foto",
+      "photoChange": "Cambiar foto",
+      "photoPermission": "Se necesita permiso para la galería",
+      "photoFailed": "No se pudo subir la foto",
+      "titleRequired": "Añade un título",
+      "descriptionRequired": "Añade una descripción",
+      "locationRequired": "Pon un punto en el mapa",
+      "labelRequired": "Añade una etiqueta de ubicación",
+      "dateRequired": "Añade una fecha y hora válidas",
+      "invalidDate": "Esa fecha no es válida",
+      "publish": "Publicar",
+      "saveChanges": "Guardar cambios",
+      "createSuccess": "Caso publicado",
+      "updateSuccess": "Cambios guardados",
+      "submitError": "No se pudo guardar el caso"
+    }
   }
 }

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -2284,7 +2284,8 @@
       "hostCalendar": "Calendario host",
       "hostReservations": "Prenotazioni host",
       "landlordApplications": "Casella candidature",
-      "insights": "Insights"
+      "insights": "Insights",
+      "evictions": "Sfratti"
     },
     "actions": {
       "addProperty": "Aggiungi Proprietà",
@@ -3513,5 +3514,148 @@
     "allowed": "Animali ammessi",
     "not_allowed": "Animali non ammessi",
     "case_by_case": "Animali caso per caso"
+  },
+  "evictions": {
+    "title": "Sfratti",
+    "subtitle": "Ci siamo per il quartiere. Segui gli sfratti e organizzati per fermarli.",
+    "eyebrow": "Bacheca di solidarietà",
+    "publishCta": "Pubblica",
+    "showMap": "Mappa",
+    "showList": "Elenco",
+    "loadError": "Impossibile caricare la bacheca degli sfratti",
+    "attend": "Ci sarò",
+    "attending": "Partecipo",
+    "attendeesCount_one": "{{count}} persona",
+    "attendeesCount_other": "{{count}} persone",
+    "filter": {
+      "upcoming": "In arrivo",
+      "stopped": "Fermati",
+      "postponed": "Rinviati",
+      "executed": "Eseguiti"
+    },
+    "status": {
+      "upcoming": "In arrivo",
+      "stopped": "Fermato!",
+      "postponed": "Rinviato",
+      "executed": "Eseguito",
+      "cancelled": "Annullato"
+    },
+    "empty": {
+      "title": "Ancora nessuno sfratto qui",
+      "subtitle": "Quando qualcuno segnala uno sfratto, appare qui così il quartiere può organizzarsi."
+    },
+    "detail": {
+      "title": "Sfratto",
+      "reportedBy": "Segnalato da",
+      "anonymous": "Una persona del quartiere",
+      "howToHelp": "Come aiutare",
+      "where": "Dove",
+      "timeline": "Aggiornamenti",
+      "comments": "Commenti",
+      "approximateNotice": "L'indirizzo esatto è nascosto: questo punto è approssimativo per proteggere la famiglia.",
+      "share": "Condividi",
+      "shareCopied": "Link copiato negli appunti",
+      "shareFailed": "Impossibile condividere",
+      "instructions": "Istruzioni",
+      "contactFailed": "Impossibile aprire il link",
+      "noContact": "Nessun contatto è stato condiviso per questo caso.",
+      "contact": {
+        "phone": "Chiama",
+        "whatsapp": "WhatsApp",
+        "telegram": "Telegram",
+        "email": "Email"
+      }
+    },
+    "owner": {
+      "title": "Gestisci il caso",
+      "edit": "Modifica caso",
+      "cancelCase": "Annulla caso"
+    },
+    "update": {
+      "messageLabel": "Aggiornamento",
+      "messagePlaceholder": "Racconta cosa sta succedendo…",
+      "newDateLabel": "Nuova data",
+      "newTimeLabel": "Nuova ora",
+      "newStatusLabel": "Cambia stato",
+      "post": "Pubblica aggiornamento",
+      "success": "Aggiornamento pubblicato",
+      "error": "Impossibile pubblicare l'aggiornamento"
+    },
+    "cancel": {
+      "confirmTitle": "Annullare questo caso?",
+      "confirmMessage": "Sarà contrassegnato come annullato e i partecipanti verranno avvisati.",
+      "confirm": "Annulla caso",
+      "success": "Caso annullato",
+      "error": "Impossibile annullare il caso"
+    },
+    "comments": {
+      "empty": "Ancora nessun commento. Inizia la conversazione.",
+      "placeholder": "Scrivi un commento…",
+      "send": "Invia",
+      "signInToComment": "Accedi per commentare",
+      "postError": "Impossibile pubblicare il commento",
+      "deleteTitle": "Eliminare il commento?",
+      "deleteMessage": "Questa azione non può essere annullata.",
+      "deleteError": "Impossibile eliminare il commento"
+    },
+    "report": {
+      "title": "Segnala questo caso",
+      "intro": "Segnala un caso che sembra falso, offensivo o inappropriato. Il nostro team controlla ogni segnalazione.",
+      "reason": {
+        "inaccurate": "Informazioni false",
+        "scam": "È falso",
+        "inappropriate": "Inappropriato",
+        "other": "Altro"
+      },
+      "details": "Dettagli (facoltativo)",
+      "detailsRequired": "Dettagli (obbligatorio)",
+      "detailsPlaceholder": "Dicci cosa non va…",
+      "submit": "Invia segnalazione",
+      "success": "Segnalazione inviata",
+      "error": "Impossibile inviare la segnalazione"
+    },
+    "form": {
+      "title": "Pubblica uno sfratto",
+      "editTitle": "Modifica caso",
+      "subtitle": "Dai al quartiere ciò che serve per presentarsi e aiutare.",
+      "whatSection": "Cosa succede",
+      "titleLabel": "Titolo",
+      "titlePlaceholder": "es. Sfratto in Via Sants 20",
+      "descriptionLabel": "Descrizione",
+      "descriptionPlaceholder": "Cosa sta succedendo e che tipo di supporto serve?",
+      "whereSection": "Dove",
+      "mapHint": "Tocca la mappa per posizionare un punto e compilare la zona.",
+      "labelLabel": "Posizione",
+      "labelPlaceholder": "Via o zona (senza numero interno)",
+      "cityLabel": "Città",
+      "cityPlaceholder": "es. Barcellona",
+      "approximateLabel": "Mostra solo la posizione approssimativa",
+      "approximateHint": "Arrotonda il punto così l'abitazione esatta non viene individuata.",
+      "whenSection": "Quando",
+      "dateLabel": "Data",
+      "timeLabel": "Ora",
+      "helpSection": "Come aiutare",
+      "instructionsLabel": "Istruzioni",
+      "instructionsPlaceholder": "es. Ritrovo alle 7, portare striscioni…",
+      "agencySection": "Agenzia o fondo (facoltativo)",
+      "agencyLabel": "Agenzia / proprietario",
+      "agencyPlaceholder": "es. Blackstone, Cerberus…",
+      "photoSection": "Foto (facoltativa)",
+      "photoAdd": "Aggiungi foto",
+      "photoChange": "Cambia foto",
+      "photoPermission": "È richiesto il permesso per la galleria",
+      "photoFailed": "Impossibile caricare la foto",
+      "titleRequired": "Aggiungi un titolo",
+      "descriptionRequired": "Aggiungi una descrizione",
+      "locationRequired": "Posiziona un punto sulla mappa",
+      "labelRequired": "Aggiungi un'etichetta di posizione",
+      "dateRequired": "Aggiungi una data e un’ora valide",
+      "invalidDate": "Questa data non è valida",
+      "publish": "Pubblica",
+      "saveChanges": "Salva le modifiche",
+      "createSuccess": "Caso pubblicato",
+      "updateSuccess": "Modifiche salvate",
+      "submitError": "Impossibile salvare il caso"
+    }
   }
 }

--- a/packages/frontend/services/evictionService.ts
+++ b/packages/frontend/services/evictionService.ts
@@ -1,0 +1,229 @@
+import { api, ApiResponse } from '@/utils/api';
+import {
+  CreateEvictionCaseData,
+  CreateEvictionReportInput,
+  CreateEvictionUpdateData,
+  EvictionCase,
+  EvictionCaseStatus,
+  EvictionComment,
+  UpdateEvictionCaseData,
+} from '@homiio/shared-types';
+
+/**
+ * Eviction solidarity board API client.
+ *
+ * Mirrors `exchangeService`: a thin class over `@/utils/api` (the Oxy-linked
+ * client + `normalizeEnvelope` bridge) that reads the `{ success, data, … }`
+ * envelope and normalises the persisted `_id` to `id`. Public reads
+ * (`list`/`getById`/`listComments`) degrade to unauthenticated requests; every
+ * write is auth-gated server-side.
+ *
+ * The backend already serialises `_id → id` in `toEvictionDTO`, so the local
+ * `normalizeCase`/`normalizeComment` steps are defensive (never trust a raw
+ * `_id` leak) rather than load-bearing.
+ */
+
+/** Public board filters. Omitting `status` lets the backend default to `upcoming`. */
+export interface ListEvictionsParams {
+  status?: EvictionCaseStatus;
+  city?: string;
+  page?: number;
+  limit?: number;
+}
+
+export interface EvictionPagination {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface EvictionListResponse {
+  items: EvictionCase[];
+  pagination: EvictionPagination;
+  hasMore: boolean;
+}
+
+export interface EvictionCommentListResponse {
+  items: EvictionComment[];
+  pagination: EvictionPagination;
+  hasMore: boolean;
+}
+
+/** Result of an RSVP toggle. */
+export interface EvictionAttendResult {
+  attending: boolean;
+  attendeeCount: number;
+}
+
+/** Backend records may carry `_id`; the frontend works with `id`. */
+type BackendEvictionCase = Omit<EvictionCase, 'id'> & { _id?: string; id?: string };
+type BackendEvictionComment = Omit<EvictionComment, 'id'> & { _id?: string; id?: string };
+
+/** Raw list envelope: the backend nests `pagination` and exposes flat aliases. */
+interface BackendEvictionListEnvelope {
+  evictions?: BackendEvictionCase[];
+  pagination?: EvictionPagination;
+  hasMore?: boolean;
+}
+
+interface BackendCommentListEnvelope {
+  comments?: BackendEvictionComment[];
+  pagination?: EvictionPagination;
+  hasMore?: boolean;
+}
+
+const normalizeCase = (raw: BackendEvictionCase): EvictionCase => {
+  const id = raw.id ?? raw._id ?? '';
+  return { ...raw, id } as EvictionCase;
+};
+
+const normalizeComment = (raw: BackendEvictionComment): EvictionComment => {
+  const id = raw.id ?? raw._id ?? '';
+  return { ...raw, id } as EvictionComment;
+};
+
+const emptyPagination = (page: number, count: number): EvictionPagination => ({
+  page,
+  limit: count,
+  total: count,
+  totalPages: 1,
+});
+
+class EvictionService {
+  private baseUrl = '/api/evictions';
+
+  /** Public board list. Defaults to soonest-first `upcoming` cases. */
+  async list(params: ListEvictionsParams = {}): Promise<EvictionListResponse> {
+    const response = await api.get<BackendEvictionListEnvelope>(this.baseUrl, {
+      params: {
+        status: params.status,
+        city: params.city,
+        page: params.page,
+        limit: params.limit,
+      },
+      requireAuth: false,
+    });
+    const items = (response.data.evictions ?? []).map(normalizeCase);
+    const pagination = response.data.pagination ?? emptyPagination(params.page ?? 1, items.length);
+    return { items, pagination, hasMore: response.data.hasMore ?? false };
+  }
+
+  /** Public case detail. `isAttending`/`isOwner` are populated for a signed viewer. */
+  async getById(id: string): Promise<EvictionCase> {
+    const response = await api.get<ApiResponse<BackendEvictionCase>>(
+      `${this.baseUrl}/${id}`,
+      { requireAuth: false },
+    );
+    if (!response.data?.data) {
+      throw new Error(response.data?.message || 'Eviction case not found');
+    }
+    return normalizeCase(response.data.data);
+  }
+
+  /** Open a new case (authed). */
+  async create(payload: CreateEvictionCaseData): Promise<EvictionCase> {
+    const response = await api.post<ApiResponse<BackendEvictionCase>>(this.baseUrl, payload);
+    if (!response.data?.data) {
+      throw new Error(response.data?.message || 'Could not create the eviction case');
+    }
+    return normalizeCase(response.data.data);
+  }
+
+  /** Edit an owned case (authed, owner-only server-side). */
+  async update(id: string, payload: UpdateEvictionCaseData): Promise<EvictionCase> {
+    const response = await api.put<ApiResponse<BackendEvictionCase>>(
+      `${this.baseUrl}/${id}`,
+      payload,
+    );
+    if (!response.data?.data) {
+      throw new Error(response.data?.message || 'Could not update the eviction case');
+    }
+    return normalizeCase(response.data.data);
+  }
+
+  /** Delete an owned case (authed, owner-only server-side). */
+  async remove(id: string): Promise<void> {
+    await api.delete(`${this.baseUrl}/${id}`);
+  }
+
+  /** RSVP toggle ("I'll show up"). Returns the new state + aggregate count. */
+  async toggleAttend(id: string): Promise<EvictionAttendResult> {
+    const response = await api.post<ApiResponse<EvictionAttendResult>>(
+      `${this.baseUrl}/${id}/attend`,
+    );
+    if (!response.data?.data) {
+      throw new Error(response.data?.message || 'Could not update your RSVP');
+    }
+    return response.data.data;
+  }
+
+  /** Owner-only: append a timeline update (reschedule / status change / note). */
+  async createUpdate(id: string, payload: CreateEvictionUpdateData): Promise<EvictionCase> {
+    const response = await api.post<ApiResponse<BackendEvictionCase>>(
+      `${this.baseUrl}/${id}/updates`,
+      payload,
+    );
+    if (!response.data?.data) {
+      throw new Error(response.data?.message || 'Could not post the update');
+    }
+    return normalizeCase(response.data.data);
+  }
+
+  /** Public coordination thread, newest-first, paginated. */
+  async listComments(id: string, page = 1, limit = 20): Promise<EvictionCommentListResponse> {
+    const response = await api.get<BackendCommentListEnvelope>(
+      `${this.baseUrl}/${id}/comments`,
+      { params: { page, limit }, requireAuth: false },
+    );
+    const items = (response.data.comments ?? []).map(normalizeComment);
+    const pagination = response.data.pagination ?? emptyPagination(page, items.length);
+    return { items, pagination, hasMore: response.data.hasMore ?? false };
+  }
+
+  /** Post a comment on a case (authed). */
+  async createComment(id: string, body: string): Promise<EvictionComment> {
+    const response = await api.post<ApiResponse<BackendEvictionComment>>(
+      `${this.baseUrl}/${id}/comments`,
+      { body },
+    );
+    if (!response.data?.data) {
+      throw new Error(response.data?.message || 'Could not post your comment');
+    }
+    return normalizeComment(response.data.data);
+  }
+
+  /** Delete a comment (author or case owner, authed). */
+  async deleteComment(id: string, commentId: string): Promise<void> {
+    await api.delete(`${this.baseUrl}/${id}/comments/${commentId}`);
+  }
+
+  /** File a trust & safety report against a case (authed). */
+  async report(id: string, input: CreateEvictionReportInput): Promise<void> {
+    await api.post(`${this.baseUrl}/${id}/report`, input);
+  }
+
+  /** The caller's own cases (authed). */
+  async myCases(page = 1, limit = 20): Promise<EvictionListResponse> {
+    const response = await api.get<BackendEvictionListEnvelope>(`${this.baseUrl}/me/list`, {
+      params: { page, limit },
+    });
+    const items = (response.data.evictions ?? []).map(normalizeCase);
+    const pagination = response.data.pagination ?? emptyPagination(page, items.length);
+    return { items, pagination, hasMore: response.data.hasMore ?? false };
+  }
+
+  /** Cases the caller RSVP'd to (authed). */
+  async myAttending(page = 1, limit = 20): Promise<EvictionListResponse> {
+    const response = await api.get<BackendEvictionListEnvelope>(`${this.baseUrl}/me/attending`, {
+      params: { page, limit },
+    });
+    const items = (response.data.evictions ?? []).map(normalizeCase);
+    const pagination = response.data.pagination ?? emptyPagination(page, items.length);
+    return { items, pagination, hasMore: response.data.hasMore ?? false };
+  }
+}
+
+export const evictionService = new EvictionService();
+
+export default evictionService;


### PR DESCRIPTION
## What
Frontend for the eviction solidarity board (desalojos / desahucios) — PR 5 in the series. Backend + shared types already merged (PR #205).

- **Board** (`/evictions`): status filter chips (Upcoming / Stopped / Postponed / Carried out), flat cards with a calendar date block, status badge, location and attendee count, a Map FAB with pins, and an image-forward empty state. Both infinite-scroll primitives (web sentinel + native handler).
- **Detail** (`/evictions/[id]`): cover, date/status, reporter, description, tappable organiser contacts (tel/mailto/WhatsApp/Telegram) + instructions, approximate-location map + privacy disclaimer, updates timeline, paginated comments with composer, a sticky RSVP CTA (optimistic toggle), header Share + Report, and owner-only controls (post update / edit / cancel).
- **Publish/edit** (`/evictions/new`): sectioned form (what / where via map address lookup + approximate-location switch / when / how-to-help / agency / optional photo).
- Wiring: SideBar "Eviction watch" entry, notification visuals + deep-link routing (`eviction_update`/`eviction_comment`/`eviction_rsvp` → `/evictions/[id]`), i18n in en/es/ca-ES/it (Spanish movement vocabulary "Desahucios"/"¡Lo paramos!", Catalan "Desnonaments").

## Why
Gives the community a first-party place to coordinate anti-eviction solidarity, using only real Homiio data and the privacy-minimal public contract (no tenant identity, approximate coordinates by default).

## Notes
- Board filter uses per-status server feeds (Upcoming/Stopped/Postponed/Carried out) rather than an "all" tab because the public endpoint serves one status per paginated query — this keeps pagination coherent and honest.
- All controls are Bloom primitives; NativeWind function-form `style` audit is zero; ZoomableImage/IconButton/infinite-scroll primitives reused per AGENTS.md.

## Verification
- tsc clean on all new/modified files; ESLint clean; i18n locale-parity check passes.
- `expo export --platform web` bundles clean (EXIT 0).
- Playwright web screenshots captured of the populated board, detail, publish form, and empty state — all render correctly (sidebar entry, cards with date blocks/badges/attendee counts, tappable contacts, updates timeline, comments, approximate-location disclaimer, image-forward empty state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)