### PR TITLE
fix: remove all user IP persistence (privacy: no IPs at rest)

### DIFF
--- a/packages/backend/controllers/leaseController.ts
+++ b/packages/backend/controllers/leaseController.ts
@@ -243,13 +243,12 @@ class LeaseController {
         throw new AppError('Lease not found', 404, 'LEASE_NOT_FOUND');
       }
 
-      const ipAddress = req.ip;
       let counterpartyOxyUserId: string | undefined;
       if (isLandlord(lease, oxyUserId)) {
-        await lease.signAsLandlord(ipAddress, signature);
+        await lease.signAsLandlord(signature);
         counterpartyOxyUserId = refToId(lease.tenantOxyUserId);
       } else if (refToId(lease.tenantOxyUserId) === oxyUserId) {
-        await lease.signAsTenant(ipAddress, signature);
+        await lease.signAsTenant(signature);
         counterpartyOxyUserId = refToId(lease.landlordOxyUserId);
       } else {
         throw new AppError('Access denied - you are not a party to this lease', 403, 'FORBIDDEN');

--- a/packages/backend/middlewares/logging.ts
+++ b/packages/backend/middlewares/logging.ts
@@ -125,13 +125,11 @@ const log = (level: string, message: string, meta: Record<string, unknown> = {})
 const requestLogger = (req: Request, res: Response, next: NextFunction): void => {
   const start = Date.now();
   const userAgent = req.get('User-Agent') || '';
-  const ip = req.ip || req.socket.remoteAddress;
 
   // Log request start
   logger.info('Request started', {
     method: req.method,
     url: req.originalUrl,
-    ip: ip,
     userAgent: userAgent,
     userId: req.userId || (req.user ? req.user.id : null),
     requestId: req.id || null
@@ -166,7 +164,6 @@ const requestLogger = (req: Request, res: Response, next: NextFunction): void =>
       statusCode: res.statusCode,
       duration: duration,
       contentLength: contentLength,
-      ip: ip,
       userId: req.userId || (req.user ? req.user.id : null),
       requestId: req.id || null
     });
@@ -210,68 +207,6 @@ const errorLogger = (err: LoggedError, req: Request, res: Response, next: NextFu
 };
 
 /**
- * Security event logger
- */
-const securityLogger = {
-  loginAttempt: (email: string, success: boolean, ip: string, userAgent: string): void => {
-    logger.info('Login attempt', {
-      event: 'AUTH_LOGIN_ATTEMPT',
-      email: email,
-      success: success,
-      ip: ip,
-      userAgent: userAgent
-    });
-  },
-
-  loginSuccess: (userId: string, email: string, ip: string, userAgent: string): void => {
-    logger.info('Login successful', {
-      event: 'AUTH_LOGIN_SUCCESS',
-      userId: userId,
-      email: email,
-      ip: ip,
-      userAgent: userAgent
-    });
-  },
-
-  loginFailure: (email: string, reason: string, ip: string, userAgent: string): void => {
-    logger.warn('Login failed', {
-      event: 'AUTH_LOGIN_FAILURE',
-      email: email,
-      reason: reason,
-      ip: ip,
-      userAgent: userAgent
-    });
-  },
-
-  tokenRefresh: (userId: string, ip: string): void => {
-    logger.info('Token refreshed', {
-      event: 'AUTH_TOKEN_REFRESH',
-      userId: userId,
-      ip: ip
-    });
-  },
-
-  unauthorizedAccess: (url: string, method: string, ip: string, userAgent: string): void => {
-    logger.warn('Unauthorized access attempt', {
-      event: 'SECURITY_UNAUTHORIZED_ACCESS',
-      url: url,
-      method: method,
-      ip: ip,
-      userAgent: userAgent
-    });
-  },
-
-  suspiciousActivity: (userId: string, activity: string, details: Record<string, unknown>): void => {
-    logger.warn('Suspicious activity detected', {
-      event: 'SECURITY_SUSPICIOUS_ACTIVITY',
-      userId: userId,
-      activity: activity,
-      details: details
-    });
-  }
-};
-
-/**
  * Business event logger
  */
 const businessLogger = {
@@ -308,6 +243,5 @@ export {
   logger,
   requestLogger,
   errorLogger,
-  securityLogger,
   businessLogger
 };

--- a/packages/backend/models/documentTypes.ts
+++ b/packages/backend/models/documentTypes.ts
@@ -80,8 +80,8 @@ export type ILease = Document & {
   createdAt: Date;
   updatedAt: Date;
   generatePaymentSchedule?: () => void;
-  signAsLandlord(ipAddress: string | undefined, digitalSignature?: string): Promise<ILease>;
-  signAsTenant(ipAddress: string | undefined, digitalSignature?: string): Promise<ILease>;
+  signAsLandlord(digitalSignature?: string): Promise<ILease>;
+  signAsTenant(digitalSignature?: string): Promise<ILease>;
   recordPayment(paymentId: string, amount: number, paymentMethod: string, transactionId?: string): Promise<ILease>;
   scheduleInspection(inspectionData: Loose): Promise<ILease>;
 } & Loose;

--- a/packages/backend/models/schemas/LeaseSchema.ts
+++ b/packages/backend/models/schemas/LeaseSchema.ts
@@ -23,8 +23,8 @@ interface LeaseDoc extends ILease {
     [key: string]: unknown;
   };
   signatures: {
-    landlord: { signed: boolean; signedDate?: Date; ipAddress?: string; digitalSignature?: string };
-    tenant: { signed: boolean; signedDate?: Date; ipAddress?: string; digitalSignature?: string };
+    landlord: { signed: boolean; signedDate?: Date; digitalSignature?: string };
+    tenant: { signed: boolean; signedDate?: Date; digitalSignature?: string };
   };
   inspections: Types.DocumentArray<import('mongoose').Document & Record<string, unknown>>;
   isFullySigned?: boolean;
@@ -247,7 +247,6 @@ const leaseSchema = new mongoose.Schema({
         default: false
       },
       signedDate: Date,
-      ipAddress: String,
       digitalSignature: String
     },
     tenant: {
@@ -256,7 +255,6 @@ const leaseSchema = new mongoose.Schema({
         default: false
       },
       signedDate: Date,
-      ipAddress: String,
       digitalSignature: String
     }
   },
@@ -496,11 +494,10 @@ leaseSchema.methods.generatePaymentSchedule = function(this: LeaseDoc) {
   return this.paymentSchedule;
 };
 
-leaseSchema.methods.signAsLandlord = function(this: LeaseDoc, ipAddress: string | undefined, digitalSignature?: string) {
+leaseSchema.methods.signAsLandlord = function(this: LeaseDoc, digitalSignature?: string) {
   this.signatures.landlord = {
     signed: true,
     signedDate: new Date(),
-    ipAddress: ipAddress,
     digitalSignature: digitalSignature
   };
 
@@ -513,11 +510,10 @@ leaseSchema.methods.signAsLandlord = function(this: LeaseDoc, ipAddress: string 
   return this.save();
 };
 
-leaseSchema.methods.signAsTenant = function(this: LeaseDoc, ipAddress: string | undefined, digitalSignature?: string) {
+leaseSchema.methods.signAsTenant = function(this: LeaseDoc, digitalSignature?: string) {
   this.signatures.tenant = {
     signed: true,
     signedDate: new Date(),
-    ipAddress: ipAddress,
     digitalSignature: digitalSignature
   };
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -23,6 +23,7 @@
     "test:subscription-save": "node scripts/test-subscription-save.js",
     "check:subscriptions": "node scripts/check-subscription-db.js",
     "cleanup:external-profile-id": "ts-node --transpile-only scripts/cleanup-external-profileId.ts",
+    "purge:lease-ip": "ts-node --transpile-only scripts/purge-lease-ip.ts",
     "clean": "rm -rf dist",
     "lint": "eslint . --ext .ts",
     "backfill:price-ethics": "ts-node --transpile-only scripts/backfillPriceEthics.ts"

--- a/packages/backend/scripts/purge-lease-ip.ts
+++ b/packages/backend/scripts/purge-lease-ip.ts
@@ -1,0 +1,57 @@
+// Purge persisted signer IP addresses from all lease e-signatures.
+//
+// Privacy mandate (ecosystem-wide): no user IPs at rest. The lease schema no
+// longer defines `signatures.{landlord,tenant}.ipAddress`, but historical
+// documents written before that change still carry the field. This one-shot
+// `$unset`s it from every `leases` document. The e-signature audit trail keeps
+// the `signedDate` timestamp + signer identity (Oxy account) — those are the
+// legal anchors; the IP is removed.
+//
+// Runs against the native collection (not the Mongoose model) so the `$unset`
+// of the now-removed schema paths is honored regardless of strict mode.
+//
+// Usage:
+//   ts-node --transpile-only scripts/purge-lease-ip.ts          # perform the purge
+//   DRY_RUN=1 ts-node --transpile-only scripts/purge-lease-ip.ts  # count only, no writes
+
+require('dotenv').config();
+import database from '../database/connection';
+import { Lease } from '../models';
+
+(async () => {
+  const dryRun = process.env.DRY_RUN === '1' || process.env.DRY_RUN === 'true';
+
+  const filter = {
+    $or: [
+      { 'signatures.landlord.ipAddress': { $exists: true } },
+      { 'signatures.tenant.ipAddress': { $exists: true } },
+    ],
+  };
+
+  try {
+    await database.connect();
+
+    const affected = await Lease.collection.countDocuments(filter);
+    console.log(`[purge-lease-ip] leases carrying a signer ipAddress: ${affected}`);
+
+    if (dryRun) {
+      console.log('[purge-lease-ip] DRY_RUN set — no documents modified.');
+    } else {
+      const res = await Lease.collection.updateMany(filter, {
+        $unset: {
+          'signatures.landlord.ipAddress': '',
+          'signatures.tenant.ipAddress': '',
+        },
+      });
+      console.log(
+        `[purge-lease-ip] matched=${res.matchedCount} modified=${res.modifiedCount}`
+      );
+    }
+  } catch (e) {
+    console.error('[purge-lease-ip] failed:', e instanceof Error ? e.message : e);
+    process.exitCode = 1;
+  } finally {
+    await database.disconnect().catch(() => {});
+    process.exit(process.exitCode ?? 0);
+  }
+})();

--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -1,6 +1,7 @@
 // Load environment variables first
 require('dotenv').config();
 
+import crypto from 'crypto';
 import express from "express";
 import type { Request, Response, NextFunction } from 'express';
 import cors, { type CorsOptions } from 'cors';
@@ -77,8 +78,16 @@ const isRateLimitExempt = (req: Request): boolean => {
 };
 
 /**
- * Per-user (authenticated) or per-IP (anonymous) key. Using the user id avoids
- * the shared-IP collision behind the ALB; `ipKeyGenerator` handles IPv6 subnets.
+ * Per-user (authenticated) or per-anonymous-client key. Authenticated requests
+ * key on the user id, which avoids the shared-IP collision behind the ALB.
+ *
+ * Anonymous requests key on a salted, non-reversible HMAC of the normalized
+ * client IP — the raw IP is never held at rest in the rate-limit store (privacy
+ * mandate: no user IPs at rest). `ipKeyGenerator` buckets IPv6 to its /56 subnet
+ * so a single v6 host can't rotate through its allocation to mint fresh keys; the
+ * result is HMAC'd with `IP_HASH_SALT` and namespaced `rl|`. Mirrors the
+ * semantics of OxyHQServices' `packages/api/src/utils/ipKey.ts`. `req.ip` is read
+ * transiently here and discarded — it is never logged or persisted.
  */
 const rateLimitKey = (req: Request): string => {
   const userId = req.user?.id || req.user?._id;
@@ -86,7 +95,9 @@ const rateLimitKey = (req: Request): string => {
     return `user:${userId}`;
   }
   const ip = req.ip || req.socket.remoteAddress || 'unknown';
-  return ipKeyGenerator(ip);
+  const normalized = ipKeyGenerator(ip);
+  const salt = process.env.IP_HASH_SALT || '';
+  return crypto.createHmac('sha256', salt).update(`rl|${normalized}`).digest('hex').slice(0, 24);
 };
 
 // Initialize database connection

--- a/packages/shared-types/src/lease.ts
+++ b/packages/shared-types/src/lease.ts
@@ -47,7 +47,6 @@ export interface LeaseRentDetails {
 export interface LeaseSignature {
   signed: boolean;
   signedDate?: string;
-  ipAddress?: string;
   digitalSignature?: string;
 }
 


### PR DESCRIPTION
Enforces the ecosystem-wide privacy mandate: no user IPs at rest — not in MongoDB, logs, DTOs, or store keys.

## Changes

**1. Lease e-signatures (primary leak).** Removed IP capture and persistence from the lease signing flow end to end:
- `controllers/leaseController.ts` — dropped the `req.ip` read; `signAsLandlord`/`signAsTenant` no longer take an IP arg.
- `models/schemas/LeaseSchema.ts` — removed `signatures.{landlord,tenant}.ipAddress` schema fields, writer-method params, and the `LeaseDoc` type field.
- `models/documentTypes.ts` — removed the IP param from the `signAsLandlord`/`signAsTenant` method signatures.
- `controllers/lease/toLeaseDTO.ts` — leaked via `...lease` spread; source of the value is gone, so the DTO no longer carries it.
- `shared-types/src/lease.ts` — removed `ipAddress?` from the public `LeaseSignature` contract.

The e-signature audit trail now keeps `signedDate` (timestamp) + signer identity (Oxy account) — the legal anchors. IP is gone.

**2. Request logs.** `middlewares/logging.ts` — removed the raw `ip` field from the request-started / request-completed log lines (and the prod file sink).

**3. Dead code.** Deleted the unused `securityLogger` (login/token/unauthorized loggers that carried `ip` and were exported but never called anywhere).

**4. Anonymous rate-limit key.** `server.ts` — anonymous requests now key on a salted, non-reversible HMAC-SHA256 of the `ipKeyGenerator`-normalized IP (`IP_HASH_SALT`, `rl|` namespace, hex sliced to 24), mirroring OxyHQServices `packages/api/src/utils/ipKey.ts`. `req.ip` is read transiently for the hash and never logged or persisted. Authenticated requests still key on `user:<id>`.

**5. Purge script.** Added `scripts/purge-lease-ip.ts` (`bun run purge:lease-ip`, `DRY_RUN=1` supported) that `$unset`s `signatures.{landlord,tenant}.ipAddress` from all historical `leases` documents. Not run here — to be run once after owner confirmation.

## Verification
- Sweep `grep -rn "req\.ip\b|remoteAddress|x-forwarded-for|ipAddress" packages/backend packages/shared-types` is clean except the transient hashed-key helper and the purge script.
- `shared-types`, `listing-providers`, `backend`, and `frontend` build clean (tsc).
- Backend test suite: 805 passed / 75 suites.
- `@homiio/shared-types` is an internal `workspace:*` package (not published to npm) — no publish needed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)