### PR TITLE
feat(listing-worker): headed browser tier for DataDome/Kasada portals

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -15,6 +15,18 @@
 ## worker task. Playwright Chromium is installed so LISTING_BROWSER_ENABLED
 ## can escalate anti-bot portals on the worker (the API never scrapes).
 ##
+## HEADED browser tier (LISTING_BROWSER_HEADED=true): DataDome/Kasada block
+## headless Chromium, so the worker can launch a real HEADED browser to clear
+## them. A headed launch needs an X display; this image bundles Xvfb (the
+## virtual framebuffer) for that. When the flag is on, the worker command MUST
+## wrap node in xvfb-run:
+##
+##   xvfb-run -a --server-args="-screen 0 1920x1080x24" \
+##     node packages/backend/dist/worker.js
+##
+## The flag defaults OFF (headless) and is set by infra alongside the xvfb-run
+## command — the image supports both modes; nothing here forces headed.
+##
 ## Listens on $PORT (default 4000). See packages/backend/.env.example for the
 ## full list of runtime environment variables.
 ##
@@ -83,8 +95,12 @@ FROM node:20-bookworm-slim
 
 # Runtime deps: tini as PID 1; Playwright OS libs installed via
 # `playwright install-deps` below (Chromium needs a full set of shared libs).
+# xvfb + xauth provide the virtual X display for the HEADED browser tier
+# (LISTING_BROWSER_HEADED=true → worker runs under `xvfb-run`, see header). The X
+# *client* libs Chromium links against come from `playwright install --with-deps`
+# below; we only add the virtual framebuffer + its auth cookie helper here.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates tini \
+      ca-certificates tini xvfb xauth \
     && rm -rf /var/lib/apt/lists/*
 
 ENV NODE_ENV=production \

--- a/packages/backend/__tests__/unit/listingFetchTiers.test.ts
+++ b/packages/backend/__tests__/unit/listingFetchTiers.test.ts
@@ -11,6 +11,7 @@ import {
   createBrowserFetcher,
   ManagedFetcher,
   PlaywrightBrowserPool,
+  PlaywrightSessionPool,
   fetchListingViaLadder,
   HostRateLimiter,
   InMemoryProviderMetrics,
@@ -237,5 +238,114 @@ describe('createBrowserFetcher', () => {
     } else {
       expect(fetcher).toBeInstanceOf(PlaywrightBrowserPool);
     }
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Headed launch gating — the `headed` option flips Chromium's headless flag   */
+/* for BOTH the browser-fetch pool and the warmed-session pool. Default OFF →   */
+/* headless (current behaviour); true → headless:false (DataDome/Kasada tier).  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Structural view of the fake page the recording module hands back. Typed so the
+ * launch/context literals stay excess-property clean against browser.ts's narrow
+ * `PwPage`, while still carrying every method the session-pool warm path needs at
+ * runtime (`url`/`waitForTimeout`/`request`/`evaluate`).
+ */
+interface RecordingPage {
+  url(): string;
+  goto(url: string, options: { timeout: number; waitUntil: string }): Promise<unknown>;
+  content(): Promise<string>;
+  waitForSelector(selector: string, options?: { timeout?: number }): Promise<unknown>;
+  waitForTimeout(ms: number): Promise<void>;
+  route(pattern: string, handler: (route: unknown) => void | Promise<void>): Promise<void>;
+  request: {
+    get(url: string, opts?: unknown): Promise<{ status(): number; text(): Promise<string> }>;
+    post(url: string, opts?: unknown): Promise<{ status(): number; text(): Promise<string> }>;
+  };
+  evaluate(fn: unknown, arg: unknown): Promise<{ status: number; body: string }>;
+}
+
+// >512 bytes so warmBrowserPage does not treat it as an unresolved DataDome body,
+// and carries the default content selector so the warm poll resolves immediately.
+const WARM_HTML = `<html><body>${'x'.repeat(520)}<article class="item">ok</article></body></html>`;
+
+function makeRecordingPage(): RecordingPage {
+  const ok = async () => ({ status: () => 200, text: async () => '{"items":[]}' });
+  return {
+    url: () => 'https://portal.example/search/',
+    goto: async () => undefined,
+    content: async () => WARM_HTML,
+    waitForSelector: async () => undefined,
+    waitForTimeout: async () => undefined,
+    route: async () => undefined,
+    request: { get: ok, post: ok },
+    evaluate: async () => ({ status: 200, body: '{}' }),
+  };
+}
+
+/** A fake Playwright module that records the `headless` flag of every launch. */
+function recordingPlaywright(): { module: PlaywrightModule; launchedHeadless: boolean[] } {
+  const launchedHeadless: boolean[] = [];
+  const module: PlaywrightModule = {
+    chromium: {
+      launch: async (options) => {
+        launchedHeadless.push(options.headless);
+        return {
+          isConnected: () => true,
+          close: async () => undefined,
+          newContext: async () => ({
+            close: async () => undefined,
+            newPage: async () => makeRecordingPage(),
+          }),
+        };
+      },
+    },
+  };
+  return { module, launchedHeadless };
+}
+
+describe('PlaywrightBrowserPool — headed gating', () => {
+  it('launches headless:false when headed is true', async () => {
+    const { module, launchedHeadless } = recordingPlaywright();
+    const pool = new PlaywrightBrowserPool(module, { headed: true });
+    await pool.fetch('https://portal.example/a');
+    expect(launchedHeadless).toEqual([false]);
+    await pool.close();
+  });
+
+  it('launches headless:true when headed is false or unset', async () => {
+    const unset = recordingPlaywright();
+    const unsetPool = new PlaywrightBrowserPool(unset.module, {});
+    await unsetPool.fetch('https://portal.example/a');
+    expect(unset.launchedHeadless).toEqual([true]);
+    await unsetPool.close();
+
+    const explicit = recordingPlaywright();
+    const explicitPool = new PlaywrightBrowserPool(explicit.module, { headed: false });
+    await explicitPool.fetch('https://portal.example/a');
+    expect(explicit.launchedHeadless).toEqual([true]);
+    await explicitPool.close();
+  });
+});
+
+describe('PlaywrightSessionPool — headed gating', () => {
+  it('launches headless:false when headed is true', async () => {
+    const { module, launchedHeadless } = recordingPlaywright();
+    const pool = new PlaywrightSessionPool(module, { headed: true, challengeWaitMs: 1_000 });
+    const session = await pool.openSession({ warmUrl: 'https://portal.example/search/' });
+    expect(launchedHeadless).toEqual([false]);
+    await session.close();
+    await pool.close();
+  });
+
+  it('launches headless:true when headed is false or unset', async () => {
+    const { module, launchedHeadless } = recordingPlaywright();
+    const pool = new PlaywrightSessionPool(module, { challengeWaitMs: 1_000 });
+    const session = await pool.openSession({ warmUrl: 'https://portal.example/search/' });
+    expect(launchedHeadless).toEqual([true]);
+    await session.close();
+    await pool.close();
   });
 });

--- a/packages/listing-providers/src/browser.ts
+++ b/packages/listing-providers/src/browser.ts
@@ -150,6 +150,15 @@ export interface BrowserPoolOptions {
    * (DataImpulse-compatible sticky IP per context).
    */
   stickyProxySession?: boolean;
+  /**
+   * When true, launch a HEADED Chromium (`headless: false`) instead of headless.
+   * DataDome/Kasada fingerprint and block headless; a real headed browser under a
+   * virtual display clears those challenges. The worker MUST then run under an X
+   * server (no `DISPLAY` → headed launch throws), e.g.
+   * `xvfb-run -a --server-args="-screen 0 1920x1080x24" node packages/backend/dist/worker.js`.
+   * Default false → current headless behaviour.
+   */
+  headed?: boolean;
 }
 
 /** Chromium flags that keep the headless browser lean and container-friendly. */
@@ -174,6 +183,7 @@ export class PlaywrightBrowserPool implements UrlFetcher {
   private readonly proxy?: ResidentialProxyConfig;
   private readonly blockAssets: boolean;
   private readonly stickyProxySession: boolean;
+  private readonly headed: boolean;
 
   private browser?: PwBrowser;
   private launching?: Promise<PwBrowser>;
@@ -192,14 +202,17 @@ export class PlaywrightBrowserPool implements UrlFetcher {
     this.proxy = options.proxy;
     this.blockAssets = options.blockAssets ?? true;
     this.stickyProxySession = options.stickyProxySession ?? false;
+    this.headed = options.headed ?? false;
   }
 
   /** Lazily launch (or relaunch after a crash) the single shared browser. */
   private async ensureBrowser(): Promise<PwBrowser> {
     if (this.browser && this.browser.isConnected()) return this.browser;
     if (this.launching) return this.launching;
+    // `headless: false` (this.headed) requires a live X display — the worker runs
+    // under `xvfb-run` when LISTING_BROWSER_HEADED=true (see Dockerfile header).
     this.launching = this.playwright.chromium
-      .launch({ headless: true, args: this.launchArgs })
+      .launch({ headless: !this.headed, args: this.launchArgs })
       .then((browser) => {
         this.browser = browser;
         this.launching = undefined;

--- a/packages/listing-providers/src/browserSession.ts
+++ b/packages/listing-providers/src/browserSession.ts
@@ -150,6 +150,13 @@ export interface PlaywrightSessionPoolOptions {
   proxy?: ResidentialProxyConfig;
   blockAssets?: boolean;
   stickyProxySession?: boolean;
+  /**
+   * When true, launch a HEADED Chromium (`headless: false`) instead of headless
+   * to clear DataDome/Kasada. Requires a live X display — the worker runs under
+   * `xvfb-run` when LISTING_BROWSER_HEADED=true (see backend Dockerfile header).
+   * Default false → current headless behaviour.
+   */
+  headed?: boolean;
 }
 
 /**
@@ -165,6 +172,7 @@ export class PlaywrightSessionPool {
   private readonly proxy?: ResidentialProxyConfig;
   private readonly blockAssets: boolean;
   private readonly stickyProxySession: boolean;
+  private readonly headed: boolean;
 
   private browser?: PwBrowser;
   private launching?: Promise<PwBrowser>;
@@ -184,14 +192,17 @@ export class PlaywrightSessionPool {
     this.proxy = options.proxy;
     this.blockAssets = options.blockAssets ?? true;
     this.stickyProxySession = options.stickyProxySession ?? false;
+    this.headed = options.headed ?? false;
   }
 
   private async ensureBrowser(): Promise<PwBrowser> {
     if (this.browser && this.browser.isConnected()) return this.browser;
     if (this.launching) return this.launching;
     const chromium = this.playwright.chromium as PwChromium;
+    // `headless: false` (this.headed) requires a live X display — the worker runs
+    // under `xvfb-run` when LISTING_BROWSER_HEADED=true (see Dockerfile header).
     this.launching = chromium
-      .launch({ headless: true, args: this.launchArgs })
+      .launch({ headless: !this.headed, args: this.launchArgs })
       .then((browser) => {
         this.browser = browser;
         this.launching = undefined;

--- a/packages/listing-providers/src/proxy.ts
+++ b/packages/listing-providers/src/proxy.ts
@@ -100,6 +100,24 @@ export function browserBlockAssetsFromEnv(): boolean {
   return envBool('LISTING_BROWSER_BLOCK_ASSETS', true);
 }
 
+/**
+ * Whether the browser tier launches a HEADED Chromium (default OFF → headless).
+ *
+ * DataDome/Kasada fingerprint and block headless Chromium; a real headed browser
+ * running under a virtual display (Xvfb) on a residential IP clears those
+ * challenges where a headless launch is detected and blocked. When this is
+ * `true`, the worker process MUST run under an X server — a headed launch with no
+ * `DISPLAY` throws. The sanctioned command (see the backend Dockerfile header) is:
+ *
+ *   xvfb-run -a --server-args="-screen 0 1920x1080x24" node packages/backend/dist/worker.js
+ *
+ * Default `false` preserves the current headless behaviour, so this flag is inert
+ * until infra flips it together with the xvfb-run worker command.
+ */
+export function browserHeadedFromEnv(): boolean {
+  return envBool('LISTING_BROWSER_HEADED', false);
+}
+
 /** Whether plain HTTP listing fetches should use the residential proxy. */
 export function httpUseProxyFromEnv(): boolean {
   return process.env.LISTING_HTTP_USE_PROXY === 'true';

--- a/packages/listing-providers/src/runtime.ts
+++ b/packages/listing-providers/src/runtime.ts
@@ -18,6 +18,7 @@ import { createManagedFetcher, type ManagedFetcherConfig } from './managed';
 import { BROWSER_USER_AGENT } from './http';
 import {
   browserBlockAssetsFromEnv,
+  browserHeadedFromEnv,
   createProxiedFetch,
   envBool,
   httpUseProxyFromEnv,
@@ -317,7 +318,9 @@ export interface ListingFetchRuntimeFromEnvOptions {
  * Build the worker's fetch runtime from environment variables:
  *   - browser tier: enabled by `LISTING_BROWSER_ENABLED=true`, tuned by
  *     `LISTING_BROWSER_MAX_CONCURRENCY` / `LISTING_BROWSER_TIMEOUT_MS`. Skipped
- *     (with a log notice) when Playwright is not installed.
+ *     (with a log notice) when Playwright is not installed. `LISTING_BROWSER_HEADED=true`
+ *     launches a headed Chromium to clear DataDome/Kasada — the worker must then
+ *     run under `xvfb-run` (see the backend Dockerfile header).
  *   - residential proxy: `LISTING_RESIDENTIAL_PROXY_URL` (+ optional
  *     `LISTING_HTTP_USE_PROXY`, `LISTING_PROXY_STICKY`, `LISTING_BROWSER_BLOCK_ASSETS`).
  *   - managed tier: enabled by `LISTING_MANAGED_FETCH_URL` (+ optional key/param
@@ -340,6 +343,11 @@ export async function createListingFetchRuntimeFromEnv(
   const browserChallengeWaitMs = browserChallengeWaitMsFromEnv(browserTimeoutMs);
   const browserMaxConcurrency = envInt('LISTING_BROWSER_MAX_CONCURRENCY', 2);
   const blockAssets = browserBlockAssetsFromEnv();
+  // Headed Chromium (LISTING_BROWSER_HEADED=true) clears DataDome/Kasada where
+  // headless is fingerprinted and blocked. It requires a virtual display — the
+  // worker must run under `xvfb-run` (see the backend Dockerfile header). Default
+  // false, so this is inert until infra flips the flag and the xvfb-run command.
+  const headed = browserHeadedFromEnv();
   const playwright = browserEnabled ? await loadPlaywright() : undefined;
   const browser = await createBrowserFetcher({
     enabled: browserEnabled,
@@ -348,6 +356,7 @@ export async function createListingFetchRuntimeFromEnv(
     proxy,
     blockAssets,
     stickyProxySession,
+    headed,
     playwright,
     onLog: options.onLog,
   });
@@ -360,6 +369,7 @@ export async function createListingFetchRuntimeFromEnv(
           proxy,
           blockAssets,
           stickyProxySession,
+          headed,
         })
       : undefined;
   const managed = createManagedFetcher(managedConfigFromEnv());


### PR DESCRIPTION
## What

Adds a **HEADED Chromium** mode to the listing worker's Playwright tiers so it can solve DataDome/Kasada JS challenges. Headless Chromium is fingerprinted and blocked by those anti-bot vendors; a real **headed** browser running under Xvfb on a residential IP clears them.

This is **CODE + Dockerfile only**. The terraform side (worker command, flag flip, task memory, provider enables) is owned separately.

## The flag — default OFF, merge is inert

- **Env var:** `LISTING_BROWSER_HEADED`
- **Default:** `false` → preserves the current headless behaviour exactly.
- `browserHeadedFromEnv()` (in `proxy.ts`) is a pure boolean env read mirroring the existing `browserBlockAssetsFromEnv()` / `*FromEnv` helpers.
- Threaded as `headed?: boolean` through `BrowserPoolOptions` (`browser.ts`) and `PlaywrightSessionPoolOptions` (`browserSession.ts`), into both `.launch({ headless: !headed, args })` sites. **Launch args are unchanged** — the existing `--no-sandbox --disable-setuid-sandbox --disable-dev-shm-usage --disable-gpu` are all headed-safe; only the `headless` boolean flips.
- `createListingFetchRuntimeFromEnv()` reads the flag and passes it to both the browser-fetch pool and the warmed-session pool.

Because the default is `false`, **nothing changes at runtime until infra sets the flag AND the xvfb-run worker command together.**

## Xvfb requirement (why the Dockerfile changes)

A headed Chromium needs a live X `DISPLAY` or it throws on launch. The runtime stage now installs **`xvfb` + `xauth`** (the virtual framebuffer + the auth-cookie helper `xvfb-run` uses). Chromium's X *client* libraries already arrive via the existing `playwright install --with-deps chromium` — this only adds the virtual display.

Verified in a `node:20-bookworm-slim` container: `xvfb` (`2:21.1.7-3+deb12u12`) and `xauth` (`1:1.1.2-1`) are valid bookworm packages; `mcookie` is already present in the base image, so `xvfb-run -a` works.

## Worker command infra must use (when the flag is on)

```
xvfb-run -a --server-args="-screen 0 1920x1080x24" node packages/backend/dist/worker.js
```

Documented in both the Dockerfile header and a comment next to each launch site. Flipping `LISTING_BROWSER_HEADED=true` and switching the worker command to the above must happen together.

## Tests

A recording fake Playwright module captures the `headless` flag of every `chromium.launch`. New assertions cover **both** pools:

- `PlaywrightBrowserPool` — `headless:false` when `headed:true`; `headless:true` when `headed:false`/unset.
- `PlaywrightSessionPool` — same, through a successful warm-session open.

Existing browser/session/tier tests remain green.

## Verification

- Builds in dependency order (`shared-types` → `listing-providers` → `backend`) all exit 0; tsc clean.
- `packages/backend` targeted suites: **548 tests / 43 suites passing** (incl. the new headed-gating tests).
- Docker image not built here (arm64), but the apt line is verified syntactically correct and the packages verified installable on bookworm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)