### PR TITLE
fix(listing-providers): escalate DataDome/Kasada 200 challenges to the browser tier

### DIFF
--- a/packages/backend/__tests__/unit/challengeParse.test.ts
+++ b/packages/backend/__tests__/unit/challengeParse.test.ts
@@ -4,10 +4,49 @@
  */
 
 import {
+  isAntiBotChallenge,
   isCloudflareChallenge,
   isDataDomeAjaxChallenge,
   isDataDomeHtmlChallenge,
 } from '@homiio/listing-providers/parse/challenge';
+
+describe('isAntiBotChallenge', () => {
+  it('flags challenge / block pages across the major anti-bot vendors', () => {
+    const walls: Record<string, string> = {
+      datadome:
+        '<html><body>Please enable JS and disable any ad blocker' +
+        '<script src="https://ct.captcha-delivery.com/c.js"></script></body></html>',
+      kasada:
+        '<html><head><script>fetch("/tl",{headers:{"x-kpsdk-ct":"a","x-kpsdk-cd":"b"}})</script></head></html>',
+      awsWaf:
+        '<html><body><script src="https://x.token.awswaf.com/x/challenge.js"></script></body></html>',
+      perimeterx:
+        '<html><body><div id="px-captcha"></div>Access to this page has been denied</body></html>',
+      cloudflare:
+        '<html><head><title>Just a moment...</title></head><body>' +
+        '<div class="cf-browser-verification"></div>/cdn-cgi/challenge-platform/h/g</body></html>',
+      incapsula:
+        '<html><body>Request unsuccessful. Incapsula incident ID: 1-234<script>_Incapsula_Resource</script></body></html>',
+      akamai: '<html><head><title>Access Denied</title></head><body>no permission</body></html>',
+    };
+    for (const [vendor, html] of Object.entries(walls)) {
+      expect([vendor, isAntiBotChallenge(html)]).toEqual([vendor, true]);
+    }
+  });
+
+  it('does NOT flag good pages that embed a passive sensor or a captcha site key', () => {
+    // A live Otodom SERP carries both of these on a real 37-listing page.
+    const goodSerp =
+      '<html><body><script>window.__cmp={"purposes":{"datadome":["C0001"]}};' +
+      'window.__CONFIG__={"googleReCaptchaApiKey":"6Ld4ej","isReCaptchaEnabled":true};</script>' +
+      '<article data-cy="listing-item">flat in Warsaw</article></body></html>';
+    expect(isAntiBotChallenge(goodSerp)).toBe(false);
+    // A page merely fronted by a CDN (Cloudflare/Akamai) is not a challenge.
+    expect(isAntiBotChallenge('<html><body>Powered by cloudflare and akamai CDN</body></html>')).toBe(
+      false,
+    );
+  });
+});
 
 describe('isDataDomeAjaxChallenge', () => {
   it('flags captcha-delivery HTML and geo challenge JSON', () => {

--- a/packages/backend/__tests__/unit/listingFetchTiers.test.ts
+++ b/packages/backend/__tests__/unit/listingFetchTiers.test.ts
@@ -63,10 +63,15 @@ describe('createListingFetchRuntime', () => {
 
 describe('fetchListingViaLadder — managed rung', () => {
   it('escalates past a blocked HTTP + browser to the managed tier', async () => {
-    // HTTP tier: bare 403 (forbidden). Browser tier: DataDome challenge body.
+    // HTTP tier: bare 403 (forbidden). Browser tier: DataDome challenge body
+    // (captcha host + interstitial text — what a real block page carries).
     (global as { fetch: unknown }).fetch = jest.fn(async () => ({ status: 403, text: async () => 'Forbidden' }));
     const runtime = createListingFetchRuntime({
-      browser: { fetch: async () => '<html>datadome captcha-delivery</html>' },
+      browser: {
+        fetch: async () =>
+          '<html><body>Please enable JS and disable any ad blocker' +
+          '<script src="https://ct.captcha-delivery.com/c.js"></script></body></html>',
+      },
       managed: { fetch: async () => BIG_OK_HTML },
     }).runtime;
     const metrics = new InMemoryProviderMetrics();

--- a/packages/backend/__tests__/unit/strategyLadder.test.ts
+++ b/packages/backend/__tests__/unit/strategyLadder.test.ts
@@ -19,6 +19,25 @@ import type { FetchRuntime } from '@homiio/listing-providers';
 
 const BIG_OK_HTML = `<!doctype html><html><body>${'<p>ok</p>'.repeat(80)}</body></html>`;
 
+/** A DataDome block served with HTTP 200 (captcha host + interstitial text). */
+const DATADOME_200_WALL =
+  `<!doctype html><html><head><title></title></head><body>` +
+  `<h1>Please enable JS and disable any ad blocker to access this site</h1>` +
+  `<script src="https://ct.captcha-delivery.com/c.js"></script>` +
+  `</body></html>`;
+
+/**
+ * A good SERP that embeds a PASSIVE DataDome sensor + reCAPTCHA site key (exactly
+ * what a live Otodom results page carries) — must classify `success`, never a
+ * challenge, so the browser tier is never invoked.
+ */
+const GOOD_SERP_WITH_SENSOR =
+  `<!doctype html><html><body>` +
+  `<script>window.__cmp={"purposes":{"datadome":["C0001"]}};` +
+  `window.__CONFIG__={"googleReCaptchaApiKey":"6Ld4ejwhatever"};</script>` +
+  `${'<article data-cy="listing-item">flat</article>'.repeat(30)}` +
+  `</body></html>`;
+
 /** Minimal runtime; `fetchViaBrowser`/`fetchViaManaged` added per test. */
 function baseRuntime(extra: Partial<FetchRuntime> = {}): FetchRuntime {
   return {
@@ -94,7 +113,7 @@ describe('fetchListingViaLadder', () => {
     mockFetch(403, 'Forbidden');
     const metrics = new InMemoryProviderMetrics();
     // Browser tier returns a DataDome challenge body → classified as challenge.
-    const runtime = baseRuntime({ fetchViaBrowser: async () => '<html>datadome captcha-delivery</html>' });
+    const runtime = baseRuntime({ fetchViaBrowser: async () => DATADOME_200_WALL });
 
     await expect(
       fetchListingViaLadder(runtime, 'https://portal.example/z', {
@@ -108,6 +127,47 @@ describe('fetchListingViaLadder', () => {
     expect(snapshot?.forbidden).toBe(1);
     expect(snapshot?.challenge).toBe(1);
     expect(snapshot?.challengeRate).toBe(1);
+  });
+
+  it('escalates a DataDome 200 challenge (HTTP tier) to the browser tier', async () => {
+    // The wall is served with HTTP 200 — only the anti-bot markers reveal it, so
+    // the ladder must escalate to the (now-live) browser tier rather than ingest
+    // it as an empty page. This is the otodom/GB regression the fix targets.
+    mockFetch(200, DATADOME_200_WALL);
+    const metrics = new InMemoryProviderMetrics();
+    const browser = jest.fn(async () => BIG_OK_HTML);
+    const runtime = baseRuntime({ fetchViaBrowser: browser });
+
+    const result = await fetchListingViaLadder(runtime, 'https://otodom.pl/x', {
+      provider: 'otodom',
+      metrics,
+      ...noDelay,
+    });
+
+    expect(result.tier).toBe('browser');
+    expect(result.html).toBe(BIG_OK_HTML);
+    expect(browser).toHaveBeenCalledTimes(1);
+    const snapshot = metrics.snapshot('otodom');
+    expect(snapshot?.challenge).toBe(1); // HTTP 200 wall classified as challenge
+    expect(snapshot?.success).toBe(1); // browser tier cleared it
+  });
+
+  it('keeps a good SERP with a passive sensor + reCAPTCHA key on the HTTP tier', async () => {
+    // A real Otodom SERP embeds a `"datadome"` consent category and a
+    // `googleReCaptchaApiKey`; those must NOT be mistaken for a challenge, so the
+    // slow browser tier is never touched.
+    mockFetch(200, GOOD_SERP_WITH_SENSOR);
+    const browser = jest.fn(async () => BIG_OK_HTML);
+    const runtime = baseRuntime({ fetchViaBrowser: browser });
+
+    const result = await fetchListingViaLadder(runtime, 'https://otodom.pl/y', {
+      provider: 'otodom',
+      ...noDelay,
+    });
+
+    expect(result.tier).toBe('http');
+    expect(result.html).toBe(GOOD_SERP_WITH_SENSOR);
+    expect(browser).not.toHaveBeenCalled();
   });
 
   it('throws ChallengeError when only HTTP is available and it is blocked', async () => {

--- a/packages/listing-providers/src/index.ts
+++ b/packages/listing-providers/src/index.ts
@@ -26,6 +26,8 @@ export * from './metrics';
 export * from './strategy';
 
 export {
+  ANTIBOT_CHALLENGE_MARKERS,
+  isAntiBotChallenge,
   isDataDomeAjaxChallenge,
   isDataDomeHtmlChallenge,
   isCloudflareChallenge,

--- a/packages/listing-providers/src/parse/challenge.ts
+++ b/packages/listing-providers/src/parse/challenge.ts
@@ -1,11 +1,72 @@
 /**
- * Shared AJAX / HTML challenge heuristics (DataDome, Cloudflare, PerimeterX).
+ * Shared AJAX / HTML challenge heuristics (DataDome, Kasada, AWS WAF,
+ * PerimeterX/HUMAN, Cloudflare, Imperva/Incapsula).
  *
  * Providers must import these — never re-copy challenge regexes per portal.
+ *
+ * CRITICAL — false positives. A portal fronted by an anti-bot vendor loads that
+ * vendor's PASSIVE sensor on EVERY good page, lists a cookie-consent category
+ * literally named after the vendor, and embeds a reCAPTCHA/hCaptcha site key in
+ * page config. Matching a bare vendor name (`datadome`, `captcha`, `recaptcha`,
+ * `cloudflare`, `akamai`) therefore flags good pages as challenges — verified
+ * against a live Otodom SERP, whose 37-listing HTML carries `"datadome":["C0001"]`
+ * in its consent config and a `googleReCaptchaApiKey`. {@link ANTIBOT_CHALLENGE_MARKERS}
+ * keys ONLY on a CHALLENGE-ONLY artefact: the vendor's captcha/challenge HOST or
+ * a block-page interstitial phrase — never a passive sensor tag or widget class.
+ * All patterns are linear (bounded quantifiers) — safe against ReDoS on ~1 MB
+ * SERP bodies.
  */
 
 const DATADOME_MARKERS =
   /captcha-delivery\.com|geo\.captcha|ct\.captcha-delivery|var\s+dd\s*=|datadome\.co\/|dd\.js/i;
+
+/**
+ * Markers that appear ONLY on an anti-bot challenge / block / captcha
+ * interstitial across the major vendors. Presence of any one means the response
+ * is a bot wall, not portal content — regardless of HTTP status (many vendors
+ * serve the wall with a 200). Consumed by {@link isAntiBotChallenge},
+ * `classifyOutcome` (the fetch ladder) and every portal warm-session detector.
+ */
+export const ANTIBOT_CHALLENGE_MARKERS: readonly RegExp[] = [
+  // DataDome — captcha iframe / redirect host + interstitial ad-block text.
+  /captcha-delivery\.com/i,
+  /please enable (?:js|javascript) and disable any ad ?blocker/i,
+  // Kasada — challenge-token header names emitted by the block bootstrap.
+  /x-kpsdk-c[dt]/i,
+  // AWS WAF — challenge / captcha token hosts.
+  /token\.awswaf\.com/i,
+  /captcha\.awswaf\.com/i,
+  // PerimeterX / HUMAN — captcha global, host + block text.
+  /_pxCaptcha/i,
+  /captcha\.px-cloud\.net/i,
+  /px-captcha/i,
+  /access to this page has been denied/i,
+  // Cloudflare — managed-challenge script path, legacy JS challenge + runtime.
+  /\/cdn-cgi\/challenge-platform\//i,
+  /cf-browser-verification/i,
+  /cf_chl_(?:opt|rt|prog|tk)/i,
+  /<title[^>]{0,120}>\s*just a moment/i,
+  /attention required!?\s*(?:\||–|-)\s*cloudflare/i,
+  // Imperva / Incapsula.
+  /_Incapsula_Resource/i,
+  /Incapsula incident ID/i,
+  // Akamai / F5 BIG-IP ASM block page (title-scoped so listing copy is safe).
+  /<title[^>]{0,120}>\s*access denied\s*<\/title>/i,
+  // Generic bot-wall interstitials.
+  /pardon our interruption/i,
+  /unusual traffic/i,
+];
+
+/**
+ * True when a response body is an anti-bot challenge / block page from any major
+ * vendor (see {@link ANTIBOT_CHALLENGE_MARKERS}). Marker-only — it does NOT flag
+ * short bodies (a small JSON payload is legitimate), so it is safe to run over
+ * both HTML SERPs and JSON tiers; portal HTML detectors add their own tiny-body
+ * heuristic on top.
+ */
+export function isAntiBotChallenge(html: string): boolean {
+  return ANTIBOT_CHALLENGE_MARKERS.some((re) => re.test(html));
+}
 
 /**
  * True when a full HTML page is still on a DataDome interstitial (not real portal
@@ -19,7 +80,7 @@ export function isDataDomeHtmlChallenge(html: string, hasContent?: boolean): boo
   if (/acceso denegado|comprueba que eres humano|verifica que eres|sentimos la interrupci|pardon our interruption/i.test(trimmed)) {
     return true;
   }
-  return DATADOME_MARKERS.test(trimmed);
+  return DATADOME_MARKERS.test(trimmed) || isAntiBotChallenge(trimmed);
 }
 
 /** True when an AJAX body is a bot challenge rather than portal JSON/HTML. */

--- a/packages/listing-providers/src/providers/gb/challenge.ts
+++ b/packages/listing-providers/src/providers/gb/challenge.ts
@@ -2,12 +2,14 @@
  * GB portal challenge heuristics shared by Rightmove, Zoopla, OnTheMarket, OpenRent.
  */
 
+import { isAntiBotChallenge } from '../../parse/challenge';
+
 /** HTML markers of a UK portal interstitial / bot wall served with HTTP 200. */
 export function isGbPortalChallenge(html: string): boolean {
   const trimmed = html.trim();
   if (trimmed.length < 200) return true;
   if (!/<html/i.test(html) && trimmed.length < 1024) return true;
-  return /just a moment|cf-browser-verification|attention required|access denied|datadome|captcha-delivery|perimeterx|px-captcha|are you a robot|unusual traffic|enable javascript and cookies/i.test(
-    html,
-  );
+  // UK-portal-specific interstitial phrases the shared vendor markers don't cover.
+  if (/are you a robot|enable javascript and cookies/i.test(html)) return true;
+  return isAntiBotChallenge(html);
 }

--- a/packages/listing-providers/src/providers/it/casaIt/index.ts
+++ b/packages/listing-providers/src/providers/it/casaIt/index.ts
@@ -23,6 +23,7 @@ import type {
 } from '../../../types';
 import { createFetchRuntime } from '../../../runtime';
 import { ChallengeError, fetchListingViaLadder } from '../../../strategy';
+import { isAntiBotChallenge } from '../../../parse/challenge';
 import { defaultProviderMetrics, type ProviderMetricsReader, type ProviderMetricsSink } from '../../../metrics';
 import type { ItSchemaListing } from '../../../parse/jsonLd';
 import { CASA_IT_BASE_URL } from './fixtures';
@@ -42,7 +43,11 @@ const MAX_SEARCH_PAGES = 3;
 
 export function isCasaItChallenge(html: string): boolean {
   if (html.trim().length < 512) return true;
-  return /datadome|captcha-delivery|accesso negato|verifica/i.test(html);
+  // Italian block-page phrases + the shared vendor markers. Bare `verifica`
+  // dropped (matches listing copy like "verifica disponibilità"); bare `datadome`
+  // dropped (passive sensor / consent name rides on good pages).
+  if (/accesso negato|verifica che sei/i.test(html)) return true;
+  return isAntiBotChallenge(html);
 }
 
 export interface CasaItProviderOptions {

--- a/packages/listing-providers/src/providers/it/idealistaIt/index.ts
+++ b/packages/listing-providers/src/providers/it/idealistaIt/index.ts
@@ -29,6 +29,7 @@ import type {
 } from '../../../types';
 import { createFetchRuntime } from '../../../runtime';
 import { ChallengeError, fetchListingViaLadder } from '../../../strategy';
+import { isAntiBotChallenge } from '../../../parse/challenge';
 import { defaultProviderMetrics, type ProviderMetricsReader, type ProviderMetricsSink } from '../../../metrics';
 import type { ItSchemaListing } from '../../../parse/jsonLd';
 import { IDEALISTA_IT_BASE_URL } from './fixtures';
@@ -60,7 +61,10 @@ const CONTENT_SELECTOR =
 
 export function isIdealistaItChallenge(html: string): boolean {
   if (html.trim().length < 512) return true;
-  return /accesso negato|verifica che sei un umano|datadome|captcha-delivery/i.test(html);
+  // Italian block-page phrases + the shared vendor markers; bare `datadome`
+  // dropped (passive sensor / consent name rides on good pages).
+  if (/accesso negato|verifica che sei un umano/i.test(html)) return true;
+  return isAntiBotChallenge(html);
 }
 
 export interface IdealistaItProviderOptions {

--- a/packages/listing-providers/src/providers/it/immobiliare/index.ts
+++ b/packages/listing-providers/src/providers/it/immobiliare/index.ts
@@ -26,6 +26,7 @@ import type {
 } from '../../../types';
 import { createFetchRuntime } from '../../../runtime';
 import { ChallengeError, fetchListingViaLadder } from '../../../strategy';
+import { isAntiBotChallenge } from '../../../parse/challenge';
 import { defaultProviderMetrics, type ProviderMetricsReader, type ProviderMetricsSink } from '../../../metrics';
 import { IMMOBILIARE_BASE_URL } from './fixtures';
 import {
@@ -45,7 +46,10 @@ const CONTENT_SELECTOR = 'a[href*="/annunci/"], main, #__NEXT_DATA__, [data-test
 
 export function isImmobiliareChallenge(html: string): boolean {
   if (html.trim().length < 512) return true;
-  return /datadome|captcha-delivery|accesso negato|verifica che sei/i.test(html);
+  // Italian block-page phrases + the shared vendor markers; bare `datadome`
+  // dropped (its passive sensor / consent name rides on good pages).
+  if (/accesso negato|verifica che sei/i.test(html)) return true;
+  return isAntiBotChallenge(html);
 }
 
 export interface ImmobiliareProviderOptions {

--- a/packages/listing-providers/src/providers/it/subito/index.ts
+++ b/packages/listing-providers/src/providers/it/subito/index.ts
@@ -26,6 +26,7 @@ import type {
 } from '../../../types';
 import { createFetchRuntime } from '../../../runtime';
 import { ChallengeError, fetchListingViaLadder } from '../../../strategy';
+import { isAntiBotChallenge } from '../../../parse/challenge';
 import { defaultProviderMetrics, type ProviderMetricsReader, type ProviderMetricsSink } from '../../../metrics';
 import { SUBITO_BASE_URL } from './fixtures';
 import {
@@ -47,7 +48,12 @@ const MAX_SEARCH_PAGES = 3;
 
 export function isSubitoChallenge(html: string): boolean {
   if (html.trim().length < 256) return true;
-  return /access denied|datadome|captcha|akamai|bot detection/i.test(html);
+  // `bot detection` is Subito's own interstitial phrase; the vendor markers
+  // (DataDome/Akamai/…) come from the shared detector. Bare `captcha`/`datadome`/
+  // `akamai` are dropped — Akamai is a CDN that also fronts good pages, and a
+  // reCAPTCHA site key lives in legit page config.
+  if (/bot detection/i.test(html)) return true;
+  return isAntiBotChallenge(html);
 }
 
 export interface SubitoProviderOptions {

--- a/packages/listing-providers/src/providers/pl/otodom/parse.ts
+++ b/packages/listing-providers/src/providers/pl/otodom/parse.ts
@@ -4,6 +4,7 @@
 
 import type { NormalizedListingContact } from '@homiio/shared-types';
 import { buildContact } from '../../../contact';
+import { isAntiBotChallenge } from '../../../parse/challenge';
 import { parseNextData, nextDataPageProps } from '../../../nextData';
 import { asNumber, asString, isRecord } from '../../../parse/guards';
 import { citySlug } from '../../../slug';
@@ -380,7 +381,14 @@ export function parseOtodomDetail(html: string, url: string): OtodomRawListing {
   return result;
 }
 
+/**
+ * True when an Otodom SERP/detail response is a bot wall rather than portal HTML.
+ * A tiny body is always a wall; otherwise defer to the shared, precise anti-bot
+ * detector. Bare `captcha`/`datadome` are deliberately NOT used — a good Otodom
+ * SERP embeds a `googleReCaptchaApiKey` and a `"datadome"` cookie-consent
+ * category, so those substrings flag real 37-listing pages as challenges.
+ */
 export function isOtodomChallenge(html: string): boolean {
   if (html.trim().length < 512) return true;
-  return /captcha|datadome|access denied|cf-challenge/i.test(html);
+  return isAntiBotChallenge(html);
 }

--- a/packages/listing-providers/src/strategy.ts
+++ b/packages/listing-providers/src/strategy.ts
@@ -28,6 +28,7 @@ import {
   hostOf,
   sleep,
 } from './http';
+import { isAntiBotChallenge } from './parse/challenge';
 import {
   defaultProviderMetrics,
   type ProviderMetricsSink,
@@ -38,21 +39,6 @@ import type { FetchRuntime, FetchRuntimeInit } from './types';
 
 /** The ordered escalation tiers a listing fetch is attempted at. */
 const DEFAULT_TIERS: readonly StrategyName[] = ['http', 'browser', 'managed'];
-
-/** Body markers that indicate an anti-bot wall rather than real listing HTML. */
-const CHALLENGE_MARKERS: readonly RegExp[] = [
-  /datadome/i,
-  /px-captcha/i,
-  /captcha-delivery/i,
-  /g-recaptcha/i,
-  /hcaptcha/i,
-  /cf-browser-verification/i,
-  /Attention Required/i, // Cloudflare
-  /Pardon Our Interruption/i,
-  /unusual traffic/i,
-  /Access Denied/i,
-  /Request unsuccessful\. Incapsula/i,
-];
 
 /**
  * Raised when every AVAILABLE tier returned an anti-bot block (403 / CAPTCHA /
@@ -71,10 +57,14 @@ export class ChallengeError extends Error {
 }
 
 /**
- * Classify a tier result. 429/503 and challenge-marked bodies are `challenge`,
- * a bare 403 is `forbidden`, other 4xx/5xx are `error`, else `success`. A
- * provider-supplied `isChallenge` catches portal-specific interstitials served
- * with a 200.
+ * Classify a tier result. 429/503 and anti-bot-challenge bodies are `challenge`,
+ * a bare 403 is `forbidden`, other 4xx/5xx are `error`, else `success`.
+ * Anti-bot detection is the shared, precise {@link isAntiBotChallenge} — it keys
+ * on vendor CHALLENGE-ONLY artefacts (captcha hosts / interstitial text), so a
+ * challenge served with HTTP 200 escalates to the browser tier while a good SERP
+ * that merely embeds a passive DataDome sensor or a reCAPTCHA site key stays
+ * `success` and never wastes a browser hop. A provider-supplied `isChallenge`
+ * catches any portal-specific 200 interstitial the shared markers miss.
  */
 export function classifyOutcome(
   status: number,
@@ -82,7 +72,7 @@ export function classifyOutcome(
   isChallenge?: (html: string) => boolean,
 ): ProviderOutcome {
   if (status === 429 || status === 503) return 'challenge';
-  if (CHALLENGE_MARKERS.some((re) => re.test(body))) return 'challenge';
+  if (isAntiBotChallenge(body)) return 'challenge';
   if (isChallenge && isChallenge(body)) return 'challenge';
   if (status === 403) return 'forbidden';
   if (status >= 400) return 'error';


### PR DESCRIPTION
## Problem (verified in prod + against live markup)

DataDome/Kasada-gated providers — **otodom** (PL), **rightmove/onthemarket/openrent** (GB), and the IT/idealista family — ingest **zero** even though the headed browser tier is now live. Two root causes, both proven against a **live otodom.pl SERP** (37 real listings) and a live rightmove SERP:

1. **Over-broad markers flag GOOD pages as challenges.** The shared ladder marker `/datadome/i` (and per-portal `/captcha/`, `/datadome/`, `/verifica/`, `/akamai/`) matched a real Otodom results page because it embeds a cookie-consent category literally named `"datadome":["C0001"]` and a `googleReCaptchaApiKey`. So a genuine 37-listing page was classified `challenge` on the HTTP tier **and** the browser tier → `ChallengeError` → discover `break` → nothing ingested. The headed browser could never "solve" a page that was never actually blocked.
2. **Real 200 walls weren't escalating.** A DataDome/Kasada block served as HTTP 200 with 0 parsed listings could be treated as an empty success, so the ladder never escalated to the browser.

## Fix — Approach (A): one precise, shared challenge detector

Added `isAntiBotChallenge` + `ANTIBOT_CHALLENGE_MARKERS` to the canonical shared module `parse/challenge.ts`, keyed **only** on vendor CHALLENGE-ONLY artefacts (never a passive sensor tag, consent category, or reCAPTCHA/hCaptcha widget):

- **DataDome:** `captcha-delivery.com`, `please enable JS and disable any ad blocker`
- **Kasada:** `x-kpsdk-ct/cd`
- **AWS WAF:** `token.awswaf.com`, `captcha.awswaf.com`
- **PerimeterX/HUMAN:** `_pxCaptcha`, `captcha.px-cloud.net`, `px-captcha`, `access to this page has been denied`
- **Cloudflare:** `/cdn-cgi/challenge-platform/`, `cf-browser-verification`, `cf_chl_*`, title-scoped `just a moment`, `attention required … cloudflare`
- **Imperva/Incapsula:** `_Incapsula_Resource`, `Incapsula incident ID`
- **Akamai/F5:** title-scoped `access denied`
- **Generic:** `pardon our interruption`, `unusual traffic`

All patterns are linear (bounded quantifiers) — ReDoS-safe on ~1 MB bodies.

`classifyOutcome` (the ladder) and the otodom / GB / subito / immobiliare / casa_it / idealista.it warm-session detectors now share it. A 200 wall → `challenge` → escalates HTTP → **headed browser**; a good SERP that merely embeds a passive sensor / captcha key → `success` and never wastes a browser hop. Working HTTP-first providers (immoweb, ML AR, kleinanzeigen, immobilienscout24) are untouched.

## Evidence (no false positives)

Ran the new marker set against the two **live** good SERPs and 7 synthetic vendor block pages:

```
GOOD pages (must be false):   otodom=false  rightmove=false
BLOCK pages (must be true):   datadome kasada awswaf cloudflare perimeterx incapsula akamai → all true
```

## Tests

- `challengeParse.test.ts` — `isAntiBotChallenge` flags all 7 vendors; does NOT flag a good SERP with `"datadome":["C0001"]` + `googleReCaptchaApiKey`, nor a page merely fronted by a CDN.
- `strategyLadder.test.ts` — DataDome 200 wall at HTTP → escalates to browser; good SERP with passive sensor + captcha key → stays HTTP (browser never called).
- Fixed two pre-existing fixtures that used an unrealistic `captcha-delivery` (no `.com`) body.
- Full run: **52 suites / 633 tests green**; `listing-providers` build + `backend tsc --noEmit` clean.

## Deploy note

Do NOT merge yet — deploy onto the live headed worker and verify otodom/GB ingest, then enable idealista/subito/immobiliare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)