### PR TITLE
fix(ingest): never drop external listings on coordinate resolution

### DIFF
--- a/packages/backend/__tests__/unit/ingestionGeocode.test.ts
+++ b/packages/backend/__tests__/unit/ingestionGeocode.test.ts
@@ -14,6 +14,7 @@ import { IngestionService } from '../../services/ingestion/IngestionService';
 import { ExternalMediaIngest } from '../../services/ingestion/ExternalMediaIngest';
 import type { ImageBufferInput } from '../../services/imageUploadService';
 import { forwardGeocode, reverseGeocode } from '../../services/geocodingService';
+import { clearResolutionCache } from '../../services/geoResolutionService';
 
 jest.mock('../../services/geocodingService', () => ({
   forwardGeocode: jest.fn(),
@@ -54,6 +55,9 @@ function buildIngestionService(): IngestionService {
 beforeEach(() => {
   mockedForwardGeocode.mockReset();
   mockedReverseGeocode.mockReset();
+  // Collections are wiped after every test; drop the in-process geo resolution
+  // cache too so a resolution never returns an id for a now-deleted geo doc.
+  clearResolutionCache();
 });
 
 describe('IngestionService.resolveAddress geocode fallbacks', () => {
@@ -110,6 +114,77 @@ describe('IngestionService.resolveAddress geocode fallbacks', () => {
     const property = await Property.findById(result.propertyId);
     expect(property).not.toBeNull();
     expect(property.get('addressId')).toBeTruthy();
+  });
+
+  it('reuses a stored City centroid for a placeholder-street listing without a second geocode', async () => {
+    // A high-volume, real prod skip class: immobilienscout24 emits a placeholder
+    // street ("Die vollständige Adresse …") with a REAL city — the street geocode
+    // can never resolve, and under a Nominatim flood the city retry was rate-limited
+    // too, so the listing was dropped. Once the city is known to us, ingest must
+    // never hit Nominatim for it again.
+    mockedReverseGeocode.mockResolvedValue({ success: false, error: 'no address' });
+
+    const service = buildIngestionService();
+
+    // Seed the city from a listing that carries portal coordinates (no geocode).
+    await service.ingest({
+      ...baseListing,
+      sourceId: 'hh-seed',
+      address: {
+        street: 'Reeperbahn 1',
+        city: 'Hamburg',
+        state: 'Hamburg',
+        country: 'Germany',
+        countryCode: 'DE',
+        coordinates: { lat: 53.5503, lng: 9.9937 },
+      },
+    });
+    expect(mockedForwardGeocode).not.toHaveBeenCalled();
+
+    // Now a placeholder-street listing in the SAME city with no coordinates.
+    // The street geocode fails; the city centroid must come from the DB City doc.
+    mockedForwardGeocode.mockResolvedValue({ success: false, error: 'No coordinates found' });
+    const result = await service.ingest({
+      ...baseListing,
+      sourceId: 'hh-vague',
+      address: {
+        street: 'Die vollständige Adresse der Immobilie erhältst du vom Anbieter.',
+        city: 'Hamburg',
+        state: 'Hamburg',
+        country: 'Germany',
+        countryCode: 'DE',
+      },
+    });
+
+    expect(result.status).toBe('created');
+    // Only the (failing) street query hit the geocoder — the city centroid was
+    // read from the DB, so NO city-level forward geocode was issued.
+    expect(mockedForwardGeocode).toHaveBeenCalledTimes(1);
+    const cityGeocodes = mockedForwardGeocode.mock.calls.filter((call) =>
+      /^Hamburg,/.test(String(call[0])),
+    );
+    expect(cityGeocodes).toHaveLength(0);
+
+    const property = await Property.findById(result.propertyId);
+    const address = await Address.findById(property.get('addressId'));
+    expect(address?.coordinates?.coordinates).toEqual([9.9937, 53.5503]);
+  });
+
+  it('skips a listing only when the city cannot be resolved by any means', async () => {
+    // Street AND city geocode both fail, and the country name is unrecognised so
+    // no DB city can be found — the one remaining case where we still skip.
+    mockedForwardGeocode.mockResolvedValue({ success: false, error: 'No coordinates found' });
+    mockedReverseGeocode.mockResolvedValue({ success: false, error: 'No address found' });
+
+    const listing: NormalizedListing = {
+      ...baseListing,
+      sourceId: 'unresolvable-city',
+      address: { street: 'Some Street', city: 'Zzqxville', country: 'Nowherestan' },
+    };
+
+    await expect(buildIngestionService().ingest(listing)).rejects.toThrow(
+      /Could not resolve coordinates/,
+    );
   });
 
   it('persists with postal fallback when geocoders return none', async () => {

--- a/packages/backend/config.ts
+++ b/packages/backend/config.ts
@@ -114,6 +114,15 @@ export interface Config {
     userAgent: string;
     /** Optional Referer header, also accepted by the OSM usage policy. */
     referer?: string;
+    /**
+     * Minimum milliseconds between Nominatim request *starts*. The OSM usage
+     * policy caps the public endpoint at ~1 req/sec, so every network call is
+     * serialized behind this interval — both to stay within policy AND to avoid
+     * self-inflicted 429s when a high-volume ingest floods the geocoder. Set to
+     * `0` (via `GEOCODING_MIN_INTERVAL_MS`) when pointing at a self-hosted
+     * Nominatim that has no such limit.
+     */
+    minIntervalMs: number;
   };
   overpass: {
     /**
@@ -293,6 +302,7 @@ const config: Config = {
     // OSM requires a descriptive, identifying User-Agent on every request.
     userAgent: process.env.GEOCODING_USER_AGENT || 'Homiio/1.0 (+https://homiio.com)',
     referer: process.env.GEOCODING_REFERER || 'https://homiio.com',
+    minIntervalMs: parseInt(process.env.GEOCODING_MIN_INTERVAL_MS || '1000', 10),
   },
 
   // Overpass Configuration (OpenStreetMap POI lookup — free, no API key)

--- a/packages/backend/services/geoResolutionService.ts
+++ b/packages/backend/services/geoResolutionService.ts
@@ -298,4 +298,83 @@ export async function resolveGeo(input: ResolveGeoInput): Promise<ResolvedGeo> {
   return resolved;
 }
 
-export default { resolveGeo };
+/** Read a City doc's stored centroid as GeoJSON `[lng, lat]`, if valid. */
+function cityDocCentroid(doc: CityDoc | null): [number, number] | null {
+  const lat = doc?.coordinates?.lat;
+  const lng = doc?.coordinates?.lng;
+  if (typeof lat !== 'number' || typeof lng !== 'number') return null;
+  return sanitizeGeoJsonCoordinates([lng, lat]) ?? null;
+}
+
+/**
+ * Resolve APPROXIMATE coordinates for a place from its city, without a
+ * per-listing external geocode. Used as the ingest coordinate fallback so an
+ * external listing is NEVER dropped for want of a precise street geocode: the
+ * city is essentially always known (discovery is city-scoped), and a
+ * city-centroid point is an acceptable location for an aggregator listing.
+ *
+ * Resolution order (cheapest first):
+ *   1. An existing City doc's stored centroid — ZERO external calls. A burst of
+ *      same-city listings therefore triggers at most ONE city geocode: the first
+ *      persists the centroid via {@link resolveGeo}'s City upsert, the rest read
+ *      it straight back from the DB (surviving the geocoder's in-memory cache
+ *      eviction and process restarts).
+ *   2. A single forward geocode of the city query (throttled + cached in
+ *      {@link forwardGeocode}, so it is reused across every listing in the city).
+ *
+ * Returns GeoJSON `[lng, lat]`, or `null` when no city name is available or the
+ * city cannot be resolved by any means.
+ */
+export async function resolveCityCentroid(names: GeoNames): Promise<[number, number] | null> {
+  const cityName = names.city?.trim();
+  if (!cityName) return null;
+
+  // 1) DB-first: reuse a City centroid we already own (no external geocode).
+  //    Resolve the country code WITHOUT the throwing `resolveCountryCodeAndName`
+  //    helper — an unrecognised country name here is not exceptional, it just
+  //    means we skip the DB shortcut and fall through to the geocoder.
+  const explicitCode = names.countryCode?.trim().toUpperCase();
+  const countryCode =
+    explicitCode && /^[A-Z]{2}$/.test(explicitCode)
+      ? explicitCode
+      : names.country
+        ? countryNameToCode(names.country)
+        : undefined;
+  if (countryCode) {
+    const { Country, Region, City } = models();
+    const country = await Country.findOne({ code: countryCode }).select('_id').lean<{
+      _id: Types.ObjectId;
+    } | null>();
+    if (country) {
+      const stateName = names.state?.trim();
+      let cityDoc: CityDoc | null = null;
+      if (stateName) {
+        const region = await Region.findOne({ countryId: country._id, name: stateName })
+          .select('_id')
+          .lean<{ _id: Types.ObjectId } | null>();
+        if (region) {
+          cityDoc = await City.findOne({ regionId: region._id, name: cityName })
+            .select('coordinates')
+            .lean<CityDoc | null>();
+        }
+      }
+      if (!cityDoc) {
+        cityDoc = await City.findOne({ countryId: country._id, name: cityName })
+          .select('coordinates')
+          .lean<CityDoc | null>();
+      }
+      const centroid = cityDocCentroid(cityDoc);
+      if (centroid) return centroid;
+    }
+  }
+
+  // 2) One forward geocode of the city (cached, so reused across the whole city).
+  const query = [cityName, names.state, names.country].filter(Boolean).join(', ');
+  const geocoded = await forwardGeocode(query);
+  if (geocoded.success && geocoded.data?.coordinates) {
+    return sanitizeGeoJsonCoordinates(geocoded.data.coordinates) ?? null;
+  }
+  return null;
+}
+
+export default { resolveGeo, resolveCityCentroid };

--- a/packages/backend/services/geocodingService.ts
+++ b/packages/backend/services/geocodingService.ts
@@ -116,6 +116,33 @@ const nominatimHeaders = (): Record<string, string> => {
   return headers;
 };
 
+/**
+ * Serialize Nominatim network requests so their *starts* are spaced by at least
+ * `config.geocoding.minIntervalMs`. Two goals: honour the OSM usage policy
+ * (~1 req/sec on the public endpoint) AND stop a high-volume ingest from
+ * self-inflicting 429s — the failure mode that silently dropped external
+ * listings whose address geocode raced a flood of concurrent lookups. Cache
+ * hits never reach this gate; only real network calls queue behind it. The
+ * chain swallows its own settle so one slot can never wedge the queue.
+ */
+let nominatimQueue: Promise<void> = Promise.resolve();
+let lastNominatimRequestAt = 0;
+
+function acquireNominatimSlot(): Promise<void> {
+  const slot = nominatimQueue.then(async () => {
+    const minInterval = config.geocoding.minIntervalMs;
+    if (minInterval > 0) {
+      const wait = lastNominatimRequestAt + minInterval - Date.now();
+      if (wait > 0) {
+        await new Promise((resolve) => setTimeout(resolve, wait));
+      }
+    }
+    lastNominatimRequestAt = Date.now();
+  });
+  nominatimQueue = slot.catch(() => undefined);
+  return slot;
+}
+
 /** Map a Nominatim place onto our flat AddressData DTO. */
 const toAddressData = (place: NominatimPlace): AddressData => {
   const address = place.address ?? {};
@@ -179,6 +206,7 @@ export async function reverseGeocode(longitude: number, latitude: number): Promi
     url.searchParams.set('lon', String(longitude));
     url.searchParams.set('addressdetails', '1');
 
+    await acquireNominatimSlot();
     const response = await fetch(url.toString(), { headers: nominatimHeaders() });
     if (!response.ok) {
       throw new Error(`Nominatim API error: ${response.status} ${response.statusText}`);
@@ -221,6 +249,7 @@ export async function forwardGeocode(address: string): Promise<GeocodingResult> 
     url.searchParams.set('addressdetails', '1');
     url.searchParams.set('limit', '1');
 
+    await acquireNominatimSlot();
     const response = await fetch(url.toString(), { headers: nominatimHeaders() });
     if (!response.ok) {
       throw new Error(`Nominatim API error: ${response.status} ${response.statusText}`);

--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -31,6 +31,7 @@ import { ensureCover } from '../cityCoverSyncService';
 import type { AddressCanonicalInput } from '../../models/Address';
 import { validateOfferings } from '../../models/schemas/offeringValidation';
 import { forwardGeocode, reverseGeocode } from '../geocodingService';
+import { resolveCityCentroid } from '../geoResolutionService';
 import { sanitizeGeoJsonCoordinates } from '../../utils/geoCoordinates';
 import { deriveStructuredFeatures } from './deriveFeatures';
 import { classifyListingContent } from './classifyListingContent';
@@ -404,8 +405,21 @@ export class IngestionService {
   }
 
   /**
-   * Forward-geocode a listing address, falling back to the city centroid when
-   * the street-level query fails (common for partial portal addresses).
+   * Resolve coordinates for a listing that did NOT supply its own, WITHOUT ever
+   * dropping the listing when its city is known.
+   *
+   *   1. Street-level forward geocode (accurate) — used when it succeeds.
+   *   2. City centroid — {@link resolveCityCentroid} reuses a City doc we already
+   *      own (zero external calls) or does one cached, throttled city geocode.
+   *      This is the guaranteed fallback: an approximate city-centroid point is
+   *      an acceptable location for an aggregator listing; losing the listing is
+   *      not. It is also what makes ingest resilient to a Nominatim rate-limit
+   *      flood — the failure mode that previously dropped ~10 providers wholesale
+   *      because the per-listing street geocode AND its city retry both raced the
+   *      same overloaded public endpoint.
+   *
+   * Only throws when the city itself cannot be resolved by ANY means — which,
+   * since discovery is city-scoped, should be vanishingly rare.
    */
   private async resolveCoordinatesWithFallback(
     address: NormalizedListingAddress,
@@ -422,18 +436,19 @@ export class IngestionService {
       };
     }
 
-    const cityQuery = [address.city, address.state, address.country].filter(Boolean).join(', ');
-    const city = await forwardGeocode(cityQuery);
-    if (city.success && city.data?.coordinates) {
+    const centroid = await resolveCityCentroid({
+      city: address.city,
+      state: address.state,
+      country: address.country,
+      countryCode: address.countryCode,
+    });
+    if (centroid) {
       this.logger.warn('Using city-centroid coordinates for external listing (street geocode failed)', {
         street: address.street,
         city: address.city,
         fullQueryError: full.error,
       });
-      return {
-        coordinates: city.data.coordinates,
-        postalCode: city.data.postalCode?.trim() || undefined,
-      };
+      return { coordinates: centroid };
     }
 
     throw new IngestionValidationError(

--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -448,7 +448,12 @@ export class IngestionService {
         city: address.city,
         fullQueryError: full.error,
       });
-      return { coordinates: centroid };
+      // Use the postal fallback directly rather than reverse-geocoding the
+      // centroid: the point is already the city center, so a reverse-geocoded
+      // postal would belong to the city center, not this listing — and, being a
+      // throttled, uncached-on-failure network call, it would re-introduce the
+      // very 1-listing/sec bottleneck this fallback exists to avoid.
+      return { coordinates: centroid, postalCode: EXTERNAL_POSTAL_FALLBACK };
     }
 
     throw new IngestionValidationError(


### PR DESCRIPTION
## Problem

After the queue-fairness rebuild, all ~14 listing providers discover + fetch correctly, but ~10 (immowelt, immoweb, otodom, mercadolibre_ar/mx, blueground, rightmove, onthemarket, openrent, pisos) ingested **~0**. Prod worker logs:

```
[ListingWorker] Skipped listing (ingest validation)
reason: "Could not resolve coordinates for external listing address: <query>"
```

`IngestionService.resolveCoordinatesWithFallback` forward-geocoded each listing's street, retried a city-only geocode, then **threw** `IngestionValidationError` when both failed — the listing was lost. Under the high-volume rebuild (immobilienscout24 dumped ~1500 refs, immowelt ~1741, …), the flood of **unique street queries** rate-limited the public Nominatim endpoint, so even the city retry (the safety net) 429'd → wholesale drops.

## Root cause: Nominatim rate-limit, **not** missing provider coords

The skip message only fires when `address.coordinates` is **absent** and the geocode then fails. Evidence:

- **immowelt** carries a fully geocodable street (`Am Maselakepark 8, Berlin, 13587, Germany`) in its payload yet ingested ~0 — the only explanation is the geocoder failing under load, not missing data.
- **immobilienscout24** dropped `"…, Hamburg, 22419, Germany"` — a REAL city+postcode that should have resolved → the city fallback itself was rate-limited.
- **immoweb** (a listed "silent" provider) was verified against a **live payload** (`GET /en/classified/get-result/{id}`) — its `parseImmowebDetail` correctly unwraps `classified.property.location` and returns `{lat:50.81, lng:4.35}`. So it is NOT dropping for coordinates; the listed set was approximate. otodom/pisos/rightmove/onthemarket/blueground already extract coords conditionally too.

So the dominant, **universal** drop mechanism is the Nominatim flood — provider coords help reduce load but don't fix the drop (a coord-less listing whose city retry is rate-limited is still lost). The decisive fix is making the city fallback independent of Nominatim under load.

## Fix

**1. `resolveCityCentroid` (geoResolutionService) — DB-first city centroid, no per-call geocode under load.**
- Reuses an existing City doc's stored centroid (`coordinates.lat/lng`) with **zero external calls**. A burst of same-city listings triggers at most **ONE** city geocode: the first listing persists the centroid via `resolveGeo`'s City upsert, every subsequent listing reads it straight back from the DB (survives the geocoder's 500-entry in-memory cache eviction and process restarts).
- Falls back to a single cached forward geocode of the city query only when the City isn't in the DB yet.

**2. `resolveCoordinatesWithFallback` — fall back to the city centroid instead of throwing.**
- Street-level geocode still runs first (accuracy preserved for working providers). On failure it now returns the city centroid. It only throws when the city itself is unresolvable by any means — near-impossible since discovery is city-scoped. Approximate city-centroid coordinates are acceptable for an aggregator listing; losing the listing is not. `sanitizeGeoJsonCoordinates` still validates.

**3. Throttle Nominatim (`geocodingService`).**
- Every request **start** is serialized behind `GEOCODING_MIN_INTERVAL_MS` (default `1000`ms) so an ingest flood can no longer self-inflict 429s and can never exceed the OSM ~1 req/sec policy. Cache hits bypass the gate. Set to `0` when pointing `NOMINATIM_BASE_URL` at a self-hosted instance.

## Behavior change (exact)

| Case | Before | After |
|------|--------|-------|
| Provider supplies coords | Used, no geocode | Used, no geocode (unchanged) |
| Street geocode succeeds | Used | Used (unchanged) |
| Street geocode fails, city known | City geocode retry; **THROW → listing dropped** if it 429s | **City centroid (DB-first, no Nominatim under load) → listing ingested** |
| City truly unresolvable | Throw | Throw (unchanged — should be vanishingly rare) |
| Any Nominatim call | Unbounded (flood → 429) | Serialized ≥ `GEOCODING_MIN_INTERVAL_MS` |

## Throughput note

The per-listing street geocode is preserved for accuracy; under the default 1s throttle a large coord-less rebuild is slow-but-correct. For high throughput, point `NOMINATIM_BASE_URL` at a self-hosted Nominatim and set `GEOCODING_MIN_INTERVAL_MS=0` (infra tuning, no code change). No paid geocoder introduced.

## Tests

`packages/backend` full suite green (72 suites / **756** tests, up from 754). New regression tests in `ingestionGeocode.test.ts`:
- a placeholder-street listing (`"Die vollständige Adresse …"`) with a known city ingests via the **DB City centroid** with **no second geocode**;
- provider coordinates are used without any geocode;
- a listing whose city is unresolvable by any means still skips.

`bun run --filter '@homiio/backend' build` and `--filter '@homiio/listing-providers' build` exit 0; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)