### PR TITLE
feat(auth): join the Oxy shared Android keychain

### DIFF
--- a/packages/frontend/app.config.js
+++ b/packages/frontend/app.config.js
@@ -156,6 +156,14 @@ module.exports = function (config) {
         'expo-image',
         'expo-localization',
         'expo-sharing',
+        // Android sharedUserId for cross-app authentication: every Oxy app
+        // signed with the shared ecosystem certificate joins the same UID, so
+        // the device session is shared ("sign in once, use everywhere").
+        './plugins/withSharedUserId',
+        // Reader side of the shared-identity native module (ships in
+        // @oxyhq/services): request the signature permission + <queries> so
+        // cold boot can silently read the Commons-hosted shared identity.
+        '@oxyhq/services/plugins/withSharedIdentityReader',
       ],
       extra: {
         eas: {

--- a/packages/frontend/plugins/withSharedUserId.js
+++ b/packages/frontend/plugins/withSharedUserId.js
@@ -1,0 +1,34 @@
+/**
+ * Expo Config Plugin: withSharedUserId
+ *
+ * Adds android:sharedUserId to AndroidManifest.xml to enable
+ * cross-app data sharing between Oxy apps (Mention, Homiio, etc.)
+ *
+ * This allows:
+ * - Shared cryptographic identity storage
+ * - Cross-app authentication (sign in once, use everywhere)
+ * - Shared session tokens
+ *
+ * IMPORTANT:
+ * - All Oxy apps MUST use the same sharedUserId: "so.oxy.shared"
+ * - Apps MUST be signed with the same certificate
+ * - Cannot change sharedUserId after publishing (requires reinstall)
+ *
+ * @see https://developer.android.com/guide/topics/manifest/manifest-element#uid
+ */
+
+const { withAndroidManifest } = require('expo/config-plugins');
+
+module.exports = function withSharedUserId(config) {
+  return withAndroidManifest(config, async (config) => {
+    const androidManifest = config.modResults.manifest;
+
+    // Add sharedUserId to the manifest root element
+    androidManifest.$ = {
+      ...androidManifest.$,
+      'android:sharedUserId': 'so.oxy.shared'
+    };
+
+    return config;
+  });
+};


### PR DESCRIPTION
## Summary
- Adds `android:sharedUserId` ("so.oxy.shared") via a new `withSharedUserId` config plugin, plus registers `@oxyhq/services/plugins/withSharedIdentityReader` in `packages/frontend/app.config.js`, so Homiio joins the shared Android keychain other Oxy apps (Commons, Mention, Allo) already use for cross-app "sign in once, use everywhere."
- Homiio must be built with the shared ecosystem release keystore going forward — every app sharing the UID needs the same signing certificate.

## Test plan
- [x] Baseline gate: `git stash -u` → `bun run lint` + `bunx tsc --noEmit` in `packages/frontend` → 47 lint problems (14 errors) / 10 tsc errors (preexisting). `git stash pop` → re-ran both → identical counts, tsc output byte-identical diff.
- [x] `bun run test` (jest --ci) → 3 suites / 32 tests, all passing.
- [x] `bun install --frozen-lockfile` passes (no dependency changes).
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)