### PR TITLE
refactor(frontend): /simplify cleanup — shared infinite-list hook, IconButton reuse, PropertyCard memoization

### DIFF
--- a/packages/frontend/components/PropertyCard.tsx
+++ b/packages/frontend/components/PropertyCard.tsx
@@ -161,7 +161,7 @@ const getVariantStyles = (variant: PropertyCardVariant) => {
   return variants[variant] || variants.default;
 };
 
-export function PropertyCard({
+export const PropertyCard = React.memo(function PropertyCard({
   // Core data
   property,
 
@@ -233,9 +233,6 @@ export function PropertyCard({
     setPressed(true);
     handlePressIn();
   }, [handlePressIn]);
-  const handleImagePressOut = useCallback(() => {
-    setPressed(false);
-  }, []);
 
   // Web hover on the WHOLE card drives the image zoom (Airbnb-style): one
   // `onPointerEnter/Leave` on the outer container below (they fire on the card's
@@ -255,6 +252,309 @@ export function PropertyCard({
     const created = new Date(createdAt).getTime();
     return Number.isFinite(created) && Date.now() - created <= NEW_LISTING_WINDOW_MS;
   }, [property?.createdAt]);
+
+  // Heavy per-listing derivations, memoized so they don't recompute on every
+  // hover/press re-render (`hovered`/`pressed` flip but these don't depend on
+  // them) or when the infinite feed appends a page and re-renders the row. The
+  // memo guards on `property` so the hook order stays stable across the early
+  // returns below (rules of hooks). Resolves the active browse mode's priced
+  // block, the other offerings, and the flattened display fields.
+  const derived = useMemo(() => {
+    if (!property) return null;
+    // The single primary price/offering this card displays — the ACTIVE browse
+    // mode's priced block (unit fixed per block): a multi-offering listing shows
+    // €1,700/month in Long-term and €110/night in Vacation. Sale shows the asking
+    // price (no per-unit suffix); exchange shows "Free". When the listing doesn't
+    // carry the active offering, it falls back to the first present block.
+    const primaryOffering = resolvePrimaryOffering(
+      property,
+      browseMode,
+      t('listing.exchange.free', 'Free'),
+    );
+    // The OTHER offerings this listing carries (excluding the one shown above)
+    // drive both the floating badges and the subtle "Also available" line.
+    const otherOfferings = resolveOfferingSummaries(property, browseMode);
+    const propertyData = {
+      id: property._id || property.id,
+      title: getPropertyTitle(property),
+      location: getPropertyLocationLabel(property),
+      price: primaryOffering.amount,
+      currency: primaryOffering.currency,
+      priceUnit: primaryOffering.priceUnit,
+      offeringKind: primaryOffering.kind,
+      offeringLabel: primaryOffering.label,
+      type: property.type === 'room' ? 'apartment' : property.type === 'studio' ? 'apartment' : property.type,
+      imageSource: getPropertyImageSource(property, variant === 'compact' ? 'small' : 'medium'),
+      bedrooms: property.bedrooms || 0,
+      bathrooms: property.bathrooms || 0,
+      size: property.squareFootage || 0,
+      sizeUnit: 'm²',
+      isVerified: property.isVerified || false,
+      rating: undefined as number | undefined,
+      reviewCount: undefined as number | undefined,
+    };
+    return { primaryOffering, otherOfferings, propertyData };
+  }, [property, browseMode, variant, t]);
+
+  /**
+   * Badge chrome that floats over the photo (rating, eco/verified, instant book,
+   * plus any caller-supplied badge/overlay). Memoized JSX so it isn't rebuilt on
+   * every hover re-render. Shared verbatim by the carousel media (as `children`)
+   * and the static-image media so the overlays read identically. Every node here
+   * is a non-interactive `View`, so it never introduces a nested `<button>`.
+   */
+  const mediaBadges = useMemo(() => {
+    if (!property || !derived) return null;
+    const { otherOfferings, propertyData } = derived;
+    const isGrid = variant === 'grid';
+    const isCompact = variant === 'compact';
+    const isEco = Boolean(property.isEcoFriendly);
+    const isFairPrice = Boolean(property.priceEthics?.isFairPrice);
+    const finalShowRating = showRating && getVariantStyles(variant).showRating;
+    return (
+      <>
+        {/* Photo-overlay chip stack — ONE absolutely-positioned, flex-driven
+            container in the top-left. Every child is a `MediaChip` (or the
+            rating chip), so they share the same height, radius, padding and
+            frosted backdrop and align on a single row regardless of which are
+            present. Suppressed in the grid variant (photo-first); the grid
+            renders ONLY the freshness chip (rich chips gated on `!isGrid`). */}
+        {!isCompact && (isNew || !isGrid) && (
+          <View style={styles.mediaChipStack}>
+            {isNew ? (
+              <View style={styles.newChip}>
+                <BloomText style={styles.newChipText}>
+                  {t('listing.badge.new', 'New')}
+                </BloomText>
+              </View>
+            ) : null}
+
+            {!isGrid ? (
+              <>
+                {finalShowRating && propertyData.rating ? (
+                  <MediaChip
+                    icon="star"
+                    accent={colors.ratingStar}
+                    label={propertyData.rating.toFixed(1)}
+                  />
+                ) : null}
+
+                {/* Offering chips — "By night" / "For sale" / "Exchange" for each
+                    OTHER offering (the active one is the price). */}
+                {otherOfferings.map((summary) => (
+                  <OfferingBadge key={summary.offering} offering={summary.offering} size="md" />
+                ))}
+
+                {/* Fair price — Homiio ethical + market badge. */}
+                {isFairPrice ? (
+                  <MediaChip
+                    icon="pricetag"
+                    accent={colors.success}
+                    label={t('listing.badge.fairPrice', 'Fair price')}
+                  />
+                ) : null}
+
+                {/* Instant Book (vacation mode only). */}
+                {showInstantBook ? (
+                  <MediaChip
+                    icon="flash"
+                    accent={colors.primarySubtleForeground}
+                    label={t('listing.badge.instantBook', 'Instant book')}
+                  />
+                ) : null}
+
+                {/* Verified — icon-only shield, brand accent. */}
+                {showVerifiedBadge && propertyData.isVerified ? (
+                  <MediaChip icon="shield-checkmark" accent={colors.primarySubtleForeground} />
+                ) : null}
+
+                {/* Eco — icon-only leaf, green accent. */}
+                {isEco ? <MediaChip icon="leaf" accent={colors.success} /> : null}
+              </>
+            ) : null}
+          </View>
+        )}
+
+        {/* Custom Badge Content */}
+        {badgeContent && <View style={styles.customBadge}>{badgeContent as React.ReactNode}</View>}
+
+        {/* Overlay Content */}
+        {overlayContent && <View style={styles.overlay}>{overlayContent as React.ReactNode}</View>}
+      </>
+    );
+  }, [property, derived, variant, showRating, showVerifiedBadge, showInstantBook, isNew, badgeContent, overlayContent, t]);
+
+  /**
+   * The text block below the photo (title, location, features, price, "also
+   * available"). Memoized JSX so it isn't rebuilt on every hover re-render — it
+   * depends only on the listing data + display props, never the hover/press
+   * state.
+   */
+  const textContent = useMemo(() => {
+    if (!derived) return null;
+    const { otherOfferings, propertyData } = derived;
+    const variantStyles = getVariantStyles(variant);
+    const isGrid = variant === 'grid';
+    const isFeatured = variant === 'featured';
+    const finalShowFeatures = showFeatures && variantStyles.showFeatures;
+    const finalShowTypeIcon = showTypeIcon && variantStyles.showTypeIcon;
+    const finalShowPrice = showPrice && (variantStyles.showPrice !== false);
+    const finalTitleLines = titleLines !== undefined ? titleLines : variantStyles.titleLines;
+    const finalLocationLines = locationLines !== undefined ? locationLines : variantStyles.locationLines;
+    // Localized per-unit suffix for the headline (fixed per priced block):
+    // long-term → "month", short-term → "night"; sale/exchange have none.
+    const priceUnitSuffix = propertyData.priceUnit
+      ? propertyData.priceUnit === PriceUnit.NIGHT
+        ? t('listing.offering.perNightUnit', 'night')
+        : t('listing.offering.perMonthUnit', 'month')
+      : '';
+    // "Also available: By night · For sale" — joins the other offerings' labels.
+    const alsoAvailableLabel =
+      otherOfferings.length > 0
+        ? `${t('listing.offering.alsoAvailable', 'Also available')}: ${otherOfferings
+            .map((summary) => t(summary.i18nKey, summary.fallback))
+            .join(' · ')}`
+        : '';
+    // Property type surfaced in the META line below the photo. Icon follows the
+    // former on-photo logic (house → home glyph, else building); the label reuses
+    // the `properties.titles.types.*` vocabulary, falling back to the capitalised
+    // raw type for kinds without a dedicated key.
+    const typeMeta: { icon: IoniconName; label: string } | null = propertyData.type
+      ? {
+          icon: propertyData.type === 'house' ? 'home-outline' : 'business-outline',
+          label: t(
+            `properties.titles.types.${propertyData.type}`,
+            propertyData.type.charAt(0).toUpperCase() + propertyData.type.slice(1),
+          ),
+        }
+      : null;
+    return (
+      <View
+        style={[
+          styles.content,
+          orientation === 'horizontal' ? styles.horizontalContent : null,
+          isGrid ? styles.gridContent : null,
+        ]}
+      >
+        {/* Title */}
+        <ThemedText
+          style={[
+            styles.title,
+            isFeatured ? styles.featuredTitle : null,
+            isGrid ? styles.gridTitle : null,
+          ]}
+          numberOfLines={orientation === 'horizontal' ? undefined : finalTitleLines}
+        >
+          {propertyData.title}
+        </ThemedText>
+
+        {/* Location */}
+        {showLocation && propertyData.location && (
+          <ThemedText
+            style={[
+              styles.location,
+              isFeatured ? styles.featuredLocation : null,
+              orientation === 'horizontal' ? styles.horizontalLocation : null,
+              isGrid ? styles.gridLocation : null,
+            ]}
+            numberOfLines={finalLocationLines}
+          >
+            {propertyData.location}
+          </ThemedText>
+        )}
+
+        {/* Features — suppressed in grid variant to keep cards photo-first */}
+        {finalShowFeatures && !isGrid && (
+          <View style={styles.features}>
+            {/* Property type leads the meta line (moved off the photo). Shown for
+                the variants that previously surfaced the on-photo type icon; the
+                compact variant keeps its own trailing type text below. */}
+            {finalShowTypeIcon && typeMeta && variant !== 'compact' && (
+              <>
+                <View style={styles.typeMeta}>
+                  <Ionicons name={typeMeta.icon} size={13} color={colors.COLOR_BLACK_LIGHT_4} />
+                  <ThemedText style={styles.featureText}>{typeMeta.label}</ThemedText>
+                </View>
+                <ThemedText style={styles.featureSeparator}>•</ThemedText>
+              </>
+            )}
+            <View style={styles.feature}>
+              <ThemedText style={styles.featureText}>
+                {`${propertyData.bedrooms} bed${propertyData.bedrooms !== 1 ? 's' : ''}`}
+              </ThemedText>
+            </View>
+            <ThemedText style={styles.featureSeparator}>•</ThemedText>
+            <View style={styles.feature}>
+              <ThemedText style={styles.featureText}>
+                {`${propertyData.bathrooms} bath${propertyData.bathrooms !== 1 ? 's' : ''}`}
+              </ThemedText>
+            </View>
+            {propertyData.size && propertyData.size > 0 && (
+              <>
+                <ThemedText style={styles.featureSeparator}>•</ThemedText>
+                <View style={styles.feature}>
+                  <ThemedText style={styles.featureText}>
+                    {`${propertyData.size} ${propertyData.sizeUnit}`}
+                  </ThemedText>
+                </View>
+              </>
+            )}
+            {variant === 'compact' && typeMeta && (
+              <>
+                <ThemedText style={styles.featureSeparator}>•</ThemedText>
+                <ThemedText style={styles.featureText}>{typeMeta.label}</ThemedText>
+              </>
+            )}
+          </View>
+        )}
+
+        {/* Price — the ACTIVE browse mode's priced block. Exchange listings have
+            no money price, so they render the "Free" label instead of
+            CurrencyFormatter; sale shows the sale price with NO per-unit suffix;
+            long-term shows `/month` and short-term `/night` (fixed per block). */}
+        {finalShowPrice &&
+          (propertyData.offeringKind === 'exchange'
+            ? propertyData.offeringLabel.length > 0
+            : propertyData.price > 0) && (
+          <View style={[styles.priceContainer, isGrid ? styles.gridPriceContainer : null]}>
+            <BloomText
+              style={[
+                styles.price,
+                isFeatured ? styles.featuredPrice : null,
+                isGrid ? styles.gridPrice : null,
+              ]}
+            >
+              {propertyData.offeringKind === 'exchange' ? (
+                propertyData.offeringLabel
+              ) : (
+                <>
+                  <CurrencyFormatter
+                    amount={propertyData.price}
+                    originalCurrency={propertyData.currency}
+                    showConversion={false}
+                  />
+                  {priceUnitSuffix ? (
+                    <BloomText style={[styles.priceUnit, isGrid ? styles.gridPriceUnit : null]}>
+                      {' / '}{priceUnitSuffix}
+                    </BloomText>
+                  ) : null}
+                </>
+              )}
+            </BloomText>
+          </View>
+        )}
+
+        {/* "Also available: By night · For sale" — the OTHER offerings this
+            multi-offering listing carries. Hidden in the dense grid + compact
+            tiles to keep them photo-first. */}
+        {finalShowPrice && !isGrid && variant !== 'compact' && alsoAvailableLabel ? (
+          <BloomText style={styles.alsoAvailable} numberOfLines={1}>
+            {alsoAvailableLabel}
+          </BloomText>
+        ) : null}
+      </View>
+    );
+  }, [derived, orientation, variant, showLocation, showFeatures, showTypeIcon, showPrice, titleLines, locationLines, t]);
 
   // The horizontal (small single-cover thumbnail) variant is too tight for the
   // save heart — suppress it there by either path (skeleton + real render).
@@ -278,339 +578,41 @@ export function PropertyCard({
     );
   }
 
-  // Early return if property is null/undefined
-  if (!property) {
+  // Early return if property is null/undefined. `derived` is null on exactly the
+  // same condition (it guards on `property`); checking it here narrows it to
+  // non-null for the render below without a non-null assertion.
+  if (!property || !derived) {
     return null;
   }
 
-  // The single primary price/offering this card displays — the ACTIVE browse
-  // mode's priced block (the unit is fixed per block, never reinterpreted): a
-  // multi-offering listing shows €1,700/month in Long-term and €110/night in
-  // Vacation. A sale shows the asking price (no per-unit suffix); an exchange
-  // shows "Free". When the listing doesn't carry the active offering,
-  // `resolvePrimaryOffering` falls back to the first present block.
-  const primaryOffering = resolvePrimaryOffering(
-    property,
-    browseMode,
-    t('listing.exchange.free', 'Free'),
-  );
+  const { propertyData } = derived;
 
-  // The OTHER offerings this multi-offering listing carries (excluding the one
-  // shown above) drive both the floating badges and the subtle "Also available"
-  // line. Empty for single-offering listings.
-  const otherOfferings = resolveOfferingSummaries(property, browseMode);
-
-  // Extract data from property object
-  const propertyData = {
-    id: property._id || property.id,
-    title: getPropertyTitle(property),
-    location: getPropertyLocationLabel(property),
-    price: primaryOffering.amount,
-    currency: primaryOffering.currency,
-    priceUnit: primaryOffering.priceUnit,
-    offeringKind: primaryOffering.kind,
-    offeringLabel: primaryOffering.label,
-    type: property.type === 'room' ? 'apartment' : property.type === 'studio' ? 'apartment' : property.type,
-    imageSource: getPropertyImageSource(property, variant === 'compact' ? 'small' : 'medium'),
-    bedrooms: property.bedrooms || 0,
-    bathrooms: property.bathrooms || 0,
-    size: property.squareFootage || 0,
-    sizeUnit: 'm²',
-    isVerified: property.isVerified || false,
-    rating: undefined as number | undefined,
-    reviewCount: undefined as number | undefined,
-  };
-
-  // Localized per-unit suffix for the headline (fixed per priced block):
-  // long-term → "month", short-term → "night"; sale/exchange have none.
-  const priceUnitSuffix = propertyData.priceUnit
-    ? propertyData.priceUnit === PriceUnit.NIGHT
-      ? t('listing.offering.perNightUnit', 'night')
-      : t('listing.offering.perMonthUnit', 'month')
-    : '';
-
-  // "Also available: By night · For sale" — joins the other offerings' labels.
-  const alsoAvailableLabel =
-    otherOfferings.length > 0
-      ? `${t('listing.offering.alsoAvailable', 'Also available')}: ${otherOfferings
-          .map((summary) => t(summary.i18nKey, summary.fallback))
-          .join(' · ')}`
-      : '';
-
-  // Property type surfaced in the META line below the photo (declutters the
-  // photo — the type icon no longer floats over the image). Icon follows the
-  // former on-photo logic (house → home glyph, everything else → building);
-  // the label reuses the `properties.titles.types.*` vocabulary, falling back to
-  // the capitalised raw type for kinds without a dedicated key.
-  const typeMeta: { icon: IoniconName; label: string } | null = propertyData.type
-    ? {
-        icon: propertyData.type === 'house' ? 'home-outline' : 'business-outline',
-        label: t(
-          `properties.titles.types.${propertyData.type}`,
-          propertyData.type.charAt(0).toUpperCase() + propertyData.type.slice(1),
-        ),
-      }
-    : null;
-
-  const isEco = Boolean(property.isEcoFriendly);
-  const isFairPrice = Boolean(property.priceEthics?.isFairPrice);
-  const isFeatured = variant === 'featured';
   const isGrid = variant === 'grid';
-  const isCompact = variant === 'compact';
-  const propertyWithSavedHint = property as PropertyWithSavedHint;
   const isPropertySavedState = propertyData.id
     ? isInitialized
       ? isPropertySaved(propertyData.id)
-      : propertyWithSavedHint.isSaved ?? false
+      : (property as PropertyWithSavedHint).isSaved ?? false
     : false;
 
   /**
-   * Grid cards present a photo-first layout. Long-term flats look better
-   * square (more wall surface visible), vacation rentals breathe in 4:3
-   * so the landscape framing reads. Featured/default carousels keep
-   * their existing square aspect.
+   * Grid cards present a photo-first layout. Long-term flats look better square
+   * (more wall surface visible), vacation rentals breathe in 4:3 so the
+   * landscape framing reads. Featured/default carousels keep their existing
+   * square aspect.
    */
   const gridAspectRatio = mode === 'vacation' ? 4 / 3 : 1;
 
   /**
-   * The swipeable in-card carousel only makes sense for the full-bleed,
-   * vertical photo box. Horizontal rows show a small square thumbnail and the
-   * tiny `compact` tile is too small to page through, so both keep the single
-   * cover image. The carousel itself renders a static photo when the listing
-   * has 0–1 images, so this gate is purely about *where* a pager belongs.
+   * The swipeable in-card carousel only makes sense for the full-bleed, vertical
+   * photo box. Horizontal rows show a small square thumbnail and the tiny
+   * `compact` tile is too small to page through, so both keep the single cover
+   * image. The carousel renders a static photo for 0–1 images, so this gate is
+   * purely about *where* a pager belongs.
    */
   const useCarousel =
     enableImageCarousel && orientation === 'vertical' && variant !== 'compact';
   const mediaAspectRatio = isGrid ? gridAspectRatio : 1;
-
-  // Get variant-specific styles
-  const variantStyles = getVariantStyles(variant);
-
-  // Apply variant-specific overrides
-  const finalImageHeight = imageHeight || variantStyles.imageHeight;
-  const finalShowFeatures = showFeatures && variantStyles.showFeatures;
-  const finalShowTypeIcon = showTypeIcon && variantStyles.showTypeIcon;
-  const finalShowRating = showRating && variantStyles.showRating;
-  const finalShowPrice = showPrice && (variantStyles.showPrice !== false);
-  const finalTitleLines = titleLines !== undefined ? titleLines : variantStyles.titleLines;
-  const finalLocationLines = locationLines !== undefined ? locationLines : variantStyles.locationLines;
-
-  /**
-   * Badge chrome that floats over the photo (rating, eco/verified, instant
-   * book, type, external source, plus any caller-supplied badge/overlay).
-   * Shared verbatim by the carousel media (as `children`) and the static-image
-   * media so the overlays read identically regardless of which path renders.
-   * Every node here is a non-interactive `View`, so it never introduces a
-   * nested `<button>` on web.
-   */
-  const mediaBadges = (
-    <>
-      {/* Photo-overlay chip stack — ONE absolutely-positioned, flex-driven
-          container in the top-left. Every child is a `MediaChip` (or the
-          rating chip), so they share the same height, radius, padding and
-          frosted backdrop and align on a single row regardless of which are
-          present — absent chips leave no gap, present ones never collide, and
-          there are no per-badge magic offsets. Suppressed in the grid variant
-          to keep those cards photo-first. The stack lives in the top-LEFT, the
-          opposite corner from the save heart (top-right), so they never
-          overlap; the carousel dots sit bottom-centre, also clear.
-
-          Order (freshness leads, then offerings, then provenance/status): new →
-          rating → offerings → instant book → verified → eco. The compact
-          ("small") card is too small to host any of this — its photo shows only
-          the save heart — so the whole stack is suppressed on compact. The grid
-          variant stays photo-first, so it renders ONLY the freshness chip (the
-          rich chips are gated on `!isGrid`). */}
-      {!isCompact && (isNew || !isGrid) && (
-        <View style={styles.mediaChipStack}>
-          {isNew ? (
-            <View style={styles.newChip}>
-              <BloomText style={styles.newChipText}>
-                {t('listing.badge.new', 'New')}
-              </BloomText>
-            </View>
-          ) : null}
-
-          {!isGrid ? (
-            <>
-          {finalShowRating && propertyData.rating ? (
-            <MediaChip
-              icon="star"
-              accent={colors.ratingStar}
-              label={propertyData.rating.toFixed(1)}
-            />
-          ) : null}
-
-          {/* Offering chips — "By night" / "For sale" / "Exchange" for each
-              OTHER offering this listing carries (the active one is the price). */}
-          {otherOfferings.map((summary) => (
-            <OfferingBadge key={summary.offering} offering={summary.offering} size="md" />
-          ))}
-
-          {/* Fair price — Homiio ethical + market badge. */}
-          {isFairPrice ? (
-            <MediaChip
-              icon="pricetag"
-              accent={colors.success}
-              label={t('listing.badge.fairPrice', 'Fair price')}
-            />
-          ) : null}
-
-          {/* Instant Book (vacation mode only). */}
-          {showInstantBook ? (
-            <MediaChip
-              icon="flash"
-              accent={colors.primarySubtleForeground}
-              label={t('listing.badge.instantBook', 'Instant book')}
-            />
-          ) : null}
-
-          {/* Verified — icon-only shield, brand accent. */}
-          {showVerifiedBadge && propertyData.isVerified ? (
-            <MediaChip icon="shield-checkmark" accent={colors.primarySubtleForeground} />
-          ) : null}
-
-          {/* Eco — icon-only leaf, green accent. */}
-          {isEco ? <MediaChip icon="leaf" accent={colors.success} /> : null}
-            </>
-          ) : null}
-        </View>
-      )}
-
-      {/* Custom Badge Content */}
-      {badgeContent && <View style={styles.customBadge}>{badgeContent as React.ReactNode}</View>}
-
-      {/* Overlay Content */}
-      {overlayContent && <View style={styles.overlay}>{overlayContent as React.ReactNode}</View>}
-    </>
-  );
-
-  const textContent = (
-    <View
-      style={[
-        styles.content,
-        orientation === 'horizontal' ? styles.horizontalContent : null,
-        isGrid ? styles.gridContent : null,
-      ]}
-    >
-      {/* Title */}
-      <ThemedText
-        style={[
-          styles.title,
-          isFeatured ? styles.featuredTitle : null,
-          isGrid ? styles.gridTitle : null,
-        ]}
-        numberOfLines={orientation === 'horizontal' ? undefined : finalTitleLines}
-      >
-        {propertyData.title}
-      </ThemedText>
-
-      {/* Location */}
-      {showLocation && propertyData.location && (
-        <ThemedText
-          style={[
-            styles.location,
-            isFeatured ? styles.featuredLocation : null,
-            orientation === 'horizontal' ? styles.horizontalLocation : null,
-            isGrid ? styles.gridLocation : null,
-          ]}
-          numberOfLines={finalLocationLines}
-        >
-          {propertyData.location}
-        </ThemedText>
-      )}
-
-      {/* Features — suppressed in grid variant to keep cards photo-first */}
-      {finalShowFeatures && !isGrid && (
-        <View style={styles.features}>
-          {/* Property type leads the meta line (moved off the photo). Shown for
-              the variants that previously surfaced the on-photo type icon; the
-              compact variant keeps its own trailing type text below. */}
-          {finalShowTypeIcon && typeMeta && variant !== 'compact' && (
-            <>
-              <View style={styles.typeMeta}>
-                <Ionicons name={typeMeta.icon} size={13} color={colors.COLOR_BLACK_LIGHT_4} />
-                <ThemedText style={styles.featureText}>{typeMeta.label}</ThemedText>
-              </View>
-              <ThemedText style={styles.featureSeparator}>•</ThemedText>
-            </>
-          )}
-          <View style={styles.feature}>
-            <ThemedText style={styles.featureText}>
-              {`${propertyData.bedrooms} bed${propertyData.bedrooms !== 1 ? 's' : ''}`}
-            </ThemedText>
-          </View>
-          <ThemedText style={styles.featureSeparator}>•</ThemedText>
-          <View style={styles.feature}>
-            <ThemedText style={styles.featureText}>
-              {`${propertyData.bathrooms} bath${propertyData.bathrooms !== 1 ? 's' : ''}`}
-            </ThemedText>
-          </View>
-          {propertyData.size && propertyData.size > 0 && (
-            <>
-              <ThemedText style={styles.featureSeparator}>•</ThemedText>
-              <View style={styles.feature}>
-                <ThemedText style={styles.featureText}>
-                  {`${propertyData.size} ${propertyData.sizeUnit}`}
-                </ThemedText>
-              </View>
-            </>
-          )}
-          {variant === 'compact' && typeMeta && (
-            <>
-              <ThemedText style={styles.featureSeparator}>•</ThemedText>
-              <ThemedText style={styles.featureText}>{typeMeta.label}</ThemedText>
-            </>
-          )}
-        </View>
-      )}
-
-      {/* Price — the ACTIVE browse mode's priced block. Exchange listings have
-          no money price, so they render the "Free" label instead of
-          CurrencyFormatter; sale shows the sale price with NO per-unit suffix;
-          long-term shows `/month` and short-term `/night` (fixed per block). */}
-      {finalShowPrice &&
-        (propertyData.offeringKind === 'exchange'
-          ? propertyData.offeringLabel.length > 0
-          : propertyData.price > 0) && (
-        <View style={[styles.priceContainer, isGrid ? styles.gridPriceContainer : null]}>
-          <BloomText
-            style={[
-              styles.price,
-              isFeatured ? styles.featuredPrice : null,
-              isGrid ? styles.gridPrice : null,
-            ]}
-          >
-            {propertyData.offeringKind === 'exchange' ? (
-              propertyData.offeringLabel
-            ) : (
-              <>
-                <CurrencyFormatter
-                  amount={propertyData.price}
-                  originalCurrency={propertyData.currency}
-                  showConversion={false}
-                />
-                {priceUnitSuffix ? (
-                  <BloomText style={[styles.priceUnit, isGrid ? styles.gridPriceUnit : null]}>
-                    {' / '}{priceUnitSuffix}
-                  </BloomText>
-                ) : null}
-              </>
-            )}
-          </BloomText>
-        </View>
-      )}
-
-      {/* "Also available: By night · For sale" — the OTHER offerings this
-          multi-offering listing carries. Hidden in the dense grid + compact
-          tiles to keep them photo-first. */}
-      {finalShowPrice && !isGrid && variant !== 'compact' && alsoAvailableLabel ? (
-        <BloomText style={styles.alsoAvailable} numberOfLines={1}>
-          {alsoAvailableLabel}
-        </BloomText>
-      ) : null}
-    </View>
-  );
+  const finalImageHeight = imageHeight || getVariantStyles(variant).imageHeight;
 
   return (
     <View
@@ -665,7 +667,7 @@ export function PropertyCard({
           ]}
           onPress={onPress}
           onPressIn={handleImagePressIn}
-          onPressOut={handleImagePressOut}
+          onPressOut={() => setPressed(false)}
           onLongPress={onLongPress}
           accessibilityRole="button"
           accessibilityLabel={propertyData.title}
@@ -686,7 +688,7 @@ export function PropertyCard({
             {/* The photo zooms inside the rounded mask on hover (anywhere on the
                 card) / press; the card never moves. Badges are siblings of the
                 zoom so they stay put. */}
-            <ZoomableImage active={imageActive} style={styles.imageZoom}>
+            <ZoomableImage active={imageActive} style={StyleSheet.absoluteFill}>
               <Image source={propertyData.imageSource} style={styles.image} resizeMode="cover" />
             </ZoomableImage>
             {mediaBadges}
@@ -766,7 +768,7 @@ export function PropertyCard({
       {footerContent && <View style={styles.footer}>{footerContent as React.ReactNode}</View>}
     </View>
   );
-}
+});
 
 const styles = StyleSheet.create({
   // ===== BASE STYLES (shared across all variants) =====
@@ -810,15 +812,6 @@ const styles = StyleSheet.create({
   image: {
     width: '100%',
     height: '100%',
-  },
-  // The masked zoom wrapper fills the image box so the photo scales inside the
-  // card's rounded corners without nudging the layout.
-  imageZoom: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
   },
   content: {
     flex: 1,

--- a/packages/frontend/components/property/PropertyImageCarousel.tsx
+++ b/packages/frontend/components/property/PropertyImageCarousel.tsx
@@ -34,9 +34,8 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
-
 import { colors } from '@/styles/colors';
+import { IconButton } from '@/components/ui/IconButton';
 import { ZoomableImage } from '@/components/ui/ZoomableImage';
 import {
   type ImageDisplaySource,
@@ -170,55 +169,15 @@ const CarouselPage: React.FC<CarouselPageProps> = ({
       onLongPress={onLongPress}
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel}
-      style={[
-        styles.page,
+      style={
         fillWhenUnmeasured && (width <= 0 || height <= 0)
           ? styles.pageFill
-          : { width, height },
-      ]}
+          : { width, height }
+      }
     >
-      <ZoomableImage active={Boolean(imageActive) || pressed} style={styles.pageZoom}>
+      <ZoomableImage active={Boolean(imageActive) || pressed} style={StyleSheet.absoluteFill}>
         <Image source={source} style={styles.image} resizeMode="cover" />
       </ZoomableImage>
-    </Pressable>
-  );
-};
-
-interface NavArrowProps {
-  direction: 'prev' | 'next';
-  onPress: () => void;
-  /** Accessibility label (e.g. "Previous photo"). */
-  accessibilityLabel: string;
-}
-
-/**
- * A single circular chevron button overlaying the photo (web only). Rendered as
- * a sibling of the `FlatList` so its press is its own target and never bubbles
- * to the page tap that opens the detail screen. Owns its own pressed state — a
- * StyleSheet array (not the NativeWind-incompatible function-form `style`)
- * drives the pressed tint, per the project's NativeWind v4 constraint.
- */
-const NavArrow: React.FC<NavArrowProps> = ({ direction, onPress, accessibilityLabel }) => {
-  const [pressed, setPressed] = useState(false);
-  const isPrev = direction === 'prev';
-  return (
-    <Pressable
-      onPress={onPress}
-      onPressIn={() => setPressed(true)}
-      onPressOut={() => setPressed(false)}
-      accessibilityRole="button"
-      accessibilityLabel={accessibilityLabel}
-      style={[
-        styles.navArrow,
-        isPrev ? styles.navArrowLeft : styles.navArrowRight,
-        pressed ? styles.navArrowPressed : null,
-      ]}
-    >
-      <Ionicons
-        name={isPrev ? 'chevron-back' : 'chevron-forward'}
-        size={NAV_ARROW_ICON_SIZE}
-        color={colors.COLOR_BLACK}
-      />
     </Pressable>
   );
 };
@@ -455,10 +414,24 @@ export const PropertyImageCarousel: React.FC<PropertyImageCarouselProps> = ({
           siblings of the FlatList so each is its own press target that never
           bubbles to the page tap that opens the detail. */}
       {showPrevArrow ? (
-        <NavArrow direction="prev" onPress={goPrev} accessibilityLabel="Previous photo" />
+        <IconButton
+          variant="overlay"
+          icon="chevron-back"
+          size={NAV_ARROW_ICON_SIZE}
+          onPress={goPrev}
+          accessibilityLabel="Previous photo"
+          style={[styles.navArrow, styles.navArrowLeft]}
+        />
       ) : null}
       {showNextArrow ? (
-        <NavArrow direction="next" onPress={goNext} accessibilityLabel="Next photo" />
+        <IconButton
+          variant="overlay"
+          icon="chevron-forward"
+          size={NAV_ARROW_ICON_SIZE}
+          onPress={goNext}
+          accessibilityLabel="Next photo"
+          style={[styles.navArrow, styles.navArrowRight]}
+        />
       ) : null}
     </View>
   );
@@ -473,23 +446,12 @@ const styles = StyleSheet.create({
   },
   // The page's size comes from the explicit `width`/`height` props (or the
   // `pageFill` fallback) — never `height: '100%'`, which collapses to 0 on web
-  // against the unsized RN-Web FlatList item wrapper. `overflow: hidden` clips
-  // the cover-resized image to the page bounds.
-  page: {
-    overflow: 'hidden',
-  },
+  // against the unsized RN-Web FlatList item wrapper. No `overflow: hidden`
+  // needed: the `ZoomableImage` mask + the rounded `container` already clip the
+  // cover-resized (and hover-zoomed) photo.
   pageFill: {
     width: '100%',
     height: '100%',
-  },
-  // The masked zoom wrapper fills the page so the photo scales inside the page
-  // bounds (and the carousel's rounded container) without moving the layout.
-  pageZoom: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
   },
   image: {
     width: '100%',
@@ -524,19 +486,20 @@ const styles = StyleSheet.create({
     borderRadius: 3,
     backgroundColor: colors.white,
   },
-  // Web hover navigation arrows. Vertically centred over the photo and inset
-  // from each edge, layered above the dots. White circle + subtle shadow +
-  // dark chevron, matching the Airbnb in-card affordance.
+  // Web hover navigation arrows — position + shadow only; the frosted-white
+  // circle, pressed/hover tint, and glyph come from `IconButton variant="overlay"`.
+  // Vertically centred over the photo, inset from each edge, layered above the
+  // dots. `padding: 0` overrides the variant's default padding so the button is
+  // exactly `NAV_ARROW_SIZE`.
   navArrow: {
     position: 'absolute',
     top: '50%',
     width: NAV_ARROW_SIZE,
     height: NAV_ARROW_SIZE,
-    borderRadius: NAV_ARROW_SIZE / 2,
     marginTop: -NAV_ARROW_SIZE / 2,
+    padding: 0,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: 'rgba(255, 255, 255, 0.95)',
     zIndex: 2,
     ...(Platform.OS === 'web'
       ? { boxShadow: '0 1px 4px rgba(0,0,0,0.18)' }
@@ -547,10 +510,6 @@ const styles = StyleSheet.create({
   },
   navArrowRight: {
     right: NAV_ARROW_INSET,
-  },
-  navArrowPressed: {
-    backgroundColor: colors.white,
-    opacity: 0.9,
   },
 });
 

--- a/packages/frontend/components/search/SearchSummaryBar.tsx
+++ b/packages/frontend/components/search/SearchSummaryBar.tsx
@@ -29,15 +29,35 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { Ionicons } from '@expo/vector-icons';
 
 import { Text as BloomText } from '@oxyhq/bloom/typography';
 
 import { OfferingType, PropertyType } from '@homiio/shared-types';
 import { useIsScreenNotMobile } from '@/hooks/useOptimizedMediaQuery';
+import { IconButton } from '@/components/ui/IconButton';
 import { colors } from '@/styles/colors';
 import { cardShadow, hairline, radius, spacing, tracker } from '@/constants/styles';
 import type { SearchQuery, SearchStep } from './types';
+
+/**
+ * Format the price-range segment shared by the wide pill's middle column and the
+ * compact summary line: an explicit min–max, a one-sided cap, or the "any price"
+ * placeholder. One helper so both call sites read identically.
+ */
+function formatPriceRange(query: SearchQuery, t: TFunction): string {
+  if (query.priceMin !== undefined && query.priceMax !== undefined) {
+    return `€${query.priceMin}–€${query.priceMax}`;
+  }
+  if (query.priceMax !== undefined) {
+    return `≤ €${query.priceMax}`;
+  }
+  if (query.priceMin !== undefined) {
+    return `≥ €${query.priceMin}`;
+  }
+  return t('search.summary.anyPrice');
+}
 
 /** i18n key for a single property type label. */
 const TYPE_I18N_KEYS: Record<PropertyType, string> = {
@@ -99,14 +119,6 @@ const COLUMN_PAD_X_NARROW = spacing.md;
 /** Single-line (compact) pill leading search-icon size. */
 const COMPACT_ICON_SIZE = 16;
 
-/**
- * Compact-pill trailing save affordance. The bookmark sits at the right end of
- * the results pill (Airbnb places the bookmark there). It is its own ~40dp tap
- * target, a SIBLING of the summary Pressable — never nested inside it — so web
- * never renders a `<button>` inside a `<button>`.
- */
-const SAVE_BUTTON_SIZE = 40;
-const SAVE_ICON_SIZE = 20;
 /** Height of the hairline divider that separates the summary from the bookmark. */
 const SAVE_DIVIDER_HEIGHT = 24;
 
@@ -208,46 +220,6 @@ const PillColumn: React.FC<PillColumnProps> = ({
   );
 };
 
-interface SaveBookmarkButtonProps {
-  isSaved: boolean;
-  onPress: () => void;
-  accessibilityLabel: string;
-}
-
-/**
- * Trailing bookmark in the compact pill. A SIBLING of the summary Pressable —
- * never nested — so web renders two independent buttons, not a `<button>` in a
- * `<button>`. Owns its own pressed/hovered state (a hook can't run in `.map()`,
- * and keeping the visual state local mirrors `PillColumn`/`SearchActionPill`).
- */
-const SaveBookmarkButton: React.FC<SaveBookmarkButtonProps> = ({
-  isSaved,
-  onPress,
-  accessibilityLabel,
-}) => {
-  const [pressed, setPressed] = useState(false);
-  const [hovered, setHovered] = useState(false);
-  return (
-    <Pressable
-      onPress={onPress}
-      onPressIn={() => setPressed(true)}
-      onPressOut={() => setPressed(false)}
-      onHoverIn={() => setHovered(true)}
-      onHoverOut={() => setHovered(false)}
-      accessibilityRole="button"
-      accessibilityState={{ selected: isSaved }}
-      accessibilityLabel={accessibilityLabel}
-      style={[styles.saveButton, (pressed || hovered) && styles.saveButtonPressed]}
-    >
-      <Ionicons
-        name={isSaved ? 'bookmark' : 'bookmark-outline'}
-        size={SAVE_ICON_SIZE}
-        color={isSaved ? colors.primaryColor : colors.COLOR_BLACK}
-      />
-    </Pressable>
-  );
-};
-
 export const SearchSummaryBar: React.FC<SearchSummaryBarProps> = ({
   query,
   onPress,
@@ -318,46 +290,24 @@ export const SearchSummaryBar: React.FC<SearchSummaryBarProps> = ({
   );
 
   // Price label for the wide pill's middle column (long-term / buy / exchange).
-  const priceLabel = useMemo(() => {
-    if (query.priceMin !== undefined && query.priceMax !== undefined) {
-      return `€${query.priceMin}–€${query.priceMax}`;
-    }
-    if (query.priceMax !== undefined) {
-      return `≤ €${query.priceMax}`;
-    }
-    if (query.priceMin !== undefined) {
-      return `≥ €${query.priceMin}`;
-    }
-    return t('search.summary.anyPrice');
-  }, [query.priceMin, query.priceMax, t]);
+  const priceLabel = useMemo(
+    () => formatPriceRange(query, t),
+    [query, t],
+  );
 
-  // Single-line summary segments (compact mode, results top bar).
+  // Single-line summary segments (compact mode, results top bar). Vacation shows
+  // the picked date range in place of price; otherwise it reuses the shared
+  // price-range formatter.
   const segments = useMemo<SummarySegments>(() => {
-    let price: string;
-    if (isVacation && query.dates?.start) {
-      price = query.dates.end
-        ? `${query.dates.start} – ${query.dates.end}`
-        : query.dates.start;
-    } else if (query.priceMin !== undefined && query.priceMax !== undefined) {
-      price = `€${query.priceMin}–€${query.priceMax}`;
-    } else if (query.priceMax !== undefined) {
-      price = `≤ €${query.priceMax}`;
-    } else if (query.priceMin !== undefined) {
-      price = `≥ €${query.priceMin}`;
-    } else {
-      price = t('search.summary.anyPrice');
-    }
+    const price =
+      isVacation && query.dates?.start
+        ? query.dates.end
+          ? `${query.dates.start} – ${query.dates.end}`
+          : query.dates.start
+        : formatPriceRange(query, t);
 
     return { where: whereLabel, type: typeLabel, price };
-  }, [
-    isVacation,
-    query.dates,
-    query.priceMin,
-    query.priceMax,
-    whereLabel,
-    typeLabel,
-    t,
-  ]);
+  }, [isVacation, query, whereLabel, typeLabel, t]);
 
   // --- Full mode (every width): slim Airbnb-style 3-column pill ---
   if (!compact) {
@@ -475,13 +425,13 @@ export const SearchSummaryBar: React.FC<SearchSummaryBarProps> = ({
       {showSave ? (
         <>
           <View style={styles.saveDivider} />
-          <SaveBookmarkButton
-            isSaved={isSaved}
+          <IconButton
+            variant="ghost"
+            icon={isSaved ? 'bookmark' : 'bookmark-outline'}
+            active={isSaved}
+            activeColor={colors.primaryColor}
             onPress={handleSavePress}
-            accessibilityLabel={
-              saveAccessibilityLabel ||
-              (t('search.actions.save'))
-            }
+            accessibilityLabel={saveAccessibilityLabel || t('search.actions.save')}
           />
         </>
       ) : null}
@@ -605,18 +555,6 @@ const styles = StyleSheet.create({
     width: hairline.width,
     height: SAVE_DIVIDER_HEIGHT,
     backgroundColor: hairline.color,
-  },
-  saveButton: {
-    flexShrink: 0,
-    width: SAVE_BUTTON_SIZE,
-    height: SAVE_BUTTON_SIZE,
-    borderRadius: SAVE_BUTTON_SIZE / 2,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginLeft: spacing.xs,
-  },
-  saveButtonPressed: {
-    backgroundColor: colors.COLOR_BLACK_LIGHT_8,
   },
   searchIcon: {
     alignItems: 'center',

--- a/packages/frontend/hooks/useInfiniteCityProperties.ts
+++ b/packages/frontend/hooks/useInfiniteCityProperties.ts
@@ -10,22 +10,14 @@
  * resolved SERVER-side so pagination stays correct — no client-side re-filtering
  * of already-loaded pages.
  */
-import {
-  useInfiniteQuery,
-  type InfiniteData,
-  type UseInfiniteQueryResult,
-} from '@tanstack/react-query';
+import { type InfiniteData, type UseInfiniteQueryResult } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
-import { api } from '@/utils/api';
 import type { Property } from '@homiio/shared-types';
-
-/** Per-page size (the city endpoint caps limit server-side). */
-const PAGE_SIZE = 24;
-/** Results stay fresh for a minute of paging before a refetch. */
-const STALE_TIME_MS = 1000 * 60;
-/** Cache retention after the query goes inactive. */
-const GC_TIME_MS = 1000 * 60 * 10;
+import {
+  PROPERTY_LIST_PAGE_SIZE,
+  useInfinitePropertyList,
+} from './useInfinitePropertyList';
 
 /** Sort options the city screen exposes, mapped to the backend `sort` param. */
 export type CitySortBy = 'newest' | 'priceAsc' | 'priceDesc';
@@ -66,7 +58,7 @@ function buildCityParams(
   filters: CityPropertyFilters,
 ): Record<string, string | number> {
   const params: Record<string, string | number> = {
-    limit: PAGE_SIZE,
+    limit: PROPERTY_LIST_PAGE_SIZE,
     sort: CITY_SORT_PARAM[sortBy],
   };
   if (filters.verified) params.verified = 'true';
@@ -99,40 +91,23 @@ export function useInfiniteCityProperties(
     () => buildCityParams(sortBy, filters),
     [sortBy, filters.verified, filters.eco, filters.minBedrooms, filters.minBathrooms],
   );
-  // `page`/`limit` are excluded from the key (the infinite query owns paging) so
-  // all pages of one city+sort+filter set share a cache entry.
-  const key = useMemo(
+  // `page` is excluded from the key (the infinite query owns paging) so all pages
+  // of one city+sort+filter set share a cache entry.
+  const queryKey = useMemo(
     () => ['cityProperties', cityId ?? '', baseParams] as const,
     [cityId, baseParams],
   );
 
-  const result = useInfiniteQuery({
-    queryKey: key,
-    initialPageParam: 1,
+  return useInfinitePropertyList<CityPropertiesResponseBody, CityPropertiesPage>({
+    queryKey,
+    endpoint: `/api/cities/${cityId}/properties`,
+    baseParams,
     enabled: Boolean(cityId),
-    staleTime: STALE_TIME_MS,
-    gcTime: GC_TIME_MS,
-    queryFn: async ({ pageParam }): Promise<CityPropertiesPage> => {
-      const { data } = await api.get<CityPropertiesResponseBody>(
-        `/api/cities/${cityId}/properties`,
-        { params: { ...baseParams, page: pageParam }, requireAuth: false },
-      );
-      return {
-        properties: data.properties ?? [],
-        page: data.pagination?.page ?? pageParam,
-        total: data.pagination?.total ?? (data.properties?.length ?? 0),
-        hasMore: data.hasMore ?? false,
-      };
-    },
-    getNextPageParam: (lastPage) =>
-      lastPage.hasMore ? lastPage.page + 1 : undefined,
+    mapResponse: (data, pageParam) => ({
+      properties: data.properties ?? [],
+      page: data.pagination?.page ?? pageParam,
+      total: data.pagination?.total ?? (data.properties?.length ?? 0),
+      hasMore: data.hasMore ?? false,
+    }),
   });
-
-  const properties = useMemo<Property[]>(
-    () => result.data?.pages.flatMap((p) => p.properties) ?? [],
-    [result.data],
-  );
-  const total = result.data?.pages[0]?.total ?? 0;
-
-  return { ...result, properties, total };
 }

--- a/packages/frontend/hooks/useInfinitePropertyList.ts
+++ b/packages/frontend/hooks/useInfinitePropertyList.ts
@@ -1,0 +1,95 @@
+/**
+ * useInfinitePropertyList — the shared core behind every paginated property
+ * feed (the Airbnb-2026 search and a city's published listings).
+ *
+ * Both feeds hit a paginated `GET` that returns a batch of {@link Property} plus
+ * a `hasMore` flag, page through it with the SAME React Query `useInfiniteQuery`
+ * config (page-size cap, stale/gc windows, `hasMore`-driven `getNextPageParam`),
+ * and expose the SAME flattened `properties` + server `total` tail. This hook
+ * owns all of that once; each feed is a thin adapter that supplies only what
+ * differs — the endpoint path, the pre-built params, the cache key, the enabled
+ * gate, and a `mapResponse` that shapes the endpoint's body into a page.
+ */
+import {
+  useInfiniteQuery,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+} from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { api } from '@/utils/api';
+import type { Property } from '@homiio/shared-types';
+
+/** Hard cap matching the backend `MAX_LIMIT`; both feeds page in this size. */
+export const PROPERTY_LIST_PAGE_SIZE = 24;
+/** Results stay fresh for a minute of panning/paging before a refetch. */
+const STALE_TIME_MS = 1000 * 60;
+/** Cache retention after the query goes inactive. */
+const GC_TIME_MS = 1000 * 60 * 10;
+
+/**
+ * One page of a paginated property feed. Adapters may extend this with extra
+ * per-page metadata (e.g. `totalPages`); the core only needs these fields to
+ * flatten the list and drive `getNextPageParam`.
+ */
+export interface PropertyListPage {
+  properties: Property[];
+  page: number;
+  total: number;
+  hasMore: boolean;
+}
+
+/** The infinite-query result plus the flattened `properties` + server `total`. */
+export type PropertyListResult<TPage extends PropertyListPage> =
+  UseInfiniteQueryResult<InfiniteData<TPage>, Error> & {
+    /** All loaded properties flattened across pages. */
+    properties: Property[];
+    /** Total match count reported by the server. */
+    total: number;
+  };
+
+interface UseInfinitePropertyListArgs<TResponse, TPage extends PropertyListPage> {
+  /** Cache key for this feed (namespace-first). All pages share one entry. */
+  queryKey: readonly unknown[];
+  /** Endpoint path fetched for each page. */
+  endpoint: string;
+  /** Params for a page BEFORE `page` is applied — built once by the adapter. */
+  baseParams: Record<string, string | number>;
+  /** Shape the raw response body for `pageParam` into a page. */
+  mapResponse: (body: TResponse, pageParam: number) => TPage;
+  /** Gate execution (e.g. a search panel mid-edit, or a missing city id). */
+  enabled: boolean;
+}
+
+export function useInfinitePropertyList<TResponse, TPage extends PropertyListPage>({
+  queryKey,
+  endpoint,
+  baseParams,
+  mapResponse,
+  enabled,
+}: UseInfinitePropertyListArgs<TResponse, TPage>): PropertyListResult<TPage> {
+  const result = useInfiniteQuery({
+    queryKey,
+    initialPageParam: 1,
+    enabled,
+    staleTime: STALE_TIME_MS,
+    gcTime: GC_TIME_MS,
+    queryFn: async ({ pageParam }): Promise<TPage> => {
+      const { data } = await api.get<TResponse>(endpoint, {
+        params: { ...baseParams, page: pageParam },
+        requireAuth: false,
+      });
+      return mapResponse(data, pageParam);
+    },
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore ? lastPage.page + 1 : undefined,
+  });
+
+  const properties = useMemo<Property[]>(
+    () => result.data?.pages.flatMap((p) => p.properties) ?? [],
+    [result.data],
+  );
+  const total = result.data?.pages[0]?.total ?? 0;
+
+  return { ...result, properties, total };
+}

--- a/packages/frontend/hooks/usePropertySearch.ts
+++ b/packages/frontend/hooks/usePropertySearch.ts
@@ -18,24 +18,17 @@
  * nightly rate, sale → sale price). Each returned property exposes
  * `address.coordinates.coordinates` as `[lng, lat]` for map pins.
  */
-import {
-  useInfiniteQuery,
-  type InfiniteData,
-  type UseInfiniteQueryResult,
-} from '@tanstack/react-query';
+import { type InfiniteData, type UseInfiniteQueryResult } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { api } from '@/utils/api';
 import { OfferingType, type Property } from '@homiio/shared-types';
 import type { SearchBounds, SearchQuery } from '@/components/search/types';
+import {
+  PROPERTY_LIST_PAGE_SIZE,
+  useInfinitePropertyList,
+} from './useInfinitePropertyList';
 
-/** Hard cap matching the backend `MAX_LIMIT`. */
-const PAGE_SIZE = 24;
 /** Endpoint path for the public property search. */
 const SEARCH_ENDPOINT = '/api/properties/search';
-/** Stale window: results stay fresh for a minute of panning/paging. */
-const STALE_TIME_MS = 1000 * 60;
-/** Cache retention after the query goes inactive. */
-const GC_TIME_MS = 1000 * 60 * 10;
 
 /**
  * Raw search response envelope. The backend returns both the nested
@@ -83,7 +76,7 @@ export function buildSearchParams(query: SearchQuery): Record<string, string | n
   const isSale = query.offering === OfferingType.SALE;
   const params: Record<string, string | number> = {
     page: 1,
-    limit: PAGE_SIZE,
+    limit: PROPERTY_LIST_PAGE_SIZE,
     // The single offering axis the backend filters membership on AND resolves
     // the price-range field from (long-term → monthly, short-term → nightly,
     // sale → sale price).
@@ -189,36 +182,26 @@ export function usePropertySearch(
 ): PropertySearchResult {
   const { enabled = true } = options;
   const baseParams = useMemo(() => buildSearchParams(query), [query]);
-  const key = useMemo(() => searchQueryKey(query), [query]);
+  // Key excludes `page`/`limit` (the infinite query owns paging) so every page of
+  // one search shares a cache entry — the same shape `searchQueryKey` returns,
+  // but derived from the already-built `baseParams` so the params object is
+  // constructed once per query instead of a second time inside `searchQueryKey`.
+  const queryKey = useMemo(() => {
+    const { page: _page, limit: _limit, ...rest } = baseParams;
+    return ['propertySearch', rest] as const;
+  }, [baseParams]);
 
-  const result = useInfiniteQuery({
-    queryKey: key,
-    initialPageParam: 1,
+  return useInfinitePropertyList<SearchResponse, PropertySearchPage>({
+    queryKey,
+    endpoint: SEARCH_ENDPOINT,
+    baseParams,
     enabled,
-    staleTime: STALE_TIME_MS,
-    gcTime: GC_TIME_MS,
-    queryFn: async ({ pageParam }): Promise<PropertySearchPage> => {
-      const { data } = await api.get<SearchResponse>(SEARCH_ENDPOINT, {
-        params: { ...baseParams, page: pageParam },
-        requireAuth: false,
-      });
-      return {
-        properties: data.data ?? [],
-        page: data.page ?? pageParam,
-        totalPages: data.totalPages ?? 1,
-        total: data.total ?? (data.data?.length ?? 0),
-        hasMore: data.hasMore ?? false,
-      };
-    },
-    getNextPageParam: (lastPage) =>
-      lastPage.hasMore ? lastPage.page + 1 : undefined,
+    mapResponse: (data, pageParam) => ({
+      properties: data.data ?? [],
+      page: data.page ?? pageParam,
+      totalPages: data.totalPages ?? 1,
+      total: data.total ?? (data.data?.length ?? 0),
+      hasMore: data.hasMore ?? false,
+    }),
   });
-
-  const properties = useMemo<Property[]>(
-    () => result.data?.pages.flatMap((p) => p.properties) ?? [],
-    [result.data],
-  );
-  const total = result.data?.pages[0]?.total ?? 0;
-
-  return { ...result, properties, total };
 }


### PR DESCRIPTION
Behavior-preserving code-quality cleanup from a 4-agent `/simplify` review of the recent Airbnb-2026 UI work. **No functional changes** — verified below.

## Landed (9 of 10)

1. **Shared infinite-list core** — new `hooks/useInfinitePropertyList.ts` owns the `useInfiniteQuery` config + `properties = pages.flatMap(...)` + `total` tail. `usePropertySearch` and `useInfiniteCityProperties` are now thin adapters (path + param builder + response mapper); public return shapes unchanged.
3. **Carousel `NavArrow` → `IconButton variant="overlay"`** — position + boxShadow via `style`; dropped the re-rolled frosted circle + local pressed state (and now-unused `Ionicons` import).
4. **SearchSummaryBar `SaveBookmarkButton` → `IconButton variant="ghost"`** — `active`/`activeColor` toggle; dropped the re-rolled chrome + local state + dead `saveButton*` styles/constants.
5. `PropertyCard.imageZoom` + carousel `pageZoom` → `StyleSheet.absoluteFill`.
6. Dropped the redundant `overflow:'hidden'` on the carousel `page` (the `ZoomableImage` mask + rounded container already clip). Kept `PropertyCard.imageContainer` overflow (clips the sibling badges).
7. Inlined the one-line `handleImagePressOut` `useCallback`.
8. `usePropertySearch` builds its params once — the key is derived from the already-built `baseParams` instead of re-calling `buildSearchParams` inside `searchQueryKey` (kept exported for its test).
9. Shared `formatPriceRange(query, t)` helper used by both `priceLabel` and `segments`.
10. **PropertyCard perf** — `resolvePrimaryOffering`/`resolveOfferingSummaries`/`propertyData` + the `mediaBadges`/`textContent` JSX are memoized (hoisted above the early returns, `property`-guarded to keep hook order stable); export wrapped in `React.memo`. So hover re-renders and infinite-feed page appends don't recompute them.

## Skipped — item 2 (false positive)

Item 2 ("ZoomableImage dead uncontrolled path") assumed all 7 callers pass `active` and none passes `borderRadius`/`aspectRatio`. That review missed **two** callers: `app/evictions/[id].tsx` uses the **uncontrolled hover path** (no `active`) **and** `borderRadius`/`aspectRatio`, and `components/evictions/EvictionCard.tsx` passes `borderRadius`/`aspectRatio` too. Making `active` required + removing those props would break the eviction detail cover (lose hover-zoom, corner radius, aspect ratio). Left as-is.

## Deferred (noted, not in scope)

`PropertyResultsGrid` passes an inline `onPress` that defeats `React.memo` there — separate follow-up (per task instruction not to touch it here).

## Verification

- `tsc --noEmit`: 10 errors == baseline, **0 new**.
- `bun run build` (expo web export): **exit 0**.
- `grep -rn "style={({" app components`: **0**.
- `jest --ci`: **32/32** pass (incl. `buildSearchParams`/`searchQueryKey`).
- Playwright smoke on the real built components: arrows appear on hover → page photos → dots advance, arrow click does **not** leak to the photo tap, photo tap opens detail, masked hover-zoom scales `1 → 1.05`, and the compact search bookmark toggles `UNSAVED → SAVED` (aria `Save → Saved`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)