### PR TITLE
fix(property): BookingCard report footer renders i18n key error over the eco widget

### DIFF
--- a/packages/frontend/components/property/BookingCard.tsx
+++ b/packages/frontend/components/property/BookingCard.tsx
@@ -147,7 +147,7 @@ export const BookingCard: React.FC<BookingCardProps> = ({
       >
         <Ionicons name="flag-outline" size={16} color={colors.COLOR_BLACK_LIGHT_3} />
         <BloomText style={styles.reportLabel}>
-          {t('property.report')}
+          {t('property.report.title')}
         </BloomText>
       </Pressable>
     </View>


### PR DESCRIPTION
## Bug
The property-detail right rail showed garbled underlined text — `key 'property.report (en-US)' returned an object instead of string.` — that wrapped to two lines and overlapped the Eco-Certified widget.

## Root cause (verified in code)
`components/property/BookingCard.tsx` rendered the footer link as `t('property.report')`, but `property.report` is an **object namespace** in every locale (en/es/ca-ES/it), so i18next returns its "returned an object instead of string" error. The footer is meant to be the "Report this listing" link (`handleReport` → `/properties/[id]/report`).

## Fix
`t('property.report')` → **`t('property.report.title')`** — the leaf key already present in all four locales ("Report this listing" / "Denunciar este anuncio" / "Denunciar aquest anunci" / "Segnala questo annuncio"). One line; it's the only bare `t('property.report')` in the app.

## Verification
- `tsc --noEmit`: 10 errors == baseline, **0 new** (BookingCard not among them).
- `bun run build` (expo web export): **exit 0**.
- Playwright check on the real built app: `t('property.report.title')` resolves to **"Report this listing"** (clean single line), while the old `t('property.report')` produced exactly the user's error string — confirming the fix removes both the error text and the wrapping overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)