### PR TITLE
fix(worker): round-robin discover-queue priority so every provider discovers

### DIFF
--- a/packages/backend/__tests__/unit/discoverPriority.test.ts
+++ b/packages/backend/__tests__/unit/discoverPriority.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Round-robin discover-priority policy (services/ingestion/queues.ts).
+ *
+ * The discover queue must give every provider's city-0 a higher priority than
+ * any provider's city-1, so the browser-heavy ES portals (~180 city scopes each)
+ * can't starve the market-wide providers' 2-3 scopes. Pure function — no Redis,
+ * no BullMQ runtime.
+ */
+
+import {
+  discoverPriorityFor,
+  fetchPriorityFor,
+  FETCH_RANK_CAP,
+  HIGH_VOLUME_PROVIDERS,
+} from '../../services/ingestion/queues';
+
+// BullMQ rejects any priority above 2^21 (Job.PRIORITY_LIMIT).
+const BULLMQ_PRIORITY_LIMIT = 2 ** 21;
+
+describe('discoverPriorityFor', () => {
+  it('maps a scope rank to rank + 1', () => {
+    expect(discoverPriorityFor('immobilienscout24', 0)).toBe(1);
+    expect(discoverPriorityFor('fotocasa', 1)).toBe(2);
+    expect(discoverPriorityFor('immoweb', 5)).toBe(6);
+  });
+
+  it('never returns 0, so discover jobs stay out of BullMQ’s unprioritised wait lane', () => {
+    for (const rank of [0, 1, 42, FETCH_RANK_CAP, FETCH_RANK_CAP * 10]) {
+      expect(discoverPriorityFor('otodom', rank)).toBeGreaterThanOrEqual(1);
+      expect(discoverPriorityFor('habitaclia', rank)).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('aligns every provider at the same rank (round-robin: city-0 before any city-1)', () => {
+    const providers = ['immobilienscout24', 'immoweb', 'blueground', 'fotocasa', 'habitaclia', 'pisos'];
+    for (const rank of [0, 1, 7, 137]) {
+      const priorities = providers.map((provider) => discoverPriorityFor(provider, rank));
+      expect(new Set(priorities).size).toBe(1);
+    }
+    // The core guarantee: every provider's city-0 outranks every provider's city-1.
+    const anyCity0 = discoverPriorityFor('habitaclia', 0);
+    const anyCity1 = discoverPriorityFor('immobilienscout24', 1);
+    expect(anyCity0).toBeLessThan(anyCity1);
+  });
+
+  it('is SINGLE-tier — unlike fetch it does not sink ES portals into a later tier', () => {
+    // fetch deprioritises the high-volume ES portals; discover intentionally does
+    // not, so an ES portal and a market-wide provider share a rank's priority.
+    for (const provider of HIGH_VOLUME_PROVIDERS) {
+      expect(discoverPriorityFor(provider, 0)).toBe(discoverPriorityFor('immobilienscout24', 0));
+      expect(fetchPriorityFor(provider, 0)).toBeGreaterThan(fetchPriorityFor('immobilienscout24', 0));
+    }
+  });
+
+  it('increases strictly with rank', () => {
+    let previous = -Infinity;
+    for (let rank = 0; rank < 200; rank += 1) {
+      const priority = discoverPriorityFor('fotocasa', rank);
+      expect(priority).toBeGreaterThan(previous);
+      previous = priority;
+    }
+  });
+
+  it('clamps pathological ranks so priority never approaches PRIORITY_LIMIT', () => {
+    const capped = discoverPriorityFor('fotocasa', FETCH_RANK_CAP);
+    expect(discoverPriorityFor('fotocasa', FETCH_RANK_CAP + 1)).toBe(capped);
+    expect(discoverPriorityFor('fotocasa', Number.MAX_SAFE_INTEGER)).toBeLessThan(BULLMQ_PRIORITY_LIMIT);
+  });
+
+  it('defends against negative and fractional ranks', () => {
+    expect(discoverPriorityFor('otodom', -5)).toBe(discoverPriorityFor('otodom', 0));
+    expect(discoverPriorityFor('otodom', 3.9)).toBe(discoverPriorityFor('otodom', 3));
+  });
+});

--- a/packages/backend/__tests__/unit/fetchPriority.test.ts
+++ b/packages/backend/__tests__/unit/fetchPriority.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Round-robin fetch-priority policy (services/ingestion/queues.ts).
+ *
+ * These are the fairness guarantees the worker relies on so every registered
+ * provider makes progress instead of the highest-volume one starving the rest.
+ * Pure function — no Redis, no BullMQ runtime.
+ */
+
+import {
+  fetchPriorityFor,
+  FETCH_RANK_CAP,
+  HIGH_VOLUME_PROVIDERS,
+} from '../../services/ingestion/queues';
+
+// BullMQ rejects any priority above 2^21 (Job.PRIORITY_LIMIT); every value we
+// emit must stay comfortably under it.
+const BULLMQ_PRIORITY_LIMIT = 2 ** 21;
+
+describe('fetchPriorityFor', () => {
+  it('maps a normal provider rank to tier-base + rank + 1', () => {
+    expect(fetchPriorityFor('immobilienscout24', 0)).toBe(1);
+    expect(fetchPriorityFor('immobilienscout24', 1)).toBe(2);
+    expect(fetchPriorityFor('immoweb', 5)).toBe(6);
+  });
+
+  it('never returns 0, so jobs stay out of BullMQ’s unprioritised wait lane', () => {
+    for (const rank of [0, 1, 42, FETCH_RANK_CAP, FETCH_RANK_CAP * 10]) {
+      expect(fetchPriorityFor('otodom', rank)).toBeGreaterThanOrEqual(1);
+      expect(fetchPriorityFor('habitaclia', rank)).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('aligns every provider at the same rank (round-robin interleave)', () => {
+    // The core fairness property: provider A's Nth job and provider B's Nth job
+    // share a priority, so BullMQ processes A0,B0,C0,A1,B1,C1,… not A0..An,B0…
+    const smalls = ['immobilienscout24', 'immoweb', 'blueground', 'mercadolibre_ar', 'otodom'];
+    for (const rank of [0, 1, 7, 500]) {
+      const priorities = smalls.map((provider) => fetchPriorityFor(provider, rank));
+      expect(new Set(priorities).size).toBe(1);
+    }
+  });
+
+  it('increases strictly with rank within a provider', () => {
+    let previous = -Infinity;
+    for (let rank = 0; rank < 50; rank += 1) {
+      const priority = fetchPriorityFor('immoweb', rank);
+      expect(priority).toBeGreaterThan(previous);
+      previous = priority;
+    }
+  });
+
+  it('places high-volume ES portals in a strictly later tier than normal providers', () => {
+    // Even the FIRST high-volume job must sort after the LAST normal-tier job so
+    // the small providers drain before the big ES portals begin.
+    const worstNormal = fetchPriorityFor('immobilienscout24', FETCH_RANK_CAP);
+    const bestHighVolume = fetchPriorityFor('habitaclia', 0);
+    expect(bestHighVolume).toBeGreaterThan(worstNormal);
+  });
+
+  it('round-robins within the high-volume tier too', () => {
+    const highVolume = [...HIGH_VOLUME_PROVIDERS];
+    for (const rank of [0, 3, 200]) {
+      const priorities = highVolume.map((provider) => fetchPriorityFor(provider, rank));
+      expect(new Set(priorities).size).toBe(1);
+    }
+    // Each of fotocasa/habitaclia/pisos/idealista rides the high-volume tier.
+    expect(highVolume).toEqual(expect.arrayContaining(['fotocasa', 'habitaclia', 'pisos', 'idealista']));
+  });
+
+  it('clamps pathological ranks so priority never approaches PRIORITY_LIMIT', () => {
+    const capped = fetchPriorityFor('immobilienscout24', FETCH_RANK_CAP);
+    expect(fetchPriorityFor('immobilienscout24', FETCH_RANK_CAP + 1)).toBe(capped);
+    expect(fetchPriorityFor('immobilienscout24', 5_000_000)).toBe(capped);
+    expect(fetchPriorityFor('habitaclia', Number.MAX_SAFE_INTEGER)).toBeLessThan(BULLMQ_PRIORITY_LIMIT);
+  });
+
+  it('defends against negative and fractional ranks', () => {
+    expect(fetchPriorityFor('otodom', -5)).toBe(fetchPriorityFor('otodom', 0));
+    expect(fetchPriorityFor('otodom', 3.9)).toBe(fetchPriorityFor('otodom', 3));
+  });
+});

--- a/packages/backend/services/ingestion/queues.ts
+++ b/packages/backend/services/ingestion/queues.ts
@@ -52,6 +52,68 @@ export function fetchJobId(ref: ExternalListingRef): string {
   return jobIdFor(['fetch', ref.provider, ref.sourceId]);
 }
 
+/* -------------------------------------------------------------------------- */
+/* Round-robin fetch priority                                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Big-volume ES portals emit thousands of fetch jobs per discover pass and are
+ * browser/rate-limit heavy. They ride a LATER priority tier so the handful of
+ * jobs from market-wide providers (immobilienscout24, immoweb, mercadolibre, …)
+ * drain first — while still round-robining among themselves inside the tier.
+ * Configurable: move a provider between tiers by editing this set.
+ */
+export const HIGH_VOLUME_PROVIDERS: ReadonlySet<string> = new Set([
+  'fotocasa',
+  'habitaclia',
+  'pisos',
+  'idealista',
+]);
+
+/**
+ * Priority tier bases. BullMQ orders prioritised jobs by
+ * `score = priority * 2^32 + insertionCounter` and pops the lowest, so a lower
+ * priority number runs first and the normal tier (base 0) fully precedes the
+ * high-volume tier. The gap MUST exceed {@link FETCH_RANK_CAP} so the two tiers
+ * never overlap.
+ */
+const FETCH_TIER_NORMAL = 0;
+const FETCH_TIER_HIGH_VOLUME = 1_000_000;
+
+/**
+ * Max round-robin rank honoured per discover batch. Clamps a pathological batch
+ * so a job's priority can never approach BullMQ's `PRIORITY_LIMIT` (2^21) — the
+ * high-volume tier tops out at `1_000_000 + 100_000 + 1`, comfortably below it.
+ * Real batches (one provider/city's refs) sit far under this.
+ */
+export const FETCH_RANK_CAP = 100_000;
+
+/** Base priority tier for a provider (normal vs high-volume). */
+function fetchTierBase(provider: string): number {
+  return HIGH_VOLUME_PROVIDERS.has(provider) ? FETCH_TIER_HIGH_VOLUME : FETCH_TIER_NORMAL;
+}
+
+/**
+ * Round-robin fetch priority for the `rank`-th ref (0-based) of a provider's
+ * discover batch.
+ *
+ * Every provider's rank-0 ref shares its tier's lowest priority, every rank-1
+ * ref the next, and so on. Because rank restarts at 0 for each discover pass,
+ * all providers stay aligned, so BullMQ interleaves them (A0,B0,C0,A1,B1,C1,…)
+ * instead of draining one provider's whole backlog first — even though the
+ * discover jobs that enqueued them ran at different times. A free-running
+ * per-provider counter would NOT do this: its rank window drifts independently
+ * per provider after the first pass, breaking the interleave.
+ *
+ * The `+ 1` keeps the value ≥ 1 so a fetch job never lands in BullMQ's
+ * unprioritised `wait` lane, which is drained in full before ANY prioritised
+ * job (`moveToActive` does `RPOPLPUSH wait` before `ZPOPMIN prioritized`).
+ */
+export function fetchPriorityFor(provider: string, rank: number): number {
+  const clamped = Math.min(Math.max(Math.trunc(rank), 0), FETCH_RANK_CAP);
+  return fetchTierBase(provider) + clamped + 1;
+}
+
 /**
  * Build a BullMQ Redis connection OPTIONS object from a `redis[s]://` URL. We
  * pass options (not an ioredis instance) so BullMQ owns the connection, and set

--- a/packages/backend/services/ingestion/queues.ts
+++ b/packages/backend/services/ingestion/queues.ts
@@ -115,6 +115,32 @@ export function fetchPriorityFor(provider: string, rank: number): number {
 }
 
 /**
+ * Round-robin priority for the `rank`-th discover scope of a provider in the
+ * interleaved boot list — `rank` is the scope's per-provider index (its city
+ * index for browser-heavy ES portals that discover one job per city, else 0 for
+ * a single market-wide scope).
+ *
+ * SINGLE tier by design — unlike {@link fetchPriorityFor}, discover does NOT sink
+ * the big-volume ES portals into a later tier. The requirement is that every
+ * provider's city-0 runs before ANY provider's city-1, so the ES portals share
+ * round 0 with the small providers and START producing fetch refs immediately;
+ * their remaining ~180 cities merely fill later rounds instead of monopolising
+ * the queue head (the observed bug: only pisos/fotocasa ever discovered while 11
+ * market-wide providers with 2-3 scopes each starved behind the ES city flood).
+ * A later ES tier would violate "city-0 before any city-1" and delay the largest
+ * inventory source, so round-robin rank alone carries the fairness here.
+ *
+ * `provider` is kept for signature parity with {@link fetchPriorityFor} and a
+ * possible future per-provider discover tier. The `+ 1` and {@link FETCH_RANK_CAP}
+ * clamp (shared bound; discover ranks sit far below it) work exactly as in fetch:
+ * priority stays ≥ 1 (out of BullMQ's unprioritised `wait` lane) and well under
+ * `PRIORITY_LIMIT`.
+ */
+export function discoverPriorityFor(provider: string, rank: number): number {
+  return Math.min(Math.max(Math.trunc(rank), 0), FETCH_RANK_CAP) + 1;
+}
+
+/**
  * Build a BullMQ Redis connection OPTIONS object from a `redis[s]://` URL. We
  * pass options (not an ioredis instance) so BullMQ owns the connection, and set
  * `maxRetriesPerRequest: null` as BullMQ requires for blocking commands.

--- a/packages/backend/worker.ts
+++ b/packages/backend/worker.ts
@@ -14,7 +14,7 @@
 
 require('dotenv').config();
 
-import { Queue, Worker, type Job, type Queue as BullQueue } from 'bullmq';
+import { Queue, Worker, UnrecoverableError, type Job, type Queue as BullQueue } from 'bullmq';
 import {
   createDefaultRegistry,
   createListingFetchRuntimeFromEnv,
@@ -40,6 +40,7 @@ import {
   QUEUE_NAMES,
   discoverJobId,
   fetchJobId,
+  fetchPriorityFor,
   parseRedisConnection,
   type DiscoverJobData,
   type FetchJobData,
@@ -64,19 +65,6 @@ const FETCH_CONCURRENCY = parseInt(process.env.LISTING_FETCH_CONCURRENCY || '6',
  * scopes serialise there while HTTP-first scopes proceed.
  */
 const DISCOVER_CONCURRENCY = parseInt(process.env.LISTING_DISCOVER_CONCURRENCY || '3', 10);
-
-/**
- * Per-city ES portals emit thousands of fetch jobs per pass. Give their fetch a
- * LOWER priority so the handful of jobs from a smaller provider (immobilienscout24,
- * mercadolibre, otodom, …) isn't stuck behind that backlog — every provider makes
- * progress instead of the big three starving the rest. BullMQ: lower number = higher
- * priority; both are >0 so neither falls into the unprioritised (top) lane.
- */
-const HIGH_VOLUME_PROVIDERS = new Set(['fotocasa', 'habitaclia', 'pisos', 'idealista']);
-const FETCH_PRIORITY_HIGH = 10;
-const FETCH_PRIORITY_LOW = 100;
-const fetchPriorityFor = (provider: string): number =>
-  HIGH_VOLUME_PROVIDERS.has(provider) ? FETCH_PRIORITY_LOW : FETCH_PRIORITY_HIGH;
 
 /** Discover jobs may hold a browser session across many cities — match worker lockDuration. */
 const DISCOVER_LOCK_MS = 600_000;
@@ -106,6 +94,13 @@ async function expireExternalListing(source: string, sourceId: string, reason: s
 
 /** Fetch + normalize a single listing ref and ingest the result. */
 async function processFetchRef(ref: ExternalListingRef): Promise<void> {
+  if (!registry.has(ref.provider)) {
+    // A queued job for a provider that is no longer registered (disabled via env,
+    // renamed, or removed) can never succeed. Fail it permanently instead of
+    // burning all 3 attempts + exponential backoff — that churn produced
+    // thousands of pointless "No provider registered" retries in prod.
+    throw new UnrecoverableError(`No provider registered for id "${ref.provider}"`);
+  }
   const provider = registry.get(ref.provider);
   try {
     const raw = await provider.fetch(ref, { runtime });
@@ -151,6 +146,9 @@ async function processFetchRef(ref: ExternalListingRef): Promise<void> {
 
 /** Enumerate a discover job's refs (BullMQ path enqueues; inline path ingests). */
 async function collectDiscoverRefs(data: DiscoverJobData): Promise<ExternalListingRef[]> {
+  if (!registry.has(data.provider)) {
+    throw new UnrecoverableError(`No provider registered for id "${data.provider}"`);
+  }
   const provider = registry.get(data.provider);
   const refs: ExternalListingRef[] = [];
   for await (const ref of provider.discover({
@@ -361,7 +359,11 @@ async function startBullMq(): Promise<() => Promise<void>> {
         city: job.data.city,
       });
       const refs = await collectDiscoverRefs(job.data);
-      for (const ref of refs) {
+      // `rank` is the ref's 0-based position in THIS discover batch. It restarts
+      // at 0 every pass, so every provider's rank-0 job shares the lowest
+      // priority in its tier and BullMQ interleaves providers round-robin rather
+      // than draining one provider's whole backlog first. See fetchPriorityFor.
+      for (const [rank, ref] of refs.entries()) {
         const jobId = fetchJobId(ref);
         const existingFetch = await fetchQueue.getJob(jobId);
         if (existingFetch) {
@@ -372,7 +374,7 @@ async function startBullMq(): Promise<() => Promise<void>> {
         }
         await fetchQueue.add(QUEUE_NAMES.fetch, { ref }, {
           jobId,
-          priority: fetchPriorityFor(ref.provider),
+          priority: fetchPriorityFor(ref.provider, rank),
           attempts: 3,
           backoff: { type: 'exponential', delay: 60_000 },
         });

--- a/packages/backend/worker.ts
+++ b/packages/backend/worker.ts
@@ -39,6 +39,7 @@ import { IngestionService, IngestionValidationError } from './services/ingestion
 import {
   QUEUE_NAMES,
   discoverJobId,
+  discoverPriorityFor,
   fetchJobId,
   fetchPriorityFor,
   parseRedisConnection,
@@ -173,8 +174,19 @@ function discoverCitiesForProvider(providerId: string): string[] | undefined {
   return undefined;
 }
 
+/**
+ * A discover scope plus its round-robin `rank` — the scope's per-provider index
+ * (city index for browser-heavy ES portals, else 0). {@link discoverPriorityFor}
+ * turns rank into a priority so every provider's city-0 runs before any
+ * provider's city-1.
+ */
+interface BootDiscoverScope {
+  data: DiscoverJobData;
+  rank: number;
+}
+
 /** The discover scopes to enqueue on boot: one per (provider, market), or per-city for browser-heavy portals. */
-function bootDiscoverJobs(): DiscoverJobData[] {
+function bootDiscoverJobs(): BootDiscoverScope[] {
   // One scope list per provider (per-city for browser-heavy portals, else market-wide).
   const perProvider = registry.all().map((provider) =>
     provider.markets.flatMap((market) => {
@@ -189,12 +201,15 @@ function bootDiscoverJobs(): DiscoverJobData[] {
   // high-scope portal (fotocasa/habitaclia = ~68 cities each) can no longer
   // monopolise the queue head — every provider gets a discover turn in the first
   // round, and consecutive jobs hit different portals (gentler on each rate limit).
-  const interleaved: DiscoverJobData[] = [];
+  // `i` is each scope's per-provider rank, which discoverPriorityFor uses so the
+  // FIFO interleave is also enforced by BullMQ priority (survives jobId dedup and
+  // recurring re-enqueue, which a plain FIFO order does not).
+  const interleaved: BootDiscoverScope[] = [];
   const maxLen = perProvider.reduce((max, list) => Math.max(max, list.length), 0);
   for (let i = 0; i < maxLen; i += 1) {
     for (const list of perProvider) {
       const scope = list[i];
-      if (scope) interleaved.push(scope);
+      if (scope) interleaved.push({ data: scope, rank: i });
     }
   }
   return interleaved;
@@ -203,7 +218,7 @@ function bootDiscoverJobs(): DiscoverJobData[] {
 /** Run the whole pipeline inline (no Redis): discover → fetch → ingest. */
 async function runInlinePass(): Promise<void> {
   logger.info('Running inline discovery pass (no REDIS_URL configured)');
-  for (const data of bootDiscoverJobs()) {
+  for (const { data } of bootDiscoverJobs()) {
     const refs = await collectDiscoverRefs(data);
     for (const ref of refs) {
       try {
@@ -405,7 +420,7 @@ async function startBullMq(): Promise<() => Promise<void>> {
 
   async function enqueueBootDiscovery(): Promise<void> {
     await logQueueCounts(discoverQueue, fetchQueue);
-    for (const data of bootDiscoverJobs()) {
+    for (const { data, rank } of bootDiscoverJobs()) {
       const jobId = discoverJobId(data);
       // Boot uses deterministic ids for dedup. Remove only a prior completed/failed
       // job so a redeploy actually re-runs discover (otherwise BullMQ keeps the
@@ -424,7 +439,14 @@ async function startBullMq(): Promise<() => Promise<void>> {
           await existing.remove();
         }
       }
-      await discoverQueue.add(QUEUE_NAMES.discover, data, { jobId });
+      // Round-robin priority so every provider's city-0 outranks any provider's
+      // city-1 — the ES per-city flood no longer starves the market-wide
+      // providers' 2-3 scopes. (New enqueues only; the stale priority-0 backlog
+      // is purged post-deploy.)
+      await discoverQueue.add(QUEUE_NAMES.discover, data, {
+        jobId,
+        priority: discoverPriorityFor(data.provider, rank),
+      });
     }
     logger.info('Enqueued boot discovery jobs');
   }
@@ -442,8 +464,9 @@ async function startBullMq(): Promise<() => Promise<void>> {
     const intervalMs = discoverIntervalHours * 60 * 60 * 1000;
     const recurringScopes = bootDiscoverJobs();
     void (async () => {
-      for (const data of recurringScopes) {
+      for (const { data, rank } of recurringScopes) {
         await discoverQueue.add(QUEUE_NAMES.discover, data, {
+          priority: discoverPriorityFor(data.provider, rank),
           repeat: { key: `repeat-${discoverJobId(data)}`, every: intervalMs },
         });
       }


### PR DESCRIPTION
> **Stacked on #216** (`fix/fetch-roundrobin-fairness`). Until #216 merges, this PR's diff to `main` also shows #216's fetch changes. The discover-only change is commit `95b194f` (files: `worker.ts`, `services/ingestion/queues.ts` `discoverPriorityFor`, `__tests__/unit/discoverPriority.test.ts`). Merge #216 first, then this.

## Problem (prod, post-#216 deploy)

#216 fixed fetch fairness, but verification found the bottleneck moved **upstream to the DISCOVER queue**. Across the deployed worker's lifetime, **only `pisos` (22) and `fotocasa` (15) discover jobs ever STARTED** — `immobilienscout24`, `immoweb`, `blueground`, `otodom`, `mercadolibre_ar/mx`, `kleinanzeigen`, `immowelt`, `rightmove`, `onthemarket`, `openrent` never ran, so they produced **zero fetch refs** and there was nothing for the #216 fetch round-robin to interleave.

Queue inspector: discover `waiting:562 delayed:224 active:3`, dominated by ES per-city scopes (pisos/fotocasa/habitaclia ~140-180 city-jobs each); the market-wide providers have ~2-3 scopes each, stuck behind the ES flood.

**Root cause:** discover jobs were enqueued with **no priority** (FIFO, priority 0). `bootDiscoverJobs()` already interleaves `scope[i]` across providers, but (1) `jobId` dedup skips re-enqueuing so the older clustered (ES-first) order persists, and (2) FIFO gives "round-0-covers-all" only *once* — the 6h recurring re-enqueue re-clusters.

## Fix — discover-queue round-robin priority (mirrors the fetch fix)

New `discoverPriorityFor(provider, rank)` in `services/ingestion/queues.ts`, where `rank` is the scope's **per-provider index** in the interleaved boot list (city index for ES portals, else 0). `bootDiscoverJobs()` now returns `{ data, rank }`; both the boot enqueue and the recurring `discoverQueue.add` pass `priority: discoverPriorityFor(data.provider, rank)`. BullMQ then enforces the interleave **regardless of dedup / re-enqueue** — a plain FIFO order can't.

**Exact formula:** `priority = min(max(trunc(rank), 0), FETCH_RANK_CAP) + 1`

**SINGLE tier by design** (justified in the doc comment): unlike `fetchPriorityFor` — which sinks the big-volume ES portals into a *later* tier so their thousands of fetch jobs drain last — discover keeps ES portals in the **same** tier. The requirement is *every provider's city-0 before any provider's city-1*, so ES portals share round 0 with the smalls and **start producing fetch refs immediately**; their remaining ~180 cities merely fill later rounds. A later ES tier would violate "city-0 before any city-1" and delay the largest inventory source. Reuses the fetch policy's `+ 1` (keeps jobs out of BullMQ's unprioritised `wait` lane, which `moveToActive` drains before any prioritised job) and the shared `FETCH_RANK_CAP` clamp (discover ranks sit far below it; keeps priority ≪ `PRIORITY_LIMIT` 2^21).

## Scope / deploy note

Affects **new** enqueues only. The stale priority-0 discover backlog (562 waiting + 224 delayed) is purged post-deploy (team lead's step) so the round-robin takes effect on a fresh boot.

## Tests

- New `__tests__/unit/discoverPriority.test.ts` (7 cases): round-robin alignment (every provider equal at a given rank; city-0 < any city-1), **single-tier vs fetch** (ES portal == market-wide provider for discover, but ES > market-wide for fetch), strict monotonicity, clamp under `PRIORITY_LIMIT`, negative/fractional defense, `≥ 1` (never the `wait` lane).
- Full backend suite green: **72 suites / 746 tests**. `bun run --filter '@homiio/backend' build` exits 0.

Does not touch habitaclia/pisos parsers (#217/#218) or the fetch `fetchPriorityFor` logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)