### PR TITLE
feat(listing-providers): enrich mercadolibre + openrent data completeness

### DIFF
--- a/packages/backend/__tests__/unit/arProviders.test.ts
+++ b/packages/backend/__tests__/unit/arProviders.test.ts
@@ -141,7 +141,10 @@ describe('MercadolibreArProvider', () => {
     expect(listing.longTermRent?.currency).toBe('ARS');
     expect(listing.address.city).toBe('Capital Federal');
     expect(listing.address.neighborhood).toBe('Belgrano');
-    expect(listing.contact?.phone).toBeTruthy();
+    // A real ML VIP page gates contact behind a form and ships NO `tel:` link, so
+    // the advertiser is captured by name only. Never synthesise a phone.
+    expect(listing.contact?.agencyName).toBe('Inmobiliaria Belgrano SRL');
+    expect(listing.contact?.phone).toBeUndefined();
     // Highlighted-specs block (`BED → "2 dorm."`, `BATHROOM → "1 baño"`, `SCALE_UP → "55 m² totales"`).
     expect(listing.bedrooms).toBe(2);
     expect(listing.bathrooms).toBe(1);
@@ -150,6 +153,31 @@ describe('MercadolibreArProvider', () => {
     expect(listing.address.state).toBe('Capital Federal');
     // Full server-rendered gallery, not the single JSON-LD image.
     expect(listing.remoteImages.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // The `andes-table` striped-specs table is the only place a VIP page states
+  // construction age, floor, parking and storage. Without it those fields were
+  // silently dropped, and the JSON-LD carries no description at all.
+  it('derives structured fields from the striped-specs table', () => {
+    const payload = parseMercadolibreArDetail(
+      MERCADOLIBRE_AR_FIXTURE_DETAIL_HTML,
+      'https://departamento.mercadolibre.com.ar/MLA-3557653074-alquiler-departamento-2-ambientes-belgrano-_JM',
+    );
+
+    expect(payload.floor).toBe(8);
+    // `Antigüedad: 1 años` is a RELATIVE age, not a year — it resolves against
+    // the current year, so this assertion must not hard-code a literal.
+    expect(payload.yearBuilt).toBe(new Date().getFullYear() - 1);
+    // `Cocheras: 1` → parking, `Bauleras: 1` → storage. Both are LatAm-Spanish
+    // terms the shared canonicalizer had no alias for before this change.
+    expect(payload.parkingType).toBe('garage');
+    expect(payload.amenities).toEqual(expect.arrayContaining(['parking', 'storage', 'elevator']));
+    // `Sí`/`No` must be read as booleans, not as presence-of-row: `Ascensor: Sí`
+    // and `Balcón: Sí` are amenities, `Terraza: No` must NOT become one.
+    expect(payload.amenities).toEqual(expect.arrayContaining(['balcony']));
+    expect(payload.amenities).not.toContain('terrace');
+    // JSON-LD ships no description; the copy comes from `ui-pdp-description__content`.
+    expect(payload.description).toMatch(/Belgrano/);
   });
 
   it('throws NonHousingListingError for car item JSON', () => {

--- a/packages/backend/__tests__/unit/canonicalAmenities.test.ts
+++ b/packages/backend/__tests__/unit/canonicalAmenities.test.ts
@@ -93,4 +93,23 @@ describe('canonicalizeAmenities', () => {
       amenities: ['pool', 'garden'],
     });
   });
+
+  // MercadoLibre AR/MX use es-419 vocabulary that differs from the peninsular
+  // Spanish already covered (`garaje`, `piscina`, `trastero`). Without these the
+  // LatAm spec tables canonicalized to nothing and the amenities were dropped.
+  it('canonicalizes es-419 (LatAm) vocabulary onto the same keys as es-ES', () => {
+    expect(canonicalizeAmenities(['Cocheras']).amenities).toEqual(['parking']);
+    expect(canonicalizeAmenities(['Estacionamientos']).amenities).toEqual(['parking']);
+    expect(canonicalizeAmenities(['Alberca']).amenities).toEqual(['pool']);
+    expect(canonicalizeAmenities(['Bauleras']).amenities).toEqual(['storage']);
+    expect(canonicalizeAmenities(['Bodegas']).amenities).toEqual(['storage']);
+    expect(canonicalizeAmenities(['Con lavandería']).amenities).toEqual(['laundry_room']);
+
+    // Regional synonyms must collapse onto ONE key, not duplicate it.
+    expect(canonicalizeAmenities(['cochera', 'estacionamiento', 'garaje']).amenities).toEqual([
+      'parking',
+    ]);
+    expect(canonicalizeAmenities(['alberca', 'piscina']).amenities).toEqual(['pool']);
+    expect(canonicalizeAmenities(['baulera', 'bodega', 'trastero']).amenities).toEqual(['storage']);
+  });
 });

--- a/packages/backend/__tests__/unit/gbProviders.test.ts
+++ b/packages/backend/__tests__/unit/gbProviders.test.ts
@@ -125,6 +125,51 @@ describe('OpenRentProvider', () => {
     expect(listing.address.countryCode).toBe('GB');
     expect(listing.address.postalCode).toBe('WC2N');
   });
+
+  // The detail page has no `og:image`, so the `lightbox_item` gallery is the only
+  // image source — and it appears TWICE: once for this property and again inside
+  // the "similar properties" rail. Scraping both would attach other listings'
+  // photos to this one.
+  it('takes the gallery from the property set only, excluding similar properties', () => {
+    const payload = parseOpenRentDetail(
+      OPENRENT_FIXTURE_DETAIL_HTML,
+      'https://www.openrent.co.uk/property-to-rent/london/1-bed-flat-london-wc2n/2865841',
+    );
+
+    expect(payload.images).toHaveLength(3);
+    // Every image belongs to this listing's own CDN set.
+    for (const url of payload.images) {
+      expect(url).toContain('/listings/2493409/');
+    }
+    // The similar-properties set must not leak in.
+    expect(payload.images.join(' ')).not.toContain('2434489');
+    // Source markup is protocol-relative (`//imagescdn…`); stored URLs must be
+    // absolute https or the media ingest cannot fetch them.
+    for (const url of payload.images) {
+      expect(url.startsWith('https://')).toBe(true);
+    }
+  });
+
+  // OpenRent states area only as free text in the description ("721sq ft"), and
+  // Homiio stores square METRES.
+  it('converts the free-text square-footage in the description to square metres', () => {
+    const payload = parseOpenRentDetail(
+      OPENRENT_FIXTURE_DETAIL_HTML,
+      'https://www.openrent.co.uk/property-to-rent/london/1-bed-flat-london-wc2n/2865841',
+    );
+    // 721 sq ft ≈ 66.98 m².
+    expect(payload.squareMeters).toBe(67);
+    // Bedrooms/bathrooms come from the `text-secondary-emphasis` summary strip.
+    expect(payload.bedrooms).toBe(1);
+    expect(payload.bathrooms).toBe(1);
+
+    const listing = provider.normalize({
+      ref: { provider: 'openrent', sourceId: payload.sourceId, url: payload.url },
+      payload,
+    });
+    // The converted area must survive normalize — it was dropped before.
+    expect(listing.squareFootage).toBe(67);
+  });
 });
 
 describe('ZooplaProvider', () => {

--- a/packages/backend/__tests__/unit/latamProviders.test.ts
+++ b/packages/backend/__tests__/unit/latamProviders.test.ts
@@ -231,7 +231,10 @@ describe('MercadolibreMxProvider', () => {
     });
     expect(listing.longTermRent?.currency).toBe('MXN');
     expect(listing.address.countryCode).toBe('MX');
-    expect(listing.contact?.phone).toBeTruthy();
+    // ML VIP contact is form-gated — no `tel:` on the page, so the publisher is
+    // captured by name only rather than inventing a phone.
+    expect(listing.contact?.agencyName).toBe('Karla Ruiz');
+    expect(listing.contact?.phone).toBeUndefined();
     // Highlighted-specs block (`BED → "2 rec."`, `BATHROOM → "2 baños"`, `SCALE_UP → "72 m² totales"`).
     expect(listing.bedrooms).toBe(2);
     expect(listing.bathrooms).toBe(2);
@@ -241,5 +244,28 @@ describe('MercadolibreMxProvider', () => {
     // Full gallery, not the single JSON-LD image.
     expect(listing.remoteImages.length).toBeGreaterThanOrEqual(2);
     expect(listing.remoteImages[0]?.url).toContain('http2.mlstatic.com');
+  });
+
+  // MX exercises the other half of the spec-table logic from AR: an OLD building
+  // (large relative age) and the negative cases — a `0` count and a `No` flag
+  // must not produce an amenity.
+  it('derives structured fields from the striped-specs table (MX vocabulary)', () => {
+    const payload = parseMercadolibreMxDetail(
+      MERCADOLIBRE_MX_FIXTURE_DETAIL_HTML,
+      'https://departamento.mercadolibre.com.mx/MLM-3847653074-renta-departamento-2-recamaras-roma-_JM',
+    );
+
+    expect(payload.floor).toBe(6);
+    // `Antigüedad: 34 años` is relative to the current year — never hard-code.
+    expect(payload.yearBuilt).toBe(new Date().getFullYear() - 34);
+    // `Con lavandería: Sí` → laundry_room (es-MX alias added with this change).
+    expect(payload.amenities).toEqual(expect.arrayContaining(['laundry_room', 'elevator']));
+    // `Estacionamientos: 0` and `Bodegas: 0` are counts of zero, and
+    // `Alberca: No` / `Balcón: No` are negatives — none may become an amenity.
+    expect(payload.parkingType).toBe('none');
+    expect(payload.amenities).not.toContain('parking');
+    expect(payload.amenities).not.toContain('storage');
+    expect(payload.amenities).not.toContain('pool');
+    expect(payload.amenities).not.toContain('balcony');
   });
 });

--- a/packages/listing-providers/src/mercadolibre.ts
+++ b/packages/listing-providers/src/mercadolibre.ts
@@ -17,6 +17,9 @@ import { buildContact, contactFromUnknown, extractContactFromHtml, mergeContact 
 import { collectJsonLdNodes, findJsonLdByType } from './jsonLd';
 import { parsePreloadedState } from './nextData';
 import { citySlug } from './slug';
+import { canonicalizeAmenities } from './parse/amenities';
+import { stripHtmlToPlainText } from './parse/htmlText';
+import { deaccent } from './parse/guards';
 
 export interface MercadolibreSiteConfig {
   /** Provider id for errors (`mercadolibre_ar`). */
@@ -59,6 +62,17 @@ export interface MercadolibreRawListing {
   bedrooms?: number;
   bathrooms?: number;
   squareMeters?: number;
+  /** Unit floor number (`Número de piso de la unidad` / `Nivel`). */
+  floor?: number;
+  /** Construction year, derived from `Antigüedad` (age → year, or a bare year). */
+  yearBuilt?: number;
+  /** Covered parking spaces (`Cocheras` / `Estacionamientos`). */
+  parkingSpaces?: number;
+  parkingType?: 'none' | 'street' | 'assigned' | 'garage';
+  /** Canonical amenity slugs derived from the VIP spec table / item attributes. */
+  amenities?: string[];
+  /** Whether the listing is furnished (`Amueblado: Sí`) — hoisted to furnishedStatus. */
+  furnished?: boolean;
   address: {
     street?: string;
     city: string;
@@ -199,6 +213,8 @@ function itemToRaw(
     }),
   );
 
+  const derived = derivedFromSpecTable(attributesToSpecMap(item.attributes));
+
   const raw: MercadolibreRawListing = {
     sourceId,
     url,
@@ -207,11 +223,21 @@ function itemToRaw(
     operation,
     price,
     currency: asString(item.currency_id) ?? asString(item.currency) ?? config.defaultCurrency,
-    bedrooms: attributeValue(item.attributes, 'BEDROOMS'),
+    bedrooms: attributeValue(item.attributes, 'BEDROOMS') ?? derived.bedrooms,
     bathrooms:
-      attributeValue(item.attributes, 'FULL_BATHROOMS') ?? attributeValue(item.attributes, 'BATHROOMS'),
+      attributeValue(item.attributes, 'FULL_BATHROOMS') ??
+      attributeValue(item.attributes, 'BATHROOMS') ??
+      derived.bathrooms,
     squareMeters:
-      attributeValue(item.attributes, 'COVERED_AREA') ?? attributeValue(item.attributes, 'TOTAL_AREA'),
+      attributeValue(item.attributes, 'COVERED_AREA') ??
+      attributeValue(item.attributes, 'TOTAL_AREA') ??
+      derived.squareMeters,
+    floor: derived.floor,
+    yearBuilt: derived.yearBuilt,
+    parkingSpaces: derived.parkingSpaces,
+    parkingType: derived.parkingType,
+    amenities: derived.amenities.length > 0 ? derived.amenities : undefined,
+    furnished: derived.furnished,
     address: { street, city, region, neighborhood, countryCode: config.countryCode },
     images,
     contact,
@@ -403,6 +429,159 @@ function extractGalleryImages(html: string): string[] {
   return out;
 }
 
+/**
+ * Full VIP description copy from the server-rendered `ui-pdp-description__content`
+ * paragraph. This is the only cold-HTTP source: the JSON-LD `Product` omits
+ * `description` and the item `/description` API is OAuth-gated.
+ */
+function extractMercadolibreDescription(html: string): string | undefined {
+  const match = html.match(/ui-pdp-description__content"[^>]{0,120}>([\s\S]{0,20000}?)<\/p>/);
+  if (!match) return undefined;
+  return stripHtmlToPlainText(match[1]);
+}
+
+/**
+ * Publisher (agency / seller) display name from the `#seller_profile` link
+ * MercadoLibre renders as `Publicado por <a href="#seller_profile">NAME</a>`.
+ * VIP contact is form-gated (no `tel:`), so this name is the only advertiser
+ * signal cold HTTP exposes — captured into {@link NormalizedListingContact.agencyName}.
+ */
+function extractMercadolibreSeller(html: string): string | undefined {
+  const anchor = html.match(/href="#seller_profile"[^>]{0,120}>([^<]{1,80})<\/a>/);
+  const name = stripHtmlToPlainText(anchor?.[1] ?? '');
+  if (!name || /^(?:ver|más|mas|perfil|mercadol)/i.test(name)) return undefined;
+  return name;
+}
+
+/**
+ * Key → value rows of the VIP "striped specs" table. Each row is
+ * `<th …><div class="andes-table__header__container">KEY</div></th>` followed by
+ * `<td …><span … class="andes-table__column--value" …>VALUE</span></td>`. Both
+ * AR (`Dormitorios`, `Cocheras`, `Antigüedad`) and MX (`Recámaras`,
+ * `Estacionamientos`) render the same structure with localized labels.
+ */
+function parseMercadolibreSpecTable(html: string): Map<string, string> {
+  const out = new Map<string, string>();
+  const rowRe =
+    /andes-table__header__container">([^<]{1,80})<\/div><\/th>[\s\S]{0,400}?andes-table__column--value[^>]{0,140}>([^<]{0,120})<\/span>/g;
+  for (const match of html.matchAll(rowRe)) {
+    const key = stripHtmlToPlainText(match[1]);
+    const value = stripHtmlToPlainText(match[2]);
+    if (key && value !== undefined && !out.has(key)) out.set(key, value);
+  }
+  return out;
+}
+
+/** Convert MercadoLibre item-API `attributes[]` into the same key→value spec map. */
+function attributesToSpecMap(attrs: unknown): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!Array.isArray(attrs)) return out;
+  for (const entry of attrs) {
+    if (!isRecord(entry)) continue;
+    const name = asString(entry.name);
+    const value = asString(entry.value_name) ?? asString(entry.value_struct);
+    if (name && value && !out.has(name)) out.set(name, value);
+  }
+  return out;
+}
+
+function specInt(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const match = value.match(/\d+/);
+  return match ? Number.parseInt(match[0], 10) : undefined;
+}
+
+function isAffirmative(value: string): boolean {
+  const v = deaccent(value);
+  return v === 'si' || v === 'yes' || v === 'true';
+}
+
+/**
+ * Construction year from an `Antigüedad` value: a bare 4-digit year is used
+ * directly; an age in years (`34 años`) or a brand-new marker (`A estrenar`)
+ * resolves to `currentYear - age` / `currentYear`.
+ */
+function yearBuiltFromAntiquity(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const now = new Date().getFullYear();
+  const yearMatch = raw.match(/\b(1[89]\d{2}|20\d{2})\b/);
+  if (yearMatch) {
+    const year = Number.parseInt(yearMatch[1], 10);
+    return year >= 1850 && year <= now ? year : undefined;
+  }
+  if (/estrenar|a estrear|nuevo|construccion/.test(deaccent(raw))) return now;
+  const age = specInt(raw);
+  if (age !== undefined && age >= 0 && age <= 200) return now - age;
+  return undefined;
+}
+
+interface MercadolibreSpecDerived {
+  bedrooms?: number;
+  bathrooms?: number;
+  squareMeters?: number;
+  floor?: number;
+  yearBuilt?: number;
+  parkingSpaces?: number;
+  parkingType?: 'none' | 'garage';
+  amenities: string[];
+  furnished?: boolean;
+}
+
+/**
+ * Derive structured fields + canonical amenities from the spec table (or item
+ * attributes). Every `Sí` boolean row feeds the shared {@link canonicalizeAmenities}
+ * (so `Ascensor`/`Aire acondicionado`/`Balcón`/… collapse onto the fixed
+ * vocabulary); counts drive parking/storage; numeric rows fill bedrooms /
+ * bathrooms / area / floor; `Antigüedad` yields `yearBuilt`.
+ */
+function derivedFromSpecTable(spec: Map<string, string>): MercadolibreSpecDerived {
+  const get = (...keys: readonly string[]): string | undefined => {
+    for (const [key, value] of spec) {
+      if (keys.includes(deaccent(key))) return value;
+    }
+    return undefined;
+  };
+
+  const affirmativeLabels: string[] = [];
+  for (const [key, value] of spec) {
+    if (isAffirmative(value)) affirmativeLabels.push(key);
+  }
+  const { amenities, furnished } = canonicalizeAmenities(affirmativeLabels);
+
+  const parkingSpaces = specInt(
+    get('cocheras', 'estacionamientos', 'cochera', 'estacionamiento', 'garages', 'garage'),
+  );
+  let parkingType: 'none' | 'garage' | undefined;
+  if (parkingSpaces !== undefined) {
+    parkingType = parkingSpaces > 0 ? 'garage' : 'none';
+    if (parkingSpaces > 0 && !amenities.includes('parking')) amenities.push('parking');
+  }
+  const storageCount = specInt(get('bauleras', 'bodegas', 'baulera', 'bodega'));
+  if (storageCount !== undefined && storageCount > 0 && !amenities.includes('storage')) {
+    amenities.push('storage');
+  }
+
+  const floorRaw = get('numero de piso de la unidad', 'numero de piso', 'nivel', 'piso');
+  let floor = specInt(floorRaw);
+  if (floor === undefined && floorRaw && /planta baja|ground|^pb$/.test(deaccent(floorRaw))) {
+    floor = 0;
+  }
+
+  return {
+    bedrooms: specInt(get('dormitorios', 'recamaras', 'habitaciones')),
+    bathrooms: specInt(get('banos', 'bano')),
+    squareMeters: labelArea(
+      get('superficie total', 'superficie cubierta', 'superficie construida', 'superficie util') ?? '',
+    ),
+    floor,
+    yearBuilt: yearBuiltFromAntiquity(get('antiguedad')),
+    parkingSpaces,
+    parkingType,
+    amenities,
+    furnished: furnished || undefined,
+  };
+}
+
 export function parseMercadolibreDetail(
   config: MercadolibreSiteConfig,
   html: string,
@@ -479,18 +658,26 @@ export function parseMercadolibreDetail(
         : 'rent';
 
   const specs = extractHighlightedSpecs(html);
+  const derived = derivedFromSpecTable(parseMercadolibreSpecTable(html));
+  const agencyName = extractMercadolibreSeller(html);
 
   const raw: MercadolibreRawListing = {
     sourceId,
     url: asString(product.url) ?? url,
     title: asString(product.name),
-    description: asString(product.description),
+    description: extractMercadolibreDescription(html) ?? asString(product.description),
     operation,
     price,
     currency: asString(offer?.priceCurrency) ?? config.defaultCurrency,
-    bedrooms: specs.bedrooms,
-    bathrooms: specs.bathrooms,
-    squareMeters: specs.squareMeters,
+    bedrooms: specs.bedrooms ?? derived.bedrooms,
+    bathrooms: specs.bathrooms ?? derived.bathrooms,
+    squareMeters: specs.squareMeters ?? derived.squareMeters,
+    floor: derived.floor,
+    yearBuilt: derived.yearBuilt,
+    parkingSpaces: derived.parkingSpaces,
+    parkingType: derived.parkingType,
+    amenities: derived.amenities.length > 0 ? derived.amenities : undefined,
+    furnished: derived.furnished,
     address: {
       street: asString(address?.streetAddress),
       city,
@@ -499,7 +686,11 @@ export function parseMercadolibreDetail(
       countryCode: config.countryCode,
     },
     images,
-    contact: mergeContact(contactFromUnknown(product.seller), extractContactFromHtml(html)),
+    contact: mergeContact(
+      contactFromUnknown(product.seller),
+      extractContactFromHtml(html),
+      buildContact({ agencyName }),
+    ),
     category: 'inmuebles',
     domainId,
   };

--- a/packages/listing-providers/src/mercadolibreProvider.ts
+++ b/packages/listing-providers/src/mercadolibreProvider.ts
@@ -176,6 +176,12 @@ export function createMercadolibreProvider(
       if (listing.bedrooms !== undefined) result.bedrooms = listing.bedrooms;
       if (listing.bathrooms !== undefined) result.bathrooms = listing.bathrooms;
       if (listing.squareMeters !== undefined) result.squareFootage = listing.squareMeters;
+      if (listing.floor !== undefined) result.floor = listing.floor;
+      if (listing.yearBuilt !== undefined) result.yearBuilt = listing.yearBuilt;
+      if (listing.parkingType !== undefined) result.parkingType = listing.parkingType;
+      if (listing.parkingSpaces !== undefined) result.parkingSpaces = listing.parkingSpaces;
+      if (listing.amenities && listing.amenities.length > 0) result.amenities = listing.amenities;
+      if (listing.furnished) result.furnishedStatus = 'furnished';
       if (listing.contact) result.contact = listing.contact;
       return result;
     },

--- a/packages/listing-providers/src/parse/amenities.ts
+++ b/packages/listing-providers/src/parse/amenities.ts
@@ -124,11 +124,16 @@ const AMENITY_ALIASES: Readonly<Record<string, CanonicalAmenity | typeof FURNISH
   plaza_de_garaje: 'parking',
   plaza_garaje: 'parking',
   off_street_parking: 'parking',
+  cochera: 'parking',
+  cocheras: 'parking',
+  estacionamiento: 'parking',
+  estacionamientos: 'parking',
   // pool
   piscina: 'pool',
   swimming_pool: 'pool',
   community_pool: 'pool',
   private_pool: 'pool',
+  alberca: 'pool',
   // garden
   jardin: 'garden',
   giardino: 'garden',
@@ -140,6 +145,10 @@ const AMENITY_ALIASES: Readonly<Record<string, CanonicalAmenity | typeof FURNISH
   cantina: 'storage',
   storage_room: 'storage',
   basement: 'storage',
+  baulera: 'storage',
+  bauleras: 'storage',
+  bodega: 'storage',
+  bodegas: 'storage',
   // washing machine / laundry
   lavadora: 'washing_machine',
   lavatrice: 'washing_machine',
@@ -147,6 +156,9 @@ const AMENITY_ALIASES: Readonly<Record<string, CanonicalAmenity | typeof FURNISH
   washer_unit: 'washing_machine',
   laundry_room_unit: 'washing_machine',
   laundry: 'laundry_room',
+  lavanderia: 'laundry_room',
+  lavadero: 'laundry_room',
+  con_lavanderia: 'laundry_room',
   // dryer / dishwasher
   secadora: 'dryer',
   tumble_dryer: 'dryer',
@@ -162,6 +174,7 @@ const AMENITY_ALIASES: Readonly<Record<string, CanonicalAmenity | typeof FURNISH
   internet: 'wifi',
   wi_fi: 'wifi',
   fiber: 'wifi',
+  acceso_a_internet: 'wifi',
   // intercom / security
   portero: 'intercom',
   portero_automatico: 'intercom',

--- a/packages/listing-providers/src/providers/ar/mercadolibre/fixtures.ts
+++ b/packages/listing-providers/src/providers/ar/mercadolibre/fixtures.ts
@@ -61,6 +61,19 @@ export const MERCADOLIBRE_AR_FIXTURE_NON_HOUSING_JSON = JSON.stringify({
   ],
 });
 
+/**
+ * Recorded from a live MLA VIP (`departamento.mercadolibre.com.ar/MLA-…`),
+ * condensed to the load-bearing structure: JSON-LD `Product` (NO description —
+ * as ML actually ships it), the VIP location tracking block, the highlighted
+ * icon/label specs, the full `andes-table` striped-specs table (`Sí`/`No`
+ * booleans + `Cocheras`/`Bauleras`/`Número de piso`/`Antigüedad`), the
+ * `ui-pdp-description__content` copy, the `#seller_profile` publisher link and
+ * the server-rendered gallery. There is NO `tel:` link — VIP contact is
+ * form-gated, so the advertiser is captured by name only.
+ */
+const MERCADOLIBRE_AR_STRIPED_ROW = (key: string, value: string): string =>
+  `<tr class="andes-table__row ui-vpp-striped-specs__row"><th class="andes-table__header andes-table__header--left ui-vpp-striped-specs__row__column ui-vpp-striped-specs__row__column--id" scope="row"><div class="andes-table__header__container">${key}</div></th><td class="andes-table__column andes-table__column--left ui-vpp-striped-specs__row__column"><span class="andes-table__column--value">${value}</span></td></tr>`;
+
 export const MERCADOLIBRE_AR_FIXTURE_DETAIL_HTML = `<!DOCTYPE html><html><head>
 <script type="application/ld+json">
 {"name":"Alquiler Departamento 2 Ambientes Belgrano","image":"https://http2.mlstatic.com/fixture-ml-ar-1.jpg","offers":{"price":650000,"availability":"https://schema.org/InStock","url":"https://departamento.mercadolibre.com.ar/MLA-3557653074-alquiler-departamento-2-ambientes-belgrano-_JM","@type":"Offer","priceCurrency":"ARS"},"sku":"MLA3557653074","@context":"https://schema.org","@type":"Product","productID":"MLA3557653074"}
@@ -69,7 +82,24 @@ export const MERCADOLIBRE_AR_FIXTURE_DETAIL_HTML = `<!DOCTYPE html><html><head>
 <script>var seller={"id":"seller_profile","type":"seller_profile","state":"VISIBLE"};</script>
 <script>var vip={"domain_id":"MLA-APARTMENTS_FOR_RENT","description_type":"plain_text","city":"Capital Federal","neighborhood":"Belgrano","state":"Capital Federal","whatsapp_available":true};</script>
 <script>var specs={"attributes":[{"icon":{"id":"BED","color":"BLACK","size":"XXSMALL"},"label":{"text":"2 dorm.","color":"BLACK"}},{"icon":{"id":"BATHROOM","color":"BLACK","size":"XXSMALL"},"label":{"text":"1 baño","color":"BLACK"}},{"icon":{"id":"SCALE_UP","color":"BLACK","size":"XXSMALL"},"label":{"text":"55 m² totales","color":"BLACK"}}]};</script>
-<a href="tel:+5491155667788">Llamar</a>
+<div class="ui-pdp-seller-good-attention__store-name"><p class="ui-pdp-color--BLACK ui-pdp-seller-validated__title"><span>Publicado por </span><a target="_self" href="#seller_profile">Inmobiliaria Belgrano SRL</a></p></div>
+<section class="ui-vpp-striped-specs"><table class="andes-table"><tbody class="andes-table__body">
+${MERCADOLIBRE_AR_STRIPED_ROW('Superficie total', '55 m²')}
+${MERCADOLIBRE_AR_STRIPED_ROW('Ambientes', '3')}
+${MERCADOLIBRE_AR_STRIPED_ROW('Dormitorios', '2')}
+${MERCADOLIBRE_AR_STRIPED_ROW('Baños', '1')}
+${MERCADOLIBRE_AR_STRIPED_ROW('Cocheras', '1')}
+${MERCADOLIBRE_AR_STRIPED_ROW('Bauleras', '1')}
+${MERCADOLIBRE_AR_STRIPED_ROW('Número de piso de la unidad', '8')}
+${MERCADOLIBRE_AR_STRIPED_ROW('Antigüedad', '1 años')}
+${MERCADOLIBRE_AR_STRIPED_ROW('Ascensor', 'Sí')}
+${MERCADOLIBRE_AR_STRIPED_ROW('Aire acondicionado', 'Sí')}
+${MERCADOLIBRE_AR_STRIPED_ROW('Balcón', 'Sí')}
+${MERCADOLIBRE_AR_STRIPED_ROW('Terraza', 'No')}
+${MERCADOLIBRE_AR_STRIPED_ROW('Acceso a internet', 'Sí')}
+${MERCADOLIBRE_AR_STRIPED_ROW('Gas natural', 'Sí')}
+</tbody></table></section>
+<h2 class="ui-pdp-description__title">Descripción</h2><p class="ui-pdp-description__content">Departamento de 2 ambientes en alquiler en Belgrano. Amplio balcón al frente con vista abierta, cocina integrada al living, aire acondicionado frío/calor. A estrenar, listo para habitar.</p>
 <div class="ui-pdp-gallery">
 <a class="gallery-image__link" href="#"><img src="https://http2.mlstatic.com/D_NQ_NP_621054-MLA109844438740_042026-F-null.webp"/></a>
 <a class="gallery-image__link" href="#"><img src="https://http2.mlstatic.com/D_NQ_NP_984582-MLA109844438786_042026-F-null.webp"/></a>

--- a/packages/listing-providers/src/providers/gb/openrent/fixtures.ts
+++ b/packages/listing-providers/src/providers/gb/openrent/fixtures.ts
@@ -13,17 +13,44 @@ export const OPENRENT_FIXTURE_SEARCH_HTML = `<!doctype html>
 </body>
 </html>`;
 
+/**
+ * Recorded from a live OpenRent detail page, condensed to the load-bearing
+ * structure: the rent/beds `<title>`, the `text-secondary-emphasis` summary
+ * strip (bedrooms + bathrooms), the `lightbox_item` gallery with
+ * PROTOCOL-RELATIVE `//imagescdn.openrent.co.uk/listings/<set>/…` photos (the
+ * property's own set THEN a "similar properties" set that must be excluded), the
+ * `#descriptionText` copy carrying a free-text floor area (`721sq ft`) and the
+ * `tel:`/`mailto:` contact. og:image is intentionally absent so the gallery is
+ * the only image source.
+ */
 export const OPENRENT_FIXTURE_DETAIL_HTML = `<!doctype html>
 <html lang="en-GB">
 <head>
 <title>London - 1 Bed Flat, London, WC2N - To Rent Now for &#xA3;2,750.00 p/m</title>
-<meta property="og:image" content="https://imagescdn.openrent.co.uk/listings/2493409/o_example.JPG"/>
 <link rel="canonical" href="https://www.openrent.co.uk/property-to-rent/london/1-bed-flat-london-wc2n/2865841"/>
 </head>
 <body>
 <h1>1 Bed Flat, London, WC2N</h1>
+<ul class="property-stats">
+<li><span class="text-secondary-emphasis">1 <span class="d-none d-md-inline">bedrooms</span></span></li>
+<li><span class="text-secondary-emphasis">1 <span class="d-none d-md-inline">bathrooms</span></span></li>
+<li><span class="text-secondary-emphasis">1 <span class="d-none d-md-inline">tenant max.</span></span></li>
+</ul>
+<div data-lightbox-gallery data-lightbox-children=".lightbox_item">
+<div class="swiper">
+<a href="//imagescdn.openrent.co.uk/listings/2493409/o_1j5ggi22phduo1aab0geueid0.JPG" class="lightbox_item"><img src="//imagescdn.openrent.co.uk/listings/2493409/o_1j5ggi22phduo1aab0geueid0.JPG" class="img-fluid w-100" alt=""/></a>
+<a href="//imagescdn.openrent.co.uk/listings/2493409/o_1j5eq9icn1unn11i3n3ptpi4uf1.JPG" class="lightbox_item"><img loading=lazy src="//imagescdn.openrent.co.uk/listings/2493409/o_1j5eq9icn1unn11i3n3ptpi4uf1.JPG" class="img-fluid w-100" alt=""/></a>
+<a href="//imagescdn.openrent.co.uk/listings/2493409/o_1j5eq9hp21h9gc41p381jcc1l7u0.JPG" class="lightbox_item"><img loading=lazy src="//imagescdn.openrent.co.uk/listings/2493409/o_1j5eq9hp21h9gc41p381jcc1l7u0.JPG" class="img-fluid w-100" alt=""/></a>
+</div>
+</div>
+<div id="descriptionText" class="description-text position-relative overflow-hidden">
+<p>A modern and contemporary one bedroom flat with lovely views from its own private balcony. 721sq ft. Located in the heart of the West End, moments from Charing Cross.</p>
+</div>
+<section class="similar-properties"><div data-lightbox-gallery>
+<a href="//imagescdn.openrent.co.uk/listings/2434489/o_1inrcjgq0o53kah1tg4l0c19kic.JPG" class="lightbox_item"><img loading=lazy src="//imagescdn.openrent.co.uk/listings/2434489/o_1inrcjgq0o53kah1tg4l0c19kic.JPG" class="img-fluid" alt=""/></a>
+<a href="//imagescdn.openrent.co.uk/listings/2434489/o_1inrcjh5b1abc12de34fg5hi6jk7.JPG" class="lightbox_item"><img loading=lazy src="//imagescdn.openrent.co.uk/listings/2434489/o_1inrcjh5b1abc12de34fg5hi6jk7.JPG" class="img-fluid" alt=""/></a>
+</div></section>
 <a href="tel:02071234567">Call</a>
 <a href="mailto:landlord@example.com">Email</a>
-<img src="https://imagescdn.openrent.co.uk/listings/2493409/o_example.JPG"/>
 </body>
 </html>`;

--- a/packages/listing-providers/src/providers/gb/openrent/index.ts
+++ b/packages/listing-providers/src/providers/gb/openrent/index.ts
@@ -199,6 +199,7 @@ export class OpenRentProvider implements ListingProvider {
     if (listing.title) result.description = listing.title;
     if (listing.bedrooms !== undefined) result.bedrooms = listing.bedrooms;
     if (listing.bathrooms !== undefined) result.bathrooms = listing.bathrooms;
+    if (listing.squareMeters !== undefined) result.squareFootage = listing.squareMeters;
     if (listing.contact) result.contact = listing.contact;
     return result;
   }

--- a/packages/listing-providers/src/providers/gb/openrent/parse.ts
+++ b/packages/listing-providers/src/providers/gb/openrent/parse.ts
@@ -7,8 +7,12 @@
 
 import type { NormalizedListingContact } from '@homiio/shared-types';
 import { buildContact } from '../../../parse/contact';
+import { stripHtmlToPlainText } from '../../../parse/htmlText';
 import { isGbHousingType, rejectGbNonHousing } from '../housing';
 import { OPENRENT_BASE_URL } from './fixtures';
+
+/** Square feet → square metres (the app stores `squareFootage` in m²). */
+const SQFT_TO_SQM = 0.092903;
 
 const DETAIL_PATH_RE =
   /href="(\/property-to-rent\/[^"]+\/(\d+))"/gi;
@@ -27,6 +31,8 @@ export interface OpenRentListingJson {
   description?: string;
   bedrooms?: number;
   bathrooms?: number;
+  /** Floor area in square metres (converted from sq ft when the copy uses it). */
+  squareMeters?: number;
   propertyType?: string;
   priceAmount?: number;
   priceCurrency?: string;
@@ -61,6 +67,81 @@ export function parseOpenRentSearch(html: string): { sourceId: string; url: stri
   return [...byId.entries()].map(([sourceId, url]) => ({ sourceId, url }));
 }
 
+/**
+ * Full property gallery. OpenRent renders each photo in a `lightbox_item`
+ * anchor as a PROTOCOL-RELATIVE `<img src="//imagescdn.openrent.co.uk/listings/
+ * <photosetId>/o_….JPG">` — the `https:`-only regex used before matched just the
+ * cover (og:image). Images group by photoset id; the FIRST set is the property's
+ * own gallery, a later set belongs to the "similar properties" carousel, so only
+ * the first set is kept. Map (`staticMapPhotoForProperty`) and avatar
+ * (`userPhotos`) images live under other paths and are excluded.
+ */
+function extractOpenRentImages(html: string): string[] {
+  const bySet = new Map<string, string[]>();
+  const re =
+    /<img[^>]{0,200}\bsrc="(?:https?:)?(\/\/imagescdn\.openrent\.co\.uk\/listings\/(\d+)\/[^"]+\.(?:jpe?g|png|webp))"/gi;
+  for (const match of html.matchAll(re)) {
+    const setId = match[2];
+    const url = `https:${match[1]}`;
+    const list = bySet.get(setId) ?? [];
+    if (!list.includes(url)) list.push(url);
+    bySet.set(setId, list);
+  }
+  for (const list of bySet.values()) {
+    if (list.length > 0) return list;
+  }
+  // Fallback: any absolute listing image (e.g. og:image cover).
+  return [
+    ...new Set(
+      [...html.matchAll(/https:\/\/imagescdn\.openrent\.co\.uk\/listings\/\d+\/[^"'>\s]+/gi)].map(
+        (m) => m[0],
+      ),
+    ),
+  ];
+}
+
+/**
+ * Count from the property summary strip, e.g.
+ * `<span class="text-secondary-emphasis">2 <span …>bathrooms</span></span>`.
+ * More reliable than title parsing for bathrooms (absent from the title).
+ */
+function summaryStat(html: string, unit: string): number | undefined {
+  const re = new RegExp(
+    `text-secondary-emphasis"[^>]{0,40}>\\s*(\\d+)\\s*(?:<[^>]{0,80}>\\s*)?${unit}`,
+    'i',
+  );
+  const match = html.match(re);
+  return match ? Number.parseInt(match[1], 10) : undefined;
+}
+
+/** The `#descriptionText` block copy (used for floor-area extraction). */
+function descriptionRegion(html: string): string | undefined {
+  const idx = html.indexOf('id="descriptionText"');
+  if (idx < 0) return undefined;
+  const open = html.indexOf('>', idx);
+  if (open < 0) return undefined;
+  return stripHtmlToPlainText(html.slice(open + 1, open + 1 + 8000));
+}
+
+/**
+ * Floor area in m² from listing copy — OpenRent only exposes it as free text
+ * (`721sq ft`, `approximately 160 sqm`), never a structured field. Square feet
+ * are converted to m²; the result is sanity-bounded (5–2000 m²).
+ */
+function floorAreaSqm(text: string | undefined): number | undefined {
+  if (!text) return undefined;
+  const match = text.match(
+    /(\d[\d,]*(?:\.\d+)?)\s*(sq\s?\.?\s?ft|sqft|square\s?f(?:ee|oo)t|m²|sqm|sq\s?m|square\s?met)/i,
+  );
+  if (!match) return undefined;
+  const value = Number.parseFloat(match[1].replace(/,/g, ''));
+  if (!Number.isFinite(value) || value <= 0) return undefined;
+  const isImperial = /ft|feet|foot/i.test(match[2]);
+  const sqm = isImperial ? value * SQFT_TO_SQM : value;
+  if (sqm < 5 || sqm > 2000) return undefined;
+  return Math.round(sqm);
+}
+
 export function parseOpenRentDetail(html: string, url: string): OpenRentListingJson {
   const sourceId = openrentSourceIdFromUrl(url);
   if (!sourceId) {
@@ -81,7 +162,9 @@ export function parseOpenRentDetail(html: string, url: string): OpenRentListingJ
   const rentMatch = title?.match(/£([\d,]+\.?\d*)\s*p\/m/i);
   const priceAmount = asNumber(rentMatch?.[1]);
   const bedsMatch = title?.match(/(\d+)\s*Bed/i);
-  const bedrooms = bedsMatch ? Number.parseInt(bedsMatch[1], 10) : undefined;
+  const bedrooms = bedsMatch ? Number.parseInt(bedsMatch[1], 10) : summaryStat(html, 'bedrooms?');
+  const bathrooms = summaryStat(html, 'bathrooms?');
+  const squareMeters = floorAreaSqm(descriptionRegion(html));
 
   // "London - 1 Bed Flat, London, WC2N - To Rent..."
   let displayAddress: string | undefined;
@@ -90,13 +173,7 @@ export function parseOpenRentDetail(html: string, url: string): OpenRentListingJ
     displayAddress = addr?.[1]?.trim();
   }
 
-  const images = [
-    ...new Set(
-      [...html.matchAll(/https:\/\/imagescdn\.openrent\.co\.uk\/listings\/\d+\/[^"'>\s]+/gi)].map(
-        (m) => m[0],
-      ),
-    ),
-  ];
+  const images = extractOpenRentImages(html);
 
   const telMatch = html.match(/href="tel:([^"]+)"/i);
   const mailMatch = html.match(/href="mailto:([^"]+)"/i);
@@ -116,7 +193,9 @@ export function parseOpenRentDetail(html: string, url: string): OpenRentListingJ
     url: url.startsWith('http') ? url : `${OPENRENT_BASE_URL}${url}`,
     title,
     displayAddress,
-    bedrooms: Number.isFinite(bedrooms) ? bedrooms : undefined,
+    bedrooms: bedrooms !== undefined && Number.isFinite(bedrooms) ? bedrooms : undefined,
+    bathrooms,
+    squareMeters,
     propertyType,
     priceAmount,
     priceCurrency: 'GBP',

--- a/packages/listing-providers/src/providers/mx/mercadolibre/fixtures.ts
+++ b/packages/listing-providers/src/providers/mx/mercadolibre/fixtures.ts
@@ -61,6 +61,17 @@ export const MERCADOLIBRE_MX_FIXTURE_NON_HOUSING_JSON = JSON.stringify({
   ],
 });
 
+/**
+ * Recorded from a live MLM VIP, condensed the same way as the AR fixture: the MX
+ * striped-specs table uses MX-localized keys (`Recámaras`, `Estacionamientos`,
+ * `Bodegas`, `Con lavandería`, `Alberca`) so the shared parser must resolve both
+ * dialects. `Estacionamientos: 0` → `parkingType: 'none'`; `Antigüedad: 34 años`
+ * → `yearBuilt = currentYear - 34`; the seller here is a private person (`Karla
+ * Ruiz`) captured as the advertiser name.
+ */
+const MERCADOLIBRE_MX_STRIPED_ROW = (key: string, value: string): string =>
+  `<tr class="andes-table__row ui-vpp-striped-specs__row"><th class="andes-table__header andes-table__header--left ui-vpp-striped-specs__row__column ui-vpp-striped-specs__row__column--id" scope="row"><div class="andes-table__header__container">${key}</div></th><td class="andes-table__column andes-table__column--left ui-vpp-striped-specs__row__column"><span class="andes-table__column--value">${value}</span></td></tr>`;
+
 export const MERCADOLIBRE_MX_FIXTURE_DETAIL_HTML = `<!DOCTYPE html><html><head>
 <script type="application/ld+json">
 {"name":"Renta departamento 2 recámaras Roma","image":"https://http2.mlstatic.com/fixture-ml-mx-1.jpg","offers":{"price":28000,"availability":"https://schema.org/InStock","url":"https://departamento.mercadolibre.com.mx/MLM-3847653074-renta-departamento-2-recamaras-roma-_JM","@type":"Offer","priceCurrency":"MXN"},"sku":"MLM3847653074","@context":"https://schema.org","@type":"Product","productID":"MLM3847653074"}
@@ -69,7 +80,25 @@ export const MERCADOLIBRE_MX_FIXTURE_DETAIL_HTML = `<!DOCTYPE html><html><head>
 <script>var seller={"id":"seller_profile","type":"seller_profile","state":"VISIBLE"};</script>
 <script>var vip={"domain_id":"MLM-APARTMENTS_FOR_RENT","description_type":"plain_text","city":"Benito Juárez","neighborhood":"Roma Norte","state":"Ciudad de México"};</script>
 <script>var specs={"attributes":[{"icon":{"id":"BED","color":"BLACK","size":"XXSMALL"},"label":{"text":"2 rec.","color":"BLACK"}},{"icon":{"id":"BATHROOM","color":"BLACK","size":"XXSMALL"},"label":{"text":"2 baños","color":"BLACK"}},{"icon":{"id":"SCALE_UP","color":"BLACK","size":"XXSMALL"},"label":{"text":"72 m² totales","color":"BLACK"}}]};</script>
-<a href="tel:+525555667788">Llamar</a>
+<div class="ui-pdp-seller-good-attention__store-name"><p class="ui-pdp-color--BLACK ui-pdp-seller-validated__title"><span>Publicado por </span><a target="_self" href="#seller_profile">Karla Ruiz</a></p></div>
+<section class="ui-vpp-striped-specs"><table class="andes-table"><tbody class="andes-table__body">
+${MERCADOLIBRE_MX_STRIPED_ROW('Superficie total', '72 m²')}
+${MERCADOLIBRE_MX_STRIPED_ROW('Superficie construida', '72 m²')}
+${MERCADOLIBRE_MX_STRIPED_ROW('Recámaras', '2')}
+${MERCADOLIBRE_MX_STRIPED_ROW('Baños', '2')}
+${MERCADOLIBRE_MX_STRIPED_ROW('Estacionamientos', '0')}
+${MERCADOLIBRE_MX_STRIPED_ROW('Bodegas', '0')}
+${MERCADOLIBRE_MX_STRIPED_ROW('Número de piso de la unidad', '6')}
+${MERCADOLIBRE_MX_STRIPED_ROW('Antigüedad', '34 años')}
+${MERCADOLIBRE_MX_STRIPED_ROW('Ascensor', 'Sí')}
+${MERCADOLIBRE_MX_STRIPED_ROW('Con lavandería', 'Sí')}
+${MERCADOLIBRE_MX_STRIPED_ROW('Acceso a internet', 'Sí')}
+${MERCADOLIBRE_MX_STRIPED_ROW('Alberca', 'No')}
+${MERCADOLIBRE_MX_STRIPED_ROW('Balcón', 'No')}
+${MERCADOLIBRE_MX_STRIPED_ROW('Aire acondicionado', 'No')}
+${MERCADOLIBRE_MX_STRIPED_ROW('Amueblado', 'No')}
+</tbody></table></section>
+<h2 class="ui-pdp-description__title">Descripción</h2><p class="ui-pdp-description__content">Departamento en renta en la colonia Roma Norte. Dos recámaras, dos baños completos, edificio con elevador y área de lavandería. Excelente ubicación.</p>
 <div class="ui-pdp-gallery">
 <a class="gallery-image__link" href="#"><img src="https://http2.mlstatic.com/D_NQ_NP_620729-MLM112636094885_062026-F.webp"/></a>
 <a class="gallery-image__link" href="#"><img src="https://http2.mlstatic.com/D_NQ_NP_708821-MLM112636094891_062026-F.webp"/></a>


### PR DESCRIPTION
Rescued from an uncommitted worktree (`fix/enrich-ml-openrent`, whose committed HEAD was already merged). The parsing work was finished but had **no test coverage** and left two fixture-driven assertions stale, so it could not land as-is. This PR adds the missing coverage and fixes the stale assertions.

## MercadoLibre (AR + MX)

The `andes-table` striped-specs table is the only place a VIP page states construction age, floor, parking and storage — all of it was being dropped. Also adds description and publisher extraction, since the JSON-LD block carries neither, and maps the relative `Antigüedad` ("34 años") to an absolute year.

## OpenRent

- Gallery comes from the property's own `lightbox_item` set and **excludes the "similar properties" rail** — scraping both attached other listings' photos to this one. The page has no `og:image`, so the gallery is the only source.
- Protocol-relative `//imagescdn.openrent.co.uk/…` URLs resolved to absolute https, or media ingest cannot fetch them.
- Free-text square footage in the description ("721sq ft") converted to square metres and mapped through `normalize` (`squareFootage`).

## Shared canonicalizer

es-419 amenity aliases — `cochera`/`estacionamiento` → parking, `alberca` → pool, `baulera`/`bodega` → storage, `lavandería` → laundry_room. Without these the LatAm spec tables canonicalized to nothing.

## Tests added (5)

- **AR spec table** — floor, relative-age → year, `Cocheras`/`Bauleras` → parking/storage, and `Terraza: No` must NOT become an amenity.
- **MX spec table** — the other half of the logic: an old building, plus the negative cases (`Estacionamientos: 0`, `Bodegas: 0`, `Alberca: No`, `Balcón: No` produce nothing).
- **OpenRent gallery** — asserts all 3 images are from set `2493409`, that the similar-properties set `2434489` does not leak in, and that URLs are absolute https.
- **OpenRent area** — 721 sq ft → 67 m², surviving `normalize`.
- **Canonical amenities** — es-419 vocabulary maps onto the same keys as es-ES, and regional synonyms collapse onto ONE key rather than duplicating.

Year assertions are computed from `new Date().getFullYear()` rather than hard-coded, since `Antigüedad` is a relative age.

## Stale assertions corrected

Both ML fixtures previously contained a `tel:` link that real VIP pages do not have — ML contact is form-gated. The patch author updated the fixtures to match reality but not the tests. Rather than have the parser synthesise a phone (AGENTS.md: never invent contacts), the two tests now assert the advertiser is captured by name and that no phone is present.

## Verification

- `bun run build` green across all workspaces.
- `bun run test` green: 75/75 suites, **817/817** tests (812 on main after #244, plus the 5 new).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)