### PR TITLE
fix(currency): expand listing-currency enum to cover scraped markets

### DIFF
--- a/packages/backend/__tests__/unit/propertyCurrencyEnum.test.ts
+++ b/packages/backend/__tests__/unit/propertyCurrencyEnum.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Property currency enum coverage.
+ *
+ * Regression guard for the prod ingest failures where real listings from
+ * expansion markets were fetched but REJECTED at save because the Property
+ * currency enum was too narrow:
+ *   - `sale.currency: PLN is not a valid enum value`      (otodom, Poland)
+ *   - `longTermRent.currency: MXN is not a valid enum value` (mercadolibre_mx)
+ *
+ * The listing-currency set now lives in `@homiio/shared-types`
+ * (`LISTING_CURRENCIES`) and must cover every ingested market, while still
+ * rejecting nonsense codes. `validateSync()` runs the schema validators without
+ * touching the DB, so we assert only on the relevant currency path.
+ */
+
+import { LISTING_CURRENCIES } from '@homiio/shared-types';
+// The active Property model is registered by models/schemas/PropertySchema.ts
+// and re-exported from models/index.ts.
+const { Property } = require('../../models');
+
+/** Validation error (if any) at a nested currency path, else undefined. */
+function currencyError(
+  block: 'longTermRent' | 'shortTermRent' | 'sale',
+  currency: string,
+): { message: string } | undefined {
+  const priced =
+    block === 'longTermRent'
+      ? { longTermRent: { monthlyAmount: 1200, currency } }
+      : block === 'shortTermRent'
+        ? { shortTermRent: { nightlyRate: 90, currency } }
+        : { sale: { price: 250000, currency } };
+  const offering = block === 'sale' ? 'sale' : block === 'shortTermRent' ? 'short_term_rent' : 'long_term_rent';
+  const doc = new Property({ type: 'apartment', offerings: [offering], ...priced });
+  const error = doc.validateSync();
+  return error?.errors?.[`${block}.currency`];
+}
+
+describe('Property currency enum', () => {
+  it('accepts every centralized listing currency on every priced block', () => {
+    for (const currency of LISTING_CURRENCIES) {
+      expect(currencyError('longTermRent', currency)).toBeUndefined();
+      expect(currencyError('shortTermRent', currency)).toBeUndefined();
+      expect(currencyError('sale', currency)).toBeUndefined();
+    }
+  });
+
+  it('accepts expansion-market currencies that previously failed ingest', () => {
+    // otodom (PL) sale, mercadolibre_mx (MX) rent, zonaprop (AR) rent.
+    expect(currencyError('sale', 'PLN')).toBeUndefined();
+    expect(currencyError('longTermRent', 'MXN')).toBeUndefined();
+    expect(currencyError('longTermRent', 'ARS')).toBeUndefined();
+  });
+
+  it('still rejects a non-ISO / unsupported currency code', () => {
+    const saleErr = currencyError('sale', 'ZZZ');
+    expect(saleErr).toBeDefined();
+    expect(saleErr?.message).toContain('ZZZ');
+
+    expect(currencyError('longTermRent', 'XYZ')).toBeDefined();
+    expect(currencyError('shortTermRent', 'FOO')).toBeDefined();
+  });
+});

--- a/packages/backend/controllers/applicationController.ts
+++ b/packages/backend/controllers/applicationController.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Request, Response, NextFunction } from 'express';
+import { PAYMENT_CURRENCIES } from '@homiio/shared-types';
 import { Property, TenantApplication, Lease } from '../models';
 import { logger } from '../middlewares/logging';
 import { AppError, successResponse, paginationResponse } from '../middlewares/errorHandler';
@@ -27,7 +28,7 @@ const {
 } = require('@homiio/shared-types');
 
 /** Currency codes the Lease `rentDetails` block accepts (schema enum). */
-const LEASE_CURRENCIES = new Set(['USD', 'EUR', 'GBP', 'CAD']);
+const LEASE_CURRENCIES = new Set<string>(PAYMENT_CURRENCIES);
 const ACTIVE_LEASE_STATUSES = [LeaseStatus.DRAFT, LeaseStatus.PENDING_SIGNATURES, LeaseStatus.ACTIVE];
 
 const ALLOWED_DOCUMENT_TYPES = new Set(Object.values(TenantApplicationDocumentType));

--- a/packages/backend/controllers/neighborhoodController.ts
+++ b/packages/backend/controllers/neighborhoodController.ts
@@ -26,7 +26,7 @@ import { Types } from 'mongoose';
 import type {
   NeighborhoodMetrics,
   NeighborhoodVsCity,
-  CurrencyCode,
+  ListingCurrency,
 } from '@homiio/shared-types';
 import { Neighborhood, Address, Property, City } from '../models';
 import { AppError, successResponse } from '../middlewares/errorHandler';
@@ -193,7 +193,7 @@ async function buildMetrics(
     centroid,
     listingCount: stats.listingCount,
     averageRent: stats.rentAvg === null ? null : roundInt(stats.rentAvg),
-    currency: cityInfo.currency as CurrencyCode | undefined,
+    currency: cityInfo.currency as ListingCurrency | undefined,
     vsCity,
   };
 }

--- a/packages/backend/middlewares/validation.ts
+++ b/packages/backend/middlewares/validation.ts
@@ -5,10 +5,8 @@
 
 import { Request, Response, NextFunction } from 'express';
 import { body, param, query, validationResult } from 'express-validator';
+import { LISTING_CURRENCIES, PAYMENT_CURRENCIES } from '@homiio/shared-types';
 import { logger } from './logging';
-
-/** Currency codes accepted on every priced block (rent / sale / exchange). */
-const CURRENCY_CODES = ['USD', 'EUR', 'GBP', 'CAD', 'FAIR'];
 
 /**
  * Handle validation errors
@@ -70,14 +68,14 @@ const validateProperty = [
   body('offerings.*').isIn(['long_term_rent', 'short_term_rent', 'sale', 'exchange']).withMessage('Invalid offering type'),
   // Long-term rent block
   body('longTermRent.monthlyAmount').optional().isFloat({ gt: 0 }).withMessage('monthlyAmount must be a positive number'),
-  body('longTermRent.currency').optional().isIn(CURRENCY_CODES).withMessage('Invalid currency'),
+  body('longTermRent.currency').optional().isIn(LISTING_CURRENCIES).withMessage('Invalid currency'),
   body('longTermRent.deposit').optional().isFloat({ min: 0 }).withMessage('deposit must be non-negative'),
   body('longTermRent.applicationFee').optional().isFloat({ min: 0 }).withMessage('applicationFee must be non-negative'),
   body('longTermRent.lateFee').optional().isFloat({ min: 0 }).withMessage('lateFee must be non-negative'),
   body('longTermRent.utilities').optional().isIn(['included', 'excluded', 'partial']).withMessage('Invalid utilities value'),
   // Short-term rent block
   body('shortTermRent.nightlyRate').optional().isFloat({ gt: 0 }).withMessage('nightlyRate must be a positive number'),
-  body('shortTermRent.currency').optional().isIn(CURRENCY_CODES).withMessage('Invalid currency'),
+  body('shortTermRent.currency').optional().isIn(LISTING_CURRENCIES).withMessage('Invalid currency'),
   body('shortTermRent.cleaningFee').optional().isFloat({ min: 0 }).withMessage('cleaningFee must be non-negative'),
   body('shortTermRent.serviceFee').optional().isFloat({ min: 0 }).withMessage('serviceFee must be non-negative'),
   body('shortTermRent.taxesPercent').optional().isFloat({ min: 0, max: 100 }).withMessage('taxesPercent must be between 0 and 100'),
@@ -94,7 +92,7 @@ const validateProperty = [
   body('shortTermRent.deposit').optional().isFloat({ min: 0 }).withMessage('deposit must be non-negative'),
   // Sale block
   body('sale.price').optional().isFloat({ gt: 0 }).withMessage('sale.price must be a positive number'),
-  body('sale.currency').optional().isIn(CURRENCY_CODES).withMessage('Invalid currency'),
+  body('sale.currency').optional().isIn(LISTING_CURRENCIES).withMessage('Invalid currency'),
   // Exchange block
   body('exchange.mode').optional().isIn(['swap', 'host', 'both']).withMessage('Invalid exchange mode'),
   // Short-term calendar + booking policy
@@ -359,9 +357,6 @@ export {
   validateExchangeReview,
 };
 
-/** Review currency codes accepted by the Review schema. */
-const REVIEW_CURRENCY_CODES = ['EUR', 'USD', 'GBP', 'CAD'];
-
 /**
  * Address review create validation rules (POST /api/reviews)
  *
@@ -380,7 +375,7 @@ const validateReviewCreate = [
   body('address.country').isString().trim().notEmpty().withMessage('address.country is required'),
   body('rating').isInt({ min: 1, max: 5 }).withMessage('Rating must be an integer between 1 and 5'),
   body('price').optional().isFloat({ min: 0 }).withMessage('price must be a non-negative number'),
-  body('currency').optional().isIn(REVIEW_CURRENCY_CODES).withMessage('Invalid currency'),
+  body('currency').optional().isIn(PAYMENT_CURRENCIES).withMessage('Invalid currency'),
   body('opinion').isString().isLength({ min: 10, max: 2000 }).withMessage('opinion must be between 10 and 2000 characters'),
   body('positiveComment').optional().isString().isLength({ max: 1000 }).withMessage('positiveComment max length is 1000'),
   body('negativeComment').optional().isString().isLength({ max: 1000 }).withMessage('negativeComment max length is 1000'),
@@ -406,7 +401,7 @@ const validateReviewUpdate = [
   param('reviewId').isMongoId().withMessage('Invalid review ID'),
   body('rating').optional().isInt({ min: 1, max: 5 }).withMessage('Rating must be an integer between 1 and 5'),
   body('price').optional().isFloat({ min: 0 }).withMessage('price must be a non-negative number'),
-  body('currency').optional().isIn(REVIEW_CURRENCY_CODES).withMessage('Invalid currency'),
+  body('currency').optional().isIn(PAYMENT_CURRENCIES).withMessage('Invalid currency'),
   body('opinion').optional().isString().isLength({ min: 10, max: 2000 }).withMessage('opinion must be between 10 and 2000 characters'),
   body('positiveComment').optional().isString().isLength({ max: 1000 }).withMessage('positiveComment max length is 1000'),
   body('negativeComment').optional().isString().isLength({ max: 1000 }).withMessage('negativeComment max length is 1000'),

--- a/packages/backend/models/Property.ts
+++ b/packages/backend/models/Property.ts
@@ -16,11 +16,9 @@ import {
   OfferingType,
   ExchangeMode,
   PropertyPriceEthics,
+  LISTING_CURRENCIES,
 } from '@homiio/shared-types';
 import { validateOfferings } from './schemas/offeringValidation';
-
-/** Currency codes accepted on every priced block (rent / sale / exchange). */
-const SUPPORTED_CURRENCIES = ['USD', 'EUR', 'GBP', 'CAD', 'FAIR'] as const;
 
 // Define the Property interface
 export interface IProperty extends Document {
@@ -223,8 +221,9 @@ export interface IPropertyModel extends Model<IProperty> {
   findInPolygon(coordinates: number[][]): PropertyQuery;
 }
 
-// Per-offering priced blocks. Each currency uses the shared 5-code set; 'FAIR'
-// is 4 chars so no length cap is applied (a 3-char cap would reject it).
+// Per-offering priced blocks. Each currency uses the shared listing-currency set
+// (LISTING_CURRENCIES, covers every ingested market); 'FAIR' is 4 chars so no
+// length cap is applied (a 3-char cap would reject it).
 const longTermRentSchema = new Schema({
   monthlyAmount: {
     type: Number,
@@ -235,7 +234,7 @@ const longTermRentSchema = new Schema({
     type: String,
     required: true,
     uppercase: true,
-    enum: SUPPORTED_CURRENCIES,
+    enum: LISTING_CURRENCIES,
     default: 'EUR'
   },
   deposit: { type: Number, min: [0, 'Deposit cannot be negative'] },
@@ -254,7 +253,7 @@ const shortTermRentSchema = new Schema({
     type: String,
     required: true,
     uppercase: true,
-    enum: SUPPORTED_CURRENCIES,
+    enum: LISTING_CURRENCIES,
     default: 'EUR'
   },
   cleaningFee: { type: Number, min: [0, 'Cleaning fee cannot be negative'] },

--- a/packages/backend/models/Review.ts
+++ b/packages/backend/models/Review.ts
@@ -20,6 +20,7 @@ import {
   DepositReturn,
   ReviewModerationStatus,
   ReviewReportReason,
+  PAYMENT_CURRENCIES,
 } from '@homiio/shared-types';
 import type {
   AgencyStats,
@@ -281,7 +282,7 @@ const ReviewSchema = new Schema<IReview, IReviewModel>({
   currency: {
     type: String,
     required: [true, 'Currency is required'],
-    enum: ['EUR', 'USD', 'GBP', 'CAD'],
+    enum: PAYMENT_CURRENCIES,
     default: 'EUR'
   },
   

--- a/packages/backend/models/schemas/CitySchema.ts
+++ b/packages/backend/models/schemas/CitySchema.ts
@@ -9,8 +9,7 @@
  */
 
 const mongoose = require('mongoose');
-
-const CURRENCY_CODES = ['USD', 'EUR', 'GBP', 'CAD', 'FAIR'];
+const { LISTING_CURRENCIES } = require('@homiio/shared-types');
 
 const citySchema = new mongoose.Schema({
   name: {
@@ -63,7 +62,7 @@ const citySchema = new mongoose.Schema({
   },
   currency: {
     type: String,
-    enum: CURRENCY_CODES,
+    enum: LISTING_CURRENCIES,
     default: 'EUR'
   },
   /**

--- a/packages/backend/models/schemas/CountrySchema.ts
+++ b/packages/backend/models/schemas/CountrySchema.ts
@@ -8,8 +8,7 @@
  */
 
 const mongoose = require('mongoose');
-
-const CURRENCY_CODES = ['USD', 'EUR', 'GBP', 'CAD', 'FAIR'];
+const { LISTING_CURRENCIES } = require('@homiio/shared-types');
 
 const countrySchema = new mongoose.Schema({
   /** ISO-3166-1 alpha-2 code, uppercase (e.g. `ES`). Unique. */
@@ -36,7 +35,7 @@ const countrySchema = new mongoose.Schema({
   /** Default currency for the country. */
   currency: {
     type: String,
-    enum: CURRENCY_CODES,
+    enum: LISTING_CURRENCIES,
     default: 'EUR'
   },
   /** Optional emoji flag (e.g. `🇪🇸`). */

--- a/packages/backend/models/schemas/LeaseSchema.ts
+++ b/packages/backend/models/schemas/LeaseSchema.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Types } from 'mongoose';
+import { PAYMENT_CURRENCIES } from '@homiio/shared-types';
 import type { ILease } from '../documentTypes';
 
 const mongoose = require('mongoose');
@@ -134,7 +135,7 @@ const leaseSchema = new mongoose.Schema({
     },
     currency: {
       type: String,
-      enum: ['USD', 'EUR', 'GBP', 'CAD'],
+      enum: PAYMENT_CURRENCIES,
       default: 'USD'
     },
     dueDate: {

--- a/packages/backend/models/schemas/PropertySchema.ts
+++ b/packages/backend/models/schemas/PropertySchema.ts
@@ -21,14 +21,13 @@ const {
   AvailabilityWindowStatus,
   CancellationPolicy,
   OfferingType,
-  ExchangeMode
+  ExchangeMode,
+  LISTING_CURRENCIES
 } = require('@homiio/shared-types');
 
-/** Currency codes accepted on every priced block (rent / sale / exchange). */
-const SUPPORTED_CURRENCIES = ['USD', 'EUR', 'GBP', 'CAD', 'FAIR'];
-
-// Monthly-rent pricing block (offering: long_term_rent). 'FAIR' is 4 chars so
-// no length cap is applied — only the shared currency enum.
+// Monthly-rent pricing block (offering: long_term_rent). Currency uses the shared
+// LISTING_CURRENCIES set (covers every ingested market). 'FAIR' is 4 chars so no
+// length cap is applied — only the shared currency enum.
 const longTermRentSchema = new mongoose.Schema({
   monthlyAmount: {
     type: Number,
@@ -39,7 +38,7 @@ const longTermRentSchema = new mongoose.Schema({
     type: String,
     required: true,
     uppercase: true,
-    enum: SUPPORTED_CURRENCIES,
+    enum: LISTING_CURRENCIES,
     default: 'EUR'
   },
   deposit: {
@@ -71,7 +70,7 @@ const shortTermRentSchema = new mongoose.Schema({
     type: String,
     required: true,
     uppercase: true,
-    enum: SUPPORTED_CURRENCIES,
+    enum: LISTING_CURRENCIES,
     default: 'EUR'
   },
   cleaningFee: {
@@ -184,10 +183,10 @@ const saleSchema = new mongoose.Schema({
   currency: {
     type: String,
     uppercase: true,
-    // Shared 5-code currency set so rent/sale codes stay consistent. Note
-    // 'FAIR' is 4 chars, so no minlength/maxlength constraint (a length cap
-    // would wrongly reject 'FAIR').
-    enum: SUPPORTED_CURRENCIES
+    // Shared LISTING_CURRENCIES set so rent/sale codes stay consistent and cover
+    // every ingested market. Note 'FAIR' is 4 chars, so no minlength/maxlength
+    // constraint (a length cap would wrongly reject 'FAIR').
+    enum: LISTING_CURRENCIES
   },
   pricePerSqm: {
     type: Number,

--- a/packages/backend/utils/countryData.ts
+++ b/packages/backend/utils/countryData.ts
@@ -7,12 +7,12 @@
  * a best-effort 2-letter code derived from the name.
  */
 
-import type { CurrencyCode } from '@homiio/shared-types';
+import type { ListingCurrency } from '@homiio/shared-types';
 
 interface CountryEntry {
   code: string;
   name: string;
-  currency: CurrencyCode;
+  currency: ListingCurrency;
 }
 
 const COUNTRIES: readonly CountryEntry[] = [
@@ -34,7 +34,7 @@ const COUNTRIES: readonly CountryEntry[] = [
   { code: 'PE', name: 'Peru', currency: 'USD' },
 ];
 
-const DEFAULT_CURRENCY: CurrencyCode = 'EUR';
+const DEFAULT_CURRENCY: ListingCurrency = 'EUR';
 
 /** Common alternative spellings → canonical ISO-2 code. */
 const NAME_ALIASES: Readonly<Record<string, string>> = {
@@ -74,6 +74,6 @@ export function countryCodeToName(code: string): string | undefined {
 }
 
 /** Default currency for an ISO-2 code (EUR when unknown). */
-export function defaultCurrencyForCountry(code: string): CurrencyCode {
+export function defaultCurrencyForCountry(code: string): ListingCurrency {
   return byCode.get(code.trim().toUpperCase())?.currency ?? DEFAULT_CURRENCY;
 }

--- a/packages/shared-types/src/city.ts
+++ b/packages/shared-types/src/city.ts
@@ -8,7 +8,8 @@
  */
 
 import { Coordinates, Pagination } from './common';
-import { City, CurrencyCode } from './geo';
+import type { ListingCurrency } from './currency';
+import { City } from './geo';
 import { Property } from './property';
 
 export interface CityFilters {
@@ -68,7 +69,7 @@ export interface NeighborhoodMetrics {
    */
   averageRent: number | null;
   /** Currency the `averageRent` is denominated in (the owning city's currency). */
-  currency?: CurrencyCode;
+  currency?: ListingCurrency;
   /** Neighborhood-vs-city rent contrast, or `null` when it can't be computed. */
   vsCity: NeighborhoodVsCity | null;
 }

--- a/packages/shared-types/src/currency.ts
+++ b/packages/shared-types/src/currency.ts
@@ -1,0 +1,62 @@
+/**
+ * Currency code sets shared by the Homiio frontend and backend.
+ *
+ * There are two DISTINCT scopes — keep them separate, never merge:
+ *
+ * 1. {@link LISTING_CURRENCIES} — the price shown ON a property / city / country
+ *    listing. Homiio ingests external listings from many markets, and each portal
+ *    emits its local currency (Otodom → PLN, MercadoLibre MX → MXN, Zonaprop →
+ *    ARS, …). This set therefore MUST cover every market the provider registry
+ *    can ingest, otherwise the Property mongoose enum rejects a real listing at
+ *    ingest. `FAIR` (FairCoin) is included for the ethical-pricing exchange flow
+ *    and is the only non-ISO-4217, 4-character code.
+ *
+ * 2. {@link PAYMENT_CURRENCIES} — money that actually MOVES through Homiio's
+ *    in-app payment + partner-commission pipeline (lease rent, review-reported
+ *    rent). Kept deliberately narrow to the currencies the payout / settlement
+ *    infrastructure supports today; widen this only alongside real payment-
+ *    processor support, not because a listing exists in that currency (external
+ *    listings never enter the in-app payment flow).
+ */
+
+/**
+ * ISO-4217 codes for every market Homiio ingests, plus `FAIR` (FairCoin).
+ *
+ * Coverage (see `packages/listing-providers` provider registry):
+ * - USD: US, EC
+ * - EUR: ES, PT, IT, FR, DE, BE, NL, IE, RO (Romanian real estate is priced in EUR)
+ * - GBP: GB
+ * - CAD: CA
+ * - PLN: PL   - MXN: MX   - ARS: AR   - RON: RO   - COP: CO
+ * - CLP: CL   - PEN: PE   - BRL: BR   - AUD: AU   - AED: AE
+ * - FAIR: FairCoin (ethical-pricing / home-exchange)
+ */
+export const LISTING_CURRENCIES = [
+  'USD',
+  'EUR',
+  'GBP',
+  'CAD',
+  'PLN',
+  'MXN',
+  'ARS',
+  'RON',
+  'COP',
+  'CLP',
+  'PEN',
+  'BRL',
+  'AUD',
+  'AED',
+  'FAIR',
+] as const;
+
+/** A currency accepted on a property / city / country listing block. */
+export type ListingCurrency = (typeof LISTING_CURRENCIES)[number];
+
+/**
+ * Currencies Homiio's in-app payment + commission pipeline settles (lease rent,
+ * review-reported rent). Narrow on purpose — see the module doc.
+ */
+export const PAYMENT_CURRENCIES = ['USD', 'EUR', 'GBP', 'CAD'] as const;
+
+/** A currency accepted for in-app payment records (lease / review). */
+export type PaymentCurrency = (typeof PAYMENT_CURRENCIES)[number];

--- a/packages/shared-types/src/geo.ts
+++ b/packages/shared-types/src/geo.ts
@@ -21,9 +21,7 @@
 
 import { Coordinates } from './common';
 import { Image } from './media';
-
-/** ISO-4217-style currency code used across the geo + pricing layer. */
-export type CurrencyCode = 'USD' | 'EUR' | 'GBP' | 'CAD' | 'FAIR';
+import type { ListingCurrency } from './currency';
 
 /**
  * A geo entity's cover-image reference as serialized by the API: the bare Image
@@ -45,7 +43,7 @@ export interface Country {
   /** Canonical English display name (e.g. `Spain`). */
   name: string;
   /** Default ISO-4217 currency for the country (e.g. `EUR`). */
-  currency: CurrencyCode;
+  currency: ListingCurrency;
   /** Optional emoji flag (e.g. `🇪🇸`). */
   flag?: string;
   /** Optional BCP-47 default locale (e.g. `es-ES`). */
@@ -114,7 +112,7 @@ export interface City {
   population?: number;
   description?: string;
   averageRent?: number;
-  currency: CurrencyCode;
+  currency: ListingCurrency;
   /**
    * The city's cover photo: the `_id` of an {@link Image} with
    * `entityType: 'city'` and `entityId` equal to this city's `_id`. Set once at

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -8,6 +8,9 @@
 // Common types and enums
 export * from './common';
 
+// Currency code sets (listing-price scope vs in-app payment scope)
+export * from './currency';
+
 // Geo hierarchy entities (Country / Region / City / Neighborhood)
 export * from './geo';
 


### PR DESCRIPTION
## Problem (prod)

External listings from expansion markets are fetched successfully but **rejected at ingest** because the Property currency enum was too narrow (`['USD','EUR','GBP','CAD','FAIR']`, duplicated in ~5 places). Verified prod failures, 100+/30min:

- `Property validation failed: sale.currency: PLN is not a valid enum value` (otodom, Poland)
- `Property validation failed: longTermRent.currency: MXN is not a valid enum value` (mercadolibre_mx, Mexico)

## Fix

**Centralized** the currency lists into ONE shared source — `@homiio/shared-types` `src/currency.ts` — and consume it everywhere the constant was duplicated. Two deliberately-separate scopes:

- **`LISTING_CURRENCIES`** (property / city / country / geo listing prices) — widened to cover every ingested market: `USD, EUR, GBP, CAD, PLN, MXN, ARS, RON, COP, CLP, PEN, BRL, AUD, AED, FAIR`. Verified against what providers emit (navent → ARS/MXN/COP/CLP/PEN, otodom → PLN, mercadolibre `currency_id`, bayut → AED, realestate.com.au → AUD, realtor.ca → CAD; EUR covers ES/PT/IT/FR/DE/BE/NL/IE/RO). Consumed by `Property`, `PropertySchema`, `CitySchema`, `CountrySchema`, `middlewares/validation` property rules, and the geo `ListingCurrency` type (clean-cut rename of the old `CurrencyCode` union).
- **`PAYMENT_CURRENCIES`** (`USD/EUR/GBP/CAD`) — kept narrow: money that moves through Homiio's in-app payment + commission pipeline. Consumed by `LeaseSchema`, `Review`, `applicationController` lease-creation, and `validation` review rules.

`Reservation` / `Profile` / `Commission` currency fields have **no enum today** (free-form 3-char ISO) — left as-is (not a widening, and not the bug). The `minlength:3/maxlength:3` caps elsewhere are fine — every new code is 3-char ISO; `FAIR` (4-char) only lives on the enum blocks that never had a length cap.

## Payment-vs-listing split rationale

A listing's currency describes an external price we merely display; it must cover any market we scrape. In-app payment currency is settled/recorded through Stripe/commission infra validated only for major currencies — widening it without processor support would let a lease record money the payout pipeline can't handle. External listings never enter the in-app payment flow, so the two sets are decoupled on purpose.

## Tests

- New `__tests__/unit/propertyCurrencyEnum.test.ts`: every `LISTING_CURRENCIES` code passes `validateSync` on longTermRent/shortTermRent/sale; PLN/MXN/ARS (the prod-failing cases) pass; `ZZZ/XYZ/FOO` still reject.
- Full backend suite: **75 suites / 805 tests green**. `tsc --noEmit` clean, `bun run build` exit 0. shared-types → listing-providers → backend all build.

Do not merge until otodom/ML-MX ingest is verified in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)