### PR TITLE
chore(lint): tell eslint where the tests are

### DIFF
--- a/packages/backend/eslint.config.mjs
+++ b/packages/backend/eslint.config.mjs
@@ -33,4 +33,20 @@ export default [
       '@typescript-eslint/no-explicit-any': 'warn',
     },
   },
+  {
+    /**
+     * Jest's globals, in the only place they exist.
+     *
+     * Without this every `describe`, `it`, `expect` and `jest` in the suite is a
+     * `no-undef` error — hundreds of them, all false, drowning the real findings
+     * in the same output. The rule is right and the config was simply never told
+     * where the tests are.
+     */
+    files: ['**/__tests__/**/*.ts', '**/*.test.ts'],
+    languageOptions: {
+      globals: {
+        ...globals.jest,
+      },
+    },
+  },
 ];


### PR DESCRIPTION
`packages/backend/eslint.config.mjs` declared only Node globals, so every `describe`, `it`, `expect`, `beforeEach` and `jest` in the test suite was reported as `no-undef`.

**3,555 of the backend's 3,899 lint errors were that one omission.** Measured on this branch against `main`:

| | errors | warnings |
|---|---|---|
| `main` | 3,892 | 275 |
| this branch | 337 | 275 |

The rule was right; the config had simply never been told where the tests live. Nothing is disabled or downgraded — one `files: ['**/__tests__/**/*.ts', '**/*.test.ts']` block adding `globals.jest`.

Why it matters beyond tidiness: at 3,899 errors the output is unreadable, which is how a lint run stops being something anyone looks at. The 337 that remain are real findings (`no-require-imports`, a few unused vars) and are now legible.

Split out of #248 at the team lead's request — a repo-wide lint change riding a 55-file integration PR is what makes a reviewer approve everything without reading any of it. Merging this first makes #248 smaller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
