### PR TITLE
fix(frontend): bump @oxyhq/bloom to 0.34.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -85,7 +85,7 @@
         "@bitdrift/react-native": "^0.12.0",
         "@expo/vector-icons": "^15.1.1",
         "@homiio/shared-types": "workspace:*",
-        "@oxyhq/bloom": "^0.34.0",
+        "@oxyhq/bloom": "^0.34.1",
         "@oxyhq/core": "^9.0.0",
         "@oxyhq/expo-splash": "^0.1.0",
         "@oxyhq/services": "^19.0.0",
@@ -753,7 +753,7 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.34.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-OrL5KJgxjaZg81KbmPkg2c8OuC5sqUpnPqRj8MWyfEv/UYrLads9KvciD4Zw8eTRKq5Se290sOUnZYOekRLkmw=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.34.2", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-oiEK04JD5aaJ6pz35Hfui2gnuQU8T2Fc9gTyBQkC7dV8TOESxotNJDpOW9t6AcLoBqpqFuedXwIpofk+/LWuWw=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.13.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-RrG/hDl5WoOuDMv23GNAih9mPkVQUZ1ghD5aJE6Nd0ZNlr0P8lUqxYx/7riiKN/k5N7qpfz8Td2Q0aaQcVm/Ow=="],
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -24,7 +24,7 @@
     "@bitdrift/react-native": "^0.12.0",
     "@expo/vector-icons": "^15.1.1",
     "@homiio/shared-types": "workspace:*",
-    "@oxyhq/bloom": "^0.34.0",
+    "@oxyhq/bloom": "^0.34.1",
     "@oxyhq/core": "^9.0.0",
     "@oxyhq/expo-splash": "^0.1.0",
     "@oxyhq/services": "^19.0.0",


### PR DESCRIPTION
## Summary
Bumps `@oxyhq/bloom` from `^0.34.0` to `^0.34.1` (resolves to `0.34.2`, latest). Picks up the web tap-to-dismiss fix from Mention's incident today — Homiio's property lightbox was still on 0.34.0, the version with the same web dismiss regression, so it likely inherited it too. `0.34.2` is an unrelated dialog CSS fix that shipped in the meantime, harmless to pick up.

## Investigated separately, not fixed here
The user also reported the property gallery's measured-origin fly-in animation (tapped tile growing into fullscreen) doesn't happen in Homiio the way it does in Mention. Root-caused as far as static analysis allows:
- Traced react-native-web's `measureInWindow` ref chain end to end (`Pressable`/`TouchableOpacity` → `View` → `usePlatformMethods`) — structurally sound, `.measureInWindow` does get attached to the DOM node.
- Compared `usePropertyPhotoGallery`'s registry-based `open(index)` (looks up a previously-registered ref by index) against Mention's `PostAttachmentMedia.tsx` (measures the tapped element directly via a local ref at press time) — a real architectural difference, but couldn't prove it's the actual failure without live reproduction.
- Ruled out: the `onOpen` callback prop (dead code — never passed at the call site), Bloom-version staleness for the fly-in mechanism itself (unchanged since 0.33.0).
- Live browser verification has been blocked all session by a shared browser-resource conflict across concurrent Claude sessions. Not shipping a speculative fix I can't verify — recommend testing after this merges and reporting back precisely what happens (plain fade vs. nothing at all) to narrow it down further.

## Test plan
- [x] Typecheck — same 10 pre-existing, unrelated errors as origin/main
- [x] Lint — clean
- [x] `bun run build` (web) — succeeds
- [ ] Live verification of dismiss + fly-in behavior — still blocked, needs manual check