### PR TITLE
docs: no admin/moderator surfaces (CRITICAL rule)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,10 @@ Event-driven in-app notifications have **one write chokepoint**: `services/notif
 
 The frontend has **no realtime socket client** for notifications. Mailbox refresh is refetch-on-focus + React Query invalidation after writes (`NotificationContext`, `services/notificationService.ts`). See `packages/frontend/docs/NOTIFICATIONS.md`.
 
+## No Admin / Moderator Surfaces (CRITICAL)
+
+Never build admin panels, moderator queues, or privileged moderation actions on user content — the user vetoed this explicitly (the admin moderation queue, PR #229, was reverted in PR #231). The one exception is `/api/scraper/*`'s `requireAdmin` (infra tooling, not content moderation). Community-level machinery is the only moderation: per-user `reports[]` on reviews with automatic `moderationStatus: under_review` at ≥3 reports, `EvictionReport`s, and owners cancelling/deleting their own content. The `removed` moderation status is intentionally unreachable. If a future need arises, ask the user first.
+
 ## Roommates
 
 Accepted roommate requests materialize a `RoommateRelationship` document (`models/schemas/RoommateRelationshipSchema.ts`). Routes: `GET /api/roommates/relationships`, `DELETE /api/roommates/relationships/:relationshipId`. Ownership and participant resolution use `Profile.findByOxyUserId` — same rule as property/lease writes.


### PR DESCRIPTION
Codifies the "no admin/moderator surfaces" rule the user already enforced by reverting the admin moderation queue (PR #229 → PR #231): adds a `## No Admin / Moderator Surfaces (CRITICAL)` section to `AGENTS.md`, right after Notifications and before Roommates, documenting the `/api/scraper/*` `requireAdmin` exception and the community-report-only moderation model (`reports[]` auto-review threshold, `EvictionReport`s, owner-only cancel/delete) so future agents don't reintroduce admin panels or moderator queues without asking first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)