### PR TITLE
fix(worker): round-robin listing-fetch priority + no-retry on unregistered provider

### DIFF
--- a/packages/backend/__tests__/unit/fetchPriority.test.ts
+++ b/packages/backend/__tests__/unit/fetchPriority.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Round-robin fetch-priority policy (services/ingestion/queues.ts).
+ *
+ * These are the fairness guarantees the worker relies on so every registered
+ * provider makes progress instead of the highest-volume one starving the rest.
+ * Pure function — no Redis, no BullMQ runtime.
+ */
+
+import {
+  fetchPriorityFor,
+  FETCH_RANK_CAP,
+  HIGH_VOLUME_PROVIDERS,
+} from '../../services/ingestion/queues';
+
+// BullMQ rejects any priority above 2^21 (Job.PRIORITY_LIMIT); every value we
+// emit must stay comfortably under it.
+const BULLMQ_PRIORITY_LIMIT = 2 ** 21;
+
+describe('fetchPriorityFor', () => {
+  it('maps a normal provider rank to tier-base + rank + 1', () => {
+    expect(fetchPriorityFor('immobilienscout24', 0)).toBe(1);
+    expect(fetchPriorityFor('immobilienscout24', 1)).toBe(2);
+    expect(fetchPriorityFor('immoweb', 5)).toBe(6);
+  });
+
+  it('never returns 0, so jobs stay out of BullMQ’s unprioritised wait lane', () => {
+    for (const rank of [0, 1, 42, FETCH_RANK_CAP, FETCH_RANK_CAP * 10]) {
+      expect(fetchPriorityFor('otodom', rank)).toBeGreaterThanOrEqual(1);
+      expect(fetchPriorityFor('habitaclia', rank)).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('aligns every provider at the same rank (round-robin interleave)', () => {
+    // The core fairness property: provider A's Nth job and provider B's Nth job
+    // share a priority, so BullMQ processes A0,B0,C0,A1,B1,C1,… not A0..An,B0…
+    const smalls = ['immobilienscout24', 'immoweb', 'blueground', 'mercadolibre_ar', 'otodom'];
+    for (const rank of [0, 1, 7, 500]) {
+      const priorities = smalls.map((provider) => fetchPriorityFor(provider, rank));
+      expect(new Set(priorities).size).toBe(1);
+    }
+  });
+
+  it('increases strictly with rank within a provider', () => {
+    let previous = -Infinity;
+    for (let rank = 0; rank < 50; rank += 1) {
+      const priority = fetchPriorityFor('immoweb', rank);
+      expect(priority).toBeGreaterThan(previous);
+      previous = priority;
+    }
+  });
+
+  it('places high-volume ES portals in a strictly later tier than normal providers', () => {
+    // Even the FIRST high-volume job must sort after the LAST normal-tier job so
+    // the small providers drain before the big ES portals begin.
+    const worstNormal = fetchPriorityFor('immobilienscout24', FETCH_RANK_CAP);
+    const bestHighVolume = fetchPriorityFor('habitaclia', 0);
+    expect(bestHighVolume).toBeGreaterThan(worstNormal);
+  });
+
+  it('round-robins within the high-volume tier too', () => {
+    const highVolume = [...HIGH_VOLUME_PROVIDERS];
+    for (const rank of [0, 3, 200]) {
+      const priorities = highVolume.map((provider) => fetchPriorityFor(provider, rank));
+      expect(new Set(priorities).size).toBe(1);
+    }
+    // Each of fotocasa/habitaclia/pisos/idealista rides the high-volume tier.
+    expect(highVolume).toEqual(expect.arrayContaining(['fotocasa', 'habitaclia', 'pisos', 'idealista']));
+  });
+
+  it('clamps pathological ranks so priority never approaches PRIORITY_LIMIT', () => {
+    const capped = fetchPriorityFor('immobilienscout24', FETCH_RANK_CAP);
+    expect(fetchPriorityFor('immobilienscout24', FETCH_RANK_CAP + 1)).toBe(capped);
+    expect(fetchPriorityFor('immobilienscout24', 5_000_000)).toBe(capped);
+    expect(fetchPriorityFor('habitaclia', Number.MAX_SAFE_INTEGER)).toBeLessThan(BULLMQ_PRIORITY_LIMIT);
+  });
+
+  it('defends against negative and fractional ranks', () => {
+    expect(fetchPriorityFor('otodom', -5)).toBe(fetchPriorityFor('otodom', 0));
+    expect(fetchPriorityFor('otodom', 3.9)).toBe(fetchPriorityFor('otodom', 3));
+  });
+});

--- a/packages/backend/services/ingestion/queues.ts
+++ b/packages/backend/services/ingestion/queues.ts
@@ -52,6 +52,68 @@ export function fetchJobId(ref: ExternalListingRef): string {
   return jobIdFor(['fetch', ref.provider, ref.sourceId]);
 }
 
+/* -------------------------------------------------------------------------- */
+/* Round-robin fetch priority                                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Big-volume ES portals emit thousands of fetch jobs per discover pass and are
+ * browser/rate-limit heavy. They ride a LATER priority tier so the handful of
+ * jobs from market-wide providers (immobilienscout24, immoweb, mercadolibre, …)
+ * drain first — while still round-robining among themselves inside the tier.
+ * Configurable: move a provider between tiers by editing this set.
+ */
+export const HIGH_VOLUME_PROVIDERS: ReadonlySet<string> = new Set([
+  'fotocasa',
+  'habitaclia',
+  'pisos',
+  'idealista',
+]);
+
+/**
+ * Priority tier bases. BullMQ orders prioritised jobs by
+ * `score = priority * 2^32 + insertionCounter` and pops the lowest, so a lower
+ * priority number runs first and the normal tier (base 0) fully precedes the
+ * high-volume tier. The gap MUST exceed {@link FETCH_RANK_CAP} so the two tiers
+ * never overlap.
+ */
+const FETCH_TIER_NORMAL = 0;
+const FETCH_TIER_HIGH_VOLUME = 1_000_000;
+
+/**
+ * Max round-robin rank honoured per discover batch. Clamps a pathological batch
+ * so a job's priority can never approach BullMQ's `PRIORITY_LIMIT` (2^21) — the
+ * high-volume tier tops out at `1_000_000 + 100_000 + 1`, comfortably below it.
+ * Real batches (one provider/city's refs) sit far under this.
+ */
+export const FETCH_RANK_CAP = 100_000;
+
+/** Base priority tier for a provider (normal vs high-volume). */
+function fetchTierBase(provider: string): number {
+  return HIGH_VOLUME_PROVIDERS.has(provider) ? FETCH_TIER_HIGH_VOLUME : FETCH_TIER_NORMAL;
+}
+
+/**
+ * Round-robin fetch priority for the `rank`-th ref (0-based) of a provider's
+ * discover batch.
+ *
+ * Every provider's rank-0 ref shares its tier's lowest priority, every rank-1
+ * ref the next, and so on. Because rank restarts at 0 for each discover pass,
+ * all providers stay aligned, so BullMQ interleaves them (A0,B0,C0,A1,B1,C1,…)
+ * instead of draining one provider's whole backlog first — even though the
+ * discover jobs that enqueued them ran at different times. A free-running
+ * per-provider counter would NOT do this: its rank window drifts independently
+ * per provider after the first pass, breaking the interleave.
+ *
+ * The `+ 1` keeps the value ≥ 1 so a fetch job never lands in BullMQ's
+ * unprioritised `wait` lane, which is drained in full before ANY prioritised
+ * job (`moveToActive` does `RPOPLPUSH wait` before `ZPOPMIN prioritized`).
+ */
+export function fetchPriorityFor(provider: string, rank: number): number {
+  const clamped = Math.min(Math.max(Math.trunc(rank), 0), FETCH_RANK_CAP);
+  return fetchTierBase(provider) + clamped + 1;
+}
+
 /**
  * Build a BullMQ Redis connection OPTIONS object from a `redis[s]://` URL. We
  * pass options (not an ioredis instance) so BullMQ owns the connection, and set

--- a/packages/backend/worker.ts
+++ b/packages/backend/worker.ts
@@ -14,7 +14,7 @@
 
 require('dotenv').config();
 
-import { Queue, Worker, type Job, type Queue as BullQueue } from 'bullmq';
+import { Queue, Worker, UnrecoverableError, type Job, type Queue as BullQueue } from 'bullmq';
 import {
   createDefaultRegistry,
   createListingFetchRuntimeFromEnv,
@@ -40,6 +40,7 @@ import {
   QUEUE_NAMES,
   discoverJobId,
   fetchJobId,
+  fetchPriorityFor,
   parseRedisConnection,
   type DiscoverJobData,
   type FetchJobData,
@@ -64,19 +65,6 @@ const FETCH_CONCURRENCY = parseInt(process.env.LISTING_FETCH_CONCURRENCY || '6',
  * scopes serialise there while HTTP-first scopes proceed.
  */
 const DISCOVER_CONCURRENCY = parseInt(process.env.LISTING_DISCOVER_CONCURRENCY || '3', 10);
-
-/**
- * Per-city ES portals emit thousands of fetch jobs per pass. Give their fetch a
- * LOWER priority so the handful of jobs from a smaller provider (immobilienscout24,
- * mercadolibre, otodom, …) isn't stuck behind that backlog — every provider makes
- * progress instead of the big three starving the rest. BullMQ: lower number = higher
- * priority; both are >0 so neither falls into the unprioritised (top) lane.
- */
-const HIGH_VOLUME_PROVIDERS = new Set(['fotocasa', 'habitaclia', 'pisos', 'idealista']);
-const FETCH_PRIORITY_HIGH = 10;
-const FETCH_PRIORITY_LOW = 100;
-const fetchPriorityFor = (provider: string): number =>
-  HIGH_VOLUME_PROVIDERS.has(provider) ? FETCH_PRIORITY_LOW : FETCH_PRIORITY_HIGH;
 
 /** Discover jobs may hold a browser session across many cities — match worker lockDuration. */
 const DISCOVER_LOCK_MS = 600_000;
@@ -106,6 +94,13 @@ async function expireExternalListing(source: string, sourceId: string, reason: s
 
 /** Fetch + normalize a single listing ref and ingest the result. */
 async function processFetchRef(ref: ExternalListingRef): Promise<void> {
+  if (!registry.has(ref.provider)) {
+    // A queued job for a provider that is no longer registered (disabled via env,
+    // renamed, or removed) can never succeed. Fail it permanently instead of
+    // burning all 3 attempts + exponential backoff — that churn produced
+    // thousands of pointless "No provider registered" retries in prod.
+    throw new UnrecoverableError(`No provider registered for id "${ref.provider}"`);
+  }
   const provider = registry.get(ref.provider);
   try {
     const raw = await provider.fetch(ref, { runtime });
@@ -151,6 +146,9 @@ async function processFetchRef(ref: ExternalListingRef): Promise<void> {
 
 /** Enumerate a discover job's refs (BullMQ path enqueues; inline path ingests). */
 async function collectDiscoverRefs(data: DiscoverJobData): Promise<ExternalListingRef[]> {
+  if (!registry.has(data.provider)) {
+    throw new UnrecoverableError(`No provider registered for id "${data.provider}"`);
+  }
   const provider = registry.get(data.provider);
   const refs: ExternalListingRef[] = [];
   for await (const ref of provider.discover({
@@ -361,7 +359,11 @@ async function startBullMq(): Promise<() => Promise<void>> {
         city: job.data.city,
       });
       const refs = await collectDiscoverRefs(job.data);
-      for (const ref of refs) {
+      // `rank` is the ref's 0-based position in THIS discover batch. It restarts
+      // at 0 every pass, so every provider's rank-0 job shares the lowest
+      // priority in its tier and BullMQ interleaves providers round-robin rather
+      // than draining one provider's whole backlog first. See fetchPriorityFor.
+      for (const [rank, ref] of refs.entries()) {
         const jobId = fetchJobId(ref);
         const existingFetch = await fetchQueue.getJob(jobId);
         if (existingFetch) {
@@ -372,7 +374,7 @@ async function startBullMq(): Promise<() => Promise<void>> {
         }
         await fetchQueue.add(QUEUE_NAMES.fetch, { ref }, {
           jobId,
-          priority: fetchPriorityFor(ref.provider),
+          priority: fetchPriorityFor(ref.provider, rank),
           attempts: 3,
           backoff: { type: 'exponential', delay: 60_000 },
         });


### PR DESCRIPTION
## Problem (prod evidence)

A live BullMQ inspection of `listing-fetch` (Valkey via `REDIS_URL`) showed **only 2 of 15 registered providers publishing**:

- `immobilienscout24` = 737 `waiting` + all 6 `active` slots
- `immoweb` = 598 `waiting`, `blueground` = 125 `waiting`
- `habitaclia` = 7217 `prioritized`, `pisos` = 214 `prioritized`

Two root causes:

1. **Volume monopoly / no fairness.** The old policy gave every normal provider the *same* priority (`10`) and every big ES portal the same `100`. BullMQ orders equal-priority jobs FIFO (`score = priority * 2^32 + insertionCounter`), so the provider that discovers the most refs (immobilienscout24, DE) fills the front of the priority-10 lane and drowns immoweb/otodom/mercadolibre/kleinanzeigen/immowelt — they never get a worker slot. habitaclia's 7217 priority-100 jobs likewise never drain behind the priority-10 flood.
2. **Dead-job churn.** Jobs for providers no longer in the registry (disabled via env, renamed, removed) threw `No provider registered for id "X"` and **retried 3× with exponential backoff forever** (thousands of pointless retries).

## Fix A — round-robin fetch fairness

`priority = tierBase(provider) + min(rank, CAP) + 1`, where `rank` is the ref's **0-based position in its discover batch**.

Because rank restarts at 0 each discover pass, every provider's rank-0 job shares its tier's lowest priority, rank-1 the next, etc. BullMQ then interleaves providers **A0,B0,C0,A1,B1,C1,…** instead of draining one provider's whole backlog first — and it re-interleaves correctly even though the discover jobs that enqueued them ran at different times (the priority ordering does the interleave in the fetch queue).

**Why not a free-running per-provider Redis counter** (the originally-suggested `INCR listing:fetchseq:<provider>`)? It does *not* actually round-robin: after pass 1 each provider's counter sits at a different total, so with any wrap/cap the per-provider rank *windows drift independently* and stop aligning at rank 0. Round-robin requires all providers aligned at the same rank each pass — which the per-batch rank gives locally, with **no Redis counter, no extra connection, and no wraparound to manage** (rank is bounded by batch size and clamped to `CAP` so priority never approaches BullMQ's `PRIORITY_LIMIT` = 2^21).

Tiers (unchanged intent): the high-volume ES portals (`fotocasa`/`habitaclia`/`pisos`/`idealista`) keep a later tier base (`1_000_000` vs `0`) so the small market-wide providers drain first — now round-robining **within** each tier. Max emitted priority `1_100_001` ≪ `2_097_152`.

## Fix B — no-retry on unregistered provider

`processFetchRef` and `collectDiscoverRefs` now guard with `registry.has(...)` and throw BullMQ's `UnrecoverableError`, which `Job.shouldRetryJob` skips — the job fails permanently without consuming retry attempts. Stops the dead-job churn when a provider is disabled while its jobs are still queued.

## Counter wraparound

N/A by design — there is no persistent counter. Rank resets to 0 per discover batch and is clamped to `FETCH_RANK_CAP` (100_000), so priority is always bounded (`1 ≤ p ≤ 1_100_001`) and never grows unbounded.

## Tests

- New `__tests__/unit/fetchPriority.test.ts` (8 cases): round-robin alignment across providers at equal rank, strict monotonicity within a provider, high-volume tier strictly after the normal tier, clamp keeps priority under `PRIORITY_LIMIT`, negative/fractional-rank defense, and `≥ 1` (never the unprioritised `wait` lane).
- Full backend suite green: **71 suites / 739 tests**. `tsc` build exits 0.

The UnrecoverableError path isn't unit-tested in isolation (it needs the worker entrypoint's live registry); it's verified against BullMQ 5.79.3's `Job.shouldRetryJob` source (`err instanceof UnrecoverableError` → no retry).

> Note: code change affects **new** enqueues only. The existing mis-prioritized backlog (immobilienscout24 737 + immoweb 598 + blueground 125 at priority 0; habitaclia 7217 + pisos 214 at priority 100) must be re-ranked or purged post-deploy (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)