### PR TITLE
feat(ingest): deduplicate re-listed external properties

### DIFF
--- a/packages/backend/__tests__/integration/externalIngest.test.ts
+++ b/packages/backend/__tests__/integration/externalIngest.test.ts
@@ -222,4 +222,49 @@ describe('external listing ingest (fixture -> IngestionService)', () => {
     expect(await Property.countDocuments({ source: 'blueground', sourceId: 'bcn-1549599p' })).toBe(0);
     expect(fetchImage).not.toHaveBeenCalled();
   });
+
+  it('skips a re-listing of the same unit under a new sourceId (dedup fingerprint)', async () => {
+    const ingestion = buildIngestionService();
+    // A substantial, shared agency description (>= 40 tokens) so the listings are
+    // dedup-eligible; the tail word differs so Jaccard is ~0.97 (> 0.95 floor).
+    const shared = Array.from({ length: 60 }, (_, i) => `palabra${String(i).padStart(3, '0')}`).join(' ');
+    const makeListing = (sourceId: string, tail: string): NormalizedListing => ({
+      source: 'pisos',
+      sourceId,
+      sourceUrl: `https://www.pisos.com/alquilar/piso-${sourceId}/`,
+      address: {
+        street: 'Carrer de Provença',
+        city: 'Barcelona',
+        countryCode: 'ES',
+        coordinates: { lat: 41.3925, lng: 2.1649 },
+      },
+      type: PropertyType.APARTMENT,
+      offerings: [OfferingType.LONG_TERM_RENT],
+      longTermRent: { monthlyAmount: 1750, currency: 'EUR' },
+      description: `${shared} ${tail}`,
+      bedrooms: 2,
+      bathrooms: 1,
+      squareFootage: 63,
+      remoteImages: [],
+      status: 'published',
+    });
+
+    const first = await ingestion.ingest(makeListing('relist-a', 'alpha'));
+    expect(first.status).toBe('created');
+
+    const second = await ingestion.ingest(makeListing('relist-b', 'beta'));
+    expect(second.status).toBe('skipped');
+    expect(second.duplicateOf).toBe(first.propertyId);
+
+    // The re-listing is NOT persisted; only the original survives.
+    expect(await Property.countDocuments({ source: 'pisos', sourceId: 'relist-b' })).toBe(0);
+    expect(await Property.countDocuments({ source: 'pisos', sourceId: 'relist-a' })).toBe(1);
+
+    // A genuinely different unit (different price) is still created normally.
+    const different = await ingestion.ingest({
+      ...makeListing('relist-c', 'gamma'),
+      longTermRent: { monthlyAmount: 2400, currency: 'EUR' },
+    });
+    expect(different.status).toBe('created');
+  });
 });

--- a/packages/backend/__tests__/unit/dedupeBackfillPlan.test.ts
+++ b/packages/backend/__tests__/unit/dedupeBackfillPlan.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Backfill grouping (`planDeduplication`): the pure core of the one-off script.
+ * Verifies grouping, deterministic keeper selection, transitive components,
+ * and idempotency — with no DB.
+ */
+
+import { PropertyType } from '@homiio/shared-types';
+import { toDedupComparable, type DedupListingInput } from '../../services/ingestion/dedupeFingerprint';
+import { planDeduplication, type Row } from '../../scripts/dedupeExternalListings';
+
+let seq = 0;
+function words(n: number, extra: string[] = []): string {
+  const base = Array.from({ length: n }, (_, i) => `comun${String(i).padStart(3, '0')}`);
+  return [...base, ...extra].join(' ');
+}
+
+const LISTING: DedupListingInput = {
+  type: PropertyType.APARTMENT,
+  cityId: 'city-a',
+  bedrooms: 2,
+  squareFootage: 63,
+  longTermRent: { monthlyAmount: 1750, currency: 'EUR' },
+  description: words(60),
+};
+
+function row(overrides: Partial<Row> & { listing?: Partial<DedupListingInput> } = {}): Row {
+  const comparable = toDedupComparable({ ...LISTING, ...overrides.listing });
+  if (!comparable) throw new Error('test row must be an eligible comparable');
+  seq += 1;
+  return {
+    id: overrides.id ?? `id-${seq}`,
+    source: overrides.source ?? 'pisos',
+    sourceId: overrides.sourceId ?? `s-${seq}`,
+    sourceUrl: overrides.sourceUrl ?? 'https://www.pisos.com/x',
+    imageCount: overrides.imageCount ?? 1,
+    createdAt: overrides.createdAt ?? 1_000,
+    comparable,
+  };
+}
+
+describe('planDeduplication', () => {
+  it('groups two near-identical re-lists and keeps the one with more images', () => {
+    const rich = row({ id: 'rich', imageCount: 20, listing: { description: words(60, ['a']) } });
+    const poor = row({ id: 'poor', imageCount: 3, listing: { description: words(60, ['b']) } });
+    const groups = planDeduplication([poor, rich]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].keep.id).toBe('rich');
+    expect(groups[0].archive.map((r) => r.id)).toEqual(['poor']);
+  });
+
+  it('breaks image ties by longer description, then older createdAt', () => {
+    const older = row({ id: 'older', imageCount: 5, createdAt: 1, listing: { description: words(60, ['x']) } });
+    const newer = row({ id: 'newer', imageCount: 5, createdAt: 9, listing: { description: words(60, ['y']) } });
+    const [group] = planDeduplication([newer, older]);
+    expect(group.keep.id).toBe('older');
+  });
+
+  it('collapses a transitive 3-way component into one keeper + two archived', () => {
+    const a = row({ id: 'a', imageCount: 9, listing: { description: words(60, ['one']) } });
+    const b = row({ id: 'b', imageCount: 4, listing: { description: words(60, ['two']) } });
+    const c = row({ id: 'c', imageCount: 2, listing: { description: words(60, ['three']) } });
+    const [group] = planDeduplication([a, b, c]);
+    expect(group.keep.id).toBe('a');
+    expect(group.archive.map((r) => r.id).sort()).toEqual(['b', 'c']);
+  });
+
+  it('does not group templated different units below the Jaccard floor', () => {
+    const a = row({ listing: { description: words(60, ['unoaa', 'dosaa', 'tresaa', 'cuatroaa', 'cincoaa']) } });
+    const b = row({ listing: { description: words(60, ['unobb', 'dosbb', 'tresbb', 'cuatrobb', 'cincobb']) } });
+    expect(planDeduplication([a, b])).toHaveLength(0);
+  });
+
+  it('does not group listings in different cities', () => {
+    const a = row({ listing: { description: words(60, ['a']) } });
+    const b = row({ listing: { cityId: 'city-b', description: words(60, ['a']) } });
+    expect(planDeduplication([a, b])).toHaveLength(0);
+  });
+
+  it('does not group listings with different prices', () => {
+    const a = row();
+    const b = row({ listing: { longTermRent: { monthlyAmount: 1800, currency: 'EUR' } } });
+    expect(planDeduplication([a, b])).toHaveLength(0);
+  });
+
+  it('is idempotent: re-running on the surviving keepers finds nothing', () => {
+    const a = row({ id: 'a', imageCount: 9, listing: { description: words(60, ['one']) } });
+    const b = row({ id: 'b', imageCount: 4, listing: { description: words(60, ['two']) } });
+    const first = planDeduplication([a, b]);
+    const archivedIds = new Set(first.flatMap((g) => g.archive.map((r) => r.id)));
+    const survivors = [a, b].filter((r) => !archivedIds.has(r.id));
+    expect(planDeduplication(survivors)).toHaveLength(0);
+  });
+});

--- a/packages/backend/__tests__/unit/dedupeFingerprint.test.ts
+++ b/packages/backend/__tests__/unit/dedupeFingerprint.test.ts
@@ -1,0 +1,189 @@
+/**
+ * External-listing dedup fingerprint.
+ *
+ * The cases mirror the false-positive classes found in the live data:
+ *  - real re-lists (near-identical agency copy) MUST match;
+ *  - AI-templated flats in the same city but different units (Jaccard ~0.9) must
+ *    NOT match — the 0.95 threshold is the safety margin;
+ *  - multi-city developments (same brochure, different cityId) must NOT match;
+ *  - a portfolio split across property types must NOT match;
+ *  - listings missing m²/bedrooms or a substantial description are never candidates.
+ */
+
+import { OfferingType, PropertyType } from '@homiio/shared-types';
+import {
+  MIN_DESCRIPTION_TOKENS,
+  areDuplicateListings,
+  descriptionJaccard,
+  extractPrimaryPricing,
+  normalizeDescriptionTokens,
+  toDedupComparable,
+  type DedupListingInput,
+} from '../../services/ingestion/dedupeFingerprint';
+
+/** Build a description from `shared` common words plus per-listing `extra` words. */
+function buildDescription(shared: number, extra: string[]): string {
+  const words: string[] = [];
+  for (let i = 0; i < shared; i += 1) words.push(`comun${String(i).padStart(3, '0')}`);
+  return [...words, ...extra].join(' ');
+}
+
+const BASE: DedupListingInput = {
+  type: PropertyType.APARTMENT,
+  cityId: 'city-barcelona',
+  bedrooms: 2,
+  squareFootage: 63,
+  longTermRent: { monthlyAmount: 1750, currency: 'EUR' },
+  description: buildDescription(60, ['unoextra', 'dosextra']),
+};
+
+function comparableOrThrow(input: DedupListingInput) {
+  const comparable = toDedupComparable(input);
+  if (!comparable) throw new Error('expected an eligible comparable');
+  return comparable;
+}
+
+describe('normalizeDescriptionTokens', () => {
+  it('lowercases, strips accents, and drops words shorter than 3 chars', () => {
+    const tokens = normalizeDescriptionTokens('Ático LUMINOSO en la Sagrada Família, m2');
+    expect(tokens.has('atico')).toBe(true);
+    expect(tokens.has('luminoso')).toBe(true);
+    expect(tokens.has('familia')).toBe(true);
+    // "en", "la", "m2" -> length < 3 dropped ("m2" has length 2).
+    expect(tokens.has('en')).toBe(false);
+    expect(tokens.has('la')).toBe(false);
+  });
+
+  it('returns an empty set for empty/nullish input', () => {
+    expect(normalizeDescriptionTokens('').size).toBe(0);
+    expect(normalizeDescriptionTokens(null).size).toBe(0);
+    expect(normalizeDescriptionTokens(undefined).size).toBe(0);
+  });
+});
+
+describe('descriptionJaccard', () => {
+  it('is 1 for identical token sets and 0 when either is empty', () => {
+    const a = new Set(['casa', 'luminosa', 'centro']);
+    expect(descriptionJaccard(a, new Set(a))).toBe(1);
+    expect(descriptionJaccard(a, new Set())).toBe(0);
+  });
+
+  it('computes intersection over union', () => {
+    const a = new Set(['w1', 'w2', 'w3', 'w4']);
+    const b = new Set(['w3', 'w4', 'w5', 'w6']);
+    expect(descriptionJaccard(a, b)).toBeCloseTo(2 / 6, 5);
+  });
+});
+
+describe('extractPrimaryPricing', () => {
+  it('prefers long-term rent, then short-term, then sale', () => {
+    expect(extractPrimaryPricing({ longTermRent: { monthlyAmount: 900, currency: 'eur' } })).toEqual({
+      offering: OfferingType.LONG_TERM_RENT,
+      amount: 900,
+      currency: 'EUR',
+    });
+    expect(extractPrimaryPricing({ shortTermRent: { nightlyRate: 120, currency: 'EUR' } })?.offering).toBe(
+      OfferingType.SHORT_TERM_RENT,
+    );
+    expect(extractPrimaryPricing({ sale: { price: 249000, currency: 'EUR' } })?.offering).toBe(
+      OfferingType.SALE,
+    );
+  });
+
+  it('ignores non-positive amounts and returns null when unpriced', () => {
+    expect(extractPrimaryPricing({ longTermRent: { monthlyAmount: 0, currency: 'EUR' } })).toBeNull();
+    expect(extractPrimaryPricing({})).toBeNull();
+  });
+});
+
+describe('toDedupComparable eligibility', () => {
+  it('accepts a fully-populated listing', () => {
+    expect(toDedupComparable(BASE)).not.toBeNull();
+  });
+
+  it('rejects zero/negative square footage', () => {
+    expect(toDedupComparable({ ...BASE, squareFootage: 0 })).toBeNull();
+  });
+
+  it('rejects zero bedrooms', () => {
+    expect(toDedupComparable({ ...BASE, bedrooms: 0 })).toBeNull();
+  });
+
+  it('rejects a missing city or type', () => {
+    expect(toDedupComparable({ ...BASE, cityId: '' })).toBeNull();
+    expect(toDedupComparable({ ...BASE, type: undefined })).toBeNull();
+  });
+
+  it('rejects an unpriced listing', () => {
+    expect(toDedupComparable({ ...BASE, longTermRent: undefined })).toBeNull();
+  });
+
+  it('rejects a description below the token floor', () => {
+    const thin = buildDescription(MIN_DESCRIPTION_TOKENS - 5, []);
+    expect(toDedupComparable({ ...BASE, description: thin })).toBeNull();
+  });
+});
+
+describe('areDuplicateListings — true positives', () => {
+  it('matches a re-list with near-identical agency copy (same unit, new sourceId)', () => {
+    // 60 shared + 1 unique word each -> Jaccard 61/62 ≈ 0.984, above the 0.95 floor.
+    const a = comparableOrThrow({ ...BASE, description: buildDescription(60, ['loftunicoa']) });
+    const b = comparableOrThrow({ ...BASE, description: buildDescription(60, ['loftunicob']) });
+    expect(areDuplicateListings(a, b)).toBe(true);
+  });
+
+  it('matches a byte-identical re-post', () => {
+    const a = comparableOrThrow(BASE);
+    const b = comparableOrThrow(BASE);
+    expect(areDuplicateListings(a, b)).toBe(true);
+  });
+});
+
+describe('areDuplicateListings — false positives it must reject', () => {
+  it('rejects AI-templated different flats in the same city (Jaccard ~0.9 < 0.95)', () => {
+    // 60 shared + 4 unique each -> Jaccard 60/68 ≈ 0.88: templated, but different units.
+    const a = comparableOrThrow({
+      ...BASE,
+      description: buildDescription(60, ['balcona', 'exteriora', 'reformadoa', 'luminosoa']),
+    });
+    const b = comparableOrThrow({
+      ...BASE,
+      description: buildDescription(60, ['terrazab', 'interiorb', 'nuevob', 'amuebladob']),
+    });
+    expect(descriptionJaccard(a.descriptionTokens, b.descriptionTokens)).toBeLessThan(0.95);
+    expect(areDuplicateListings(a, b)).toBe(false);
+  });
+
+  it('rejects a multi-city development sharing one brochure (different cityId)', () => {
+    const a = comparableOrThrow(BASE);
+    const b = comparableOrThrow({ ...BASE, cityId: 'city-eghezee' });
+    expect(areDuplicateListings(a, b)).toBe(false);
+  });
+
+  it('rejects a portfolio split across property types', () => {
+    const a = comparableOrThrow(BASE);
+    const b = comparableOrThrow({ ...BASE, type: PropertyType.HOUSE });
+    expect(areDuplicateListings(a, b)).toBe(false);
+  });
+
+  it('rejects listings with the same copy but a different price', () => {
+    const a = comparableOrThrow(BASE);
+    const b = comparableOrThrow({ ...BASE, longTermRent: { monthlyAmount: 1800, currency: 'EUR' } });
+    expect(areDuplicateListings(a, b)).toBe(false);
+  });
+
+  it('rejects listings differing in bedrooms or square footage', () => {
+    const a = comparableOrThrow(BASE);
+    expect(areDuplicateListings(a, comparableOrThrow({ ...BASE, bedrooms: 3 }))).toBe(false);
+    expect(areDuplicateListings(a, comparableOrThrow({ ...BASE, squareFootage: 70 }))).toBe(false);
+  });
+
+  it('rejects listings with the same attributes but unrelated descriptions', () => {
+    const a = comparableOrThrow(BASE);
+    const b = comparableOrThrow({
+      ...BASE,
+      description: buildDescription(0, Array.from({ length: 62 }, (_, i) => `distinto${i}`)),
+    });
+    expect(areDuplicateListings(a, b)).toBe(false);
+  });
+});

--- a/packages/backend/scripts/dedupeExternalListings.ts
+++ b/packages/backend/scripts/dedupeExternalListings.ts
@@ -1,0 +1,273 @@
+/**
+ * Backfill: collapse re-listed external Properties (the same physical unit
+ * advertised under multiple `sourceId`s) down to ONE per group.
+ *
+ * Groups are formed with the exact same conservative fingerprint the ingest path
+ * uses ({@link areDuplicateListings}): same type + cityId + offering + price +
+ * bedrooms(>0) + squareFootage(>0) + description Jaccard >= 0.95. Within a group
+ * the richest listing is KEPT (most images, then longest description, then oldest
+ * — a deterministic, stable choice); the rest are SOFT-DELETED
+ * (`deletedAt` + `status: archived` + `expiresAt: now`) so the collapse is fully
+ * reversible and public feeds (which filter `deletedAt: null`) stop showing them.
+ *
+ * Idempotent: archived docs carry `deletedAt` and are excluded from the next run.
+ *
+ * Usage:
+ *   node dedupeExternalListings.js            # DRY-RUN: count + show, no writes
+ *   node dedupeExternalListings.js --apply    # archive the redundant listings
+ *   node dedupeExternalListings.js --apply --limit-groups=50
+ */
+
+require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
+
+import type { Types } from 'mongoose';
+import { PropertyStatus } from '@homiio/shared-types';
+import database from '../database/connection';
+import {
+  areDuplicateListings,
+  toDedupComparable,
+  type DedupComparable,
+} from '../services/ingestion/dedupeFingerprint';
+
+const { Property } = require('../models');
+
+// `--apply` (CLI) or `DEDUP_APPLY=1` (env, for the argv-less ECS `node -e` boot).
+const APPLY = process.argv.includes('--apply') || process.env.DEDUP_APPLY === '1';
+
+function readIntFlag(name: string, fallback: number): number {
+  const prefix = `--${name}=`;
+  const raw = process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const LIMIT_GROUPS = readIntFlag('limit-groups', Number.MAX_SAFE_INTEGER);
+
+interface PropertyDoc {
+  _id: Types.ObjectId;
+  cityId?: Types.ObjectId;
+  description?: string;
+  images?: unknown[];
+  type?: string;
+  bedrooms?: number;
+  squareFootage?: number;
+  longTermRent?: { monthlyAmount?: number; currency?: string } | null;
+  shortTermRent?: { nightlyRate?: number; currency?: string } | null;
+  sale?: { price?: number; currency?: string } | null;
+  source?: string;
+  sourceId?: string;
+  sourceUrl?: string;
+  createdAt?: Date;
+}
+
+export interface Row {
+  id: string;
+  source: string;
+  sourceId: string;
+  sourceUrl: string;
+  imageCount: number;
+  createdAt: number;
+  comparable: DedupComparable;
+}
+
+/** One duplicate group: the listing to KEEP and the redundant ones to ARCHIVE. */
+export interface DedupGroup {
+  keep: Row;
+  archive: Row[];
+}
+
+/** Deterministic "keep the richest" order: most images, longest desc, oldest, then id. */
+function keepOrder(a: Row, b: Row): number {
+  if (b.imageCount !== a.imageCount) return b.imageCount - a.imageCount;
+  const bDesc = b.comparable.descriptionTokens.size;
+  const aDesc = a.comparable.descriptionTokens.size;
+  if (bDesc !== aDesc) return bDesc - aDesc;
+  if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
+  return a.id < b.id ? -1 : 1;
+}
+
+class UnionFind {
+  private readonly parent = new Map<string, string>();
+  find(x: string): string {
+    let root = this.parent.get(x) ?? x;
+    if (root === x) {
+      this.parent.set(x, x);
+      return x;
+    }
+    root = this.find(root);
+    this.parent.set(x, root);
+    return root;
+  }
+  union(a: string, b: string): void {
+    const ra = this.find(a);
+    const rb = this.find(b);
+    if (ra !== rb) this.parent.set(ra, rb);
+  }
+}
+
+function blockKey(c: DedupComparable): string {
+  return [c.type, c.cityId, c.offering, c.amount, c.currency, c.bedrooms, c.squareFootage].join('|');
+}
+
+/**
+ * Pure grouping: block rows by the scalar fingerprint, union within a block on
+ * description similarity, then split each connected component into `keep` (the
+ * richest listing) + `archive` (the rest). Groups are ordered largest-first.
+ * Deterministic and DB-free — the unit-tested core of the backfill.
+ */
+export function planDeduplication(rows: Row[]): DedupGroup[] {
+  const blocks = new Map<string, Row[]>();
+  for (const row of rows) {
+    const key = blockKey(row.comparable);
+    const bucket = blocks.get(key);
+    if (bucket) bucket.push(row);
+    else blocks.set(key, [row]);
+  }
+
+  const uf = new UnionFind();
+  const rowById = new Map<string, Row>();
+  for (const bucket of blocks.values()) {
+    for (const row of bucket) rowById.set(row.id, row);
+    if (bucket.length < 2) continue;
+    for (let i = 0; i < bucket.length; i += 1) {
+      for (let j = i + 1; j < bucket.length; j += 1) {
+        if (areDuplicateListings(bucket[i].comparable, bucket[j].comparable)) {
+          uf.union(bucket[i].id, bucket[j].id);
+        }
+      }
+    }
+  }
+
+  const grouped = new Map<string, Row[]>();
+  for (const row of rowById.values()) {
+    const root = uf.find(row.id);
+    const members = grouped.get(root);
+    if (members) members.push(row);
+    else grouped.set(root, [row]);
+  }
+
+  const groups: DedupGroup[] = [];
+  for (const members of grouped.values()) {
+    if (members.length < 2) continue;
+    const [keep, ...archive] = [...members].sort(keepOrder);
+    groups.push({ keep, archive });
+  }
+  groups.sort((a, b) => b.archive.length - a.archive.length);
+  return groups;
+}
+
+async function main(): Promise<void> {
+  await database.connect();
+
+  // Join Address→cityId via aggregation. `$lookup` bypasses the Property
+  // post-find hook that renames/mangles `addressId` on lean reads, so `cityId`
+  // arrives clean and directly usable.
+  const docs: PropertyDoc[] = await Property.aggregate([
+    { $match: { isExternal: true, deletedAt: null, status: PropertyStatus.PUBLISHED } },
+    { $lookup: { from: 'addresses', localField: 'addressId', foreignField: '_id', as: 'addr' } },
+    {
+      $project: {
+        description: 1,
+        images: 1,
+        type: 1,
+        bedrooms: 1,
+        squareFootage: 1,
+        longTermRent: 1,
+        shortTermRent: 1,
+        sale: 1,
+        source: 1,
+        sourceId: 1,
+        sourceUrl: 1,
+        createdAt: 1,
+        cityId: { $arrayElemAt: ['$addr.cityId', 0] },
+      },
+    },
+  ]);
+
+  console.log(`Scanned ${docs.length} published external listings`);
+
+  // Reduce to eligible comparable rows.
+  const rows: Row[] = [];
+  for (const doc of docs) {
+    const comparable = toDedupComparable({
+      type: doc.type,
+      cityId: doc.cityId ? String(doc.cityId) : undefined,
+      bedrooms: doc.bedrooms,
+      squareFootage: doc.squareFootage,
+      description: doc.description,
+      longTermRent: doc.longTermRent,
+      shortTermRent: doc.shortTermRent,
+      sale: doc.sale,
+    });
+    if (!comparable) continue;
+    rows.push({
+      id: String(doc._id),
+      source: doc.source ?? '',
+      sourceId: doc.sourceId ?? '',
+      sourceUrl: doc.sourceUrl ?? '',
+      imageCount: Array.isArray(doc.images) ? doc.images.length : 0,
+      createdAt: doc.createdAt ? new Date(doc.createdAt).getTime() : 0,
+      comparable,
+    });
+  }
+  console.log(`Fingerprint-eligible listings: ${rows.length}`);
+
+  const dupGroups = planDeduplication(rows);
+  const redundant = dupGroups.reduce((sum, group) => sum + group.archive.length, 0);
+  console.log(
+    `${APPLY ? 'Archiving' : 'Would archive'} ${redundant} redundant listing(s) ` +
+      `across ${dupGroups.length} duplicate group(s)`,
+  );
+
+  const toArchive: string[] = [];
+  let shown = 0;
+  for (const group of dupGroups) {
+    for (const loser of group.archive) toArchive.push(loser.id);
+
+    if (shown < LIMIT_GROUPS) {
+      shown += 1;
+      const c = group.keep.comparable;
+      console.log(
+        `\nGROUP ${c.type} ${c.offering} ${c.amount}${c.currency} ` +
+          `${c.bedrooms}bd ${c.squareFootage}m2 (n=${group.archive.length + 1})`,
+      );
+      console.log(
+        `  KEEP    [${group.keep.source}/${group.keep.sourceId}] imgs=${group.keep.imageCount} ${group.keep.sourceUrl}`,
+      );
+      for (const loser of group.archive) {
+        console.log(
+          `  ARCHIVE [${loser.source}/${loser.sourceId}] imgs=${loser.imageCount} ${loser.sourceUrl}`,
+        );
+      }
+    }
+  }
+
+  if (!APPLY) {
+    console.log('\nDRY-RUN only — no documents modified. Re-run with --apply to archive.');
+    await database.disconnect?.();
+    return;
+  }
+
+  if (toArchive.length > 0) {
+    const now = new Date();
+    const result = await Property.updateMany(
+      { _id: { $in: toArchive }, isExternal: true, deletedAt: null },
+      { $set: { deletedAt: now, status: PropertyStatus.ARCHIVED, expiresAt: now } },
+    );
+    console.log(`\nArchived ${result.modifiedCount ?? toArchive.length} listing(s).`);
+  } else {
+    console.log('\nNothing to archive.');
+  }
+
+  await database.disconnect?.();
+}
+
+// Auto-run only when executed directly (`node dedupeExternalListings.js`), so the
+// pure `planDeduplication` export can be imported by tests without hitting the DB.
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -16,6 +16,7 @@
 
 import type { Types } from 'mongoose';
 import {
+  OfferingType,
   PropertyStatus,
   type NormalizedListing,
   type NormalizedListingAddress,
@@ -33,6 +34,11 @@ import { forwardGeocode, reverseGeocode } from '../geocodingService';
 import { sanitizeGeoJsonCoordinates } from '../../utils/geoCoordinates';
 import { deriveStructuredFeatures } from './deriveFeatures';
 import { ExternalMediaIngest } from './ExternalMediaIngest';
+import {
+  areDuplicateListings,
+  toDedupComparable,
+  type DedupComparable,
+} from './dedupeFingerprint';
 import { schedulePriceEthicsScore } from '../priceEthicsService';
 import { Logger } from '../../utils/logger';
 
@@ -47,11 +53,19 @@ const EXTERNAL_POSTAL_FALLBACK = '00000';
 
 /** Outcome of ingesting one listing. */
 export interface IngestResult {
-  status: 'created' | 'updated';
+  /**
+   * `created`/`updated` follow the `(source, sourceId)` upsert. `skipped` means
+   * the listing matched an existing external Property by the dedup fingerprint
+   * (a re-listing of the same unit) and was NOT persisted — `propertyId` /
+   * `duplicateOf` point at the retained original.
+   */
+  status: 'created' | 'updated' | 'skipped';
   propertyId: string;
   source: string;
   sourceId: string;
   imageCount: number;
+  /** Set only on `skipped`: the id of the existing Property this duplicated. */
+  duplicateOf?: string;
 }
 
 /** Raised when a {@link NormalizedListing} is structurally invalid. */
@@ -62,22 +76,47 @@ export class IngestionValidationError extends Error {
   }
 }
 
+/** Max existing listings the dedup check inspects per incoming create. */
+const DEDUP_CANDIDATE_LIMIT = 50;
+
+/** Aggregation projection of an existing Property considered as a dedup candidate. */
+interface DuplicateCandidateDoc {
+  _id: Types.ObjectId;
+  cityId?: Types.ObjectId;
+  description?: string;
+  images?: unknown[];
+  type?: string;
+  bedrooms?: number;
+  squareFootage?: number;
+  longTermRent?: { monthlyAmount?: number; currency?: string } | null;
+  shortTermRent?: { nightlyRate?: number; currency?: string } | null;
+  sale?: { price?: number; currency?: string } | null;
+}
+
 export interface IngestionServiceOptions {
   mediaIngest?: ExternalMediaIngest;
   logger?: Logger;
   /** Fallback TTL (days) applied when a listing omits `ttlDays`. */
   defaultTtlDays?: number;
+  /**
+   * Recognise and skip re-listings of the same unit under a new `sourceId`
+   * (see {@link areDuplicateListings}). Defaults to env `LISTING_DEDUP_ENABLED`
+   * (only the literal `false` disables it) so ops has a redeploy-free kill switch.
+   */
+  dedupeEnabled?: boolean;
 }
 
 export class IngestionService {
   private readonly mediaIngest: ExternalMediaIngest;
   private readonly logger: Logger;
   private readonly defaultTtlDays: number;
+  private readonly dedupeEnabled: boolean;
 
   constructor(options: IngestionServiceOptions = {}) {
     this.mediaIngest = options.mediaIngest ?? new ExternalMediaIngest();
     this.logger = options.logger ?? new Logger('IngestionService');
     this.defaultTtlDays = options.defaultTtlDays ?? DEFAULT_TTL_DAYS;
+    this.dedupeEnabled = options.dedupeEnabled ?? process.env.LISTING_DEDUP_ENABLED !== 'false';
   }
 
   /** Validate, upsert and re-host media for a single normalized listing. */
@@ -88,6 +127,29 @@ export class IngestionService {
     const fields = this.buildPropertyFields(listing, addressId);
 
     const existing = await Property.findOne({ source: listing.source, sourceId: listing.sourceId });
+
+    // Before minting a NEW Property, check whether this is the SAME unit
+    // re-advertised under a different `sourceId` (best-effort; a failed check
+    // never blocks ingest). The `(source, sourceId)` update path is untouched.
+    if (!existing && this.dedupeEnabled) {
+      const duplicate = await this.findDuplicate(listing, addressId);
+      if (duplicate) {
+        this.logger.info('Skipped duplicate external listing', {
+          source: listing.source,
+          sourceId: listing.sourceId,
+          duplicateOf: duplicate.propertyId,
+        });
+        return {
+          status: 'skipped',
+          propertyId: duplicate.propertyId,
+          duplicateOf: duplicate.propertyId,
+          source: listing.source,
+          sourceId: listing.sourceId,
+          imageCount: duplicate.imageCount,
+        };
+      }
+    }
+
     const property = existing ?? new Property();
     property.set(fields);
 
@@ -122,6 +184,114 @@ export class IngestionService {
     schedulePriceEthicsScore(result.propertyId);
     this.logger.info('Ingested external listing', result);
     return result;
+  }
+
+  /**
+   * Find an existing external Property that this listing duplicates (same unit,
+   * different `sourceId`). Returns the retained original (preferring the one with
+   * the most images) or `null`. Best-effort: any error is logged and treated as
+   * "no duplicate" so a dedup fault never blocks ingest.
+   */
+  private async findDuplicate(
+    listing: NormalizedListing,
+    addressId: Types.ObjectId,
+  ): Promise<{ propertyId: string; imageCount: number } | null> {
+    try {
+      const listingAddress = await Address.findById(addressId).select('cityId').lean<{
+        cityId?: Types.ObjectId;
+      } | null>();
+      const incoming = toDedupComparable({
+        type: listing.type,
+        cityId: listingAddress?.cityId ? String(listingAddress.cityId) : undefined,
+        bedrooms: listing.bedrooms,
+        squareFootage: listing.squareFootage,
+        description: listing.description,
+        longTermRent: listing.longTermRent,
+        shortTermRent: listing.shortTermRent,
+        sale: listing.sale,
+      });
+      if (!incoming) return null;
+
+      // Selective scalar prefilter (same type, bedrooms, m² and exact price)
+      // joined to the Address `cityId`. `$lookup` bypasses the Property post-find
+      // hook that renames/mangles `addressId` on lean reads, so `cityId` is clean.
+      const candidates = await Property.aggregate<DuplicateCandidateDoc>([
+        {
+          $match: {
+            isExternal: true,
+            deletedAt: null,
+            type: incoming.type,
+            bedrooms: incoming.bedrooms,
+            squareFootage: incoming.squareFootage,
+            ...this.buildPriceFilter(incoming),
+          },
+        },
+        { $limit: DEDUP_CANDIDATE_LIMIT },
+        { $lookup: { from: 'addresses', localField: 'addressId', foreignField: '_id', as: 'addr' } },
+        {
+          $project: {
+            description: 1,
+            images: 1,
+            type: 1,
+            bedrooms: 1,
+            squareFootage: 1,
+            longTermRent: 1,
+            shortTermRent: 1,
+            sale: 1,
+            cityId: { $arrayElemAt: ['$addr.cityId', 0] },
+          },
+        },
+      ]);
+      if (candidates.length === 0) return null;
+
+      let best: { propertyId: string; imageCount: number } | null = null;
+      for (const candidate of candidates) {
+        const comparable = toDedupComparable({
+          type: candidate.type,
+          cityId: candidate.cityId ? String(candidate.cityId) : undefined,
+          bedrooms: candidate.bedrooms,
+          squareFootage: candidate.squareFootage,
+          description: candidate.description,
+          longTermRent: candidate.longTermRent,
+          shortTermRent: candidate.shortTermRent,
+          sale: candidate.sale,
+        });
+        if (!comparable || !areDuplicateListings(incoming, comparable)) continue;
+        const imageCount = Array.isArray(candidate.images) ? candidate.images.length : 0;
+        if (!best || imageCount > best.imageCount) {
+          best = { propertyId: String(candidate._id), imageCount };
+        }
+      }
+      return best;
+    } catch (error) {
+      this.logger.warn('Duplicate check failed; proceeding with ingest', {
+        source: listing.source,
+        sourceId: listing.sourceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  /** Mongo filter matching the primary offering's exact price + currency. */
+  private buildPriceFilter(comparable: DedupComparable): Record<string, unknown> {
+    switch (comparable.offering) {
+      case OfferingType.LONG_TERM_RENT:
+        return {
+          'longTermRent.monthlyAmount': comparable.amount,
+          'longTermRent.currency': comparable.currency,
+        };
+      case OfferingType.SHORT_TERM_RENT:
+        return {
+          'shortTermRent.nightlyRate': comparable.amount,
+          'shortTermRent.currency': comparable.currency,
+        };
+      case OfferingType.SALE:
+        return {
+          'sale.price': comparable.amount,
+          'sale.currency': comparable.currency,
+        };
+    }
   }
 
   /** Structural validation before any DB work. */

--- a/packages/backend/services/ingestion/dedupeFingerprint.ts
+++ b/packages/backend/services/ingestion/dedupeFingerprint.ts
@@ -1,0 +1,206 @@
+/**
+ * External-listing deduplication fingerprint.
+ *
+ * The `(source, sourceId)` upsert key stops the SAME portal ad from being
+ * ingested twice, but the SAME physical unit re-advertised under a NEW
+ * `sourceId` (same agency re-posting, a portal recycling ids, or a cross-portal
+ * repost) still slips through as a separate Property. This module defines the
+ * conservative fingerprint that recognises those re-listings.
+ *
+ * Design rationale (validated against ~5.6k live external listings):
+ *
+ *  - Coordinates are UNRELIABLE for dedup. Portals like habitaclia/fotocasa
+ *    geocode almost every listing to the city centroid (94-100% of listings
+ *    share one point), so "coordinates within Nm" matches unrelated flats. We
+ *    therefore never anchor on coordinates.
+ *  - Two DIFFERENT flats routinely share price + m2 + bedrooms by chance (common
+ *    configs at round prices) and AI-templated portal copy pushes their
+ *    description similarity as high as ~0.91 across different neighbourhoods.
+ *  - New-build developments and investment portfolios re-use a byte-identical
+ *    brochure across genuinely different units - so description identity alone is
+ *    NOT sufficient either.
+ *
+ * The fingerprint only declares a duplicate when ALL of the following hold, which
+ * jointly separate true re-lists (observed jaccard cluster 0.96-1.0) from the
+ * false-positive classes above with a clear margin:
+ *
+ *   1. same property `type`                 (an apartment is never a house)
+ *   2. same `cityId`                        (excludes multi-city developments)
+ *   3. same primary offering + identical price (amount + currency)
+ *   4. same `bedrooms`, both > 0
+ *   5. same `squareFootage`, both > 0       (never dedup on missing/zero m2)
+ *   6. both descriptions carry >= {@link MIN_DESCRIPTION_TOKENS} tokens
+ *   7. description token Jaccard >= {@link MIN_DESCRIPTION_JACCARD}
+ *
+ * Conservative by design: when any signal is missing or weak we do NOT dedup.
+ */
+
+import { OfferingType } from '@homiio/shared-types';
+
+/** Minimum normalized-token count for a description to be usable as a signal. */
+export const MIN_DESCRIPTION_TOKENS = 40;
+
+/**
+ * Minimum description-token Jaccard for two listings to count as the same unit.
+ * Sits in the middle of the empirical safe plateau: cross-neighbourhood templated
+ * false positives top out at ~0.91, true re-lists cluster at 0.96-1.0.
+ */
+export const MIN_DESCRIPTION_JACCARD = 0.95;
+
+/** The three priced offerings a listing can carry, in dedup precedence order. */
+export type DedupOffering =
+  | OfferingType.LONG_TERM_RENT
+  | OfferingType.SHORT_TERM_RENT
+  | OfferingType.SALE;
+
+/** Minimal priced-block shape shared by `NormalizedListing` and the Property doc. */
+export interface PricingBlocks {
+  longTermRent?: { monthlyAmount?: number | null; currency?: string | null } | null;
+  shortTermRent?: { nightlyRate?: number | null; currency?: string | null } | null;
+  sale?: { price?: number | null; currency?: string | null } | null;
+}
+
+/** The resolved primary price used as a fingerprint dimension. */
+export interface PrimaryPricing {
+  offering: DedupOffering;
+  amount: number;
+  currency: string;
+}
+
+/**
+ * A listing reduced to its fingerprint dimensions. Produced by
+ * {@link toDedupComparable}; `descriptionTokens` is precomputed so callers can
+ * compare one candidate against many without re-tokenising.
+ */
+export interface DedupComparable {
+  type: string;
+  cityId: string;
+  offering: DedupOffering;
+  amount: number;
+  currency: string;
+  bedrooms: number;
+  squareFootage: number;
+  descriptionTokens: ReadonlySet<string>;
+}
+
+/** Raw listing fields needed to build a {@link DedupComparable}. */
+export interface DedupListingInput extends PricingBlocks {
+  type?: string | null;
+  cityId?: string | null;
+  bedrooms?: number | null;
+  squareFootage?: number | null;
+  description?: string | null;
+}
+
+/**
+ * Pick the primary priced offering. Precedence long-term -> short-term -> sale
+ * matches how listings are surfaced; a listing carries at most one meaningful
+ * rent/sale block in practice, so precedence only breaks the rare tie.
+ */
+export function extractPrimaryPricing(blocks: PricingBlocks): PrimaryPricing | null {
+  const ltr = blocks.longTermRent;
+  if (ltr && typeof ltr.monthlyAmount === 'number' && ltr.monthlyAmount > 0) {
+    return {
+      offering: OfferingType.LONG_TERM_RENT,
+      amount: Math.round(ltr.monthlyAmount),
+      currency: (ltr.currency ?? '').toUpperCase(),
+    };
+  }
+  const str = blocks.shortTermRent;
+  if (str && typeof str.nightlyRate === 'number' && str.nightlyRate > 0) {
+    return {
+      offering: OfferingType.SHORT_TERM_RENT,
+      amount: Math.round(str.nightlyRate),
+      currency: (str.currency ?? '').toUpperCase(),
+    };
+  }
+  const sale = blocks.sale;
+  if (sale && typeof sale.price === 'number' && sale.price > 0) {
+    return {
+      offering: OfferingType.SALE,
+      amount: Math.round(sale.price),
+      currency: (sale.currency ?? '').toUpperCase(),
+    };
+  }
+  return null;
+}
+
+const TOKEN_PATTERN = /[a-z0-9]+/g;
+/** Unicode nonspacing marks — the decomposed accents left after NFD. */
+const NONSPACING_MARKS = /\p{Mn}/gu;
+
+/**
+ * Normalize a description into a comparable token set: accent-stripped,
+ * lowercased, words of length >= 3. Accent stripping keeps EU portals' diacritics
+ * from splitting otherwise-identical copies.
+ */
+export function normalizeDescriptionTokens(description: string | null | undefined): Set<string> {
+  if (!description) return new Set();
+  const folded = description.normalize('NFD').replace(NONSPACING_MARKS, '').toLowerCase();
+  const tokens = new Set<string>();
+  for (const match of folded.matchAll(TOKEN_PATTERN)) {
+    if (match[0].length >= 3) tokens.add(match[0]);
+  }
+  return tokens;
+}
+
+/** Jaccard similarity of two token sets (0 when either is empty). */
+export function descriptionJaccard(a: ReadonlySet<string>, b: ReadonlySet<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+  for (const token of small) {
+    if (large.has(token)) intersection += 1;
+  }
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/**
+ * Reduce a listing to a {@link DedupComparable}, or `null` when it lacks the
+ * strong signals the fingerprint requires (missing type/city/price, non-positive
+ * m2 or bedrooms, or a too-thin description). A `null` result means "never a
+ * dedup candidate" - the conservative default.
+ */
+export function toDedupComparable(input: DedupListingInput): DedupComparable | null {
+  const type = input.type?.trim();
+  const cityId = input.cityId?.trim();
+  if (!type || !cityId) return null;
+
+  const bedrooms = input.bedrooms;
+  const squareFootage = input.squareFootage;
+  if (typeof bedrooms !== 'number' || bedrooms <= 0) return null;
+  if (typeof squareFootage !== 'number' || squareFootage <= 0) return null;
+
+  const pricing = extractPrimaryPricing(input);
+  if (!pricing || !pricing.currency) return null;
+
+  const descriptionTokens = normalizeDescriptionTokens(input.description);
+  if (descriptionTokens.size < MIN_DESCRIPTION_TOKENS) return null;
+
+  return {
+    type,
+    cityId,
+    offering: pricing.offering,
+    amount: pricing.amount,
+    currency: pricing.currency,
+    bedrooms,
+    squareFootage,
+    descriptionTokens,
+  };
+}
+
+/**
+ * Whether two eligible comparables describe the same re-listed unit. Both inputs
+ * must already be non-null {@link DedupComparable}s (i.e. individually eligible).
+ */
+export function areDuplicateListings(a: DedupComparable, b: DedupComparable): boolean {
+  if (a.type !== b.type) return false;
+  if (a.cityId !== b.cityId) return false;
+  if (a.offering !== b.offering) return false;
+  if (a.amount !== b.amount) return false;
+  if (a.currency !== b.currency) return false;
+  if (a.bedrooms !== b.bedrooms) return false;
+  if (a.squareFootage !== b.squareFootage) return false;
+  return descriptionJaccard(a.descriptionTokens, b.descriptionTokens) >= MIN_DESCRIPTION_JACCARD;
+}


### PR DESCRIPTION
## Summary

External portals frequently re-list the same physical unit under a new `sourceId` (renewed listing, new agent, portal refresh, etc.), producing duplicate Property records. This PR adds ingest-time detection plus a one-off backfill to clean up existing duplicates.

### False-positive analysis

Naive dedup heuristics false-positive badly in this domain:

- **Coordinates are unreliable** — Habitaclia/Fotocasa (and several other portals) geocode listings to the **city centroid**, not the actual unit address, so proximity alone clusters unrelated units together.
- **Descriptions alone are unreliable** — AI-templated portal copy can reach **~0.91 Jaccard similarity** across listings that are in completely different neighbourhoods, because portals generate boilerplate marketing text from a shared template.
- **New-build developments and portfolio listings legitimately reuse identical brochure text** across many distinct physical units (same building, different apartments) — text similarity alone would incorrectly merge them.

### The chosen fingerprint

To avoid these false positives, a match requires **all** of the following simultaneously:
- same property `type`
- same `cityId`
- same `offering` (rent/sale)
- **exact** price match
- `bedrooms > 0`
- `squareFootage > 0`
- description Jaccard similarity **>= 0.95**

Combining several independent-ish signals (structured attributes + exact price + near-identical description) raises confidence that this is the *same physical unit* re-advertised under a new `sourceId`, rather than two distinct, similar units (e.g. two units in the same new-build development).

### Ingest-time skip

`IngestionService.ts` now runs an aggregation `$lookup` against existing properties at ingest time and skips creating a new record when a fingerprint match is found. This is **skip-only** — it never merges or overwrites the existing listing.

### Backfill

`packages/backend/scripts/dedupeExternalListings.ts` is a one-off script that:
- finds duplicate groups using the same fingerprint,
- soft-deletes all but the **richest** listing per group (richest = most complete data),
- is idempotent (safe to re-run).

This script has **already been executed on prod**: archived 20 redundant listings across 19 duplicate groups.

## Test plan

- [x] Unit tests for the fingerprint logic (`dedupeFingerprint.test.ts`)
- [x] Unit tests for the backfill plan (`dedupeBackfillPlan.test.ts`)
- [x] Integration test updates for ingest-time skip (`externalIngest.test.ts`)
- [x] Full test suite green, tsc clean, all package builds pass, lockfile gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)