### PR TITLE
chore+fix: pisos watermark backfill script + subito.it parser repair (consolidates #200, #189)

### DIFF
--- a/packages/backend/__tests__/unit/italyProviders.test.ts
+++ b/packages/backend/__tests__/unit/italyProviders.test.ts
@@ -30,9 +30,11 @@ import {
   CASA_IT_FIXTURE_SEARCH_HTML,
   CASA_IT_FIXTURE_SEARCH_JSON,
   SubitoProvider,
+  coerceSubitoRaw,
   parseSubitoDetail,
   parseSubitoSearch,
   parseSubitoSearchJson,
+  parseSubitoSearchListings,
   isSubitoHousingCategory,
   SUBITO_FIXTURE_DETAIL_HTML,
   SUBITO_FIXTURE_NON_HOUSING_HTML,
@@ -200,7 +202,69 @@ describe('SubitoProvider (housing-only)', () => {
     expect(listing.sourceId).toBe('632623436');
     expect(listing.longTermRent?.monthlyAmount).toBe(1000);
     expect(listing.address.city).toBe('Milano');
+    expect(listing.bedrooms).toBe(2);
+    expect(listing.squareFootage).toBe(51);
+    expect(listing.furnishedStatus).toBe('furnished');
     expect(listing.contact?.phone).toBeTruthy();
+    expect(listing.contact?.agencyName).toContain('Tempocasa');
+    // Image CDN base gets the render `rule` query appended.
+    expect(listing.remoteImages[0]?.url).toContain('rule=');
+  });
+
+  it('parses full search-page ad objects (features dict) and carries them via hints', () => {
+    const listings = parseSubitoSearchListings(SUBITO_FIXTURE_SEARCH_HTML);
+    // The car ad is filtered; only the two housing ads survive, both priced.
+    expect(listings.map((l) => l.sourceId).sort()).toEqual(['632623436', '632623437']);
+    expect(listings.every((l) => typeof l.price === 'number')).toBe(true);
+    expect(listings.every((l) => isSubitoHousingCategory(l.categoryUri || l.url))).toBe(true);
+
+    // A hint survives BullMQ JSON serialization and re-coerces to a SubitoRaw.
+    const serialized = JSON.parse(JSON.stringify(listings[0])) as unknown;
+    const coerced = coerceSubitoRaw(serialized);
+    expect(coerced?.sourceId).toBe('632623436');
+    expect(coerced?.price).toBe(1000);
+    expect(coerceSubitoRaw({ sourceId: 'x' })).toBeUndefined();
+  });
+
+  it('discovers refs with hints and fetches without a detail request', async () => {
+    let detailRequested = false;
+    const runtime: FetchRuntime = {
+      fetchHttp: async () => ({ status: 500, body: '' }),
+      fetchJson: async () => {
+        throw new Error('unused');
+      },
+      fetchText: async () => {
+        throw new Error('unused');
+      },
+      loadFixture: async () => {
+        throw new Error('unused');
+      },
+      openBrowserSession: async ({ warmUrl }) => ({
+        request: async () => {
+          detailRequested = true;
+          return { status: 200, body: '' };
+        },
+        content: async () => SUBITO_FIXTURE_SEARCH_HTML,
+        pageUrl: () => warmUrl,
+        warmNavigate: async () => undefined,
+        exportStorageState: async () => ({ cookies: [] }),
+        close: async () => undefined,
+      }),
+    };
+    const local = new SubitoProvider({ runtime, cities: ['milano'] });
+    const refs: ExternalListingRef[] = [];
+    for await (const ref of local.discover({ provider: 'subito', market: 'IT', city: 'milano', limit: 5, runtime })) {
+      refs.push(ref);
+    }
+    expect(refs.map((r) => r.sourceId).sort()).toEqual(['632623436', '632623437']);
+    expect(refs[0]?.hints?.listing).toBeTruthy();
+
+    const raw = await local.fetch(refs[0], { runtime });
+    const listing = local.normalize(raw);
+    expect(listing.sourceId).toBe(refs[0]?.sourceId);
+    expect(listing.longTermRent?.monthlyAmount).toBeGreaterThan(0);
+    // The hint payload means fetch never had to hit the (dead) detail page.
+    expect(detailRequested).toBe(false);
   });
 
   it('rejects non-housing detail and filters cars from search JSON', () => {

--- a/packages/backend/scripts/backfillPisosCleanImages.ts
+++ b/packages/backend/scripts/backfillPisosCleanImages.ts
@@ -1,0 +1,489 @@
+/**
+ * Backfill: replace pisos.com watermarked listing images with clean renditions.
+ *
+ * ## Why
+ * pisos.com serves every property photo under several `fotos.imghs.net` size
+ * prefixes. The hero/cover renditions (`xl-wp`, `fch-wp`) and the `appswm-wp`
+ * duplicate have the **pisos.com watermark** burned into the pixels; the agency
+ * `prof-wp/logos/…` is not a property photo. Listings ingested BEFORE the parser
+ * fix (`readPisosImageUrls`/`classifyPisosImage`, PR #193) re-hosted those
+ * watermarked renditions to S3, so the stored gallery — and usually the primary
+ * cover — shows the watermark. A normal re-fetch does NOT repair them: the ingest
+ * only downloads media when the property has no images (`needsMedia`).
+ *
+ * ## Why re-fetch (not derive)
+ * The original `fotos.imghs.net` URL is NOT persisted anywhere: each Image doc is
+ * re-hosted under a fresh `uuidv4` storage key with no source-URL/hash field. The
+ * clean `apps-wp` URL of a photo can only be learned from the (DataDome-gated)
+ * detail page, so the clean gallery must be re-fetched + re-normalized with the
+ * fixed parser. The listing HTML fetch uses the same proxy/browser ladder the
+ * worker already runs; the clean photos themselves download DIRECT (no proxy).
+ *
+ * ## Detector (cheap, DB-only) + idempotency
+ * A property needs the backfill iff any CURRENTLY-REFERENCED image has an original
+ * width >= {@link DEFAULT_WATERMARK_MIN_WIDTH} — the 800-wide `xl`/`fch` hero the
+ * fixed parser never keeps (verified: clean galleries are `apps-wp` 640-wide +
+ * `fchm-wp` 400-wide only). After a successful replace the property references
+ * only clean (<700-wide) images, so a re-run skips it — the detector IS the
+ * idempotency guard. Orphaned Image docs from an interrupted run are swept on the
+ * next pass (cleanup deletes every Image for the entity not in the new gallery).
+ *
+ * ## Safety
+ * Dry-run by default (counts + width distribution, no writes, no S3 deletes).
+ * `--apply` performs the replacement. Per property: re-fetch → normalize → ingest
+ * clean media (new Image docs) → swap `Property.images` → then delete the stale
+ * Image docs + their S3 blobs. New media is created and referenced BEFORE the old
+ * is deleted, so a crash never leaves a property imageless, and a property is only
+ * ever touched when a good clean replacement was produced.
+ *
+ * Usage (inside the VPC / ECS one-off; needs Mongo + the pisos proxy/browser env):
+ *   bun run packages/backend/scripts/backfillPisosCleanImages.ts            # dry-run
+ *   bun run packages/backend/scripts/backfillPisosCleanImages.ts --apply
+ *   ... --apply --limit=25 --concurrency=2 --min-width=700
+ */
+
+require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
+
+import { Types } from 'mongoose';
+import {
+  createDefaultRegistry,
+  createListingFetchRuntimeFromEnv,
+  type ExternalListingRef,
+  type FetchRuntime,
+  type ListingFetchRuntimeHandle,
+  type ListingProvider,
+} from '@homiio/listing-providers';
+import database from '../database/connection';
+import { Property, Image } from '../models';
+import { ExternalMediaIngest } from '../services/ingestion/ExternalMediaIngest';
+import imageUploadService from '../services/imageUploadService';
+
+/** Min original width (px) that marks a re-hosted rendition as a watermarked hero. */
+const DEFAULT_WATERMARK_MIN_WIDTH = 700;
+
+/** Abort budget (ms) for re-fetching one listing's detail page. */
+const FETCH_TIMEOUT_MS = 90_000;
+
+/** How many properties' referenced images to resolve widths for per DB round-trip. */
+const WIDTH_LOOKUP_BATCH = 500;
+
+/** Default parallel re-fetch/replace workers (tune down if DataDome throttles). */
+const DEFAULT_CONCURRENCY = 3;
+
+/** Minimal pisos Property projection the scan needs. */
+interface LeanPisosProperty {
+  _id: Types.ObjectId;
+  sourceId?: string;
+  sourceUrl?: string;
+  images?: Array<{ imageId?: string | Types.ObjectId }>;
+}
+
+/** Minimal Image projection: identity, source width, storage keys to delete. */
+interface LeanImageWidth {
+  _id: Types.ObjectId;
+  width?: number;
+  keys?: { original?: string; small?: string; medium?: string; large?: string };
+}
+
+/** A property flagged for backfill plus the counts the summary reports. */
+interface Candidate {
+  id: Types.ObjectId;
+  sourceId: string;
+  sourceUrl: string;
+  currentImageCount: number;
+  watermarkedCount: number;
+}
+
+interface CliOptions {
+  apply: boolean;
+  limit: number;
+  concurrency: number;
+  minWidth: number;
+  /** This worker's index in a sharded run (0-based). */
+  shardIndex: number;
+  /** Total shards; 1 = process every candidate in one task. */
+  shardTotal: number;
+}
+
+function parseCli(argv: string[]): CliOptions {
+  const apply = argv.includes('--apply');
+  const numeric = (flag: string, fallback: number): number => {
+    const entry = argv.find((arg) => arg.startsWith(`${flag}=`));
+    if (!entry) return fallback;
+    const value = Number.parseInt(entry.slice(flag.length + 1), 10);
+    return Number.isFinite(value) && value > 0 ? value : fallback;
+  };
+  // `--shard=INDEX/TOTAL` splits the candidate list across parallel tasks so
+  // each task can run its own sticky proxy IP (independent anti-bot session).
+  let shardIndex = 0;
+  let shardTotal = 1;
+  const shardEntry = argv.find((arg) => arg.startsWith('--shard='));
+  if (shardEntry) {
+    const [rawIndex, rawTotal] = shardEntry.slice('--shard='.length).split('/');
+    const total = Number.parseInt(rawTotal ?? '', 10);
+    const index = Number.parseInt(rawIndex ?? '', 10);
+    if (Number.isFinite(total) && total > 0 && Number.isFinite(index) && index >= 0 && index < total) {
+      shardIndex = index;
+      shardTotal = total;
+    } else {
+      throw new Error(`Invalid --shard value "${shardEntry}", expected INDEX/TOTAL with 0<=INDEX<TOTAL`);
+    }
+  }
+  return {
+    apply,
+    limit: numeric('--limit', Number.POSITIVE_INFINITY),
+    concurrency: numeric('--concurrency', DEFAULT_CONCURRENCY),
+    minWidth: numeric('--min-width', DEFAULT_WATERMARK_MIN_WIDTH),
+    shardIndex,
+    shardTotal,
+  };
+}
+
+/** All variant storage keys present on an Image doc (for S3 deletion). */
+function storageKeysOf(image: LeanImageWidth): string[] {
+  const keys = image.keys;
+  if (!keys) return [];
+  return [keys.original, keys.small, keys.medium, keys.large].filter(
+    (key): key is string => typeof key === 'string' && key.length > 0,
+  );
+}
+
+/** Resolve the width of every referenced image, batched, into an id→width map. */
+async function loadReferencedWidths(
+  properties: readonly LeanPisosProperty[],
+): Promise<Map<string, number | undefined>> {
+  const widthById = new Map<string, number | undefined>();
+  const allIds: Types.ObjectId[] = [];
+  for (const property of properties) {
+    for (const ref of property.images ?? []) {
+      if (ref.imageId && Types.ObjectId.isValid(String(ref.imageId))) {
+        allIds.push(new Types.ObjectId(String(ref.imageId)));
+      }
+    }
+  }
+  for (let i = 0; i < allIds.length; i += WIDTH_LOOKUP_BATCH) {
+    const batch = allIds.slice(i, i + WIDTH_LOOKUP_BATCH);
+    const docs = await Image.find({ _id: { $in: batch } }, { width: 1 }).lean<LeanImageWidth[]>();
+    for (const doc of docs) {
+      widthById.set(String(doc._id), doc.width);
+    }
+  }
+  return widthById;
+}
+
+interface ScanResult {
+  scanned: number;
+  candidates: Candidate[];
+  cleanProperties: number;
+  imagelessProperties: number;
+  /** width bucket -> count, across every referenced pisos image (reporting). */
+  widthDistribution: Map<string, number>;
+}
+
+/** Classify every pisos property as watermarked (candidate), clean, or imageless. */
+async function scan(minWidth: number): Promise<ScanResult> {
+  const properties = await Property.find(
+    { source: 'pisos' },
+    { sourceId: 1, sourceUrl: 1, 'images.imageId': 1 },
+  ).lean<LeanPisosProperty[]>();
+
+  const widthById = await loadReferencedWidths(properties);
+  const widthDistribution = new Map<string, number>();
+  const candidates: Candidate[] = [];
+  let cleanProperties = 0;
+  let imagelessProperties = 0;
+
+  for (const property of properties) {
+    const refs = property.images ?? [];
+    if (refs.length === 0) {
+      imagelessProperties += 1;
+      continue;
+    }
+    let watermarkedCount = 0;
+    for (const ref of refs) {
+      const width = ref.imageId ? widthById.get(String(ref.imageId)) : undefined;
+      const bucket = typeof width === 'number' ? String(width) : 'unknown';
+      widthDistribution.set(bucket, (widthDistribution.get(bucket) ?? 0) + 1);
+      if (typeof width === 'number' && width >= minWidth) watermarkedCount += 1;
+    }
+    if (watermarkedCount === 0) {
+      cleanProperties += 1;
+      continue;
+    }
+    const sourceId = typeof property.sourceId === 'string' ? property.sourceId : '';
+    const sourceUrl = typeof property.sourceUrl === 'string' ? property.sourceUrl : '';
+    if (!sourceId || !sourceUrl) {
+      // Cannot re-fetch without a stable id + URL; report but do not touch.
+      continue;
+    }
+    candidates.push({
+      id: property._id,
+      sourceId,
+      sourceUrl,
+      currentImageCount: refs.length,
+      watermarkedCount,
+    });
+  }
+
+  return {
+    scanned: properties.length,
+    candidates,
+    cleanProperties,
+    imagelessProperties,
+    widthDistribution,
+  };
+}
+
+type ReplaceStatus =
+  | 'replaced'
+  | 'refetch-no-images'
+  | 'ingest-no-images'
+  | 'gone'
+  | 'fetch-error';
+
+interface ReplaceOutcome {
+  status: ReplaceStatus;
+  newImageCount: number;
+  deletedImageDocs: number;
+  deletedBlobs: number;
+  /** Failure reason (fetch/normalize error message), when the status is a failure. */
+  detail?: string;
+}
+
+/** Re-fetch one listing, ingest clean media, swap it in, delete the stale media. */
+async function replaceOne(
+  candidate: Candidate,
+  provider: ListingProvider,
+  runtime: FetchRuntime,
+  mediaIngest: ExternalMediaIngest,
+): Promise<ReplaceOutcome> {
+  const ref: ExternalListingRef = {
+    provider: 'pisos',
+    sourceId: candidate.sourceId,
+    url: candidate.sourceUrl,
+  };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  let remoteImages;
+  try {
+    const raw = await provider.fetch(ref, { runtime, signal: controller.signal });
+    remoteImages = provider.normalize(raw).remoteImages;
+  } catch (error) {
+    return {
+      status: 'fetch-error',
+      newImageCount: 0,
+      deletedImageDocs: 0,
+      deletedBlobs: 0,
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!remoteImages || remoteImages.length === 0) {
+    return { status: 'refetch-no-images', newImageCount: 0, deletedImageDocs: 0, deletedBlobs: 0 };
+  }
+
+  // Create the clean, re-hosted media first (new Image docs, entityId = property).
+  const newRefs = await mediaIngest.ingestForProperty(candidate.id, remoteImages);
+  if (newRefs.length === 0) {
+    return { status: 'ingest-no-images', newImageCount: 0, deletedImageDocs: 0, deletedBlobs: 0 };
+  }
+
+  // Point the property at the clean gallery before deleting anything.
+  const doc = await Property.findById(candidate.id);
+  if (!doc) {
+    return { status: 'gone', newImageCount: newRefs.length, deletedImageDocs: 0, deletedBlobs: 0 };
+  }
+  doc.set('images', newRefs);
+  await doc.save();
+
+  // Sweep every Image doc for this property that the new gallery does NOT
+  // reference (the stale watermarked set + any orphan from a prior interrupted
+  // run) and delete its S3 blobs, then the docs.
+  const keepIds = new Set(newRefs.map((newRef) => String(newRef.imageId)));
+  const allImages = await Image.find(
+    { entityType: 'property', entityId: candidate.id },
+    { keys: 1 },
+  ).lean<LeanImageWidth[]>();
+  const stale = allImages.filter((image) => !keepIds.has(String(image._id)));
+  const staleKeys = stale.flatMap(storageKeysOf);
+
+  let deletedBlobs = 0;
+  if (staleKeys.length > 0) {
+    try {
+      await imageUploadService.deleteImageVariants(staleKeys);
+      deletedBlobs = staleKeys.length;
+    } catch (error) {
+      console.warn(
+        `  ! S3 blob delete failed for ${candidate.id.toString()} (${staleKeys.length} keys): ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+  if (stale.length > 0) {
+    await Image.deleteMany({ _id: { $in: stale.map((image) => image._id) } });
+  }
+
+  return {
+    status: 'replaced',
+    newImageCount: newRefs.length,
+    deletedImageDocs: stale.length,
+    deletedBlobs,
+  };
+}
+
+/** Run `worker` over `items` with at most `concurrency` in flight. */
+async function runPool<T>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const lanes = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    for (;;) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) return;
+      await worker(items[index], index);
+    }
+  });
+  await Promise.all(lanes);
+}
+
+function printWidthDistribution(distribution: Map<string, number>): void {
+  const rows = [...distribution.entries()].sort((a, b) => b[1] - a[1]);
+  console.log('Referenced-image original-width distribution (all pisos images):');
+  for (const [bucket, count] of rows.slice(0, 20)) {
+    console.log(`  width ${bucket.padStart(6)} : ${count}`);
+  }
+}
+
+/** Shared media ingester (default env fetcher: clean pisos photos download direct). */
+const mediaIngestSingleton = new ExternalMediaIngest();
+
+async function main(): Promise<void> {
+  const options = parseCli(process.argv.slice(2));
+  console.log(
+    `pisos watermark backfill — mode=${options.apply ? 'APPLY' : 'DRY-RUN'} ` +
+      `minWidth=${options.minWidth} concurrency=${options.concurrency} ` +
+      `limit=${Number.isFinite(options.limit) ? options.limit : 'all'} ` +
+      `shard=${options.shardIndex}/${options.shardTotal}`,
+  );
+
+  await database.connect();
+
+  const result = await scan(options.minWidth);
+  console.log('--- scan ---');
+  console.log(`pisos properties scanned : ${result.scanned}`);
+  console.log(`already clean            : ${result.cleanProperties}`);
+  console.log(`imageless (skipped)      : ${result.imagelessProperties}`);
+  console.log(`WATERMARKED (candidates) : ${result.candidates.length}`);
+  const totalWatermarkedImages = result.candidates.reduce((sum, c) => sum + c.watermarkedCount, 0);
+  console.log(`watermarked images total : ${totalWatermarkedImages}`);
+  printWidthDistribution(result.widthDistribution);
+  console.log('sample candidates:');
+  for (const candidate of result.candidates.slice(0, 10)) {
+    console.log(
+      `  - ${candidate.id.toString()} imgs=${candidate.currentImageCount} ` +
+        `wm=${candidate.watermarkedCount} ${candidate.sourceUrl}`,
+    );
+  }
+
+  if (!options.apply) {
+    console.log('\nDry-run only — no writes, no S3 deletions. Re-run with --apply to replace.');
+    await database.disconnect?.();
+    return;
+  }
+
+  const registry = createDefaultRegistry();
+  if (!registry.has('pisos')) {
+    throw new Error(
+      'pisos provider not registered — set PROVIDER_PISOS_ENABLED=true in this task env',
+    );
+  }
+  const provider = registry.get('pisos');
+  const runtimeHandle: ListingFetchRuntimeHandle = await createListingFetchRuntimeFromEnv({
+    onLog: (message) => console.log(`[runtime] ${message}`),
+  });
+  const runtime = runtimeHandle.runtime;
+  console.log(
+    `runtime ready — browserTier=${Boolean(runtime.fetchViaBrowser)} ` +
+      `managedTier=${Boolean(runtime.fetchViaManaged)}`,
+  );
+
+  const sharded =
+    options.shardTotal > 1
+      ? result.candidates.filter((_, index) => index % options.shardTotal === options.shardIndex)
+      : result.candidates;
+  const toProcess = Number.isFinite(options.limit) ? sharded.slice(0, options.limit) : sharded;
+  console.log(
+    `\n--- applying to ${toProcess.length} propert${toProcess.length === 1 ? 'y' : 'ies'}` +
+      `${options.shardTotal > 1 ? ` (shard ${options.shardIndex}/${options.shardTotal})` : ''} ---`,
+  );
+
+  const tally: Record<ReplaceStatus, number> = {
+    replaced: 0,
+    'refetch-no-images': 0,
+    'ingest-no-images': 0,
+    gone: 0,
+    'fetch-error': 0,
+  };
+  let processed = 0;
+  let deletedImageDocs = 0;
+  let deletedBlobs = 0;
+
+  try {
+    await runPool(toProcess, options.concurrency, async (candidate) => {
+      let outcome: ReplaceOutcome;
+      try {
+        outcome = await replaceOne(candidate, provider, runtime, mediaIngestSingleton);
+      } catch (error) {
+        console.warn(
+          `  ! unexpected error for ${candidate.id.toString()}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        tally['fetch-error'] += 1;
+        processed += 1;
+        return;
+      }
+      tally[outcome.status] += 1;
+      deletedImageDocs += outcome.deletedImageDocs;
+      deletedBlobs += outcome.deletedBlobs;
+      processed += 1;
+      if (outcome.status === 'replaced') {
+        console.log(
+          `  [${processed}/${toProcess.length}] replaced ${candidate.id.toString()} ` +
+            `new=${outcome.newImageCount} deletedDocs=${outcome.deletedImageDocs} ` +
+            `deletedBlobs=${outcome.deletedBlobs}`,
+        );
+      } else {
+        console.log(
+          `  [${processed}/${toProcess.length}] ${outcome.status} ${candidate.id.toString()} ` +
+            `(kept existing images)${outcome.detail ? ` — ${outcome.detail}` : ''}`,
+        );
+      }
+    });
+  } finally {
+    await runtimeHandle.shutdown();
+  }
+
+  console.log('\n--- summary ---');
+  console.log(`replaced            : ${tally.replaced}`);
+  console.log(`refetch-no-images   : ${tally['refetch-no-images']}`);
+  console.log(`ingest-no-images    : ${tally['ingest-no-images']}`);
+  console.log(`property gone       : ${tally.gone}`);
+  console.log(`fetch-error         : ${tally['fetch-error']}`);
+  console.log(`stale Image docs deleted : ${deletedImageDocs}`);
+  console.log(`stale S3 blobs deleted   : ${deletedBlobs}`);
+
+  await database.disconnect?.();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -624,9 +624,11 @@ export {
   isSubitoHousingCategory,
 } from './providers/it/subito';
 export {
+  coerceSubitoRaw,
   parseSubitoDetail,
   parseSubitoSearch,
   parseSubitoSearchJson,
+  parseSubitoSearchListings,
   type SubitoRaw,
 } from './providers/it/subito/parse';
 export {

--- a/packages/listing-providers/src/providers/it/subito/fixtures.ts
+++ b/packages/listing-providers/src/providers/it/subito/fixtures.ts
@@ -1,5 +1,11 @@
 /**
  * Subito.it housing fixtures. General classifieds — housing category only.
+ *
+ * Shapes mirror the real portal: the search page embeds full ad objects in
+ * `__NEXT_DATA__` at `props.pageProps.initialState.items.originalList`, each ad
+ * carrying price/size/rooms inside a `features` dict keyed by `/price`, `/size`,
+ * `/room`, … and its offering encoded in `type.key` (`u` = affitto, `s` =
+ * vendita). Images are CDN base URLs that need a `?rule=…` query to render.
  */
 
 export const SUBITO_BASE_URL = 'https://www.subito.it';
@@ -14,114 +20,83 @@ export const SUBITO_HOUSING_CATEGORIES = [
   'uffici-e-locali-commerciali',
 ] as const;
 
-export const SUBITO_FIXTURE_DETAIL_HTML = `<!doctype html>
-<html lang="it">
-<head>
-<title>Appartamento a Milano 2 locali — Subito</title>
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Product",
-  "name": "Appartamento a Milano 2 locali",
-  "description": "Bilocale arredato vicino alla metro.",
-  "url": "https://www.subito.it/appartamenti/appartamento-a-milano-2-locali-milano-632623436.htm",
-  "image": ["https://images.subito.it/632623436/1.jpg"],
-  "offers": {
-    "@type": "Offer",
-    "price": "1000",
-    "priceCurrency": "EUR",
-    "businessFunction": "http://purl.org/goodrelations/v1#LeaseOut"
-  },
-  "address": {
-    "@type": "PostalAddress",
-    "addressLocality": "Milano",
-    "addressRegion": "Lombardia",
-    "addressCountry": "IT"
-  }
+/** A real-shaped housing ad node (`originalList[i]`). */
+function housingAd(id: string, subject: string, price: string, rooms: string): string {
+  return `{
+    "kind": "AdItem",
+    "urn": "id:ad:${id}00:list:${id}",
+    "type": { "key": "u", "value": "In affitto", "weight": 0 },
+    "category": { "id": "7", "label": "Appartamenti", "friendlyName": "appartamenti" },
+    "subject": "${subject}",
+    "body": "Bilocale arredato vicino alla metro.",
+    "images": [{ "cdnBaseUrl": "https://images.sbito.it/api/v1/sbt-ads-images-pro/images/c8/${id}" }],
+    "features": {
+      "/price": { "type": "number", "uri": "/price", "label": "Affitto mensile", "values": [{ "key": "${price}", "value": "${price} €" }] },
+      "/size": { "type": "number", "uri": "/size", "label": "Superficie", "values": [{ "key": "51", "value": "51 mq" }] },
+      "/room": { "type": "list", "uri": "/room", "label": "Locali", "values": [{ "key": "${rooms}", "value": "${rooms}" }] },
+      "/bathrooms": { "type": "list", "uri": "/bathrooms", "label": "Bagni", "values": [{ "key": "1", "value": "1" }] },
+      "/furnished": { "type": "bool", "uri": "/furnished", "label": "Arredato", "values": [{ "key": "1", "value": "Sì" }] }
+    },
+    "geo": {
+      "region": { "value": "Lombardia" },
+      "city": { "value": "Milano", "label": "Provincia" },
+      "town": { "value": "Milano" }
+    },
+    "advertiser": { "name": "Tempocasa Milano", "company": true, "phone": "+39 02 55667788", "shopName": "Tempocasa Milano" },
+    "urls": { "default": "https://www.subito.it/appartamenti/${subject
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')}-milano-${id}.htm" }
+  }`;
 }
-</script>
-<script id="__NEXT_DATA__" type="application/json">
-{
-  "props": {
-    "pageProps": {
-      "ad": {
-        "urn": "id:ad:632623436:list:1001",
-        "subject": "Appartamento a Milano 2 locali",
-        "body": "Bilocale arredato vicino alla metro.",
-        "category": { "label": "Appartamenti", "uri": "/appartamenti" },
-        "features": {
-          "rooms": { "value": "2" },
-          "bathroom": { "value": "1" },
-          "size": { "value": "51" },
-          "furnished": { "value": "1" }
-        },
-        "geo": {
-          "city": { "value": "Milano" },
-          "region": { "value": "Lombardia" },
-          "town": { "value": "Milano" }
-        },
-        "price": { "value": 1000 },
-        "urls": { "default": "https://www.subito.it/appartamenti/appartamento-a-milano-2-locali-milano-632623436.htm" },
-        "images": [{ "cdnBaseUrl": "https://images.subito.it/632623436/1.jpg" }],
-        "advertiser": {
-          "name": "Tempocasa Milano",
-          "phones": [{ "value": "+39 02 55667788" }],
-          "type": 1
-        }
-      }
-    }
-  }
-}
-</script>
-</head>
-<body><main><h1>Appartamento a Milano 2 locali</h1></main></body>
-</html>`;
 
-/** Non-housing fixture — must be rejected by normalize. */
-export const SUBITO_FIXTURE_NON_HOUSING_HTML = `<!doctype html>
-<html lang="it">
-<head>
-<script id="__NEXT_DATA__" type="application/json">
-{
-  "props": {
-    "pageProps": {
-      "ad": {
-        "urn": "id:ad:999888777:list:2",
-        "subject": "Fiat Punto usata",
-        "category": { "label": "Auto", "uri": "/auto" },
-        "price": { "value": 3500 },
-        "urls": { "default": "https://www.subito.it/auto/fiat-punto-salerno-999888777.htm" },
-        "geo": { "city": { "value": "Salerno" } }
-      }
-    }
-  }
-}
-</script>
-</head>
-<body></body>
-</html>`;
+const AD_632623436 = housingAd('632623436', 'Appartamento a Milano 2 locali', '1000', '2');
+const AD_632623437 = housingAd('632623437', 'Trilocale Milano', '1400', '3');
 
-export const SUBITO_FIXTURE_SEARCH_HTML = `<!doctype html>
-<html lang="it"><body>
-<a href="/appartamenti/appartamento-a-milano-2-locali-milano-632623436.htm">a</a>
-<a href="https://www.subito.it/appartamenti/trilocale-milano-632623437.htm">b</a>
-<a href="/auto/fiat-punto-999888777.htm">car — must be ignored by housing search parser</a>
+/** A non-housing ad node (must be rejected by the housing guards). */
+const AD_AUTO_999888777 = `{
+    "kind": "AdItem",
+    "urn": "id:ad:99988877700:list:999888777",
+    "type": { "key": "s", "value": "In vendita", "weight": 0 },
+    "category": { "id": "1", "label": "Auto", "friendlyName": "auto" },
+    "subject": "Fiat Punto usata",
+    "features": { "/price": { "type": "number", "uri": "/price", "label": "Prezzo", "values": [{ "key": "3500", "value": "3500 €" }] } },
+    "geo": { "city": { "value": "Salerno" } },
+    "urls": { "default": "https://www.subito.it/auto/fiat-punto-salerno-999888777.htm" }
+  }`;
+
+function searchPage(ads: string[]): string {
+  return `<!doctype html>
+<html lang="it"><head><title>Appartamenti in affitto Milano — Subito</title></head>
+<body>
+<script id="__NEXT_DATA__" type="application/json">
+{"props":{"pageProps":{"pageName":"listing","initialState":{"items":{"total":${ads.length},"totalPages":1,"originalList":[${ads.join(',')}],"galleryList":[]}}}}}
+</script>
 </body></html>`;
+}
 
+export const SUBITO_FIXTURE_DETAIL_HTML = searchPage([AD_632623436]);
+
+/** Non-housing detail — must be rejected by parse/normalize. */
+export const SUBITO_FIXTURE_NON_HOUSING_HTML = searchPage([AD_AUTO_999888777]);
+
+/** Search page with two housing ads plus one car (car must be filtered out). */
+export const SUBITO_FIXTURE_SEARCH_HTML = searchPage([AD_632623436, AD_632623437, AD_AUTO_999888777]);
+
+/** Portal-shaped JSON search response (housing categories + one car to reject). */
 export const SUBITO_FIXTURE_SEARCH_JSON = `{
   "ads": [
     {
-      "urn": "id:ad:632623436:list:1001",
+      "urn": "id:ad:632623436:list:632623436",
       "urls": { "default": "https://www.subito.it/appartamenti/appartamento-a-milano-2-locali-milano-632623436.htm" },
       "category": { "uri": "/appartamenti" }
     },
     {
-      "urn": "id:ad:632623437:list:1001",
+      "urn": "id:ad:632623437:list:632623437",
       "urls": { "default": "https://www.subito.it/appartamenti/trilocale-milano-632623437.htm" },
       "category": { "uri": "/appartamenti" }
     },
     {
-      "urn": "id:ad:999888777:list:2",
+      "urn": "id:ad:999888777:list:999888777",
       "urls": { "default": "https://www.subito.it/auto/fiat-punto-999888777.htm" },
       "category": { "uri": "/auto" }
     }

--- a/packages/listing-providers/src/providers/it/subito/index.ts
+++ b/packages/listing-providers/src/providers/it/subito/index.ts
@@ -29,15 +29,17 @@ import { ChallengeError, fetchListingViaLadder } from '../../../strategy';
 import { defaultProviderMetrics, type ProviderMetricsReader, type ProviderMetricsSink } from '../../../metrics';
 import { SUBITO_BASE_URL } from './fixtures';
 import {
+  coerceSubitoRaw,
   isSubitoHousingCategory,
   parseSubitoDetail,
   parseSubitoSearch,
-  parseSubitoSearchJson,
-  subitoSearchApiUrl,
+  parseSubitoSearchListings,
   subitoSourceIdFromUrl,
   subitoWarmSearchUrl,
   type SubitoRaw,
 } from './parse';
+
+const CONTENT_SELECTOR = 'a[href*="/appartamenti/"], main, #__NEXT_DATA__';
 
 const PROVIDER_ID: ProviderId = 'subito';
 const DEFAULT_CITIES: readonly string[] = ['roma', 'milano', 'napoli', 'torino', 'firenze'];
@@ -80,6 +82,34 @@ function yieldRefs(
   return out;
 }
 
+/**
+ * Yield refs from full search-page ad objects, carrying the parsed listing in
+ * `hints.listing`. The detail page (Next App Router) exposes no usable JSON, so
+ * `fetch` normalizes from this hint instead of re-fetching the ad.
+ */
+function yieldListings(
+  listings: readonly SubitoRaw[],
+  seen: Set<string>,
+  limit: number,
+  yielded: { count: number },
+): ExternalListingRef[] {
+  const out: ExternalListingRef[] = [];
+  for (const listing of listings) {
+    if (yielded.count >= limit) break;
+    if (seen.has(listing.sourceId)) continue;
+    if (!isSubitoHousingCategory(listing.categoryUri || listing.url)) continue;
+    seen.add(listing.sourceId);
+    out.push({
+      provider: PROVIDER_ID,
+      sourceId: listing.sourceId,
+      url: listing.url,
+      hints: { listing },
+    });
+    yielded.count += 1;
+  }
+  return out;
+}
+
 export class SubitoProvider implements ListingProvider {
   readonly id: ProviderId = PROVIDER_ID;
   readonly markets = ['IT'] as const;
@@ -105,12 +135,12 @@ export class SubitoProvider implements ListingProvider {
 
     for (const city of cities) {
       if (yielded.count >= limit) return;
-      const viaAjax = runtime.openBrowserSession
-        ? await this.discoverCityViaAjax(runtime, city, job.signal, seen, limit, yielded)
+      const viaBrowser = runtime.openBrowserSession
+        ? await this.discoverCityViaBrowser(runtime, city, job.signal, seen, limit, yielded)
         : [];
-      for (const ref of viaAjax) yield ref;
+      for (const ref of viaBrowser) yield ref;
       if (yielded.count >= limit) return;
-      if (viaAjax.length === 0) {
+      if (viaBrowser.length === 0) {
         for await (const ref of this.discoverCityViaHtml(runtime, city, job.signal, seen, limit, yielded)) {
           yield ref;
         }
@@ -118,7 +148,12 @@ export class SubitoProvider implements ListingProvider {
     }
   }
 
-  private async discoverCityViaAjax(
+  /**
+   * Warm the Akamai-gated search page and parse the full ad objects embedded in
+   * `__NEXT_DATA__` (JSON-first — no HTML scraping). Pages 2+ reuse the warmed
+   * context via `warmNavigate` rather than re-opening a session per page.
+   */
+  private async discoverCityViaBrowser(
     runtime: FetchRuntime,
     city: string,
     signal: AbortSignal | undefined,
@@ -136,7 +171,7 @@ export class SubitoProvider implements ListingProvider {
       session = await runtime.openBrowserSession({
         warmUrl: subitoWarmSearchUrl(city, 1),
         signal,
-        contentSelector: 'a[href*="/appartamenti/"], main, #__NEXT_DATA__',
+        contentSelector: CONTENT_SELECTOR,
         isChallenge: isSubitoChallenge,
         challengeWaitMs: 45_000,
         stickyProxySession: sticky,
@@ -149,26 +184,27 @@ export class SubitoProvider implements ListingProvider {
       const collected: ExternalListingRef[] = [];
       for (let page = 1; page <= MAX_SEARCH_PAGES; page += 1) {
         if (yielded.count >= limit) break;
-        const ajaxUrl = subitoSearchApiUrl(city, page);
-        const { status, body } = await session.request(ajaxUrl, {
-          referer: session.pageUrl(),
-          timeoutMs: 30_000,
-        });
-        let pageRefs =
-          status < 400 && !isSubitoChallenge(body) ? parseSubitoSearchJson(body) : [];
-        if (pageRefs.length === 0 && page === 1) {
-          pageRefs = parseSubitoSearch(await session.content());
+        if (page > 1) {
+          await session.warmNavigate({
+            warmUrl: subitoWarmSearchUrl(city, page),
+            signal,
+            contentSelector: CONTENT_SELECTOR,
+            isChallenge: isSubitoChallenge,
+            challengeWaitMs: 45_000,
+          });
         }
-        if (pageRefs.length === 0) break;
+        const html = await session.content();
+        if (isSubitoChallenge(html)) break;
+        const listings = parseSubitoSearchListings(html);
+        if (listings.length === 0) break;
         this.metrics.record({
           provider: this.id,
           strategy: 'browser',
           outcome: 'success',
-          status,
           latencyMs: Date.now() - start,
-          url: ajaxUrl,
+          url: session.pageUrl(),
         });
-        collected.push(...yieldRefs(pageRefs, seen, limit, yielded));
+        collected.push(...yieldListings(listings, seen, limit, yielded));
       }
       if (sticky) this.stickyStorageState = await session.exportStorageState();
       return collected;
@@ -224,6 +260,10 @@ export class SubitoProvider implements ListingProvider {
     if (!isSubitoHousingCategory(ref.url)) {
       throw new Error(`subito: refusing to fetch non-housing URL ${ref.url}`);
     }
+    // Discover already parsed the full ad from the search page __NEXT_DATA__ and
+    // carried it via hints (the detail page exposes no usable JSON). Prefer it.
+    const hinted = coerceSubitoRaw(ref.hints?.listing);
+    if (hinted) return { ref, payload: hinted };
     if (ctx.runtime.openBrowserSession) {
       let session: BrowserSession | undefined;
       try {

--- a/packages/listing-providers/src/providers/it/subito/parse.ts
+++ b/packages/listing-providers/src/providers/it/subito/parse.ts
@@ -3,10 +3,17 @@
  *
  * Subito is a general classifieds portal. Discover URLs and normalize() MUST
  * reject non-housing categories (auto, lavoro, elettronica, …).
+ *
+ * The search page embeds full ad objects in `__NEXT_DATA__`
+ * (`props.pageProps.initialState.items.originalList` / `galleryList`); each ad
+ * carries price/size/rooms inside a `features` dict keyed by `/price`, `/size`,
+ * `/room`, … The detail page migrated to the Next App Router and no longer
+ * exposes a usable JSON payload, so the provider carries the full ad object from
+ * discover to fetch via `ExternalListingRef.hints`.
  */
 
 import type { NormalizedListingContact } from '@homiio/shared-types';
-import { contactFromAdvertiser, normalizePhone } from '../../../parse/contact';
+import { buildContact, normalizePhone } from '../../../parse/contact';
 import { asNumber as parseNumberFromGuard, asRecord, asString } from '../../../parse/guards';
 import { extractItSchemaListings, pickItListing } from '../../../parse/jsonLd';
 import { parseNextData } from '../../../parse/nextData';
@@ -36,6 +43,9 @@ const HOUSING_DETAIL_RE =
 
 const HOUSING_SET = new Set<string>(SUBITO_HOUSING_CATEGORIES);
 
+/** Subito image CDN entries are base URLs; a `rule` query is required to render. */
+const SUBITO_IMAGE_RULE = 'rule=fullscreen-1x-auto';
+
 /** Coerce portal feature/price blobs that wrap the number in `{ value }`. */
 function asNumber(value: unknown): number | undefined {
   return parseNumberFromGuard(value) ?? parseNumberFromGuard(asRecord(value)?.value);
@@ -63,30 +73,22 @@ const CITY_REGIONS: Readonly<Record<string, string>> = {
   bologna: 'emilia-romagna',
 };
 
-export function subitoWarmSearchUrl(city: string, page = 1): string {
-  const slug = city
+function citySlug(city: string): string {
+  return city
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
     .toLowerCase()
     .trim()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
+}
+
+export function subitoWarmSearchUrl(city: string, page = 1): string {
+  const slug = citySlug(city);
   const region = CITY_REGIONS[slug] ?? 'lazio';
   // Housing-only: appartamenti in affitto (never site-wide crawl).
   const base = `${SUBITO_BASE_URL}/annunci-${region}/affitto/appartamenti/${slug}/`;
   return page <= 1 ? base : `${base}?o=${page}`;
-}
-
-export function subitoSearchApiUrl(city: string, page = 1): string {
-  const slug = city
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-  const region = CITY_REGIONS[slug] ?? 'lazio';
-  return `${SUBITO_BASE_URL}/api/v1.0/search/items?t=2&q=&c=appartamenti&r=${encodeURIComponent(region)}&ci=${encodeURIComponent(slug)}&o=${page}`;
 }
 
 function categoryFromUrl(url: string): string {
@@ -94,6 +96,21 @@ function categoryFromUrl(url: string): string {
     /\/(appartamenti|camere-posti-letto|ville-singole-e-a-schiera|terreni-e-rustici|garage-e-box|uffici-e-locali-commerciali|auto|motori|lavoro)\//i,
   );
   return match?.[1]?.toLowerCase() ?? '';
+}
+
+function categoryUriFromAd(record: Record<string, unknown>, url: string): string {
+  const category = asRecord(record.category);
+  return (
+    asString(category?.friendlyName) ??
+    asString(category?.uri) ??
+    asString(category?.label) ??
+    categoryFromUrl(url)
+  );
+}
+
+function urnSourceId(urn: string | undefined): string | undefined {
+  if (!urn) return undefined;
+  return urn.match(/:list:(\d{6,})/i)?.[1] ?? urn.match(/:(\d{6,})/)?.[1];
 }
 
 function collectHousingRefs(value: unknown, out: Map<string, string>): void {
@@ -107,22 +124,13 @@ function collectHousingRefs(value: unknown, out: Map<string, string>): void {
   const urls = asRecord(record.urls);
   const url =
     asString(urls?.default) ?? asString(record.url) ?? asString(record.detailUrl) ?? asString(record.href);
-  const category =
-    asString(asRecord(record.category)?.uri) ??
-    asString(asRecord(record.category)?.label) ??
-    (url ? categoryFromUrl(url) : '');
-
-  if (url && isSubitoHousingCategory(category || url)) {
+  if (url && isSubitoHousingCategory(categoryUriFromAd(record, url) || url)) {
     const sourceId =
-      subitoSourceIdFromUrl(url) ??
-      asString(record.urn)?.match(/:(\d{6,}):/)?.[1] ??
-      asString(record.id);
+      subitoSourceIdFromUrl(url) ?? urnSourceId(asString(record.urn)) ?? asString(record.id);
     if (sourceId) out.set(sourceId, url.startsWith('http') ? url : `${SUBITO_BASE_URL}${url}`);
   }
 
-  for (const key of ['ads', 'items', 'results', 'list', 'data', 'pageProps', 'props', 'adList']) {
-    if (key in record) collectHousingRefs(record[key], out);
-  }
+  for (const child of Object.values(record)) collectHousingRefs(child, out);
 }
 
 export function parseSubitoSearchJson(body: string): { sourceId: string; url: string }[] {
@@ -138,6 +146,10 @@ export function parseSubitoSearchJson(body: string): { sourceId: string; url: st
 }
 
 export function parseSubitoSearch(html: string): { sourceId: string; url: string }[] {
+  const listings = parseSubitoSearchListings(html);
+  if (listings.length > 0) {
+    return listings.map((listing) => ({ sourceId: listing.sourceId, url: listing.url }));
+  }
   const next = parseNextData(html);
   if (next) {
     const out = new Map<string, string>();
@@ -159,60 +171,78 @@ export function parseSubitoSearch(html: string): { sourceId: string; url: string
   return refs;
 }
 
-function featureValue(features: Record<string, unknown> | undefined, key: string): number | undefined {
-  if (!features) return undefined;
-  return asNumber(features[key]);
+/** First `{ key, value }` of a Subito feature (`features['/price'].values[0]`). */
+function featureFirstValue(
+  features: Record<string, unknown> | undefined,
+  uri: string,
+): Record<string, unknown> | undefined {
+  const feature = asRecord(features?.[uri]);
+  const values = feature?.values;
+  return Array.isArray(values) ? asRecord(values[0]) : undefined;
+}
+
+function featureNumber(features: Record<string, unknown> | undefined, uri: string): number | undefined {
+  const first = featureFirstValue(features, uri);
+  return parseNumberFromGuard(first?.key) ?? parseNumberFromGuard(first?.value);
+}
+
+function featureIsYes(features: Record<string, unknown> | undefined, uri: string): boolean {
+  return asString(featureFirstValue(features, uri)?.key) === '1';
+}
+
+/** Subito ad `type` encodes the offering: `u` = affitto (rent), `s` = vendita (sale). */
+function operationFromAd(ad: Record<string, unknown>, url: string, categoryUri: string): 'rent' | 'sale' {
+  const type = asRecord(ad.type);
+  const typeKey = asString(type?.key)?.toLowerCase();
+  const typeValue = asString(type?.value)?.toLowerCase() ?? '';
+  if (typeKey === 's' || /vendita|vendo/.test(typeValue)) return 'sale';
+  if (typeKey === 'u' || /affitto/.test(typeValue)) return 'rent';
+  if (/vendita/i.test(url) || /vendita/i.test(categoryUri)) return 'sale';
+  return 'rent';
+}
+
+/** Absolute, render-ready image URL from a Subito CDN entry (base needs a `rule`). */
+function subitoImageUrl(raw: string): string | undefined {
+  if (!raw.startsWith('http')) return undefined;
+  return raw.includes('?') ? raw : `${raw}?${SUBITO_IMAGE_RULE}`;
+}
+
+function subitoContact(advertiser: Record<string, unknown> | undefined): NormalizedListingContact | undefined {
+  if (!advertiser) return undefined;
+  const isCompany = advertiser.company === true;
+  const name = asString(advertiser.name);
+  return buildContact({
+    phone: normalizePhone(asString(advertiser.phone)),
+    name: isCompany ? undefined : name,
+    agencyName: asString(advertiser.shopName) ?? (isCompany ? name : undefined),
+    kind: isCompany ? 'agency' : 'private',
+  });
 }
 
 function listingFromAd(ad: Record<string, unknown>, fallbackUrl: string): SubitoRaw {
   const urls = asRecord(ad.urls);
   const url = asString(urls?.default) ?? asString(ad.url) ?? fallbackUrl;
-  const categoryUri =
-    asString(asRecord(ad.category)?.uri) ??
-    asString(asRecord(ad.category)?.label) ??
-    categoryFromUrl(url);
+  const categoryUri = categoryUriFromAd(ad, url);
   const sourceId =
-    subitoSourceIdFromUrl(url) ??
-    asString(ad.urn)?.match(/:(\d{6,}):/)?.[1] ??
-    asString(ad.id) ??
-    'unknown';
+    subitoSourceIdFromUrl(url) ?? urnSourceId(asString(ad.urn)) ?? asString(ad.id) ?? 'unknown';
 
   const geo = asRecord(ad.geo) ?? {};
-  const features = asRecord(ad.features) ?? {};
-  const price = asNumber(ad.price) ?? asNumber(asRecord(ad.price)?.value);
+  const features = asRecord(ad.features);
+
   const images: string[] = [];
   const imageNodes = Array.isArray(ad.images) ? ad.images : [];
   for (const image of imageNodes) {
     const record = asRecord(image);
-    const src = asString(record?.cdnBaseUrl) ?? asString(record?.url);
-    if (src?.startsWith('http')) images.push(src);
+    const raw = asString(record?.cdnBaseUrl) ?? asString(record?.url) ?? asString(record?.uri);
+    const src = raw ? subitoImageUrl(raw) : undefined;
+    if (src) images.push(src);
   }
-
-  const advertiser = asRecord(ad.advertiser);
-  let contact = contactFromAdvertiser(advertiser);
-  if (advertiser) {
-    const phones = Array.isArray(advertiser.phones) ? advertiser.phones : [];
-    const phone = normalizePhone(asString(asRecord(phones[0])?.value) ?? asString(phones[0]));
-    if (phone || asString(advertiser.name)) {
-      contact = {
-        ...(contact ?? {}),
-        ...(phone ? { phone: contact?.phone ?? phone } : {}),
-        ...(asString(advertiser.name) && !contact?.agencyName
-          ? { agencyName: asString(advertiser.name) }
-          : {}),
-        kind: contact?.kind ?? 'agency',
-      };
-    }
-  }
-
-  const operation: 'rent' | 'sale' =
-    /vendita|sale/i.test(url) || /vendita/i.test(categoryUri) ? 'sale' : 'rent';
 
   const raw: SubitoRaw = {
     sourceId,
     url,
     currency: 'EUR',
-    operation,
+    operation: operationFromAd(ad, url, categoryUri),
     categoryUri,
     images,
   };
@@ -220,24 +250,26 @@ function listingFromAd(ad: Record<string, unknown>, fallbackUrl: string): Subito
   if (title) raw.title = title;
   const description = asString(ad.body) ?? asString(ad.description);
   if (description) raw.description = description;
+  const price = featureNumber(features, '/price') ?? asNumber(ad.price);
   if (price !== undefined) raw.price = price;
-  const bedrooms = featureValue(features, 'rooms') ?? featureValue(features, 'locali');
+  const bedrooms =
+    featureNumber(features, '/room') ?? featureNumber(features, '/rooms') ?? featureNumber(features, '/locali');
   if (bedrooms !== undefined) raw.bedrooms = bedrooms;
-  const bathrooms = featureValue(features, 'bathroom') ?? featureValue(features, 'bathrooms');
+  const bathrooms = featureNumber(features, '/bathrooms') ?? featureNumber(features, '/bathroom');
   if (bathrooms !== undefined) raw.bathrooms = bathrooms;
-  const squareMeters = featureValue(features, 'size') ?? featureValue(features, 'surface');
+  const squareMeters = featureNumber(features, '/size') ?? featureNumber(features, '/surface');
   if (squareMeters !== undefined) raw.squareMeters = squareMeters;
-  const city = asString(asRecord(geo.city)?.value) ?? asString(asRecord(geo.town)?.value);
+  const city = asString(asRecord(geo.town)?.value) ?? asString(asRecord(geo.city)?.value);
   if (city) raw.city = city;
   const region = asString(asRecord(geo.region)?.value);
   if (region) raw.region = region;
-  if (asNumber(features.furnished) === 1 || asString(asRecord(features.furnished)?.value) === '1') {
-    raw.furnished = true;
-  }
+  if (featureIsYes(features, '/furnished')) raw.furnished = true;
+  const contact = subitoContact(asRecord(ad.advertiser));
   if (contact) raw.contact = contact;
   return raw;
 }
 
+/** A node is a Subito ad when it carries a detail URL plus ad-shaped fields. */
 function findAdNodes(value: unknown, out: Record<string, unknown>[]): void {
   if (Array.isArray(value)) {
     for (const entry of value) findAdNodes(entry, out);
@@ -245,32 +277,70 @@ function findAdNodes(value: unknown, out: Record<string, unknown>[]): void {
   }
   const record = asRecord(value);
   if (!record) return;
-  if (record.urn || record.subject || (record.category && record.urls)) {
+  const hasUrl = record.urls !== undefined || record.url !== undefined;
+  const looksLikeAd =
+    hasUrl &&
+    (record.urn !== undefined || record.category !== undefined) &&
+    (record.subject !== undefined || record.features !== undefined || record.title !== undefined);
+  if (looksLikeAd) {
     out.push(record);
+    return;
   }
-  for (const key of ['ad', 'item', 'pageProps', 'props', 'data']) {
-    if (key in record) findAdNodes(record[key], out);
+  for (const child of Object.values(record)) findAdNodes(child, out);
+}
+
+/** Full ad objects from the search page `__NEXT_DATA__` (housing-only, priced). */
+export function parseSubitoSearchListings(html: string): SubitoRaw[] {
+  const next = parseNextData(html);
+  if (!next) return [];
+  const ads: Record<string, unknown>[] = [];
+  findAdNodes(next, ads);
+  const out: SubitoRaw[] = [];
+  const seen = new Set<string>();
+  for (const ad of ads) {
+    const listing = listingFromAd(ad, '');
+    if (listing.sourceId === 'unknown' || !listing.url) continue;
+    if (!isSubitoHousingCategory(listing.categoryUri || listing.url)) continue;
+    if (listing.price === undefined) continue;
+    if (seen.has(listing.sourceId)) continue;
+    seen.add(listing.sourceId);
+    out.push(listing);
   }
+  return out;
+}
+
+/**
+ * Validate a `hints.listing` payload carried from discover (survives BullMQ JSON).
+ * Returns a `SubitoRaw` only when it has the minimum shape to normalize.
+ */
+export function coerceSubitoRaw(value: unknown): SubitoRaw | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+  if (
+    typeof record.sourceId !== 'string' ||
+    typeof record.url !== 'string' ||
+    typeof record.categoryUri !== 'string' ||
+    typeof record.price !== 'number' ||
+    !Array.isArray(record.images)
+  ) {
+    return undefined;
+  }
+  return record as unknown as SubitoRaw;
 }
 
 export function parseSubitoDetail(html: string, url: string): SubitoRaw {
   const next = parseNextData(html);
   if (next) {
-    try {
-      const ads: Record<string, unknown>[] = [];
-      findAdNodes(next, ads);
-      for (const ad of ads) {
-        const listing = listingFromAd(ad, url);
-        if (!isSubitoHousingCategory(listing.categoryUri || listing.url)) {
-          throw new Error(
-            `subito: non-housing category rejected (${listing.categoryUri || listing.url})`,
-          );
-        }
-        return listing;
+    const ads: Record<string, unknown>[] = [];
+    findAdNodes(next, ads);
+    const wantId = subitoSourceIdFromUrl(url);
+    const parsed = ads.map((ad) => listingFromAd(ad, url)).filter((listing) => listing.price !== undefined);
+    const chosen = parsed.find((listing) => listing.sourceId === wantId) ?? parsed[0];
+    if (chosen) {
+      if (!isSubitoHousingCategory(chosen.categoryUri || chosen.url)) {
+        throw new Error(`subito: non-housing category rejected (${chosen.categoryUri || chosen.url})`);
       }
-    } catch (error) {
-      if (error instanceof Error && error.message.startsWith('subito: non-housing')) throw error;
-      // Fall through to JSON-LD.
+      return chosen;
     }
   }
 
@@ -285,21 +355,22 @@ export function parseSubitoDetail(html: string, url: string): SubitoRaw {
   }
   const sourceId = subitoSourceIdFromUrl(schema.url ?? url) ?? subitoSourceIdFromUrl(url);
   if (!sourceId) throw new Error(`subito: cannot derive source id from ${url}`);
-  return {
+  const raw: SubitoRaw = {
     sourceId,
     url: schema.url ?? url,
-    title: schema.name,
-    description: schema.description,
     price: schema.price,
     currency: schema.priceCurrency ?? 'EUR',
     operation: schema.operation ?? 'rent',
     categoryUri: categoryFromUrl(schema.url ?? url),
-    bedrooms: schema.bedrooms,
-    bathrooms: schema.bathrooms,
-    squareMeters: schema.squareMeters,
-    city: schema.address.city,
-    region: schema.address.region,
     images: schema.images,
-    furnished: schema.furnished,
   };
+  if (schema.name) raw.title = schema.name;
+  if (schema.description) raw.description = schema.description;
+  if (schema.bedrooms !== undefined) raw.bedrooms = schema.bedrooms;
+  if (schema.bathrooms !== undefined) raw.bathrooms = schema.bathrooms;
+  if (schema.squareMeters !== undefined) raw.squareMeters = schema.squareMeters;
+  if (schema.address.city) raw.city = schema.address.city;
+  if (schema.address.region) raw.region = schema.address.region;
+  if (schema.furnished !== undefined) raw.furnished = schema.furnished;
+  return raw;
 }


### PR DESCRIPTION
Batches the two remaining open PRs into one merge (both runtime-inert: a standalone script + a default-OFF provider).

- **#200** — `scripts/backfillPisosCleanImages.ts`: the one-off (already running in prod via ECS) that re-fetches pisos listings and replaces watermarked/framed first images with clean versions. Documents it in-repo.
- **#189** — subito.it parser repaired against real markup + IT provider verification. Provider stays OFF (needs a headed browser tier for DataDome/Akamai), so no runtime change.

Verification: shared-types → listing-providers → backend build clean; 72 suites / 754 tests green.

Closes #200, #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)