### PR TITLE
fix(property): stop crashing web on load, RNImage.resolveAssetSource doesn't exist there

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,6 +98,7 @@
         "date-fns": "^4.3.0",
         "expo": "~56.0.12",
         "expo-application": "~56.0.3",
+        "expo-asset": "~56.0.17",
         "expo-blur": "~56.0.3",
         "expo-build-properties": "~56.0.18",
         "expo-camera": "~56.0.8",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -37,6 +37,7 @@
     "date-fns": "^4.3.0",
     "expo": "~56.0.12",
     "expo-application": "~56.0.3",
+    "expo-asset": "~56.0.17",
     "expo-blur": "~56.0.3",
     "expo-build-properties": "~56.0.18",
     "expo-camera": "~56.0.8",

--- a/packages/frontend/utils/propertyUtils.ts
+++ b/packages/frontend/utils/propertyUtils.ts
@@ -1,4 +1,4 @@
-import { Image as RNImage } from 'react-native';
+import { Asset } from 'expo-asset';
 import { generatePropertyTitle, TitleFormat } from './propertyTitleGenerator';
 import {
   OfferingType,
@@ -467,8 +467,14 @@ export function getPropertyImageSources(
 }
 
 /** The bundled placeholder resolved once to a plain URI, so a photo whose URL is
- * missing still yields a valid, index-aligned gallery page. */
-const PLACEHOLDER_GALLERY_URI = RNImage.resolveAssetSource(propertyPlaceholder)?.uri ?? '';
+ * missing still yields a valid, index-aligned gallery page. `Asset.fromModule`
+ * (not RN core's `Image.resolveAssetSource`, which react-native-web doesn't
+ * implement) resolves synchronously and works on both native and web. A
+ * `require()`'d image is always the opaque numeric asset id `Asset.fromModule`
+ * expects (see `global.d.ts`) — `ImageSourcePropType` is only declared that
+ * broadly so it also satisfies `<Image source>` props elsewhere. */
+const PLACEHOLDER_GALLERY_URI =
+  typeof propertyPlaceholder === 'number' ? Asset.fromModule(propertyPlaceholder).uri : '';
 
 /**
  * Build the `GalleryImage[]` for the fullscreen lightbox


### PR DESCRIPTION
## Summary
**Live production regression, white screen on web.** #237 added a module-level call to `Image.resolveAssetSource(propertyPlaceholder)` in `propertyUtils.ts` to resolve the property-photo placeholder's URI for the new Bloom gallery. Confirmed via source inspection: `react-native-web`'s `Image` component doesn't implement `resolveAssetSource` at all (only `displayName` is a static on its export) — the call throws `TypeError: resolveAssetSource is not a function` immediately at module-evaluation time, before React ever renders, crashing every page that transitively imports this file.

Fix: use `Asset.fromModule` (`expo-asset`, added as an explicit dependency — was previously only a transitive one) instead. It's the Expo ecosystem's designed cross-platform abstraction for resolving a bundled `require()`'d asset to a URI synchronously, and works identically on native and web (confirmed react-native-web internally resolves `require()`'d images via its own numeric-asset-id registry, same shape as native, just not exposed as a public `Image.resolveAssetSource` method).

Verified the fix actually compiles into the shipped bundle, not just passes type/lint checks: `resolveAssetSource` no longer appears anywhere in the built web output (`grep` returned 0 matches, was present before the fix).

## Test plan
- [x] `bunx tsc --noEmit` — same 11 pre-existing, unrelated errors as `origin/main` (confirmed via diff), zero from the changed file
- [x] `eslint` on the changed file — clean
- [x] `bun run build` (web) — succeeds, and I confirmed at the bundle level (`grep resolveAssetSource dist/.../entry-*.js`) that the broken call path is fully gone from shipped output
- [ ] Live browser verification — blocked all session by a shared browser-resource conflict across concurrent Claude sessions; strongly recommend loading a property detail page on web immediately after this merges to confirm the white screen is gone