### PR TITLE
feat(frontend): reviucasa-parity reviews — wizard, agencia, explore, helpful/report

### DIFF
--- a/packages/frontend/app/addresses/[id].tsx
+++ b/packages/frontend/app/addresses/[id].tsx
@@ -1,31 +1,23 @@
 /**
  * Address detail — properties + reviews at one address.
  *
- * Stream Q polish:
- *   - Bloom Typography (H2/H3/Text) everywhere, no raw <Text>.
- *   - Bloom Button replaces TouchableOpacity CTAs (Write review, Helpful,
- *     Report, Reply, Switch).
- *   - Flat cards with radius.lg + hairline borders.
- *   - Shared EmptyState / ErrorState / SectionEyebrow.
- *   - Skeleton via PropertyListSkeleton for properties, Skeleton.Box rows
- *     for reviews while loading.
+ * The reviews tab has sub-tabs (Overall / Apartment / Management / Building /
+ * Area): each non-overall tab shows a client-side aggregate distribution per
+ * dimension (`DimensionBreakdown`) plus the reviews that carry that section's
+ * fields, rendered with the shared `ReviewCard`. Authors are hydrated ONCE at
+ * the screen level (`useOxyAvatars`). No fake confidence/evidence badges, no
+ * Alert stubs — Helpful / Report are real inside `ReviewCard`.
  */
-import React, { useCallback, useEffect, useState } from 'react';
-import {
-  Alert,
-  Pressable,
-  RefreshControl,
-  ScrollView,
-  StyleSheet,
-  View,
-} from 'react-native';
+import React, { useMemo, useState } from 'react';
+import { Pressable, RefreshControl, ScrollView, StyleSheet, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useQuery } from '@tanstack/react-query';
 import { Ionicons } from '@expo/vector-icons';
 import { Button } from '@oxyhq/bloom/button';
-import * as Skeleton from '@oxyhq/bloom/skeleton';
 import { H2, H3, Text as BloomText } from '@oxyhq/bloom/typography';
 import { useTranslation } from 'react-i18next';
+
 import { AddressDisplay } from '@/components/AddressDisplay';
 import { Header } from '@/components/Header';
 import { PropertyCard } from '@/components/PropertyCard';
@@ -34,8 +26,14 @@ import { EmptyState } from '@/components/ui/EmptyState';
 import { ErrorState } from '@/components/ui/ErrorState';
 import { SectionEyebrow } from '@/components/ui/SectionEyebrow';
 import { NeighborhoodRatingWidget } from '@/components/widgets/NeighborhoodRatingWidget';
+import { ReviewCard } from '@/components/ReviewCard';
+import { DimensionBreakdown } from '@/components/reviews/DimensionBreakdown';
+import { ReviewTabPill } from '@/components/reviews/ReviewTabPill';
+import { reviewHasSection, type ReviewSection } from '@/components/reviews/dimensions';
+import { useOxyAvatars } from '@/hooks/useOxyAvatars';
+import { reviewService } from '@/services/reviewService';
 import { api } from '@/utils/api';
-import { Property } from '@homiio/shared-types';
+import type { Property, ReviewDTO } from '@homiio/shared-types';
 import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
@@ -45,246 +43,27 @@ interface AddressData {
   _id: string;
   street: string;
   postal_code?: string;
-  /** Server-resolved geo display names (geo is relational). */
   cityName?: string;
   regionName?: string;
   countryName?: string;
   neighborhoodName?: string;
-  coordinates: {
+  coordinates?: {
     type: 'Point';
     coordinates: [number, number];
   };
-  /** Composed display label ("City, Region, Country"), when geo resolves. */
   location?: string;
-  createdAt: string;
-  updatedAt: string;
 }
 
-interface ReviewData {
-  _id: string;
-  addressId: string;
-  addressLevel: 'BUILDING' | 'UNIT';
-  greenHouse?: string;
-  price: number;
-  currency: string;
-  livedFrom: string;
-  livedTo: string;
-  livedForMonths: number;
-  recommendation: boolean;
-  opinion: string;
-  positiveComment?: string;
-  negativeComment?: string;
-  images: string[];
-  rating: number;
-  summerTemperature?: string;
-  winterTemperature?: string;
-  noise?: string;
-  light?: string;
-  conditionAndMaintenance?: string;
-  services?: string[];
-  landlordTreatment?: string;
-  problemResponse?: string;
-  depositReturned?: boolean;
-  staircaseNeighbors?: string;
-  touristApartments?: boolean;
-  neighborRelations?: string;
-  cleaning?: string;
-  areaTourists?: string;
-  areaSecurity?: string;
-  createdAt: string;
-  updatedAt: string;
-  verified: boolean;
-  isAnonymous?: boolean;
-  confidenceScore?: number;
-  evidenceAttached?: boolean;
-  flaggedIssues?: string[];
-  karmaScore?: number;
-  replyAllowed?: boolean;
-  moderationStatus?: 'pending' | 'approved' | 'flagged' | 'removed';
-  helpfulVotes?: number;
-  unhelpfulVotes?: number;
-  reportCount?: number;
-  livedDurationText?: string;
-  evidenceCount?: number;
-}
-
-type ReviewTab = 'overall' | 'apartments' | 'community' | 'area';
+type ReviewTab = 'overall' | ReviewSection;
 type ContentTab = 'properties' | 'reviews';
 
-const REVIEW_TAB_IDS: ReviewTab[] = ['overall', 'apartments', 'community', 'area'];
-
-const reviewTabKey = (tab: ReviewTab): string => {
-  switch (tab) {
-    case 'overall':
-      return 'addresses.detail.tabOverall';
-    case 'apartments':
-      return 'addresses.detail.tabApartments';
-    case 'community':
-      return 'addresses.detail.tabCommunity';
-    case 'area':
-      return 'addresses.detail.tabArea';
-  }
-};
-
-const Stars: React.FC<{ rating: number }> = ({ rating }) => {
-  const fullStars = Math.floor(rating);
-  const halfStar = rating % 1 >= 0.5;
-  const emptyStars = 5 - fullStars - (halfStar ? 1 : 0);
-
-  return (
-    <View style={styles.starsContainer}>
-      {Array.from({ length: fullStars }).map((_, i) => (
-        <Ionicons
-          key={`full-${i}`}
-          name="star"
-          size={16}
-          color={colors.ratingStar}
-        />
-      ))}
-      {halfStar ? (
-        <Ionicons name="star-half" size={16} color={colors.ratingStar} />
-      ) : null}
-      {Array.from({ length: emptyStars }).map((_, i) => (
-        <Ionicons
-          key={`empty-${i}`}
-          name="star-outline"
-          size={16}
-          color={colors.ratingStar}
-        />
-      ))}
-    </View>
-  );
-};
-
-const ReviewCardItem: React.FC<{
-  review: ReviewData;
-  onHelpful: () => void;
-  onReport: () => void;
-  onReply: () => void;
-}> = ({ review, onHelpful, onReport, onReply }) => {
-  const confidenceColor =
-    (review.confidenceScore ?? 0) >= 80
-      ? colors.success
-      : (review.confidenceScore ?? 0) >= 60
-        ? colors.warning
-        : colors.danger;
-
-  return (
-    <View style={styles.reviewCard}>
-      <View style={styles.reviewHeader}>
-        <View style={styles.avatarSmall}>
-          <Ionicons name="person" size={18} color={colors.muted} />
-        </View>
-        <View style={styles.reviewerInfo}>
-          <BloomText style={styles.reviewerName}>
-            {review.isAnonymous ? 'Anonymous' : 'Verified Resident'}
-          </BloomText>
-          <View style={styles.metaRow}>
-            <BloomText style={styles.metaText}>
-              {new Date(review.createdAt).toLocaleDateString()}
-            </BloomText>
-            <BloomText style={styles.metaText}>·</BloomText>
-            <BloomText style={styles.metaText}>
-              Lived {review.livedForMonths} months
-            </BloomText>
-          </View>
-        </View>
-        <Stars rating={review.rating} />
-      </View>
-
-      <View style={styles.badgesRow}>
-        {review.verified ? (
-          <View
-            style={[styles.badge, { backgroundColor: colors.infoSubtle }]}
-          >
-            <Ionicons name="checkmark-circle" size={12} color={colors.info} />
-            <BloomText style={[styles.badgeText, { color: colors.info }]}>
-              Verified
-            </BloomText>
-          </View>
-        ) : null}
-        <View
-          style={[
-            styles.badge,
-            { backgroundColor: confidenceColor + '20' },
-          ]}
-        >
-          <BloomText style={[styles.badgeText, { color: confidenceColor }]}>
-            {review.confidenceScore ?? 0}% confident
-          </BloomText>
-        </View>
-        {review.evidenceAttached ? (
-          <View
-            style={[styles.badge, { backgroundColor: colors.mutedSubtle }]}
-          >
-            <Ionicons
-              name="document-attach"
-              size={12}
-              color={colors.COLOR_BLACK_LIGHT_2}
-            />
-            <BloomText style={styles.badgeText}>
-              {review.evidenceCount ?? 1} proof
-              {(review.evidenceCount ?? 1) > 1 ? 's' : ''}
-            </BloomText>
-          </View>
-        ) : null}
-      </View>
-
-      <BloomText style={styles.reviewBody}>{review.opinion}</BloomText>
-
-      {review.positiveComment ? (
-        <View style={styles.commentSection}>
-          <BloomText style={styles.commentLabel}>What I liked</BloomText>
-          <BloomText style={styles.commentText}>
-            {review.positiveComment}
-          </BloomText>
-        </View>
-      ) : null}
-
-      {review.negativeComment ? (
-        <View style={styles.commentSection}>
-          <BloomText style={styles.commentLabel}>What I disliked</BloomText>
-          <BloomText style={styles.commentText}>
-            {review.negativeComment}
-          </BloomText>
-        </View>
-      ) : null}
-
-      <View style={styles.reviewFooter}>
-        <View style={styles.actionRow}>
-          <Button variant="ghost" size="small" onPress={onHelpful}>
-            Helpful ({review.helpfulVotes ?? 0})
-          </Button>
-          <Button variant="ghost" size="small" onPress={onReport}>
-            Report
-          </Button>
-          {review.replyAllowed ? (
-            <Button variant="ghost" size="small" onPress={onReply}>
-              Reply
-            </Button>
-          ) : null}
-        </View>
-        <BloomText
-          style={[
-            styles.recommendation,
-            {
-              color: review.recommendation ? colors.success : colors.danger,
-            },
-          ]}
-        >
-          {review.recommendation ? 'Recommends' : 'Does not recommend'}
-        </BloomText>
-      </View>
-    </View>
-  );
-};
-
-interface ContentTabSwitcherProps {
-  selected: ContentTab;
-  propertyCount: number;
-  reviewCount: number;
-  onChange: (value: ContentTab) => void;
-}
+const REVIEW_TABS: { id: ReviewTab; labelKey: string }[] = [
+  { id: 'overall', labelKey: 'addresses.detail.tabOverall' },
+  { id: 'apartment', labelKey: 'addresses.detail.tabApartment' },
+  { id: 'management', labelKey: 'addresses.detail.tabManagement' },
+  { id: 'building', labelKey: 'addresses.detail.tabBuilding' },
+  { id: 'area', labelKey: 'addresses.detail.tabArea' },
+];
 
 interface ContentTabButtonProps {
   label: string;
@@ -293,256 +72,105 @@ interface ContentTabButtonProps {
   onPress: () => void;
 }
 
-const ContentTabButton: React.FC<ContentTabButtonProps> = ({
-  label,
-  icon,
-  active,
-  onPress,
-}) => {
+const ContentTabButton: React.FC<ContentTabButtonProps> = ({ label, icon, active, onPress }) => {
   const [pressed, setPressed] = useState(false);
   return (
     <Pressable
       onPress={onPress}
       onPressIn={() => setPressed(true)}
       onPressOut={() => setPressed(false)}
-      style={[
-        styles.tabPill,
-        active && styles.tabPillActive,
-        pressed && styles.tabPillPressed,
-      ]}
       accessibilityRole="tab"
       accessibilityState={{ selected: active }}
+      style={[styles.tabPill, active && styles.tabPillActive, pressed && styles.tabPillPressed]}
     >
-      <Ionicons
-        name={icon}
-        size={16}
-        color={active ? colors.white : colors.COLOR_BLACK_LIGHT_2}
-      />
-      <BloomText
-        style={[styles.tabPillLabel, active && styles.tabPillLabelActive]}
-      >
+      <Ionicons name={icon} size={16} color={active ? colors.white : colors.COLOR_BLACK_LIGHT_2} />
+      <BloomText style={[styles.tabPillLabel, active && styles.tabPillLabelActive]}>
         {label}
       </BloomText>
     </Pressable>
   );
 };
 
-const ContentTabSwitcher: React.FC<ContentTabSwitcherProps> = ({
-  selected,
-  propertyCount,
-  reviewCount,
-  onChange,
-}) => {
-  const { t } = useTranslation();
-  return (
-    <View style={styles.tabSwitcher}>
-      {(
-        [
-          { id: 'properties' as const, label: t('addresses.detail.tabProperties', { count: propertyCount }), icon: 'home-outline' as IoniconName },
-          { id: 'reviews' as const, label: t('addresses.detail.tabReviews', { count: reviewCount }), icon: 'chatbubbles-outline' as IoniconName },
-        ] as const
-      ).map((tab) => (
-        <ContentTabButton
-          key={tab.id}
-          label={tab.label}
-          icon={tab.icon}
-          active={selected === tab.id}
-          onPress={() => onChange(tab.id)}
-        />
-      ))}
-    </View>
-  );
-};
-
-interface ReviewTabSwitcherProps {
-  selected: ReviewTab;
-  onChange: (tab: ReviewTab) => void;
-}
-
-const ReviewTabSwitcher: React.FC<ReviewTabSwitcherProps> = ({
-  selected,
-  onChange,
-}) => {
-  const { t } = useTranslation();
-  return (
-    <View style={styles.reviewTabBar}>
-      {REVIEW_TAB_IDS.map((tabId) => {
-        const active = selected === tabId;
-        return (
-          <Pressable
-            key={tabId}
-            onPress={() => onChange(tabId)}
-            style={[styles.reviewTab, active && styles.reviewTabActive]}
-            accessibilityRole="tab"
-            accessibilityState={{ selected: active }}
-          >
-            <BloomText
-              style={[
-                styles.reviewTabLabel,
-                active && styles.reviewTabLabelActive,
-              ]}
-            >
-              {t(reviewTabKey(tabId))}
-            </BloomText>
-          </Pressable>
-        );
-      })}
-    </View>
-  );
+const computeSummary = (reviews: ReviewDTO[]) => {
+  if (reviews.length === 0) {
+    return { averageRating: 0, totalReviews: 0, recommendationPercentage: 0 };
+  }
+  const ratingSum = reviews.reduce((sum, r) => sum + (r.rating || 0), 0);
+  const recommended = reviews.filter((r) => r.recommendation).length;
+  return {
+    averageRating: ratingSum / reviews.length,
+    totalReviews: reviews.length,
+    recommendationPercentage: (recommended / reviews.length) * 100,
+  };
 };
 
 export default function AddressDetailsPage() {
   const { t } = useTranslation();
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const { id, tab } = useLocalSearchParams<{ id: string; tab?: string }>();
   const router = useRouter();
-  const [refreshing, setRefreshing] = useState(false);
-  const [activeTab, setActiveTab] = useState<ReviewTab>('overall');
-  const [contentTab, setContentTab] = useState<ContentTab>('properties');
-  const [address, setAddress] = useState<AddressData | null>(null);
-  const [properties, setProperties] = useState<Property[]>([]);
-  const [reviews, setReviews] = useState<ReviewData[]>([]);
-  const [loading, setLoading] = useState(true);
-
   const addressId = id;
 
-  const filteredReviews = (() => {
-    if (!Array.isArray(reviews)) return [];
-    switch (activeTab) {
-      case 'apartments':
-        return reviews.filter(
-          (review) =>
-            review.summerTemperature ||
-            review.winterTemperature ||
-            review.noise ||
-            review.light ||
-            review.conditionAndMaintenance ||
-            (review.services?.length || 0) > 0,
-        );
-      case 'community':
-        return reviews.filter(
-          (review) =>
-            review.landlordTreatment ||
-            review.problemResponse ||
-            review.depositReturned !== undefined ||
-            review.staircaseNeighbors ||
-            review.touristApartments !== undefined ||
-            review.neighborRelations,
-        );
-      case 'area':
-        return reviews.filter(
-          (review) => review.areaTourists || review.areaSecurity,
-        );
-      case 'overall':
-      default:
-        return reviews;
-    }
-  })();
-
-  const fetchAddress = useCallback(async () => {
-    const response = await api.get(`/api/addresses/${addressId}`);
-    setAddress(response.data?.address || response.data);
-  }, [addressId]);
-
-  const fetchPropertiesAtAddress = useCallback(async () => {
-    const response = await api.get('/api/properties/search', {
-      params: { addressId, limit: 50 },
-    });
-    const list =
-      response.data?.data || response.data?.properties || [];
-    setProperties(list);
-  }, [addressId]);
-
-  const fetchAddressReviews = useCallback(async () => {
-    const response = await api.get(`/api/reviews/address/${addressId}`);
-    let data: ReviewData[] = [];
-    const payload = response.data;
-    if (payload?.success) {
-      const buildingReviews = payload.buildingReviews || [];
-      const unitReviews = payload.unitReviews || [];
-      data = [...buildingReviews, ...unitReviews].map(
-        (review: Partial<ReviewData>) => ({
-          ...(review as ReviewData),
-          isAnonymous: review.isAnonymous ?? true,
-          confidenceScore: review.confidenceScore ?? 75,
-          evidenceAttached: review.evidenceAttached ?? false,
-          flaggedIssues: review.flaggedIssues ?? [],
-          karmaScore: review.karmaScore ?? 0,
-          replyAllowed: review.replyAllowed ?? true,
-          moderationStatus: review.moderationStatus ?? 'approved',
-          helpfulVotes: review.helpfulVotes ?? 0,
-          unhelpfulVotes: review.unhelpfulVotes ?? 0,
-          reportCount: review.reportCount ?? 0,
-          evidenceCount: review.evidenceCount ?? 0,
-        }),
-      );
-    } else {
-      const fallback =
-        payload?.data || payload?.reviews || payload || [];
-      data = Array.isArray(fallback) ? fallback : [];
-    }
-    setReviews(data);
-  }, [addressId]);
-
-  const fetchAllData = useCallback(
-    async (refresh = false) => {
-      if (refresh) setRefreshing(true);
-      else setLoading(true);
-      try {
-        await Promise.all([
-          fetchAddress(),
-          fetchPropertiesAtAddress(),
-          fetchAddressReviews(),
-        ]);
-      } finally {
-        setLoading(false);
-        setRefreshing(false);
-      }
-    },
-    [fetchAddress, fetchPropertiesAtAddress, fetchAddressReviews],
+  const [contentTab, setContentTab] = useState<ContentTab>(
+    tab === 'reviews' ? 'reviews' : 'properties',
   );
+  const [reviewTab, setReviewTab] = useState<ReviewTab>('overall');
+  const [refreshing, setRefreshing] = useState(false);
 
-  useEffect(() => {
-    // Inline async wrapper keeps the fetchers' internal setState off the
-    // synchronous effect path (avoids cascading renders).
-    void (async () => {
-      await fetchAllData();
-    })();
-  }, [fetchAllData]);
+  const addressQuery = useQuery<AddressData | null>({
+    queryKey: ['address', addressId],
+    enabled: Boolean(addressId),
+    queryFn: async () => {
+      const response = await api.get(`/api/addresses/${addressId}`);
+      return (response.data?.address || response.data) as AddressData;
+    },
+  });
 
-  const handleWriteReview = () => {
-    router.push(`/reviews/write?addressId=${addressId}`);
-  };
+  const propertiesQuery = useQuery<Property[]>({
+    queryKey: ['addressProperties', addressId],
+    enabled: Boolean(addressId),
+    queryFn: async () => {
+      const response = await api.get('/api/properties/search', {
+        params: { addressId, limit: 50 },
+        requireAuth: false,
+      });
+      return (response.data?.data || response.data?.properties || []) as Property[];
+    },
+  });
 
-  const handleReviewHelpful = (_reviewId: string) => {
-    Alert.alert(t('reviews.card.alertThankYouTitle'), t('reviews.card.alertThankYouBody'));
-  };
+  const reviewsQuery = useQuery<ReviewDTO[]>({
+    queryKey: ['addressReviews', addressId],
+    enabled: Boolean(addressId),
+    queryFn: async () => {
+      if (!addressId) return [];
+      const result = await reviewService.getReviewsByAddress(addressId);
+      return result.reviews;
+    },
+  });
 
-  const handleReviewReport = (_reviewId: string) => {
-    Alert.alert(
-      t('reviews.card.alertReportTitle'),
-      t('reviews.card.alertReportBody'),
-      [
-        { text: t('common.cancel'), style: 'cancel' },
-        {
-          text: t('reviews.card.alertReportConfirm'),
-          style: 'destructive',
-          onPress: () => {
-            Alert.alert(
-              t('reviews.card.alertReportedTitle'),
-              t('reviews.card.alertReportedBody'),
-            );
-          },
-        },
-      ],
-    );
-  };
+  const address = addressQuery.data ?? null;
+  const properties = propertiesQuery.data ?? [];
+  const reviews = useMemo(() => reviewsQuery.data ?? [], [reviewsQuery.data]);
 
-  const handleReplyToReview = (_reviewId: string) => {
-    Alert.alert(
-      t('reviews.card.alertReplyTitle'),
-      t('reviews.card.alertReplyBody'),
-      [{ text: t('common.confirm') }],
-    );
+  const { usersById } = useOxyAvatars(reviews.map((review) => review.oxyUserId));
+
+  const summary = useMemo(() => computeSummary(reviews), [reviews]);
+
+  const filteredReviews = useMemo(() => {
+    if (reviewTab === 'overall') return reviews;
+    return reviews.filter((review) => reviewHasSection(review, reviewTab));
+  }, [reviews, reviewTab]);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await Promise.all([
+        addressQuery.refetch(),
+        propertiesQuery.refetch(),
+        reviewsQuery.refetch(),
+      ]);
+    } finally {
+      setRefreshing(false);
+    }
   };
 
   const getAddressTitle = () => {
@@ -558,17 +186,15 @@ export default function AddressDetailsPage() {
     return raw.length > 35 ? `${raw.substring(0, 32)}...` : raw;
   })();
 
-  if (loading && !refreshing) {
+  const handleWriteReview = () => {
+    router.push(`/reviews/write?addressId=${addressId}`);
+  };
+
+  if (addressQuery.isLoading && !refreshing) {
     return (
       <View style={styles.root}>
-        <Header
-          options={{ title: headerTitle, showBackButton: true }}
-        />
+        <Header options={{ title: headerTitle, showBackButton: true }} />
         <ScrollView contentContainerStyle={styles.content}>
-          <View style={styles.sectionCard}>
-            <Skeleton.Text style={{ width: 220, lineHeight: 22 }} />
-            <Skeleton.Text style={{ width: 180, lineHeight: 14 }} />
-          </View>
           <PropertyListSkeleton viewMode="list" />
         </ScrollView>
       </View>
@@ -578,9 +204,7 @@ export default function AddressDetailsPage() {
   if (!address) {
     return (
       <View style={styles.root}>
-        <Header
-          options={{ title: t('addresses.detail.title'), showBackButton: true }}
-        />
+        <Header options={{ title: t('addresses.detail.title'), showBackButton: true }} />
         <ErrorState
           icon="search-outline"
           title={t('addresses.detail.notFound')}
@@ -594,29 +218,14 @@ export default function AddressDetailsPage() {
 
   const addressForDisplay = {
     street: address.street,
-    // Geo is relational: feed the resolved display NAMES into the presentational
-    // AddressDisplay (which renders city/state/zip/country strings).
     city: address.cityName ?? '',
     state: address.regionName ?? '',
     zipCode: address.postal_code ?? '',
     country: address.countryName,
     coordinates: address.coordinates
-      ? {
-          lat: address.coordinates.coordinates[1],
-          lng: address.coordinates.coordinates[0],
-        }
+      ? { lat: address.coordinates.coordinates[1], lng: address.coordinates.coordinates[0] }
       : undefined,
   };
-
-  const avgConfidence =
-    reviews.length > 0
-      ? Math.round(
-          reviews.reduce((acc, r) => acc + (r.confidenceScore ?? 0), 0) /
-            reviews.length,
-        )
-      : 0;
-  const verifiedCount = reviews.filter((r) => r.verified).length;
-  const evidenceCount = reviews.filter((r) => r.evidenceAttached).length;
 
   return (
     <View style={styles.root}>
@@ -627,43 +236,44 @@ export default function AddressDetailsPage() {
           refreshControl={
             <RefreshControl
               refreshing={refreshing}
-              onRefresh={() => fetchAllData(true)}
+              onRefresh={handleRefresh}
               colors={[colors.primaryColor]}
             />
           }
         >
           <View style={styles.sectionCard}>
-            <AddressDisplay
-              address={addressForDisplay}
-              variant="detailed"
-              showActions
-            />
+            <AddressDisplay address={addressForDisplay} variant="detailed" showActions />
           </View>
 
-          <View style={styles.sectionCard}>
-            <SectionEyebrow>Trust & transparency</SectionEyebrow>
-            <H3 style={styles.cardHeading}>Community signal</H3>
-            <View style={styles.metricsRow}>
-              <View style={styles.metric}>
-                <BloomText style={styles.metricValue}>
-                  {avgConfidence}%
-                </BloomText>
-                <BloomText style={styles.metricLabel}>Confidence</BloomText>
-              </View>
-              <View style={styles.metric}>
-                <BloomText style={styles.metricValue}>
-                  {verifiedCount}
-                </BloomText>
-                <BloomText style={styles.metricLabel}>Verified</BloomText>
-              </View>
-              <View style={styles.metric}>
-                <BloomText style={styles.metricValue}>
-                  {evidenceCount}
-                </BloomText>
-                <BloomText style={styles.metricLabel}>With evidence</BloomText>
+          {reviews.length > 0 ? (
+            <View style={styles.sectionCard}>
+              <SectionEyebrow>{t('addresses.detail.reviewsSection')}</SectionEyebrow>
+              <View style={styles.metricsRow}>
+                <View style={styles.metric}>
+                  <BloomText style={styles.metricValue}>
+                    {summary.averageRating.toFixed(1)}
+                  </BloomText>
+                  <BloomText style={styles.metricLabel}>
+                    {t('addresses.detail.metricRating')}
+                  </BloomText>
+                </View>
+                <View style={styles.metric}>
+                  <BloomText style={styles.metricValue}>{summary.totalReviews}</BloomText>
+                  <BloomText style={styles.metricLabel}>
+                    {t('addresses.detail.metricReviews')}
+                  </BloomText>
+                </View>
+                <View style={styles.metric}>
+                  <BloomText style={styles.metricValue}>
+                    {Math.round(summary.recommendationPercentage)}%
+                  </BloomText>
+                  <BloomText style={styles.metricLabel}>
+                    {t('addresses.detail.metricRecommend')}
+                  </BloomText>
+                </View>
               </View>
             </View>
-          </View>
+          ) : null}
 
           <View style={styles.sectionCard}>
             <NeighborhoodRatingWidget
@@ -673,12 +283,20 @@ export default function AddressDetailsPage() {
             />
           </View>
 
-          <ContentTabSwitcher
-            selected={contentTab}
-            propertyCount={properties.length}
-            reviewCount={reviews.length}
-            onChange={setContentTab}
-          />
+          <View style={styles.tabSwitcher}>
+            <ContentTabButton
+              label={t('addresses.detail.tabProperties', { count: properties.length })}
+              icon="home-outline"
+              active={contentTab === 'properties'}
+              onPress={() => setContentTab('properties')}
+            />
+            <ContentTabButton
+              label={t('addresses.detail.tabReviews', { count: reviews.length })}
+              icon="chatbubbles-outline"
+              active={contentTab === 'reviews'}
+              onPress={() => setContentTab('reviews')}
+            />
+          </View>
 
           {contentTab === 'properties' ? (
             <View style={styles.sectionCard}>
@@ -695,9 +313,7 @@ export default function AddressDetailsPage() {
                     <PropertyCard
                       key={property._id}
                       property={property}
-                      onPress={() =>
-                        router.push(`/properties/${property._id}`)
-                      }
+                      onPress={() => router.push(`/properties/${property._id}`)}
                       variant="compact"
                       orientation="horizontal"
                     />
@@ -716,42 +332,41 @@ export default function AddressDetailsPage() {
                   variant="primary"
                   size="medium"
                   onPress={handleWriteReview}
-                  icon={
-                    <Ionicons
-                      name="create-outline"
-                      size={16}
-                      color={colors.primaryForeground}
-                    />
-                  }
+                  icon={<Ionicons name="create-outline" size={16} color={colors.primaryForeground} />}
                 >
                   {t('addresses.detail.writeReview')}
                 </Button>
               </View>
 
-              <ReviewTabSwitcher
-                selected={activeTab}
-                onChange={setActiveTab}
-              />
+              <View style={styles.reviewTabBar}>
+                {REVIEW_TABS.map((entry) => (
+                  <ReviewTabPill
+                    key={entry.id}
+                    label={t(entry.labelKey)}
+                    active={reviewTab === entry.id}
+                    onPress={() => setReviewTab(entry.id)}
+                  />
+                ))}
+              </View>
+
+              {reviewTab !== 'overall' && reviews.length > 0 ? (
+                <DimensionBreakdown reviews={reviews} section={reviewTab} />
+              ) : null}
 
               {filteredReviews.length === 0 ? (
                 <EmptyState
                   icon="chatbubble-outline"
-                  title={
-                    activeTab === 'overall'
-                      ? t('addresses.detail.emptyReviewsTitle')
-                      : t('addresses.detail.emptyReviewsTitle')
-                  }
+                  title={t('addresses.detail.emptyReviewsTitle')}
                   description={t('addresses.detail.emptyReviewsDescription')}
                 />
               ) : (
                 <View style={styles.reviewsList}>
                   {filteredReviews.map((review) => (
-                    <ReviewCardItem
-                      key={review._id}
+                    <ReviewCard
+                      key={review.id}
                       review={review}
-                      onHelpful={() => handleReviewHelpful(review._id)}
-                      onReport={() => handleReviewReport(review._id)}
-                      onReply={() => handleReplyToReview(review._id)}
+                      author={usersById.get(review.oxyUserId)}
+                      onPressAgency={(slug) => router.push(`/agency/${slug}`)}
                     />
                   ))}
                 </View>
@@ -859,132 +474,10 @@ const styles = StyleSheet.create({
   },
   reviewTabBar: {
     flexDirection: 'row',
-    backgroundColor: colors.mutedSubtle,
-    borderRadius: radius.md,
-    padding: spacing.xs,
+    flexWrap: 'wrap',
     gap: spacing.xs,
-  },
-  reviewTab: {
-    flex: 1,
-    paddingVertical: spacing.sm,
-    paddingHorizontal: spacing.md,
-    borderRadius: radius.md,
-    alignItems: 'center',
-  },
-  reviewTabActive: {
-    backgroundColor: colors.primaryColor,
-  },
-  reviewTabLabel: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: colors.muted,
-  },
-  reviewTabLabelActive: {
-    color: colors.primaryForeground,
   },
   reviewsList: {
     gap: spacing.md,
-  },
-  reviewCard: {
-    backgroundColor: colors.surface,
-    padding: spacing.lg,
-    borderRadius: radius.lg,
-    gap: spacing.sm,
-    borderWidth: 1,
-    borderColor: colors.border,
-  },
-  reviewHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.sm,
-  },
-  avatarSmall: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: colors.mutedSubtle,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  reviewerInfo: {
-    flex: 1,
-    gap: 2,
-  },
-  reviewerName: {
-    fontSize: 14,
-    fontWeight: '700',
-    color: colors.COLOR_BLACK,
-  },
-  metaRow: {
-    flexDirection: 'row',
-    gap: spacing.xs,
-  },
-  metaText: {
-    fontSize: 12,
-    color: colors.muted,
-  },
-  starsContainer: {
-    flexDirection: 'row',
-    gap: 2,
-  },
-  badgesRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: spacing.xs,
-  },
-  badge: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.xs,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: 4,
-    borderRadius: radius.pill,
-  },
-  badgeText: {
-    fontSize: 11,
-    fontWeight: '600',
-    color: colors.COLOR_BLACK_LIGHT_2,
-  },
-  reviewBody: {
-    fontSize: 14,
-    lineHeight: 20,
-    color: colors.COLOR_BLACK_LIGHT_2,
-  },
-  commentSection: {
-    backgroundColor: colors.mutedSubtle,
-    padding: spacing.sm,
-    borderRadius: radius.md,
-    gap: 2,
-  },
-  commentLabel: {
-    fontSize: 11,
-    fontWeight: '700',
-    color: colors.muted,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-  },
-  commentText: {
-    fontSize: 13,
-    color: colors.COLOR_BLACK_LIGHT_2,
-    lineHeight: 18,
-  },
-  reviewFooter: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingTop: spacing.sm,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: colors.border,
-    flexWrap: 'wrap',
-    gap: spacing.sm,
-  },
-  actionRow: {
-    flexDirection: 'row',
-    gap: spacing.xs,
-    flexShrink: 1,
-  },
-  recommendation: {
-    fontSize: 12,
-    fontWeight: '600',
   },
 });

--- a/packages/frontend/app/agency/[slug].tsx
+++ b/packages/frontend/app/agency/[slug].tsx
@@ -1,0 +1,342 @@
+/**
+ * Agency profile — an agency's aggregate reputation, reviews, and listings.
+ *
+ * Header: name + stat tiles (avg rating, total reviews, recommend %, deposit-full
+ * %, listings count). Tabs: Reviews (paginated `useAgencyReviews`, each review
+ * linking to its address page) and Listings (paginated `useAgencyProperties`
+ * rendered with the shared `PropertyResultsGrid`). Infinite scroll wires BOTH
+ * primitives — `LoadMoreSentinel` (web) + `useInfiniteScroll` (native).
+ */
+import React, { useState } from 'react';
+import { Platform, Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { Ionicons } from '@expo/vector-icons';
+
+import * as Skeleton from '@oxyhq/bloom/skeleton';
+import { H1, Text as BloomText } from '@oxyhq/bloom/typography';
+
+import { Header } from '@/components/Header';
+import { ReviewCard } from '@/components/ReviewCard';
+import { ReviewTabPill } from '@/components/reviews/ReviewTabPill';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { ErrorState } from '@/components/ui/ErrorState';
+import { PropertyResultsGrid } from '@/components/ui/PropertyResultsGrid';
+import { LoadMoreSentinel } from '@/components/common/LoadMoreSentinel';
+import { useAgency, useAgencyReviews, useAgencyProperties } from '@/hooks/useAgencyReviews';
+import { useOxyAvatars } from '@/hooks/useOxyAvatars';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import type { ReviewDTO } from '@homiio/shared-types';
+import type { User } from '@oxyhq/core';
+import { colors } from '@/styles/colors';
+import { hairline, radius, spacing } from '@/constants/styles';
+
+const IS_WEB = Platform.OS === 'web';
+
+type AgencyTab = 'reviews' | 'listings';
+
+interface StatTileProps {
+  value: string;
+  label: string;
+}
+
+const StatTile: React.FC<StatTileProps> = ({ value, label }) => (
+  <View style={styles.statTile}>
+    <BloomText style={styles.statValue}>{value}</BloomText>
+    <BloomText style={styles.statLabel}>{label}</BloomText>
+  </View>
+);
+
+interface AgencyReviewItemProps {
+  review: ReviewDTO;
+  author?: User;
+  onPressAddress: () => void;
+}
+
+/** One agency review — an address link (own press state) above the review card. */
+const AgencyReviewItem: React.FC<AgencyReviewItemProps> = ({ review, author, onPressAddress }) => {
+  const { t } = useTranslation();
+  const [pressed, setPressed] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const label = review.populatedAddress?.street || t('agency.viewAddress');
+  return (
+    <View style={styles.reviewItem}>
+      <Pressable
+        onPress={onPressAddress}
+        onPressIn={() => setPressed(true)}
+        onPressOut={() => setPressed(false)}
+        onHoverIn={IS_WEB ? () => setHovered(true) : undefined}
+        onHoverOut={IS_WEB ? () => setHovered(false) : undefined}
+        accessibilityRole="link"
+        accessibilityLabel={label}
+        style={[styles.addressLink, (pressed || hovered) && styles.addressLinkActive]}
+      >
+        <Ionicons name="location-outline" size={14} color={colors.primaryColor} />
+        <BloomText style={styles.addressLinkText}>{label}</BloomText>
+        <Ionicons name="chevron-forward" size={13} color={colors.primaryColor} />
+      </Pressable>
+      <ReviewCard review={review} author={author} />
+    </View>
+  );
+};
+
+export default function AgencyProfileScreen() {
+  const { slug } = useLocalSearchParams<{ slug: string }>();
+  const router = useRouter();
+  const { t } = useTranslation();
+  const [tab, setTab] = useState<AgencyTab>('reviews');
+
+  const agencyQuery = useAgency(slug);
+  const reviewsQuery = useAgencyReviews(slug);
+  const propertiesQuery = useAgencyProperties(slug);
+
+  const reviews = reviewsQuery.reviews;
+  const properties = propertiesQuery.properties;
+  const { usersById } = useOxyAvatars(reviews.map((review) => review.oxyUserId));
+
+  const loadMoreReviews = () => {
+    if (reviewsQuery.hasNextPage && !reviewsQuery.isFetchingNextPage) {
+      reviewsQuery.fetchNextPage();
+    }
+  };
+  const loadMoreProperties = () => {
+    if (propertiesQuery.hasNextPage && !propertiesQuery.isFetchingNextPage) {
+      propertiesQuery.fetchNextPage();
+    }
+  };
+
+  const onReviewsTab = tab === 'reviews';
+  const { onScroll } = useInfiniteScroll({
+    onEndReached: onReviewsTab ? loadMoreReviews : loadMoreProperties,
+    enabled: onReviewsTab
+      ? Boolean(reviewsQuery.hasNextPage)
+      : Boolean(propertiesQuery.hasNextPage),
+  });
+
+  const agency = agencyQuery.data?.agency;
+  const stats = agencyQuery.data?.stats;
+  const title = agency?.name ?? t('agency.title');
+
+  if (agencyQuery.isLoading) {
+    return (
+      <View style={styles.root}>
+        <Header options={{ title: t('agency.title'), showBackButton: true }} />
+        <View style={styles.content}>
+          <Skeleton.Box width="60%" height={28} borderRadius={radius.md} />
+          <Skeleton.Box width="100%" height={80} borderRadius={radius.md} />
+        </View>
+      </View>
+    );
+  }
+
+  if (agencyQuery.isError || !agency || !stats) {
+    return (
+      <View style={styles.root}>
+        <Header options={{ title: t('agency.title'), showBackButton: true }} />
+        <ErrorState
+          icon="business-outline"
+          title={t('agency.notFound')}
+          description={t('agency.notFoundDescription')}
+          retryLabel={t('common.goBack')}
+          onRetry={() => router.back()}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.root}>
+      <Header options={{ title, showBackButton: true }} />
+      <SafeAreaView edges={['bottom']} style={styles.safeArea}>
+        <ScrollView
+          contentContainerStyle={styles.content}
+          onScroll={onScroll}
+          scrollEventThrottle={16}
+        >
+          <View style={styles.headerBlock}>
+            <View style={styles.agencyIcon}>
+              <Ionicons name="business" size={28} color={colors.primaryColor} />
+            </View>
+            <H1 style={styles.agencyName}>{agency.name}</H1>
+          </View>
+
+          <View style={styles.statsRow}>
+            <StatTile value={stats.averageRating.toFixed(1)} label={t('agency.stats.rating')} />
+            <StatTile value={String(stats.totalReviews)} label={t('agency.stats.reviews')} />
+            <StatTile
+              value={`${Math.round(stats.recommendationPercentage)}%`}
+              label={t('agency.stats.recommend')}
+            />
+            {typeof stats.depositFullPct === 'number' ? (
+              <StatTile
+                value={`${Math.round(stats.depositFullPct)}%`}
+                label={t('agency.stats.depositFull')}
+              />
+            ) : null}
+            {typeof stats.listingsCount === 'number' ? (
+              <StatTile value={String(stats.listingsCount)} label={t('agency.stats.listings')} />
+            ) : null}
+          </View>
+
+          <View style={styles.tabsRow}>
+            <ReviewTabPill
+              label={t('agency.tabs.reviews')}
+              active={tab === 'reviews'}
+              onPress={() => setTab('reviews')}
+            />
+            <ReviewTabPill
+              label={t('agency.tabs.listings')}
+              active={tab === 'listings'}
+              onPress={() => setTab('listings')}
+            />
+          </View>
+
+          {tab === 'reviews' ? (
+            reviewsQuery.isLoading ? (
+              <Skeleton.Box width="100%" height={120} borderRadius={radius.md} />
+            ) : reviews.length === 0 ? (
+              <EmptyState
+                icon="chatbubbles-outline"
+                title={t('agency.emptyReviewsTitle')}
+                description={t('agency.emptyReviewsDescription')}
+              />
+            ) : (
+              <View style={styles.reviewsList}>
+                {reviews.map((review) => (
+                  <AgencyReviewItem
+                    key={review.id}
+                    review={review}
+                    author={usersById.get(review.oxyUserId)}
+                    onPressAddress={() =>
+                      router.push(`/addresses/${review.addressId}?tab=reviews`)
+                    }
+                  />
+                ))}
+                <LoadMoreSentinel
+                  onLoadMore={loadMoreReviews}
+                  enabled={Boolean(reviewsQuery.hasNextPage)}
+                />
+              </View>
+            )
+          ) : propertiesQuery.isLoading ? (
+            <Skeleton.Box width="100%" height={200} borderRadius={radius.md} />
+          ) : properties.length === 0 ? (
+            <EmptyState
+              icon="home-outline"
+              title={t('agency.emptyListingsTitle')}
+              description={t('agency.emptyListingsDescription')}
+            />
+          ) : (
+            <View>
+              <PropertyResultsGrid
+                properties={properties}
+                onPropertyPress={(property) => router.push(`/properties/${property._id}`)}
+              />
+              <LoadMoreSentinel
+                onLoadMore={loadMoreProperties}
+                enabled={Boolean(propertiesQuery.hasNextPage)}
+              />
+            </View>
+          )}
+        </ScrollView>
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  safeArea: {
+    flex: 1,
+  },
+  content: {
+    padding: spacing.lg,
+    gap: spacing.lg,
+    paddingBottom: spacing['4xl'],
+  },
+  headerBlock: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  agencyIcon: {
+    width: 56,
+    height: 56,
+    borderRadius: radius.md,
+    backgroundColor: colors.primaryLight_2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  agencyName: {
+    flex: 1,
+    fontSize: 26,
+    fontWeight: '700',
+    color: colors.COLOR_BLACK,
+    letterSpacing: -0.5,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  statTile: {
+    flexGrow: 1,
+    minWidth: 96,
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radius.md,
+    borderWidth: hairline.width,
+    borderColor: colors.COLOR_BLACK_LIGHT_6,
+    backgroundColor: colors.surfaceElevated,
+  },
+  statValue: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.COLOR_BLACK,
+    letterSpacing: -0.4,
+  },
+  statLabel: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: colors.COLOR_BLACK_LIGHT_3,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+    textAlign: 'center',
+  },
+  tabsRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  reviewsList: {
+    gap: spacing.lg,
+  },
+  reviewItem: {
+    gap: spacing.xs,
+    borderBottomWidth: hairline.width,
+    borderBottomColor: hairline.color,
+    paddingBottom: spacing.lg,
+  },
+  addressLink: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.md,
+  },
+  addressLinkActive: {
+    backgroundColor: colors.COLOR_BLACK_LIGHT_7,
+  },
+  addressLinkText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.primaryColor,
+  },
+});

--- a/packages/frontend/app/reviews/city/[cityId].tsx
+++ b/packages/frontend/app/reviews/city/[cityId].tsx
@@ -1,0 +1,90 @@
+/**
+ * Review explore — a city's neighborhoods (name + review count + average
+ * rating). Tapping a neighborhood drills into its reviewed buildings.
+ */
+import React from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+
+import * as Skeleton from '@oxyhq/bloom/skeleton';
+
+import { Header } from '@/components/Header';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { ErrorState } from '@/components/ui/ErrorState';
+import { ExploreRow } from '@/components/reviews/ExploreRow';
+import { useExploreCity } from '@/hooks/useExploreReviews';
+import { colors } from '@/styles/colors';
+import { radius, spacing } from '@/constants/styles';
+
+export default function ReviewExploreCityScreen() {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const { cityId } = useLocalSearchParams<{ cityId: string }>();
+  const cityQuery = useExploreCity(cityId);
+  const neighborhoods = cityQuery.data ?? [];
+
+  return (
+    <View style={styles.root}>
+      <Header options={{ title: t('reviews.explore.neighborhoodsTitle'), showBackButton: true }} />
+      <SafeAreaView edges={['bottom']} style={styles.safeArea}>
+        <ScrollView contentContainerStyle={styles.content}>
+          {cityQuery.isLoading ? (
+            <View style={styles.list}>
+              {Array.from({ length: 5 }).map((_, idx) => (
+                <Skeleton.Box key={idx} width="100%" height={56} borderRadius={radius.md} />
+              ))}
+            </View>
+          ) : cityQuery.isError ? (
+            <ErrorState
+              icon="cloud-offline-outline"
+              title={t('reviews.explore.errorTitle')}
+              description={t('reviews.explore.errorDescription')}
+              retryLabel={t('common.tryAgain')}
+              onRetry={() => cityQuery.refetch()}
+            />
+          ) : neighborhoods.length === 0 ? (
+            <EmptyState
+              icon="map-outline"
+              title={t('reviews.explore.emptyNeighborhoodsTitle')}
+              description={t('reviews.explore.emptyNeighborhoodsDescription')}
+            />
+          ) : (
+            <View style={styles.list}>
+              {neighborhoods.map((neighborhood) => (
+                <ExploreRow
+                  key={neighborhood.neighborhoodId}
+                  title={neighborhood.name}
+                  subtitle={t('reviews.explore.reviewCount', { count: neighborhood.reviewCount })}
+                  rightLabel={`${neighborhood.averageRating.toFixed(1)} ★`}
+                  onPress={() =>
+                    router.push(`/reviews/neighborhood/${neighborhood.neighborhoodId}`)
+                  }
+                />
+              ))}
+            </View>
+          )}
+        </ScrollView>
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  safeArea: {
+    flex: 1,
+  },
+  content: {
+    padding: spacing.lg,
+    gap: spacing.md,
+    paddingBottom: spacing['4xl'],
+  },
+  list: {
+    gap: spacing.sm,
+  },
+});

--- a/packages/frontend/app/reviews/index.tsx
+++ b/packages/frontend/app/reviews/index.tsx
@@ -1,0 +1,131 @@
+/**
+ * Review explore — landing. An intro, a "Write a review" CTA, and the list of
+ * cities that have reviews (name + review count + average rating). Tapping a
+ * city drills into its neighborhoods.
+ */
+import React from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { Ionicons } from '@expo/vector-icons';
+
+import { Button } from '@oxyhq/bloom/button';
+import * as Skeleton from '@oxyhq/bloom/skeleton';
+import { H1, Text as BloomText } from '@oxyhq/bloom/typography';
+
+import { Header } from '@/components/Header';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { ErrorState } from '@/components/ui/ErrorState';
+import { ExploreRow } from '@/components/reviews/ExploreRow';
+import { useExploreCities } from '@/hooks/useExploreReviews';
+import { colors } from '@/styles/colors';
+import { radius, spacing } from '@/constants/styles';
+
+export default function ReviewExploreScreen() {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const citiesQuery = useExploreCities();
+  const cities = citiesQuery.data ?? [];
+
+  return (
+    <View style={styles.root}>
+      <Header options={{ title: t('reviews.explore.title'), showBackButton: true }} />
+      <SafeAreaView edges={['bottom']} style={styles.safeArea}>
+        <ScrollView contentContainerStyle={styles.content}>
+          <View style={styles.intro}>
+            <H1 style={styles.introTitle}>{t('reviews.explore.heroTitle')}</H1>
+            <BloomText style={styles.introText}>{t('reviews.explore.heroSubtitle')}</BloomText>
+            <Button
+              variant="primary"
+              size="large"
+              onPress={() => router.push('/reviews/write')}
+              icon={<Ionicons name="create-outline" size={18} color={colors.primaryForeground} />}
+              style={styles.cta}
+            >
+              {t('reviews.explore.writeCta')}
+            </Button>
+          </View>
+
+          <BloomText style={styles.sectionTitle}>{t('reviews.explore.citiesTitle')}</BloomText>
+
+          {citiesQuery.isLoading ? (
+            <View style={styles.list}>
+              {Array.from({ length: 4 }).map((_, idx) => (
+                <Skeleton.Box key={idx} width="100%" height={56} borderRadius={radius.md} />
+              ))}
+            </View>
+          ) : citiesQuery.isError ? (
+            <ErrorState
+              icon="cloud-offline-outline"
+              title={t('reviews.explore.errorTitle')}
+              description={t('reviews.explore.errorDescription')}
+              retryLabel={t('common.tryAgain')}
+              onRetry={() => citiesQuery.refetch()}
+            />
+          ) : cities.length === 0 ? (
+            <EmptyState
+              icon="map-outline"
+              title={t('reviews.explore.emptyCitiesTitle')}
+              description={t('reviews.explore.emptyCitiesDescription')}
+            />
+          ) : (
+            <View style={styles.list}>
+              {cities.map((city) => (
+                <ExploreRow
+                  key={city.cityId}
+                  title={city.name}
+                  subtitle={t('reviews.explore.reviewCount', { count: city.reviewCount })}
+                  rightLabel={`${city.averageRating.toFixed(1)} ★`}
+                  onPress={() => router.push(`/reviews/city/${city.cityId}`)}
+                />
+              ))}
+            </View>
+          )}
+        </ScrollView>
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  safeArea: {
+    flex: 1,
+  },
+  content: {
+    padding: spacing.lg,
+    gap: spacing.xl,
+    paddingBottom: spacing['4xl'],
+  },
+  intro: {
+    gap: spacing.sm,
+  },
+  introTitle: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: colors.COLOR_BLACK,
+    letterSpacing: -0.6,
+  },
+  introText: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: colors.COLOR_BLACK_LIGHT_3,
+  },
+  cta: {
+    alignSelf: 'flex-start',
+    marginTop: spacing.sm,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.COLOR_BLACK,
+    letterSpacing: -0.3,
+  },
+  list: {
+    gap: spacing.sm,
+  },
+});

--- a/packages/frontend/app/reviews/neighborhood/[neighborhoodId].tsx
+++ b/packages/frontend/app/reviews/neighborhood/[neighborhoodId].tsx
@@ -1,0 +1,116 @@
+/**
+ * Review explore — a neighborhood's reviewed buildings (street + number, review
+ * count, average rating, recommend %). Paginated: infinite scroll wires BOTH
+ * primitives — `LoadMoreSentinel` (web) + `useInfiniteScroll` (native). Tapping a
+ * building opens its address page on the reviews tab.
+ */
+import React from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+
+import * as Skeleton from '@oxyhq/bloom/skeleton';
+
+import { Header } from '@/components/Header';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { ErrorState } from '@/components/ui/ErrorState';
+import { ExploreRow } from '@/components/reviews/ExploreRow';
+import { LoadMoreSentinel } from '@/components/common/LoadMoreSentinel';
+import { useExploreNeighborhood } from '@/hooks/useExploreReviews';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { colors } from '@/styles/colors';
+import { radius, spacing } from '@/constants/styles';
+
+export default function ReviewExploreNeighborhoodScreen() {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const { neighborhoodId } = useLocalSearchParams<{ neighborhoodId: string }>();
+  const query = useExploreNeighborhood(neighborhoodId);
+  const buildings = query.buildings;
+
+  const loadMore = () => {
+    if (query.hasNextPage && !query.isFetchingNextPage) {
+      query.fetchNextPage();
+    }
+  };
+
+  const { onScroll } = useInfiniteScroll({
+    onEndReached: loadMore,
+    enabled: Boolean(query.hasNextPage),
+  });
+
+  const buildingTitle = (street: string, number?: string) =>
+    number ? `${street}, ${number}` : street;
+
+  return (
+    <View style={styles.root}>
+      <Header options={{ title: t('reviews.explore.buildingsTitle'), showBackButton: true }} />
+      <SafeAreaView edges={['bottom']} style={styles.safeArea}>
+        <ScrollView
+          contentContainerStyle={styles.content}
+          onScroll={onScroll}
+          scrollEventThrottle={16}
+        >
+          {query.isLoading ? (
+            <View style={styles.list}>
+              {Array.from({ length: 6 }).map((_, idx) => (
+                <Skeleton.Box key={idx} width="100%" height={56} borderRadius={radius.md} />
+              ))}
+            </View>
+          ) : query.isError ? (
+            <ErrorState
+              icon="cloud-offline-outline"
+              title={t('reviews.explore.errorTitle')}
+              description={t('reviews.explore.errorDescription')}
+              retryLabel={t('common.tryAgain')}
+              onRetry={() => query.refetch()}
+            />
+          ) : buildings.length === 0 ? (
+            <EmptyState
+              icon="business-outline"
+              title={t('reviews.explore.emptyBuildingsTitle')}
+              description={t('reviews.explore.emptyBuildingsDescription')}
+            />
+          ) : (
+            <View style={styles.list}>
+              {buildings.map((building) => (
+                <ExploreRow
+                  key={building.buildingLevelId}
+                  title={buildingTitle(building.street, building.number)}
+                  subtitle={t('reviews.explore.buildingMeta', {
+                    count: building.reviewCount,
+                    recommend: Math.round(building.recommendationPercentage),
+                  })}
+                  rightLabel={`${building.averageRating.toFixed(1)} ★`}
+                  onPress={() =>
+                    router.push(`/addresses/${building.buildingLevelId}?tab=reviews`)
+                  }
+                />
+              ))}
+              <LoadMoreSentinel onLoadMore={loadMore} enabled={Boolean(query.hasNextPage)} />
+            </View>
+          )}
+        </ScrollView>
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  safeArea: {
+    flex: 1,
+  },
+  content: {
+    padding: spacing.lg,
+    gap: spacing.md,
+    paddingBottom: spacing['4xl'],
+  },
+  list: {
+    gap: spacing.sm,
+  },
+});

--- a/packages/frontend/app/reviews/write.tsx
+++ b/packages/frontend/app/reviews/write.tsx
@@ -1,103 +1,59 @@
 /**
- * Write review — full review form (address + tenancy + ratings + opinion).
+ * Write review — the 8-step review wizard route + state owner.
  *
- * Stream Q polish:
- *   - Bloom TextField for every input (no raw TextInput / inline styles).
- *   - Bloom Button for submit + recommendation choice + retry.
- *   - Flat section cards with radius.lg + hairline borders.
- *   - Bloom Skeleton + shared EmptyState / ErrorState while loading.
- *   - Stars now use Bloom Typography for the count label, semantic
- *     ratingStar token instead of hex literals.
+ * This screen owns the single `ReviewWizardData` object, the step index, the
+ * `?addressId=` prefill (seeds the address step from an existing Homiio
+ * address), and the submit → `CreateReviewPayload`. Each step is a component
+ * under `components/reviews/write/`; `WizardProgress` is the bottom nav.
+ *
+ * Hard-required steps gate `Next`/`Submit` (address, price + dates, title +
+ * opinion, rating + recommendation); every dimension step is skippable. On
+ * submit the review is created and we `router.replace` to the reviewed
+ * address's page on its reviews tab. `livedForMonths` is NOT sent — the server
+ * derives it from the dates.
  */
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  Alert,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  View,
-} from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { Ionicons } from '@expo/vector-icons';
-import { Button } from '@oxyhq/bloom/button';
+
 import * as Skeleton from '@oxyhq/bloom/skeleton';
-import { TextFieldInput } from '@oxyhq/bloom/text-field';
-import { H2, H3, Text as BloomText } from '@oxyhq/bloom/typography';
+import { Text as BloomText } from '@oxyhq/bloom/typography';
 import { useOxy } from '@oxyhq/services';
+
 import { Header } from '@/components/Header';
-import Map, { type MapApi } from '@/components/Map';
+import type { MapApi, AddressData } from '@/components/Map';
 import { ErrorState } from '@/components/ui/ErrorState';
-import { SectionEyebrow } from '@/components/ui/SectionEyebrow';
-import reviewService from '@/services/reviewService';
+import { WizardProgress } from '@/components/reviews/WizardProgress';
+import { StepAddress } from '@/components/reviews/write/StepAddress';
+import { StepApartment } from '@/components/reviews/write/StepApartment';
+import { StepManagement } from '@/components/reviews/write/StepManagement';
+import { StepBuilding } from '@/components/reviews/write/StepBuilding';
+import { StepArea } from '@/components/reviews/write/StepArea';
+import { StepPriceDates } from '@/components/reviews/write/StepPriceDates';
+import { StepTexts } from '@/components/reviews/write/StepTexts';
+import { StepPhotosRecommend } from '@/components/reviews/write/StepPhotosRecommend';
+import {
+  INITIAL_WIZARD_DATA,
+  type ReviewWizardData,
+} from '@/components/reviews/write/types';
+import { reviewService } from '@/services/reviewService';
 import { api } from '@/utils/api';
+import type { CreateReviewPayload, CreateReviewAddressInput } from '@homiio/shared-types';
 import { radius, spacing } from '@/constants/styles';
 import { colors } from '@/styles/colors';
 
-interface ReviewFormData {
-  street: string;
-  city: string;
-  state: string;
-  postal_code: string;
-  country: string;
-  number?: string;
-  building_name?: string;
-  floor?: string;
-  unit?: string;
-  latitude?: number;
-  longitude?: number;
-  greenHouse: string;
-  price: string;
-  currency: string;
-  livedFrom: string;
-  livedTo: string;
-  recommendation: boolean | null;
-  opinion: string;
-  positiveComment: string;
-  negativeComment: string;
-  rating: number;
-}
-
-const INITIAL_FORM: ReviewFormData = {
-  street: '',
-  city: '',
-  state: '',
-  postal_code: '',
-  country: '',
-  number: '',
-  building_name: '',
-  floor: '',
-  unit: '',
-  latitude: undefined,
-  longitude: undefined,
-  greenHouse: '',
-  price: '',
-  currency: 'EUR',
-  livedFrom: '',
-  livedTo: '',
-  recommendation: null,
-  opinion: '',
-  positiveComment: '',
-  negativeComment: '',
-  rating: 0,
-};
-
-interface AddressLookupResult {
-  street?: string;
-  houseNumber?: string;
-  city?: string;
-  state?: string;
-  country?: string;
-  postalCode?: string;
-}
+const TOTAL_STEPS = 8;
+const LAST_STEP = TOTAL_STEPS - 1;
+const MIN_TITLE_LENGTH = 5;
+const MIN_OPINION_LENGTH = 10;
 
 const WriteReviewSkeleton: React.FC = () => (
   <View style={styles.content}>
     {Array.from({ length: 3 }).map((_, idx) => (
-      <View key={idx} style={styles.sectionCard}>
+      <View key={idx} style={styles.skeletonBlock}>
         <Skeleton.Text style={{ width: 200, lineHeight: 20 }} />
-        <Skeleton.Box width="100%" height={48} borderRadius={radius.md} />
         <Skeleton.Box width="100%" height={48} borderRadius={radius.md} />
         <Skeleton.Box width="100%" height={48} borderRadius={radius.md} />
       </View>
@@ -106,17 +62,28 @@ const WriteReviewSkeleton: React.FC = () => (
 );
 
 export default function WriteReviewPage() {
-  const { addressId } = useLocalSearchParams<{ addressId: string }>();
+  const { addressId } = useLocalSearchParams<{ addressId?: string }>();
   const router = useRouter();
   const { t } = useTranslation();
   const { oxyServices, activeSessionId } = useOxy();
   const mapRef = useRef<MapApi | null>(null);
+  const scrollRef = useRef<ScrollView | null>(null);
 
-  const [formData, setFormData] = useState<ReviewFormData>(INITIAL_FORM);
+  const [data, setData] = useState<ReviewWizardData>(INITIAL_WIZARD_DATA);
+  const [step, setStep] = useState(0);
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
+  const update = useCallback(
+    <K extends keyof ReviewWizardData>(field: K, value: ReviewWizardData[K]) => {
+      setData((prev) => ({ ...prev, [field]: value }));
+    },
+    [],
+  );
+
+  // Prefill the address step when arriving from an existing Homiio address.
   useEffect(() => {
     if (!addressId || !oxyServices || !activeSessionId) return;
     let cancelled = false;
@@ -126,11 +93,9 @@ export default function WriteReviewPage() {
         const response = await api.get(`/api/addresses/${addressId}`);
         if (cancelled) return;
         const address = response.data?.address || response.data;
-        setFormData((prev) => ({
+        setData((prev) => ({
           ...prev,
           street: address.street || '',
-          // Geo is relational: the address exposes resolved display NAMES; seed
-          // the form's resolution inputs from them (fall back to legacy strings).
           city: address.cityName || address.city || '',
           state: address.regionName || address.state || '',
           postal_code: address.postal_code || address.zipCode || '',
@@ -139,6 +104,7 @@ export default function WriteReviewPage() {
           building_name: address.building_name || '',
           floor: address.floor || '',
           unit: address.unit || '',
+          neighborhood: address.neighborhoodName || address.neighborhood || '',
           latitude: address.coordinates?.coordinates?.[1],
           longitude: address.coordinates?.coordinates?.[0],
         }));
@@ -147,20 +113,20 @@ export default function WriteReviewPage() {
           mapRef.current.navigateToLocation([lng, lat], 15);
         }
       } catch {
-        if (!cancelled) setError(t('reviews.write.loadAddressFailed'));
+        if (!cancelled) setLoadError(t('reviews.write.loadAddressFailed'));
       } finally {
         if (!cancelled) setLoading(false);
       }
     };
-    load();
+    void load();
     return () => {
       cancelled = true;
     };
   }, [addressId, oxyServices, activeSessionId, t]);
 
   const handleAddressSelect = useCallback(
-    (address: AddressLookupResult, coordinates: [number, number]) => {
-      setFormData((prev) => ({
+    (address: AddressData, coordinates: [number, number]) => {
+      setData((prev) => ({
         ...prev,
         latitude: coordinates[1],
         longitude: coordinates[0],
@@ -171,146 +137,161 @@ export default function WriteReviewPage() {
         ...(address.country ? { country: address.country } : null),
         ...(address.postalCode ? { postal_code: address.postalCode } : null),
       }));
-      if (mapRef.current) {
-        mapRef.current.navigateToLocation(coordinates, 15);
-      }
+      mapRef.current?.navigateToLocation(coordinates, 15);
     },
     [],
   );
 
-  const updateFormData = <K extends keyof ReviewFormData>(
-    field: K,
-    value: ReviewFormData[K],
-  ) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-  };
-
-  const validateForm = (): boolean => {
-    if (!formData.street.trim()) {
-      Alert.alert(t('reviews.write.validationTitle'), t('reviews.write.streetRequired'));
-      return false;
-    }
-    if (!formData.city.trim()) {
-      Alert.alert(t('reviews.write.validationTitle'), t('reviews.write.cityRequired'));
-      return false;
-    }
-    if (!formData.postal_code.trim()) {
-      Alert.alert(t('reviews.write.validationTitle'), t('reviews.write.postalCodeRequired'));
-      return false;
-    }
-    if (!formData.country.trim()) {
-      Alert.alert(t('reviews.write.validationTitle'), t('reviews.write.countryRequired'));
-      return false;
-    }
-    if (!formData.opinion.trim()) {
-      Alert.alert(
-        t('reviews.write.validationTitle'),
-        t('reviews.write.opinionRequired'),
-      );
-      return false;
-    }
-    if (formData.opinion.trim().length < 10) {
-      Alert.alert(
-        t('reviews.write.validationTitle'),
-        t('reviews.write.opinionMinLength'),
-      );
-      return false;
-    }
-    if (!formData.price || parseFloat(formData.price) <= 0) {
-      Alert.alert(t('reviews.write.validationTitle'), t('reviews.write.priceRequired'));
-      return false;
-    }
-    if (!formData.livedFrom || !formData.livedTo) {
-      Alert.alert(
-        t('reviews.write.validationTitle'),
-        t('reviews.write.datesRequired'),
-      );
-      return false;
-    }
-    if (formData.recommendation === null) {
-      Alert.alert(
-        t('reviews.write.validationTitle'),
-        t('reviews.write.recommendationRequired'),
-      );
-      return false;
-    }
-    if (formData.rating === 0) {
-      Alert.alert(
-        t('reviews.write.validationTitle'),
-        t('reviews.write.ratingRequired'),
-      );
-      return false;
-    }
-    return true;
-  };
-
-  const handleSubmit = async () => {
-    if (!validateForm()) return;
-    if (!oxyServices || !activeSessionId) return;
-
-    setSubmitting(true);
-    try {
-      const startDate = new Date(formData.livedFrom);
-      const endDate = new Date(formData.livedTo);
-      const diffMs = Math.abs(endDate.getTime() - startDate.getTime());
-      const livedForMonths = Math.ceil(diffMs / (1000 * 60 * 60 * 24 * 30.44));
-
-      const reviewData = {
-        address: {
-          street: formData.street.trim(),
-          city: formData.city.trim(),
-          state: formData.state.trim() || undefined,
-          postal_code: formData.postal_code.trim(),
-          country: formData.country.trim(),
-          number: formData.number?.trim() || undefined,
-          building_name: formData.building_name?.trim() || undefined,
-          floor: formData.floor?.trim() || undefined,
-          unit: formData.unit?.trim() || undefined,
-          ...(formData.latitude !== undefined && formData.longitude !== undefined
-            ? { latitude: formData.latitude, longitude: formData.longitude }
-            : null),
-        },
-        greenHouse: formData.greenHouse,
-        price: formData.price ? parseFloat(formData.price) : undefined,
-        currency: formData.currency,
-        livedFrom: formData.livedFrom ? new Date(formData.livedFrom) : undefined,
-        livedTo: formData.livedTo ? new Date(formData.livedTo) : undefined,
-        livedForMonths,
-        recommendation: formData.recommendation as boolean,
-        opinion: formData.opinion.trim(),
-        positiveComment: formData.positiveComment.trim() || undefined,
-        negativeComment: formData.negativeComment.trim() || undefined,
-        rating: formData.rating,
-      };
-
-      const result = await reviewService.createReview(
-        reviewData,
-        oxyServices,
-        activeSessionId,
-      );
-      if (result.success) {
-        Alert.alert(t('common.success'), t('reviews.write.submitSuccess'), [
-          { text: t('common.ok'), onPress: () => router.back() },
-        ]);
-      } else {
-        Alert.alert(
-          t('common.error'),
-          result.error || t('reviews.write.submitFailed'),
+  const canProceed = useMemo(() => {
+    switch (step) {
+      case 0:
+        return Boolean(
+          data.street.trim() &&
+            data.city.trim() &&
+            data.postal_code.trim() &&
+            data.country.trim(),
         );
-      }
-    } catch {
-      Alert.alert(t('common.error'), t('reviews.write.submitFailedRetry'));
+      case 5:
+        return Boolean(
+          Number(data.price) > 0 && data.livedFrom.trim() && data.livedTo.trim(),
+        );
+      case 6:
+        return (
+          data.title.trim().length >= MIN_TITLE_LENGTH &&
+          data.opinion.trim().length >= MIN_OPINION_LENGTH
+        );
+      case 7:
+        return data.rating > 0 && data.recommendation !== null;
+      default:
+        return true;
+    }
+  }, [step, data]);
+
+  const scrollToTop = useCallback(() => {
+    scrollRef.current?.scrollTo({ y: 0, animated: true });
+  }, []);
+
+  const goNext = useCallback(() => {
+    if (!canProceed) return;
+    setStep((prev) => Math.min(prev + 1, LAST_STEP));
+    scrollToTop();
+  }, [canProceed, scrollToTop]);
+
+  const goBack = useCallback(() => {
+    setStep((prev) => Math.max(prev - 1, 0));
+    scrollToTop();
+  }, [scrollToTop]);
+
+  const buildPayload = useCallback((): CreateReviewPayload => {
+    const address: CreateReviewAddressInput = {
+      street: data.street.trim(),
+      number: data.number.trim() || undefined,
+      building_name: data.building_name.trim() || undefined,
+      floor: data.floor.trim() || undefined,
+      unit: data.unit.trim() || undefined,
+      postal_code: data.postal_code.trim(),
+      city: data.city.trim(),
+      state: data.state.trim() || undefined,
+      country: data.country.trim(),
+      neighborhood: data.neighborhood.trim() || undefined,
+      ...(data.latitude !== undefined && data.longitude !== undefined
+        ? { latitude: data.latitude, longitude: data.longitude }
+        : null),
+    };
+    return {
+      address,
+      title: data.title.trim(),
+      opinion: data.opinion.trim(),
+      rating: data.rating,
+      recommendation: data.recommendation === true,
+      price: Number(data.price),
+      currency: data.currency,
+      livedFrom: new Date(data.livedFrom),
+      livedTo: new Date(data.livedTo),
+      prosItems: data.prosItems,
+      consItems: data.consItems,
+      // Store the display URL (reviews have no server-side image pipeline), so
+      // the card can render the photo directly via `resolveBackendImageUrl`.
+      images: data.images.map((image) => image.urls.medium || image.urls.original),
+      agencyName: data.agencyName.trim() || undefined,
+      adviceToAgency: data.adviceToAgency.trim() || undefined,
+      adviceToLandlord: data.adviceToLandlord.trim() || undefined,
+      summerTemperature: data.summerTemperature,
+      winterTemperature: data.winterTemperature,
+      noise: data.noise,
+      light: data.light,
+      conditionAndMaintenance: data.conditionAndMaintenance,
+      landlordTreatment: data.landlordTreatment,
+      problemResponse: data.problemResponse,
+      depositReturned: data.depositReturned,
+      staircaseNeighbors: data.staircaseNeighbors,
+      touristApartments: data.touristApartments,
+      neighborRelations: data.neighborRelations,
+      cleaning: data.cleaning,
+      services: data.services.length > 0 ? data.services : undefined,
+      areaTourists: data.areaTourists,
+      areaNoise: data.areaNoise,
+      areaCleanliness: data.areaCleanliness,
+      areaSecurity: data.areaSecurity,
+    };
+  }, [data]);
+
+  const isComplete =
+    Boolean(data.street.trim() && data.city.trim() && data.postal_code.trim() && data.country.trim()) &&
+    Number(data.price) > 0 &&
+    Boolean(data.livedFrom.trim() && data.livedTo.trim()) &&
+    data.title.trim().length >= MIN_TITLE_LENGTH &&
+    data.opinion.trim().length >= MIN_OPINION_LENGTH &&
+    data.rating > 0 &&
+    data.recommendation !== null;
+
+  const handleSubmit = useCallback(async () => {
+    if (!isComplete || submitting) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const review = await reviewService.createReview(buildPayload());
+      router.replace(`/addresses/${review.addressId}?tab=reviews`);
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : t('reviews.write.submitFailed'));
     } finally {
       setSubmitting(false);
+    }
+  }, [isComplete, submitting, buildPayload, router, t]);
+
+  const renderStep = () => {
+    switch (step) {
+      case 0:
+        return (
+          <StepAddress
+            data={data}
+            update={update}
+            mapRef={mapRef}
+            onAddressSelect={handleAddressSelect}
+          />
+        );
+      case 1:
+        return <StepApartment data={data} update={update} />;
+      case 2:
+        return <StepManagement data={data} update={update} />;
+      case 3:
+        return <StepBuilding data={data} update={update} />;
+      case 4:
+        return <StepArea data={data} update={update} />;
+      case 5:
+        return <StepPriceDates data={data} update={update} />;
+      case 6:
+        return <StepTexts data={data} update={update} />;
+      case 7:
+      default:
+        return <StepPhotosRecommend data={data} update={update} />;
     }
   };
 
   if (loading) {
     return (
       <View style={styles.root}>
-        <Header
-          options={{ title: t('reviews.write.title'), showBackButton: true }}
-        />
+        <Header options={{ title: t('reviews.write.title'), showBackButton: true }} />
         <ScrollView>
           <WriteReviewSkeleton />
         </ScrollView>
@@ -318,16 +299,14 @@ export default function WriteReviewPage() {
     );
   }
 
-  if (error) {
+  if (loadError) {
     return (
       <View style={styles.root}>
-        <Header
-          options={{ title: t('reviews.write.title'), showBackButton: true }}
-        />
+        <Header options={{ title: t('reviews.write.title'), showBackButton: true }} />
         <ErrorState
           icon="cloud-offline-outline"
           title={t('reviews.write.loadAddressFailed')}
-          description={error}
+          description={loadError}
           retryLabel={t('common.goBack')}
           onRetry={() => router.back()}
         />
@@ -337,269 +316,29 @@ export default function WriteReviewPage() {
 
   return (
     <View style={styles.root}>
-      <Header
-        options={{ title: t('reviews.write.title'), showBackButton: true }}
-      />
+      <Header options={{ title: t('reviews.write.title'), showBackButton: true }} />
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>
-        <ScrollView contentContainerStyle={styles.content}>
-          <View style={styles.titleBlock}>
-            <SectionEyebrow>Tell others</SectionEyebrow>
-            <H2 style={styles.title}>Review this address</H2>
-            <BloomText style={styles.subtitle}>
-              Honest, anonymous reviews help future tenants choose with
-              confidence.
-            </BloomText>
-          </View>
-
-          <View style={styles.sectionCard}>
-            <H3 style={styles.sectionTitle}>Address</H3>
-            <TextFieldInput
-              label="Street address"
-              placeholder="e.g. 123 Main Street"
-              value={formData.street}
-              onChangeText={(text) => updateFormData('street', text)}
-            />
-            <TextFieldInput
-              label="Building number"
-              placeholder="e.g. 123A"
-              value={formData.number || ''}
-              onChangeText={(text) => updateFormData('number', text)}
-            />
-            <TextFieldInput
-              label="Building name"
-              placeholder="e.g. Sunset Apartments"
-              value={formData.building_name || ''}
-              onChangeText={(text) => updateFormData('building_name', text)}
-            />
-            <View style={styles.row}>
-              <View style={styles.rowField}>
-                <TextFieldInput
-                  label="Floor"
-                  placeholder="e.g. 3"
-                  value={formData.floor || ''}
-                  onChangeText={(text) => updateFormData('floor', text)}
-                />
-              </View>
-              <View style={styles.rowField}>
-                <TextFieldInput
-                  label="Unit / Apt"
-                  placeholder="e.g. 3B"
-                  value={formData.unit || ''}
-                  onChangeText={(text) => updateFormData('unit', text)}
-                />
-              </View>
-            </View>
-            <View style={styles.row}>
-              <View style={styles.rowField}>
-                <TextFieldInput
-                  label="City"
-                  placeholder="e.g. Barcelona"
-                  value={formData.city}
-                  onChangeText={(text) => updateFormData('city', text)}
-                />
-              </View>
-              <View style={styles.rowField}>
-                <TextFieldInput
-                  label="State / Province"
-                  placeholder="e.g. Catalonia"
-                  value={formData.state}
-                  onChangeText={(text) => updateFormData('state', text)}
-                />
-              </View>
-            </View>
-            <View style={styles.row}>
-              <View style={styles.rowField}>
-                <TextFieldInput
-                  label="Postal code"
-                  placeholder="e.g. 08001"
-                  value={formData.postal_code}
-                  onChangeText={(text) => updateFormData('postal_code', text)}
-                />
-              </View>
-              <View style={styles.rowField}>
-                <TextFieldInput
-                  label="Country"
-                  placeholder="e.g. Spain"
-                  value={formData.country}
-                  onChangeText={(text) => updateFormData('country', text)}
-                />
-              </View>
-            </View>
-
-            <View style={styles.mapWrapper}>
-              <Map
-                ref={mapRef}
-                style={styles.mapInner}
-                enableAddressLookup
-                showAddressInstructions
-                onAddressSelect={handleAddressSelect}
-                screenId="write-review"
-              />
-            </View>
-            <BloomText style={styles.mapHint}>
-              Tap on the map to drop a pin and auto-fill the address.
-            </BloomText>
-          </View>
-
-          <View style={styles.sectionCard}>
-            <H3 style={styles.sectionTitle}>Basics</H3>
-            <TextFieldInput
-              label="Monthly rent (€)"
-              placeholder="0.00"
-              value={formData.price}
-              onChangeText={(text) => updateFormData('price', text)}
-              keyboardType="numeric"
-            />
-            <TextFieldInput
-              label="Apartment description"
-              placeholder="e.g. 2nd floor, garden view"
-              value={formData.greenHouse}
-              onChangeText={(text) => updateFormData('greenHouse', text)}
-              multiline
-            />
-            <View style={styles.row}>
-              <View style={styles.rowField}>
-                <TextFieldInput
-                  label="Lived from"
-                  placeholder="YYYY-MM-DD"
-                  value={formData.livedFrom}
-                  onChangeText={(text) => updateFormData('livedFrom', text)}
-                />
-              </View>
-              <View style={styles.rowField}>
-                <TextFieldInput
-                  label="Lived to"
-                  placeholder="YYYY-MM-DD"
-                  value={formData.livedTo}
-                  onChangeText={(text) => updateFormData('livedTo', text)}
-                />
-              </View>
-            </View>
-          </View>
-
-          <View style={styles.sectionCard}>
-            <H3 style={styles.sectionTitle}>Your verdict</H3>
-            <View style={styles.starsBlock}>
-              <BloomText style={styles.fieldLabel}>Overall rating</BloomText>
-              <View style={styles.starsRow}>
-                {[1, 2, 3, 4, 5].map((star) => {
-                  const active = star <= formData.rating;
-                  return (
-                    <Pressable
-                      key={star}
-                      onPress={() => updateFormData('rating', star)}
-                      style={styles.starButton}
-                      accessibilityRole="button"
-                      accessibilityLabel={`Rate ${star} of 5`}
-                    >
-                      <Ionicons
-                        name={active ? 'star' : 'star-outline'}
-                        size={30}
-                        color={active ? colors.ratingStar : colors.muted}
-                      />
-                    </Pressable>
-                  );
-                })}
-              </View>
-              <BloomText style={styles.ratingLabel}>
-                {formData.rating > 0
-                  ? `${formData.rating} of 5`
-                  : 'No rating yet'}
-              </BloomText>
-            </View>
-
-            <View style={styles.recommendBlock}>
-              <BloomText style={styles.fieldLabel}>
-                Would you recommend this address?
-              </BloomText>
-              <View style={styles.recommendRow}>
-                <Button
-                  variant={formData.recommendation === true ? 'primary' : 'secondary'}
-                  size="medium"
-                  onPress={() => updateFormData('recommendation', true)}
-                  icon={
-                    <Ionicons
-                      name="thumbs-up"
-                      size={18}
-                      color={
-                        formData.recommendation === true
-                          ? colors.primaryForeground
-                          : colors.COLOR_BLACK
-                      }
-                    />
-                  }
-                  style={styles.recommendButton}
-                >
-                  Yes
-                </Button>
-                <Button
-                  variant={formData.recommendation === false ? 'primary' : 'secondary'}
-                  size="medium"
-                  onPress={() => updateFormData('recommendation', false)}
-                  icon={
-                    <Ionicons
-                      name="thumbs-down"
-                      size={18}
-                      color={
-                        formData.recommendation === false
-                          ? colors.primaryForeground
-                          : colors.COLOR_BLACK
-                      }
-                    />
-                  }
-                  style={styles.recommendButton}
-                >
-                  No
-                </Button>
-              </View>
-            </View>
-
-            <TextFieldInput
-              label="Your opinion"
-              placeholder="Share your experience (10+ characters)"
-              value={formData.opinion}
-              onChangeText={(text) => updateFormData('opinion', text)}
-              multiline
-            />
-            <TextFieldInput
-              label="What did you like?"
-              placeholder="Positive aspects of living here"
-              value={formData.positiveComment}
-              onChangeText={(text) => updateFormData('positiveComment', text)}
-              multiline
-            />
-            <TextFieldInput
-              label="What could be improved?"
-              placeholder="Areas for improvement"
-              value={formData.negativeComment}
-              onChangeText={(text) => updateFormData('negativeComment', text)}
-              multiline
-            />
-          </View>
-
-          <View style={styles.noteCard}>
-            <Ionicons
-              name="information-circle"
-              size={20}
-              color={colors.info}
-            />
-            <BloomText style={styles.noteText}>
-              Additional detailed ratings for the apartment, community, and
-              area are optional and can be added later.
-            </BloomText>
-          </View>
-
-          <Button
-            variant="primary"
-            size="large"
-            onPress={handleSubmit}
-            loading={submitting}
-            disabled={submitting}
-            style={styles.submitButton}
-          >
-            Submit review
-          </Button>
+        <ScrollView
+          ref={scrollRef}
+          contentContainerStyle={styles.content}
+          keyboardShouldPersistTaps="handled"
+        >
+          {renderStep()}
+          {submitError ? (
+            <BloomText style={styles.submitError}>{submitError}</BloomText>
+          ) : null}
         </ScrollView>
+        <WizardProgress
+          step={step}
+          totalSteps={TOTAL_STEPS}
+          onBack={goBack}
+          onNext={goNext}
+          onSubmit={handleSubmit}
+          isFirst={step === 0}
+          isLast={step === LAST_STEP}
+          nextDisabled={!canProceed}
+          submitting={submitting}
+        />
       </SafeAreaView>
     </View>
   );
@@ -618,92 +357,12 @@ const styles = StyleSheet.create({
     gap: spacing.lg,
     paddingBottom: spacing['4xl'],
   },
-  titleBlock: {
-    gap: spacing.xs,
+  skeletonBlock: {
+    gap: spacing.md,
   },
-  title: {
-    letterSpacing: -0.5,
-  },
-  subtitle: {
+  submitError: {
     fontSize: 14,
-    color: colors.muted,
-  },
-  sectionCard: {
-    backgroundColor: colors.surfaceElevated,
-    padding: spacing.lg,
-    borderRadius: radius.lg,
-    gap: spacing.md,
-    borderWidth: 1,
-    borderColor: colors.border,
-  },
-  sectionTitle: {
-    letterSpacing: -0.3,
-  },
-  row: {
-    flexDirection: 'row',
-    gap: spacing.md,
-  },
-  rowField: {
-    flex: 1,
-  },
-  mapWrapper: {
-    marginTop: spacing.sm,
-    borderRadius: radius.md,
-    overflow: 'hidden',
-    backgroundColor: colors.mutedSubtle,
-  },
-  mapInner: {
-    height: 280,
-  },
-  mapHint: {
-    fontSize: 12,
-    color: colors.muted,
+    color: colors.error,
     textAlign: 'center',
-  },
-  starsBlock: {
-    gap: spacing.sm,
-  },
-  fieldLabel: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: colors.COLOR_BLACK_LIGHT_2,
-  },
-  starsRow: {
-    flexDirection: 'row',
-    gap: spacing.xs,
-  },
-  starButton: {
-    padding: spacing.xs,
-  },
-  ratingLabel: {
-    fontSize: 13,
-    color: colors.muted,
-  },
-  recommendBlock: {
-    gap: spacing.sm,
-  },
-  recommendRow: {
-    flexDirection: 'row',
-    gap: spacing.sm,
-  },
-  recommendButton: {
-    flex: 1,
-  },
-  noteCard: {
-    backgroundColor: colors.infoSubtle,
-    padding: spacing.md,
-    borderRadius: radius.md,
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    gap: spacing.sm,
-  },
-  noteText: {
-    flex: 1,
-    fontSize: 13,
-    color: colors.COLOR_BLACK_LIGHT_2,
-    lineHeight: 20,
-  },
-  submitButton: {
-    alignSelf: 'stretch',
   },
 });

--- a/packages/frontend/components/ReviewCard.tsx
+++ b/packages/frontend/components/ReviewCard.tsx
@@ -1,625 +1,568 @@
 /**
- * ReviewCard Component
- * Reusable component for displaying review data with ethical review system features
+ * ReviewCard — the canonical read view for a single reviucasa-style review.
+ *
+ * The PARENT hydrates the author (`useOxyAvatars(reviews.map(r => r.oxyUserId))`)
+ * and passes the resolved Oxy `User` as `author`; the card renders the Bloom
+ * `Avatar` (variant-aware resolver) + display name (falling back to the handle,
+ * then an anonymous label). Body: title, stars, recommendation line, opinion,
+ * pros/cons (falling back to the legacy `positiveComment`/`negativeComment`),
+ * dimension chips grouped by section (apartment / management / building / area,
+ * only the present ones), advice blocks, an agency link, and a photo row.
+ * Footer: a real Helpful toggle (disabled on your own review) + a Report action.
  */
-
-import React from 'react';
-import {
-    View,
-    StyleSheet,
-    TouchableOpacity,
-    Alert,
-} from 'react-native';
+import React, { useState } from 'react';
+import { Image, Platform, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
-import { ThemedText } from './ThemedText';
-import { colors } from '@/styles/colors';
-import { radius, spacing } from '@/constants/styles';
+
+import { Avatar } from '@oxyhq/bloom/avatar';
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+import { useOxy } from '@oxyhq/services';
+import type { User } from '@oxyhq/core';
+
+import {
+  ReviewModerationStatus,
+  type ReviewDTO,
+  type ReviewReportReason,
+} from '@homiio/shared-types';
+
+import { Stars } from '@/components/ui/Stars';
+import { ReportReviewSheet } from '@/components/reviews/ReportReviewSheet';
+import {
+  APARTMENT_DIMENSIONS,
+  MANAGEMENT_DIMENSIONS,
+  BUILDING_DIMENSIONS,
+  AREA_DIMENSIONS,
+  type DimensionDescriptor,
+} from '@/components/reviews/dimensions';
+import { useToggleHelpful, useReportReview } from '@/hooks/useReviewMutations';
+import { resolveBackendImageUrl } from '@/utils/imageUrl';
 import { formatLocalized } from '@/utils/dateLocale';
+import { colors } from '@/styles/colors';
+import { hairline, radius, spacing } from '@/constants/styles';
 
-export interface ReviewData {
-    _id: string;
-    addressId: string;
-    addressLevel: 'BUILDING' | 'UNIT';
-    streetLevelId: string;
-    buildingLevelId: string;
-    unitLevelId?: string;
-    greenHouse?: string;
-    price: number;
-    currency: string;
-    livedFrom: string;
-    livedTo: string;
-    livedForMonths: number;
-    recommendation: boolean;
-    opinion: string;
-    positiveComment?: string;
-    negativeComment?: string;
-    images: string[];
-    rating: number;
+const IS_WEB = Platform.OS === 'web';
 
-    // Apartment-specific ratings (optional)
-    summerTemperature?: string;
-    winterTemperature?: string;
-    noise?: string;
-    light?: string;
-    conditionAndMaintenance?: string;
-    services?: string[];
-
-    // Community-specific ratings (optional)
-    landlordTreatment?: string;
-    problemResponse?: string;
-    depositReturned?: boolean;
-    staircaseNeighbors?: string;
-    touristApartments?: boolean;
-    neighborRelations?: string;
-    cleaning?: string;
-
-    // Area-specific ratings (optional)
-    areaTourists?: string;
-    areaSecurity?: string;
-
-    // Profile and metadata
-    profileId: { id: string } | string;
-    createdAt: string;
-    updatedAt: string;
-    verified: boolean;
-
-    // Ethical review system features (optional, with defaults)
-    isAnonymous?: boolean;
-    confidenceScore?: number;
-    evidenceAttached?: boolean;
-    flaggedIssues?: string[];
-    karmaScore?: number;
-    replyAllowed?: boolean;
-    moderationStatus?: 'pending' | 'approved' | 'flagged' | 'removed';
-    takedownReason?: string;
-    helpfulVotes?: number;
-    unhelpfulVotes?: number;
-    reportCount?: number;
-
-    // Display fields
-    livedDurationText?: string;
-    evidenceCount?: number;
+interface DimensionChipData {
+  label: string;
+  value: string;
 }
 
-interface ReviewCardProps {
-    review: ReviewData;
-    onHelpful?: (reviewId: string) => void;
-    onReport?: (reviewId: string) => void;
-    onReply?: (reviewId: string) => void;
-    variant?: 'default' | 'compact';
-    showActions?: boolean;
+/** Collect the i18n key pairs for every dimension present on the review. */
+function collectEnumKeys(
+  review: ReviewDTO,
+  dimensions: DimensionDescriptor[],
+): { labelKey: string; valueKey: string }[] {
+  const chips: { labelKey: string; valueKey: string }[] = [];
+  for (const dimension of dimensions) {
+    const raw = review[dimension.field];
+    if (typeof raw === 'string' && raw.length > 0) {
+      chips.push({ labelKey: dimension.labelKey, valueKey: `${dimension.enumPrefix}.${raw}` });
+    }
+  }
+  return chips;
 }
 
-export const ReviewCard: React.FC<ReviewCardProps> = ({
-    review,
-    onHelpful,
-    onReport,
-    onReply,
-    variant = 'default',
-    showActions = true
-}) => {
-    const { t } = useTranslation();
+const DimensionChip: React.FC<DimensionChipData> = ({ label, value }) => (
+  <View style={styles.dimChip}>
+    <BloomText style={styles.dimChipLabel}>{label}</BloomText>
+    <BloomText style={styles.dimChipValue}>{value}</BloomText>
+  </View>
+);
 
-    const renderStars = (rating: number) => {
-        const fullStars = Math.floor(rating);
-        const halfStar = rating % 1 >= 0.5;
-        const emptyStars = 5 - fullStars - (halfStar ? 1 : 0);
+interface DimensionGroupProps {
+  title: string;
+  chips: DimensionChipData[];
+}
 
-        return (
-            <View style={styles.starsContainer}>
-                {[...Array(fullStars)].map((_, i) => (
-                    <Ionicons key={`full-${i}`} name="star" size={16} color={colors.ratingStar} />
-                ))}
-                {halfStar && <Ionicons name="star-half" size={16} color={colors.ratingStar} />}
-                {[...Array(emptyStars)].map((_, i) => (
-                    <Ionicons key={`empty-${i}`} name="star-outline" size={16} color={colors.ratingStar} />
-                ))}
-            </View>
-        );
-    };
+const DimensionGroup: React.FC<DimensionGroupProps> = ({ title, chips }) => {
+  if (chips.length === 0) return null;
+  return (
+    <View style={styles.dimGroup}>
+      <BloomText style={styles.dimGroupTitle}>{title}</BloomText>
+      <View style={styles.dimChips}>
+        {chips.map((chip) => (
+          <DimensionChip key={chip.label} label={chip.label} value={chip.value} />
+        ))}
+      </View>
+    </View>
+  );
+};
 
-    const handleHelpful = () => {
-        if (onHelpful) {
-            onHelpful(review._id);
-        } else {
-            Alert.alert(
-                t('reviews.card.alertThankYouTitle'),
-                t('reviews.card.alertThankYouBody'),
-            );
-        }
-    };
+interface FooterButtonProps {
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+  label: string;
+  active?: boolean;
+  disabled?: boolean;
+  onPress: () => void;
+}
 
-    const handleReport = () => {
-        if (onReport) {
-            onReport(review._id);
-        } else {
-            Alert.alert(
-                t('reviews.card.alertReportTitle'),
-                t('reviews.card.alertReportBody'),
-                [
-                    { text: t('common.cancel'), style: 'cancel' },
-                    {
-                        text: t('reviews.card.alertReportConfirm'),
-                        style: 'destructive',
-                        onPress: () => {
-                            Alert.alert(
-                                t('reviews.card.alertReportedTitle'),
-                                t('reviews.card.alertReportedBody'),
-                            );
-                        }
-                    }
-                ]
-            );
-        }
-    };
+/** Footer affordance (Helpful / Report) — owns its own pressed/hovered state. */
+const FooterButton: React.FC<FooterButtonProps> = ({ icon, label, active, disabled, onPress }) => {
+  const [pressed, setPressed] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const tint = active ? colors.success : colors.COLOR_BLACK_LIGHT_3;
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      onHoverIn={IS_WEB ? () => setHovered(true) : undefined}
+      onHoverOut={IS_WEB ? () => setHovered(false) : undefined}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ disabled: Boolean(disabled), selected: Boolean(active) }}
+      style={[
+        styles.footerButton,
+        !disabled && (pressed || hovered) && styles.footerButtonActive,
+        disabled && styles.footerButtonDisabled,
+      ]}
+    >
+      <Ionicons name={icon} size={16} color={tint} />
+      <BloomText style={[styles.footerButtonLabel, { color: tint }]}>{label}</BloomText>
+    </Pressable>
+  );
+};
 
-    const handleReply = () => {
-        if (onReply) {
-            onReply(review._id);
-        } else {
-            Alert.alert(
-                t('reviews.card.alertReplyTitle'),
-                t('reviews.card.alertReplyBody'),
-                [{ text: t('common.ok') }]
-            );
-        }
-    };
+export interface ReviewCardProps {
+  review: ReviewDTO;
+  /** Author resolved by the parent via `useOxyAvatars` (avatar file id + name). */
+  author?: User;
+  /** Fired with the agency slug when the "managed by" link is pressed. */
+  onPressAgency?: (slug: string) => void;
+}
 
-    const evidenceCount = review.evidenceCount || 1;
-    const isCompact = variant === 'compact';
+export const ReviewCard: React.FC<ReviewCardProps> = ({ review, author, onPressAgency }) => {
+  const { t } = useTranslation();
+  const { user } = useOxy();
+  const toggleHelpful = useToggleHelpful();
+  const reportReview = useReportReview();
+  const [reportVisible, setReportVisible] = useState(false);
 
-    return (
-        <View style={[styles.reviewCard, isCompact && styles.compactCard]}>
-            <View style={styles.reviewHeader}>
-                <View style={styles.reviewerInfo}>
-                    <View style={styles.avatar}>
-                        <Ionicons name="person" size={24} color={colors.primaryColor} />
-                    </View>
-                    <View style={styles.reviewerDetails}>
-                        <View style={styles.reviewerNameRow}>
-                            <ThemedText style={styles.reviewerName}>
-                                {review.isAnonymous
-                                    ? t('reviews.card.anonymous')
-                                    : t('reviews.card.verifiedResident')}
-                            </ThemedText>
+  const isOwnReview = Boolean(user?.id && user.id === review.oxyUserId);
+  const displayName =
+    author?.name?.displayName?.trim() || author?.username || t('reviews.card.anonymous');
+  const isUnderReview = review.moderationStatus === ReviewModerationStatus.UNDER_REVIEW;
 
-                            <View style={styles.trustIndicators}>
-                                {review.verified && (
-                                    <View style={styles.verifiedBadge}>
-                                        <Ionicons name="checkmark-circle" size={14} color={colors.primaryColor} />
-                                        <ThemedText style={styles.verifiedText}>
-                                            {t('reviews.card.verified')}
-                                        </ThemedText>
-                                    </View>
-                                )}
+  const pros = review.prosItems?.length
+    ? review.prosItems
+    : review.positiveComment
+      ? [review.positiveComment]
+      : [];
+  const cons = review.consItems?.length
+    ? review.consItems
+    : review.negativeComment
+      ? [review.negativeComment]
+      : [];
 
-                                {!isCompact && (
-                                    <View style={[styles.confidenceBadge, {
-                                        backgroundColor: (review.confidenceScore || 0) >= 80 ? colors.success :
-                                            (review.confidenceScore || 0) >= 60 ? colors.warning : colors.danger
-                                    }]}>
-                                        <ThemedText style={styles.confidenceText}>
-                                            {t('reviews.card.confident', { score: review.confidenceScore || 0 })}
-                                        </ThemedText>
-                                    </View>
-                                )}
+  const translateChips = (keys: { labelKey: string; valueKey: string }[]): DimensionChipData[] =>
+    keys.map((entry) => ({ label: t(entry.labelKey), value: t(entry.valueKey) }));
 
-                                {review.evidenceAttached && (
-                                    <View style={styles.evidenceBadge}>
-                                        <Ionicons name="document-attach" size={12} color={colors.COLOR_BLACK_LIGHT_3} />
-                                        <ThemedText style={styles.evidenceText}>
-                                            {evidenceCount}{' '}
-                                            {evidenceCount > 1
-                                                ? t('reviews.card.proofs')
-                                                : t('reviews.card.proof')}
-                                        </ThemedText>
-                                    </View>
-                                )}
+  const apartmentChips = translateChips(collectEnumKeys(review, APARTMENT_DIMENSIONS));
+  const managementChips = translateChips(collectEnumKeys(review, MANAGEMENT_DIMENSIONS));
+  const buildingChips = translateChips(collectEnumKeys(review, BUILDING_DIMENSIONS));
+  if (typeof review.touristApartments === 'boolean') {
+    buildingChips.push({
+      label: t('reviews.write.fields.touristApartments'),
+      value: review.touristApartments ? t('common.yes') : t('common.no'),
+    });
+  }
+  if (review.services && review.services.length > 0) {
+    buildingChips.push({
+      label: t('reviews.write.fields.services'),
+      value: review.services.map((service) => t(`reviews.enums.services.${service}`)).join(', '),
+    });
+  }
+  const areaChips = translateChips(collectEnumKeys(review, AREA_DIMENSIONS));
 
-                                {!isCompact && (review.karmaScore || 0) > 0 && (
-                                    <View style={styles.karmaBadge}>
-                                        <Ionicons name="trending-up" size={12} color={colors.info} />
-                                        <ThemedText style={styles.karmaText}>
-                                            {t('reviews.card.karma', { score: review.karmaScore || 0 })}
-                                        </ThemedText>
-                                    </View>
-                                )}
-                            </View>
-                        </View>
+  const images = Array.isArray(review.images) ? review.images.filter((url) => Boolean(url)) : [];
 
-                        <View style={styles.reviewMetaRow}>
-                            <ThemedText style={styles.reviewDate}>
-                                {formatLocalized(new Date(review.createdAt), 'PP')}
-                            </ThemedText>
-                            <ThemedText style={styles.livedDuration}>
-                                {t('reviews.card.livedMonths', { count: review.livedForMonths })}
-                            </ThemedText>
-                            {review.price ? (
-                                <ThemedText style={styles.price}>
-                                    {t('reviews.card.perMonth', {
-                                        price: review.price,
-                                        currency: review.currency,
-                                    })}
-                                </ThemedText>
-                            ) : null}
-                        </View>
-
-                        {!isCompact && review.flaggedIssues && review.flaggedIssues.length > 0 && (
-                            <View style={styles.issueTagsContainer}>
-                                {review.flaggedIssues.slice(0, 3).map((issue, index) => (
-                                    <View key={index} style={styles.issueTag}>
-                                        <ThemedText style={styles.issueTagText}>⚠️ {issue}</ThemedText>
-                                    </View>
-                                ))}
-                                {review.flaggedIssues.length > 3 && (
-                                    <View style={styles.issueTag}>
-                                        <ThemedText style={styles.issueTagText}>
-                                            {t('reviews.card.moreIssues', {
-                                                count: review.flaggedIssues.length - 3,
-                                            })}
-                                        </ThemedText>
-                                    </View>
-                                )}
-                            </View>
-                        )}
-                    </View>
-                </View>
-                {renderStars(review.rating)}
-            </View>
-
-            <ThemedText style={[styles.reviewText, isCompact && styles.compactReviewText]} numberOfLines={isCompact ? 3 : undefined}>
-                {review.opinion}
-            </ThemedText>
-
-            {!isCompact && review.positiveComment && (
-                <View style={styles.commentSection}>
-                    <ThemedText style={styles.commentLabel}>{t('reviews.card.positive')}</ThemedText>
-                    <ThemedText style={styles.commentText}>{review.positiveComment}</ThemedText>
-                </View>
-            )}
-
-            {!isCompact && review.negativeComment && (
-                <View style={styles.commentSection}>
-                    <ThemedText style={styles.commentLabel}>{t('reviews.card.negative')}</ThemedText>
-                    <ThemedText style={styles.commentText}>{review.negativeComment}</ThemedText>
-                </View>
-            )}
-
-            {showActions && (
-                <View style={styles.reviewFooter}>
-                    <View style={styles.moderationSection}>
-                        <TouchableOpacity
-                            style={[styles.helpfulButton, {
-                                backgroundColor: (review.helpfulVotes || 0) > 0 ? colors.successSubtle : colors.surface,
-                                borderColor: (review.helpfulVotes || 0) > 0 ? colors.success : colors.border
-                            }]}
-                            onPress={handleHelpful}
-                        >
-                            <Ionicons
-                                name="thumbs-up"
-                                size={18}
-                                color={(review.helpfulVotes || 0) > 0 ? colors.success : colors.COLOR_BLACK_LIGHT_4}
-                            />
-                            <ThemedText style={[styles.helpfulText, {
-                                color: (review.helpfulVotes || 0) > 0 ? colors.success : colors.COLOR_BLACK_LIGHT_4
-                            }]}>
-                                {t('reviews.card.helpful', { count: review.helpfulVotes || 0 })}
-                            </ThemedText>
-                        </TouchableOpacity>
-
-                        <TouchableOpacity
-                            style={[styles.helpfulButton, {
-                                backgroundColor: colors.surface,
-                                borderColor: colors.border
-                            }]}
-                            onPress={handleReport}
-                        >
-                            <Ionicons name="flag" size={18} color={colors.error} />
-                            <ThemedText style={[styles.helpfulText, { color: colors.error }]}>
-                                {t('reviews.card.report')}
-                            </ThemedText>
-                        </TouchableOpacity>
-
-                        {review.replyAllowed && (
-                            <TouchableOpacity
-                                style={[styles.helpfulButton, {
-                                    backgroundColor: colors.primaryLight_2,
-                                    borderColor: colors.primaryColor
-                                }]}
-                                onPress={handleReply}
-                            >
-                                <Ionicons name="chatbubble" size={18} color={colors.primaryColor} />
-                                <ThemedText style={[styles.helpfulText, { color: colors.primaryColor }]}>
-                                    {t('reviews.card.reply')}
-                                </ThemedText>
-                            </TouchableOpacity>
-                        )}
-                    </View>
-
-                    <View style={styles.recommendationSection}>
-                        <ThemedText style={styles.recommendationText}>
-                            {review.recommendation
-                                ? t('reviews.card.recommends')
-                                : t('reviews.card.doesNotRecommend')}
-                        </ThemedText>
-
-                        {review.moderationStatus === 'flagged' && (
-                            <View style={styles.flaggedIndicator}>
-                                <Ionicons name="warning" size={12} color={colors.warning} />
-                                <ThemedText style={styles.flaggedText}>
-                                    {t('reviews.card.underReview')}
-                                </ThemedText>
-                            </View>
-                        )}
-                    </View>
-                </View>
-            )}
-        </View>
+  const handleReportSubmit = (reason: ReviewReportReason, details?: string) => {
+    reportReview.mutate(
+      { reviewId: review.id, reason, details },
+      { onSuccess: () => setReportVisible(false) },
     );
+  };
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <Avatar source={author?.avatar ?? undefined} variant="thumb" size={44} />
+        <View style={styles.headerText}>
+          <View style={styles.nameRow}>
+            <BloomText style={styles.authorName}>{displayName}</BloomText>
+            {review.verified ? (
+              <View style={styles.chip}>
+                <Ionicons name="checkmark-circle" size={13} color={colors.success} />
+                <BloomText style={[styles.chipText, { color: colors.success }]}>
+                  {t('reviews.card.verified')}
+                </BloomText>
+              </View>
+            ) : null}
+            {isUnderReview ? (
+              <View style={[styles.chip, styles.chipWarning]}>
+                <Ionicons name="warning-outline" size={12} color={colors.warning} />
+                <BloomText style={[styles.chipText, { color: colors.warning }]}>
+                  {t('reviews.card.underReview')}
+                </BloomText>
+              </View>
+            ) : null}
+          </View>
+          <View style={styles.metaRow}>
+            <BloomText style={styles.metaText}>
+              {formatLocalized(new Date(review.createdAt), 'PP')}
+            </BloomText>
+            {review.livedForMonths > 0 ? (
+              <>
+                <BloomText style={styles.metaDot}>·</BloomText>
+                <BloomText style={styles.metaText}>
+                  {t('reviews.card.livedMonths', { count: review.livedForMonths })}
+                </BloomText>
+              </>
+            ) : null}
+            {review.price ? (
+              <>
+                <BloomText style={styles.metaDot}>·</BloomText>
+                <BloomText style={styles.metaText}>
+                  {t('reviews.card.perMonth', { price: review.price, currency: review.currency })}
+                </BloomText>
+              </>
+            ) : null}
+          </View>
+        </View>
+      </View>
+
+      {review.title ? <BloomText style={styles.title}>{review.title}</BloomText> : null}
+
+      <View style={styles.ratingRow}>
+        <Stars rating={review.rating} size={16} />
+        <View style={styles.recommendRow}>
+          <Ionicons
+            name={review.recommendation ? 'thumbs-up' : 'thumbs-down'}
+            size={14}
+            color={review.recommendation ? colors.success : colors.COLOR_BLACK_LIGHT_3}
+          />
+          <BloomText
+            style={[
+              styles.recommendText,
+              { color: review.recommendation ? colors.success : colors.COLOR_BLACK_LIGHT_3 },
+            ]}
+          >
+            {review.recommendation
+              ? t('reviews.card.recommends')
+              : t('reviews.card.doesNotRecommend')}
+          </BloomText>
+        </View>
+      </View>
+
+      {review.opinion ? <BloomText style={styles.opinion}>{review.opinion}</BloomText> : null}
+
+      {pros.length > 0 ? (
+        <View style={styles.prosConsBlock}>
+          <BloomText style={[styles.prosConsLabel, { color: colors.success }]}>
+            {t('reviews.card.pros')}
+          </BloomText>
+          {pros.map((item, index) => (
+            <View key={`pro-${index}`} style={styles.prosConsRow}>
+              <Ionicons name="add-circle-outline" size={14} color={colors.success} />
+              <BloomText style={styles.prosConsText}>{item}</BloomText>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      {cons.length > 0 ? (
+        <View style={styles.prosConsBlock}>
+          <BloomText style={[styles.prosConsLabel, { color: colors.error }]}>
+            {t('reviews.card.cons')}
+          </BloomText>
+          {cons.map((item, index) => (
+            <View key={`con-${index}`} style={styles.prosConsRow}>
+              <Ionicons name="remove-circle-outline" size={14} color={colors.error} />
+              <BloomText style={styles.prosConsText}>{item}</BloomText>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      <DimensionGroup title={t('reviews.card.sections.apartment')} chips={apartmentChips} />
+      <DimensionGroup title={t('reviews.card.sections.management')} chips={managementChips} />
+      <DimensionGroup title={t('reviews.card.sections.building')} chips={buildingChips} />
+      <DimensionGroup title={t('reviews.card.sections.area')} chips={areaChips} />
+
+      {review.adviceToLandlord ? (
+        <View style={styles.adviceBlock}>
+          <BloomText style={styles.adviceLabel}>{t('reviews.card.adviceToLandlord')}</BloomText>
+          <BloomText style={styles.adviceText}>{review.adviceToLandlord}</BloomText>
+        </View>
+      ) : null}
+      {review.adviceToAgency ? (
+        <View style={styles.adviceBlock}>
+          <BloomText style={styles.adviceLabel}>{t('reviews.card.adviceToAgency')}</BloomText>
+          <BloomText style={styles.adviceText}>{review.adviceToAgency}</BloomText>
+        </View>
+      ) : null}
+
+      {review.agency ? (
+        <Pressable
+          onPress={() => onPressAgency?.(review.agency?.slug ?? '')}
+          disabled={!onPressAgency}
+          accessibilityRole="link"
+          accessibilityLabel={t('reviews.card.managedBy', { name: review.agency.name })}
+          style={styles.agencyRow}
+        >
+          <Ionicons name="business-outline" size={15} color={colors.primaryColor} />
+          <BloomText style={styles.agencyText}>
+            {t('reviews.card.managedBy', { name: review.agency.name })}
+          </BloomText>
+          {onPressAgency ? (
+            <Ionicons name="chevron-forward" size={14} color={colors.primaryColor} />
+          ) : null}
+        </Pressable>
+      ) : null}
+
+      {images.length > 0 ? (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.imagesRow}
+        >
+          {images.map((url, index) => (
+            <Image
+              key={`${url}-${index}`}
+              source={{ uri: resolveBackendImageUrl(url) }}
+              style={styles.reviewImage}
+            />
+          ))}
+        </ScrollView>
+      ) : null}
+
+      <View style={styles.footer}>
+        <FooterButton
+          icon={review.viewerHasVotedHelpful ? 'thumbs-up' : 'thumbs-up-outline'}
+          label={t('reviews.card.helpful', { count: review.helpfulCount })}
+          active={review.viewerHasVotedHelpful}
+          disabled={isOwnReview || toggleHelpful.isPending}
+          onPress={() => toggleHelpful.mutate(review.id)}
+        />
+        {isOwnReview ? null : (
+          <FooterButton
+            icon="flag-outline"
+            label={t('reviews.card.report')}
+            onPress={() => setReportVisible(true)}
+          />
+        )}
+      </View>
+
+      <ReportReviewSheet
+        visible={reportVisible}
+        onClose={() => setReportVisible(false)}
+        onSubmit={handleReportSubmit}
+        submitting={reportReview.isPending}
+      />
+    </View>
+  );
 };
 
 const styles = StyleSheet.create({
-    reviewCard: {
-        backgroundColor: colors.surfaceElevated,
-        borderRadius: radius.lg,
-        padding: spacing.xl,
-        marginBottom: spacing.lg,
-        borderWidth: 1,
-        borderColor: colors.border,
-    },
-    compactCard: {
-        padding: spacing.lg,
-        marginBottom: spacing.md,
-        borderRadius: radius.md,
-    },
-    reviewHeader: {
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'flex-start',
-        marginBottom: 16,
-    },
-    reviewerInfo: {
-        flexDirection: 'row',
-        flex: 1,
-        marginRight: 12,
-    },
-    avatar: {
-        width: 48,
-        height: 48,
-        borderRadius: 24,
-        backgroundColor: colors.primaryLight_2,
-        justifyContent: 'center',
-        alignItems: 'center',
-        marginRight: 16,
-        borderWidth: 2,
-        borderColor: colors.primaryColor,
-    },
-    reviewerDetails: {
-        flex: 1,
-    },
-    reviewerNameRow: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        marginBottom: 6,
-    },
-    reviewerName: {
-        fontSize: 18,
-        fontWeight: '700',
-        color: colors.primaryDark,
-    },
-    trustIndicators: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        flexWrap: 'wrap',
-        gap: 8,
-    },
-    verifiedBadge: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        backgroundColor: colors.successSubtle,
-        paddingHorizontal: 8,
-        paddingVertical: 3,
-        borderRadius: 12,
-        gap: 4,
-        borderWidth: 1,
-        borderColor: colors.success,
-    },
-    verifiedText: {
-        fontSize: 11,
-        color: colors.success,
-        fontWeight: '700',
-    },
-    confidenceBadge: {
-        paddingHorizontal: 8,
-        paddingVertical: 3,
-        borderRadius: 14,
-        alignItems: 'center',
-    },
-    confidenceText: {
-        fontSize: 11,
-        color: colors.white,
-        fontWeight: '700',
-    },
-    evidenceBadge: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        backgroundColor: colors.mutedSubtle,
-        paddingHorizontal: 8,
-        paddingVertical: 3,
-        borderRadius: 12,
-        gap: 4,
-        borderWidth: 1,
-        borderColor: colors.border,
-    },
-    evidenceText: {
-        fontSize: 11,
-        color: colors.muted,
-        fontWeight: '600',
-    },
-    karmaBadge: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        backgroundColor: colors.infoSubtle,
-        paddingHorizontal: 8,
-        paddingVertical: 3,
-        borderRadius: 12,
-        gap: 4,
-        borderWidth: 1,
-        borderColor: colors.info,
-    },
-    karmaText: {
-        fontSize: 11,
-        color: colors.info,
-        fontWeight: '600',
-    },
-    reviewMetaRow: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: 16,
-        marginTop: 6,
-    },
-    reviewDate: {
-        fontSize: 13,
-        color: colors.COLOR_BLACK_LIGHT_4,
-        fontWeight: '500',
-    },
-    livedDuration: {
-        fontSize: 13,
-        color: colors.COLOR_BLACK_LIGHT_4,
-        fontWeight: '500',
-    },
-    price: {
-        fontSize: 13,
-        color: colors.primaryColor,
-        fontWeight: '700',
-        backgroundColor: colors.primaryLight_2,
-        paddingHorizontal: 8,
-        paddingVertical: 2,
-        borderRadius: 8,
-    },
-    issueTagsContainer: {
-        flexDirection: 'row',
-        flexWrap: 'wrap',
-        gap: 8,
-        marginTop: 12,
-    },
-    issueTag: {
-        backgroundColor: colors.warningSubtle,
-        paddingHorizontal: 10,
-        paddingVertical: 5,
-        borderRadius: 14,
-        borderWidth: 1,
-        borderColor: colors.warning,
-    },
-    issueTagText: {
-        fontSize: 12,
-        color: colors.warning,
-        fontWeight: '600',
-    },
-    starsContainer: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: 3,
-        backgroundColor: colors.warningSubtle,
-        paddingHorizontal: 10,
-        paddingVertical: 6,
-        borderRadius: 12,
-        borderWidth: 1,
-        borderColor: colors.ratingStar,
-    },
-    reviewText: {
-        fontSize: 16,
-        lineHeight: 24,
-        color: colors.COLOR_BLACK_LIGHT_2,
-        marginBottom: 16,
-        fontWeight: '400',
-    },
-    compactReviewText: {
-        fontSize: 14,
-        lineHeight: 20,
-        marginBottom: 12,
-    },
-    commentSection: {
-        marginBottom: 12,
-        backgroundColor: colors.surface,
-        padding: 12,
-        borderRadius: 12,
-        borderLeftWidth: 4,
-        borderLeftColor: colors.primaryColor,
-    },
-    commentLabel: {
-        fontSize: 13,
-        fontWeight: '700',
-        color: colors.primaryColor,
-        marginBottom: 6,
-        textTransform: 'uppercase',
-    },
-    commentText: {
-        fontSize: 14,
-        lineHeight: 20,
-        color: colors.COLOR_BLACK_LIGHT_2,
-    },
-    reviewFooter: {
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        marginTop: 16,
-        paddingTop: 16,
-        borderTopWidth: 1,
-        borderTopColor: colors.border,
-    },
-    moderationSection: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: 16,
-        flex: 1,
-    },
-    helpfulButton: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: 6,
-        paddingHorizontal: 12,
-        paddingVertical: 8,
-        borderRadius: 12,
-        borderWidth: 1,
-        borderColor: 'transparent',
-    },
-    helpfulText: {
-        fontSize: 13,
-        fontWeight: '600',
-    },
-    recommendationSection: {
-        alignItems: 'flex-end',
-    },
-    recommendationText: {
-        fontSize: 14,
-        fontWeight: '700',
-        color: colors.primaryDark,
-        backgroundColor: colors.primaryLight_2,
-        paddingHorizontal: 12,
-        paddingVertical: 6,
-        borderRadius: 12,
-        overflow: 'hidden',
-    },
-    flaggedIndicator: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        backgroundColor: colors.warningSubtle,
-        paddingHorizontal: 8,
-        paddingVertical: 4,
-        borderRadius: 10,
-        gap: 4,
-        marginTop: 6,
-        borderWidth: 1,
-        borderColor: colors.warning,
-    },
-    flaggedText: {
-        fontSize: 11,
-        color: colors.warning,
-        fontWeight: '600',
-    },
+  card: {
+    gap: spacing.md,
+    paddingVertical: spacing.lg,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.md,
+  },
+  headerText: {
+    flex: 1,
+    minWidth: 0,
+    gap: 2,
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  authorName: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.COLOR_BLACK,
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: radius.pill,
+    backgroundColor: colors.successSubtle,
+  },
+  chipWarning: {
+    backgroundColor: colors.warningSubtle,
+  },
+  chipText: {
+    fontSize: 11,
+    fontWeight: '700',
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  metaText: {
+    fontSize: 13,
+    color: colors.COLOR_BLACK_LIGHT_3,
+  },
+  metaDot: {
+    fontSize: 13,
+    color: colors.COLOR_BLACK_LIGHT_5,
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: colors.COLOR_BLACK,
+    letterSpacing: -0.3,
+  },
+  ratingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: spacing.md,
+  },
+  recommendRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  recommendText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  opinion: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: colors.COLOR_BLACK_LIGHT_2,
+  },
+  prosConsBlock: {
+    gap: spacing.xs,
+  },
+  prosConsLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  prosConsRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.xs,
+  },
+  prosConsText: {
+    flex: 1,
+    fontSize: 14,
+    lineHeight: 20,
+    color: colors.COLOR_BLACK_LIGHT_2,
+  },
+  dimGroup: {
+    gap: spacing.xs,
+  },
+  dimGroupTitle: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: colors.COLOR_BLACK_LIGHT_3,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  dimChips: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xs,
+  },
+  dimChip: {
+    flexDirection: 'row',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.md,
+    borderWidth: hairline.width,
+    borderColor: colors.COLOR_BLACK_LIGHT_6,
+    backgroundColor: colors.surfaceElevated,
+  },
+  dimChipLabel: {
+    fontSize: 12,
+    color: colors.COLOR_BLACK_LIGHT_3,
+  },
+  dimChipValue: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.COLOR_BLACK,
+  },
+  adviceBlock: {
+    gap: 2,
+    paddingLeft: spacing.md,
+    borderLeftWidth: 2,
+    borderLeftColor: colors.COLOR_BLACK_LIGHT_6,
+  },
+  adviceLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: colors.COLOR_BLACK_LIGHT_3,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  adviceText: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: colors.COLOR_BLACK_LIGHT_2,
+  },
+  agencyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    alignSelf: 'flex-start',
+  },
+  agencyText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.primaryColor,
+  },
+  imagesRow: {
+    gap: spacing.sm,
+  },
+  reviewImage: {
+    width: 120,
+    height: 90,
+    borderRadius: radius.md,
+    backgroundColor: colors.mutedSubtle,
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginTop: spacing.xs,
+  },
+  footerButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.md,
+  },
+  footerButtonActive: {
+    backgroundColor: colors.COLOR_BLACK_LIGHT_7,
+  },
+  footerButtonDisabled: {
+    opacity: 0.6,
+  },
+  footerButtonLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
 });
 
 export default ReviewCard;

--- a/packages/frontend/components/SideBar/index.tsx
+++ b/packages/frontend/components/SideBar/index.tsx
@@ -28,6 +28,7 @@ import {
   Users,
   CalendarClock,
   Bookmark,
+  Star,
   ChevronsLeft,
   ChevronsRight,
   ChevronRight,
@@ -316,6 +317,15 @@ export function SideBar() {
       iconActive: Megaphone,
       label: t('sidebar.navigation.evictions'),
       route: '/evictions',
+    });
+
+    // Reviews explore — public (address reputation, reviucasa-style).
+    entries.push({
+      key: 'reviews',
+      icon: Star,
+      iconActive: Star,
+      label: t('sidebar.navigation.reviews'),
+      route: '/reviews',
     });
 
     if (canAccessRoommates) {

--- a/packages/frontend/components/property/CommunityNoteCard.tsx
+++ b/packages/frontend/components/property/CommunityNoteCard.tsx
@@ -1,28 +1,15 @@
 /**
- * CommunityNoteCard — a single community note (formerly "review") rendered
- * in the property detail's Community Notes section.
+ * CommunityNoteCard — a single community note (a `ReviewDTO`) rendered in the
+ * property detail's Community Notes preview. Flat Airbnb-2026 aesthetic (no card
+ * chrome); separation is owned by the parent's hairline divider.
  *
- * Flat Airbnb-2026 aesthetic: no card chrome (no shadow, no border, no
- * filled background) so notes sit directly on the page like the rest of the
- * property sections. Separation between notes is owned by the parent via a
- * hairline divider.
- *
- * Layout:
- *  - Header row: avatar + author (Anonymous / Verified Resident) + a
- *    small verified check, with the star rating pinned to the right.
- *  - Meta line: date · months lived · monthly price.
- *  - Body: the note opinion, clamped to `BODY_CLAMP_LINES` with an inline
- *    "Read more" / "Read less" toggle when it overflows.
- *  - Footer (optional, full variant): a "Helpful" affordance + report /
- *    reply, plus a recommends / does-not-recommend pill.
- *
- * The underlying data shape is the Review model (`ReviewData`) — only the
- * presentation is rebranded. Notes are anonymous by design, so there is no
- * real name/photo to show; the avatar is a neutral glyph.
+ * Read-only: the full interactive review card (real Helpful / Report) lives on
+ * the address page via `ReviewCard`. Here we surface the title, stars, opinion,
+ * pros/cons (falling back to the legacy `positiveComment`/`negativeComment`),
+ * the recommendation, a read-only helpful count, and an under-review flag.
  */
 import React, { useState } from 'react';
 import {
-  Alert,
   Pressable,
   StyleSheet,
   View,
@@ -34,186 +21,48 @@ import { Ionicons } from '@expo/vector-icons';
 
 import { Text as BloomText } from '@oxyhq/bloom/typography';
 
+import { ReviewModerationStatus, type ReviewDTO } from '@homiio/shared-types';
 import { Stars } from '@/components/ui/Stars';
 import { formatLocalized } from '@/utils/dateLocale';
 import { colors } from '@/styles/colors';
-import { radius, spacing } from '@/constants/styles';
-
-export interface ReviewData {
-  _id: string;
-  addressId: string;
-  addressLevel: 'BUILDING' | 'UNIT';
-  streetLevelId: string;
-  buildingLevelId: string;
-  unitLevelId?: string;
-  greenHouse?: string;
-  price: number;
-  currency: string;
-  livedFrom: string;
-  livedTo: string;
-  livedForMonths: number;
-  recommendation: boolean;
-  opinion: string;
-  positiveComment?: string;
-  negativeComment?: string;
-  images: string[];
-  rating: number;
-
-  // Apartment-specific ratings (optional)
-  summerTemperature?: string;
-  winterTemperature?: string;
-  noise?: string;
-  light?: string;
-  conditionAndMaintenance?: string;
-  services?: string[];
-
-  // Community-specific ratings (optional)
-  landlordTreatment?: string;
-  problemResponse?: string;
-  depositReturned?: boolean;
-  staircaseNeighbors?: string;
-  touristApartments?: boolean;
-  neighborRelations?: string;
-  cleaning?: string;
-
-  // Area-specific ratings (optional)
-  areaTourists?: string;
-  areaSecurity?: string;
-
-  // Profile and metadata
-  profileId: { id: string } | string;
-  createdAt: string;
-  updatedAt: string;
-  verified: boolean;
-
-  // Ethical review system features (optional, with defaults)
-  isAnonymous?: boolean;
-  confidenceScore?: number;
-  evidenceAttached?: boolean;
-  flaggedIssues?: string[];
-  karmaScore?: number;
-  replyAllowed?: boolean;
-  moderationStatus?: 'pending' | 'approved' | 'flagged' | 'removed';
-  takedownReason?: string;
-  helpfulVotes?: number;
-  unhelpfulVotes?: number;
-  reportCount?: number;
-
-  // Display fields
-  livedDurationText?: string;
-  evidenceCount?: number;
-}
+import { spacing } from '@/constants/styles';
 
 const BODY_CLAMP_LINES = 4;
 const AVATAR_SIZE = 40;
-
-interface FooterButtonProps {
-  icon: React.ComponentProps<typeof Ionicons>['name'];
-  label: string;
-  tone?: 'default' | 'active';
-  onPress: () => void;
-}
-
-/** Footer affordance (Helpful / Report / Reply) — owns its own pressed state. */
-const FooterButton: React.FC<FooterButtonProps> = ({
-  icon,
-  label,
-  tone = 'default',
-  onPress,
-}) => {
-  const [pressed, setPressed] = useState(false);
-  const tint = tone === 'active' ? colors.primaryColor : colors.COLOR_BLACK_LIGHT_3;
-  return (
-    <Pressable
-      onPress={onPress}
-      onPressIn={() => setPressed(true)}
-      onPressOut={() => setPressed(false)}
-      accessibilityRole="button"
-      accessibilityLabel={label}
-      style={[styles.footerButton, pressed && styles.footerButtonPressed]}
-    >
-      <Ionicons name={icon} size={16} color={tint} />
-      <BloomText style={[styles.footerButtonLabel, { color: tint }]}>{label}</BloomText>
-    </Pressable>
-  );
-};
+const MAX_PROS_CONS = 3;
 
 interface CommunityNoteCardProps {
-  note: ReviewData;
-  onHelpful?: (noteId: string) => void;
-  onReport?: (noteId: string) => void;
-  onReply?: (noteId: string) => void;
-  showActions?: boolean;
+  note: ReviewDTO;
 }
 
-export const CommunityNoteCard: React.FC<CommunityNoteCardProps> = ({
-  note,
-  onHelpful,
-  onReport,
-  onReply,
-  showActions = true,
-}) => {
+export const CommunityNoteCard: React.FC<CommunityNoteCardProps> = ({ note }) => {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
   const [isTruncatable, setIsTruncatable] = useState(false);
 
-  const authorName = note.isAnonymous
-    ? t('property.communityNotes.anonymous')
-    : t('property.communityNotes.verifiedResident');
+  const authorName = note.verified
+    ? t('property.communityNotes.verifiedResident')
+    : t('property.communityNotes.anonymous');
 
   const formattedDate = formatLocalized(new Date(note.createdAt), 'MMMM yyyy');
 
-  // Measure once (collapsed) to decide whether "Read more" is needed; the
-  // measurement only matters before expansion, so it's a no-op afterwards.
+  const pros = (note.prosItems?.length
+    ? note.prosItems
+    : note.positiveComment
+      ? [note.positiveComment]
+      : []
+  ).slice(0, MAX_PROS_CONS);
+  const cons = (note.consItems?.length
+    ? note.consItems
+    : note.negativeComment
+      ? [note.negativeComment]
+      : []
+  ).slice(0, MAX_PROS_CONS);
+
   const handleTextLayout = (event: NativeSyntheticEvent<TextLayoutEventData>) => {
     if (!expanded && event.nativeEvent.lines.length > BODY_CLAMP_LINES) {
       setIsTruncatable(true);
     }
-  };
-
-  const handleHelpful = () => {
-    if (onHelpful) {
-      onHelpful(note._id);
-      return;
-    }
-    Alert.alert(
-      t('property.communityNotes.helpfulThanksTitle'),
-      t('property.communityNotes.helpfulThanksBody'),
-    );
-  };
-
-  const handleReport = () => {
-    if (onReport) {
-      onReport(note._id);
-      return;
-    }
-    Alert.alert(
-      t('property.communityNotes.reportTitle'),
-      t('property.communityNotes.reportBody'),
-      [
-        { text: t('common.cancel'), style: 'cancel' },
-        {
-          text: t('property.communityNotes.reportConfirm'),
-          style: 'destructive',
-          onPress: () =>
-            Alert.alert(
-              t('property.communityNotes.reportedTitle'),
-              t('property.communityNotes.reportedBody'),
-            ),
-        },
-      ],
-    );
-  };
-
-  const handleReply = () => {
-    if (onReply) {
-      onReply(note._id);
-      return;
-    }
-    Alert.alert(
-      t('property.communityNotes.replyTitle'),
-      t('property.communityNotes.replyBody'),
-    );
   };
 
   return (
@@ -257,6 +106,8 @@ export const CommunityNoteCard: React.FC<CommunityNoteCardProps> = ({
         <Stars rating={note.rating} />
       </View>
 
+      {note.title ? <BloomText style={styles.title}>{note.title}</BloomText> : null}
+
       <BloomText
         style={styles.body}
         numberOfLines={expanded ? undefined : BODY_CLAMP_LINES}
@@ -279,81 +130,62 @@ export const CommunityNoteCard: React.FC<CommunityNoteCardProps> = ({
         </Pressable>
       ) : null}
 
-      {note.positiveComment ? (
+      {pros.length > 0 ? (
         <View style={styles.commentBlock}>
-          <BloomText style={styles.commentLabel}>
-            {t('property.communityNotes.liked')}
-          </BloomText>
-          <BloomText style={styles.commentText}>{note.positiveComment}</BloomText>
+          <BloomText style={styles.commentLabel}>{t('property.communityNotes.liked')}</BloomText>
+          {pros.map((item, index) => (
+            <BloomText key={`pro-${index}`} style={styles.commentText}>
+              • {item}
+            </BloomText>
+          ))}
         </View>
       ) : null}
 
-      {note.negativeComment ? (
+      {cons.length > 0 ? (
         <View style={styles.commentBlock}>
-          <BloomText style={styles.commentLabel}>
-            {t('property.communityNotes.disliked')}
-          </BloomText>
-          <BloomText style={styles.commentText}>{note.negativeComment}</BloomText>
+          <BloomText style={styles.commentLabel}>{t('property.communityNotes.disliked')}</BloomText>
+          {cons.map((item, index) => (
+            <BloomText key={`con-${index}`} style={styles.commentText}>
+              • {item}
+            </BloomText>
+          ))}
         </View>
       ) : null}
 
-      {showActions ? (
-        <View style={styles.footer}>
-          <View style={styles.footerActions}>
-            <FooterButton
-              icon="thumbs-up-outline"
-              tone={(note.helpfulVotes ?? 0) > 0 ? 'active' : 'default'}
-              label={t('property.communityNotes.helpful', {
-                count: note.helpfulVotes ?? 0,
-              })}
-              onPress={handleHelpful}
-            />
-            <FooterButton
-              icon="flag-outline"
-              label={t('property.communityNotes.report')}
-              onPress={handleReport}
-            />
-            {note.replyAllowed ? (
-              <FooterButton
-                icon="chatbubble-outline"
-                label={t('property.communityNotes.reply')}
-                onPress={handleReply}
-              />
-            ) : null}
-          </View>
+      <View style={styles.footer}>
+        <View style={styles.recommendRow}>
+          <Ionicons
+            name={note.recommendation ? 'thumbs-up' : 'thumbs-down'}
+            size={13}
+            color={note.recommendation ? colors.success : colors.COLOR_BLACK_LIGHT_3}
+          />
+          <BloomText
+            style={[
+              styles.recommendText,
+              { color: note.recommendation ? colors.success : colors.COLOR_BLACK_LIGHT_3 },
+            ]}
+          >
+            {note.recommendation
+              ? t('property.communityNotes.recommends')
+              : t('property.communityNotes.doesNotRecommend')}
+          </BloomText>
+        </View>
 
-          <View style={styles.recommendRow}>
-            <Ionicons
-              name={note.recommendation ? 'thumbs-up' : 'thumbs-down'}
-              size={13}
-              color={note.recommendation ? colors.success : colors.COLOR_BLACK_LIGHT_3}
-            />
-            <BloomText
-              style={[
-                styles.recommendText,
-                {
-                  color: note.recommendation
-                    ? colors.success
-                    : colors.COLOR_BLACK_LIGHT_3,
-                },
-              ]}
-            >
-              {note.recommendation
-                ? t('property.communityNotes.recommends')
-                : t('property.communityNotes.doesNotRecommend')}
+        {note.helpfulCount > 0 ? (
+          <BloomText style={styles.helpfulCount}>
+            {t('property.communityNotes.helpful', { count: note.helpfulCount })}
+          </BloomText>
+        ) : null}
+
+        {note.moderationStatus === ReviewModerationStatus.UNDER_REVIEW ? (
+          <View style={styles.underReview}>
+            <Ionicons name="warning-outline" size={12} color={colors.warning} />
+            <BloomText style={styles.underReviewText}>
+              {t('property.communityNotes.underReview')}
             </BloomText>
           </View>
-
-          {note.moderationStatus === 'flagged' ? (
-            <View style={styles.underReview}>
-              <Ionicons name="warning-outline" size={12} color={colors.warning} />
-              <BloomText style={styles.underReviewText}>
-                {t('property.communityNotes.underReview')}
-              </BloomText>
-            </View>
-          ) : null}
-        </View>
-      ) : null}
+        ) : null}
+      </View>
     </View>
   );
 };
@@ -404,6 +236,11 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: colors.COLOR_BLACK_LIGHT_5,
   },
+  title: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.COLOR_BLACK,
+  },
   body: {
     fontSize: 15,
     lineHeight: 22,
@@ -443,36 +280,18 @@ const styles = StyleSheet.create({
     gap: spacing.md,
     marginTop: spacing.xs,
   },
-  footerActions: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.xs,
-    flexShrink: 1,
-  },
-  footerButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.xs,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
-    borderRadius: radius.md,
-  },
-  footerButtonPressed: {
-    backgroundColor: colors.COLOR_BLACK_LIGHT_7,
-  },
-  footerButtonLabel: {
-    fontSize: 13,
-    fontWeight: '600',
-  },
   recommendRow: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.xs,
-    marginLeft: 'auto',
   },
   recommendText: {
     fontSize: 13,
     fontWeight: '600',
+  },
+  helpfulCount: {
+    fontSize: 13,
+    color: colors.COLOR_BLACK_LIGHT_3,
   },
   underReview: {
     flexDirection: 'row',
@@ -480,8 +299,9 @@ const styles = StyleSheet.create({
     gap: spacing.xs,
     paddingHorizontal: spacing.sm,
     paddingVertical: 2,
-    borderRadius: radius.md,
+    borderRadius: 8,
     backgroundColor: colors.warningSubtle,
+    marginLeft: 'auto',
   },
   underReviewText: {
     fontSize: 11,

--- a/packages/frontend/components/property/CommunityNotesSection.tsx
+++ b/packages/frontend/components/property/CommunityNotesSection.tsx
@@ -1,27 +1,19 @@
 /**
- * CommunityNotesSection — the "Community Notes" block on the property
- * detail page (formerly "Reviews"). Community-sourced notes about the
- * building, rebranded at the presentation layer only; the underlying data
- * is still the Review model served from `/api/reviews/address/:id`.
+ * CommunityNotesSection — the "Community Notes" block on the property detail.
+ * Community-sourced notes about the building, served from
+ * `/api/reviews/address/:id` via the shared `useAddressReviews` hook (the same
+ * `['addressReviews', addressId]` cache the booking card + reviews block read).
  *
- * Airbnb-2026 flat aesthetic (matches the other property sections via the
- * `Section` primitive): no cards/shadows, content sits on the page, blocks
- * separated by hairlines and inset by `SECTION_GUTTER`.
+ * Airbnb-2026 flat aesthetic (matches the other property sections): no cards or
+ * shadows; blocks separated by hairlines and inset by `SECTION_GUTTER`.
  *
- * Composition:
- *  - Rating summary: large average score + star row + total count, plus a
- *    compact 5→1 star-distribution with proportional bars.
- *  - Sort control (Most recent / Highest rated / Most helpful) — the
- *    endpoint does not sort, so we sort the loaded set client-side.
- *  - A list of `CommunityNoteCard`s separated by hairline dividers,
- *    capped at `maxVisible` with a "Show more" toggle and a "View all"
- *    link to the address page for the full thread.
- *  - Loading (Skeleton), error (ErrorState) and empty (EmptyState) states
- *    consistent with the rest of the app.
+ * Composition: a rating summary (average + star distribution), a client-side
+ * sort control (the endpoint does not sort), and a list of read-only
+ * `CommunityNoteCard`s capped at `maxVisible` with a "Show all" toggle + a
+ * "View all" link to the address page.
  */
 import React, { useMemo, useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
-import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
@@ -30,15 +22,15 @@ import { Button } from '@oxyhq/bloom/button';
 import * as Skeleton from '@oxyhq/bloom/skeleton';
 import { H1, Text as BloomText } from '@oxyhq/bloom/typography';
 
-import { CommunityNoteCard, type ReviewData } from '@/components/property/CommunityNoteCard';
+import { CommunityNoteCard } from '@/components/property/CommunityNoteCard';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ErrorState } from '@/components/ui/ErrorState';
 import { Stars } from '@/components/ui/Stars';
 import { SectionHeader, SECTION_GUTTER } from '@/components/property/Section';
-import { api } from '@/utils/api';
+import { useAddressReviews } from '@/hooks/useAddressReviews';
 import { colors } from '@/styles/colors';
 import { hairline, radius, spacing } from '@/constants/styles';
-import type { Property } from '@homiio/shared-types';
+import type { Property, ReviewDTO } from '@homiio/shared-types';
 
 interface CommunityNotesSectionProps {
   property: Property;
@@ -56,28 +48,7 @@ interface AggregatedStats {
   distribution: Record<number, number>;
 }
 
-type ReviewsResponse = {
-  success?: boolean;
-  buildingReviews?: ReviewData[];
-  unitReviews?: ReviewData[];
-  data?: {
-    buildingReviews?: ReviewData[];
-    unitReviews?: ReviewData[];
-  };
-};
-
-const normalizeNote = (raw: ReviewData): ReviewData => ({
-  ...raw,
-  positiveComment: raw.positiveComment ?? '',
-  negativeComment: raw.negativeComment ?? '',
-  isAnonymous: raw.isAnonymous ?? true,
-  evidenceAttached: raw.evidenceAttached ?? false,
-  replyAllowed: raw.replyAllowed ?? true,
-  moderationStatus: raw.moderationStatus ?? 'approved',
-  helpfulVotes: raw.helpfulVotes ?? 0,
-});
-
-const computeStats = (notes: ReviewData[]): AggregatedStats | null => {
+const computeStats = (notes: ReviewDTO[]): AggregatedStats | null => {
   if (notes.length === 0) return null;
   const distribution: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
   let ratingSum = 0;
@@ -94,13 +65,13 @@ const computeStats = (notes: ReviewData[]): AggregatedStats | null => {
   };
 };
 
-const sortNotes = (notes: ReviewData[], sort: SortKey): ReviewData[] => {
+const sortNotes = (notes: ReviewDTO[], sort: SortKey): ReviewDTO[] => {
   const copy = [...notes];
   switch (sort) {
     case 'highest':
       return copy.sort((a, b) => (b.rating || 0) - (a.rating || 0));
     case 'helpful':
-      return copy.sort((a, b) => (b.helpfulVotes ?? 0) - (a.helpfulVotes ?? 0));
+      return copy.sort((a, b) => (b.helpfulCount ?? 0) - (a.helpfulCount ?? 0));
     case 'recent':
     default:
       return copy.sort(
@@ -140,10 +111,7 @@ const RatingSummary: React.FC<RatingSummaryProps> = ({ stats }) => {
               <Ionicons name="star" size={11} color={colors.COLOR_BLACK_LIGHT_5} />
               <View style={styles.distributionTrack}>
                 <View
-                  style={[
-                    styles.distributionFill,
-                    { width: `${Math.round(ratio * 100)}%` },
-                  ]}
+                  style={[styles.distributionFill, { width: `${Math.round(ratio * 100)}%` }]}
                 />
               </View>
               <BloomText style={styles.distributionCount}>{count}</BloomText>
@@ -201,41 +169,11 @@ export const CommunityNotesSection: React.FC<CommunityNotesSectionProps> = ({
   const [sort, setSort] = useState<SortKey>('recent');
   const [expanded, setExpanded] = useState(false);
 
-  // Address id can arrive in a few shapes depending on whether the
-  // property was hydrated from the list vs the detail endpoint.
-  const addressId = useMemo<string | undefined>(() => {
-    const address = property?.address;
-    if (!address || typeof address !== 'object') return undefined;
-    if ('_id' in address) {
-      const id = (address as { _id?: unknown })._id;
-      if (typeof id === 'string') return id;
-    }
-    if ('id' in address) {
-      const id = (address as { id?: unknown }).id;
-      if (typeof id === 'string') return id;
-    }
-    return undefined;
-  }, [property?.address]);
-
   const {
-    data: notes = [],
-    isLoading: loading,
-    error: queryError,
-    refetch,
-  } = useQuery<ReviewData[]>({
-    queryKey: ['addressReviews', addressId],
-    enabled: Boolean(addressId),
-    queryFn: async () => {
-      const response = await api.get<ReviewsResponse>(
-        `/api/reviews/address/${addressId}`,
-      );
-      const payload = response.data;
-      const responseData = payload?.success ? payload : payload?.data ?? payload;
-      const buildingNotes = responseData?.buildingReviews ?? [];
-      const unitNotes = responseData?.unitReviews ?? [];
-      return [...buildingNotes, ...unitNotes].map(normalizeNote);
-    },
-  });
+    addressId,
+    reviews: notes,
+    query: { isLoading: loading, error: queryError, refetch },
+  } = useAddressReviews(property);
 
   const error = queryError
     ? queryError instanceof Error
@@ -286,26 +224,11 @@ export const CommunityNotesSection: React.FC<CommunityNotesSectionProps> = ({
                   <Skeleton.Box width={40} height={40} borderRadius={20} />
                   <View style={styles.skeletonHeaderText}>
                     <Skeleton.Box width="50%" height={13} borderRadius={4} />
-                    <Skeleton.Box
-                      width="35%"
-                      height={11}
-                      borderRadius={4}
-                      style={styles.skeletonLine}
-                    />
+                    <Skeleton.Box width="35%" height={11} borderRadius={4} style={styles.skeletonLine} />
                   </View>
                 </View>
-                <Skeleton.Box
-                  width="100%"
-                  height={12}
-                  borderRadius={4}
-                  style={styles.skeletonLine}
-                />
-                <Skeleton.Box
-                  width="80%"
-                  height={12}
-                  borderRadius={4}
-                  style={styles.skeletonLine}
-                />
+                <Skeleton.Box width="100%" height={12} borderRadius={4} style={styles.skeletonLine} />
+                <Skeleton.Box width="80%" height={12} borderRadius={4} style={styles.skeletonLine} />
               </View>
             ))}
           </View>
@@ -354,10 +277,10 @@ export const CommunityNotesSection: React.FC<CommunityNotesSectionProps> = ({
             <View style={styles.notesList}>
               {visibleNotes.map((note, index) => (
                 <View
-                  key={note._id}
+                  key={note.id}
                   style={[styles.noteRow, index > 0 && styles.noteRowDivider]}
                 >
-                  <CommunityNoteCard note={note} showActions={!isPreview} />
+                  <CommunityNoteCard note={note} />
                 </View>
               ))}
             </View>
@@ -368,9 +291,7 @@ export const CommunityNotesSection: React.FC<CommunityNotesSectionProps> = ({
                   onPress={() => setExpanded(true)}
                   variant="secondary"
                   size="medium"
-                  accessibilityLabel={t('property.communityNotes.showAll', {
-                    count: notes.length,
-                  })}
+                  accessibilityLabel={t('property.communityNotes.showAll', { count: notes.length })}
                 >
                   {t('property.communityNotes.showAll', { count: notes.length })}
                 </Button>
@@ -381,13 +302,7 @@ export const CommunityNotesSection: React.FC<CommunityNotesSectionProps> = ({
                   onPress={handleViewAll}
                   variant="ghost"
                   size="medium"
-                  icon={
-                    <Ionicons
-                      name="open-outline"
-                      size={16}
-                      color={colors.COLOR_BLACK}
-                    />
-                  }
+                  icon={<Ionicons name="open-outline" size={16} color={colors.COLOR_BLACK} />}
                   iconPosition="left"
                   accessibilityLabel={t('property.communityNotes.showMore')}
                 >
@@ -399,9 +314,7 @@ export const CommunityNotesSection: React.FC<CommunityNotesSectionProps> = ({
                 onPress={handleAddNote}
                 variant="ghost"
                 size="medium"
-                icon={
-                  <Ionicons name="create-outline" size={16} color={colors.COLOR_BLACK} />
-                }
+                icon={<Ionicons name="create-outline" size={16} color={colors.COLOR_BLACK} />}
                 iconPosition="left"
                 accessibilityLabel={t('property.communityNotes.addAction')}
               >

--- a/packages/frontend/components/property/ReviewsSection.tsx
+++ b/packages/frontend/components/property/ReviewsSection.tsx
@@ -4,12 +4,11 @@
  * Layout:
  *  - Large rating number + summary line (e.g. "4.8 · 124 reviews").
  *  - 2-column grid of review cards on web, 1-column on mobile.
- *  - "Show all N reviews" Bloom Button when more than `maxVisible`
- *    exist.
+ *  - "Show all N reviews" Bloom Button when more than `maxVisible` exist.
  *
- * Migrated to Bloom Typography, Bloom Button, Bloom Skeleton for
- * the loading state. The actual review-card rendering still uses
- * the shared `ReviewCard` component.
+ * Reads the shared `['addressReviews', addressId]` cache via `useAddressReviews`
+ * and hydrates the authors ONCE (`useOxyAvatars`) so each `ReviewCard` renders a
+ * real avatar + display name.
  */
 import React, { useMemo } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
@@ -21,14 +20,15 @@ import { Button } from '@oxyhq/bloom/button';
 import * as Skeleton from '@oxyhq/bloom/skeleton';
 import { H1, Text as BloomText } from '@oxyhq/bloom/typography';
 
-import { ReviewCard, type ReviewData } from '@/components/ReviewCard';
+import { ReviewCard } from '@/components/ReviewCard';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ErrorState } from '@/components/ui/ErrorState';
 import { SectionHeader, SECTION_GUTTER } from '@/components/property/Section';
 import { useAddressReviews } from '@/hooks/useAddressReviews';
+import { useOxyAvatars } from '@/hooks/useOxyAvatars';
 import { colors } from '@/styles/colors';
 import { hairline, radius, spacing } from '@/constants/styles';
-import type { Property } from '@homiio/shared-types';
+import type { Property, ReviewDTO } from '@homiio/shared-types';
 
 interface ReviewsSectionProps {
   property: Property;
@@ -40,38 +40,17 @@ interface AggregatedStats {
   totalReviews: number;
   recommendationPercentage: number;
   verifiedCount: number;
-  withEvidenceCount: number;
 }
 
-const normalizeReview = (raw: ReviewData): ReviewData => ({
-  ...raw,
-  positiveComment: raw.positiveComment ?? '',
-  negativeComment: raw.negativeComment ?? '',
-  images: raw.images ?? [],
-  services: raw.services ?? [],
-  isAnonymous: raw.isAnonymous ?? true,
-  confidenceScore: raw.confidenceScore ?? 75,
-  evidenceAttached: raw.evidenceAttached ?? false,
-  flaggedIssues: raw.flaggedIssues ?? [],
-  karmaScore: raw.karmaScore ?? 0,
-  replyAllowed: raw.replyAllowed ?? true,
-  moderationStatus: raw.moderationStatus ?? 'approved',
-  helpfulVotes: raw.helpfulVotes ?? 0,
-  unhelpfulVotes: raw.unhelpfulVotes ?? 0,
-  reportCount: raw.reportCount ?? 0,
-  evidenceCount: raw.evidenceCount ?? 0,
-});
-
-const computeStats = (reviews: ReviewData[]): AggregatedStats | null => {
+const computeStats = (reviews: ReviewDTO[]): AggregatedStats | null => {
   if (reviews.length === 0) return null;
   const avg = reviews.reduce((sum, r) => sum + (r.rating || 0), 0) / reviews.length;
-  const recommended = reviews.filter((r) => (r.rating || 0) >= 4).length;
+  const recommended = reviews.filter((r) => r.recommendation).length;
   return {
     averageRating: avg,
     totalReviews: reviews.length,
     recommendationPercentage: (recommended / reviews.length) * 100,
     verifiedCount: reviews.filter((r) => r.verified).length,
-    withEvidenceCount: reviews.filter((r) => r.evidenceAttached).length,
   };
 };
 
@@ -87,8 +66,7 @@ const RatingHeader: React.FC<RatingHeaderProps> = ({ stats }) => {
         <Ionicons name="star" size={28} color={colors.COLOR_BLACK} />
         <H1 style={styles.ratingNumber}>{stats.averageRating.toFixed(1)}</H1>
         <BloomText style={styles.ratingMeta}>
-          · {stats.totalReviews}{' '}
-          {t('property.reviews.count')}
+          · {stats.totalReviews} {t('property.reviews.count')}
         </BloomText>
       </View>
       <View style={styles.statsRow}>
@@ -96,23 +74,11 @@ const RatingHeader: React.FC<RatingHeaderProps> = ({ stats }) => {
           <BloomText style={styles.statValue}>
             {Math.round(stats.recommendationPercentage)}%
           </BloomText>
-          <BloomText style={styles.statLabel}>
-            {t('property.reviews.recommend')}
-          </BloomText>
+          <BloomText style={styles.statLabel}>{t('property.reviews.recommend')}</BloomText>
         </View>
         <View style={styles.statItem}>
           <BloomText style={styles.statValue}>{stats.verifiedCount}</BloomText>
-          <BloomText style={styles.statLabel}>
-            {t('property.reviews.verified')}
-          </BloomText>
-        </View>
-        <View style={styles.statItem}>
-          <BloomText style={styles.statValue}>
-            {stats.withEvidenceCount}
-          </BloomText>
-          <BloomText style={styles.statLabel}>
-            {t('property.reviews.evidence')}
-          </BloomText>
+          <BloomText style={styles.statLabel}>{t('property.reviews.verified')}</BloomText>
         </View>
       </View>
     </View>
@@ -129,17 +95,13 @@ export const ReviewsSection: React.FC<ReviewsSectionProps> = ({
   const isPreview = variant === 'preview';
   const maxVisible = isPreview ? 6 : 10;
 
-  // Shared address-reviews source — the SAME `['addressReviews', addressId]`
-  // query the booking card reads, so the rating math comes from one cache key
-  // and no request is duplicated. Raw reviews are normalized here for the
-  // section's richer card + stats rendering.
   const {
     addressId,
-    reviews: rawReviews,
+    reviews,
     query: { isLoading: loading, error: queryError, refetch },
   } = useAddressReviews(property);
 
-  const reviews = useMemo(() => rawReviews.map(normalizeReview), [rawReviews]);
+  const { usersById } = useOxyAvatars(reviews.map((review) => review.oxyUserId));
 
   const error = queryError
     ? queryError instanceof Error
@@ -148,7 +110,6 @@ export const ReviewsSection: React.FC<ReviewsSectionProps> = ({
     : null;
 
   const stats = useMemo(() => computeStats(reviews), [reviews]);
-
   const visibleReviews = useMemo(
     () => reviews.slice(0, maxVisible),
     [reviews, maxVisible],
@@ -168,123 +129,82 @@ export const ReviewsSection: React.FC<ReviewsSectionProps> = ({
     <View>
       <SectionHeader title={t('property.reviews.title')} />
       <View style={styles.body}>
-      <BloomText style={styles.disclaimer}>
-        {t('property.reviews.disclaimer')}
-      </BloomText>
+        <BloomText style={styles.disclaimer}>{t('property.reviews.disclaimer')}</BloomText>
 
-      {loading ? (
-        <View style={styles.skeletonGrid}>
-          {Array.from({ length: 4 }).map((_, idx) => (
-            <View key={idx} style={styles.skeletonCard}>
-              <Skeleton.Box width="60%" height={14} borderRadius={4} />
-              <Skeleton.Box
-                width="100%"
-                height={12}
-                borderRadius={4}
-                style={styles.skeletonLine}
-              />
-              <Skeleton.Box
-                width="85%"
-                height={12}
-                borderRadius={4}
-                style={styles.skeletonLine}
-              />
-              <Skeleton.Box
-                width="70%"
-                height={12}
-                borderRadius={4}
-                style={styles.skeletonLine}
-              />
-            </View>
-          ))}
-        </View>
-      ) : null}
-
-      {error ? (
-        <ErrorState
-          icon="chatbubbles-outline"
-          title={
-            t('property.reviews.errorTitle')
-          }
-          description={error}
-          retryLabel={t('common.tryAgain')}
-          onRetry={() => {
-            refetch();
-          }}
-        />
-      ) : null}
-
-      {!loading && !error && reviews.length === 0 ? (
-        <EmptyState
-          icon="chatbubbles-outline"
-          title={
-            t('property.reviews.emptyTitle')
-          }
-          description={
-            t('property.reviews.emptyDescription')
-          }
-          actionText={
-            t('property.reviews.writeAction')
-          }
-          actionIcon="create-outline"
-          onAction={handleWriteReview}
-        />
-      ) : null}
-
-      {!loading && !error && reviews.length > 0 ? (
-        <>
-          {stats ? <RatingHeader stats={stats} /> : null}
-          <View style={styles.grid}>
-            {visibleReviews.map((review) => (
-              <View key={review._id} style={styles.gridCell}>
-                <ReviewCard
-                  review={review}
-                  variant={isPreview ? 'compact' : 'default'}
-                  showActions={!isPreview}
-                />
+        {loading ? (
+          <View style={styles.skeletonGrid}>
+            {Array.from({ length: 4 }).map((_, idx) => (
+              <View key={idx} style={styles.skeletonCard}>
+                <Skeleton.Box width="60%" height={14} borderRadius={4} />
+                <Skeleton.Box width="100%" height={12} borderRadius={4} style={styles.skeletonLine} />
+                <Skeleton.Box width="85%" height={12} borderRadius={4} style={styles.skeletonLine} />
+                <Skeleton.Box width="70%" height={12} borderRadius={4} style={styles.skeletonLine} />
               </View>
             ))}
           </View>
-          <View style={styles.actionsRow}>
-            {reviews.length > maxVisible ? (
+        ) : null}
+
+        {error ? (
+          <ErrorState
+            icon="chatbubbles-outline"
+            title={t('property.reviews.errorTitle')}
+            description={error}
+            retryLabel={t('common.tryAgain')}
+            onRetry={() => {
+              refetch();
+            }}
+          />
+        ) : null}
+
+        {!loading && !error && reviews.length === 0 ? (
+          <EmptyState
+            icon="chatbubbles-outline"
+            title={t('property.reviews.emptyTitle')}
+            description={t('property.reviews.emptyDescription')}
+            actionText={t('property.reviews.writeAction')}
+            actionIcon="create-outline"
+            onAction={handleWriteReview}
+          />
+        ) : null}
+
+        {!loading && !error && reviews.length > 0 ? (
+          <>
+            {stats ? <RatingHeader stats={stats} /> : null}
+            <View style={styles.grid}>
+              {visibleReviews.map((review) => (
+                <View key={review.id} style={styles.gridCell}>
+                  <ReviewCard
+                    review={review}
+                    author={usersById.get(review.oxyUserId)}
+                    onPressAgency={(slug) => router.push(`/agency/${slug}`)}
+                  />
+                </View>
+              ))}
+            </View>
+            <View style={styles.actionsRow}>
+              {reviews.length > maxVisible ? (
+                <Button
+                  onPress={handleViewAll}
+                  variant="secondary"
+                  size="medium"
+                  accessibilityLabel={t('property.reviews.showAll', { count: reviews.length })}
+                >
+                  {t('property.reviews.showAll', { count: reviews.length })}
+                </Button>
+              ) : null}
               <Button
-                onPress={handleViewAll}
-                variant="secondary"
+                onPress={handleWriteReview}
+                variant="ghost"
                 size="medium"
-                accessibilityLabel={
-                  t(
-                    'property.reviews.showAll',
-                    `Show all ${reviews.length} reviews`,
-                  ) || `Show all ${reviews.length} reviews`
-                }
+                icon={<Ionicons name="create-outline" size={16} color={colors.COLOR_BLACK} />}
+                iconPosition="left"
+                accessibilityLabel={t('property.reviews.writeAction')}
               >
-                {t(
-                  'property.reviews.showAll',
-                  `Show all ${reviews.length} reviews`,
-                ) || `Show all ${reviews.length} reviews`}
+                {t('property.reviews.writeAction')}
               </Button>
-            ) : null}
-            <Button
-              onPress={handleWriteReview}
-              variant="ghost"
-              size="medium"
-              icon={
-                <Ionicons
-                  name="create-outline"
-                  size={16}
-                  color={colors.COLOR_BLACK}
-                />
-              }
-              iconPosition="left"
-              accessibilityLabel={
-                t('property.reviews.writeAction')
-              }
-            >
-              {t('property.reviews.writeAction')}
-            </Button>
-          </View>
-        </>
-      ) : null}
+            </View>
+          </>
+        ) : null}
       </View>
     </View>
   );

--- a/packages/frontend/components/reviews/DimensionBreakdown.tsx
+++ b/packages/frontend/components/reviews/DimensionBreakdown.tsx
@@ -1,0 +1,165 @@
+/**
+ * DimensionBreakdown — the client-side aggregate distribution for one review
+ * section (apartment / management / building / area), computed from the loaded
+ * reviews. For each dimension present in the set it shows the count of each
+ * enum value as a proportional bar. Renders nothing when the section has no data.
+ */
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+
+import type { ReviewDTO } from '@homiio/shared-types';
+
+import {
+  SECTION_DIMENSIONS,
+  SERVICE_VALUES,
+  type ReviewSection,
+} from '@/components/reviews/dimensions';
+import { colors } from '@/styles/colors';
+import { radius, spacing } from '@/constants/styles';
+
+interface DistributionEntry {
+  label: string;
+  count: number;
+}
+
+interface DistributionBlock {
+  title: string;
+  entries: DistributionEntry[];
+}
+
+interface DimensionBreakdownProps {
+  reviews: ReviewDTO[];
+  section: ReviewSection;
+}
+
+const DistributionRow: React.FC<{ entry: DistributionEntry; max: number }> = ({ entry, max }) => {
+  const ratio = max > 0 ? entry.count / max : 0;
+  return (
+    <View style={styles.row}>
+      <BloomText style={styles.rowLabel} numberOfLines={1}>
+        {entry.label}
+      </BloomText>
+      <View style={styles.track}>
+        <View style={[styles.fill, { width: `${Math.round(ratio * 100)}%` }]} />
+      </View>
+      <BloomText style={styles.rowCount}>{entry.count}</BloomText>
+    </View>
+  );
+};
+
+export const DimensionBreakdown: React.FC<DimensionBreakdownProps> = ({ reviews, section }) => {
+  const { t } = useTranslation();
+  const blocks: DistributionBlock[] = [];
+
+  for (const dimension of SECTION_DIMENSIONS[section]) {
+    const counts = new Map<string, number>();
+    for (const review of reviews) {
+      const raw = review[dimension.field];
+      if (typeof raw === 'string' && raw.length > 0) {
+        counts.set(raw, (counts.get(raw) ?? 0) + 1);
+      }
+    }
+    const entries: DistributionEntry[] = dimension.values
+      .filter((value) => counts.has(value))
+      .map((value) => ({ label: t(`${dimension.enumPrefix}.${value}`), count: counts.get(value) ?? 0 }));
+    if (entries.length > 0) {
+      blocks.push({ title: t(dimension.labelKey), entries });
+    }
+  }
+
+  if (section === 'building') {
+    let yes = 0;
+    let no = 0;
+    for (const review of reviews) {
+      if (review.touristApartments === true) yes += 1;
+      else if (review.touristApartments === false) no += 1;
+    }
+    if (yes + no > 0) {
+      blocks.push({
+        title: t('reviews.write.fields.touristApartments'),
+        entries: [
+          { label: t('common.yes'), count: yes },
+          { label: t('common.no'), count: no },
+        ].filter((entry) => entry.count > 0),
+      });
+    }
+
+    const serviceCounts = new Map<string, number>();
+    for (const review of reviews) {
+      for (const service of review.services ?? []) {
+        serviceCounts.set(service, (serviceCounts.get(service) ?? 0) + 1);
+      }
+    }
+    const serviceEntries: DistributionEntry[] = SERVICE_VALUES.filter((value) => serviceCounts.has(value)).map(
+      (value) => ({ label: t(`reviews.enums.services.${value}`), count: serviceCounts.get(value) ?? 0 }),
+    );
+    if (serviceEntries.length > 0) {
+      blocks.push({ title: t('reviews.write.fields.services'), entries: serviceEntries });
+    }
+  }
+
+  if (blocks.length === 0) return null;
+
+  return (
+    <View style={styles.container}>
+      {blocks.map((block) => {
+        const max = Math.max(...block.entries.map((entry) => entry.count), 1);
+        return (
+          <View key={block.title} style={styles.block}>
+            <BloomText style={styles.blockTitle}>{block.title}</BloomText>
+            {block.entries.map((entry) => (
+              <DistributionRow key={entry.label} entry={entry} max={max} />
+            ))}
+          </View>
+        );
+      })}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.lg,
+  },
+  block: {
+    gap: spacing.xs,
+  },
+  blockTitle: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: colors.COLOR_BLACK,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  rowLabel: {
+    width: 120,
+    fontSize: 12,
+    color: colors.COLOR_BLACK_LIGHT_2,
+  },
+  track: {
+    flex: 1,
+    height: 6,
+    borderRadius: radius.pill,
+    backgroundColor: colors.COLOR_BLACK_LIGHT_7,
+    overflow: 'hidden',
+  },
+  fill: {
+    height: '100%',
+    borderRadius: radius.pill,
+    backgroundColor: colors.primaryColor,
+  },
+  rowCount: {
+    minWidth: 20,
+    fontSize: 12,
+    color: colors.COLOR_BLACK_LIGHT_3,
+    textAlign: 'right',
+  },
+});
+
+export default DimensionBreakdown;

--- a/packages/frontend/components/reviews/EnumChipSelector.tsx
+++ b/packages/frontend/components/reviews/EnumChipSelector.tsx
@@ -1,0 +1,153 @@
+/**
+ * EnumChipSelector — a generic chip row for a dimension enum.
+ *
+ * Give it the enum's values + an i18n key prefix (`reviews.enums.<field>`) and
+ * it renders one labelled chip per value. `multiple` switches between
+ * single-select (tap replaces, tapping the selected chip clears) and
+ * multi-select (toggle in/out of the set). The value in and out is ALWAYS a
+ * flat array, so a single-select field wraps its optional value:
+ * `selected={value ? [value] : []}` / `onChange={(next) => update(field, next[0])}`.
+ *
+ * The chip is its OWN component (`EnumChip`) with static style arrays +
+ * `onPressIn`/`onPressOut`/`onHoverIn`/`onHoverOut` state — never the
+ * NativeWind-incompatible function-form `style`, and safe inside the `.map`
+ * (AGENTS.md §NativeWind Pressable).
+ */
+import React, { useState } from 'react';
+import { Platform, Pressable, StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+
+import { colors } from '@/styles/colors';
+import { hairline, radius, spacing } from '@/constants/styles';
+
+const IS_WEB = Platform.OS === 'web';
+
+interface EnumChipProps {
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+}
+
+/** One selectable chip — owns its own pressed/hovered state. */
+const EnumChip: React.FC<EnumChipProps> = ({ label, selected, onPress }) => {
+  const [pressed, setPressed] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      onHoverIn={IS_WEB ? () => setHovered(true) : undefined}
+      onHoverOut={IS_WEB ? () => setHovered(false) : undefined}
+      accessibilityRole="button"
+      accessibilityState={{ selected }}
+      accessibilityLabel={label}
+      style={[
+        styles.chip,
+        selected && styles.chipSelected,
+        !selected && (pressed || hovered) && styles.chipHovered,
+      ]}
+    >
+      <BloomText style={[styles.chipLabel, selected && styles.chipLabelSelected]}>
+        {label}
+      </BloomText>
+    </Pressable>
+  );
+};
+
+export interface EnumChipSelectorProps<T extends string> {
+  /** Enum values to render, in display order. */
+  values: readonly T[];
+  /** i18n key prefix — each chip's label is `t(`${labelPrefix}.${value}`)`. */
+  labelPrefix: string;
+  /** Optional field label rendered above the chip row. */
+  label?: string;
+  /** Multi-select toggles set membership; single-select replaces / clears. */
+  multiple?: boolean;
+  /** Currently selected values (always an array; empty when nothing is chosen). */
+  selected: readonly T[];
+  /** Fired with the next selected array. */
+  onChange: (next: T[]) => void;
+}
+
+export function EnumChipSelector<T extends string>({
+  values,
+  labelPrefix,
+  label,
+  multiple = false,
+  selected,
+  onChange,
+}: EnumChipSelectorProps<T>) {
+  const { t } = useTranslation();
+
+  const toggle = (value: T) => {
+    if (multiple) {
+      onChange(
+        selected.includes(value)
+          ? selected.filter((entry) => entry !== value)
+          : [...selected, value],
+      );
+      return;
+    }
+    onChange(selected.includes(value) ? [] : [value]);
+  };
+
+  return (
+    <View style={styles.container}>
+      {label ? <BloomText style={styles.label}>{label}</BloomText> : null}
+      <View style={styles.chips}>
+        {values.map((value) => (
+          <EnumChip
+            key={value}
+            label={t(`${labelPrefix}.${value}`)}
+            selected={selected.includes(value)}
+            onPress={() => toggle(value)}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.sm,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.COLOR_BLACK_LIGHT_2,
+  },
+  chips: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  chip: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.pill,
+    borderWidth: hairline.width,
+    borderColor: colors.COLOR_BLACK_LIGHT_6,
+    backgroundColor: colors.surfaceElevated,
+  },
+  chipHovered: {
+    backgroundColor: colors.COLOR_BLACK_LIGHT_7,
+  },
+  chipSelected: {
+    backgroundColor: colors.COLOR_BLACK,
+    borderColor: colors.COLOR_BLACK,
+  },
+  chipLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.COLOR_BLACK,
+  },
+  chipLabelSelected: {
+    color: colors.white,
+  },
+});
+
+export default EnumChipSelector;

--- a/packages/frontend/components/reviews/ExploreRow.tsx
+++ b/packages/frontend/components/reviews/ExploreRow.tsx
@@ -1,0 +1,91 @@
+/**
+ * ExploreRow — a single tappable row in the review-explore lists (city →
+ * neighborhood → building). Owns its own pressed/hovered state with static style
+ * arrays (AGENTS.md §NativeWind Pressable); safe inside a `.map`.
+ */
+import React, { useState } from 'react';
+import { Platform, Pressable, StyleSheet, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+
+import { colors } from '@/styles/colors';
+import { hairline, radius, spacing } from '@/constants/styles';
+
+const IS_WEB = Platform.OS === 'web';
+
+interface ExploreRowProps {
+  title: string;
+  subtitle?: string;
+  /** Right-aligned metric (e.g. "4.6 ★"). */
+  rightLabel?: string;
+  onPress: () => void;
+}
+
+export const ExploreRow: React.FC<ExploreRowProps> = ({ title, subtitle, rightLabel, onPress }) => {
+  const [pressed, setPressed] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      onHoverIn={IS_WEB ? () => setHovered(true) : undefined}
+      onHoverOut={IS_WEB ? () => setHovered(false) : undefined}
+      accessibilityRole="button"
+      accessibilityLabel={title}
+      style={[styles.row, (pressed || hovered) && styles.rowActive]}
+    >
+      <View style={styles.text}>
+        <BloomText style={styles.title} numberOfLines={1}>
+          {title}
+        </BloomText>
+        {subtitle ? (
+          <BloomText style={styles.subtitle} numberOfLines={1}>
+            {subtitle}
+          </BloomText>
+        ) : null}
+      </View>
+      {rightLabel ? <BloomText style={styles.rightLabel}>{rightLabel}</BloomText> : null}
+      <Ionicons name="chevron-forward" size={18} color={colors.COLOR_BLACK_LIGHT_4} />
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderRadius: radius.md,
+    borderWidth: hairline.width,
+    borderColor: colors.COLOR_BLACK_LIGHT_6,
+    backgroundColor: colors.surfaceElevated,
+  },
+  rowActive: {
+    backgroundColor: colors.COLOR_BLACK_LIGHT_7,
+  },
+  text: {
+    flex: 1,
+    minWidth: 0,
+    gap: 2,
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.COLOR_BLACK,
+  },
+  subtitle: {
+    fontSize: 13,
+    color: colors.COLOR_BLACK_LIGHT_3,
+  },
+  rightLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.COLOR_BLACK,
+  },
+});
+
+export default ExploreRow;

--- a/packages/frontend/components/reviews/ReportReviewSheet.tsx
+++ b/packages/frontend/components/reviews/ReportReviewSheet.tsx
@@ -1,0 +1,132 @@
+/**
+ * ReportReviewSheet — the trust & safety report modal. Pick a reason (the
+ * `ReviewReportReason` values as chips); the "other" reason reveals a required
+ * details field. Submit fires `onSubmit(reason, details?)` — the caller wires
+ * `useReportReview`.
+ */
+import React, { useState } from 'react';
+import { Modal, Pressable, StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@oxyhq/bloom/button';
+import { TextFieldInput } from '@oxyhq/bloom/text-field';
+import { H3, Text as BloomText } from '@oxyhq/bloom/typography';
+
+import { ReviewReportReason } from '@homiio/shared-types';
+
+import { EnumChipSelector } from '@/components/reviews/EnumChipSelector';
+import { colors } from '@/styles/colors';
+import { radius, spacing } from '@/constants/styles';
+
+interface ReportReviewSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  onSubmit: (reason: ReviewReportReason, details?: string) => void;
+  submitting: boolean;
+}
+
+export const ReportReviewSheet: React.FC<ReportReviewSheetProps> = ({
+  visible,
+  onClose,
+  onSubmit,
+  submitting,
+}) => {
+  const { t } = useTranslation();
+  const [reason, setReason] = useState<ReviewReportReason | undefined>(undefined);
+  const [details, setDetails] = useState('');
+
+  const needsDetails = reason === ReviewReportReason.OTHER;
+  const canSubmit = Boolean(reason) && (!needsDetails || details.trim().length > 0);
+
+  const handleSubmit = () => {
+    if (!reason || !canSubmit) return;
+    onSubmit(reason, details.trim() || undefined);
+  };
+
+  const handleClose = () => {
+    setReason(undefined);
+    setDetails('');
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={handleClose}>
+      <Pressable
+        style={[StyleSheet.absoluteFill, styles.backdrop]}
+        onPress={handleClose}
+        accessibilityRole="button"
+      />
+      <SafeAreaView edges={['bottom']} style={styles.sheetWrap} pointerEvents="box-none">
+        <View style={styles.sheet}>
+          <H3 style={styles.title}>{t('reviews.card.reportTitle')}</H3>
+          <BloomText style={styles.subtitle}>{t('reviews.card.reportSubtitle')}</BloomText>
+
+          <EnumChipSelector
+            labelPrefix="reviews.card.reportReasons"
+            values={Object.values(ReviewReportReason)}
+            selected={reason ? [reason] : []}
+            onChange={(next) => setReason(next[0])}
+          />
+
+          {needsDetails ? (
+            <TextFieldInput
+              label={t('reviews.card.reportDetails')}
+              placeholder={t('reviews.card.reportDetailsPlaceholder')}
+              value={details}
+              onChangeText={setDetails}
+              multiline
+            />
+          ) : null}
+
+          <View style={styles.actions}>
+            <Button variant="secondary" size="medium" onPress={handleClose} disabled={submitting}>
+              {t('common.cancel')}
+            </Button>
+            <Button
+              variant="primary"
+              size="medium"
+              onPress={handleSubmit}
+              disabled={!canSubmit || submitting}
+              loading={submitting}
+            >
+              {t('reviews.card.reportSubmit')}
+            </Button>
+          </View>
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  backdrop: {
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+  },
+  sheetWrap: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    backgroundColor: colors.background,
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    padding: spacing.xl,
+    gap: spacing.lg,
+  },
+  title: {
+    letterSpacing: -0.3,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: colors.COLOR_BLACK_LIGHT_3,
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+});
+
+export default ReportReviewSheet;

--- a/packages/frontend/components/reviews/ReviewTabPill.tsx
+++ b/packages/frontend/components/reviews/ReviewTabPill.tsx
@@ -1,0 +1,72 @@
+/**
+ * ReviewTabPill — a sub-tab pill for the address review sections. Owns its own
+ * pressed/hovered state with static style arrays (AGENTS.md §NativeWind
+ * Pressable); safe inside a `.map`.
+ */
+import React, { useState } from 'react';
+import { Platform, Pressable, StyleSheet } from 'react-native';
+
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+
+import { colors } from '@/styles/colors';
+import { hairline, radius, spacing } from '@/constants/styles';
+
+const IS_WEB = Platform.OS === 'web';
+
+interface ReviewTabPillProps {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}
+
+export const ReviewTabPill: React.FC<ReviewTabPillProps> = ({ label, active, onPress }) => {
+  const [pressed, setPressed] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      onHoverIn={IS_WEB ? () => setHovered(true) : undefined}
+      onHoverOut={IS_WEB ? () => setHovered(false) : undefined}
+      accessibilityRole="tab"
+      accessibilityState={{ selected: active }}
+      accessibilityLabel={label}
+      style={[
+        styles.pill,
+        active && styles.pillActive,
+        !active && (pressed || hovered) && styles.pillHovered,
+      ]}
+    >
+      <BloomText style={[styles.label, active && styles.labelActive]}>{label}</BloomText>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  pill: {
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.pill,
+    borderWidth: hairline.width,
+    borderColor: colors.COLOR_BLACK_LIGHT_6,
+    backgroundColor: colors.surfaceElevated,
+  },
+  pillHovered: {
+    backgroundColor: colors.COLOR_BLACK_LIGHT_7,
+  },
+  pillActive: {
+    backgroundColor: colors.COLOR_BLACK,
+    borderColor: colors.COLOR_BLACK,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.COLOR_BLACK,
+  },
+  labelActive: {
+    color: colors.white,
+  },
+});
+
+export default ReviewTabPill;

--- a/packages/frontend/components/reviews/WizardProgress.tsx
+++ b/packages/frontend/components/reviews/WizardProgress.tsx
@@ -1,0 +1,125 @@
+/**
+ * WizardProgress — the persistent bottom bar for the write-review wizard: a
+ * step-dot row + "Step X of N" counter above a Back / Next (or Submit on the
+ * last step) button row. The wizard's step content scrolls above it.
+ *
+ * Uses Bloom `Button` for the nav actions (owns its own press state); the dots
+ * are plain Views. `nextDisabled` gates a hard-required step from advancing.
+ */
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@oxyhq/bloom/button';
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+
+import { colors } from '@/styles/colors';
+import { hairline, radius, spacing } from '@/constants/styles';
+
+interface WizardProgressProps {
+  /** Zero-based current step index. */
+  step: number;
+  /** Total number of steps. */
+  totalSteps: number;
+  onBack: () => void;
+  onNext: () => void;
+  onSubmit: () => void;
+  isFirst: boolean;
+  isLast: boolean;
+  /** Disables Next/Submit while a hard-required step is incomplete. */
+  nextDisabled: boolean;
+  submitting: boolean;
+}
+
+export const WizardProgress: React.FC<WizardProgressProps> = ({
+  step,
+  totalSteps,
+  onBack,
+  onNext,
+  onSubmit,
+  isFirst,
+  isLast,
+  nextDisabled,
+  submitting,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.bar}>
+      <View style={styles.dotsRow}>
+        {Array.from({ length: totalSteps }).map((_, index) => (
+          <View
+            key={index}
+            style={[styles.dot, index <= step ? styles.dotActive : null]}
+          />
+        ))}
+      </View>
+      <View style={styles.footerRow}>
+        <BloomText style={styles.counter}>
+          {t('reviews.write.stepCounter', { current: step + 1, total: totalSteps })}
+        </BloomText>
+        <View style={styles.actions}>
+          <Button
+            variant="secondary"
+            size="medium"
+            onPress={onBack}
+            disabled={isFirst || submitting}
+          >
+            {t('common.back')}
+          </Button>
+          <Button
+            variant="primary"
+            size="medium"
+            onPress={isLast ? onSubmit : onNext}
+            disabled={nextDisabled || submitting}
+            loading={isLast && submitting}
+          >
+            {isLast ? t('reviews.write.submit') : t('common.next')}
+          </Button>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  bar: {
+    gap: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.md,
+    borderTopWidth: hairline.width,
+    borderTopColor: hairline.color,
+    backgroundColor: colors.background,
+  },
+  dotsRow: {
+    flexDirection: 'row',
+    gap: spacing.xs,
+  },
+  dot: {
+    flex: 1,
+    height: 4,
+    borderRadius: radius.pill,
+    backgroundColor: colors.COLOR_BLACK_LIGHT_6,
+  },
+  dotActive: {
+    backgroundColor: colors.primaryColor,
+  },
+  footerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.md,
+  },
+  counter: {
+    fontSize: 13,
+    color: colors.COLOR_BLACK_LIGHT_3,
+    fontWeight: '600',
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+});
+
+export default WizardProgress;

--- a/packages/frontend/components/reviews/dimensions.ts
+++ b/packages/frontend/components/reviews/dimensions.ts
@@ -1,0 +1,87 @@
+/**
+ * Dimension metadata shared by the review read surfaces — the `ReviewCard`
+ * dimension chips, the address-page per-section breakdown, and the section
+ * filters. ONE source of truth for "which review fields belong to which section
+ * and how to label them" so the card and the address tabs never drift.
+ */
+import {
+  TemperatureRating,
+  NoiseLevel,
+  LightLevel,
+  ConditionRating,
+  LandlordTreatment,
+  ResponseRating,
+  DepositReturn,
+  NeighborRating,
+  NeighborRelations,
+  CleaningRating,
+  TouristLevel,
+  SecurityLevel,
+  ServiceType,
+  type ReviewDTO,
+} from '@homiio/shared-types';
+
+export type ReviewSection = 'apartment' | 'management' | 'building' | 'area';
+
+export interface DimensionDescriptor {
+  /** The review field this dimension reads. */
+  field: keyof ReviewDTO;
+  /** i18n key for the dimension's label (reuses the wizard field labels). */
+  labelKey: string;
+  /** i18n key prefix for the dimension's enum-value labels. */
+  enumPrefix: string;
+  /** Ordered enum values (drives distribution row ordering). */
+  values: readonly string[];
+}
+
+export const APARTMENT_DIMENSIONS: DimensionDescriptor[] = [
+  { field: 'summerTemperature', labelKey: 'reviews.write.fields.summerTemperature', enumPrefix: 'reviews.enums.temperature', values: Object.values(TemperatureRating) },
+  { field: 'winterTemperature', labelKey: 'reviews.write.fields.winterTemperature', enumPrefix: 'reviews.enums.temperature', values: Object.values(TemperatureRating) },
+  { field: 'noise', labelKey: 'reviews.write.fields.noise', enumPrefix: 'reviews.enums.noise', values: Object.values(NoiseLevel) },
+  { field: 'light', labelKey: 'reviews.write.fields.light', enumPrefix: 'reviews.enums.light', values: Object.values(LightLevel) },
+  { field: 'conditionAndMaintenance', labelKey: 'reviews.write.fields.conditionAndMaintenance', enumPrefix: 'reviews.enums.condition', values: Object.values(ConditionRating) },
+];
+
+export const MANAGEMENT_DIMENSIONS: DimensionDescriptor[] = [
+  { field: 'landlordTreatment', labelKey: 'reviews.write.fields.landlordTreatment', enumPrefix: 'reviews.enums.landlordTreatment', values: Object.values(LandlordTreatment) },
+  { field: 'problemResponse', labelKey: 'reviews.write.fields.problemResponse', enumPrefix: 'reviews.enums.problemResponse', values: Object.values(ResponseRating) },
+  { field: 'depositReturned', labelKey: 'reviews.write.fields.depositReturned', enumPrefix: 'reviews.enums.depositReturned', values: Object.values(DepositReturn) },
+];
+
+export const BUILDING_DIMENSIONS: DimensionDescriptor[] = [
+  { field: 'staircaseNeighbors', labelKey: 'reviews.write.fields.staircaseNeighbors', enumPrefix: 'reviews.enums.staircaseNeighbors', values: Object.values(NeighborRating) },
+  { field: 'neighborRelations', labelKey: 'reviews.write.fields.neighborRelations', enumPrefix: 'reviews.enums.neighborRelations', values: Object.values(NeighborRelations) },
+  { field: 'cleaning', labelKey: 'reviews.write.fields.cleaning', enumPrefix: 'reviews.enums.cleaning', values: Object.values(CleaningRating) },
+];
+
+export const AREA_DIMENSIONS: DimensionDescriptor[] = [
+  { field: 'areaTourists', labelKey: 'reviews.write.fields.areaTourists', enumPrefix: 'reviews.enums.areaTourists', values: Object.values(TouristLevel) },
+  { field: 'areaNoise', labelKey: 'reviews.write.fields.areaNoise', enumPrefix: 'reviews.enums.noise', values: Object.values(NoiseLevel) },
+  { field: 'areaCleanliness', labelKey: 'reviews.write.fields.areaCleanliness', enumPrefix: 'reviews.enums.cleaning', values: Object.values(CleaningRating) },
+  { field: 'areaSecurity', labelKey: 'reviews.write.fields.areaSecurity', enumPrefix: 'reviews.enums.areaSecurity', values: Object.values(SecurityLevel) },
+];
+
+export const SERVICE_VALUES: readonly string[] = Object.values(ServiceType);
+
+export const SECTION_DIMENSIONS: Record<ReviewSection, DimensionDescriptor[]> = {
+  apartment: APARTMENT_DIMENSIONS,
+  management: MANAGEMENT_DIMENSIONS,
+  building: BUILDING_DIMENSIONS,
+  area: AREA_DIMENSIONS,
+};
+
+/** True when the review carries at least one field belonging to `section`. */
+export function reviewHasSection(review: ReviewDTO, section: ReviewSection): boolean {
+  const hasEnum = SECTION_DIMENSIONS[section].some((dimension) => {
+    const raw = review[dimension.field];
+    return typeof raw === 'string' && raw.length > 0;
+  });
+  if (hasEnum) return true;
+  if (section === 'building') {
+    return (
+      typeof review.touristApartments === 'boolean' ||
+      (Array.isArray(review.services) && review.services.length > 0)
+    );
+  }
+  return false;
+}

--- a/packages/frontend/components/reviews/write/EditableList.tsx
+++ b/packages/frontend/components/reviews/write/EditableList.tsx
@@ -1,0 +1,165 @@
+/**
+ * EditableList — the pros / cons capped string-list editor. Type an item, tap
+ * Add (or submit), and it appends to the list (max `maxItems`, each clamped to
+ * `maxLength`). Each row shows the text with a remove button; the remove button
+ * is the shared `IconButton` (owns its own press state → safe in the `.map`).
+ */
+import React, { useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@oxyhq/bloom/button';
+import { TextFieldInput } from '@oxyhq/bloom/text-field';
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+
+import { IconButton } from '@/components/ui/IconButton';
+import { colors } from '@/styles/colors';
+import { hairline, radius, spacing } from '@/constants/styles';
+
+interface EditableListProps {
+  label: string;
+  items: string[];
+  onChange: (items: string[]) => void;
+  placeholder: string;
+  addLabel: string;
+  removeLabel: string;
+  /** Accent tint for the row bullet. */
+  tone: 'positive' | 'negative';
+  maxItems?: number;
+  maxLength?: number;
+}
+
+export const EditableList: React.FC<EditableListProps> = ({
+  label,
+  items,
+  onChange,
+  placeholder,
+  addLabel,
+  removeLabel,
+  tone,
+  maxItems = 10,
+  maxLength = 140,
+}) => {
+  const { t } = useTranslation();
+  const [draft, setDraft] = useState('');
+  const atCapacity = items.length >= maxItems;
+
+  const addItem = () => {
+    const value = draft.trim();
+    if (!value || atCapacity) return;
+    onChange([...items, value.slice(0, maxLength)]);
+    setDraft('');
+  };
+
+  const removeItem = (index: number) => {
+    onChange(items.filter((_, i) => i !== index));
+  };
+
+  const bulletColor = tone === 'positive' ? colors.success : colors.error;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.labelRow}>
+        <BloomText style={styles.label}>{label}</BloomText>
+        <BloomText style={styles.count}>
+          {t('reviews.write.listCount', { current: items.length, max: maxItems })}
+        </BloomText>
+      </View>
+
+      {items.length > 0 ? (
+        <View style={styles.list}>
+          {items.map((item, index) => (
+            <View key={`${item}-${index}`} style={styles.itemRow}>
+              <View style={[styles.bullet, { backgroundColor: bulletColor }]} />
+              <BloomText style={styles.itemText}>{item}</BloomText>
+              <IconButton
+                icon="close"
+                variant="ghost"
+                size={16}
+                onPress={() => removeItem(index)}
+                accessibilityLabel={removeLabel}
+              />
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      {atCapacity ? null : (
+        <View style={styles.addRow}>
+          <View style={styles.addField}>
+            <TextFieldInput
+              label={placeholder}
+              value={draft}
+              onChangeText={setDraft}
+              maxLength={maxLength}
+              onSubmitEditing={addItem}
+              returnKeyType="done"
+            />
+          </View>
+          <Button
+            variant="secondary"
+            size="medium"
+            onPress={addItem}
+            disabled={draft.trim().length === 0}
+          >
+            {addLabel}
+          </Button>
+        </View>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.sm,
+  },
+  labelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.COLOR_BLACK_LIGHT_2,
+  },
+  count: {
+    fontSize: 12,
+    color: colors.COLOR_BLACK_LIGHT_4,
+  },
+  list: {
+    gap: spacing.xs,
+  },
+  itemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radius.md,
+    borderWidth: hairline.width,
+    borderColor: colors.COLOR_BLACK_LIGHT_6,
+    backgroundColor: colors.surfaceElevated,
+  },
+  bullet: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  itemText: {
+    flex: 1,
+    fontSize: 14,
+    color: colors.COLOR_BLACK,
+  },
+  addRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+  },
+  addField: {
+    flex: 1,
+  },
+});
+
+export default EditableList;

--- a/packages/frontend/components/reviews/write/StepAddress.tsx
+++ b/packages/frontend/components/reviews/write/StepAddress.tsx
@@ -1,0 +1,163 @@
+/**
+ * StepAddress — the reviewed address (street/number/building/unit + city/state/
+ * postal/country/neighborhood) plus the map picker. Tapping the map drops a pin
+ * and auto-fills the address via `onAddressSelect` (owned by `write.tsx` so it
+ * can update several fields + navigate the map at once).
+ */
+import React, { type RefObject } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import { TextFieldInput } from '@oxyhq/bloom/text-field';
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+
+import Map, { type MapApi, type AddressData } from '@/components/Map';
+import { StepHeader } from '@/components/reviews/write/StepHeader';
+import type { StepProps } from '@/components/reviews/write/types';
+import { colors } from '@/styles/colors';
+import { radius, spacing } from '@/constants/styles';
+
+interface StepAddressProps extends StepProps {
+  mapRef: RefObject<MapApi | null>;
+  onAddressSelect: (address: AddressData, coordinates: [number, number]) => void;
+}
+
+export const StepAddress: React.FC<StepAddressProps> = ({
+  data,
+  update,
+  mapRef,
+  onAddressSelect,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.container}>
+      <StepHeader
+        title={t('reviews.write.steps.address.title')}
+        subtitle={t('reviews.write.steps.address.subtitle')}
+      />
+
+      <TextFieldInput
+        label={t('reviews.write.fields.street')}
+        placeholder={t('reviews.write.placeholders.street')}
+        value={data.street}
+        onChangeText={(text) => update('street', text)}
+      />
+      <TextFieldInput
+        label={t('reviews.write.fields.number')}
+        placeholder={t('reviews.write.placeholders.number')}
+        value={data.number}
+        onChangeText={(text) => update('number', text)}
+      />
+      <TextFieldInput
+        label={t('reviews.write.fields.buildingName')}
+        placeholder={t('reviews.write.placeholders.buildingName')}
+        value={data.building_name}
+        onChangeText={(text) => update('building_name', text)}
+      />
+      <View style={styles.row}>
+        <View style={styles.rowField}>
+          <TextFieldInput
+            label={t('reviews.write.fields.floor')}
+            placeholder={t('reviews.write.placeholders.floor')}
+            value={data.floor}
+            onChangeText={(text) => update('floor', text)}
+          />
+        </View>
+        <View style={styles.rowField}>
+          <TextFieldInput
+            label={t('reviews.write.fields.unit')}
+            placeholder={t('reviews.write.placeholders.unit')}
+            value={data.unit}
+            onChangeText={(text) => update('unit', text)}
+          />
+        </View>
+      </View>
+      <View style={styles.row}>
+        <View style={styles.rowField}>
+          <TextFieldInput
+            label={t('reviews.write.fields.city')}
+            placeholder={t('reviews.write.placeholders.city')}
+            value={data.city}
+            onChangeText={(text) => update('city', text)}
+          />
+        </View>
+        <View style={styles.rowField}>
+          <TextFieldInput
+            label={t('reviews.write.fields.state')}
+            placeholder={t('reviews.write.placeholders.state')}
+            value={data.state}
+            onChangeText={(text) => update('state', text)}
+          />
+        </View>
+      </View>
+      <View style={styles.row}>
+        <View style={styles.rowField}>
+          <TextFieldInput
+            label={t('reviews.write.fields.postalCode')}
+            placeholder={t('reviews.write.placeholders.postalCode')}
+            value={data.postal_code}
+            onChangeText={(text) => update('postal_code', text)}
+          />
+        </View>
+        <View style={styles.rowField}>
+          <TextFieldInput
+            label={t('reviews.write.fields.country')}
+            placeholder={t('reviews.write.placeholders.country')}
+            value={data.country}
+            onChangeText={(text) => update('country', text)}
+          />
+        </View>
+      </View>
+      <TextFieldInput
+        label={t('reviews.write.fields.neighborhood')}
+        placeholder={t('reviews.write.placeholders.neighborhood')}
+        value={data.neighborhood}
+        onChangeText={(text) => update('neighborhood', text)}
+      />
+
+      <View style={styles.mapWrapper}>
+        <Map
+          ref={mapRef}
+          style={styles.mapInner}
+          enableAddressLookup
+          showAddressInstructions
+          onAddressSelect={onAddressSelect}
+          screenId="write-review"
+        />
+      </View>
+      <BloomText style={styles.mapHint}>
+        {t('reviews.write.mapHint')}
+      </BloomText>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.md,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: spacing.md,
+  },
+  rowField: {
+    flex: 1,
+  },
+  mapWrapper: {
+    marginTop: spacing.sm,
+    borderRadius: radius.md,
+    overflow: 'hidden',
+    backgroundColor: colors.mutedSubtle,
+  },
+  mapInner: {
+    height: 280,
+  },
+  mapHint: {
+    fontSize: 12,
+    color: colors.muted,
+    textAlign: 'center',
+  },
+});
+
+export default StepAddress;

--- a/packages/frontend/components/reviews/write/StepApartment.tsx
+++ b/packages/frontend/components/reviews/write/StepApartment.tsx
@@ -1,0 +1,76 @@
+/**
+ * StepApartment — optional apartment dimensions: summer/winter temperature,
+ * noise, light, condition & maintenance. Every field is skippable.
+ */
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import {
+  TemperatureRating,
+  NoiseLevel,
+  LightLevel,
+  ConditionRating,
+} from '@homiio/shared-types';
+
+import { EnumChipSelector } from '@/components/reviews/EnumChipSelector';
+import { StepHeader } from '@/components/reviews/write/StepHeader';
+import type { StepProps } from '@/components/reviews/write/types';
+import { spacing } from '@/constants/styles';
+
+export const StepApartment: React.FC<StepProps> = ({ data, update }) => {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.container}>
+      <StepHeader
+        title={t('reviews.write.steps.apartment.title')}
+        subtitle={t('reviews.write.steps.apartment.subtitle')}
+      />
+
+      <EnumChipSelector
+        label={t('reviews.write.fields.summerTemperature')}
+        labelPrefix="reviews.enums.temperature"
+        values={Object.values(TemperatureRating)}
+        selected={data.summerTemperature ? [data.summerTemperature] : []}
+        onChange={(next) => update('summerTemperature', next[0])}
+      />
+      <EnumChipSelector
+        label={t('reviews.write.fields.winterTemperature')}
+        labelPrefix="reviews.enums.temperature"
+        values={Object.values(TemperatureRating)}
+        selected={data.winterTemperature ? [data.winterTemperature] : []}
+        onChange={(next) => update('winterTemperature', next[0])}
+      />
+      <EnumChipSelector
+        label={t('reviews.write.fields.noise')}
+        labelPrefix="reviews.enums.noise"
+        values={Object.values(NoiseLevel)}
+        selected={data.noise ? [data.noise] : []}
+        onChange={(next) => update('noise', next[0])}
+      />
+      <EnumChipSelector
+        label={t('reviews.write.fields.light')}
+        labelPrefix="reviews.enums.light"
+        values={Object.values(LightLevel)}
+        selected={data.light ? [data.light] : []}
+        onChange={(next) => update('light', next[0])}
+      />
+      <EnumChipSelector
+        label={t('reviews.write.fields.conditionAndMaintenance')}
+        labelPrefix="reviews.enums.condition"
+        values={Object.values(ConditionRating)}
+        selected={data.conditionAndMaintenance ? [data.conditionAndMaintenance] : []}
+        onChange={(next) => update('conditionAndMaintenance', next[0])}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.xl,
+  },
+});
+
+export default StepApartment;

--- a/packages/frontend/components/reviews/write/StepArea.tsx
+++ b/packages/frontend/components/reviews/write/StepArea.tsx
@@ -1,0 +1,69 @@
+/**
+ * StepArea — the surrounding area: tourist pressure, street noise, cleanliness,
+ * and safety. All optional.
+ */
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import {
+  TouristLevel,
+  NoiseLevel,
+  CleaningRating,
+  SecurityLevel,
+} from '@homiio/shared-types';
+
+import { EnumChipSelector } from '@/components/reviews/EnumChipSelector';
+import { StepHeader } from '@/components/reviews/write/StepHeader';
+import type { StepProps } from '@/components/reviews/write/types';
+import { spacing } from '@/constants/styles';
+
+export const StepArea: React.FC<StepProps> = ({ data, update }) => {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.container}>
+      <StepHeader
+        title={t('reviews.write.steps.area.title')}
+        subtitle={t('reviews.write.steps.area.subtitle')}
+      />
+
+      <EnumChipSelector
+        label={t('reviews.write.fields.areaTourists')}
+        labelPrefix="reviews.enums.areaTourists"
+        values={Object.values(TouristLevel)}
+        selected={data.areaTourists ? [data.areaTourists] : []}
+        onChange={(next) => update('areaTourists', next[0])}
+      />
+      <EnumChipSelector
+        label={t('reviews.write.fields.areaNoise')}
+        labelPrefix="reviews.enums.noise"
+        values={Object.values(NoiseLevel)}
+        selected={data.areaNoise ? [data.areaNoise] : []}
+        onChange={(next) => update('areaNoise', next[0])}
+      />
+      <EnumChipSelector
+        label={t('reviews.write.fields.areaCleanliness')}
+        labelPrefix="reviews.enums.cleaning"
+        values={Object.values(CleaningRating)}
+        selected={data.areaCleanliness ? [data.areaCleanliness] : []}
+        onChange={(next) => update('areaCleanliness', next[0])}
+      />
+      <EnumChipSelector
+        label={t('reviews.write.fields.areaSecurity')}
+        labelPrefix="reviews.enums.areaSecurity"
+        values={Object.values(SecurityLevel)}
+        selected={data.areaSecurity ? [data.areaSecurity] : []}
+        onChange={(next) => update('areaSecurity', next[0])}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.xl,
+  },
+});
+
+export default StepArea;

--- a/packages/frontend/components/reviews/write/StepBuilding.tsx
+++ b/packages/frontend/components/reviews/write/StepBuilding.tsx
@@ -1,0 +1,77 @@
+/**
+ * StepBuilding — the building & neighbours: staircase neighbours, tourist
+ * apartments (yes/no), neighbour relations, common-area cleaning, and the
+ * building's shared services (multi-select). All optional.
+ */
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import {
+  NeighborRating,
+  NeighborRelations,
+  CleaningRating,
+  ServiceType,
+} from '@homiio/shared-types';
+
+import { EnumChipSelector } from '@/components/reviews/EnumChipSelector';
+import { StepHeader } from '@/components/reviews/write/StepHeader';
+import { YesNoSelector } from '@/components/reviews/write/YesNoSelector';
+import type { StepProps } from '@/components/reviews/write/types';
+import { spacing } from '@/constants/styles';
+
+export const StepBuilding: React.FC<StepProps> = ({ data, update }) => {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.container}>
+      <StepHeader
+        title={t('reviews.write.steps.building.title')}
+        subtitle={t('reviews.write.steps.building.subtitle')}
+      />
+
+      <EnumChipSelector
+        label={t('reviews.write.fields.staircaseNeighbors')}
+        labelPrefix="reviews.enums.staircaseNeighbors"
+        values={Object.values(NeighborRating)}
+        selected={data.staircaseNeighbors ? [data.staircaseNeighbors] : []}
+        onChange={(next) => update('staircaseNeighbors', next[0])}
+      />
+      <YesNoSelector
+        label={t('reviews.write.fields.touristApartments')}
+        value={data.touristApartments}
+        onChange={(value) => update('touristApartments', value)}
+      />
+      <EnumChipSelector
+        label={t('reviews.write.fields.neighborRelations')}
+        labelPrefix="reviews.enums.neighborRelations"
+        values={Object.values(NeighborRelations)}
+        selected={data.neighborRelations ? [data.neighborRelations] : []}
+        onChange={(next) => update('neighborRelations', next[0])}
+      />
+      <EnumChipSelector
+        label={t('reviews.write.fields.cleaning')}
+        labelPrefix="reviews.enums.cleaning"
+        values={Object.values(CleaningRating)}
+        selected={data.cleaning ? [data.cleaning] : []}
+        onChange={(next) => update('cleaning', next[0])}
+      />
+      <EnumChipSelector
+        label={t('reviews.write.fields.services')}
+        labelPrefix="reviews.enums.services"
+        multiple
+        values={Object.values(ServiceType)}
+        selected={data.services}
+        onChange={(next) => update('services', next)}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.xl,
+  },
+});
+
+export default StepBuilding;

--- a/packages/frontend/components/reviews/write/StepHeader.tsx
+++ b/packages/frontend/components/reviews/write/StepHeader.tsx
@@ -1,0 +1,38 @@
+/**
+ * StepHeader — the title + optional subtitle block shared by every wizard step.
+ */
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { H2, Text as BloomText } from '@oxyhq/bloom/typography';
+
+import { colors } from '@/styles/colors';
+import { spacing } from '@/constants/styles';
+
+interface StepHeaderProps {
+  title: string;
+  subtitle?: string;
+}
+
+export const StepHeader: React.FC<StepHeaderProps> = ({ title, subtitle }) => (
+  <View style={styles.container}>
+    <H2 style={styles.title}>{title}</H2>
+    {subtitle ? <BloomText style={styles.subtitle}>{subtitle}</BloomText> : null}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.xs,
+  },
+  title: {
+    letterSpacing: -0.4,
+  },
+  subtitle: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: colors.COLOR_BLACK_LIGHT_3,
+  },
+});
+
+export default StepHeader;

--- a/packages/frontend/components/reviews/write/StepManagement.tsx
+++ b/packages/frontend/components/reviews/write/StepManagement.tsx
@@ -1,0 +1,189 @@
+/**
+ * StepManagement — who managed the tenancy and how it went: agency name (with a
+ * debounced typeahead against `/api/agencies/search`), landlord treatment,
+ * problem response, deposit outcome, and free-text advice to the agency /
+ * landlord. All optional.
+ *
+ * The agency search debounces WITHOUT a `useEffect`: each keystroke resets a
+ * timer ref that publishes the debounced term into a `useQuery` key. Result
+ * rows own their own pressed state (extracted `AgencyResultRow`, safe in `.map`).
+ */
+import React, { useRef, useState } from 'react';
+import { Platform, Pressable, StyleSheet, View } from 'react-native';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { Ionicons } from '@expo/vector-icons';
+
+import { TextFieldInput } from '@oxyhq/bloom/text-field';
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+
+import {
+  LandlordTreatment,
+  ResponseRating,
+  DepositReturn,
+  type AgencySummary,
+} from '@homiio/shared-types';
+
+import { EnumChipSelector } from '@/components/reviews/EnumChipSelector';
+import { StepHeader } from '@/components/reviews/write/StepHeader';
+import type { StepProps } from '@/components/reviews/write/types';
+import { reviewService } from '@/services/reviewService';
+import { colors } from '@/styles/colors';
+import { hairline, radius, spacing } from '@/constants/styles';
+
+const IS_WEB = Platform.OS === 'web';
+const SEARCH_DEBOUNCE_MS = 300;
+const MIN_SEARCH_LENGTH = 2;
+
+interface AgencyResultRowProps {
+  agency: AgencySummary;
+  onSelect: () => void;
+}
+
+/** One agency typeahead suggestion — owns its own pressed/hovered state. */
+const AgencyResultRow: React.FC<AgencyResultRowProps> = ({ agency, onSelect }) => {
+  const [pressed, setPressed] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  return (
+    <Pressable
+      onPress={onSelect}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      onHoverIn={IS_WEB ? () => setHovered(true) : undefined}
+      onHoverOut={IS_WEB ? () => setHovered(false) : undefined}
+      accessibilityRole="button"
+      accessibilityLabel={agency.name}
+      style={[styles.resultRow, (pressed || hovered) && styles.resultRowActive]}
+    >
+      <Ionicons name="business-outline" size={16} color={colors.COLOR_BLACK_LIGHT_3} />
+      <BloomText style={styles.resultLabel}>{agency.name}</BloomText>
+    </Pressable>
+  );
+};
+
+export const StepManagement: React.FC<StepProps> = ({ data, update }) => {
+  const { t } = useTranslation();
+  const [term, setTerm] = useState('');
+  const [showResults, setShowResults] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const search = useQuery<AgencySummary[]>({
+    queryKey: ['agencySearch', term],
+    queryFn: () => reviewService.searchAgencies(term),
+    enabled: term.trim().length >= MIN_SEARCH_LENGTH,
+    staleTime: 1000 * 30,
+  });
+
+  const handleAgencyChange = (text: string) => {
+    update('agencyName', text);
+    setShowResults(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setTerm(text), SEARCH_DEBOUNCE_MS);
+  };
+
+  const handleSelectAgency = (agency: AgencySummary) => {
+    update('agencyName', agency.name);
+    setShowResults(false);
+    setTerm('');
+  };
+
+  const results = search.data ?? [];
+  const showSuggestions =
+    showResults && data.agencyName.trim().length >= MIN_SEARCH_LENGTH && results.length > 0;
+
+  return (
+    <View style={styles.container}>
+      <StepHeader
+        title={t('reviews.write.steps.management.title')}
+        subtitle={t('reviews.write.steps.management.subtitle')}
+      />
+
+      <View>
+        <TextFieldInput
+          label={t('reviews.write.fields.agencyName')}
+          placeholder={t('reviews.write.placeholders.agencyName')}
+          value={data.agencyName}
+          onChangeText={handleAgencyChange}
+        />
+        {showSuggestions ? (
+          <View style={styles.results}>
+            {results.map((agency) => (
+              <AgencyResultRow
+                key={agency.id}
+                agency={agency}
+                onSelect={() => handleSelectAgency(agency)}
+              />
+            ))}
+          </View>
+        ) : null}
+      </View>
+
+      <EnumChipSelector
+        label={t('reviews.write.fields.landlordTreatment')}
+        labelPrefix="reviews.enums.landlordTreatment"
+        values={Object.values(LandlordTreatment)}
+        selected={data.landlordTreatment ? [data.landlordTreatment] : []}
+        onChange={(next) => update('landlordTreatment', next[0])}
+      />
+      <EnumChipSelector
+        label={t('reviews.write.fields.problemResponse')}
+        labelPrefix="reviews.enums.problemResponse"
+        values={Object.values(ResponseRating)}
+        selected={data.problemResponse ? [data.problemResponse] : []}
+        onChange={(next) => update('problemResponse', next[0])}
+      />
+      <EnumChipSelector
+        label={t('reviews.write.fields.depositReturned')}
+        labelPrefix="reviews.enums.depositReturned"
+        values={Object.values(DepositReturn)}
+        selected={data.depositReturned ? [data.depositReturned] : []}
+        onChange={(next) => update('depositReturned', next[0])}
+      />
+
+      <TextFieldInput
+        label={t('reviews.write.fields.adviceToAgency')}
+        placeholder={t('reviews.write.placeholders.adviceToAgency')}
+        value={data.adviceToAgency}
+        onChangeText={(text) => update('adviceToAgency', text)}
+        multiline
+      />
+      <TextFieldInput
+        label={t('reviews.write.fields.adviceToLandlord')}
+        placeholder={t('reviews.write.placeholders.adviceToLandlord')}
+        value={data.adviceToLandlord}
+        onChangeText={(text) => update('adviceToLandlord', text)}
+        multiline
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.xl,
+  },
+  results: {
+    marginTop: spacing.xs,
+    borderWidth: hairline.width,
+    borderColor: colors.COLOR_BLACK_LIGHT_6,
+    borderRadius: radius.md,
+    overflow: 'hidden',
+    backgroundColor: colors.surfaceElevated,
+  },
+  resultRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  resultRowActive: {
+    backgroundColor: colors.COLOR_BLACK_LIGHT_7,
+  },
+  resultLabel: {
+    fontSize: 14,
+    color: colors.COLOR_BLACK,
+  },
+});
+
+export default StepManagement;

--- a/packages/frontend/components/reviews/write/StepPhotosRecommend.tsx
+++ b/packages/frontend/components/reviews/write/StepPhotosRecommend.tsx
@@ -1,0 +1,110 @@
+/**
+ * StepPhotosRecommend — the final step: optional photos (uploaded to the
+ * 'reviews' folder), the required overall star rating, and the required
+ * recommendation. Submit is the wizard's `WizardProgress` "Submit" action.
+ */
+import React from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Ionicons } from '@expo/vector-icons';
+
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+
+import { ImageUpload } from '@/components/ImageUpload';
+import { StepHeader } from '@/components/reviews/write/StepHeader';
+import { YesNoSelector } from '@/components/reviews/write/YesNoSelector';
+import type { StepProps } from '@/components/reviews/write/types';
+import { colors } from '@/styles/colors';
+import { spacing } from '@/constants/styles';
+
+const MAX_REVIEW_PHOTOS = 6;
+const STAR_SIZE = 34;
+
+export const StepPhotosRecommend: React.FC<StepProps> = ({ data, update }) => {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.container}>
+      <StepHeader
+        title={t('reviews.write.steps.photos.title')}
+        subtitle={t('reviews.write.steps.photos.subtitle')}
+      />
+
+      <View style={styles.block}>
+        <BloomText style={styles.fieldLabel}>
+          {t('reviews.write.fields.photos')}
+        </BloomText>
+        <ImageUpload
+          images={data.images}
+          onImagesChange={(images) => update('images', images)}
+          folder="reviews"
+          maxImages={MAX_REVIEW_PHOTOS}
+        />
+      </View>
+
+      <View style={styles.block}>
+        <BloomText style={styles.fieldLabel}>
+          {t('reviews.write.fields.rating')}
+        </BloomText>
+        <View style={styles.starsRow}>
+          {[1, 2, 3, 4, 5].map((star) => {
+            const active = star <= data.rating;
+            return (
+              <Pressable
+                key={star}
+                onPress={() => update('rating', star)}
+                style={styles.starButton}
+                accessibilityRole="button"
+                accessibilityLabel={t('reviews.write.rateStar', { star })}
+              >
+                <Ionicons
+                  name={active ? 'star' : 'star-outline'}
+                  size={STAR_SIZE}
+                  color={active ? colors.ratingStar : colors.COLOR_BLACK_LIGHT_5}
+                />
+              </Pressable>
+            );
+          })}
+        </View>
+        <BloomText style={styles.ratingHint}>
+          {data.rating > 0
+            ? t('reviews.write.ratingValue', { rating: data.rating })
+            : t('reviews.write.ratingNone')}
+        </BloomText>
+      </View>
+
+      <YesNoSelector
+        label={t('reviews.write.fields.recommendation')}
+        value={data.recommendation}
+        onChange={(value) => update('recommendation', value)}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.xl,
+  },
+  block: {
+    gap: spacing.sm,
+  },
+  fieldLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.COLOR_BLACK_LIGHT_2,
+  },
+  starsRow: {
+    flexDirection: 'row',
+    gap: spacing.xs,
+  },
+  starButton: {
+    padding: spacing.xs,
+  },
+  ratingHint: {
+    fontSize: 13,
+    color: colors.muted,
+  },
+});
+
+export default StepPhotosRecommend;

--- a/packages/frontend/components/reviews/write/StepPriceDates.tsx
+++ b/packages/frontend/components/reviews/write/StepPriceDates.tsx
@@ -1,0 +1,81 @@
+/**
+ * StepPriceDates — the tenancy money + timeline: monthly rent, currency, and
+ * the lived-from / lived-to dates (kept as the existing YYYY-MM-DD text inputs).
+ * `livedForMonths` is NOT collected — the server derives it from the dates.
+ * Hard-required: price, both dates.
+ */
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import { TextFieldInput } from '@oxyhq/bloom/text-field';
+
+import { EnumChipSelector } from '@/components/reviews/EnumChipSelector';
+import { StepHeader } from '@/components/reviews/write/StepHeader';
+import type { StepProps } from '@/components/reviews/write/types';
+import { spacing } from '@/constants/styles';
+
+const CURRENCIES = ['EUR', 'USD', 'GBP', 'CAD'] as const;
+
+export const StepPriceDates: React.FC<StepProps> = ({ data, update }) => {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.container}>
+      <StepHeader
+        title={t('reviews.write.steps.priceDates.title')}
+        subtitle={t('reviews.write.steps.priceDates.subtitle')}
+      />
+
+      <TextFieldInput
+        label={t('reviews.write.fields.price')}
+        placeholder={t('reviews.write.placeholders.price')}
+        value={data.price}
+        onChangeText={(text) => update('price', text)}
+        keyboardType="numeric"
+      />
+
+      <EnumChipSelector
+        label={t('reviews.write.fields.currency')}
+        labelPrefix="reviews.write.currencies"
+        values={CURRENCIES}
+        selected={[data.currency]}
+        onChange={(next) => update('currency', next[0] ?? data.currency)}
+      />
+
+      <View style={styles.row}>
+        <View style={styles.rowField}>
+          <TextFieldInput
+            label={t('reviews.write.fields.livedFrom')}
+            placeholder={t('reviews.write.placeholders.date')}
+            value={data.livedFrom}
+            onChangeText={(text) => update('livedFrom', text)}
+          />
+        </View>
+        <View style={styles.rowField}>
+          <TextFieldInput
+            label={t('reviews.write.fields.livedTo')}
+            placeholder={t('reviews.write.placeholders.date')}
+            value={data.livedTo}
+            onChangeText={(text) => update('livedTo', text)}
+          />
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.xl,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: spacing.md,
+  },
+  rowField: {
+    flex: 1,
+  },
+});
+
+export default StepPriceDates;

--- a/packages/frontend/components/reviews/write/StepTexts.tsx
+++ b/packages/frontend/components/reviews/write/StepTexts.tsx
@@ -1,0 +1,71 @@
+/**
+ * StepTexts — the written review: a required title + opinion (≥10 chars) and the
+ * optional pros / cons lists (max 10 items each, ≤140 chars).
+ */
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import { TextFieldInput } from '@oxyhq/bloom/text-field';
+
+import { EditableList } from '@/components/reviews/write/EditableList';
+import { StepHeader } from '@/components/reviews/write/StepHeader';
+import type { StepProps } from '@/components/reviews/write/types';
+import { spacing } from '@/constants/styles';
+
+const TITLE_MAX_LENGTH = 120;
+
+export const StepTexts: React.FC<StepProps> = ({ data, update }) => {
+  const { t } = useTranslation();
+
+  return (
+    <View style={styles.container}>
+      <StepHeader
+        title={t('reviews.write.steps.texts.title')}
+        subtitle={t('reviews.write.steps.texts.subtitle')}
+      />
+
+      <TextFieldInput
+        label={t('reviews.write.fields.reviewTitle')}
+        placeholder={t('reviews.write.placeholders.reviewTitle')}
+        value={data.title}
+        onChangeText={(text) => update('title', text)}
+        maxLength={TITLE_MAX_LENGTH}
+      />
+      <TextFieldInput
+        label={t('reviews.write.fields.opinion')}
+        placeholder={t('reviews.write.placeholders.opinion')}
+        value={data.opinion}
+        onChangeText={(text) => update('opinion', text)}
+        multiline
+      />
+
+      <EditableList
+        label={t('reviews.write.fields.pros')}
+        tone="positive"
+        items={data.prosItems}
+        onChange={(items) => update('prosItems', items)}
+        placeholder={t('reviews.write.placeholders.pros')}
+        addLabel={t('reviews.write.addItem')}
+        removeLabel={t('reviews.write.removeItem')}
+      />
+      <EditableList
+        label={t('reviews.write.fields.cons')}
+        tone="negative"
+        items={data.consItems}
+        onChange={(items) => update('consItems', items)}
+        placeholder={t('reviews.write.placeholders.cons')}
+        addLabel={t('reviews.write.addItem')}
+        removeLabel={t('reviews.write.removeItem')}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.xl,
+  },
+});
+
+export default StepTexts;

--- a/packages/frontend/components/reviews/write/YesNoSelector.tsx
+++ b/packages/frontend/components/reviews/write/YesNoSelector.tsx
@@ -1,0 +1,116 @@
+/**
+ * YesNoSelector — a two-chip boolean picker (tourist apartments, recommendation).
+ * The chip is its own component with static style arrays + press/hover state
+ * (AGENTS.md §NativeWind Pressable).
+ */
+import React, { useState } from 'react';
+import { Platform, Pressable, StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import { Text as BloomText } from '@oxyhq/bloom/typography';
+
+import { colors } from '@/styles/colors';
+import { hairline, radius, spacing } from '@/constants/styles';
+
+const IS_WEB = Platform.OS === 'web';
+
+interface ToggleChipProps {
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+}
+
+const ToggleChip: React.FC<ToggleChipProps> = ({ label, selected, onPress }) => {
+  const [pressed, setPressed] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
+      onHoverIn={IS_WEB ? () => setHovered(true) : undefined}
+      onHoverOut={IS_WEB ? () => setHovered(false) : undefined}
+      accessibilityRole="button"
+      accessibilityState={{ selected }}
+      accessibilityLabel={label}
+      style={[
+        styles.chip,
+        selected && styles.chipSelected,
+        !selected && (pressed || hovered) && styles.chipHovered,
+      ]}
+    >
+      <BloomText style={[styles.chipLabel, selected && styles.chipLabelSelected]}>
+        {label}
+      </BloomText>
+    </Pressable>
+  );
+};
+
+interface YesNoSelectorProps {
+  label: string;
+  value: boolean | null | undefined;
+  onChange: (value: boolean) => void;
+}
+
+export const YesNoSelector: React.FC<YesNoSelectorProps> = ({ label, value, onChange }) => {
+  const { t } = useTranslation();
+  return (
+    <View style={styles.container}>
+      <BloomText style={styles.fieldLabel}>{label}</BloomText>
+      <View style={styles.row}>
+        <ToggleChip
+          label={t('common.yes')}
+          selected={value === true}
+          onPress={() => onChange(true)}
+        />
+        <ToggleChip
+          label={t('common.no')}
+          selected={value === false}
+          onPress={() => onChange(false)}
+        />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.sm,
+  },
+  fieldLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.COLOR_BLACK_LIGHT_2,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  chip: {
+    minWidth: 88,
+    alignItems: 'center',
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.pill,
+    borderWidth: hairline.width,
+    borderColor: colors.COLOR_BLACK_LIGHT_6,
+    backgroundColor: colors.surfaceElevated,
+  },
+  chipHovered: {
+    backgroundColor: colors.COLOR_BLACK_LIGHT_7,
+  },
+  chipSelected: {
+    backgroundColor: colors.COLOR_BLACK,
+    borderColor: colors.COLOR_BLACK,
+  },
+  chipLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.COLOR_BLACK,
+  },
+  chipLabelSelected: {
+    color: colors.white,
+  },
+});
+
+export default YesNoSelector;

--- a/packages/frontend/components/reviews/write/types.ts
+++ b/packages/frontend/components/reviews/write/types.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared form state for the write-review wizard. `write.tsx` owns one
+ * `ReviewWizardData` object and a generic `update(field, value)`; each step
+ * component reads + writes fields on it. Enum-typed fields stay optional (every
+ * dimension step is skippable); only the hard-required fields are validated per
+ * step in `write.tsx` before advancing.
+ */
+import type {
+  TemperatureRating,
+  NoiseLevel,
+  LightLevel,
+  ConditionRating,
+  LandlordTreatment,
+  ResponseRating,
+  DepositReturn,
+  NeighborRating,
+  NeighborRelations,
+  CleaningRating,
+  ServiceType,
+  TouristLevel,
+  SecurityLevel,
+} from '@homiio/shared-types';
+import type { UploadedImage } from '@/services/imageUploadService';
+
+export interface ReviewWizardData {
+  // Address (nested address input resolved server-side).
+  street: string;
+  number: string;
+  building_name: string;
+  floor: string;
+  unit: string;
+  city: string;
+  state: string;
+  postal_code: string;
+  country: string;
+  neighborhood: string;
+  latitude?: number;
+  longitude?: number;
+
+  // Apartment dimensions.
+  summerTemperature?: TemperatureRating;
+  winterTemperature?: TemperatureRating;
+  noise?: NoiseLevel;
+  light?: LightLevel;
+  conditionAndMaintenance?: ConditionRating;
+
+  // Management.
+  agencyName: string;
+  landlordTreatment?: LandlordTreatment;
+  problemResponse?: ResponseRating;
+  depositReturned?: DepositReturn;
+  adviceToAgency: string;
+  adviceToLandlord: string;
+
+  // Building.
+  staircaseNeighbors?: NeighborRating;
+  touristApartments?: boolean;
+  neighborRelations?: NeighborRelations;
+  cleaning?: CleaningRating;
+  services: ServiceType[];
+
+  // Area.
+  areaTourists?: TouristLevel;
+  areaNoise?: NoiseLevel;
+  areaCleanliness?: CleaningRating;
+  areaSecurity?: SecurityLevel;
+
+  // Price & dates.
+  price: string;
+  currency: string;
+  livedFrom: string;
+  livedTo: string;
+
+  // Texts.
+  title: string;
+  opinion: string;
+  prosItems: string[];
+  consItems: string[];
+
+  // Photos & recommendation.
+  images: UploadedImage[];
+  rating: number;
+  recommendation: boolean | null;
+}
+
+export const INITIAL_WIZARD_DATA: ReviewWizardData = {
+  street: '',
+  number: '',
+  building_name: '',
+  floor: '',
+  unit: '',
+  city: '',
+  state: '',
+  postal_code: '',
+  country: '',
+  neighborhood: '',
+  latitude: undefined,
+  longitude: undefined,
+  summerTemperature: undefined,
+  winterTemperature: undefined,
+  noise: undefined,
+  light: undefined,
+  conditionAndMaintenance: undefined,
+  agencyName: '',
+  landlordTreatment: undefined,
+  problemResponse: undefined,
+  depositReturned: undefined,
+  adviceToAgency: '',
+  adviceToLandlord: '',
+  staircaseNeighbors: undefined,
+  touristApartments: undefined,
+  neighborRelations: undefined,
+  cleaning: undefined,
+  services: [],
+  areaTourists: undefined,
+  areaNoise: undefined,
+  areaCleanliness: undefined,
+  areaSecurity: undefined,
+  price: '',
+  currency: 'EUR',
+  livedFrom: '',
+  livedTo: '',
+  title: '',
+  opinion: '',
+  prosItems: [],
+  consItems: [],
+  images: [],
+  rating: 0,
+  recommendation: null,
+};
+
+/** Every step receives the current data + a typed field updater. */
+export interface StepProps {
+  data: ReviewWizardData;
+  update: <K extends keyof ReviewWizardData>(field: K, value: ReviewWizardData[K]) => void;
+}

--- a/packages/frontend/hooks/useAddressReviews.ts
+++ b/packages/frontend/hooks/useAddressReviews.ts
@@ -2,33 +2,20 @@
  * useAddressReviews — single source of truth for a property's
  * community/address reviews.
  *
- * Both `ReviewsSection` and `CommunityNotesSection` (and now the booking
- * card's rating badge) read the same `/api/reviews/address/:id` endpoint
- * under the `['addressReviews', addressId]` React Query key. Centralising
- * the address-id extraction + the fetch here keeps that ONE cache key the
- * shared source — so the booking card's rating, the reviews block, and the
- * community-notes block never fire duplicate requests, and the rating math
- * (`averageRating`, `totalReviews`) is computed once, the same way, for every
- * consumer.
+ * Both `ReviewsSection` and `CommunityNotesSection` (and the booking card's
+ * rating badge) read the same `/api/reviews/address/:id` endpoint under the
+ * `['addressReviews', addressId]` React Query key. Centralising the address-id
+ * extraction + the fetch here keeps that ONE cache key the shared source — so
+ * the booking card's rating, the reviews block, and the community-notes block
+ * never fire duplicate requests, and the rating math (`averageRating`,
+ * `totalReviews`) is computed once, the same way, for every consumer.
  */
 import { useMemo } from 'react';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
-import type { Property } from '@homiio/shared-types';
+import type { Property, ReviewDTO } from '@homiio/shared-types';
 
-import type { ReviewData } from '@/components/ReviewCard';
-import { api } from '@/utils/api';
-
-/** Shape of the `/api/reviews/address/:id` payload (success-flag or `data` envelope). */
-interface AddressReviewsResponse {
-  success?: boolean;
-  buildingReviews?: ReviewData[];
-  unitReviews?: ReviewData[];
-  data?: {
-    buildingReviews?: ReviewData[];
-    unitReviews?: ReviewData[];
-  };
-}
+import { reviewService } from '@/services/reviewService';
 
 /** Aggregated rating summary derived from a property's reviews. */
 export interface ReviewRatingSummary {
@@ -58,7 +45,7 @@ export function getReviewAddressId(property: Property | null | undefined): strin
 }
 
 /** Compute the rating summary for a loaded review list. */
-export function computeReviewRatingSummary(reviews: ReviewData[]): ReviewRatingSummary {
+export function computeReviewRatingSummary(reviews: ReviewDTO[]): ReviewRatingSummary {
   if (reviews.length === 0) {
     return { averageRating: 0, totalReviews: 0 };
   }
@@ -73,11 +60,11 @@ export interface UseAddressReviewsResult {
   /** The resolved address id (undefined when the property carries none). */
   addressId: string | undefined;
   /** Raw reviews (building + unit) for the address. */
-  reviews: ReviewData[];
+  reviews: ReviewDTO[];
   /** Aggregated rating summary (`averageRating`, `totalReviews`). */
   ratingSummary: ReviewRatingSummary;
   /** The underlying query, exposed for loading/error/refetch handling. */
-  query: UseQueryResult<ReviewData[], Error>;
+  query: UseQueryResult<ReviewDTO[], Error>;
 }
 
 /**
@@ -91,26 +78,20 @@ export function useAddressReviews(
 ): UseAddressReviewsResult {
   const addressId = useMemo(() => getReviewAddressId(property), [property]);
 
-  const query = useQuery<ReviewData[], Error>({
+  const query = useQuery<ReviewDTO[], Error>({
     queryKey: ['addressReviews', addressId],
     enabled: Boolean(addressId),
     queryFn: async () => {
-      const response = await api.get<AddressReviewsResponse>(
-        `/api/reviews/address/${addressId}`,
-      );
-      const payload = response.data;
-      const responseData = payload?.success ? payload : payload?.data ?? payload;
-      const buildingReviews = responseData?.buildingReviews ?? [];
-      const unitReviews = responseData?.unitReviews ?? [];
-      return [...buildingReviews, ...unitReviews];
+      if (!addressId) return [];
+      const result = await reviewService.getReviewsByAddress(addressId);
+      return result.reviews;
     },
   });
 
-  const reviews = query.data ?? [];
   const ratingSummary = useMemo(
-    () => computeReviewRatingSummary(reviews),
-    [reviews],
+    () => computeReviewRatingSummary(query.data ?? []),
+    [query.data],
   );
 
-  return { addressId, reviews, ratingSummary, query };
+  return { addressId, reviews: query.data ?? [], ratingSummary, query };
 }

--- a/packages/frontend/hooks/useAgencyReviews.ts
+++ b/packages/frontend/hooks/useAgencyReviews.ts
@@ -1,0 +1,96 @@
+/**
+ * Agency data hooks — profile header, paginated reviews, paginated listings.
+ *
+ * The two lists are page-based `useInfiniteQuery`s mirroring
+ * {@link useInfiniteCityProperties}: `getNextPageParam` reads the flat `hasMore`
+ * alias the backend attaches, and the consumer flattens `pages` for rendering.
+ * The reviews query key is `['agencyReviews', slug]` so `useToggleHelpful`'s
+ * optimistic flip reaches it.
+ */
+import {
+  useInfiniteQuery,
+  useQuery,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import type { Property, ReviewDTO } from '@homiio/shared-types';
+
+import {
+  reviewService,
+  type AgencyProfile,
+  type AgencyReviewsPage,
+  type AgencyPropertiesPage,
+} from '@/services/reviewService';
+
+const STALE_TIME_MS = 1000 * 60;
+const GC_TIME_MS = 1000 * 60 * 10;
+
+export function useAgency(slug: string | undefined): UseQueryResult<AgencyProfile, Error> {
+  return useQuery<AgencyProfile, Error>({
+    queryKey: ['agency', slug ?? ''],
+    enabled: Boolean(slug),
+    staleTime: STALE_TIME_MS,
+    gcTime: GC_TIME_MS,
+    queryFn: () => reviewService.getAgency(slug ?? ''),
+  });
+}
+
+export type AgencyReviewsResult = UseInfiniteQueryResult<
+  InfiniteData<AgencyReviewsPage>,
+  Error
+> & {
+  /** All loaded reviews flattened across pages. */
+  reviews: ReviewDTO[];
+};
+
+export function useAgencyReviews(slug: string | undefined): AgencyReviewsResult {
+  const result = useInfiniteQuery({
+    queryKey: ['agencyReviews', slug ?? ''],
+    initialPageParam: 1,
+    enabled: Boolean(slug),
+    staleTime: STALE_TIME_MS,
+    gcTime: GC_TIME_MS,
+    queryFn: ({ pageParam }) => reviewService.getAgencyReviews(slug ?? '', pageParam),
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.page + 1 : undefined),
+  });
+
+  const reviews = useMemo<ReviewDTO[]>(
+    () => result.data?.pages.flatMap((page) => page.reviews) ?? [],
+    [result.data],
+  );
+
+  return { ...result, reviews };
+}
+
+export type AgencyPropertiesResult = UseInfiniteQueryResult<
+  InfiniteData<AgencyPropertiesPage>,
+  Error
+> & {
+  /** All loaded properties flattened across pages. */
+  properties: Property[];
+  /** Total match count reported by the server. */
+  total: number;
+};
+
+export function useAgencyProperties(slug: string | undefined): AgencyPropertiesResult {
+  const result = useInfiniteQuery({
+    queryKey: ['agencyProperties', slug ?? ''],
+    initialPageParam: 1,
+    enabled: Boolean(slug),
+    staleTime: STALE_TIME_MS,
+    gcTime: GC_TIME_MS,
+    queryFn: ({ pageParam }) => reviewService.getAgencyProperties(slug ?? '', pageParam),
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.page + 1 : undefined),
+  });
+
+  const properties = useMemo<Property[]>(
+    () => result.data?.pages.flatMap((page) => page.properties) ?? [],
+    [result.data],
+  );
+  const total = result.data?.pages[0]?.total ?? 0;
+
+  return { ...result, properties, total };
+}

--- a/packages/frontend/hooks/useExploreReviews.ts
+++ b/packages/frontend/hooks/useExploreReviews.ts
@@ -1,0 +1,78 @@
+/**
+ * Review-explore hooks — cities → neighborhoods → buildings.
+ *
+ * Cities and neighborhoods are flat lists (`useQuery`); the building list is
+ * page-based (`useInfiniteQuery`, `getNextPageParam` reads the flat `hasMore`
+ * alias) mirroring {@link useInfiniteCityProperties}. The consumer flattens
+ * `pages` for rendering + wires the shared infinite-scroll primitives.
+ */
+import {
+  useInfiniteQuery,
+  useQuery,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import type {
+  ExploreCitySummary,
+  ExploreNeighborhoodSummary,
+  ExploreBuildingSummary,
+} from '@homiio/shared-types';
+
+import { reviewService, type ExploreBuildingsPage } from '@/services/reviewService';
+
+const STALE_TIME_MS = 1000 * 60 * 2;
+const GC_TIME_MS = 1000 * 60 * 10;
+
+export function useExploreCities(): UseQueryResult<ExploreCitySummary[], Error> {
+  return useQuery<ExploreCitySummary[], Error>({
+    queryKey: ['exploreCities'],
+    staleTime: STALE_TIME_MS,
+    gcTime: GC_TIME_MS,
+    queryFn: () => reviewService.getExploreCities(),
+  });
+}
+
+export function useExploreCity(
+  cityId: string | undefined,
+): UseQueryResult<ExploreNeighborhoodSummary[], Error> {
+  return useQuery<ExploreNeighborhoodSummary[], Error>({
+    queryKey: ['exploreCity', cityId ?? ''],
+    enabled: Boolean(cityId),
+    staleTime: STALE_TIME_MS,
+    gcTime: GC_TIME_MS,
+    queryFn: () => reviewService.getExploreCity(cityId ?? ''),
+  });
+}
+
+export type ExploreNeighborhoodResult = UseInfiniteQueryResult<
+  InfiniteData<ExploreBuildingsPage>,
+  Error
+> & {
+  /** All loaded buildings flattened across pages. */
+  buildings: ExploreBuildingSummary[];
+};
+
+export function useExploreNeighborhood(
+  neighborhoodId: string | undefined,
+): ExploreNeighborhoodResult {
+  const result = useInfiniteQuery({
+    queryKey: ['exploreNeighborhood', neighborhoodId ?? ''],
+    initialPageParam: 1,
+    enabled: Boolean(neighborhoodId),
+    staleTime: STALE_TIME_MS,
+    gcTime: GC_TIME_MS,
+    queryFn: ({ pageParam }) =>
+      reviewService.getExploreNeighborhood(neighborhoodId ?? '', pageParam),
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.page + 1 : undefined),
+  });
+
+  const buildings = useMemo<ExploreBuildingSummary[]>(
+    () => result.data?.pages.flatMap((page) => page.buildings) ?? [],
+    [result.data],
+  );
+
+  return { ...result, buildings };
+}

--- a/packages/frontend/hooks/useReviewMutations.ts
+++ b/packages/frontend/hooks/useReviewMutations.ts
@@ -1,0 +1,102 @@
+/**
+ * Review mutation hooks — helpful votes + reports.
+ *
+ * `useToggleHelpful` optimistically flips `viewerHasVotedHelpful` +
+ * `helpfulCount` on EVERY loaded review list that could contain the review: the
+ * address-review caches (`['addressReviews', addressId]`, a flat `ReviewDTO[]`)
+ * AND the agency-review caches (`['agencyReviews', slug]`, an infinite query of
+ * `{ reviews }` pages). It snapshots every matched cache, applies the flip, and
+ * rolls back on error; on success it writes the server's authoritative
+ * `{ helpfulCount, viewerHasVotedHelpful }`.
+ */
+import {
+  useMutation,
+  useQueryClient,
+  type InfiniteData,
+  type Query,
+} from '@tanstack/react-query';
+
+import type { ReviewDTO, ReviewReportReason } from '@homiio/shared-types';
+
+import { reviewService, type HelpfulResult } from '@/services/reviewService';
+
+/** True for any cache that holds review lists a helpful-flip should touch. */
+const isReviewListQuery = (query: Query): boolean => {
+  const root = query.queryKey[0];
+  return root === 'addressReviews' || root === 'agencyReviews';
+};
+
+type ReviewPage = { reviews: ReviewDTO[] };
+
+/** Apply `mapFn` to every review inside either cache shape (flat array or infinite pages). */
+function mapReviewsInCache(old: unknown, mapFn: (review: ReviewDTO) => ReviewDTO): unknown {
+  if (Array.isArray(old)) {
+    return (old as ReviewDTO[]).map(mapFn);
+  }
+  if (old && typeof old === 'object' && 'pages' in old) {
+    const infinite = old as InfiniteData<ReviewPage>;
+    return {
+      ...infinite,
+      pages: infinite.pages.map((page) => ({
+        ...page,
+        reviews: Array.isArray(page.reviews) ? page.reviews.map(mapFn) : page.reviews,
+      })),
+    };
+  }
+  return old;
+}
+
+export function useToggleHelpful() {
+  const queryClient = useQueryClient();
+
+  return useMutation<HelpfulResult, Error, string, { snapshots: [readonly unknown[], unknown][] }>({
+    mutationFn: (reviewId: string) => reviewService.toggleHelpful(reviewId),
+    onMutate: async (reviewId) => {
+      await queryClient.cancelQueries({ predicate: isReviewListQuery });
+      const snapshots = queryClient.getQueriesData({ predicate: isReviewListQuery });
+      queryClient.setQueriesData({ predicate: isReviewListQuery }, (old) =>
+        mapReviewsInCache(old, (review) =>
+          review.id === reviewId
+            ? {
+                ...review,
+                viewerHasVotedHelpful: !review.viewerHasVotedHelpful,
+                helpfulCount: review.helpfulCount + (review.viewerHasVotedHelpful ? -1 : 1),
+              }
+            : review,
+        ),
+      );
+      return { snapshots };
+    },
+    onError: (_error, _reviewId, context) => {
+      context?.snapshots.forEach(([key, data]) => {
+        queryClient.setQueryData(key, data);
+      });
+    },
+    onSuccess: (result, reviewId) => {
+      queryClient.setQueriesData({ predicate: isReviewListQuery }, (old) =>
+        mapReviewsInCache(old, (review) =>
+          review.id === reviewId
+            ? {
+                ...review,
+                viewerHasVotedHelpful: result.viewerHasVotedHelpful,
+                helpfulCount: result.helpfulCount,
+              }
+            : review,
+        ),
+      );
+    },
+  });
+}
+
+export interface ReportReviewInput {
+  reviewId: string;
+  reason: ReviewReportReason;
+  details?: string;
+}
+
+export function useReportReview() {
+  return useMutation({
+    mutationFn: ({ reviewId, reason, details }: ReportReviewInput) =>
+      reviewService.reportReview(reviewId, reason, details),
+  });
+}

--- a/packages/frontend/locales/ca-ES.json
+++ b/packages/frontend/locales/ca-ES.json
@@ -1425,7 +1425,8 @@
       "verified": "Verified",
       "recommend": "Recommend",
       "count": "reviews",
-      "countWithNumber": "({{count}} ressenyes)"
+      "countWithNumber": "({{count}} ressenyes)",
+      "showAll": "Mostra les {{count}} ressenyes"
     },
     "notFoundHelp": "It may have been removed or the link is broken.",
     "sections": {
@@ -2289,7 +2290,8 @@
       "hostReservations": "Reserves d'amfitrió",
       "landlordApplications": "Safata de sol·licituds",
       "insights": "Insights",
-      "evictions": "Desnonaments"
+      "evictions": "Desnonaments",
+      "reviews": "Ressenyes"
     },
     "actions": {
       "addProperty": "Afegir Propietat",
@@ -3021,7 +3023,30 @@
       "alertReportedTitle": "Reportada",
       "alertReportedBody": "Aquesta ressenya s'ha reportat al nostre equip de moderació.",
       "alertReplyTitle": "Respondre a la ressenya",
-      "alertReplyBody": "La funció de resposta permetrà a arrendadors i administradors de propietats respondre a les ressenyes."
+      "alertReplyBody": "La funció de resposta permetrà a arrendadors i administradors de propietats respondre a les ressenyes.",
+      "pros": "El millor",
+      "cons": "El que es pot millorar",
+      "adviceToLandlord": "Consell per al propietari",
+      "adviceToAgency": "Consell per a l'agència",
+      "managedBy": "Gestionat per {{name}}",
+      "sections": {
+        "apartment": "Habitatge",
+        "management": "Gestió",
+        "building": "Edifici",
+        "area": "Zona"
+      },
+      "reportTitle": "Denuncia aquesta ressenya",
+      "reportSubtitle": "Digues-nos què passa amb aquesta ressenya.",
+      "reportDetails": "Detalls",
+      "reportDetailsPlaceholder": "Afegeix detalls que ens ajudin a revisar-la.",
+      "reportSubmit": "Envia la denúncia",
+      "reportReasons": {
+        "fake": "Falsa o fraudulenta",
+        "offensive": "Ofensiva o abusiva",
+        "personal_data": "Conté dades personals",
+        "spam": "Correu brossa",
+        "other": "Altres"
+      }
     },
     "write": {
       "validationTitle": "Error de validació",
@@ -3039,7 +3064,236 @@
       "submitFailed": "No s'ha pogut enviar la ressenya",
       "submitFailedRetry": "No s'ha pogut enviar la ressenya. Torna-ho a provar.",
       "loadAddressFailed": "Couldn't load address",
-      "title": "Write review"
+      "title": "Write review",
+      "stepCounter": "Pas {{current}} de {{total}}",
+      "submit": "Envia la ressenya",
+      "mapHint": "Toca el mapa per posar un pin i emplenar l'adreça automàticament.",
+      "listCount": "{{current}}/{{max}}",
+      "addItem": "Afegeix",
+      "removeItem": "Treu",
+      "rateStar": "Puntua {{star}} de 5",
+      "ratingValue": "{{rating}} de 5",
+      "ratingNone": "Sense valoració",
+      "steps": {
+        "address": {
+          "title": "On vas viure?",
+          "subtitle": "Indica l'adreça que vols ressenyar. Toca el mapa per emplenar-la."
+        },
+        "apartment": {
+          "title": "L'habitatge",
+          "subtitle": "Opcional: com era viure a la casa."
+        },
+        "management": {
+          "title": "Propietari i agència",
+          "subtitle": "Opcional: qui va gestionar el lloguer i com va anar."
+        },
+        "building": {
+          "title": "L'edifici",
+          "subtitle": "Opcional: veïns, espais comuns i serveis."
+        },
+        "area": {
+          "title": "La zona",
+          "subtitle": "Opcional: el barri al voltant de l'edifici."
+        },
+        "priceDates": {
+          "title": "Lloguer i dates",
+          "subtitle": "Quant pagaves i quan hi vas viure."
+        },
+        "texts": {
+          "title": "La teva ressenya",
+          "subtitle": "Un títol, la teva opinió sincera i el millor i el pitjor."
+        },
+        "photos": {
+          "title": "Fotos i valoració",
+          "subtitle": "Afegeix fotos, valora l'estada i envia."
+        }
+      },
+      "fields": {
+        "street": "Carrer",
+        "number": "Número",
+        "buildingName": "Nom de l'edifici",
+        "floor": "Planta",
+        "unit": "Porta / Pis",
+        "city": "Ciutat",
+        "state": "Província",
+        "postalCode": "Codi postal",
+        "country": "País",
+        "neighborhood": "Barri",
+        "summerTemperature": "Temperatura a l'estiu",
+        "winterTemperature": "Temperatura a l'hivern",
+        "noise": "Soroll",
+        "light": "Llum natural",
+        "conditionAndMaintenance": "Estat i manteniment",
+        "agencyName": "Agència",
+        "landlordTreatment": "Tracte del propietari",
+        "problemResponse": "Resposta davant problemes",
+        "depositReturned": "Devolució de la fiança",
+        "adviceToAgency": "Consell per a l'agència",
+        "adviceToLandlord": "Consell per al propietari",
+        "staircaseNeighbors": "Veïns d'escala",
+        "touristApartments": "Pisos turístics a l'edifici",
+        "neighborRelations": "Relació amb els veïns",
+        "cleaning": "Neteja de zones comunes",
+        "services": "Serveis de l'edifici",
+        "areaTourists": "Turistes a la zona",
+        "areaNoise": "Soroll de la zona",
+        "areaCleanliness": "Neteja de la zona",
+        "areaSecurity": "Seguretat de la zona",
+        "price": "Lloguer mensual",
+        "currency": "Moneda",
+        "livedFrom": "Des de",
+        "livedTo": "Fins a",
+        "reviewTitle": "Títol",
+        "opinion": "La teva opinió",
+        "pros": "El millor",
+        "cons": "El que es pot millorar",
+        "photos": "Fotos",
+        "rating": "Valoració global",
+        "recommendation": "Recomanaries aquesta adreça?"
+      },
+      "placeholders": {
+        "street": "p. ex. Carrer Major 123",
+        "number": "p. ex. 123A",
+        "buildingName": "p. ex. Residencial Sol",
+        "floor": "p. ex. 3",
+        "unit": "p. ex. 3B",
+        "city": "p. ex. Barcelona",
+        "state": "p. ex. Catalunya",
+        "postalCode": "p. ex. 08001",
+        "country": "p. ex. Espanya",
+        "neighborhood": "p. ex. Eixample",
+        "agencyName": "Comença a escriure el nom de l'agència",
+        "adviceToAgency": "Què hauria de millorar l'agència?",
+        "adviceToLandlord": "Què hauria de saber el propietari?",
+        "price": "0,00",
+        "date": "AAAA-MM-DD",
+        "reviewTitle": "Resumeix la teva experiència",
+        "opinion": "Comparteix la teva experiència (més de 10 caràcters)",
+        "pros": "Afegeix una cosa que t'agradés",
+        "cons": "Afegeix una cosa a millorar"
+      },
+      "currencies": {
+        "EUR": "EUR (€)",
+        "USD": "USD ($)",
+        "GBP": "GBP (£)",
+        "CAD": "CAD ($)"
+      }
+    },
+    "explore": {
+      "title": "Ressenyes",
+      "heroTitle": "Explora ressenyes sinceres d'habitatges",
+      "heroSubtitle": "Ressenyes reals d'adreces reals, de qui hi va viure.",
+      "writeCta": "Escriu una ressenya",
+      "citiesTitle": "Ciutats amb ressenyes",
+      "neighborhoodsTitle": "Barris",
+      "buildingsTitle": "Edificis",
+      "reviewCount": "{{count}} ressenyes",
+      "buildingMeta": "{{count}} ressenyes · {{recommend}}% recomanen",
+      "errorTitle": "No s'ha pogut carregar",
+      "errorDescription": "Torna-ho a provar.",
+      "emptyCitiesTitle": "Encara no hi ha ressenyes",
+      "emptyCitiesDescription": "Sigues el primer a ressenyar una adreça de la teva ciutat.",
+      "emptyNeighborhoodsTitle": "Encara no hi ha barris",
+      "emptyNeighborhoodsDescription": "Encara no hi ha barris ressenyats en aquesta ciutat.",
+      "emptyBuildingsTitle": "Encara no hi ha edificis",
+      "emptyBuildingsDescription": "Encara no hi ha edificis ressenyats en aquest barri."
+    },
+    "enums": {
+      "temperature": {
+        "very_cold": "Molt freda",
+        "cold": "Freda",
+        "moderate": "Temperada",
+        "warm": "Càlida",
+        "very_warm": "Molt càlida"
+      },
+      "noise": {
+        "very_quiet": "Molt silenciós",
+        "quiet": "Silenciós",
+        "moderate": "Moderat",
+        "noisy": "Sorollós",
+        "very_noisy": "Molt sorollós"
+      },
+      "light": {
+        "very_dark": "Molt fosca",
+        "dark": "Fosca",
+        "moderate": "Moderada",
+        "bright": "Lluminosa",
+        "very_bright": "Molt lluminosa"
+      },
+      "condition": {
+        "poor": "Dolent",
+        "fair": "Regular",
+        "good": "Bo",
+        "very_good": "Molt bo",
+        "excellent": "Excel·lent"
+      },
+      "landlordTreatment": {
+        "very_poor": "Molt dolent",
+        "poor": "Dolent",
+        "fair": "Regular",
+        "good": "Bo",
+        "excellent": "Excel·lent"
+      },
+      "problemResponse": {
+        "never_responded": "Mai va respondre",
+        "very_slow": "Molt lenta",
+        "slow": "Lenta",
+        "reasonable": "Raonable",
+        "fast": "Ràpida",
+        "very_fast": "Molt ràpida"
+      },
+      "depositReturned": {
+        "full": "Tornada íntegra",
+        "partial": "Tornada en part",
+        "no": "No tornada"
+      },
+      "staircaseNeighbors": {
+        "very_unfriendly": "Molt antipàtics",
+        "unfriendly": "Antipàtics",
+        "neutral": "Neutrals",
+        "friendly": "Amables",
+        "very_friendly": "Molt amables"
+      },
+      "neighborRelations": {
+        "very_poor": "Molt dolentes",
+        "poor": "Dolentes",
+        "fair": "Regulars",
+        "good": "Bones",
+        "excellent": "Excel·lents"
+      },
+      "cleaning": {
+        "very_dirty": "Molt bruta",
+        "dirty": "Bruta",
+        "acceptable": "Acceptable",
+        "clean": "Neta",
+        "very_clean": "Molt neta"
+      },
+      "areaTourists": {
+        "none": "Cap",
+        "few": "Pocs",
+        "moderate": "Moderat",
+        "many": "Molts",
+        "overwhelming": "Excessiu"
+      },
+      "areaSecurity": {
+        "very_unsafe": "Molt insegura",
+        "unsafe": "Insegura",
+        "neutral": "Neutral",
+        "safe": "Segura",
+        "very_safe": "Molt segura"
+      },
+      "services": {
+        "internet": "Internet",
+        "cable_tv": "TV per cable",
+        "parking": "Pàrquing",
+        "laundry": "Bugaderia",
+        "gym": "Gimnàs",
+        "pool": "Piscina",
+        "concierge": "Consergeria",
+        "security": "Seguretat",
+        "maintenance": "Manteniment",
+        "cleaning": "Neteja"
+      }
     }
   },
   "subscriptions": {
@@ -3219,7 +3473,13 @@
       "tabCommunity": "Comunitat",
       "tabArea": "Zona",
       "tabProperties": "Propietats ({{count}})",
-      "tabReviews": "Ressenyes ({{count}})"
+      "tabReviews": "Ressenyes ({{count}})",
+      "tabApartment": "Habitatge",
+      "tabManagement": "Gestió",
+      "tabBuilding": "Edifici",
+      "metricRating": "Valoració mitjana",
+      "metricReviews": "Ressenyes",
+      "metricRecommend": "Recomanen"
     },
     "display": {
       "copySuccess": "Adreça copiada al porta-retalls",
@@ -3673,5 +3933,26 @@
       "updateSuccess": "Canvis desats",
       "submitError": "No s'ha pogut desar el cas"
     }
+  },
+  "agency": {
+    "title": "Agència",
+    "viewAddress": "Mostra l'adreça",
+    "notFound": "Agència no trobada",
+    "notFoundDescription": "No hem trobat aquesta agència.",
+    "stats": {
+      "rating": "Valoració",
+      "reviews": "Ressenyes",
+      "recommend": "Recomanen",
+      "depositFull": "Fiança tornada",
+      "listings": "Anuncis"
+    },
+    "tabs": {
+      "reviews": "Ressenyes",
+      "listings": "Anuncis"
+    },
+    "emptyReviewsTitle": "Encara no hi ha ressenyes",
+    "emptyReviewsDescription": "Aquesta agència encara no té ressenyes.",
+    "emptyListingsTitle": "Sense anuncis",
+    "emptyListingsDescription": "Aquesta agència no té anuncis actius."
   }
 }

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -1939,7 +1939,8 @@
       "hostCalendar": "Host calendar",
       "hostReservations": "Host reservations",
       "landlordApplications": "Applicant inbox",
-      "evictions": "Eviction watch"
+      "evictions": "Eviction watch",
+      "reviews": "Reviews"
     },
     "actions": {
       "addProperty": "Add Property",
@@ -2300,7 +2301,8 @@
       "verified": "Verified",
       "recommend": "Recommend",
       "count": "reviews",
-      "countWithNumber": "({{count}} reviews)"
+      "countWithNumber": "({{count}} reviews)",
+      "showAll": "Show all {{count}} reviews"
     },
     "notFoundHelp": "It may have been removed or the link is broken.",
     "sections": {
@@ -2956,7 +2958,30 @@
       "alertReportedTitle": "Reported",
       "alertReportedBody": "This review has been reported to our moderation team.",
       "alertReplyTitle": "Reply to Review",
-      "alertReplyBody": "Reply functionality will allow landlords and property managers to respond to reviews."
+      "alertReplyBody": "Reply functionality will allow landlords and property managers to respond to reviews.",
+      "pros": "What went well",
+      "cons": "What could be better",
+      "adviceToLandlord": "Advice to the landlord",
+      "adviceToAgency": "Advice to the agency",
+      "managedBy": "Managed by {{name}}",
+      "sections": {
+        "apartment": "Apartment",
+        "management": "Management",
+        "building": "Building",
+        "area": "Area"
+      },
+      "reportTitle": "Report this review",
+      "reportSubtitle": "Tell us what's wrong with this review.",
+      "reportDetails": "Details",
+      "reportDetailsPlaceholder": "Add any details that help us review this.",
+      "reportSubmit": "Submit report",
+      "reportReasons": {
+        "fake": "Fake or fraudulent",
+        "offensive": "Offensive or abusive",
+        "personal_data": "Contains personal data",
+        "spam": "Spam",
+        "other": "Other"
+      }
     },
     "write": {
       "validationTitle": "Validation Error",
@@ -2974,7 +2999,236 @@
       "submitFailed": "Failed to submit review",
       "submitFailedRetry": "Failed to submit review. Please try again.",
       "loadAddressFailed": "Couldn't load address",
-      "title": "Write review"
+      "title": "Write review",
+      "stepCounter": "Step {{current}} of {{total}}",
+      "submit": "Submit review",
+      "mapHint": "Tap the map to drop a pin and auto-fill the address.",
+      "listCount": "{{current}}/{{max}}",
+      "addItem": "Add",
+      "removeItem": "Remove",
+      "rateStar": "Rate {{star}} of 5",
+      "ratingValue": "{{rating}} of 5",
+      "ratingNone": "No rating yet",
+      "steps": {
+        "address": {
+          "title": "Where did you live?",
+          "subtitle": "Enter the address you're reviewing. Tap the map to auto-fill it."
+        },
+        "apartment": {
+          "title": "The apartment",
+          "subtitle": "Optional — how the home itself felt to live in."
+        },
+        "management": {
+          "title": "Landlord & agency",
+          "subtitle": "Optional — who managed the tenancy and how it went."
+        },
+        "building": {
+          "title": "The building",
+          "subtitle": "Optional — neighbours, shared spaces and services."
+        },
+        "area": {
+          "title": "The area",
+          "subtitle": "Optional — the neighbourhood around the building."
+        },
+        "priceDates": {
+          "title": "Rent & dates",
+          "subtitle": "What you paid and when you lived there."
+        },
+        "texts": {
+          "title": "Your review",
+          "subtitle": "A title, your honest opinion, and the highs and lows."
+        },
+        "photos": {
+          "title": "Photos & rating",
+          "subtitle": "Add photos, rate your stay, and submit."
+        }
+      },
+      "fields": {
+        "street": "Street address",
+        "number": "Building number",
+        "buildingName": "Building name",
+        "floor": "Floor",
+        "unit": "Unit / Apt",
+        "city": "City",
+        "state": "State / Province",
+        "postalCode": "Postal code",
+        "country": "Country",
+        "neighborhood": "Neighborhood",
+        "summerTemperature": "Summer temperature",
+        "winterTemperature": "Winter temperature",
+        "noise": "Noise",
+        "light": "Natural light",
+        "conditionAndMaintenance": "Condition & maintenance",
+        "agencyName": "Agency",
+        "landlordTreatment": "Landlord treatment",
+        "problemResponse": "Response to problems",
+        "depositReturned": "Deposit returned",
+        "adviceToAgency": "Advice to the agency",
+        "adviceToLandlord": "Advice to the landlord",
+        "staircaseNeighbors": "Staircase neighbours",
+        "touristApartments": "Tourist apartments in the building",
+        "neighborRelations": "Neighbour relations",
+        "cleaning": "Common-area cleaning",
+        "services": "Building services",
+        "areaTourists": "Tourists in the area",
+        "areaNoise": "Area noise",
+        "areaCleanliness": "Area cleanliness",
+        "areaSecurity": "Area safety",
+        "price": "Monthly rent",
+        "currency": "Currency",
+        "livedFrom": "Lived from",
+        "livedTo": "Lived to",
+        "reviewTitle": "Title",
+        "opinion": "Your opinion",
+        "pros": "What went well",
+        "cons": "What could be better",
+        "photos": "Photos",
+        "rating": "Overall rating",
+        "recommendation": "Would you recommend this address?"
+      },
+      "placeholders": {
+        "street": "e.g. 123 Main Street",
+        "number": "e.g. 123A",
+        "buildingName": "e.g. Sunset Apartments",
+        "floor": "e.g. 3",
+        "unit": "e.g. 3B",
+        "city": "e.g. Barcelona",
+        "state": "e.g. Catalonia",
+        "postalCode": "e.g. 08001",
+        "country": "e.g. Spain",
+        "neighborhood": "e.g. Eixample",
+        "agencyName": "Start typing the agency name",
+        "adviceToAgency": "What should the agency improve?",
+        "adviceToLandlord": "What should the landlord know?",
+        "price": "0.00",
+        "date": "YYYY-MM-DD",
+        "reviewTitle": "Sum up your experience",
+        "opinion": "Share your experience (10+ characters)",
+        "pros": "Add something you liked",
+        "cons": "Add something to improve"
+      },
+      "currencies": {
+        "EUR": "EUR (€)",
+        "USD": "USD ($)",
+        "GBP": "GBP (£)",
+        "CAD": "CAD ($)"
+      }
+    },
+    "explore": {
+      "title": "Reviews",
+      "heroTitle": "Explore honest home reviews",
+      "heroSubtitle": "Real reviews of real addresses, from the people who lived there.",
+      "writeCta": "Write a review",
+      "citiesTitle": "Cities with reviews",
+      "neighborhoodsTitle": "Neighborhoods",
+      "buildingsTitle": "Buildings",
+      "reviewCount": "{{count}} reviews",
+      "buildingMeta": "{{count}} reviews · {{recommend}}% recommend",
+      "errorTitle": "Couldn't load",
+      "errorDescription": "Please try again.",
+      "emptyCitiesTitle": "No reviews yet",
+      "emptyCitiesDescription": "Be the first to review an address in your city.",
+      "emptyNeighborhoodsTitle": "No neighborhoods yet",
+      "emptyNeighborhoodsDescription": "No reviewed neighborhoods in this city yet.",
+      "emptyBuildingsTitle": "No buildings yet",
+      "emptyBuildingsDescription": "No reviewed buildings in this neighborhood yet."
+    },
+    "enums": {
+      "temperature": {
+        "very_cold": "Very cold",
+        "cold": "Cold",
+        "moderate": "Moderate",
+        "warm": "Warm",
+        "very_warm": "Very warm"
+      },
+      "noise": {
+        "very_quiet": "Very quiet",
+        "quiet": "Quiet",
+        "moderate": "Moderate",
+        "noisy": "Noisy",
+        "very_noisy": "Very noisy"
+      },
+      "light": {
+        "very_dark": "Very dark",
+        "dark": "Dark",
+        "moderate": "Moderate",
+        "bright": "Bright",
+        "very_bright": "Very bright"
+      },
+      "condition": {
+        "poor": "Poor",
+        "fair": "Fair",
+        "good": "Good",
+        "very_good": "Very good",
+        "excellent": "Excellent"
+      },
+      "landlordTreatment": {
+        "very_poor": "Very poor",
+        "poor": "Poor",
+        "fair": "Fair",
+        "good": "Good",
+        "excellent": "Excellent"
+      },
+      "problemResponse": {
+        "never_responded": "Never responded",
+        "very_slow": "Very slow",
+        "slow": "Slow",
+        "reasonable": "Reasonable",
+        "fast": "Fast",
+        "very_fast": "Very fast"
+      },
+      "depositReturned": {
+        "full": "Returned in full",
+        "partial": "Partially returned",
+        "no": "Not returned"
+      },
+      "staircaseNeighbors": {
+        "very_unfriendly": "Very unfriendly",
+        "unfriendly": "Unfriendly",
+        "neutral": "Neutral",
+        "friendly": "Friendly",
+        "very_friendly": "Very friendly"
+      },
+      "neighborRelations": {
+        "very_poor": "Very poor",
+        "poor": "Poor",
+        "fair": "Fair",
+        "good": "Good",
+        "excellent": "Excellent"
+      },
+      "cleaning": {
+        "very_dirty": "Very dirty",
+        "dirty": "Dirty",
+        "acceptable": "Acceptable",
+        "clean": "Clean",
+        "very_clean": "Very clean"
+      },
+      "areaTourists": {
+        "none": "None",
+        "few": "Few",
+        "moderate": "Moderate",
+        "many": "Many",
+        "overwhelming": "Overwhelming"
+      },
+      "areaSecurity": {
+        "very_unsafe": "Very unsafe",
+        "unsafe": "Unsafe",
+        "neutral": "Neutral",
+        "safe": "Safe",
+        "very_safe": "Very safe"
+      },
+      "services": {
+        "internet": "Internet",
+        "cable_tv": "Cable TV",
+        "parking": "Parking",
+        "laundry": "Laundry",
+        "gym": "Gym",
+        "pool": "Pool",
+        "concierge": "Concierge",
+        "security": "Security",
+        "maintenance": "Maintenance",
+        "cleaning": "Cleaning"
+      }
     }
   },
   "subscriptions": {
@@ -3169,7 +3423,13 @@
       "tabCommunity": "Community",
       "tabArea": "Area",
       "tabProperties": "Properties ({{count}})",
-      "tabReviews": "Reviews ({{count}})"
+      "tabReviews": "Reviews ({{count}})",
+      "tabApartment": "Apartment",
+      "tabManagement": "Management",
+      "tabBuilding": "Building",
+      "metricRating": "Avg rating",
+      "metricReviews": "Reviews",
+      "metricRecommend": "Recommend"
     },
     "display": {
       "copySuccess": "Address copied to clipboard",
@@ -3608,5 +3868,26 @@
       "updateSuccess": "Changes saved",
       "submitError": "Couldn't save the case"
     }
+  },
+  "agency": {
+    "title": "Agency",
+    "viewAddress": "View address",
+    "notFound": "Agency not found",
+    "notFoundDescription": "We couldn't find this agency.",
+    "stats": {
+      "rating": "Rating",
+      "reviews": "Reviews",
+      "recommend": "Recommend",
+      "depositFull": "Deposit back",
+      "listings": "Listings"
+    },
+    "tabs": {
+      "reviews": "Reviews",
+      "listings": "Listings"
+    },
+    "emptyReviewsTitle": "No reviews yet",
+    "emptyReviewsDescription": "This agency has no reviews yet.",
+    "emptyListingsTitle": "No listings",
+    "emptyListingsDescription": "This agency has no active listings."
   }
 }

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -1404,7 +1404,8 @@
       "verified": "Verified",
       "recommend": "Recommend",
       "count": "reviews",
-      "countWithNumber": "({{count}} reseñas)"
+      "countWithNumber": "({{count}} reseñas)",
+      "showAll": "Ver las {{count}} reseñas"
     },
     "notFoundHelp": "It may have been removed or the link is broken.",
     "sections": {
@@ -2268,7 +2269,8 @@
       "hostReservations": "Reservas de anfitrión",
       "landlordApplications": "Bandeja de solicitudes",
       "insights": "Insights",
-      "evictions": "Desahucios"
+      "evictions": "Desahucios",
+      "reviews": "Reseñas"
     },
     "actions": {
       "addProperty": "Agregar Propiedad",
@@ -3000,7 +3002,30 @@
       "alertReportedTitle": "Reportada",
       "alertReportedBody": "Esta reseña ha sido reportada a nuestro equipo de moderación.",
       "alertReplyTitle": "Responder a la reseña",
-      "alertReplyBody": "La función de respuesta permitirá a arrendadores y administradores de propiedades responder a las reseñas."
+      "alertReplyBody": "La función de respuesta permitirá a arrendadores y administradores de propiedades responder a las reseñas.",
+      "pros": "Lo mejor",
+      "cons": "Lo mejorable",
+      "adviceToLandlord": "Consejo para el propietario",
+      "adviceToAgency": "Consejo para la agencia",
+      "managedBy": "Gestionado por {{name}}",
+      "sections": {
+        "apartment": "Vivienda",
+        "management": "Gestión",
+        "building": "Edificio",
+        "area": "Zona"
+      },
+      "reportTitle": "Denunciar esta reseña",
+      "reportSubtitle": "Dinos qué problema tiene esta reseña.",
+      "reportDetails": "Detalles",
+      "reportDetailsPlaceholder": "Añade detalles que nos ayuden a revisarla.",
+      "reportSubmit": "Enviar denuncia",
+      "reportReasons": {
+        "fake": "Falsa o fraudulenta",
+        "offensive": "Ofensiva o abusiva",
+        "personal_data": "Contiene datos personales",
+        "spam": "Spam",
+        "other": "Otro"
+      }
     },
     "write": {
       "validationTitle": "Error de validación",
@@ -3018,7 +3043,236 @@
       "submitFailed": "No se pudo enviar la reseña",
       "submitFailedRetry": "No se pudo enviar la reseña. Inténtalo de nuevo.",
       "loadAddressFailed": "Couldn't load address",
-      "title": "Write review"
+      "title": "Write review",
+      "stepCounter": "Paso {{current}} de {{total}}",
+      "submit": "Enviar reseña",
+      "mapHint": "Toca el mapa para colocar un pin y autocompletar la dirección.",
+      "listCount": "{{current}}/{{max}}",
+      "addItem": "Añadir",
+      "removeItem": "Quitar",
+      "rateStar": "Puntúa {{star}} de 5",
+      "ratingValue": "{{rating}} de 5",
+      "ratingNone": "Sin valoración",
+      "steps": {
+        "address": {
+          "title": "¿Dónde viviste?",
+          "subtitle": "Indica la dirección que quieres reseñar. Toca el mapa para autocompletarla."
+        },
+        "apartment": {
+          "title": "La vivienda",
+          "subtitle": "Opcional: cómo se vivía en la propia casa."
+        },
+        "management": {
+          "title": "Propietario y agencia",
+          "subtitle": "Opcional: quién gestionó el alquiler y cómo fue."
+        },
+        "building": {
+          "title": "El edificio",
+          "subtitle": "Opcional: vecinos, zonas comunes y servicios."
+        },
+        "area": {
+          "title": "La zona",
+          "subtitle": "Opcional: el barrio alrededor del edificio."
+        },
+        "priceDates": {
+          "title": "Alquiler y fechas",
+          "subtitle": "Cuánto pagabas y cuándo viviste allí."
+        },
+        "texts": {
+          "title": "Tu reseña",
+          "subtitle": "Un título, tu opinión sincera y lo mejor y lo peor."
+        },
+        "photos": {
+          "title": "Fotos y valoración",
+          "subtitle": "Añade fotos, valora tu estancia y envía."
+        }
+      },
+      "fields": {
+        "street": "Calle",
+        "number": "Número",
+        "buildingName": "Nombre del edificio",
+        "floor": "Planta",
+        "unit": "Puerta / Piso",
+        "city": "Ciudad",
+        "state": "Provincia",
+        "postalCode": "Código postal",
+        "country": "País",
+        "neighborhood": "Barrio",
+        "summerTemperature": "Temperatura en verano",
+        "winterTemperature": "Temperatura en invierno",
+        "noise": "Ruido",
+        "light": "Luz natural",
+        "conditionAndMaintenance": "Estado y mantenimiento",
+        "agencyName": "Agencia",
+        "landlordTreatment": "Trato del propietario",
+        "problemResponse": "Respuesta ante problemas",
+        "depositReturned": "Devolución de la fianza",
+        "adviceToAgency": "Consejo para la agencia",
+        "adviceToLandlord": "Consejo para el propietario",
+        "staircaseNeighbors": "Vecinos de escalera",
+        "touristApartments": "Pisos turísticos en el edificio",
+        "neighborRelations": "Relación con los vecinos",
+        "cleaning": "Limpieza de zonas comunes",
+        "services": "Servicios del edificio",
+        "areaTourists": "Turistas en la zona",
+        "areaNoise": "Ruido en la zona",
+        "areaCleanliness": "Limpieza de la zona",
+        "areaSecurity": "Seguridad de la zona",
+        "price": "Alquiler mensual",
+        "currency": "Moneda",
+        "livedFrom": "Desde",
+        "livedTo": "Hasta",
+        "reviewTitle": "Título",
+        "opinion": "Tu opinión",
+        "pros": "Lo mejor",
+        "cons": "Lo mejorable",
+        "photos": "Fotos",
+        "rating": "Valoración global",
+        "recommendation": "¿Recomendarías esta dirección?"
+      },
+      "placeholders": {
+        "street": "p. ej. Calle Mayor 123",
+        "number": "p. ej. 123A",
+        "buildingName": "p. ej. Residencial Sol",
+        "floor": "p. ej. 3",
+        "unit": "p. ej. 3B",
+        "city": "p. ej. Barcelona",
+        "state": "p. ej. Cataluña",
+        "postalCode": "p. ej. 08001",
+        "country": "p. ej. España",
+        "neighborhood": "p. ej. Eixample",
+        "agencyName": "Empieza a escribir el nombre de la agencia",
+        "adviceToAgency": "¿Qué debería mejorar la agencia?",
+        "adviceToLandlord": "¿Qué debería saber el propietario?",
+        "price": "0,00",
+        "date": "AAAA-MM-DD",
+        "reviewTitle": "Resume tu experiencia",
+        "opinion": "Comparte tu experiencia (más de 10 caracteres)",
+        "pros": "Añade algo que te gustó",
+        "cons": "Añade algo mejorable"
+      },
+      "currencies": {
+        "EUR": "EUR (€)",
+        "USD": "USD ($)",
+        "GBP": "GBP (£)",
+        "CAD": "CAD ($)"
+      }
+    },
+    "explore": {
+      "title": "Reseñas",
+      "heroTitle": "Explora reseñas sinceras de viviendas",
+      "heroSubtitle": "Reseñas reales de direcciones reales, de quienes vivieron allí.",
+      "writeCta": "Escribir reseña",
+      "citiesTitle": "Ciudades con reseñas",
+      "neighborhoodsTitle": "Barrios",
+      "buildingsTitle": "Edificios",
+      "reviewCount": "{{count}} reseñas",
+      "buildingMeta": "{{count}} reseñas · {{recommend}}% recomiendan",
+      "errorTitle": "No se pudo cargar",
+      "errorDescription": "Inténtalo de nuevo.",
+      "emptyCitiesTitle": "Aún no hay reseñas",
+      "emptyCitiesDescription": "Sé el primero en reseñar una dirección de tu ciudad.",
+      "emptyNeighborhoodsTitle": "Aún no hay barrios",
+      "emptyNeighborhoodsDescription": "Todavía no hay barrios reseñados en esta ciudad.",
+      "emptyBuildingsTitle": "Aún no hay edificios",
+      "emptyBuildingsDescription": "Todavía no hay edificios reseñados en este barrio."
+    },
+    "enums": {
+      "temperature": {
+        "very_cold": "Muy fría",
+        "cold": "Fría",
+        "moderate": "Templada",
+        "warm": "Cálida",
+        "very_warm": "Muy cálida"
+      },
+      "noise": {
+        "very_quiet": "Muy silencioso",
+        "quiet": "Silencioso",
+        "moderate": "Moderado",
+        "noisy": "Ruidoso",
+        "very_noisy": "Muy ruidoso"
+      },
+      "light": {
+        "very_dark": "Muy oscura",
+        "dark": "Oscura",
+        "moderate": "Moderada",
+        "bright": "Luminosa",
+        "very_bright": "Muy luminosa"
+      },
+      "condition": {
+        "poor": "Malo",
+        "fair": "Regular",
+        "good": "Bueno",
+        "very_good": "Muy bueno",
+        "excellent": "Excelente"
+      },
+      "landlordTreatment": {
+        "very_poor": "Muy malo",
+        "poor": "Malo",
+        "fair": "Regular",
+        "good": "Bueno",
+        "excellent": "Excelente"
+      },
+      "problemResponse": {
+        "never_responded": "Nunca respondió",
+        "very_slow": "Muy lenta",
+        "slow": "Lenta",
+        "reasonable": "Razonable",
+        "fast": "Rápida",
+        "very_fast": "Muy rápida"
+      },
+      "depositReturned": {
+        "full": "Devuelta íntegra",
+        "partial": "Devuelta en parte",
+        "no": "No devuelta"
+      },
+      "staircaseNeighbors": {
+        "very_unfriendly": "Muy antipáticos",
+        "unfriendly": "Antipáticos",
+        "neutral": "Neutrales",
+        "friendly": "Amables",
+        "very_friendly": "Muy amables"
+      },
+      "neighborRelations": {
+        "very_poor": "Muy malas",
+        "poor": "Malas",
+        "fair": "Regulares",
+        "good": "Buenas",
+        "excellent": "Excelentes"
+      },
+      "cleaning": {
+        "very_dirty": "Muy sucia",
+        "dirty": "Sucia",
+        "acceptable": "Aceptable",
+        "clean": "Limpia",
+        "very_clean": "Muy limpia"
+      },
+      "areaTourists": {
+        "none": "Ninguno",
+        "few": "Pocos",
+        "moderate": "Moderado",
+        "many": "Muchos",
+        "overwhelming": "Excesivo"
+      },
+      "areaSecurity": {
+        "very_unsafe": "Muy insegura",
+        "unsafe": "Insegura",
+        "neutral": "Neutral",
+        "safe": "Segura",
+        "very_safe": "Muy segura"
+      },
+      "services": {
+        "internet": "Internet",
+        "cable_tv": "TV por cable",
+        "parking": "Parking",
+        "laundry": "Lavandería",
+        "gym": "Gimnasio",
+        "pool": "Piscina",
+        "concierge": "Conserjería",
+        "security": "Seguridad",
+        "maintenance": "Mantenimiento",
+        "cleaning": "Limpieza"
+      }
     }
   },
   "subscriptions": {
@@ -3198,7 +3452,13 @@
       "tabCommunity": "Comunidad",
       "tabArea": "Zona",
       "tabProperties": "Propiedades ({{count}})",
-      "tabReviews": "Reseñas ({{count}})"
+      "tabReviews": "Reseñas ({{count}})",
+      "tabApartment": "Vivienda",
+      "tabManagement": "Gestión",
+      "tabBuilding": "Edificio",
+      "metricRating": "Valoración media",
+      "metricReviews": "Reseñas",
+      "metricRecommend": "Recomiendan"
     },
     "display": {
       "copySuccess": "Dirección copiada al portapapeles",
@@ -3652,5 +3912,26 @@
       "updateSuccess": "Cambios guardados",
       "submitError": "No se pudo guardar el caso"
     }
+  },
+  "agency": {
+    "title": "Agencia",
+    "viewAddress": "Ver dirección",
+    "notFound": "Agencia no encontrada",
+    "notFoundDescription": "No hemos encontrado esta agencia.",
+    "stats": {
+      "rating": "Valoración",
+      "reviews": "Reseñas",
+      "recommend": "Recomiendan",
+      "depositFull": "Fianza devuelta",
+      "listings": "Anuncios"
+    },
+    "tabs": {
+      "reviews": "Reseñas",
+      "listings": "Anuncios"
+    },
+    "emptyReviewsTitle": "Aún no hay reseñas",
+    "emptyReviewsDescription": "Esta agencia todavía no tiene reseñas.",
+    "emptyListingsTitle": "Sin anuncios",
+    "emptyListingsDescription": "Esta agencia no tiene anuncios activos."
   }
 }

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -1572,7 +1572,8 @@
       "verified": "Verified",
       "recommend": "Recommend",
       "count": "reviews",
-      "countWithNumber": "({{count}} recensioni)"
+      "countWithNumber": "({{count}} recensioni)",
+      "showAll": "Mostra tutte le {{count}} recensioni"
     },
     "notFoundHelp": "It may have been removed or the link is broken.",
     "sections": {
@@ -2285,7 +2286,8 @@
       "hostReservations": "Prenotazioni host",
       "landlordApplications": "Casella candidature",
       "insights": "Insights",
-      "evictions": "Sfratti"
+      "evictions": "Sfratti",
+      "reviews": "Recensioni"
     },
     "actions": {
       "addProperty": "Aggiungi Proprietà",
@@ -3005,7 +3007,30 @@
       "alertReportedTitle": "Segnalata",
       "alertReportedBody": "Questa recensione è stata segnalata al nostro team di moderazione.",
       "alertReplyTitle": "Rispondi alla recensione",
-      "alertReplyBody": "La funzione di risposta permetterà a proprietari e gestori immobiliari di rispondere alle recensioni."
+      "alertReplyBody": "La funzione di risposta permetterà a proprietari e gestori immobiliari di rispondere alle recensioni.",
+      "pros": "Cosa è andato bene",
+      "cons": "Cosa si può migliorare",
+      "adviceToLandlord": "Consiglio per il proprietario",
+      "adviceToAgency": "Consiglio per l'agenzia",
+      "managedBy": "Gestito da {{name}}",
+      "sections": {
+        "apartment": "Appartamento",
+        "management": "Gestione",
+        "building": "Edificio",
+        "area": "Zona"
+      },
+      "reportTitle": "Segnala questa recensione",
+      "reportSubtitle": "Dicci cosa c'è che non va in questa recensione.",
+      "reportDetails": "Dettagli",
+      "reportDetailsPlaceholder": "Aggiungi dettagli utili per la verifica.",
+      "reportSubmit": "Invia segnalazione",
+      "reportReasons": {
+        "fake": "Falsa o fraudolenta",
+        "offensive": "Offensiva o abusiva",
+        "personal_data": "Contiene dati personali",
+        "spam": "Spam",
+        "other": "Altro"
+      }
     },
     "write": {
       "validationTitle": "Errore di validazione",
@@ -3023,7 +3048,236 @@
       "submitFailed": "Impossibile inviare la recensione",
       "submitFailedRetry": "Impossibile inviare la recensione. Riprova.",
       "loadAddressFailed": "Couldn't load address",
-      "title": "Write review"
+      "title": "Write review",
+      "stepCounter": "Passo {{current}} di {{total}}",
+      "submit": "Invia recensione",
+      "mapHint": "Tocca la mappa per posizionare un segnaposto e compilare l'indirizzo.",
+      "listCount": "{{current}}/{{max}}",
+      "addItem": "Aggiungi",
+      "removeItem": "Rimuovi",
+      "rateStar": "Vota {{star}} su 5",
+      "ratingValue": "{{rating}} su 5",
+      "ratingNone": "Nessun voto",
+      "steps": {
+        "address": {
+          "title": "Dove hai vissuto?",
+          "subtitle": "Inserisci l'indirizzo da recensire. Tocca la mappa per compilarlo."
+        },
+        "apartment": {
+          "title": "L'appartamento",
+          "subtitle": "Facoltativo: com'era vivere nella casa."
+        },
+        "management": {
+          "title": "Proprietario e agenzia",
+          "subtitle": "Facoltativo: chi ha gestito l'affitto e com'è andata."
+        },
+        "building": {
+          "title": "L'edificio",
+          "subtitle": "Facoltativo: vicini, spazi comuni e servizi."
+        },
+        "area": {
+          "title": "La zona",
+          "subtitle": "Facoltativo: il quartiere intorno all'edificio."
+        },
+        "priceDates": {
+          "title": "Affitto e date",
+          "subtitle": "Quanto pagavi e quando ci hai vissuto."
+        },
+        "texts": {
+          "title": "La tua recensione",
+          "subtitle": "Un titolo, la tua opinione sincera e i pro e i contro."
+        },
+        "photos": {
+          "title": "Foto e voto",
+          "subtitle": "Aggiungi foto, vota il soggiorno e invia."
+        }
+      },
+      "fields": {
+        "street": "Via",
+        "number": "Civico",
+        "buildingName": "Nome dell'edificio",
+        "floor": "Piano",
+        "unit": "Interno / Appartamento",
+        "city": "Città",
+        "state": "Provincia",
+        "postalCode": "CAP",
+        "country": "Paese",
+        "neighborhood": "Quartiere",
+        "summerTemperature": "Temperatura in estate",
+        "winterTemperature": "Temperatura in inverno",
+        "noise": "Rumore",
+        "light": "Luce naturale",
+        "conditionAndMaintenance": "Stato e manutenzione",
+        "agencyName": "Agenzia",
+        "landlordTreatment": "Trattamento del proprietario",
+        "problemResponse": "Risposta ai problemi",
+        "depositReturned": "Restituzione della cauzione",
+        "adviceToAgency": "Consiglio per l'agenzia",
+        "adviceToLandlord": "Consiglio per il proprietario",
+        "staircaseNeighbors": "Vicini di pianerottolo",
+        "touristApartments": "Case vacanza nell'edificio",
+        "neighborRelations": "Rapporti con i vicini",
+        "cleaning": "Pulizia delle aree comuni",
+        "services": "Servizi dell'edificio",
+        "areaTourists": "Turisti nella zona",
+        "areaNoise": "Rumore della zona",
+        "areaCleanliness": "Pulizia della zona",
+        "areaSecurity": "Sicurezza della zona",
+        "price": "Affitto mensile",
+        "currency": "Valuta",
+        "livedFrom": "Dal",
+        "livedTo": "Al",
+        "reviewTitle": "Titolo",
+        "opinion": "La tua opinione",
+        "pros": "Cosa è andato bene",
+        "cons": "Cosa si può migliorare",
+        "photos": "Foto",
+        "rating": "Voto complessivo",
+        "recommendation": "Consiglieresti questo indirizzo?"
+      },
+      "placeholders": {
+        "street": "es. Via Roma 123",
+        "number": "es. 123A",
+        "buildingName": "es. Residenza Sole",
+        "floor": "es. 3",
+        "unit": "es. 3B",
+        "city": "es. Barcellona",
+        "state": "es. Catalogna",
+        "postalCode": "es. 08001",
+        "country": "es. Spagna",
+        "neighborhood": "es. Eixample",
+        "agencyName": "Inizia a digitare il nome dell'agenzia",
+        "adviceToAgency": "Cosa dovrebbe migliorare l'agenzia?",
+        "adviceToLandlord": "Cosa dovrebbe sapere il proprietario?",
+        "price": "0,00",
+        "date": "AAAA-MM-GG",
+        "reviewTitle": "Riassumi la tua esperienza",
+        "opinion": "Condividi la tua esperienza (più di 10 caratteri)",
+        "pros": "Aggiungi qualcosa che ti è piaciuto",
+        "cons": "Aggiungi qualcosa da migliorare"
+      },
+      "currencies": {
+        "EUR": "EUR (€)",
+        "USD": "USD ($)",
+        "GBP": "GBP (£)",
+        "CAD": "CAD ($)"
+      }
+    },
+    "explore": {
+      "title": "Recensioni",
+      "heroTitle": "Esplora recensioni sincere sulle case",
+      "heroSubtitle": "Recensioni reali di indirizzi reali, da chi ci ha vissuto.",
+      "writeCta": "Scrivi una recensione",
+      "citiesTitle": "Città con recensioni",
+      "neighborhoodsTitle": "Quartieri",
+      "buildingsTitle": "Edifici",
+      "reviewCount": "{{count}} recensioni",
+      "buildingMeta": "{{count}} recensioni · {{recommend}}% consigliano",
+      "errorTitle": "Impossibile caricare",
+      "errorDescription": "Riprova.",
+      "emptyCitiesTitle": "Ancora nessuna recensione",
+      "emptyCitiesDescription": "Sii il primo a recensire un indirizzo nella tua città.",
+      "emptyNeighborhoodsTitle": "Ancora nessun quartiere",
+      "emptyNeighborhoodsDescription": "Ancora nessun quartiere recensito in questa città.",
+      "emptyBuildingsTitle": "Ancora nessun edificio",
+      "emptyBuildingsDescription": "Ancora nessun edificio recensito in questo quartiere."
+    },
+    "enums": {
+      "temperature": {
+        "very_cold": "Molto fredda",
+        "cold": "Fredda",
+        "moderate": "Moderata",
+        "warm": "Calda",
+        "very_warm": "Molto calda"
+      },
+      "noise": {
+        "very_quiet": "Molto silenzioso",
+        "quiet": "Silenzioso",
+        "moderate": "Moderato",
+        "noisy": "Rumoroso",
+        "very_noisy": "Molto rumoroso"
+      },
+      "light": {
+        "very_dark": "Molto buia",
+        "dark": "Buia",
+        "moderate": "Moderata",
+        "bright": "Luminosa",
+        "very_bright": "Molto luminosa"
+      },
+      "condition": {
+        "poor": "Scarso",
+        "fair": "Discreto",
+        "good": "Buono",
+        "very_good": "Molto buono",
+        "excellent": "Eccellente"
+      },
+      "landlordTreatment": {
+        "very_poor": "Pessimo",
+        "poor": "Scarso",
+        "fair": "Discreto",
+        "good": "Buono",
+        "excellent": "Eccellente"
+      },
+      "problemResponse": {
+        "never_responded": "Non ha mai risposto",
+        "very_slow": "Molto lenta",
+        "slow": "Lenta",
+        "reasonable": "Ragionevole",
+        "fast": "Rapida",
+        "very_fast": "Molto rapida"
+      },
+      "depositReturned": {
+        "full": "Resa per intero",
+        "partial": "Resa in parte",
+        "no": "Non resa"
+      },
+      "staircaseNeighbors": {
+        "very_unfriendly": "Molto scortesi",
+        "unfriendly": "Scortesi",
+        "neutral": "Neutrali",
+        "friendly": "Cordiali",
+        "very_friendly": "Molto cordiali"
+      },
+      "neighborRelations": {
+        "very_poor": "Pessimi",
+        "poor": "Scarsi",
+        "fair": "Discreti",
+        "good": "Buoni",
+        "excellent": "Eccellenti"
+      },
+      "cleaning": {
+        "very_dirty": "Molto sporca",
+        "dirty": "Sporca",
+        "acceptable": "Accettabile",
+        "clean": "Pulita",
+        "very_clean": "Molto pulita"
+      },
+      "areaTourists": {
+        "none": "Nessuno",
+        "few": "Pochi",
+        "moderate": "Moderato",
+        "many": "Molti",
+        "overwhelming": "Eccessivo"
+      },
+      "areaSecurity": {
+        "very_unsafe": "Molto insicura",
+        "unsafe": "Insicura",
+        "neutral": "Neutrale",
+        "safe": "Sicura",
+        "very_safe": "Molto sicura"
+      },
+      "services": {
+        "internet": "Internet",
+        "cable_tv": "TV via cavo",
+        "parking": "Parcheggio",
+        "laundry": "Lavanderia",
+        "gym": "Palestra",
+        "pool": "Piscina",
+        "concierge": "Portineria",
+        "security": "Sicurezza",
+        "maintenance": "Manutenzione",
+        "cleaning": "Pulizia"
+      }
     }
   },
   "subscriptions": {
@@ -3203,7 +3457,13 @@
       "tabCommunity": "Comunità",
       "tabArea": "Zona",
       "tabProperties": "Proprietà ({{count}})",
-      "tabReviews": "Recensioni ({{count}})"
+      "tabReviews": "Recensioni ({{count}})",
+      "tabApartment": "Appartamento",
+      "tabManagement": "Gestione",
+      "tabBuilding": "Edificio",
+      "metricRating": "Voto medio",
+      "metricReviews": "Recensioni",
+      "metricRecommend": "Consigliano"
     },
     "display": {
       "copySuccess": "Indirizzo copiato negli appunti",
@@ -3657,5 +3917,26 @@
       "updateSuccess": "Modifiche salvate",
       "submitError": "Impossibile salvare il caso"
     }
+  },
+  "agency": {
+    "title": "Agenzia",
+    "viewAddress": "Vedi indirizzo",
+    "notFound": "Agenzia non trovata",
+    "notFoundDescription": "Non abbiamo trovato questa agenzia.",
+    "stats": {
+      "rating": "Voto",
+      "reviews": "Recensioni",
+      "recommend": "Consigliano",
+      "depositFull": "Cauzione resa",
+      "listings": "Annunci"
+    },
+    "tabs": {
+      "reviews": "Recensioni",
+      "listings": "Annunci"
+    },
+    "emptyReviewsTitle": "Ancora nessuna recensione",
+    "emptyReviewsDescription": "Questa agenzia non ha ancora recensioni.",
+    "emptyListingsTitle": "Nessun annuncio",
+    "emptyListingsDescription": "Questa agenzia non ha annunci attivi."
   }
 }

--- a/packages/frontend/services/reviewService.ts
+++ b/packages/frontend/services/reviewService.ts
@@ -1,261 +1,307 @@
 /**
- * Review Service
- * API calls for review-related operations
+ * Review Service — the single transport for every review/agency/explore read
+ * and write.
+ *
+ * EVERY method goes through the authed `api` client (`@/utils/api`), which is
+ * the Oxy linked client: it mirrors the session token, so the public reads
+ * degrade to unauthenticated requests automatically and the authed writes carry
+ * the bearer token without any per-call plumbing. The backend wraps its
+ * responses in `{ success, <key>, ... }`; `normalizeEnvelope` keeps that whole
+ * object on `response.data`, so each method reads the named key it needs
+ * (`review`, `reviews`, `cities`, `agency`, …). There is NO raw `fetch` /
+ * `API_URL` here — that was the bug this rewrite removes.
  */
 
 import { api } from '@/utils/api';
-import { API_URL } from '@/config';
-import { OxyServices } from '@oxyhq/core';
-import { ApiResponse } from '../types/api';
+import type { Property } from '@homiio/shared-types';
 import {
   ReviewDTO,
   CreateReviewPayload,
-  UpdateReviewPayload
+  UpdateReviewPayload,
+  ReviewReportReason,
+  ReviewModerationStatus,
+  AgencySummary,
+  AgencyStats,
+  ExploreCitySummary,
+  ExploreNeighborhoodSummary,
+  ExploreBuildingSummary,
 } from '@homiio/shared-types';
 
-// Re-export shared types
+// Re-export shared types under the legacy consumer aliases.
 export type ReviewData = ReviewDTO;
 export type CreateReview = CreateReviewPayload;
 export type UpdateReview = UpdateReviewPayload;
 
-export interface ReviewStats {
-  averageRating: number;
-  totalReviews: number;
-  recommendationPercentage: number;
-  ratingDistribution: {
-    _id: number;
-    count: number;
-  }[];
-  categoryAverages: {
-    condition: number;
-    landlord: number;
-    neighbors: number;
-    security: number;
-  };
+/** Paging metadata the list endpoints attach. */
+export interface ReviewPagination {
+  currentPage: number;
+  totalPages: number;
+  limit: number;
+  total?: number;
+  totalReviews?: number;
 }
 
-export interface ReviewsResponse {
-  reviews: ReviewData[];
-  pagination: {
-    currentPage: number;
-    totalPages: number;
-    totalReviews: number;
-    limit: number;
-  };
-  stats: {
-    averageRating: number;
-    totalReviews: number;
-    recommendationPercentage: number;
-  };
+/** Flattened address-review payload consumed by the review sections + hooks. */
+export interface AddressReviewsResult {
+  level?: 'UNIT' | 'BUILDING' | 'STREET';
+  /** Building-level reviews (attached directly to the building address). */
+  buildingReviews: ReviewDTO[];
+  /** Unit-level reviews (attached to a unit under the building). */
+  unitReviews: ReviewDTO[];
+  /** Building + unit reviews flattened — the list every card row renders. */
+  reviews: ReviewDTO[];
+  totalReviews: number;
+  pagination?: ReviewPagination;
 }
+
+/** Result of the helpful-vote toggle. */
+export interface HelpfulResult {
+  helpfulCount: number;
+  viewerHasVotedHelpful: boolean;
+}
+
+/** Agency profile header payload. */
+export interface AgencyProfile {
+  agency: AgencySummary;
+  stats: AgencyStats;
+}
+
+/** One page of an agency's reviews. */
+export interface AgencyReviewsPage {
+  agency: AgencySummary;
+  reviews: ReviewDTO[];
+  hasMore: boolean;
+  totalPages: number;
+  page: number;
+}
+
+/** One page of an agency's active listings. */
+export interface AgencyPropertiesPage {
+  properties: Property[];
+  hasMore: boolean;
+  totalPages: number;
+  total: number;
+  page: number;
+}
+
+/** One page of buildings for a neighborhood explore list. */
+export interface ExploreBuildingsPage {
+  buildings: ExploreBuildingSummary[];
+  hasMore: boolean;
+  totalPages: number;
+  page: number;
+}
+
+interface AddressReviewsBody {
+  level?: 'UNIT' | 'BUILDING' | 'STREET';
+  buildingReviews?: ReviewDTO[];
+  unitReviews?: ReviewDTO[];
+  totalReviews?: number;
+  pagination?: ReviewPagination;
+}
+
+const toReviewList = (value: unknown): ReviewDTO[] =>
+  Array.isArray(value) ? (value as ReviewDTO[]) : [];
 
 class ReviewService {
-  private baseUrl = API_URL;
+  // -----------------------------------------------------------------------
+  // Hierarchical address reads (public).
+  // -----------------------------------------------------------------------
 
-  /**
-   * Get reviews for a specific address
-   */
   async getReviewsByAddress(
     addressId: string,
-    page: number = 1,
-    limit: number = 10,
-    sortBy: string = 'createdAt',
-    sortOrder: 'asc' | 'desc' = 'desc'
-  ): Promise<ApiResponse<ReviewsResponse>> {
-    try {
-      const response = await fetch(
-        `${this.baseUrl}/api/reviews/address/${addressId}?page=${page}&limit=${limit}&sortBy=${sortBy}&sortOrder=${sortOrder}`
-      );
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const data = await response.json();
-      return {
-        success: true,
-        data: data,
-        message: 'Reviews fetched successfully'
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to fetch reviews',
-        data: null
-      };
-    }
+    page = 1,
+    limit = 10,
+  ): Promise<AddressReviewsResult> {
+    const { data } = await api.get<AddressReviewsBody>(
+      `/api/reviews/address/${addressId}`,
+      { params: { page, limit }, requireAuth: false },
+    );
+    const buildingReviews = toReviewList(data.buildingReviews);
+    const unitReviews = toReviewList(data.unitReviews);
+    return {
+      level: data.level,
+      buildingReviews,
+      unitReviews,
+      reviews: [...buildingReviews, ...unitReviews],
+      totalReviews: data.totalReviews ?? buildingReviews.length + unitReviews.length,
+      pagination: data.pagination,
+    };
   }
 
-  /**
-   * Get review statistics for an address
-   */
-  async getAddressReviewStats(addressId: string): Promise<ApiResponse<ReviewStats>> {
-    try {
-      const response = await fetch(`${this.baseUrl}/api/reviews/address/${addressId}/stats`);
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const data = await response.json();
-      return {
-        success: true,
-        data: data,
-        message: 'Review stats fetched successfully'
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to fetch review stats',
-        data: null
-      };
-    }
+  async getAddressReviewStats(addressId: string): Promise<Record<string, unknown>> {
+    const { data } = await api.get<{ stats?: Record<string, unknown> }>(
+      `/api/reviews/address/${addressId}/stats`,
+      { requireAuth: false },
+    );
+    return data.stats ?? {};
   }
 
-  /**
-   * Create a new review
-   */
-  async createReview(
-    reviewData: Partial<ReviewData>,
-    oxyServices?: OxyServices,
-    activeSessionId?: string
-  ): Promise<ApiResponse<{ review: ReviewData }>> {
-    try {
-      const response = await api.post('/api/reviews', reviewData);
+  // -----------------------------------------------------------------------
+  // Single review CRUD.
+  // -----------------------------------------------------------------------
 
-      return {
-        success: true,
-        data: response.data,
-        message: 'Review created successfully'
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to create review',
-        data: null
-      };
-    }
+  async createReview(payload: CreateReviewPayload): Promise<ReviewDTO> {
+    const { data } = await api.post<{ review: ReviewDTO }>('/api/reviews', payload);
+    return data.review;
   }
 
-  /**
-   * Get a specific review by ID
-   */
-  async getReviewById(reviewId: string): Promise<ApiResponse<{ review: ReviewData }>> {
-    try {
-      const response = await fetch(`${this.baseUrl}/api/reviews/${reviewId}`);
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const data = await response.json();
-      return {
-        success: true,
-        data: data,
-        message: 'Review fetched successfully'
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to fetch review',
-        data: null
-      };
-    }
+  async getReviewById(reviewId: string): Promise<ReviewDTO> {
+    const { data } = await api.get<{ review: ReviewDTO }>(
+      `/api/reviews/${reviewId}`,
+      { requireAuth: false },
+    );
+    return data.review;
   }
 
-  /**
-   * Update a review
-   */
-  async updateReview(
-    reviewId: string, 
-    updateData: Partial<ReviewData>
-  ): Promise<ApiResponse<{ review: ReviewData }>> {
-    try {
-      const response = await fetch(`${this.baseUrl}/api/reviews/${reviewId}`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(updateData),
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const data = await response.json();
-      return {
-        success: true,
-        data: data,
-        message: 'Review updated successfully'
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to update review',
-        data: null
-      };
-    }
+  async updateReview(reviewId: string, payload: UpdateReviewPayload): Promise<ReviewDTO> {
+    const { data } = await api.put<{ review: ReviewDTO }>(
+      `/api/reviews/${reviewId}`,
+      payload,
+    );
+    return data.review;
   }
 
-  /**
-   * Delete a review
-   */
-  async deleteReview(reviewId: string): Promise<ApiResponse<{ message: string }>> {
-    try {
-      const response = await fetch(`${this.baseUrl}/api/reviews/${reviewId}`, {
-        method: 'DELETE',
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const data = await response.json();
-      return {
-        success: true,
-        data: data,
-        message: 'Review deleted successfully'
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to delete review',
-        data: null
-      };
-    }
+  async deleteReview(reviewId: string): Promise<void> {
+    await api.delete(`/api/reviews/${reviewId}`);
   }
 
-  /**
-   * Get user's reviews
-   */
   async getUserReviews(
-    userId: string,
-    page: number = 1,
-    limit: number = 10
-  ): Promise<ApiResponse<ReviewsResponse>> {
-    try {
-      const response = await fetch(
-        `${this.baseUrl}/api/reviews/user/${userId}?page=${page}&limit=${limit}`
-      );
+    oxyUserId: string,
+    page = 1,
+    limit = 10,
+  ): Promise<{ reviews: ReviewDTO[]; hasMore: boolean; totalPages: number; page: number }> {
+    const { data } = await api.get<{
+      reviews?: ReviewDTO[];
+      hasMore?: boolean;
+      totalPages?: number;
+      pagination?: ReviewPagination;
+    }>(`/api/reviews/user/${oxyUserId}`, { params: { page, limit }, requireAuth: false });
+    return {
+      reviews: toReviewList(data.reviews),
+      hasMore: data.hasMore ?? false,
+      totalPages: data.totalPages ?? data.pagination?.totalPages ?? 1,
+      page: data.pagination?.currentPage ?? page,
+    };
+  }
 
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
+  // -----------------------------------------------------------------------
+  // Helpful votes + reports (authed).
+  // -----------------------------------------------------------------------
 
-      const data = await response.json();
-      return {
-        success: true,
-        data: data,
-        message: 'User reviews fetched successfully'
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to fetch user reviews',
-        data: null
-      };
-    }
+  async toggleHelpful(reviewId: string): Promise<HelpfulResult> {
+    const { data } = await api.post<HelpfulResult>(`/api/reviews/${reviewId}/helpful`);
+    return {
+      helpfulCount: data.helpfulCount ?? 0,
+      viewerHasVotedHelpful: Boolean(data.viewerHasVotedHelpful),
+    };
+  }
+
+  async reportReview(
+    reviewId: string,
+    reason: ReviewReportReason,
+    details?: string,
+  ): Promise<{ moderationStatus: ReviewModerationStatus }> {
+    const { data } = await api.post<{ moderationStatus: ReviewModerationStatus }>(
+      `/api/reviews/${reviewId}/report`,
+      { reason, details },
+    );
+    return { moderationStatus: data.moderationStatus };
+  }
+
+  // -----------------------------------------------------------------------
+  // Agencies (public reads).
+  // -----------------------------------------------------------------------
+
+  async searchAgencies(q: string): Promise<AgencySummary[]> {
+    const { data } = await api.get<{ agencies?: AgencySummary[] }>(
+      '/api/agencies/search',
+      { params: { q }, requireAuth: false },
+    );
+    return Array.isArray(data.agencies) ? data.agencies : [];
+  }
+
+  async getAgency(slug: string): Promise<AgencyProfile> {
+    const { data } = await api.get<AgencyProfile>(`/api/agencies/${slug}`, {
+      requireAuth: false,
+    });
+    return { agency: data.agency, stats: data.stats };
+  }
+
+  async getAgencyReviews(slug: string, page = 1, limit = 10): Promise<AgencyReviewsPage> {
+    const { data } = await api.get<{
+      agency: AgencySummary;
+      reviews?: ReviewDTO[];
+      hasMore?: boolean;
+      totalPages?: number;
+      pagination?: ReviewPagination;
+    }>(`/api/agencies/${slug}/reviews`, { params: { page, limit }, requireAuth: false });
+    return {
+      agency: data.agency,
+      reviews: toReviewList(data.reviews),
+      hasMore: data.hasMore ?? false,
+      totalPages: data.totalPages ?? data.pagination?.totalPages ?? 1,
+      page: data.pagination?.currentPage ?? page,
+    };
+  }
+
+  async getAgencyProperties(slug: string, page = 1, limit = 10): Promise<AgencyPropertiesPage> {
+    const { data } = await api.get<{
+      data?: Property[];
+      hasMore?: boolean;
+      totalPages?: number;
+      total?: number;
+      page?: number;
+    }>(`/api/agencies/${slug}/properties`, { params: { page, limit }, requireAuth: false });
+    return {
+      properties: Array.isArray(data.data) ? data.data : [],
+      hasMore: data.hasMore ?? false,
+      totalPages: data.totalPages ?? 1,
+      total: data.total ?? 0,
+      page: data.page ?? page,
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // Review-explore aggregations (public reads).
+  // -----------------------------------------------------------------------
+
+  async getExploreCities(): Promise<ExploreCitySummary[]> {
+    const { data } = await api.get<{ cities?: ExploreCitySummary[] }>(
+      '/api/reviews/explore',
+      { requireAuth: false },
+    );
+    return Array.isArray(data.cities) ? data.cities : [];
+  }
+
+  async getExploreCity(cityId: string): Promise<ExploreNeighborhoodSummary[]> {
+    const { data } = await api.get<{ neighborhoods?: ExploreNeighborhoodSummary[] }>(
+      `/api/reviews/explore/city/${cityId}`,
+      { requireAuth: false },
+    );
+    return Array.isArray(data.neighborhoods) ? data.neighborhoods : [];
+  }
+
+  async getExploreNeighborhood(
+    neighborhoodId: string,
+    page = 1,
+    limit = 10,
+  ): Promise<ExploreBuildingsPage> {
+    const { data } = await api.get<{
+      buildings?: ExploreBuildingSummary[];
+      hasMore?: boolean;
+      totalPages?: number;
+      pagination?: ReviewPagination;
+    }>(`/api/reviews/explore/neighborhood/${neighborhoodId}`, {
+      params: { page, limit },
+      requireAuth: false,
+    });
+    return {
+      buildings: Array.isArray(data.buildings) ? data.buildings : [],
+      hasMore: data.hasMore ?? false,
+      totalPages: data.totalPages ?? data.pagination?.totalPages ?? 1,
+      page: data.pagination?.currentPage ?? page,
+    };
   }
 }
 


### PR DESCRIPTION
## What
Frontend for the reviucasa-parity review system (backend #207, shared types #201).

- **Service fix**: `services/reviewService.ts` — every method now routes through the authed `api` linked client (fixes update/delete/reads that used raw unauthenticated `fetch`); adds `toggleHelpful`, `reportReview`, agency reads, and the explore aggregations, all typed from shared-types.
- **Hooks**: `useAddressReviews` retyped to `ReviewDTO`; new `useReviewMutations` (optimistic Helpful flip across the address + agency caches with rollback; report), `useAgencyReviews`, `useExploreReviews` (page-based `useInfiniteQuery`).
- **Write wizard** (`app/reviews/write.tsx` + `components/reviews/write/`): 8 steps (address → apartment → management → building → area → price/dates → texts → photos/recommend), shared `EnumChipSelector` + `WizardProgress` primitives, agency typeahead, pros/cons editors, submit → `CreateReviewPayload` (server derives `livedForMonths`) → address page.
- **Read surfaces**: rewritten `ReviewCard` (Bloom Avatar + display name, dimension chips grouped by section, advice, agency link, real Helpful/Report with a report-reason sheet); address detail sub-tabs (Overall/Apartment/Management/Building/Area) with client-side per-dimension aggregates; `ReviewsSection`/`CommunityNotes` adapted to `ReviewDTO`; new agency profile (`/agency/[slug]`) and review-explore screens (`/reviews`, `/reviews/city/[cityId]`, `/reviews/neighborhood/[neighborhoodId]`) — both infinite-scroll primitives wired.
- **Wiring**: Sidebar "Reviews" entry; i18n across en/es/ca-ES/it (steps, ~70 enum labels, card, explore, agency).

## Why
Delivers PR 3 (frontend) of the reviucasa-parity review system, consuming the merged backend + shared types.

## Verification
- Frontend lint clean (0 errors), Jest 32/32 green, locale parity passes, web export builds all routes.
- `grep style={({` → 0; no `as any` / `@ts-ignore` / `console.log` / TODO in new code; new files type-clean under `tsc`.
- Visual (Playwright over the web export, real Chromium): `/reviews` explore landing (hero + CTA + city list), `/reviews/write` wizard stepped through steps 1–3 (address form → apartment enum chips → management typeahead + chips + advice), 8-dot progress + Back/Next gating working, sidebar "Reviews" entry active.
- `createReview` payload code-traced against `reviewController.createReview` + `CREATABLE_REVIEW_FIELDS` (nested `address`, `livedForMonths` omitted/server-derived, `{ success, review }` envelope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)