### PR TITLE
fix(review): idealista fetch-priority + com.ec suffix

### DIFF
--- a/packages/backend/worker.ts
+++ b/packages/backend/worker.ts
@@ -72,7 +72,7 @@ const DISCOVER_CONCURRENCY = parseInt(process.env.LISTING_DISCOVER_CONCURRENCY |
  * progress instead of the big three starving the rest. BullMQ: lower number = higher
  * priority; both are >0 so neither falls into the unprioritised (top) lane.
  */
-const HIGH_VOLUME_PROVIDERS = new Set(['fotocasa', 'habitaclia', 'pisos']);
+const HIGH_VOLUME_PROVIDERS = new Set(['fotocasa', 'habitaclia', 'pisos', 'idealista']);
 const FETCH_PRIORITY_HIGH = 10;
 const FETCH_PRIORITY_LOW = 100;
 const fetchPriorityFor = (provider: string): number =>

--- a/packages/listing-providers/src/requestFilter.ts
+++ b/packages/listing-providers/src/requestFilter.ts
@@ -19,6 +19,7 @@ const COMPOUND_SUFFIXES = new Set([
   'com.ar',
   'com.br',
   'com.co',
+  'com.ec',
   'com.pe',
   'com.py',
   'co.nz',


### PR DESCRIPTION
Fixes triviales de la revisión adversarial de la sesión (#2 y #5):
- **idealista** añadido a `HIGH_VOLUME_PROVIDERS` (worker.ts): es per-city ES (miles de fetch jobs) pero faltaba, así que al activarlo ahogaría a los pequeños con prioridad alta.
- **com.ec** añadido a `COMPOUND_SUFFIXES` (requestFilter.ts): `registrableDomain` sobre-permitía `*.com.ec` en el tier browser (latente — Ecuador OFF — pero se arregla antes de activar).

Los findings graves (#1 data-loss del dedup, #3 dedup limit) los arregla el agente de dedup en otro PR. #4 (title al clasificador) requiere ampliar el contrato — irá con el refactor a Zod.

Build + test verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)