### PR TITLE
fix(immowelt): parse detail from SSR lifecycle blob, not SERP init-data

### DIFF
--- a/packages/backend/__tests__/unit/immoweltProvider.test.ts
+++ b/packages/backend/__tests__/unit/immoweltProvider.test.ts
@@ -6,9 +6,13 @@ import {
   ImmoweltProvider,
   parseImmoweltCard,
   parseImmoweltSearch,
+  parseImmoweltDetail,
   immoweltSourceIdFromUrl,
   IMMOWELT_FIXTURE_CARD_JSON,
   IMMOWELT_FIXTURE_SEARCH_HTML,
+  IMMOWELT_FIXTURE_DETAIL_HTML,
+  IMMOWELT_FIXTURE_DETAIL_HIDDEN_HTML,
+  IMMOWELT_FIXTURE_DETAIL_URL,
 } from '@homiio/listing-providers';
 import type { ExternalListingRef } from '@homiio/listing-providers';
 import { OfferingType, PropertyType } from '@homiio/shared-types';
@@ -50,5 +54,85 @@ describe('ImmoweltProvider', () => {
         'https://www.immowelt.de/expose/311aaa07-ac4a-477e-ba23-bb35a3754385',
       ),
     ).toBe('311aaa07-ac4a-477e-ba23-bb35a3754385');
+  });
+
+  // Regression: the live 2025+ `/expose/{uuid}` detail page serves the listing in
+  // the SSR blob `window["__UFRN_LIFECYCLE_SERVERREQUEST__"]=JSON.parse("…")` →
+  // `app_cldp.data.classified`, NOT the SERP `classified-serp-init-data`. The old
+  // detail parser only looked for the SERP blob and failed every fetch with
+  // "no classified JSON". Fixtures are real payloads captured from live pages.
+  it('parses the SSR lifecycle blob on a published-address detail page', () => {
+    const payload = parseImmoweltDetail(IMMOWELT_FIXTURE_DETAIL_HTML, IMMOWELT_FIXTURE_DETAIL_URL);
+    expect(payload.sourceId).toBe('00b915d7-1122-40d0-a68d-916854f75987');
+    expect(payload.price).toBe(499000);
+    expect(payload.currency).toBe('EUR');
+    expect(payload.operation).toBe('sale');
+    expect(payload.address.city).toBe('Sommerhausen');
+    expect(payload.address.street).toBe('Ochsenfurter Straße 10');
+    expect(payload.address.postalCode).toBe('97286');
+    expect(payload.address.state).toBe('Bavaria');
+    expect(payload.address.coordinates).toEqual({
+      lat: 49.70295715332031,
+      lng: 10.024897575378418,
+    });
+    expect(payload.bedrooms).toBe(3);
+    expect(payload.squareMeters).toBeCloseTo(79.8);
+    expect(payload.images).toHaveLength(2);
+    expect(payload.contact?.phone).toMatch(/093135901968/);
+    expect(payload.contact?.agencyName).toMatch(/Spanheimer Wohnbau/i);
+    expect(payload.contact?.name).toMatch(/Ralf Spanheimer/i);
+    expect(payload.contact?.kind).toBe('agency');
+  });
+
+  it('normalizes a detail payload into a published DE sale listing with coords', () => {
+    const payload = parseImmoweltDetail(IMMOWELT_FIXTURE_DETAIL_HTML, IMMOWELT_FIXTURE_DETAIL_URL);
+    const ref: ExternalListingRef = {
+      provider: 'immowelt',
+      sourceId: payload.sourceId,
+      url: payload.url,
+    };
+    const listing = provider.normalize({ ref, payload });
+    expect(listing.status).toBe('published');
+    expect(listing.offerings).toEqual([OfferingType.SALE]);
+    expect(listing.sale?.price).toBe(499000);
+    expect(listing.sale?.currency).toBe('EUR');
+    expect(listing.longTermRent).toBeUndefined();
+    expect(listing.type).toBe(PropertyType.APARTMENT);
+    expect(listing.address.city).toBe('Sommerhausen');
+    expect(listing.address.state).toBe('Bavaria');
+    expect(listing.address.countryCode).toBe('DE');
+    expect(listing.address.coordinates?.lat).toBeCloseTo(49.70295, 4);
+    expect(listing.address.coordinates?.lng).toBeCloseTo(10.02489, 4);
+    expect(listing.contact?.agencyName).toMatch(/Spanheimer Wohnbau/i);
+  });
+
+  it('skips coordinates when the detail geometry is a district MultiPolygon', () => {
+    const payload = parseImmoweltDetail(
+      IMMOWELT_FIXTURE_DETAIL_HIDDEN_HTML,
+      'https://www.immowelt.de/expose/0006bab0-7f77-4be5-b15f-fefc5a01ec6b',
+    );
+    expect(payload.sourceId).toBe('0006bab0-7f77-4be5-b15f-fefc5a01ec6b');
+    expect(payload.price).toBe(363000);
+    expect(payload.operation).toBe('sale');
+    expect(payload.address.city).toBe('Chamerau');
+    expect(payload.address.street).toBeUndefined();
+    expect(payload.address.coordinates).toBeUndefined();
+
+    // Address hidden → normalize falls the street back to the city, never throws.
+    const ref: ExternalListingRef = {
+      provider: 'immowelt',
+      sourceId: payload.sourceId,
+      url: payload.url,
+    };
+    const listing = provider.normalize({ ref, payload });
+    expect(listing.address.city).toBe('Chamerau');
+    expect(listing.address.street).toBe('Chamerau');
+    expect(listing.address.coordinates).toBeUndefined();
+  });
+
+  it('throws a precise reason when neither detail blob is present', () => {
+    expect(() =>
+      parseImmoweltDetail('<html><body>no data here</body></html>', IMMOWELT_FIXTURE_DETAIL_URL),
+    ).toThrow(/__UFRN_LIFECYCLE_SERVERREQUEST__/);
   });
 });

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -441,10 +441,17 @@ export {
   IMMOWELT_BASE_URL,
   IMMOWELT_FIXTURE_CARD_JSON,
   IMMOWELT_FIXTURE_SEARCH_HTML,
+  IMMOWELT_FIXTURE_DETAIL_HTML,
+  IMMOWELT_FIXTURE_DETAIL_HIDDEN_HTML,
+  IMMOWELT_FIXTURE_DETAIL_CLASSIFIED_JSON,
+  IMMOWELT_FIXTURE_DETAIL_HIDDEN_CLASSIFIED_JSON,
+  IMMOWELT_FIXTURE_DETAIL_URL,
 } from './providers/de/immowelt/fixtures';
 export {
   parseImmoweltCard,
   parseImmoweltSearchCards,
+  parseImmoweltDetailClassified,
+  parseImmoweltLifecycleClassified,
   isImmoweltChallenge,
   type ImmoweltRawListing,
 } from './providers/de/immowelt/parse';

--- a/packages/listing-providers/src/providers/de/immowelt/fixtures.ts
+++ b/packages/listing-providers/src/providers/de/immowelt/fixtures.ts
@@ -83,3 +83,166 @@ export const IMMOWELT_FIXTURE_SEARCH_HTML = `<!doctype html>
 window["__UFRN_FETCHER__"]=JSON.parse("{\\"data\\":{\\"classified-serp-init-data\\":\\"PLACEHOLDER\\"}}");
 </script>
 </body></html>`;
+
+/**
+ * Real detail `classified` payload captured from a live immowelt `/expose` page
+ * (Sommerhausen apartment for sale — published address, `Point` coordinates,
+ * agency `contactSections`). Source
+ * `https://www.immowelt.de/expose/00b915d7-1122-40d0-a68d-916854f75987`, captured
+ * 2026-02. Pruned to the `sections` the detail parser reads; every value is
+ * verbatim from the live SSR `__UFRN_LIFECYCLE_SERVERREQUEST__` → `app_cldp.data.classified`.
+ */
+export const IMMOWELT_FIXTURE_DETAIL_CLASSIFIED_JSON = `{
+  "brand": "immowelt",
+  "id": "26J3FH6EXPSN",
+  "metadata": { "legacyId": "00b915d7-1122-40d0-a68d-916854f75987" },
+  "tracking": {
+    "av_items": [
+      {
+        "id": "26J3FH6EXPSN",
+        "price": 499000,
+        "estate_type": "av_2",
+        "distribution_type": "2",
+        "country": "Germany",
+        "city": "Sommerhausen",
+        "region": "Bavaria",
+        "currency": "EUR",
+        "zip_code": "97286",
+        "legacy_id": "00b915d7-1122-40d0-a68d-916854f75987"
+      }
+    ]
+  },
+  "sections": {
+    "location": {
+      "address": {
+        "country": "DEU",
+        "city": "Sommerhausen",
+        "zipCode": "97286",
+        "street": "Ochsenfurter Straße 10"
+      },
+      "isAddressPublished": true,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [10.024897575378418, 49.70295715332031]
+      }
+    },
+    "price": {
+      "base": {
+        "type": "SALE",
+        "main": { "value": { "main": { "value": "499.000 €", "ariaLabel": "499000 €" } } }
+      }
+    },
+    "hardFacts": {
+      "title": "Wohnung zum Kauf",
+      "facts": [
+        { "type": "numberOfRooms", "value": "3 Zimmer", "splitValue": "3", "label": "Zimmer" },
+        { "type": "livingSpace", "value": "79,8 m²", "splitValue": "79,8", "label": "m²" },
+        { "type": "availability", "value": "frei ab 31.10.2027", "splitValue": "frei", "label": "ab 31.10.2027" }
+      ],
+      "price": { "ariaLabel": "499000 €" }
+    },
+    "gallery": {
+      "images": [
+        { "url": "https://mms.immowelt.de/f/8/4/f/f84f9760-d2d3-451b-bb40-527bec0ed50a.png?ci_seal=4b3dd8a592410d8af24b74c446954c7f531a5045" },
+        { "url": "https://mms.immowelt.de/6/5/a/f/65afb998-877b-46ef-9d26-70ce7032c4ce.png?ci_seal=cdcee6465a473b0e760806ea26613fa71673e426" }
+      ]
+    },
+    "mainDescription": {
+      "headline": "Zwischen Main und Wein - Wohnen und Leben in Sommerhausen",
+      "description": "Auf dem optimal geschnittenen und nach Süden ausgerichteten Grundstück entsteht ein Haus mit 11 Wohnungen im besonders nachhaltigen und förderfähigen „Effizienzhaus 40“ Standard der Kreditanstalt für Wiederaufbau."
+    }
+  },
+  "contactSections": {
+    "static": { "phoneNumbers": ["0931-35901968", "01637848779"] },
+    "contactCard": {
+      "title": "Spanheimer Wohnbau GmbH",
+      "subtitle": "Herr Ralf Spanheimer",
+      "phoneNumbers": ["0931-35901968", "01637848779"],
+      "isPrivateOwner": false
+    },
+    "provider": {
+      "intermediaryCard": { "title": "Spanheimer Wohnbau GmbH" },
+      "contactCard": { "title": "Herr Ralf Spanheimer" },
+      "isPrivateOwner": false,
+      "publisherType": "AGENCY"
+    }
+  }
+}`;
+
+/**
+ * Address-hidden real variant (Chamerau plot). `isAddressPublished:false`, no
+ * street, and a `MultiPolygon` district boundary instead of a `Point` — proves
+ * coords are skipped when the portal exposes no exact point. Source
+ * `https://www.immowelt.de/expose/0006bab0-7f77-4be5-b15f-fefc5a01ec6b`.
+ */
+export const IMMOWELT_FIXTURE_DETAIL_HIDDEN_CLASSIFIED_JSON = `{
+  "metadata": { "legacyId": "0006bab0-7f77-4be5-b15f-fefc5a01ec6b" },
+  "tracking": {
+    "av_items": [
+      {
+        "id": "248QVVHQQZGG",
+        "price": 363000,
+        "estate_type": "av_9",
+        "distribution_type": "2",
+        "city": "Chamerau",
+        "region": "Bavaria",
+        "currency": "EUR",
+        "zip_code": "93466"
+      }
+    ]
+  },
+  "sections": {
+    "location": {
+      "address": { "country": "DEU", "city": "Chamerau", "zipCode": "93466" },
+      "isAddressPublished": false,
+      "geometry": { "type": "MultiPolygon", "coordinates": [[12.74011, 49.20713], [12.72537, 49.20116]] }
+    },
+    "price": { "base": { "type": "SALE" } },
+    "hardFacts": {
+      "title": "Grundstück zum Kauf",
+      "facts": [
+        { "type": "plotSpace", "value": "3.823 m² Grundstück", "splitValue": "3.823", "label": "m² Grundstück" }
+      ]
+    },
+    "gallery": {
+      "images": [
+        { "url": "https://mms.immowelt.de/1/3/e/0/13e02204-f7cf-49ec-9207-50ff6fd905cb.jpg?ci_seal=d86df0a77b90651040b04458de012ddc647cc6ba" }
+      ]
+    },
+    "mainDescription": { "headline": "Gewerbegrundstück in Top Lage sofort Verfügbar" }
+  }
+}`;
+
+/**
+ * Wrap a captured `classified` payload in the exact on-page SSR form immowelt
+ * serves detail data in: a `window["__UFRN_LIFECYCLE_SERVERREQUEST__"]=JSON.parse("…")`
+ * script whose argument is the double-encoded blob (`JSON.stringify` twice — the
+ * inner JSON string, then string-escaped for the JS literal). A preceding
+ * `__UFRN_FETCHER__` `JSON.parse(...)` script mirrors the live page so the
+ * extractor must target the lifecycle key rather than the first blob.
+ */
+function immoweltDetailFixtureHtml(classifiedJson: string): string {
+  const lifecycle = { app_cldp: { data: { classified: JSON.parse(classifiedJson) as unknown } } };
+  const scriptArg = JSON.stringify(JSON.stringify(lifecycle));
+  return (
+    '<!doctype html><html lang="de"><head><title>immowelt.de</title></head><body>' +
+    '<script>window["__UFRN_FETCHER__"]=JSON.parse("{\\"data\\":{},\\"errors\\":{}}");</script>' +
+    '<script id="__UFRN_LIFECYCLE_SERVERREQUEST__">' +
+    `window["__UFRN_LIFECYCLE_SERVERREQUEST__"]=JSON.parse(${scriptArg});</script>` +
+    '</body></html>'
+  );
+}
+
+/** Detail HTML for the published-address Sommerhausen listing (Point coords). */
+export const IMMOWELT_FIXTURE_DETAIL_HTML = immoweltDetailFixtureHtml(
+  IMMOWELT_FIXTURE_DETAIL_CLASSIFIED_JSON,
+);
+
+/** Detail HTML for the address-hidden Chamerau plot (MultiPolygon, no coords). */
+export const IMMOWELT_FIXTURE_DETAIL_HIDDEN_HTML = immoweltDetailFixtureHtml(
+  IMMOWELT_FIXTURE_DETAIL_HIDDEN_CLASSIFIED_JSON,
+);
+
+/** Canonical `/expose/{uuid}` URL of the published-address detail fixture. */
+export const IMMOWELT_FIXTURE_DETAIL_URL =
+  'https://www.immowelt.de/expose/00b915d7-1122-40d0-a68d-916854f75987';

--- a/packages/listing-providers/src/providers/de/immowelt/index.ts
+++ b/packages/listing-providers/src/providers/de/immowelt/index.ts
@@ -8,8 +8,12 @@
  *      (structured JSON cards — preferred over link scraping).
  *   3. UUID `/expose/{uuid}` link scrape as last resort.
  *
- * Fetch prefers the card JSON (hints) or re-parses search/detail HTML JSON.
- * Contact (phone / email / agency) is taken from the card `provider` block.
+ * Fetch prefers the card JSON (hints); otherwise it parses the `/expose/{uuid}`
+ * detail page's SSR lifecycle blob (`window["__UFRN_LIFECYCLE_SERVERREQUEST__"]`
+ * → `app_cldp.data.classified`), which is where immowelt now serves the full
+ * listing (address, `tracking.av_items[].price`, gallery, Point coords, and the
+ * `contactSections` agency block). Detail pages no longer carry the SERP
+ * `classified-serp-init-data` blob.
  *
  * Registered OFF by default (`PROVIDER_IMMOWELT_ENABLED`).
  */
@@ -271,22 +275,18 @@ export class ImmoweltProvider implements ListingProvider {
       if (fromSession) return fromSession;
     }
 
+    // The ladder only returns HTML on a non-challenge outcome (DataDome pages
+    // raise `ChallengeError` upstream), so the body here is real detail markup:
+    // parse its SSR lifecycle blob. `parseImmoweltDetail` throws a precise
+    // reason if the structure is missing — the worker logs + requeues.
     const { html } = await fetchListingViaLadder(ctx.runtime, ref.url, {
       provider: this.id,
       isChallenge: isImmoweltChallenge,
       init: { signal: ctx.signal },
       metrics: this.metrics,
     });
-    // Detail pages may not embed SERP cards — try parsing; if fail, re-fetch city search is too heavy.
-    // Prefer hint-less: parseImmoweltDetail throws clearly.
-    try {
-      const payload = parseImmoweltDetail(html, ref.url);
-      return { ref, payload };
-    } catch {
-      // Fall back: discover-shaped HTML sometimes redirects; scrape UUID-only is insufficient.
-      // Re-fetch a Berlin search is wrong. Use minimal payload from URL only — reject.
-      throw new Error(`immowelt: no classified JSON on detail page ${ref.url}`);
-    }
+    const payload = parseImmoweltDetail(html, ref.url);
+    return { ref, payload };
   }
 
   private async fetchViaSession(
@@ -315,31 +315,8 @@ export class ImmoweltProvider implements ListingProvider {
         blockAssets: true,
       });
       const html = await session.content();
-      // Detail pages embed UFRN lifecycle JSON; also try SERP-shaped cards.
-      const cards = parseImmoweltSearchCards(html);
-      let payload: ImmoweltRawListing | undefined;
-      for (const card of cards) {
-        try {
-          const parsed = parseImmoweltCard(card);
-          if (parsed.sourceId === ref.sourceId) {
-            payload = parsed;
-            break;
-          }
-        } catch {
-          // skip malformed card
-        }
-      }
-      if (!payload && cards[0]) {
-        try {
-          payload = parseImmoweltCard(cards[0]);
-        } catch {
-          payload = undefined;
-        }
-      }
-      if (!payload) {
-        // Try parseImmoweltDetail on full HTML (may throw).
-        payload = parseImmoweltDetail(html, ref.url);
-      }
+      // Detail pages embed the UFRN lifecycle JSON (not a SERP card list).
+      const payload = parseImmoweltDetail(html, ref.url);
       this.metrics.record({
         provider: this.id,
         strategy: 'browser',
@@ -384,10 +361,12 @@ export class ImmoweltProvider implements ListingProvider {
       address: {
         street,
         city,
+        state: listing.address.state,
         country: 'Germany',
         countryCode: listing.address.countryCode ?? 'DE',
         postalCode: listing.address.postalCode,
         neighborhood: listing.address.neighborhood,
+        coordinates: listing.address.coordinates,
       },
       type: resolvePropertyType(listing.propertyType),
       offerings: isSale ? [OfferingType.SALE] : [OfferingType.LONG_TERM_RENT],

--- a/packages/listing-providers/src/providers/de/immowelt/parse.ts
+++ b/packages/listing-providers/src/providers/de/immowelt/parse.ts
@@ -1,6 +1,13 @@
 /**
- * Immowelt SERP JSON parsing — shared html/contact; LZ decompress for
- * `classified-serp-init-data` (no duplicated JSON.parse-blob extractor).
+ * Immowelt JSON parsing — shared html/contact; no duplicated blob extractor.
+ *
+ * SERP: LZ-decompress `classified-serp-init-data` cards.
+ * Detail (`/expose/{uuid}`): the listing lives in the SSR micro-frontend blob
+ * `window["__UFRN_LIFECYCLE_SERVERREQUEST__"]=JSON.parse("…")` under
+ * `app_cldp.data.classified` — a `sections.{location,price,hardFacts,gallery,…}`
+ * shape distinct from the SERP card. Detail pages carry NO
+ * `classified-serp-init-data` blob, which is why the old detail parser (which
+ * only looked for that) failed every fetch with "no classified JSON".
  */
 
 import { decompressFromBase64 } from 'lz-string';
@@ -14,6 +21,7 @@ import {
   extractJsonParseBlob,
   parseEuroAmount,
 } from '../../../html';
+import { asCoordinate } from '../../../parse/guards';
 import { IMMOWELT_BASE_URL } from './fixtures';
 
 export interface ImmoweltSearchRef {
@@ -39,7 +47,11 @@ export interface ImmoweltRawListing {
     city?: string;
     postalCode?: string;
     neighborhood?: string;
+    /** State / region name (detail `tracking.av_items[].region`). */
+    state?: string;
     countryCode?: string;
+    /** Exact point coords, only when the detail geometry is a `Point`. */
+    coordinates?: { lat: number; lng: number };
   };
   images: string[];
   contact?: NormalizedListingContact;
@@ -192,13 +204,171 @@ export function parseImmoweltCard(card: Record<string, unknown>): ImmoweltRawLis
   };
 }
 
+/** Micro-frontend SSR key holding the detail `classified` payload. */
+const IMMOWELT_LIFECYCLE_KEY = '__UFRN_LIFECYCLE_SERVERREQUEST__';
+
+/**
+ * Extract the SSR `classified` object from a detail page's
+ * `window["__UFRN_LIFECYCLE_SERVERREQUEST__"]=JSON.parse("…")` blob. The
+ * `JSON.parse` argument is itself a JSON string (double-encoded), so decode
+ * twice: unescape the JS string literal, then parse the JSON it contains. The
+ * app key is `app_cldp` (classified-detail-page) but any `*.data.classified`
+ * entry is accepted so a portal rename of the app id degrades gracefully.
+ */
+export function parseImmoweltLifecycleClassified(
+  html: string,
+): Record<string, unknown> | undefined {
+  const blob = extractJsonParseBlob(html, IMMOWELT_LIFECYCLE_KEY);
+  if (!blob) return undefined;
+  try {
+    const outerString = JSON.parse(`"${blob}"`) as string;
+    const root = asRecord(JSON.parse(outerString) as unknown);
+    if (!root) return undefined;
+    for (const app of Object.values(root)) {
+      const classified = asRecord(asRecord(asRecord(app)?.data)?.classified);
+      if (classified) return classified;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+/** First record entry of `classified.tracking.av_items`. */
+function detailAvItem(classified: Record<string, unknown>): Record<string, unknown> | undefined {
+  const items = asRecord(classified.tracking)?.av_items;
+  if (!Array.isArray(items)) return undefined;
+  for (const item of items) {
+    const record = asRecord(item);
+    if (record) return record;
+  }
+  return undefined;
+}
+
+/** Exact coords only when the geometry is a GeoJSON `Point` (`[lng, lat]`). */
+function detailCoordinates(
+  location: Record<string, unknown> | undefined,
+): { lat: number; lng: number } | undefined {
+  const geometry = asRecord(location?.geometry);
+  if (asString(geometry?.type) !== 'Point') return undefined;
+  const coords = geometry?.coordinates;
+  if (!Array.isArray(coords) || coords.length < 2) return undefined;
+  const lng = asCoordinate(coords[0]);
+  const lat = asCoordinate(coords[1]);
+  if (lat === undefined || lng === undefined) return undefined;
+  return { lat, lng };
+}
+
+/** Map the detail `contactSections` block via the shared contact chokepoint. */
+function detailContact(
+  contactSections: Record<string, unknown> | undefined,
+): NormalizedListingContact | undefined {
+  if (!contactSections) return undefined;
+  const provider = asRecord(contactSections.provider);
+  const contactCard = asRecord(contactSections.contactCard);
+  const staticNode = asRecord(contactSections.static);
+  return contactFromAdvertiser({
+    intermediaryCard: provider?.intermediaryCard,
+    contactCard: provider?.contactCard ?? contactCard,
+    phoneNumbers: staticNode?.phoneNumbers ?? contactCard?.phoneNumbers,
+    isPrivateOwner: provider?.isPrivateOwner ?? contactCard?.isPrivateOwner,
+    publisherType: provider?.publisherType,
+  });
+}
+
+/**
+ * Map a detail-page `classified` object (from the SSR lifecycle blob) to the
+ * common {@link ImmoweltRawListing}. Price comes from the numeric
+ * `tracking.av_items[].price` first (already parsed by immowelt), falling back
+ * to the formatted `sections.price`/`sections.hardFacts` labels.
+ */
+export function parseImmoweltDetailClassified(
+  classified: Record<string, unknown>,
+  url: string,
+): ImmoweltRawListing {
+  const metadata = asRecord(classified.metadata);
+  const item = detailAvItem(classified);
+  const legacyId =
+    asString(metadata?.legacyId) ??
+    asString(item?.legacy_id) ??
+    immoweltSourceIdFromUrl(url);
+  if (!legacyId) throw new Error('immowelt: detail classified missing legacyId / expose uuid');
+
+  const sections = asRecord(classified.sections);
+  const location = asRecord(sections?.location);
+  const addressNode = asRecord(location?.address) ?? {};
+  const hardFacts = asRecord(sections?.hardFacts) ?? {};
+  const gallery = asRecord(sections?.gallery);
+  const priceBase = asRecord(asRecord(sections?.price)?.base);
+  const priceMain = asRecord(asRecord(asRecord(priceBase?.main)?.value)?.main);
+  const mainDescription = asRecord(sections?.mainDescription);
+
+  const price =
+    asNumber(item?.price) ??
+    parseEuroAmount(asString(priceMain?.ariaLabel)) ??
+    parseEuroAmount(asString(priceMain?.value)) ??
+    parseEuroAmount(asString(asRecord(hardFacts.price)?.ariaLabel)) ??
+    parseEuroAmount(asString(asRecord(hardFacts.price)?.formatted));
+
+  const distribution = asString(item?.distribution_type);
+  const priceType = asString(priceBase?.type)?.toUpperCase();
+  const operation: 'rent' | 'sale' =
+    distribution === '2' || priceType === 'SALE' ? 'sale' : 'rent';
+
+  const images: string[] = [];
+  if (Array.isArray(gallery?.images)) {
+    for (const image of gallery.images) {
+      const imageUrl = asString(asRecord(image)?.url);
+      if (imageUrl) images.push(imageUrl);
+    }
+  }
+
+  const headline = asString(mainDescription?.headline) ?? asString(hardFacts.title);
+
+  return {
+    sourceId: legacyId,
+    onlineId: asString(classified.id) ?? asString(item?.id),
+    url: immoweltExposeUrl(legacyId),
+    title: headline,
+    description: asString(mainDescription?.description) ?? headline,
+    operation,
+    propertyType: asString(hardFacts.title) ?? asString(item?.estate_type) ?? 'APARTMENT',
+    price,
+    currency: asString(item?.currency) ?? 'EUR',
+    bedrooms: asNumber(factValue(hardFacts.facts, 'numberOfRooms')),
+    squareMeters: asNumber(factValue(hardFacts.facts, 'livingSpace')),
+    floor: asNumber(factValue(hardFacts.facts, 'numberOfFloors')),
+    address: {
+      street: asString(addressNode.street),
+      city: asString(addressNode.city) ?? asString(item?.city),
+      postalCode: asString(addressNode.zipCode) ?? asString(item?.zip_code),
+      neighborhood: asString(addressNode.district),
+      state: asString(item?.region),
+      countryCode: 'DE',
+      coordinates: detailCoordinates(location),
+    },
+    images,
+    contact: detailContact(asRecord(classified.contactSections)),
+  };
+}
+
 export function parseImmoweltDetail(htmlOrJson: string, url: string): ImmoweltRawListing {
   const trimmed = htmlOrJson.trim();
   if (trimmed.startsWith('{')) {
-    const card = asRecord(JSON.parse(trimmed) as unknown);
-    if (!card) throw new Error('immowelt: detail JSON is not an object');
-    return parseImmoweltCard(card);
+    const parsed = asRecord(JSON.parse(trimmed) as unknown);
+    if (!parsed) throw new Error('immowelt: detail JSON is not an object');
+    // A detail `classified` carries `sections`/`contactSections`; a SERP card does not.
+    if (asRecord(parsed.sections) || asRecord(parsed.contactSections)) {
+      return parseImmoweltDetailClassified(parsed, url);
+    }
+    return parseImmoweltCard(parsed);
   }
+
+  // Current detail structure (2025+): the SSR lifecycle blob.
+  const classified = parseImmoweltLifecycleClassified(htmlOrJson);
+  if (classified) return parseImmoweltDetailClassified(classified, url);
+
+  // Fallback: a SERP-shaped HTML snapshot with `classified-serp-init-data`.
   const sourceId = immoweltSourceIdFromUrl(url);
   const cards = parseImmoweltSearchCards(htmlOrJson);
   if (sourceId) {
@@ -207,10 +377,12 @@ export function parseImmoweltDetail(htmlOrJson: string, url: string): ImmoweltRa
         const parsed = parseImmoweltCard(card);
         if (parsed.sourceId === sourceId) return parsed;
       } catch {
-        // skip
+        // skip malformed card
       }
     }
   }
   if (cards[0]) return parseImmoweltCard(cards[0]);
-  throw new Error(`immowelt: no classified JSON for ${url}`);
+  throw new Error(
+    `immowelt: no detail JSON (__UFRN_LIFECYCLE_SERVERREQUEST__ / classified-serp-init-data) on ${url}`,
+  );
 }


### PR DESCRIPTION
## Problem (prod)

The immowelt provider discovered + fetched detail URLs but failed almost every DETAIL fetch with `immowelt: no classified JSON on detail page https://www.immowelt.de/expose/…` — ~1741 immowelt fetch jobs affected, ~0 ingests (41 such failures in one recent 25‑min window). Discover works; the detail parse was broken.

## Live-markup finding (verified, not guessed)

Per AGENTS.md I verified against real markup — live immowelt + Wayback captures of real `/expose/{uuid}` pages, and a live SERP.

- `/expose/{uuid}` detail pages are DataDome-gated (`geo.captcha-delivery.com`) from datacenter IPs (prod gets past this via the residential proxy). Past the challenge, the **detail listing no longer contains the SERP `classified-serp-init-data` blob** the old parser looked for — that blob is SERP-only, so `parseImmoweltDetail` always threw.
- The detail listing now lives in the SSR micro-frontend blob:

  ```
  <script id="__UFRN_LIFECYCLE_SERVERREQUEST__">
  window["__UFRN_LIFECYCLE_SERVERREQUEST__"]=JSON.parse("{\"app_cldp\":{\"data\":{\"classified\":{…}}}}");
  </script>
  ```

  The `JSON.parse("…")` argument is itself a JSON string (double-encoded). Under `app_cldp.data.classified` the shape is **distinct from the SERP card**:
  - `metadata.legacyId` → the `/expose/{uuid}` source id
  - `tracking.av_items[0]` → numeric `price`, `distribution_type` (`"1"`=rent / `"2"`=sale), `currency`, `city`, `region`, `zip_code`
  - `sections.location.{address, geometry}` → `geometry.type: "Point"` gives `coordinates: [lng, lat]`; a `MultiPolygon` is only a district boundary (no exact point)
  - `sections.{price, hardFacts, gallery, mainDescription}` and `contactSections` (agency phone/name/agency)

Evidence — parsing two real captured detail pages with the built provider:

```
/expose/00b915d7-… (Sommerhausen) => price 499000 EUR, sale, street "Ochsenfurter Straße 10",
  state Bavaria, coords {lat:49.70295…, lng:10.02489…}, 4 imgs, 3 beds, 79.8 m²,
  contact {phone, name "Herr Ralf Spanheimer", agency "Spanheimer Wohnbau GmbH", kind agency}
/expose/0006bab0-… (Chamerau)     => price 363000 EUR, sale, city Chamerau, state Bavaria,
  coords undefined (MultiPolygon → skipped), 10 imgs, contact captured
```

## Fix

- `parseImmoweltLifecycleClassified` (double-decode the JS‑string→JSON blob, tolerant of an `app_*` id rename) + `parseImmoweltDetailClassified` (map the detail structure), reusing the shared `html`/`parse/guards`/`contact` helpers — no per-portal parser.
- Price from numeric `tracking.av_items[].price` first, falling back to the formatted `sections.price` / `hardFacts` labels; operation from `distribution_type` / `price.base.type`.
- Populate `address.coordinates` from a `Point` geometry so the ingest can skip geocoding; carry `state` from `tracking.region`; skip district `MultiPolygon` boundaries.
- Capture agency contact from `contactSections` (phone/name/agency/kind).
- Drop the generic `catch`→rethrow that masked the real cause; the parser now throws a precise reason naming both expected blob keys.

## Tests

`packages/backend/__tests__/unit/immoweltProvider.test.ts` — regression tests use **real captured detail markup** (published-address Point-coords listing + address-hidden MultiPolygon listing) proving price/address/coords/contact extraction and the coords-skip path.

- shared-types → listing-providers → backend build: all exit 0
- `bunx jest __tests__/unit`: 61 suites / 666 tests pass (immowelt: 7/7)
- eslint on changed files: clean

Do not merge yet — will be batched with the next deploy so we can verify immowelt starts ingesting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)