### PR TITLE
fix(ingest+review): clique-only dedup + review findings (consolidates #214, #211)

### DIFF
--- a/packages/backend/__tests__/integration/externalIngest.test.ts
+++ b/packages/backend/__tests__/integration/externalIngest.test.ts
@@ -50,9 +50,9 @@ const fetchImage = jest.fn(
   async (_url: string): Promise<ImageBufferInput> => ({ buffer: ONE_BY_ONE_PNG, mimetype: 'image/png' }),
 );
 
-function buildIngestionService(): IngestionService {
+function buildIngestionService(dedupeEnabled = false): IngestionService {
   const mediaIngest = new ExternalMediaIngest({ fetchImage });
-  return new IngestionService({ mediaIngest });
+  return new IngestionService({ mediaIngest, dedupeEnabled });
 }
 
 async function normalizeAll(): Promise<NormalizedListing[]> {
@@ -264,7 +264,8 @@ describe('external listing ingest (fixture -> IngestionService)', () => {
   });
 
   it('skips a re-listing of the same unit under a new sourceId (dedup fingerprint)', async () => {
-    const ingestion = buildIngestionService();
+    // Dedup is opt-in (off by default); enable it explicitly for this test.
+    const ingestion = buildIngestionService(true);
     // A substantial, shared agency description (>= 40 tokens) so the listings are
     // dedup-eligible; the tail word differs so Jaccard is ~0.97 (> 0.95 floor).
     const shared = Array.from({ length: 60 }, (_, i) => `palabra${String(i).padStart(3, '0')}`).join(' ');

--- a/packages/backend/__tests__/unit/dedupeBackfillPlan.test.ts
+++ b/packages/backend/__tests__/unit/dedupeBackfillPlan.test.ts
@@ -55,13 +55,30 @@ describe('planDeduplication', () => {
     expect(group.keep.id).toBe('older');
   });
 
-  it('collapses a transitive 3-way component into one keeper + two archived', () => {
+  it('collapses a 3-way CLIQUE (all pairs duplicate) into one keeper + two archived', () => {
+    // a,b,c share 60 tokens + 1 unique each → every pair Jaccard 60/62 ≈ 0.968.
     const a = row({ id: 'a', imageCount: 9, listing: { description: words(60, ['one']) } });
     const b = row({ id: 'b', imageCount: 4, listing: { description: words(60, ['two']) } });
     const c = row({ id: 'c', imageCount: 2, listing: { description: words(60, ['three']) } });
     const [group] = planDeduplication([a, b, c]);
     expect(group.keep.id).toBe('a');
     expect(group.archive.map((r) => r.id).sort()).toEqual(['b', 'c']);
+  });
+
+  it('does NOT collapse a NON-clique transitive chain (A~B, B~C, A≁C keeps A and C)', () => {
+    // The single-linkage data-loss case: A~B and B~C both pass, but A~C is below
+    // the floor, so A and C are DISTINCT units. Only the middle B may be archived;
+    // union-find would wrongly archive two of three.
+    //   A = 60 common + 2 unique, C = 60 common + 2 (different) unique, B = 60 common
+    //   Jaccard(A,B)=Jaccard(B,C)=60/62≈0.968 (dup); Jaccard(A,C)=60/64=0.9375 (not)
+    const a = row({ id: 'aaa', imageCount: 5, listing: { description: words(60, ['extraaa', 'extrabb']) } });
+    const b = row({ id: 'bbb', imageCount: 5, listing: { description: words(60) } });
+    const c = row({ id: 'ccc', imageCount: 5, listing: { description: words(60, ['gammaaa', 'gammabb']) } });
+    const groups = planDeduplication([a, b, c]);
+    const archivedIds = groups.flatMap((g) => g.archive.map((r) => r.id));
+    // B is a duplicate of the keeper A; C is NOT and must survive.
+    expect(archivedIds).toEqual(['bbb']);
+    expect(archivedIds).not.toContain('ccc');
   });
 
   it('does not group templated different units below the Jaccard floor', () => {

--- a/packages/backend/scripts/dedupeExternalListings.ts
+++ b/packages/backend/scripts/dedupeExternalListings.ts
@@ -87,34 +87,22 @@ function keepOrder(a: Row, b: Row): number {
   return a.id < b.id ? -1 : 1;
 }
 
-class UnionFind {
-  private readonly parent = new Map<string, string>();
-  find(x: string): string {
-    let root = this.parent.get(x) ?? x;
-    if (root === x) {
-      this.parent.set(x, x);
-      return x;
-    }
-    root = this.find(root);
-    this.parent.set(x, root);
-    return root;
-  }
-  union(a: string, b: string): void {
-    const ra = this.find(a);
-    const rb = this.find(b);
-    if (ra !== rb) this.parent.set(ra, rb);
-  }
-}
-
 function blockKey(c: DedupComparable): string {
   return [c.type, c.cityId, c.offering, c.amount, c.currency, c.bedrooms, c.squareFootage].join('|');
 }
 
 /**
- * Pure grouping: block rows by the scalar fingerprint, union within a block on
- * description similarity, then split each connected component into `keep` (the
- * richest listing) + `archive` (the rest). Groups are ordered largest-first.
- * Deterministic and DB-free — the unit-tested core of the backfill.
+ * Pure grouping: block rows by the scalar fingerprint, then within each block run
+ * a greedy CLIQUE cover. A member is archived ONLY when it is a mutual duplicate
+ * (`areDuplicateListings`) of the chosen keeper AND of every other member already
+ * archived into that group — i.e. the group is a clique.
+ *
+ * This deliberately avoids single-linkage (union-find) clustering:
+ * `areDuplicateListings` (description Jaccard >= 0.95) is NOT transitive, so
+ * A~B and B~C do not imply A~C. Single-linkage would chain A-B-C and archive two
+ * of three even when A and C are distinct units (the templated new-build case the
+ * fingerprint is meant to reject). Clique-only archiving guarantees no distinct
+ * unit is ever collapsed via a transitive chain. Deterministic and DB-free.
  */
 export function planDeduplication(rows: Row[]): DedupGroup[] {
   const blocks = new Map<string, Row[]>();
@@ -125,33 +113,36 @@ export function planDeduplication(rows: Row[]): DedupGroup[] {
     else blocks.set(key, [row]);
   }
 
-  const uf = new UnionFind();
-  const rowById = new Map<string, Row>();
+  const groups: DedupGroup[] = [];
   for (const bucket of blocks.values()) {
-    for (const row of bucket) rowById.set(row.id, row);
     if (bucket.length < 2) continue;
-    for (let i = 0; i < bucket.length; i += 1) {
-      for (let j = i + 1; j < bucket.length; j += 1) {
-        if (areDuplicateListings(bucket[i].comparable, bucket[j].comparable)) {
-          uf.union(bucket[i].id, bucket[j].id);
+    // Anchor on the richest listing; process the rest richest-first.
+    const remaining = [...bucket].sort(keepOrder);
+    while (remaining.length >= 2) {
+      const keep = remaining[0];
+      const clique: Row[] = [keep];
+      const archive: Row[] = [];
+      for (let i = 1; i < remaining.length; i += 1) {
+        const candidate = remaining[i];
+        const dupOfWholeClique = clique.every((member) =>
+          areDuplicateListings(member.comparable, candidate.comparable),
+        );
+        if (dupOfWholeClique) {
+          clique.push(candidate);
+          archive.push(candidate);
         }
       }
+      if (archive.length > 0) {
+        groups.push({ keep, archive });
+        const assigned = new Set([keep.id, ...archive.map((row) => row.id)]);
+        for (let i = remaining.length - 1; i >= 0; i -= 1) {
+          if (assigned.has(remaining[i].id)) remaining.splice(i, 1);
+        }
+      } else {
+        // Keeper has no clique-duplicate; keep it standalone and move on.
+        remaining.shift();
+      }
     }
-  }
-
-  const grouped = new Map<string, Row[]>();
-  for (const row of rowById.values()) {
-    const root = uf.find(row.id);
-    const members = grouped.get(root);
-    if (members) members.push(row);
-    else grouped.set(root, [row]);
-  }
-
-  const groups: DedupGroup[] = [];
-  for (const members of grouped.values()) {
-    if (members.length < 2) continue;
-    const [keep, ...archive] = [...members].sort(keepOrder);
-    groups.push({ keep, archive });
   }
   groups.sort((a, b) => b.archive.length - a.archive.length);
   return groups;
@@ -250,10 +241,14 @@ async function main(): Promise<void> {
   }
 
   if (toArchive.length > 0) {
-    const now = new Date();
+    // Soft-delete ONLY: set `deletedAt` (public feeds filter `deletedAt: null`)
+    // and `status: archived`. Do NOT touch `expiresAt` — it carries a TTL index
+    // (`expireAfterSeconds: 0`), so writing `expiresAt: now` would HARD-delete the
+    // document within ~60s, making the archive irreversible. Leaving `expiresAt`
+    // at its existing future value keeps the soft-delete reversible.
     const result = await Property.updateMany(
       { _id: { $in: toArchive }, isExternal: true, deletedAt: null },
-      { $set: { deletedAt: now, status: PropertyStatus.ARCHIVED, expiresAt: now } },
+      { $set: { deletedAt: new Date(), status: PropertyStatus.ARCHIVED } },
     );
     console.log(`\nArchived ${result.modifiedCount ?? toArchive.length} listing(s).`);
   } else {

--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -102,7 +102,14 @@ export interface IngestionServiceOptions {
   /**
    * Recognise and skip re-listings of the same unit under a new `sourceId`
    * (see {@link areDuplicateListings}). Defaults to env `LISTING_DEDUP_ENABLED`
-   * (only the literal `false` disables it) so ops has a redeploy-free kill switch.
+   * and is OPT-IN (only the literal `true` enables it).
+   *
+   * Off by default because the description-Jaccard fingerprint has a known
+   * false-positive class: new-build developments (e.g. immobilienscout24 Neubau
+   * projects) list many DISTINCT units that share one developer brochure, so
+   * their descriptions are near-identical at the same price/m²/bedrooms even
+   * though they are different apartments. Until a development-safe signal exists,
+   * enabling dedup broadly risks skipping legitimate units, so it stays opt-in.
    */
   dedupeEnabled?: boolean;
 }
@@ -117,7 +124,7 @@ export class IngestionService {
     this.mediaIngest = options.mediaIngest ?? new ExternalMediaIngest();
     this.logger = options.logger ?? new Logger('IngestionService');
     this.defaultTtlDays = options.defaultTtlDays ?? DEFAULT_TTL_DAYS;
-    this.dedupeEnabled = options.dedupeEnabled ?? process.env.LISTING_DEDUP_ENABLED !== 'false';
+    this.dedupeEnabled = options.dedupeEnabled ?? process.env.LISTING_DEDUP_ENABLED === 'true';
   }
 
   /** Validate, upsert and re-host media for a single normalized listing. */
@@ -209,9 +216,10 @@ export class IngestionService {
       const listingAddress = await Address.findById(addressId).select('cityId').lean<{
         cityId?: Types.ObjectId;
       } | null>();
+      const cityId = listingAddress?.cityId;
       const incoming = toDedupComparable({
         type: listing.type,
-        cityId: listingAddress?.cityId ? String(listingAddress.cityId) : undefined,
+        cityId: cityId ? String(cityId) : undefined,
         bedrooms: listing.bedrooms,
         squareFootage: listing.squareFootage,
         description: listing.description,
@@ -219,11 +227,13 @@ export class IngestionService {
         shortTermRent: listing.shortTermRent,
         sale: listing.sale,
       });
-      if (!incoming) return null;
+      if (!incoming || !cityId) return null;
 
-      // Selective scalar prefilter (same type, bedrooms, m² and exact price)
-      // joined to the Address `cityId`. `$lookup` bypasses the Property post-find
-      // hook that renames/mangles `addressId` on lean reads, so `cityId` is clean.
+      // Selective scalar prefilter (same type, bedrooms, m² and price) joined to
+      // the Address `cityId`. The `$lookup` bypasses the Property post-find hook
+      // that renames/mangles `addressId` on lean reads, so `cityId` is clean. The
+      // same-city `$match` runs BEFORE `$limit` so a bounded candidate scan for a
+      // common config never drops the actually-matching (same-city) listing.
       const candidates = await Property.aggregate<DuplicateCandidateDoc>([
         {
           $match: {
@@ -235,8 +245,10 @@ export class IngestionService {
             ...this.buildPriceFilter(incoming),
           },
         },
-        { $limit: DEDUP_CANDIDATE_LIMIT },
         { $lookup: { from: 'addresses', localField: 'addressId', foreignField: '_id', as: 'addr' } },
+        { $addFields: { cityId: { $arrayElemAt: ['$addr.cityId', 0] } } },
+        { $match: { cityId } },
+        { $limit: DEDUP_CANDIDATE_LIMIT },
         {
           $project: {
             description: 1,
@@ -247,7 +259,7 @@ export class IngestionService {
             longTermRent: 1,
             shortTermRent: 1,
             sale: 1,
-            cityId: { $arrayElemAt: ['$addr.cityId', 0] },
+            cityId: 1,
           },
         },
       ]);
@@ -282,22 +294,30 @@ export class IngestionService {
     }
   }
 
-  /** Mongo filter matching the primary offering's exact price + currency. */
+  /**
+   * Mongo filter matching the primary offering's price + currency. `amount` is the
+   * rounded integer from the comparable, but stored prices may carry decimals, so
+   * the filter is a half-unit range `[amount - 0.5, amount + 0.5)` — every stored
+   * value that rounds to `amount` matches (the exact per-listing equality is then
+   * re-checked in {@link areDuplicateListings}). Exact equality here would miss a
+   * stored `850.4` for an incoming `850`.
+   */
   private buildPriceFilter(comparable: DedupComparable): Record<string, unknown> {
+    const range = { $gte: comparable.amount - 0.5, $lt: comparable.amount + 0.5 };
     switch (comparable.offering) {
       case OfferingType.LONG_TERM_RENT:
         return {
-          'longTermRent.monthlyAmount': comparable.amount,
+          'longTermRent.monthlyAmount': range,
           'longTermRent.currency': comparable.currency,
         };
       case OfferingType.SHORT_TERM_RENT:
         return {
-          'shortTermRent.nightlyRate': comparable.amount,
+          'shortTermRent.nightlyRate': range,
           'shortTermRent.currency': comparable.currency,
         };
       case OfferingType.SALE:
         return {
-          'sale.price': comparable.amount,
+          'sale.price': range,
           'sale.currency': comparable.currency,
         };
     }

--- a/packages/backend/worker.ts
+++ b/packages/backend/worker.ts
@@ -72,7 +72,7 @@ const DISCOVER_CONCURRENCY = parseInt(process.env.LISTING_DISCOVER_CONCURRENCY |
  * progress instead of the big three starving the rest. BullMQ: lower number = higher
  * priority; both are >0 so neither falls into the unprioritised (top) lane.
  */
-const HIGH_VOLUME_PROVIDERS = new Set(['fotocasa', 'habitaclia', 'pisos']);
+const HIGH_VOLUME_PROVIDERS = new Set(['fotocasa', 'habitaclia', 'pisos', 'idealista']);
 const FETCH_PRIORITY_HIGH = 10;
 const FETCH_PRIORITY_LOW = 100;
 const fetchPriorityFor = (provider: string): number =>

--- a/packages/listing-providers/src/requestFilter.ts
+++ b/packages/listing-providers/src/requestFilter.ts
@@ -19,6 +19,7 @@ const COMPOUND_SUFFIXES = new Set([
   'com.ar',
   'com.br',
   'com.co',
+  'com.ec',
   'com.pe',
   'com.py',
   'co.nz',


### PR DESCRIPTION
Consolidates **#214** (dedup data-loss fix) and **#211** (review findings) into one deploy — both branches are single-commit and touch disjoint files, cherry-picked onto current main. Merging one PR avoids two back-to-back worker redeploys.

## From #214 — dedup data-loss fix (adversarial-review remediation)
- **Clique-only clustering** (was single-linkage union-find): `areDuplicateListings` (Jaccard ≥ 0.95) is NOT transitive, so union-find could chain 3 distinct units and archive 2. A member is archived only if it is a mutual duplicate of the keeper AND every prior member (a clique). Regression test: non-clique `A~B~C` chain keeps `A` and `C`.
- **Reversible soft-delete**: backfill no longer writes `expiresAt: now` (that hit the TTL index → irreversible hard-delete in ~60s). Sets only `deletedAt` + `status: archived`.
- **Ingest `findDuplicate`**: same-city `$match` now runs before `$limit`; `buildPriceFilter` uses a `[amount−0.5, amount+0.5)` range instead of exact-rounded equality.
- **Dedup defaulted OFF** (`LISTING_DEDUP_ENABLED` to opt in): a fixed-backfill dry-run surfaced immobilienscout24 new-build developments (distinct units sharing one brochure → Jaccard ~1.0) that the description fingerprint cannot separate from re-lists. Opt-in until a development-safe signal (per-unit reference / image-hash) exists.

Prod status: the already-applied buggy backfill archived 20 genuine duplicates across 19 groups; a pairwise re-verification confirmed **0 were wrongly archived** (all 19 keepers survive) — nothing to restore.

## From #211 — review findings
- Add `idealista` to `HIGH_VOLUME_PROVIDERS` fetch-priority set (harmless while disabled; correct when re-enabled).
- Add `com.ec` to `COMPOUND_SUFFIXES` in `requestFilter.ts` (Ecuador registrable-domain correctness).

## Verification
- shared-types → listing-providers → backend build clean.
- Backend suite: **70 suites / 731 tests green** (includes the non-clique regression test).

Closes #214, #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)