### PR TITLE
test(moderation): prove Homiio passes its own secret to the webhook receiver

### DIFF
--- a/packages/backend/__tests__/integration/crowdSourceWebhookMount.test.ts
+++ b/packages/backend/__tests__/integration/crowdSourceWebhookMount.test.ts
@@ -52,6 +52,7 @@ import { decisionApplyEventId } from '../../services/moderation/ModerationOutbox
 
 /** Must match what `__tests__/jest.setup.ts` puts in the environment. */
 const WEBHOOK_SECRET = 'test-webhook-secret-at-least-16-chars';
+const PREVIOUS_SECRET = 'test-previous-secret-at-least-16-chars';
 
 /**
  * The app in the SAME order `server.ts` uses: webhook first, parsers after.
@@ -364,6 +365,101 @@ describe('crowdsource webhook mount', () => {
     expect(stored).not.toBeNull();
     expect(stored?.state).toBe('ignored');
     expect(await ModerationOutbox.countDocuments({})).toBe(0);
+  });
+
+  /**
+   * Does HOMIIO pass its secret through, or do these tests only prove the SDK
+   * can verify a signature?
+   *
+   * `configuredSecrets` in `@oxyhq/crowdsource-express` is
+   * `options.secret ?? process.env.CROWDSOURCE_WEBHOOK_SECRET`, and
+   * `jest.setup.ts` sets that variable — so deleting `secret:` from the route
+   * leaves the SDK falling back to the identical value and **every other test in
+   * this file stays green.** Measured, not assumed: with the pass-through
+   * removed, all twelve passed.
+   *
+   * The discriminator is to make the two sources DISAGREE. `config` captured the
+   * real secret at module load; moving `process.env` afterwards means only a
+   * receiver reading its own configuration can still verify. A receiver leaning
+   * on the environment now holds a different string and refuses.
+   *
+   * This is not a contrived arrangement — it is the production one. The
+   * environment is where the secret comes FROM, config is the authority the
+   * route reads, and the two diverging is exactly what a redeploy-less rotation
+   * looks like.
+   */
+  it('verifies with the secret Homiio configured, not the SDK’s environment fallback', async () => {
+    const observed: { body: unknown } = { body: 'never set' };
+    const delivery = signedDelivery(
+      envelope({ id: 'evt_passthrough', type: 'case.created', data: { caseId: 'case_pt' } }),
+    );
+
+    const realEnv = process.env.CROWDSOURCE_WEBHOOK_SECRET;
+    process.env.CROWDSOURCE_WEBHOOK_SECRET = 'an-entirely-different-environment-secret';
+    try {
+      const res = await request(buildApp(observed))
+        .post('/webhooks/crowdsource')
+        .set(delivery.headers)
+        .send(delivery.body);
+
+      expect(res.status).toBeLessThan(300);
+      // The side effect, not the status: a 200 that wrote nothing would agree
+      // with a receiver that had verified nothing.
+      expect(await ModerationEvent.findById('evt_passthrough').lean()).not.toBeNull();
+    } finally {
+      process.env.CROWDSOURCE_WEBHOOK_SECRET = realEnv;
+    }
+  });
+
+  /**
+   * The rotation path, which otherwise runs for the first time in production
+   * during a rotation somebody scheduled.
+   *
+   * Both secrets are accepted while one is being retired. Same environment
+   * divergence as above, so this also proves `previousSecret` reaches the
+   * middleware from Homiio's config rather than from the SDK's own
+   * `CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS` fallback.
+   */
+  it('accepts a delivery signed with the previous secret during a rotation', async () => {
+    const observed: { body: unknown } = { body: 'never set' };
+    const signed = signWebhookDelivery({
+      secret: PREVIOUS_SECRET,
+      event: envelope({ id: 'evt_rotating', type: 'case.created', data: { caseId: 'case_rot' } }),
+    });
+
+    const realEnv = process.env.CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS;
+    process.env.CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS = 'an-entirely-different-previous-secret';
+    try {
+      const res = await request(buildApp(observed))
+        .post('/webhooks/crowdsource')
+        .set({ ...signed.headers })
+        .send(signed.body);
+
+      expect(res.status).toBeLessThan(300);
+      expect(await ModerationEvent.findById('evt_rotating').lean()).not.toBeNull();
+    } finally {
+      process.env.CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS = realEnv;
+    }
+  });
+
+  /**
+   * And a secret that was never configured at all is still refused — otherwise
+   * the two tests above would pass for a receiver that accepted anything.
+   */
+  it('refuses a delivery signed with a secret nobody configured', async () => {
+    const observed: { body: unknown } = { body: 'never set' };
+    const signed = signWebhookDelivery({
+      secret: 'a-secret-this-deployment-has-never-held',
+      event: envelope({ id: 'evt_stranger', type: 'case.created', data: { caseId: 'case_str' } }),
+    });
+
+    const res = await request(buildApp(observed))
+      .post('/webhooks/crowdsource')
+      .set({ ...signed.headers })
+      .send(signed.body);
+
+    expect((res.body as { rejection?: string }).rejection).toBe('signature_mismatch');
+    expect(await ModerationEvent.countDocuments({})).toBe(0);
   });
 
   it('deduplicates a redelivery of the same event', async () => {

--- a/packages/backend/__tests__/jest.setup.ts
+++ b/packages/backend/__tests__/jest.setup.ts
@@ -46,6 +46,14 @@ process.env.PUBLIC_API_URL = process.env.PUBLIC_API_URL || 'https://api.homiio.t
  */
 process.env.CROWDSOURCE_WEBHOOK_SECRET =
   process.env.CROWDSOURCE_WEBHOOK_SECRET || 'test-webhook-secret-at-least-16-chars';
+/**
+ * The rotation secret, set for the same reason: `config` captures it once at
+ * module load, so a test cannot introduce it later. Without this the route omits
+ * `previousSecret` entirely and the rotation path — the one that runs for the
+ * first time during a rotation somebody scheduled — would never be exercised.
+ */
+process.env.CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS =
+  process.env.CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS || 'test-previous-secret-at-least-16-chars';
 
 let mongoServer: MongoMemoryReplSet | undefined;
 


### PR DESCRIPTION
`alia-syra` asked of their own webhook file: *would every test in it pass with the signature check deleted?* Moovo, Allo, Syra and Mercaria all had the hole. **So does Homiio**, and this closes it.

## Measured, not reasoned about

Deleting `secret:` from `routes/crowdSourceWebhook.ts` left **all twelve** webhook tests green.

`configuredSecrets` in `@oxyhq/crowdsource-express` is `options.secret ?? process.env.CROWDSOURCE_WEBHOOK_SECRET`, and `jest.setup.ts` sets that variable. So the SDK fell back to the identical value, and the whole file was proving *the SDK can verify a signature* while proving nothing about whether Homiio wires one through. The one thing that route is responsible for was the one thing untested.

## The discriminator

Make the two sources disagree. `config` captures the secret at module load; moving `process.env` afterwards means only a receiver reading its own configuration can still verify, while one leaning on the environment now holds a different string.

That is not a contrived arrangement — it is the production one. The environment is where the secret comes *from*, `config` is the authority the route reads, and the two diverging is exactly what a rotation looks like.

## Three tests, each with a mutation behind it

| test | mutation | before | after |
|---|---|---|---|
| verifies with the secret Homiio configured | delete `secret:` | all 12 green | that test fails |
| accepts a delivery signed with the previous secret | delete `previousSecret:` | all 12 green | that test fails |
| refuses a secret nobody configured | — | — | asserts `signature_mismatch` |

Both mutations were confirmed present and type-clean before their failures were believed.

**`CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS` was plumbed and never exercised** — its first real run would have been during a rotation somebody had scheduled, which is the worst possible clock for a first run. `jest.setup.ts` now sets it, because `config` captures it once at module load and a test cannot introduce it later.

The third test exists so the first two cannot pass for a receiver that accepts anything.

Every assertion is on the **side effect** — the `ModerationEvent` row exists — rather than the status code, because a 200 that wrote nothing agrees with a receiver that verified nothing.

Follow-up to #248, which merged while this was being measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
