### PR TITLE
fix(frontend): bump @oxyhq/bloom to 0.34.3 (backdrop dismiss fix)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -85,7 +85,7 @@
         "@bitdrift/react-native": "^0.12.12",
         "@expo/vector-icons": "^15.1.1",
         "@homiio/shared-types": "workspace:*",
-        "@oxyhq/bloom": "^0.34.2",
+        "@oxyhq/bloom": "^0.34.3",
         "@oxyhq/core": "^12.2.1",
         "@oxyhq/expo-splash": "^0.1.0",
         "@oxyhq/services": "^22.2.0",
@@ -738,7 +738,7 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.34.2", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-oiEK04JD5aaJ6pz35Hfui2gnuQU8T2Fc9gTyBQkC7dV8TOESxotNJDpOW9t6AcLoBqpqFuedXwIpofk+/LWuWw=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.34.3", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-5Vz57ogXAn1wl+NxsSNDpAPmOQLnZmWWhj1ij3KD+cyDzC3WCGJaomWbo2vQ1j7M2tNWHhEbiUOe0kWsaXhqSw=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.15.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-2UsyiRw+dxlwKa3rY50iJvBtsbSslUJwvfA27EmB1+DM4fSXS5raNoxzZ7FBeug1A0l4TQE1qd0PjpII2uDavA=="],
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -24,7 +24,7 @@
     "@bitdrift/react-native": "^0.12.12",
     "@expo/vector-icons": "^15.1.1",
     "@homiio/shared-types": "workspace:*",
-    "@oxyhq/bloom": "^0.34.2",
+    "@oxyhq/bloom": "^0.34.3",
     "@oxyhq/core": "^12.2.1",
     "@oxyhq/expo-splash": "^0.1.0",
     "@oxyhq/services": "^22.2.0",


### PR DESCRIPTION
## Summary
Bumps `@oxyhq/bloom` to `^0.34.3`, which converts the gallery backdrop's tap-to-dismiss from a plain RN `Pressable` to `Gesture.Tap()` — fixes the reported "tapping the backdrop doesn't close it" regression on web.

## Test plan
- [x] Typecheck — same pre-existing errors as origin/main (one fewer than the prior baseline, fixed by an unrelated concurrent `@oxyhq/services`/`@oxyhq/core` bump, not this change)
- [x] Lint — clean
- [x] `bun run build` (web) — succeeds
- [ ] Live verification of backdrop-tap dismiss — recommend testing after this merges