### PR TITLE
feat(admin): moderation queue — review & eviction reports

### DIFF
--- a/packages/backend/__tests__/integration/adminModeration.test.ts
+++ b/packages/backend/__tests__/integration/adminModeration.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Admin moderation queue — the admin gate, the review + eviction queue filters,
+ * the moderation transitions, and the admin-only `reports` projection.
+ *
+ * Uses the real admin router (so `requireAdmin` runs end-to-end) + real models
+ * on in-memory Mongo, behind a fake-auth middleware (mirrors evictionBoard /
+ * leaseOwnership). `config.admin.oxyUserIds` is set per test to drive the gate.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { Types } from 'mongoose';
+
+import config from '../../config';
+
+const adminRouter = require('../../routes/admin').default;
+const reviewController = require('../../controllers/reviewController');
+const { Review, EvictionCase, EvictionReport } = require('../../models');
+const { errorHandler } = require('../../middlewares/errorHandler');
+
+const ADMIN = 'oxy-admin';
+
+beforeEach(() => {
+  // Default: a single configured admin. Individual tests override this.
+  config.admin.oxyUserIds = [ADMIN];
+});
+
+function buildApp(oxyUserId?: string): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (oxyUserId) {
+      const authed = req as unknown as { user: { id: string }; userId: string };
+      authed.user = { id: oxyUserId };
+      authed.userId = oxyUserId;
+    }
+    next();
+  });
+  app.use('/api/admin', adminRouter());
+  // Public read — used to prove the public DTO still strips `reports`.
+  app.get('/api/reviews/:reviewId', (req, res) => reviewController.getReviewById(req, res));
+  app.use(errorHandler);
+  return app;
+}
+
+interface ReviewReportSeed {
+  oxyUserId: string;
+  reason: string;
+  details?: string;
+}
+
+async function seedReview(
+  overrides: Record<string, unknown> = {},
+  reports: ReviewReportSeed[] = [],
+): Promise<string> {
+  const addressId = new Types.ObjectId();
+  const review = await Review.create({
+    addressId,
+    addressLevel: 'BUILDING',
+    streetLevelId: addressId,
+    buildingLevelId: addressId,
+    oxyUserId: 'oxy-author',
+    title: 'A perfectly reasonable review title',
+    price: 1000,
+    currency: 'EUR',
+    livedFrom: new Date('2020-01-01'),
+    livedTo: new Date('2021-01-01'),
+    rating: 4,
+    recommendation: true,
+    opinion: 'Lived here a while — a reasonable opinion string.',
+    reports,
+    ...overrides,
+  });
+  return String(review._id);
+}
+
+async function seedCase(overrides: Record<string, unknown> = {}): Promise<string> {
+  const evictionCase = await EvictionCase.create({
+    oxyUserId: 'oxy-owner',
+    title: 'Desahucio en Carrer de Sants',
+    description: 'Familia con menores — necesitamos presencia para pararlo.',
+    location: {
+      label: 'Carrer de Sants, Barcelona',
+      coordinates: { type: 'Point', coordinates: [2.132, 41.376] },
+      precision: 'approximate',
+      city: 'Barcelona',
+      countryCode: 'ES',
+    },
+    scheduledAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    ...overrides,
+  });
+  return String(evictionCase._id);
+}
+
+async function seedEvictionReport(
+  caseId: string,
+  reporter: string,
+  overrides: Record<string, unknown> = {},
+): Promise<void> {
+  await EvictionReport.create({
+    caseId,
+    reporterOxyUserId: reporter,
+    reason: 'inappropriate',
+    status: 'open',
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Admin gate.
+// ---------------------------------------------------------------------------
+
+describe('admin gate (requireAdmin)', () => {
+  const dummyId = new Types.ObjectId().toString();
+  const endpoints: { method: 'get' | 'post'; path: string }[] = [
+    { method: 'get', path: '/api/admin/moderation/reviews' },
+    { method: 'post', path: `/api/admin/moderation/reviews/${dummyId}` },
+    { method: 'get', path: '/api/admin/moderation/evictions' },
+    { method: 'post', path: `/api/admin/moderation/evictions/${dummyId}` },
+  ];
+
+  it('rejects an authenticated non-admin with 403 on every endpoint', async () => {
+    for (const { method, path } of endpoints) {
+      const app = buildApp('oxy-rando');
+      const res = await (method === 'get'
+        ? request(app).get(path)
+        : request(app).post(path).send({ action: 'remove' }));
+      expect(res.status).toBe(403);
+    }
+  });
+
+  it('rejects an unauthenticated request with 401 on every endpoint', async () => {
+    for (const { method, path } of endpoints) {
+      const app = buildApp();
+      const res = await (method === 'get'
+        ? request(app).get(path)
+        : request(app).post(path).send({ action: 'remove' }));
+      expect(res.status).toBe(401);
+    }
+  });
+
+  it('denies everyone — including a would-be admin — when the allowlist is empty', async () => {
+    config.admin.oxyUserIds = [];
+    for (const { method, path } of endpoints) {
+      const app = buildApp(ADMIN);
+      const res = await (method === 'get'
+        ? request(app).get(path)
+        : request(app).post(path).send({ action: 'remove' }));
+      expect(res.status).toBe(403);
+    }
+  });
+
+  it('lets a configured admin through the gate (200)', async () => {
+    const res = await request(buildApp(ADMIN)).get('/api/admin/moderation/reviews');
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reviews queue.
+// ---------------------------------------------------------------------------
+
+describe('GET /api/admin/moderation/reviews — filters + admin reports projection', () => {
+  async function seedQueue() {
+    const underReview = await seedReview(
+      { moderationStatus: 'under_review' },
+      [
+        { oxyUserId: 'r1', reason: 'spam' },
+        { oxyUserId: 'r2', reason: 'offensive', details: 'abusive' },
+        { oxyUserId: 'r3', reason: 'fake' },
+      ],
+    );
+    const reportedActive = await seedReview({ moderationStatus: 'active' }, [
+      { oxyUserId: 'r4', reason: 'spam' },
+    ]);
+    const removed = await seedReview({ moderationStatus: 'removed' });
+    const clean = await seedReview({ moderationStatus: 'active' });
+    return { underReview, reportedActive, removed, clean };
+  }
+
+  it('under_review returns only reviews flagged for moderation', async () => {
+    const seeded = await seedQueue();
+    const res = await request(buildApp(ADMIN)).get('/api/admin/moderation/reviews?filter=under_review');
+    expect(res.status).toBe(200);
+    const ids = res.body.reviews.map((r: { id: string }) => r.id);
+    expect(ids).toEqual([seeded.underReview]);
+  });
+
+  it('reported returns every review with at least one report', async () => {
+    const seeded = await seedQueue();
+    const res = await request(buildApp(ADMIN)).get('/api/admin/moderation/reviews?filter=reported');
+    expect(res.status).toBe(200);
+    const ids = res.body.reviews.map((r: { id: string }) => r.id).sort();
+    expect(ids).toEqual([seeded.underReview, seeded.reportedActive].sort());
+  });
+
+  it('removed returns only removed reviews', async () => {
+    const seeded = await seedQueue();
+    const res = await request(buildApp(ADMIN)).get('/api/admin/moderation/reviews?filter=removed');
+    expect(res.status).toBe(200);
+    const ids = res.body.reviews.map((r: { id: string }) => r.id);
+    expect(ids).toEqual([seeded.removed]);
+  });
+
+  it('defaults to the under_review filter when none is supplied', async () => {
+    const seeded = await seedQueue();
+    const res = await request(buildApp(ADMIN)).get('/api/admin/moderation/reviews');
+    expect(res.status).toBe(200);
+    const ids = res.body.reviews.map((r: { id: string }) => r.id);
+    expect(ids).toEqual([seeded.underReview]);
+  });
+
+  it('rejects an unknown filter with 400', async () => {
+    const res = await request(buildApp(ADMIN)).get('/api/admin/moderation/reviews?filter=bogus');
+    expect(res.status).toBe(400);
+  });
+
+  it('INCLUDES the reports array in the admin response', async () => {
+    const seeded = await seedQueue();
+    const res = await request(buildApp(ADMIN)).get('/api/admin/moderation/reviews?filter=under_review');
+    const review = res.body.reviews.find((r: { id: string }) => r.id === seeded.underReview);
+    expect(Array.isArray(review.reports)).toBe(true);
+    expect(review.reports).toHaveLength(3);
+    expect(review.reports[0]).toMatchObject({ oxyUserId: 'r1', reason: 'spam' });
+    expect(review.reports[1]).toMatchObject({ reason: 'offensive', details: 'abusive' });
+  });
+
+  it('the PUBLIC review read still strips reports', async () => {
+    const seeded = await seedQueue();
+    const res = await request(buildApp()).get(`/api/reviews/${seeded.underReview}`);
+    expect(res.status).toBe(200);
+    expect(res.body.review.reports).toBeUndefined();
+    expect(res.body.review.helpfulVoters).toBeUndefined();
+  });
+
+  it('exposes flat hasMore / totalPages pagination aliases', async () => {
+    await seedReview({ moderationStatus: 'under_review' });
+    const res = await request(buildApp(ADMIN)).get('/api/admin/moderation/reviews?limit=1');
+    expect(res.body).toHaveProperty('hasMore');
+    expect(res.body).toHaveProperty('totalPages');
+    expect(res.body.pagination).toMatchObject({ currentPage: 1, limit: 1 });
+  });
+});
+
+describe('POST /api/admin/moderation/reviews/:reviewId — transitions', () => {
+  it('remove sets moderationStatus to removed', async () => {
+    const id = await seedReview({ moderationStatus: 'under_review' });
+    const res = await request(buildApp(ADMIN)).post(`/api/admin/moderation/reviews/${id}`).send({ action: 'remove' });
+    expect(res.status).toBe(200);
+    expect(res.body.review.moderationStatus).toBe('removed');
+    expect((await Review.findById(id)).moderationStatus).toBe('removed');
+  });
+
+  it('restore sets moderationStatus back to active', async () => {
+    const id = await seedReview({ moderationStatus: 'removed' });
+    const res = await request(buildApp(ADMIN)).post(`/api/admin/moderation/reviews/${id}`).send({ action: 'restore' });
+    expect(res.status).toBe(200);
+    expect(res.body.review.moderationStatus).toBe('active');
+    expect((await Review.findById(id)).moderationStatus).toBe('active');
+  });
+
+  it('dismiss_reports clears reports and returns to active', async () => {
+    const id = await seedReview({ moderationStatus: 'under_review' }, [
+      { oxyUserId: 'r1', reason: 'spam' },
+      { oxyUserId: 'r2', reason: 'fake' },
+    ]);
+    const res = await request(buildApp(ADMIN)).post(`/api/admin/moderation/reviews/${id}`).send({ action: 'dismiss_reports' });
+    expect(res.status).toBe(200);
+    expect(res.body.review.moderationStatus).toBe('active');
+    expect(res.body.review.reports).toHaveLength(0);
+    const persisted = await Review.findById(id);
+    expect(persisted.reports).toHaveLength(0);
+    expect(persisted.moderationStatus).toBe('active');
+  });
+
+  it('rejects an invalid action with 400', async () => {
+    const id = await seedReview({ moderationStatus: 'under_review' });
+    const res = await request(buildApp(ADMIN)).post(`/api/admin/moderation/reviews/${id}`).send({ action: 'nuke' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for an unknown review', async () => {
+    const missing = new Types.ObjectId().toString();
+    const res = await request(buildApp(ADMIN)).post(`/api/admin/moderation/reviews/${missing}`).send({ action: 'remove' });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Evictions queue.
+// ---------------------------------------------------------------------------
+
+describe('GET /api/admin/moderation/evictions — grouped open reports', () => {
+  it('groups open reports per case and omits cases without open reports', async () => {
+    const reportedCase = await seedCase({ title: 'Reported case' });
+    await seedEvictionReport(reportedCase, 'reporter-a');
+    await seedEvictionReport(reportedCase, 'reporter-b', { reason: 'scam' });
+    await seedCase({ title: 'Clean case' }); // no reports → excluded
+
+    const res = await request(buildApp(ADMIN)).get('/api/admin/moderation/evictions');
+    expect(res.status).toBe(200);
+    expect(res.body.cases).toHaveLength(1);
+    expect(res.body.cases[0].case.id).toBe(reportedCase);
+    expect(res.body.cases[0].case.title).toBe('Reported case');
+    expect(res.body.cases[0].reports).toHaveLength(2);
+    expect(res.body).toHaveProperty('hasMore');
+    expect(res.body).toHaveProperty('totalPages');
+  });
+
+  it('ignores already-resolved / dismissed reports', async () => {
+    const caseId = await seedCase();
+    await seedEvictionReport(caseId, 'reporter-a', { status: 'resolved' });
+    const res = await request(buildApp(ADMIN)).get('/api/admin/moderation/evictions');
+    expect(res.body.cases).toHaveLength(0);
+  });
+});
+
+describe('POST /api/admin/moderation/evictions/:caseId — transitions', () => {
+  it('remove cancels the case and resolves its open reports', async () => {
+    const caseId = await seedCase();
+    await seedEvictionReport(caseId, 'reporter-a');
+    await seedEvictionReport(caseId, 'reporter-b');
+
+    const res = await request(buildApp(ADMIN)).post(`/api/admin/moderation/evictions/${caseId}`).send({ action: 'remove' });
+    expect(res.status).toBe(200);
+    expect(res.body.case.status).toBe('cancelled');
+    expect(res.body.resolvedReports).toBe(2);
+
+    expect((await EvictionCase.findById(caseId)).status).toBe('cancelled');
+    expect(await EvictionReport.countDocuments({ caseId, status: 'open' })).toBe(0);
+    expect(await EvictionReport.countDocuments({ caseId, status: 'resolved' })).toBe(2);
+    // Non-destructive: the case document is NOT deleted.
+    expect(await EvictionCase.findById(caseId)).not.toBeNull();
+  });
+
+  it('dismiss_reports dismisses open reports and leaves the case untouched', async () => {
+    const caseId = await seedCase();
+    await seedEvictionReport(caseId, 'reporter-a');
+
+    const res = await request(buildApp(ADMIN)).post(`/api/admin/moderation/evictions/${caseId}`).send({ action: 'dismiss_reports' });
+    expect(res.status).toBe(200);
+    expect(res.body.case.status).toBe('upcoming');
+    expect(res.body.dismissedReports).toBe(1);
+
+    expect((await EvictionCase.findById(caseId)).status).toBe('upcoming');
+    expect(await EvictionReport.countDocuments({ caseId, status: 'dismissed' })).toBe(1);
+  });
+
+  it('rejects an invalid action with 400', async () => {
+    const caseId = await seedCase();
+    const res = await request(buildApp(ADMIN)).post(`/api/admin/moderation/evictions/${caseId}`).send({ action: 'restore' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for an unknown case', async () => {
+    const missing = new Types.ObjectId().toString();
+    const res = await request(buildApp(ADMIN)).post(`/api/admin/moderation/evictions/${missing}`).send({ action: 'remove' });
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/backend/controllers/admin/moderationController.ts
+++ b/packages/backend/controllers/admin/moderationController.ts
@@ -1,0 +1,313 @@
+/**
+ * Admin moderation queue controller.
+ *
+ * Powers the platform trust & safety review of user-reported content: reviucasa
+ * reviews (`reports[]` / `moderationStatus`) and eviction-board cases
+ * (`EvictionReport`). Mounted behind `requireAdmin` (`routes/admin.ts`), so
+ * every handler here has already passed the env-allowlist admin gate — there is
+ * NO additional role logic in these handlers.
+ *
+ * Security invariants (see AGENTS.md):
+ *   - Reads use the admin-only serializer (`toAdminReviewDTO`) that INCLUDES the
+ *     `reports` array; the public `toReviewDTO` still strips it — the public DTO
+ *     is never weakened.
+ *   - Writes only ever touch the fields dictated by an explicit action
+ *     allowlist. `remove` on an eviction case is non-destructive (status →
+ *     `cancelled`); the owner DELETE remains the only hard delete.
+ */
+
+import { Request, Response } from 'express';
+import { Types } from 'mongoose';
+import { Review, EvictionCase, EvictionReport } from '../../models';
+import {
+  ReviewModerationStatus,
+  ListingReportStatus,
+  EvictionCaseStatus,
+  ADMIN_REVIEW_ACTIONS,
+  ADMIN_EVICTION_ACTIONS,
+  type AdminReviewModerationAction,
+  type AdminEvictionModerationAction,
+} from '@homiio/shared-types';
+import { getOxyUserId } from '@oxyhq/core/server';
+import { toAdminReviewDTO } from '../review/toReviewDTO';
+import { toEvictionDTO, toEvictionReportDTO } from '../eviction/toEvictionDTO';
+import { logger } from '../../middlewares/logging';
+
+const ok = (res: Response, data: Record<string, unknown>) => res.status(200).json({ success: true, ...data });
+const badRequest = (res: Response, data: Record<string, unknown>) => res.status(400).json({ success: false, ...data });
+const notFound = (res: Response, data: Record<string, unknown>) => res.status(404).json({ success: false, ...data });
+const serverError = (res: Response, data: Record<string, unknown>) => res.status(500).json({ success: false, ...data });
+
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 50;
+
+/** Parse `?page`/`?limit` with sane clamps (mirrors the review controller). */
+function parsePageLimit(req: Request): { page: number; limit: number; skip: number } {
+  const page = Math.max(1, parseInt(String(req.query.page ?? '1'), 10) || 1);
+  const rawLimit = parseInt(String(req.query.limit ?? DEFAULT_PAGE_SIZE), 10) || DEFAULT_PAGE_SIZE;
+  const limit = Math.min(MAX_PAGE_SIZE, Math.max(1, rawLimit));
+  return { page, limit, skip: (page - 1) * limit };
+}
+
+/** Address populate used to surface a human-readable label on queued reviews. */
+const REVIEW_ADDRESS_POPULATE = {
+  path: 'addressId',
+  select: 'street number postal_code countryCode cityId regionId countryId neighborhoodId coordinates',
+  populate: [
+    { path: 'cityId', select: 'name' },
+    { path: 'regionId', select: 'name' },
+    { path: 'countryId', select: 'name code' },
+    { path: 'neighborhoodId', select: 'name' },
+  ],
+};
+
+const REVIEW_FILTERS = ['under_review', 'reported', 'removed'] as const;
+type ReviewFilter = (typeof REVIEW_FILTERS)[number];
+
+const REVIEW_ACTIONS = new Set<string>(ADMIN_REVIEW_ACTIONS);
+const EVICTION_ACTIONS = new Set<string>(ADMIN_EVICTION_ACTIONS);
+
+/** Translate a queue filter into the Mongo query that selects its review set. */
+function reviewFilterQuery(filter: ReviewFilter): Record<string, unknown> {
+  switch (filter) {
+    case 'reported':
+      return { 'reports.0': { $exists: true } };
+    case 'removed':
+      return { moderationStatus: ReviewModerationStatus.REMOVED };
+    case 'under_review':
+    default:
+      return { moderationStatus: ReviewModerationStatus.UNDER_REVIEW };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reviews queue.
+// ---------------------------------------------------------------------------
+
+export const getModerationReviews = async (req: Request, res: Response) => {
+  try {
+    const rawFilter = typeof req.query.filter === 'string' ? req.query.filter : 'under_review';
+    if (!REVIEW_FILTERS.includes(rawFilter as ReviewFilter)) {
+      return badRequest(res, { message: 'Invalid filter' });
+    }
+    const filter = rawFilter as ReviewFilter;
+    const query = reviewFilterQuery(filter);
+    const { page, limit, skip } = parsePageLimit(req);
+
+    const [reviews, total] = await Promise.all([
+      Review.find(query)
+        .populate(REVIEW_ADDRESS_POPULATE)
+        .populate({ path: 'agencyId', select: 'name slug' })
+        .sort({ updatedAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      Review.countDocuments(query),
+    ]);
+
+    const totalPages = Math.max(1, Math.ceil(total / limit));
+    return ok(res, {
+      reviews: reviews.map((review) => toAdminReviewDTO(review)),
+      pagination: { currentPage: page, totalPages, total, limit },
+      hasMore: page < totalPages,
+      totalPages,
+    });
+  } catch (error) {
+    logger.error('Error fetching moderation reviews', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return serverError(res, { message: 'Failed to fetch moderation reviews' });
+  }
+};
+
+export const moderateReview = async (req: Request, res: Response) => {
+  try {
+    const { reviewId } = req.params;
+    const action = (req.body?.action ?? '') as string;
+
+    if (!Types.ObjectId.isValid(reviewId)) {
+      return badRequest(res, { message: 'Invalid review ID' });
+    }
+    if (!REVIEW_ACTIONS.has(action)) {
+      return badRequest(res, { message: 'A valid action is required' });
+    }
+
+    const review = await Review.findById(reviewId);
+    if (!review) {
+      return notFound(res, { message: 'Review not found' });
+    }
+
+    switch (action as AdminReviewModerationAction) {
+      case 'remove':
+        review.moderationStatus = ReviewModerationStatus.REMOVED;
+        break;
+      case 'restore':
+        review.moderationStatus = ReviewModerationStatus.ACTIVE;
+        break;
+      case 'dismiss_reports':
+        review.reports = [];
+        review.moderationStatus = ReviewModerationStatus.ACTIVE;
+        break;
+    }
+
+    await review.save();
+
+    logger.info('Admin moderated review', {
+      reviewId: String(review._id),
+      action,
+      adminOxyUserId: getOxyUserId(req),
+      moderationStatus: review.moderationStatus,
+    });
+
+    const populated = await Review.findById(reviewId)
+      .populate(REVIEW_ADDRESS_POPULATE)
+      .populate({ path: 'agencyId', select: 'name slug' })
+      .lean();
+
+    return ok(res, { review: toAdminReviewDTO(populated ?? review) });
+  } catch (error) {
+    logger.error('Error moderating review', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return serverError(res, { message: 'Failed to moderate review' });
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Evictions queue.
+// ---------------------------------------------------------------------------
+
+export const getModerationEvictions = async (req: Request, res: Response) => {
+  try {
+    const { page, limit, skip } = parsePageLimit(req);
+
+    // Group open reports by case, most-recently-reported case first, and
+    // paginate on the CASE (one queue row per reported case).
+    const groupStages = [
+      { $match: { status: ListingReportStatus.OPEN } },
+      { $group: { _id: '$caseId', latest: { $max: '$createdAt' } } },
+    ];
+
+    const [totalGroups, pageGroups] = await Promise.all([
+      EvictionReport.aggregate([...groupStages, { $count: 'count' }]),
+      EvictionReport.aggregate([
+        ...groupStages,
+        { $sort: { latest: -1 } },
+        { $skip: skip },
+        { $limit: limit },
+      ]),
+    ]);
+    const total = totalGroups[0]?.count ?? 0;
+
+    const caseIds = pageGroups.map((group) => group._id).filter(Boolean);
+
+    const [cases, reports] = await Promise.all([
+      EvictionCase.find({ _id: { $in: caseIds } }).lean(),
+      EvictionReport.find({ caseId: { $in: caseIds }, status: ListingReportStatus.OPEN })
+        .sort({ createdAt: -1 })
+        .lean(),
+    ]);
+
+    const caseById = new Map(cases.map((doc) => [String(doc._id), doc]));
+    const reportsByCase = new Map<string, unknown[]>();
+    for (const report of reports) {
+      const key = String(report.caseId);
+      const bucket = reportsByCase.get(key) ?? [];
+      bucket.push(report);
+      reportsByCase.set(key, bucket);
+    }
+
+    // Preserve the reported-order of `pageGroups`; skip orphaned reports whose
+    // case was hard-deleted by its owner (no case DTO to show).
+    const items = caseIds
+      .map((caseId) => {
+        const key = String(caseId);
+        const caseDoc = caseById.get(key);
+        if (!caseDoc) return null;
+        return {
+          case: toEvictionDTO(caseDoc),
+          reports: (reportsByCase.get(key) ?? []).map((report) => toEvictionReportDTO(report)),
+        };
+      })
+      .filter((entry): entry is { case: ReturnType<typeof toEvictionDTO>; reports: ReturnType<typeof toEvictionReportDTO>[] } => entry !== null);
+
+    const totalPages = Math.max(1, Math.ceil(total / limit));
+    return ok(res, {
+      cases: items,
+      pagination: { currentPage: page, totalPages, total, limit },
+      hasMore: page < totalPages,
+      totalPages,
+    });
+  } catch (error) {
+    logger.error('Error fetching moderation evictions', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return serverError(res, { message: 'Failed to fetch moderation evictions' });
+  }
+};
+
+export const moderateEviction = async (req: Request, res: Response) => {
+  try {
+    const { caseId } = req.params;
+    const action = (req.body?.action ?? '') as string;
+
+    if (!Types.ObjectId.isValid(caseId)) {
+      return badRequest(res, { message: 'Invalid case ID' });
+    }
+    if (!EVICTION_ACTIONS.has(action)) {
+      return badRequest(res, { message: 'A valid action is required' });
+    }
+
+    const evictionCase = await EvictionCase.findById(caseId);
+    if (!evictionCase) {
+      return notFound(res, { message: 'Eviction case not found' });
+    }
+
+    if ((action as AdminEvictionModerationAction) === 'remove') {
+      // Non-destructive: cancel the case (owner DELETE stays the only hard
+      // delete) and resolve its open reports.
+      const updated = await EvictionCase.findByIdAndUpdate(
+        caseId,
+        { $set: { status: EvictionCaseStatus.CANCELLED } },
+        { new: true },
+      );
+      const { modifiedCount } = await EvictionReport.updateMany(
+        { caseId, status: ListingReportStatus.OPEN },
+        { $set: { status: ListingReportStatus.RESOLVED } },
+      );
+
+      logger.info('Admin cancelled eviction case', {
+        caseId: String(caseId),
+        adminOxyUserId: getOxyUserId(req),
+        resolvedReports: modifiedCount,
+      });
+
+      return ok(res, {
+        case: toEvictionDTO(updated ?? evictionCase),
+        resolvedReports: modifiedCount,
+      });
+    }
+
+    // dismiss_reports: leave the case; mark its open reports dismissed.
+    const { modifiedCount } = await EvictionReport.updateMany(
+      { caseId, status: ListingReportStatus.OPEN },
+      { $set: { status: ListingReportStatus.DISMISSED } },
+    );
+
+    logger.info('Admin dismissed eviction reports', {
+      caseId: String(caseId),
+      adminOxyUserId: getOxyUserId(req),
+      dismissedReports: modifiedCount,
+    });
+
+    return ok(res, {
+      case: toEvictionDTO(evictionCase),
+      dismissedReports: modifiedCount,
+    });
+  } catch (error) {
+    logger.error('Error moderating eviction case', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return serverError(res, { message: 'Failed to moderate eviction case' });
+  }
+};

--- a/packages/backend/controllers/eviction/toEvictionDTO.ts
+++ b/packages/backend/controllers/eviction/toEvictionDTO.ts
@@ -17,6 +17,7 @@ import {
   type EvictionComment,
   type EvictionContactInfo,
   type EvictionLocation,
+  type EvictionReportDTO,
   type EvictionUpdate,
 } from '@homiio/shared-types';
 
@@ -212,6 +213,26 @@ export function toEvictionCommentDTO(commentDoc: unknown): EvictionComment {
     caseId: refToId(src.caseId) ?? '',
     oxyUserId: asString(src.oxyUserId),
     body: asString(src.body),
+    createdAt: toIso(src.createdAt) ?? '',
+    updatedAt: toIso(src.updatedAt) ?? '',
+  };
+}
+
+/**
+ * Serialize an EvictionReport document/lean object into an
+ * {@link EvictionReportDTO}. Admin moderation queue only — reports carry no
+ * public visibility.
+ */
+export function toEvictionReportDTO(reportDoc: unknown): EvictionReportDTO {
+  const src = toLoose(reportDoc);
+  return {
+    id: refToId(src._id ?? src.id) ?? '',
+    caseId: refToId(src.caseId) ?? '',
+    reporterOxyUserId: asString(src.reporterOxyUserId),
+    reason: asString(src.reason) as EvictionReportDTO['reason'],
+    details: asOptString(src.details),
+    contactEmail: asOptString(src.contactEmail),
+    status: asString(src.status) as EvictionReportDTO['status'],
     createdAt: toIso(src.createdAt) ?? '',
     updatedAt: toIso(src.updatedAt) ?? '',
   };

--- a/packages/backend/controllers/review/toReviewDTO.ts
+++ b/packages/backend/controllers/review/toReviewDTO.ts
@@ -116,4 +116,42 @@ export function toReviewDTO(reviewDoc: unknown, viewerOxyUserId?: string | null)
   return dto;
 }
 
+/** ISO-string a Date, or pass through an already-serialized value. */
+function toIso(value: unknown): string | undefined {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? undefined : value.toISOString();
+  }
+  if (typeof value === 'string' && value.length) return value;
+  return undefined;
+}
+
+/** Normalize the embedded `reports` array into the admin-facing report shape. */
+function normalizeReports(value: unknown): Loose[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((entry) => {
+    const report = plain(entry);
+    const normalized: Loose = {
+      oxyUserId: report.oxyUserId != null ? String(report.oxyUserId) : '',
+      reason: report.reason,
+      createdAt: toIso(report.createdAt) ?? '',
+    };
+    if (typeof report.details === 'string' && report.details.length) {
+      normalized.details = report.details;
+    }
+    return normalized;
+  });
+}
+
+/**
+ * Admin-only serializer variant. Reuses {@link toReviewDTO} for the full public
+ * projection, then re-attaches the `reports` array that the public DTO strips.
+ * Used exclusively by the admin moderation queue — do NOT call from a public
+ * read path.
+ */
+export function toAdminReviewDTO(reviewDoc: unknown, viewerOxyUserId?: string | null): Loose {
+  const dto = toReviewDTO(reviewDoc, viewerOxyUserId);
+  dto.reports = normalizeReports(plain(reviewDoc).reports);
+  return dto;
+}
+
 export default toReviewDTO;

--- a/packages/backend/routes/admin.ts
+++ b/packages/backend/routes/admin.ts
@@ -1,0 +1,33 @@
+/**
+ * Admin routes (authenticated + admin-gated).
+ *
+ * Mounted at /api/admin behind the global `oxy.auth()` in server.ts, so
+ * `req.user` is resolved here. `requireAdmin` additionally restricts every route
+ * to the configured platform-admin allowlist (`config.admin.oxyUserIds`), which
+ * fails closed on an empty allowlist. Same mounting pattern as `routes/scraper.ts`.
+ */
+
+import express from 'express';
+import { asyncHandler } from '../middlewares';
+import { requireAdmin } from '../middlewares/requireAdmin';
+import {
+  getModerationReviews,
+  moderateReview,
+  getModerationEvictions,
+  moderateEviction,
+} from '../controllers/admin/moderationController';
+
+export default function () {
+  const router = express.Router();
+
+  // Admin gate for every route under /api/admin.
+  router.use(requireAdmin);
+
+  // Trust & safety moderation queue.
+  router.get('/moderation/reviews', asyncHandler(getModerationReviews));
+  router.post('/moderation/reviews/:reviewId', asyncHandler(moderateReview));
+  router.get('/moderation/evictions', asyncHandler(getModerationEvictions));
+  router.post('/moderation/evictions/:caseId', asyncHandler(moderateEviction));
+
+  return router;
+}

--- a/packages/backend/routes/index.ts
+++ b/packages/backend/routes/index.ts
@@ -25,6 +25,7 @@ const applications = require('./applications').default;
 const exchanges = require('./exchanges').default;
 const partners = require('./partners').default;
 const evictions = require('./evictions').default;
+const admin = require('./admin').default;
 
 export default function() {
   const propertyRoutes = properties();
@@ -47,6 +48,7 @@ export default function() {
   const exchangeRoutes = exchanges();
   const partnerRoutes = partners();
   const evictionRoutes = evictions();
+  const adminRoutes = admin();
 
   const router = express.Router();
 
@@ -79,6 +81,7 @@ export default function() {
   router.use('/scraper', scraperRoutes);
   router.use('/reviews', reviewRoutes);
   router.use('/addresses', addressRoutes);
+  router.use('/admin', adminRoutes);
 
   // Admin-only city routes (authenticated)
   router.post('/cities', asyncHandler(require('../controllers').cityController.createCity));

--- a/packages/frontend/app/admin/moderation.tsx
+++ b/packages/frontend/app/admin/moderation.tsx
@@ -1,0 +1,692 @@
+/**
+ * Admin moderation queue (hidden route — no sidebar entry).
+ *
+ * The reviews queue endpoint is the GATE: it is called on mount, and a 403
+ * renders a clean "not authorised" state (i18n). There is NO client-side role
+ * logic — the server allowlist (`requireAdmin`) is the sole authority.
+ *
+ * Two Bloom-chip tabs: Reseñas (reviews) / Desalojos (evictions). Each row shows
+ * the reported content + its reports and offers admin actions (behind a confirm
+ * prompt) that mutate + invalidate the queue. Actions use Bloom `Button` (owns
+ * its own pressed state) — never a function-form `Pressable` style.
+ */
+import React, { useCallback, useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTranslation } from 'react-i18next';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+
+import { Button } from '@oxyhq/bloom/button';
+import { Chip } from '@oxyhq/bloom/chip';
+import { H2, H3, Text as BloomText } from '@oxyhq/bloom/typography';
+
+import type {
+  AdminReviewDTO,
+  AdminReviewModerationAction,
+  AdminEvictionModerationAction,
+  EvictionModerationItem,
+  ReviewReport,
+  EvictionReportDTO,
+} from '@homiio/shared-types';
+
+import { Header } from '@/components/Header';
+import { ErrorState } from '@/components/ui/ErrorState';
+import { LoadMoreSentinel } from '@/components/common/LoadMoreSentinel';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import {
+  useModerationReviews,
+  useModerationEvictions,
+  useModerateReview,
+  useModerateEviction,
+} from '@/hooks/useAdminModeration';
+import type { ReviewModerationFilter } from '@/services/adminModerationService';
+import { webAlert } from '@/utils/api';
+import { formatLocalized } from '@/utils/dateLocale';
+import { colors } from '@/styles/colors';
+import { radius, spacing } from '@/constants/styles';
+
+type Tab = 'reviews' | 'evictions';
+type Tone = 'success' | 'warning' | 'error' | 'info' | 'neutral';
+
+const REVIEW_FILTERS: ReviewModerationFilter[] = ['under_review', 'reported', 'removed'];
+
+const REVIEW_STATUS_TONE: Record<string, Tone> = {
+  active: 'success',
+  under_review: 'warning',
+  removed: 'error',
+};
+
+const EVICTION_STATUS_TONE: Record<string, Tone> = {
+  upcoming: 'info',
+  stopped: 'success',
+  postponed: 'warning',
+  executed: 'neutral',
+  cancelled: 'error',
+};
+
+function toneColor(tone: Tone): string {
+  switch (tone) {
+    case 'success':
+      return colors.success;
+    case 'warning':
+      return colors.warning;
+    case 'error':
+      return colors.error;
+    case 'info':
+      return colors.info;
+    case 'neutral':
+    default:
+      return colors.textSecondary;
+  }
+}
+
+/** Small bordered status pill (colored text + border, transparent fill). */
+const StatusBadge: React.FC<{ label: string; tone: Tone }> = ({ label, tone }) => {
+  const tint = toneColor(tone);
+  return (
+    <View style={[styles.badge, { borderColor: tint }]}>
+      <BloomText style={[styles.badgeText, { color: tint }]}>{label}</BloomText>
+    </View>
+  );
+};
+
+/** ISO date → localized short date (formatLocalized reads the active locale). */
+function safeDate(value: string): string {
+  if (!value) return '';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return '';
+  return formatLocalized(parsed, 'PP');
+}
+
+interface ReportRowData {
+  reasonLabel: string;
+  details?: string;
+  date: string;
+}
+
+const ReportRow: React.FC<ReportRowData> = ({ reasonLabel, details, date }) => (
+  <View style={styles.reportRow}>
+    <Ionicons name="flag" size={13} color={colors.error} style={styles.reportIcon} />
+    <View style={styles.reportBody}>
+      <View style={styles.reportMeta}>
+        <BloomText style={styles.reportReason}>{reasonLabel}</BloomText>
+        {date ? <BloomText style={styles.reportDate}>{date}</BloomText> : null}
+      </View>
+      {details ? <BloomText style={styles.reportDetails}>{details}</BloomText> : null}
+    </View>
+  </View>
+);
+
+// ---------------------------------------------------------------------------
+// Review row.
+// ---------------------------------------------------------------------------
+
+interface AdminReviewRowProps {
+  review: AdminReviewDTO;
+  pending: boolean;
+  onAction: (action: AdminReviewModerationAction) => void;
+}
+
+const AdminReviewRow: React.FC<AdminReviewRowProps> = ({ review, pending, onAction }) => {
+  const { t } = useTranslation();
+  const reports = Array.isArray(review.reports) ? review.reports : [];
+  const isRemoved = review.moderationStatus === 'removed';
+
+  return (
+    <View style={styles.row}>
+      <View style={styles.rowHeader}>
+        <BloomText style={styles.rowTitle} numberOfLines={2}>
+          {review.title || t('admin.moderation.reviews.untitled')}
+        </BloomText>
+        <StatusBadge
+          label={t(`admin.moderation.reviewStatus.${review.moderationStatus}`)}
+          tone={REVIEW_STATUS_TONE[review.moderationStatus] ?? 'neutral'}
+        />
+      </View>
+
+      {review.opinion ? (
+        <BloomText style={styles.rowExcerpt} numberOfLines={4}>
+          {review.opinion}
+        </BloomText>
+      ) : null}
+
+      <BloomText style={styles.rowMeta}>
+        {t('admin.moderation.reviews.author', { id: review.oxyUserId })}
+      </BloomText>
+
+      {reports.length > 0 ? (
+        <View style={styles.reportsBlock}>
+          <BloomText style={styles.reportsTitle}>
+            {t('admin.moderation.reports.title', { count: reports.length })}
+          </BloomText>
+          {reports.map((report: ReviewReport, index) => (
+            <ReportRow
+              key={`${report.oxyUserId}-${index}`}
+              reasonLabel={t(`admin.moderation.reviewReason.${report.reason}`)}
+              details={report.details}
+              date={safeDate(report.createdAt)}
+            />
+          ))}
+        </View>
+      ) : null}
+
+      <View style={styles.actions}>
+        {!isRemoved ? (
+          <Button
+            variant="destructive"
+            size="small"
+            loading={pending}
+            onPress={() => onAction('remove')}
+          >
+            {t('admin.moderation.actions.remove')}
+          </Button>
+        ) : (
+          <Button
+            variant="secondary"
+            size="small"
+            loading={pending}
+            onPress={() => onAction('restore')}
+          >
+            {t('admin.moderation.actions.restore')}
+          </Button>
+        )}
+        {reports.length > 0 ? (
+          <Button
+            variant="outline"
+            size="small"
+            loading={pending}
+            onPress={() => onAction('dismiss_reports')}
+          >
+            {t('admin.moderation.actions.dismissReports')}
+          </Button>
+        ) : null}
+      </View>
+    </View>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Eviction row.
+// ---------------------------------------------------------------------------
+
+interface AdminEvictionRowProps {
+  item: EvictionModerationItem;
+  pending: boolean;
+  onOpen: () => void;
+  onAction: (action: AdminEvictionModerationAction) => void;
+}
+
+const AdminEvictionRow: React.FC<AdminEvictionRowProps> = ({ item, pending, onOpen, onAction }) => {
+  const { t } = useTranslation();
+  const evictionCase = item.case;
+  const reports = Array.isArray(item.reports) ? item.reports : [];
+  const isCancelled = evictionCase.status === 'cancelled';
+  const locationLabel = evictionCase.location?.label ?? '';
+  const scheduled = safeDate(evictionCase.scheduledAt);
+
+  return (
+    <View style={styles.row}>
+      <View style={styles.rowHeader}>
+        <Button
+          variant="text"
+          size="small"
+          onPress={onOpen}
+          style={styles.caseLink}
+          accessibilityLabel={t('admin.moderation.evictions.viewCase')}
+        >
+          {evictionCase.title || t('admin.moderation.evictions.untitled')}
+        </Button>
+        <StatusBadge
+          label={t(`evictions.status.${evictionCase.status}`)}
+          tone={EVICTION_STATUS_TONE[evictionCase.status] ?? 'neutral'}
+        />
+      </View>
+
+      <View style={styles.rowMetaRow}>
+        {scheduled ? (
+          <View style={styles.metaItem}>
+            <Ionicons name="calendar-outline" size={13} color={colors.textSecondary} />
+            <BloomText style={styles.rowMeta}>{scheduled}</BloomText>
+          </View>
+        ) : null}
+        {locationLabel ? (
+          <View style={styles.metaItem}>
+            <Ionicons name="location-outline" size={13} color={colors.textSecondary} />
+            <BloomText style={styles.rowMeta} numberOfLines={1}>
+              {locationLabel}
+            </BloomText>
+          </View>
+        ) : null}
+      </View>
+
+      {reports.length > 0 ? (
+        <View style={styles.reportsBlock}>
+          <BloomText style={styles.reportsTitle}>
+            {t('admin.moderation.reports.title', { count: reports.length })}
+          </BloomText>
+          {reports.map((report: EvictionReportDTO) => (
+            <ReportRow
+              key={report.id}
+              reasonLabel={t(`admin.moderation.evictionReason.${report.reason}`)}
+              details={report.details}
+              date={safeDate(report.createdAt)}
+            />
+          ))}
+        </View>
+      ) : null}
+
+      <View style={styles.actions}>
+        {!isCancelled ? (
+          <Button
+            variant="destructive"
+            size="small"
+            loading={pending}
+            onPress={() => onAction('remove')}
+          >
+            {t('admin.moderation.actions.cancelCase')}
+          </Button>
+        ) : null}
+        {reports.length > 0 ? (
+          <Button
+            variant="outline"
+            size="small"
+            loading={pending}
+            onPress={() => onAction('dismiss_reports')}
+          >
+            {t('admin.moderation.actions.dismissReports')}
+          </Button>
+        ) : null}
+      </View>
+    </View>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Screen.
+// ---------------------------------------------------------------------------
+
+export default function AdminModerationScreen() {
+  const { t } = useTranslation();
+  const router = useRouter();
+
+  const [tab, setTab] = useState<Tab>('reviews');
+  const [reviewFilter, setReviewFilter] = useState<ReviewModerationFilter>('under_review');
+
+  // Reviews query is ALWAYS enabled — it is the admin gate + the mount call.
+  const reviewsQuery = useModerationReviews(reviewFilter);
+  const evictionsQuery = useModerationEvictions({ enabled: tab === 'evictions' });
+
+  const moderateReview = useModerateReview();
+  const moderateEviction = useModerateEviction();
+
+  const gateError = reviewsQuery.error as { status?: number } | null;
+  const unauthorized = reviewsQuery.isError && gateError?.status === 403;
+
+  const activeQuery = tab === 'reviews' ? reviewsQuery : evictionsQuery;
+  const handleEndReached = useCallback(() => {
+    if (activeQuery.hasNextPage && !activeQuery.isFetchingNextPage) {
+      void activeQuery.fetchNextPage();
+    }
+  }, [activeQuery]);
+  const { onScroll } = useInfiniteScroll({
+    onEndReached: handleEndReached,
+    enabled: activeQuery.hasNextPage,
+  });
+
+  const confirmAndRun = useCallback(
+    (title: string, message: string, confirmLabel: string, destructive: boolean, run: () => void) => {
+      webAlert(title, message, [
+        { text: t('common.cancel'), style: 'cancel' },
+        { text: confirmLabel, style: destructive ? 'destructive' : 'default', onPress: run },
+      ]);
+    },
+    [t],
+  );
+
+  const onReviewAction = useCallback(
+    (reviewId: string, action: AdminReviewModerationAction) => {
+      const labelKey =
+        action === 'remove'
+          ? 'remove'
+          : action === 'restore'
+            ? 'restore'
+            : 'dismissReports';
+      confirmAndRun(
+        t(`admin.moderation.confirm.review.${action}.title`),
+        t(`admin.moderation.confirm.review.${action}.message`),
+        t(`admin.moderation.actions.${labelKey}`),
+        action === 'remove',
+        () => moderateReview.mutate({ reviewId, action }),
+      );
+    },
+    [confirmAndRun, moderateReview, t],
+  );
+
+  const onEvictionAction = useCallback(
+    (caseId: string, action: AdminEvictionModerationAction) => {
+      const labelKey = action === 'remove' ? 'cancelCase' : 'dismissReports';
+      confirmAndRun(
+        t(`admin.moderation.confirm.eviction.${action}.title`),
+        t(`admin.moderation.confirm.eviction.${action}.message`),
+        t(`admin.moderation.actions.${labelKey}`),
+        action === 'remove',
+        () => moderateEviction.mutate({ caseId, action }),
+      );
+    },
+    [confirmAndRun, moderateEviction, t],
+  );
+
+  const reviewPendingId =
+    moderateReview.isPending ? moderateReview.variables?.reviewId : undefined;
+  const evictionPendingId =
+    moderateEviction.isPending ? moderateEviction.variables?.caseId : undefined;
+
+  const reviewsBody = () => {
+    if (reviewsQuery.isLoading && reviewsQuery.reviews.length === 0) {
+      return <BloomText style={styles.stateText}>{t('common.loading')}</BloomText>;
+    }
+    if (reviewsQuery.isError) {
+      return (
+        <ErrorState
+          icon="cloud-offline-outline"
+          title={t('admin.moderation.reviews.loadError')}
+          description={reviewsQuery.error?.message ?? t('common.tryAgain')}
+          onRetry={() => void reviewsQuery.refetch()}
+        />
+      );
+    }
+    if (reviewsQuery.reviews.length === 0) {
+      return <BloomText style={styles.stateText}>{t('admin.moderation.reviews.empty')}</BloomText>;
+    }
+    return (
+      <View style={styles.list}>
+        {reviewsQuery.reviews.map((review) => (
+          <AdminReviewRow
+            key={review.id}
+            review={review}
+            pending={reviewPendingId === review.id}
+            onAction={(action) => onReviewAction(review.id, action)}
+          />
+        ))}
+      </View>
+    );
+  };
+
+  const evictionsBody = () => {
+    if (evictionsQuery.isLoading && evictionsQuery.items.length === 0) {
+      return <BloomText style={styles.stateText}>{t('common.loading')}</BloomText>;
+    }
+    if (evictionsQuery.isError) {
+      return (
+        <ErrorState
+          icon="cloud-offline-outline"
+          title={t('admin.moderation.evictions.loadError')}
+          description={evictionsQuery.error?.message ?? t('common.tryAgain')}
+          onRetry={() => void evictionsQuery.refetch()}
+        />
+      );
+    }
+    if (evictionsQuery.items.length === 0) {
+      return <BloomText style={styles.stateText}>{t('admin.moderation.evictions.empty')}</BloomText>;
+    }
+    return (
+      <View style={styles.list}>
+        {evictionsQuery.items.map((item) => (
+          <AdminEvictionRow
+            key={item.case.id}
+            item={item}
+            pending={evictionPendingId === item.case.id}
+            onOpen={() => router.push(`/evictions/${item.case.id}`)}
+            onAction={(action) => onEvictionAction(item.case.id, action)}
+          />
+        ))}
+      </View>
+    );
+  };
+
+  return (
+    <View style={styles.root}>
+      <Header options={{ title: t('admin.moderation.title') }} />
+      <SafeAreaView edges={['bottom']} style={styles.safeArea}>
+        {unauthorized ? (
+          <View style={styles.unauthorized}>
+            <Ionicons name="lock-closed-outline" size={48} color={colors.textSecondary} />
+            <H3 style={styles.unauthorizedTitle}>{t('admin.moderation.unauthorized.title')}</H3>
+            <BloomText style={styles.unauthorizedMessage}>
+              {t('admin.moderation.unauthorized.message')}
+            </BloomText>
+          </View>
+        ) : (
+          <ScrollView
+            contentContainerStyle={styles.content}
+            onScroll={onScroll}
+            scrollEventThrottle={16}
+            showsVerticalScrollIndicator={false}
+          >
+            <View style={styles.titleBlock}>
+              <H2 style={styles.title}>{t('admin.moderation.title')}</H2>
+              <BloomText style={styles.subtitle}>{t('admin.moderation.subtitle')}</BloomText>
+            </View>
+
+            <View style={styles.tabRow}>
+              <Chip
+                onPress={() => setTab('reviews')}
+                variant={tab === 'reviews' ? 'solid' : 'outlined'}
+                color={tab === 'reviews' ? 'primary' : 'default'}
+                selected={tab === 'reviews'}
+              >
+                {t('admin.moderation.tabs.reviews')}
+              </Chip>
+              <Chip
+                onPress={() => setTab('evictions')}
+                variant={tab === 'evictions' ? 'solid' : 'outlined'}
+                color={tab === 'evictions' ? 'primary' : 'default'}
+                selected={tab === 'evictions'}
+              >
+                {t('admin.moderation.tabs.evictions')}
+              </Chip>
+            </View>
+
+            {tab === 'reviews' ? (
+              <>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={styles.filterRow}
+                >
+                  {REVIEW_FILTERS.map((filter) => (
+                    <Chip
+                      key={filter}
+                      onPress={() => setReviewFilter(filter)}
+                      variant={reviewFilter === filter ? 'solid' : 'outlined'}
+                      color={reviewFilter === filter ? 'primary' : 'default'}
+                      selected={reviewFilter === filter}
+                    >
+                      {t(`admin.moderation.reviews.filters.${filter}`)}
+                    </Chip>
+                  ))}
+                </ScrollView>
+                {reviewsBody()}
+              </>
+            ) : (
+              evictionsBody()
+            )}
+
+            <LoadMoreSentinel enabled={activeQuery.hasNextPage} onLoadMore={handleEndReached} />
+          </ScrollView>
+        )}
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  safeArea: {
+    flex: 1,
+  },
+  content: {
+    padding: spacing.lg,
+    gap: spacing.lg,
+    paddingBottom: spacing['5xl'],
+  },
+  titleBlock: {
+    gap: spacing.xs,
+  },
+  title: {
+    letterSpacing: -0.5,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: colors.muted,
+  },
+  tabRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  filterRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    paddingVertical: spacing.xs,
+  },
+  list: {
+    gap: spacing.md,
+  },
+  row: {
+    gap: spacing.sm,
+    padding: spacing.md,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surfaceElevated,
+  },
+  rowHeader: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+  },
+  rowTitle: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  caseLink: {
+    flex: 1,
+    alignSelf: 'flex-start',
+    paddingHorizontal: 0,
+  },
+  rowExcerpt: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: colors.textSecondary,
+  },
+  rowMeta: {
+    fontSize: 12,
+    color: colors.textSecondary,
+  },
+  rowMetaRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.md,
+  },
+  metaItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    flexShrink: 1,
+  },
+  badge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: radius.pill,
+    borderWidth: 1,
+  },
+  badgeText: {
+    fontSize: 11,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  reportsBlock: {
+    gap: spacing.xs,
+    paddingTop: spacing.xs,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  reportsTitle: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: colors.textSecondary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  reportRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.xs,
+  },
+  reportIcon: {
+    marginTop: 2,
+  },
+  reportBody: {
+    flex: 1,
+    gap: 1,
+  },
+  reportMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  reportReason: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  reportDate: {
+    fontSize: 12,
+    color: colors.textSecondary,
+  },
+  reportDetails: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: colors.textSecondary,
+  },
+  actions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+    marginTop: spacing.xs,
+  },
+  stateText: {
+    fontSize: 14,
+    color: colors.textSecondary,
+    paddingVertical: spacing.xl,
+    textAlign: 'center',
+  },
+  unauthorized: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.xl,
+    gap: spacing.md,
+  },
+  unauthorizedTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.text,
+    textAlign: 'center',
+  },
+  unauthorizedMessage: {
+    fontSize: 14,
+    color: colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 20,
+    maxWidth: 340,
+  },
+});

--- a/packages/frontend/hooks/useAdminModeration.ts
+++ b/packages/frontend/hooks/useAdminModeration.ts
@@ -1,0 +1,135 @@
+/**
+ * Admin moderation queue hooks (React Query).
+ *
+ * Page-based `useInfiniteQuery` feeds (mechanics mirror `useEvictionQueries`):
+ * the review queue is keyed by its `filter` tab, the eviction queue is a single
+ * feed. Mutations invalidate the queue so a moderated row disappears/updates on
+ * the next refetch. The reviews query is the admin GATE — the screen inspects
+ * its error `status` (403 → not authorised); no client-side role logic here.
+ */
+
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+  type UseMutationResult,
+} from '@tanstack/react-query';
+import { useMemo } from 'react';
+import type {
+  AdminReviewDTO,
+  AdminReviewModerationAction,
+  AdminEvictionModerationAction,
+  EvictionModerationItem,
+} from '@homiio/shared-types';
+import {
+  adminModerationService,
+  type AdminReviewsPage,
+  type AdminEvictionsPage,
+  type ReviewModerationFilter,
+} from '@/services/adminModerationService';
+
+const PAGE_SIZE = 20;
+const STALE_TIME = 1000 * 30;
+
+const ROOT_KEY = 'admin-moderation';
+
+export const adminModerationKeys = {
+  root: [ROOT_KEY] as const,
+  reviews: (filter: ReviewModerationFilter) => [ROOT_KEY, 'reviews', filter] as const,
+  evictions: () => [ROOT_KEY, 'evictions'] as const,
+};
+
+export type AdminReviewsInfiniteResult = UseInfiniteQueryResult<
+  InfiniteData<AdminReviewsPage>,
+  Error
+> & {
+  /** All loaded reviews flattened across pages. */
+  reviews: AdminReviewDTO[];
+};
+
+/** Paginated review moderation queue for a given filter tab. */
+export function useModerationReviews(
+  filter: ReviewModerationFilter,
+  options: { enabled?: boolean } = {},
+): AdminReviewsInfiniteResult {
+  const result = useInfiniteQuery<AdminReviewsPage, Error>({
+    queryKey: adminModerationKeys.reviews(filter),
+    initialPageParam: 1,
+    enabled: options.enabled ?? true,
+    staleTime: STALE_TIME,
+    retry: false,
+    queryFn: ({ pageParam }) =>
+      adminModerationService.getReviews(filter, pageParam as number, PAGE_SIZE),
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.page + 1 : undefined),
+  });
+
+  const reviews = useMemo<AdminReviewDTO[]>(
+    () => result.data?.pages.flatMap((page) => page.reviews) ?? [],
+    [result.data],
+  );
+
+  return { ...result, reviews };
+}
+
+export type AdminEvictionsInfiniteResult = UseInfiniteQueryResult<
+  InfiniteData<AdminEvictionsPage>,
+  Error
+> & {
+  /** All loaded queue items flattened across pages. */
+  items: EvictionModerationItem[];
+};
+
+/** Paginated eviction moderation queue (grouped per reported case). */
+export function useModerationEvictions(
+  options: { enabled?: boolean } = {},
+): AdminEvictionsInfiniteResult {
+  const result = useInfiniteQuery<AdminEvictionsPage, Error>({
+    queryKey: adminModerationKeys.evictions(),
+    initialPageParam: 1,
+    enabled: options.enabled ?? true,
+    staleTime: STALE_TIME,
+    retry: false,
+    queryFn: ({ pageParam }) =>
+      adminModerationService.getEvictions(pageParam as number, PAGE_SIZE),
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.page + 1 : undefined),
+  });
+
+  const items = useMemo<EvictionModerationItem[]>(
+    () => result.data?.pages.flatMap((page) => page.items) ?? [],
+    [result.data],
+  );
+
+  return { ...result, items };
+}
+
+export function useModerateReview(): UseMutationResult<
+  AdminReviewDTO,
+  Error,
+  { reviewId: string; action: AdminReviewModerationAction }
+> {
+  const queryClient = useQueryClient();
+  return useMutation<AdminReviewDTO, Error, { reviewId: string; action: AdminReviewModerationAction }>({
+    mutationFn: ({ reviewId, action }) => adminModerationService.moderateReview(reviewId, action),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: adminModerationKeys.root });
+    },
+  });
+}
+
+export function useModerateEviction(): UseMutationResult<
+  void,
+  Error,
+  { caseId: string; action: AdminEvictionModerationAction }
+> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, { caseId: string; action: AdminEvictionModerationAction }>({
+    mutationFn: ({ caseId, action }) => adminModerationService.moderateEviction(caseId, action),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: adminModerationKeys.evictions() });
+      // A cancelled case changes the public board too.
+      queryClient.invalidateQueries({ queryKey: ['evictions'] });
+    },
+  });
+}

--- a/packages/frontend/locales/ca-ES.json
+++ b/packages/frontend/locales/ca-ES.json
@@ -3955,5 +3955,90 @@
     "emptyReviewsDescription": "Aquesta agència encara no té ressenyes.",
     "emptyListingsTitle": "Sense anuncis",
     "emptyListingsDescription": "Aquesta agència no té anuncis actius."
+  },
+  "admin": {
+    "moderation": {
+      "title": "Cua de moderació",
+      "subtitle": "Revisa el contingut denunciat i pren mesures.",
+      "tabs": {
+        "reviews": "Ressenyes",
+        "evictions": "Desnonaments"
+      },
+      "unauthorized": {
+        "title": "No autoritzat",
+        "message": "No tens accés a la cua de moderació. Aquesta àrea està restringida als administradors de la plataforma."
+      },
+      "reviews": {
+        "filters": {
+          "under_review": "En revisió",
+          "reported": "Denunciades",
+          "removed": "Eliminades"
+        },
+        "empty": "No hi ha res per moderar aquí.",
+        "loadError": "No s'ha pogut carregar la cua de ressenyes",
+        "author": "Autor: {{id}}",
+        "untitled": "Ressenya sense títol"
+      },
+      "reviewStatus": {
+        "active": "Activa",
+        "under_review": "En revisió",
+        "removed": "Eliminada"
+      },
+      "reports": {
+        "title": "Denúncies ({{count}})"
+      },
+      "reviewReason": {
+        "fake": "Falsa",
+        "offensive": "Ofensiva",
+        "personal_data": "Dades personals",
+        "spam": "Spam",
+        "other": "Altre"
+      },
+      "evictionReason": {
+        "inaccurate": "Inexacta",
+        "scam": "Falsa",
+        "inappropriate": "Inapropiada",
+        "unavailable": "No disponible",
+        "other": "Altre"
+      },
+      "evictions": {
+        "empty": "No hi ha casos denunciats.",
+        "loadError": "No s'ha pogut carregar la cua de desnonaments",
+        "viewCase": "Veure cas",
+        "untitled": "Cas sense títol"
+      },
+      "actions": {
+        "remove": "Eliminar",
+        "restore": "Restaurar",
+        "dismissReports": "Descartar denúncies",
+        "cancelCase": "Cancel·lar cas"
+      },
+      "confirm": {
+        "review": {
+          "remove": {
+            "title": "Vols eliminar la ressenya?",
+            "message": "Això amaga la ressenya per a tothom. La podràs restaurar més tard."
+          },
+          "restore": {
+            "title": "Vols restaurar la ressenya?",
+            "message": "Això torna a fer pública la ressenya."
+          },
+          "dismiss_reports": {
+            "title": "Vols descartar les denúncies?",
+            "message": "Això esborra les denúncies i manté la ressenya activa."
+          }
+        },
+        "eviction": {
+          "remove": {
+            "title": "Vols cancel·lar el cas?",
+            "message": "Això marca el cas com a cancel·lat i resol les seves denúncies. El cas no s'elimina."
+          },
+          "dismiss_reports": {
+            "title": "Vols descartar les denúncies?",
+            "message": "Això descarta les denúncies obertes i deixa el cas sense canvis."
+          }
+        }
+      }
+    }
   }
 }

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -3890,5 +3890,90 @@
     "emptyReviewsDescription": "This agency has no reviews yet.",
     "emptyListingsTitle": "No listings",
     "emptyListingsDescription": "This agency has no active listings."
+  },
+  "admin": {
+    "moderation": {
+      "title": "Moderation queue",
+      "subtitle": "Review reported content and take action.",
+      "tabs": {
+        "reviews": "Reviews",
+        "evictions": "Evictions"
+      },
+      "unauthorized": {
+        "title": "Not authorized",
+        "message": "You don't have access to the moderation queue. This area is restricted to platform administrators."
+      },
+      "reviews": {
+        "filters": {
+          "under_review": "Under review",
+          "reported": "Reported",
+          "removed": "Removed"
+        },
+        "empty": "Nothing to moderate here.",
+        "loadError": "Couldn't load the review queue",
+        "author": "Author: {{id}}",
+        "untitled": "Untitled review"
+      },
+      "reviewStatus": {
+        "active": "Active",
+        "under_review": "Under review",
+        "removed": "Removed"
+      },
+      "reports": {
+        "title": "Reports ({{count}})"
+      },
+      "reviewReason": {
+        "fake": "Fake",
+        "offensive": "Offensive",
+        "personal_data": "Personal data",
+        "spam": "Spam",
+        "other": "Other"
+      },
+      "evictionReason": {
+        "inaccurate": "Inaccurate",
+        "scam": "Fake",
+        "inappropriate": "Inappropriate",
+        "unavailable": "Unavailable",
+        "other": "Other"
+      },
+      "evictions": {
+        "empty": "No reported cases.",
+        "loadError": "Couldn't load the eviction queue",
+        "viewCase": "View case",
+        "untitled": "Untitled case"
+      },
+      "actions": {
+        "remove": "Remove",
+        "restore": "Restore",
+        "dismissReports": "Dismiss reports",
+        "cancelCase": "Cancel case"
+      },
+      "confirm": {
+        "review": {
+          "remove": {
+            "title": "Remove review?",
+            "message": "This hides the review from everyone. You can restore it later."
+          },
+          "restore": {
+            "title": "Restore review?",
+            "message": "This makes the review public again."
+          },
+          "dismiss_reports": {
+            "title": "Dismiss reports?",
+            "message": "This clears the reports and keeps the review active."
+          }
+        },
+        "eviction": {
+          "remove": {
+            "title": "Cancel case?",
+            "message": "This marks the case as cancelled and resolves its reports. The case is not deleted."
+          },
+          "dismiss_reports": {
+            "title": "Dismiss reports?",
+            "message": "This dismisses the open reports and leaves the case unchanged."
+          }
+        }
+      }
+    }
   }
 }

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -3934,5 +3934,90 @@
     "emptyReviewsDescription": "Esta agencia todavía no tiene reseñas.",
     "emptyListingsTitle": "Sin anuncios",
     "emptyListingsDescription": "Esta agencia no tiene anuncios activos."
+  },
+  "admin": {
+    "moderation": {
+      "title": "Cola de moderación",
+      "subtitle": "Revisa el contenido denunciado y toma medidas.",
+      "tabs": {
+        "reviews": "Reseñas",
+        "evictions": "Desalojos"
+      },
+      "unauthorized": {
+        "title": "No autorizado",
+        "message": "No tienes acceso a la cola de moderación. Esta área está restringida a los administradores de la plataforma."
+      },
+      "reviews": {
+        "filters": {
+          "under_review": "En revisión",
+          "reported": "Denunciadas",
+          "removed": "Eliminadas"
+        },
+        "empty": "No hay nada que moderar aquí.",
+        "loadError": "No se pudo cargar la cola de reseñas",
+        "author": "Autor: {{id}}",
+        "untitled": "Reseña sin título"
+      },
+      "reviewStatus": {
+        "active": "Activa",
+        "under_review": "En revisión",
+        "removed": "Eliminada"
+      },
+      "reports": {
+        "title": "Denuncias ({{count}})"
+      },
+      "reviewReason": {
+        "fake": "Falsa",
+        "offensive": "Ofensiva",
+        "personal_data": "Datos personales",
+        "spam": "Spam",
+        "other": "Otro"
+      },
+      "evictionReason": {
+        "inaccurate": "Inexacta",
+        "scam": "Falsa",
+        "inappropriate": "Inapropiada",
+        "unavailable": "No disponible",
+        "other": "Otro"
+      },
+      "evictions": {
+        "empty": "No hay casos denunciados.",
+        "loadError": "No se pudo cargar la cola de desalojos",
+        "viewCase": "Ver caso",
+        "untitled": "Caso sin título"
+      },
+      "actions": {
+        "remove": "Eliminar",
+        "restore": "Restaurar",
+        "dismissReports": "Descartar denuncias",
+        "cancelCase": "Cancelar caso"
+      },
+      "confirm": {
+        "review": {
+          "remove": {
+            "title": "¿Eliminar reseña?",
+            "message": "Esto oculta la reseña para todos. Podrás restaurarla más tarde."
+          },
+          "restore": {
+            "title": "¿Restaurar reseña?",
+            "message": "Esto vuelve a hacer pública la reseña."
+          },
+          "dismiss_reports": {
+            "title": "¿Descartar denuncias?",
+            "message": "Esto borra las denuncias y mantiene la reseña activa."
+          }
+        },
+        "eviction": {
+          "remove": {
+            "title": "¿Cancelar caso?",
+            "message": "Esto marca el caso como cancelado y resuelve sus denuncias. El caso no se elimina."
+          },
+          "dismiss_reports": {
+            "title": "¿Descartar denuncias?",
+            "message": "Esto descarta las denuncias abiertas y deja el caso sin cambios."
+          }
+        }
+      }
+    }
   }
 }

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -3939,5 +3939,90 @@
     "emptyReviewsDescription": "Questa agenzia non ha ancora recensioni.",
     "emptyListingsTitle": "Nessun annuncio",
     "emptyListingsDescription": "Questa agenzia non ha annunci attivi."
+  },
+  "admin": {
+    "moderation": {
+      "title": "Coda di moderazione",
+      "subtitle": "Esamina i contenuti segnalati e intervieni.",
+      "tabs": {
+        "reviews": "Recensioni",
+        "evictions": "Sfratti"
+      },
+      "unauthorized": {
+        "title": "Non autorizzato",
+        "message": "Non hai accesso alla coda di moderazione. Quest'area è riservata agli amministratori della piattaforma."
+      },
+      "reviews": {
+        "filters": {
+          "under_review": "In revisione",
+          "reported": "Segnalate",
+          "removed": "Rimosse"
+        },
+        "empty": "Non c'è nulla da moderare qui.",
+        "loadError": "Impossibile caricare la coda delle recensioni",
+        "author": "Autore: {{id}}",
+        "untitled": "Recensione senza titolo"
+      },
+      "reviewStatus": {
+        "active": "Attiva",
+        "under_review": "In revisione",
+        "removed": "Rimossa"
+      },
+      "reports": {
+        "title": "Segnalazioni ({{count}})"
+      },
+      "reviewReason": {
+        "fake": "Falsa",
+        "offensive": "Offensiva",
+        "personal_data": "Dati personali",
+        "spam": "Spam",
+        "other": "Altro"
+      },
+      "evictionReason": {
+        "inaccurate": "Inesatta",
+        "scam": "Falsa",
+        "inappropriate": "Inappropriata",
+        "unavailable": "Non disponibile",
+        "other": "Altro"
+      },
+      "evictions": {
+        "empty": "Nessun caso segnalato.",
+        "loadError": "Impossibile caricare la coda degli sfratti",
+        "viewCase": "Vedi caso",
+        "untitled": "Caso senza titolo"
+      },
+      "actions": {
+        "remove": "Rimuovi",
+        "restore": "Ripristina",
+        "dismissReports": "Ignora segnalazioni",
+        "cancelCase": "Annulla caso"
+      },
+      "confirm": {
+        "review": {
+          "remove": {
+            "title": "Rimuovere la recensione?",
+            "message": "Questo nasconde la recensione a tutti. Potrai ripristinarla in seguito."
+          },
+          "restore": {
+            "title": "Ripristinare la recensione?",
+            "message": "Questo rende di nuovo pubblica la recensione."
+          },
+          "dismiss_reports": {
+            "title": "Ignorare le segnalazioni?",
+            "message": "Questo cancella le segnalazioni e mantiene la recensione attiva."
+          }
+        },
+        "eviction": {
+          "remove": {
+            "title": "Annullare il caso?",
+            "message": "Questo segna il caso come annullato e risolve le sue segnalazioni. Il caso non viene eliminato."
+          },
+          "dismiss_reports": {
+            "title": "Ignorare le segnalazioni?",
+            "message": "Questo ignora le segnalazioni aperte e lascia il caso invariato."
+          }
+        }
+      }
+    }
   }
 }

--- a/packages/frontend/services/adminModerationService.ts
+++ b/packages/frontend/services/adminModerationService.ts
@@ -1,0 +1,104 @@
+/**
+ * Admin moderation service — transport for the platform trust & safety queue.
+ *
+ * Thin class over the Oxy-linked `api` client (`@/utils/api` + `normalizeEnvelope`).
+ * Every route is admin-gated server-side (`requireAdmin`); a caller who is not on
+ * the admin allowlist gets a 403, which the client surfaces as an `ApiError` with
+ * `status: 403` — the screen uses that to render its "not authorised" state
+ * (there is NO client-side role logic). The backend wraps its responses in
+ * `{ success, <key>, pagination, ... }`; `normalizeEnvelope` keeps that object on
+ * `response.data`, so each method reads the named key it needs.
+ */
+
+import { api } from '@/utils/api';
+import type {
+  AdminReviewDTO,
+  AdminReviewModerationAction,
+  AdminEvictionModerationAction,
+  EvictionModerationItem,
+} from '@homiio/shared-types';
+
+/** Review queue filter — one paginated server set per tab of the queue. */
+export type ReviewModerationFilter = 'under_review' | 'reported' | 'removed';
+
+interface Pagination {
+  currentPage: number;
+  totalPages: number;
+  total?: number;
+  limit: number;
+}
+
+/** One page of the review moderation queue. */
+export interface AdminReviewsPage {
+  reviews: AdminReviewDTO[];
+  hasMore: boolean;
+  totalPages: number;
+  page: number;
+}
+
+/** One page of the eviction moderation queue (grouped per reported case). */
+export interface AdminEvictionsPage {
+  items: EvictionModerationItem[];
+  hasMore: boolean;
+  totalPages: number;
+  page: number;
+}
+
+const toArray = <T>(value: unknown): T[] => (Array.isArray(value) ? (value as T[]) : []);
+
+class AdminModerationService {
+  async getReviews(
+    filter: ReviewModerationFilter,
+    page = 1,
+    limit = 20,
+  ): Promise<AdminReviewsPage> {
+    const { data } = await api.get<{
+      reviews?: AdminReviewDTO[];
+      hasMore?: boolean;
+      totalPages?: number;
+      pagination?: Pagination;
+    }>('/api/admin/moderation/reviews', { params: { filter, page, limit } });
+    return {
+      reviews: toArray<AdminReviewDTO>(data.reviews),
+      hasMore: data.hasMore ?? false,
+      totalPages: data.totalPages ?? data.pagination?.totalPages ?? 1,
+      page: data.pagination?.currentPage ?? page,
+    };
+  }
+
+  async moderateReview(
+    reviewId: string,
+    action: AdminReviewModerationAction,
+  ): Promise<AdminReviewDTO> {
+    const { data } = await api.post<{ review: AdminReviewDTO }>(
+      `/api/admin/moderation/reviews/${reviewId}`,
+      { action },
+    );
+    return data.review;
+  }
+
+  async getEvictions(page = 1, limit = 20): Promise<AdminEvictionsPage> {
+    const { data } = await api.get<{
+      cases?: EvictionModerationItem[];
+      hasMore?: boolean;
+      totalPages?: number;
+      pagination?: Pagination;
+    }>('/api/admin/moderation/evictions', { params: { page, limit } });
+    return {
+      items: toArray<EvictionModerationItem>(data.cases),
+      hasMore: data.hasMore ?? false,
+      totalPages: data.totalPages ?? data.pagination?.totalPages ?? 1,
+      page: data.pagination?.currentPage ?? page,
+    };
+  }
+
+  async moderateEviction(
+    caseId: string,
+    action: AdminEvictionModerationAction,
+  ): Promise<void> {
+    await api.post(`/api/admin/moderation/evictions/${caseId}`, { action });
+  }
+}
+
+export const adminModerationService = new AdminModerationService();
+export default adminModerationService;

--- a/packages/shared-types/src/eviction.ts
+++ b/packages/shared-types/src/eviction.ts
@@ -14,7 +14,7 @@
  */
 
 import { ISODate } from './common';
-import { ListingReportReason } from './report';
+import { ListingReportReason, ListingReportStatus } from './report';
 
 /** Lifecycle of an eviction case. Defaults to `UPCOMING` at creation. */
 export enum EvictionCaseStatus {
@@ -140,3 +140,42 @@ export interface CreateEvictionReportInput {
   details?: string;
   contactEmail?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Admin moderation queue.
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialized eviction report (`EvictionReport` document → DTO). Surfaced ONLY
+ * on the admin moderation queue — reports carry no public visibility.
+ */
+export interface EvictionReportDTO {
+  id: string;
+  caseId: string;
+  /** Oxy user id of the reporter. */
+  reporterOxyUserId: string;
+  reason: ListingReportReason;
+  details?: string;
+  contactEmail?: string;
+  status: ListingReportStatus;
+  createdAt: ISODate;
+  updatedAt: ISODate;
+}
+
+/**
+ * One grouped entry in the admin eviction moderation queue: a reported case
+ * plus its open reports (`GET /api/admin/moderation/evictions`).
+ */
+export interface EvictionModerationItem {
+  case: EvictionCase;
+  reports: EvictionReportDTO[];
+}
+
+/**
+ * Actions an admin may take on a reported case. `remove` cancels the case
+ * (non-destructive — the owner DELETE remains the only hard delete) and marks
+ * its open reports resolved; `dismiss_reports` marks its open reports
+ * dismissed and leaves the case untouched.
+ */
+export const ADMIN_EVICTION_ACTIONS = ['remove', 'dismiss_reports'] as const;
+export type AdminEvictionModerationAction = (typeof ADMIN_EVICTION_ACTIONS)[number];

--- a/packages/shared-types/src/review.ts
+++ b/packages/shared-types/src/review.ts
@@ -12,6 +12,8 @@
  * Mongoose transparently casts these string ids to `ObjectId` at the DB layer.
  */
 
+import { ISODate } from './common';
+
 // ---------------------------------------------------------------------------
 // Dimension enums — the backend model is the authority; values are verbatim.
 // ---------------------------------------------------------------------------
@@ -283,6 +285,43 @@ export interface ReviewDTO extends Review {
     zipCode?: string;
   };
 }
+
+// ---------------------------------------------------------------------------
+// Trust & safety / admin moderation.
+// ---------------------------------------------------------------------------
+
+/**
+ * A single trust & safety report embedded on a review. This is INTERNAL
+ * moderation data — the public {@link ReviewDTO} strips it (see
+ * `controllers/review/toReviewDTO.ts`). It is exposed ONLY on the admin
+ * moderation-queue projection {@link AdminReviewDTO}.
+ */
+export interface ReviewReport {
+  /** Oxy user id of the reporter. */
+  oxyUserId: string;
+  reason: ReviewReportReason;
+  /** Free-text context (present for `OTHER`, optional otherwise). */
+  details?: string;
+  createdAt: ISODate;
+}
+
+/**
+ * Admin moderation-queue projection: the full review DTO PLUS the raw
+ * `reports` array. Only ever returned by the admin moderation endpoints
+ * (`GET /api/admin/moderation/reviews`) — never by a public review read.
+ */
+export interface AdminReviewDTO extends ReviewDTO {
+  reports: ReviewReport[];
+}
+
+/**
+ * Actions an admin may take on a queued review. `remove` hides it everywhere,
+ * `restore` returns it to `active`, `dismiss_reports` clears the reports and
+ * returns it to `active`. Single source of truth for the request enum on both
+ * the backend allowlist and the frontend client.
+ */
+export const ADMIN_REVIEW_ACTIONS = ['remove', 'restore', 'dismiss_reports'] as const;
+export type AdminReviewModerationAction = (typeof ADMIN_REVIEW_ACTIONS)[number];
 
 // ---------------------------------------------------------------------------
 // Write payloads.


### PR DESCRIPTION
## Summary
- **Backend**: new `/api/admin` routes behind `requireAdmin` (env allowlist, fails closed) — `GET/POST /admin/moderation/reviews[/:reviewId]` and `/admin/moderation/evictions[/:caseId]`. Review queue filters (`under_review`|`reported`|`removed`); review actions `remove`|`restore`|`dismiss_reports`; grouped open eviction reports; eviction actions `remove` (→ `cancelled` + resolves reports, non-destructive) | `dismiss_reports`. Explicit action allowlists — no free-form status writes. `toAdminReviewDTO` reuses `toReviewDTO` but re-attaches reports (the public DTO still strips them); new `toEvictionReportDTO` serializer.
- **shared-types**: `AdminReviewDTO`/`ReviewReport`, `EvictionReportDTO`/`EvictionModerationItem`, plus the action tuples/unions consumed by both backend and frontend.
- **Frontend**: hidden route `app/admin/moderation.tsx` (no sidebar entry) — a non-admin/403 response renders a dedicated "not authorized" gate state rather than crashing; Reseñas/Desalojos Bloom-chip tabs; review + eviction rows show their reports with confirm-gated moderation actions. `adminModerationService` + `useAdminModeration` (React Query) own data fetching/mutation. i18n: `admin.moderation.*` added to all 4 locales (en/es/ca-ES/it).
- **Tests**: new `adminModeration.test.ts` integration suite — admin gate 403 on every endpoint (plus 401 unauthenticated, empty-allowlist deny-all), review remove/restore/dismiss_reports transitions, eviction remove→cancelled+resolve-reports and dismiss_reports transitions, queue filters, and admin-includes-reports vs public-strips-reports parity checks.

## Test plan
- [x] `bun run build` — shared-types, listing-providers, backend: all exit 0
- [x] Backend: `NODE_OPTIONS='--max-old-space-size=6144' bun run test` — 75 suites / 821 tests pass (includes the new 23-test `adminModeration.test.ts`, verified in isolation too)
- [x] Frontend: `bun run test` (jest) — 3 suites / 32 tests pass
- [x] Frontend: `bun run lint` — zero issues in this PR's new/changed files (`app/admin/moderation.tsx`, `services/adminModerationService.ts`, `hooks/useAdminModeration.ts`); remaining lint errors in the repo are pre-existing in files this PR does not touch (verified via `git diff` against the pre-rebase merge-base showing zero delta on those files)
- [x] Rebased cleanly onto origin/main (which now includes `feat/evictions-phase2`) — no conflicts; both the new `admin.moderation.*` locale keys and evictions-phase2's `contactLockedNotice` key coexist in all 4 locale files, validated as parseable JSON post-rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)