### PR TITLE
fix(habitaclia): HTTP-GET-first discover, browser only as per-city fallback

### DIFF
--- a/packages/backend/__tests__/unit/habitacliaProvider.test.ts
+++ b/packages/backend/__tests__/unit/habitacliaProvider.test.ts
@@ -259,12 +259,33 @@ describe('HabitacliaProvider.discover listainmuebles path', () => {
     expect(postPages).toBeGreaterThanOrEqual(0);
   });
 
-  it('falls back to HTML ladder when the listainmuebles session fails', async () => {
-    let htmlFetches = 0;
+  it('paginates the search over cold HTTP GET across pages without opening a browser', async () => {
+    // Regression for the prod `page.goto: net::ERR_TIMED_OUT at
+    // …/alquiler-<city>-<page>.htm` timeouts: deep search pages are the
+    // canonical `-<page>.htm` GET URLs and return listings cold, so discover must
+    // walk them over HTTP and never escalate a healthy city to the browser tier.
+    const page2 = HABITACLIA_FIXTURE_SEARCH_HTML.replace('i12345678900000', 'i22222222200000')
+      .replace('i98765432100000', 'i33333333300000');
+    // A real exhausted-pagination page is a full-size results page with search
+    // chrome but no listing cards — NOT a short challenge stub (which the
+    // >512-char challenge heuristic would otherwise flag and escalate).
+    const emptyPage = `<!doctype html><html lang="es"><head><title>Alquiler barcelona</title></head><body>
+<nav class="header">${'<a href="/">habitaclia</a>'.repeat(4)}</nav>
+<section class="search-filters"><form>${'<label>Filtro</label><input />'.repeat(8)}</form></section>
+<main><ul class="list-items"></ul><p class="no-results">No hemos encontrado más resultados para tu búsqueda.</p></main>
+<footer>${'<a href="/aviso-legal.htm">Aviso legal</a>'.repeat(6)}</footer>
+</body></html>`;
+    const fetchedUrls: string[] = [];
+    let sessionsOpened = 0;
     const runtime: FetchRuntime = {
-      fetchHttp: async () => {
-        htmlFetches += 1;
-        return { status: 200, body: HABITACLIA_FIXTURE_SEARCH_HTML };
+      fetchHttp: async (url) => {
+        fetchedUrls.push(url);
+        if (url.endsWith('/alquiler-barcelona.htm')) {
+          return { status: 200, body: HABITACLIA_FIXTURE_SEARCH_HTML };
+        }
+        if (url.endsWith('/alquiler-barcelona-2.htm')) return { status: 200, body: page2 };
+        // Page 3 onward: no more cards → pagination stops (city exhausted, not blocked).
+        return { status: 200, body: emptyPage };
       },
       fetchJson: async () => {
         throw new Error('unused');
@@ -276,7 +297,58 @@ describe('HabitacliaProvider.discover listainmuebles path', () => {
         throw new Error('unused');
       },
       openBrowserSession: async () => {
-        throw new Error('warm-up blocked');
+        sessionsOpened += 1;
+        throw new Error('browser should not be needed for a healthy city');
+      },
+    };
+
+    const local = new HabitacliaProvider({ runtime });
+    const refs: ExternalListingRef[] = [];
+    for await (const ref of local.discover({
+      provider: 'habitaclia',
+      market: 'ES',
+      city: 'barcelona',
+      limit: 50,
+      runtime,
+    })) {
+      refs.push(ref);
+    }
+
+    expect(sessionsOpened).toBe(0);
+    expect(refs.map((ref) => ref.sourceId).sort()).toEqual([
+      '12345678900000',
+      '22222222200000',
+      '33333333300000',
+      '98765432100000',
+    ]);
+    expect(fetchedUrls).toContain('https://www.habitaclia.com/alquiler-barcelona.htm');
+    expect(fetchedUrls).toContain('https://www.habitaclia.com/alquiler-barcelona-2.htm');
+  });
+
+  it('opens the warmed session only for a city cold HTTP challenges', async () => {
+    let sessionsOpened = 0;
+    const runtime: FetchRuntime = {
+      // Imperva challenges every cold HTTP page for this city.
+      fetchHttp: async () => ({ status: 403, body: 'Pardon Our Interruption' }),
+      fetchJson: async () => {
+        throw new Error('unused');
+      },
+      fetchText: async () => {
+        throw new Error('unused');
+      },
+      loadFixture: async () => {
+        throw new Error('unused');
+      },
+      openBrowserSession: async () => {
+        sessionsOpened += 1;
+        return {
+          request: async () => ({ status: 200, body: '<html></html>' }),
+          content: async () => HABITACLIA_FIXTURE_SEARCH_HTML,
+          pageUrl: () => 'https://www.habitaclia.com/alquiler-barcelona.htm',
+          warmNavigate: async () => undefined,
+          exportStorageState: async () => ({ cookies: [] }),
+          close: async () => undefined,
+        };
       },
     };
 
@@ -292,7 +364,52 @@ describe('HabitacliaProvider.discover listainmuebles path', () => {
       refs.push(ref);
     }
 
-    expect(htmlFetches).toBeGreaterThan(0);
+    expect(sessionsOpened).toBe(1);
+    expect(refs.map((ref) => ref.sourceId).sort()).toEqual(['12345678900000', '98765432100000']);
+  });
+
+  it('does not abort discover when a cold HTTP page throws — falls through to the session', async () => {
+    let sessionsOpened = 0;
+    const runtime: FetchRuntime = {
+      // Proxy timeout: fetchHttp rejects rather than returning a status.
+      fetchHttp: async () => {
+        throw new Error('net::ERR_TIMED_OUT');
+      },
+      fetchJson: async () => {
+        throw new Error('unused');
+      },
+      fetchText: async () => {
+        throw new Error('unused');
+      },
+      loadFixture: async () => {
+        throw new Error('unused');
+      },
+      openBrowserSession: async () => {
+        sessionsOpened += 1;
+        return {
+          request: async () => ({ status: 200, body: '<html></html>' }),
+          content: async () => HABITACLIA_FIXTURE_SEARCH_HTML,
+          pageUrl: () => 'https://www.habitaclia.com/alquiler-barcelona.htm',
+          warmNavigate: async () => undefined,
+          exportStorageState: async () => ({ cookies: [] }),
+          close: async () => undefined,
+        };
+      },
+    };
+
+    const local = new HabitacliaProvider({ runtime });
+    const refs: ExternalListingRef[] = [];
+    for await (const ref of local.discover({
+      provider: 'habitaclia',
+      market: 'ES',
+      city: 'barcelona',
+      limit: 5,
+      runtime,
+    })) {
+      refs.push(ref);
+    }
+
+    expect(sessionsOpened).toBe(1);
     expect(refs.map((ref) => ref.sourceId).sort()).toEqual(['12345678900000', '98765432100000']);
   });
 });

--- a/packages/listing-providers/src/providers/habitaclia/index.ts
+++ b/packages/listing-providers/src/providers/habitaclia/index.ts
@@ -1,9 +1,14 @@
 /**
- * Habitaclia provider (Spain).
+ * Habitaclia provider (Spain) — HTTP-first.
  *
- * Discover prefers warmed Playwright session → POST `/dotnet/listados/listainmuebles`
- * (HTML fragments with `data-href` cards); fetch uses the shared ladder for detail
- * HTML (JSON-LD when present, microdata/meta fallback). Registered OFF by default.
+ * Discover paginates the server-rendered search over plain HTTP GET
+ * (`/alquiler-<city>-<page>.htm`, `data-href` cards) through the residential
+ * proxy — the canonical paginated URLs return every page cold, so no browser is
+ * needed. A warmed Playwright session (`POST /dotnet/listados/listainmuebles`)
+ * is the per-city FALLBACK, opened only for cities Imperva challenges over cold
+ * HTTP. Fetch uses the shared ladder for detail HTML (JSON-LD when present,
+ * microdata/meta fallback), which escalates to the browser tier when the
+ * detail page is challenged. Registered OFF by default.
  */
 
 import {
@@ -23,7 +28,7 @@ import type {
   RawListing,
 } from '../../types';
 import { createFetchRuntime } from '../../runtime';
-import { fetchListingViaLadder, ChallengeError } from '../../strategy';
+import { fetchListingViaLadder, classifyOutcome } from '../../strategy';
 import { defaultProviderMetrics, type ProviderMetricsReader, type ProviderMetricsSink } from '../../metrics';
 import { providerMaxSearchPages } from '../../discoverLimits';
 import { BrowserSessionChallengeError, type BrowserSession, type BrowserStorageState } from '../../browserSession';
@@ -131,35 +136,30 @@ export class HabitacliaProvider implements ListingProvider {
     const yielded = { count: 0 };
     const runtime = job.runtime ?? this.runtime;
 
+    // HTTP-first: the server-rendered `-<page>.htm` search paginates fully over
+    // plain HTTP GET, so cold HTTP covers every page without a browser. Cities
+    // Imperva challenges over cold HTTP fall through to the warmed session.
+    const browserFallbackCities: string[] = [];
     for (const city of cities) {
       if (yielded.count >= limit) return;
-      for await (const ref of this.discoverCityViaHttpListainmuebles(
-        runtime,
-        city,
-        job.signal,
-        seen,
-        limit,
-        yielded,
-      )) {
+      const http = { challenged: false };
+      for await (const ref of this.discoverCityViaHttp(runtime, city, job.signal, seen, limit, yielded, http)) {
         yield ref;
       }
+      // Escalate ONLY cities cold HTTP was actually blocked on — a city that
+      // simply has no (more) listings resolved fine over HTTP and must not open
+      // an expensive browser session.
+      if (http.challenged) browserFallbackCities.push(city);
     }
     if (yielded.count >= limit) return;
 
-    // Cold HTTP search HTML + listainmuebles POST pagination.
-    for (const city of cities) {
-      if (yielded.count >= limit) return;
-      for await (const ref of this.discoverCityViaHtml(runtime, city, job.signal, seen, limit, yielded)) {
-        yield ref;
-      }
-    }
-    if (yielded.count >= limit) return;
-
-    const beforeSession = yielded.count;
-    if (runtime.openBrowserSession) {
+    // Browser FALLBACK only for cities cold HTTP couldn't crack — a single
+    // warmed Playwright session with same-origin `listainmuebles` POST
+    // pagination, not a per-page `page.goto` (which times out via the proxy).
+    if (browserFallbackCities.length > 0 && runtime.openBrowserSession) {
       for await (const ref of this.discoverViaListainmueblesSession(
         runtime,
-        cities,
+        browserFallbackCities,
         job.signal,
         seen,
         limit,
@@ -167,51 +167,89 @@ export class HabitacliaProvider implements ListingProvider {
       )) {
         yield ref;
       }
-      if (yielded.count >= limit) return;
     }
-
-    if (yielded.count > beforeSession) return;
   }
 
   /**
-   * HTTP-first listainmuebles: proxied search page → POST pagination without
-   * Playwright when Imperva allows same-origin XHR on a sticky ES exit.
+   * HTTP-first search pagination: GET each `/alquiler-<city>-<page>.htm` server
+   * page through the residential proxy and parse its `data-href` cards. These
+   * canonical paginated URLs return real listings cold (no Playwright), so this
+   * replaces the old browser `page.goto` deep-page loop that timed out via the
+   * proxy. Stops on a challenge/error page, an empty page, or the first page
+   * that adds no new refs (portals clamp `-<page>.htm` to the last real page).
    */
-  private async *discoverCityViaHttpListainmuebles(
+  private async *discoverCityViaHttp(
     runtime: FetchRuntime,
     city: string,
     signal: AbortSignal | undefined,
     seen: Set<string>,
     limit: number,
     yielded: { count: number },
+    http: { challenged: boolean },
   ): AsyncIterable<ExternalListingRef> {
-    const referer = habitacliaWarmSearchUrl(city, 1);
-    const { status, body } = await runtime.fetchHttp(referer, {
-      signal,
-      proxyCountry: ES_PROXY_COUNTRY,
-      timeoutMs: HABITACLIA_HTTP_SEARCH_TIMEOUT_MS,
-      headers: {
-        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-        'Accept-Language': 'es-ES,es;q=0.9,en;q=0.8',
-      },
-    });
-    if (status >= 400 || isHabitacliaChallenge(body)) return;
+    for (let page = 1; page <= this.maxSearchPages; page += 1) {
+      if (yielded.count >= limit) return;
+      const url = habitacliaWarmSearchUrl(city, page);
+      const start = Date.now();
+      let status: number;
+      let body: string;
+      try {
+        ({ status, body } = await runtime.fetchHttp(url, {
+          signal,
+          proxyCountry: ES_PROXY_COUNTRY,
+          timeoutMs: HABITACLIA_HTTP_SEARCH_TIMEOUT_MS,
+          headers: {
+            Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'Accept-Language': 'es-ES,es;q=0.9,en;q=0.8',
+          },
+        }));
+      } catch (error) {
+        // A proxy timeout / network error on one page must not abort discover;
+        // mark the city challenged so it falls through to the warmed session.
+        http.challenged = true;
+        this.metrics.record({
+          provider: this.id,
+          strategy: 'http',
+          outcome: 'error',
+          latencyMs: Date.now() - start,
+          url,
+          detail: error instanceof Error ? error.message : String(error),
+        });
+        break;
+      }
 
-    const pageRefs = parseHabitacliaSearch(body);
-    for (const ref of yieldRefs(pageRefs, seen, limit, yielded)) {
-      yield ref;
-    }
+      const outcome = classifyOutcome(status, body, isHabitacliaChallenge);
+      if (outcome !== 'success') {
+        // Blocked (challenge/forbidden/error) — record it (health) and escalate.
+        http.challenged = true;
+        this.metrics.record({
+          provider: this.id,
+          strategy: 'http',
+          outcome,
+          status,
+          latencyMs: Date.now() - start,
+          url,
+        });
+        break;
+      }
 
-    for (const ref of await this.discoverCityViaHttpAjax(
-      runtime,
-      city,
-      body,
-      signal,
-      seen,
-      limit,
-      yielded,
-    )) {
-      yield ref;
+      const pageRefs = parseHabitacliaSearch(body);
+      // A clean page with no cards means the city is exhausted, NOT blocked — do
+      // not escalate to a browser session.
+      if (pageRefs.length === 0) break;
+      const newRefs = yieldRefs(pageRefs, seen, limit, yielded);
+      this.metrics.record({
+        provider: this.id,
+        strategy: 'http',
+        outcome: 'success',
+        status,
+        latencyMs: Date.now() - start,
+        url,
+      });
+      for (const ref of newRefs) {
+        yield ref;
+      }
+      if (page > 1 && newRefs.length === 0) break;
     }
   }
 
@@ -354,89 +392,6 @@ export class HabitacliaProvider implements ListingProvider {
       });
     } finally {
       await session?.close();
-    }
-  }
-
-  private async discoverCityViaHttpAjax(
-    runtime: FetchRuntime,
-    city: string,
-    firstPageHtml: string,
-    signal: AbortSignal | undefined,
-    seen: Set<string>,
-    limit: number,
-    yielded: { count: number },
-  ): Promise<ExternalListingRef[]> {
-    const formFields = extractHabitacliaListadoFormFields(firstPageHtml);
-    if (Object.keys(formFields).length === 0) return [];
-
-    const collected: ExternalListingRef[] = [];
-    const referer = habitacliaWarmSearchUrl(city, 1);
-    for (let page = 2; page <= this.maxSearchPages; page += 1) {
-      if (yielded.count >= limit) break;
-      const { status, body } = await runtime.fetchHttp(HABITACLIA_LISTAINMUEBLES_URL, {
-        signal,
-        proxyCountry: ES_PROXY_COUNTRY,
-        method: 'POST',
-        body: buildHabitacliaListainmueblesBody(formFields, page),
-        headers: {
-          Accept: 'text/html, */*',
-          'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
-          Referer: referer,
-          'X-Requested-With': 'XMLHttpRequest',
-        },
-      });
-      if (status >= 400 || isHabitacliaListainmueblesChallenge(body)) break;
-      const pageRefs = parseHabitacliaListainmuebles(body);
-      if (pageRefs.length === 0) break;
-      collected.push(...yieldRefs(pageRefs, seen, limit, yielded));
-    }
-    return collected;
-  }
-
-  private async *discoverCityViaHtml(
-    runtime: FetchRuntime,
-    city: string,
-    signal: AbortSignal | undefined,
-    seen: Set<string>,
-    limit: number,
-    yielded: { count: number },
-  ): AsyncIterable<ExternalListingRef> {
-    let firstPageHtml = '';
-    for (let page = 1; page <= this.maxSearchPages; page += 1) {
-      if (yielded.count >= limit) return;
-      if (page > 1 && !runtime.fetchViaBrowser) break;
-      try {
-        const { html } = await fetchListingViaLadder(runtime, habitacliaWarmSearchUrl(city, page), {
-          provider: this.id,
-          isChallenge: isHabitacliaChallenge,
-          metrics: this.metrics,
-          init: { signal, proxyCountry: ES_PROXY_COUNTRY },
-          tiers: page === 1 ? undefined : ['browser'],
-        });
-        if (page === 1) firstPageHtml = html;
-        const refs = parseHabitacliaSearch(html);
-        if (refs.length === 0) break;
-        for (const ref of yieldRefs(refs, seen, limit, yielded)) {
-          yield ref;
-        }
-      } catch (error) {
-        if (error instanceof ChallengeError) return;
-        throw error;
-      }
-    }
-
-    if (firstPageHtml.length > 0) {
-      for (const ref of await this.discoverCityViaHttpAjax(
-        runtime,
-        city,
-        firstPageHtml,
-        signal,
-        seen,
-        limit,
-        yielded,
-      )) {
-        yield ref;
-      }
     }
   }
 


### PR DESCRIPTION
## Prod evidence
CloudWatch `/oxy/ecs` → `homiio-worker` (last 3–6h): habitaclia ingested **ZERO**, with repeated
```
page.goto: net::ERR_TIMED_OUT at https://www.habitaclia.com/alquiler-granada-22.htm
page.goto: net::ERR_CONNECTION_CLOSED at https://www.habitaclia.com/...
```
Those URLs are **search** pages (discover), reached via the browser tier (`page.goto`) through the residential proxy, which times out.

## Root cause (traced in source, verified against live markup)
`discover()` ran the browser tier (`tiers: ['browser']`, i.e. `page.goto`) for deep search pages 2..50 **unconditionally** — even after the HTTP-first path already had page 1 — in `discoverCityViaHtml`. Through the residential proxy those `page.goto` calls time out, and a browser timeout thrown mid-generator starved the fetch/ingest pipeline.

Live cold HTTP (datacenter IP, no browser) proves the browser deep-page loop was unnecessary — the canonical server-rendered pagination returns real listings over plain GET:

| URL | HTTP | unique `-i…` listings | challenge |
|---|---|---|---|
| `/alquiler-barcelona-2.htm` | 200 | 15 | none |
| `/alquiler-barcelona-5.htm` | 200 | 15 | none |
| `/alquiler-madrid-3.htm` | 200 | 15 | none |
| `/alquiler-barcelona-22.htm` | 200 | 15 | none |

The browser deep-page pagination was both **redundant** with those GET URLs and the **source of the timeouts**. (Detail pages *are* Imperva-challenged over cold HTTP — "Pardon Our Interruption" — which the shared ladder already handles by escalating `fetch()` to the browser tier.)

## Fix
- `discover()` walks `/alquiler-<city>-<page>.htm` over cold HTTP GET (residential proxy), per city, stopping on a challenge/error page, an empty page, or the first page that adds no new refs (portals clamp `-<page>.htm` to the last real page).
- The warmed Playwright `listainmuebles` POST session is now a **per-city fallback**, opened only for cities Imperva challenges over cold HTTP — never a per-page `page.goto`.
- Removed the browser `page.goto` deep-page loop (`discoverCityViaHtml`) and the cold `listainmuebles` POST HTTP path (`discoverCityViaHttpAjax`).
- `fetch()` unchanged: HTTP-first via the shared ladder, escalating to browser only when the detail page is genuinely challenged.

## Tests
`packages/backend/__tests__/unit/habitacliaProvider.test.ts` — 16 pass, incl. new:
- paginates the search over cold HTTP GET across pages **without opening a browser**;
- opens the warmed session **only** for a city cold HTTP challenges.

`bun run --filter '@homiio/listing-providers' build` / `--filter '@homiio/backend' build` exit 0. Broader `listing|provider|ingest|proxy|browser|strategy|…` suite: 42 suites / 515 tests green.