### PR TITLE
ci: scan bun install output, and write the two red gates without arming them

### DIFF
--- a/.github/scripts/assert-install-clean.sh
+++ b/.github/scripts/assert-install-clean.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Decides whether a `bun install` actually completed, from its log and its exit
+# status. Kept separate from the install itself so it can be exercised against
+# fixture logs — see test-assert-install-clean.sh.
+#
+# WHY THE EXIT CODE IS NOT ENOUGH
+#
+# `bun install` has printed `error: Fail extracting tarball for "<pkg>"` and then
+# **exited 0**, leaving that package absent from node_modules with a correct
+# lockfile and a clean `git status`. Everything downstream then fails for a reason
+# that has nothing to do with the commit: dozens of TS2307s in files nobody
+# touched, which get reported as "N pre-existing errors" and believed. It is
+# transient (cache contention with a concurrent install), so a retry fixes it —
+# but only if somebody realises that is what happened, and the exit code says the
+# install was fine.
+#
+# So the install's own output is read too, and the two are allowed to disagree.
+
+set -uo pipefail
+
+LOG="${1:-}"
+STATUS="${2:-}"
+
+if [ -z "$LOG" ] || [ -z "$STATUS" ]; then
+  echo "usage: assert-install-clean.sh <install-log> <install-exit-status>" >&2
+  exit 1
+fi
+
+if [ ! -f "$LOG" ]; then
+  echo "::error::The install log $LOG does not exist, so whether the install completed is unknown." >&2
+  exit 1
+fi
+
+if [ "$STATUS" -ne 0 ]; then
+  echo "::error::\`bun install\` exited $STATUS." >&2
+  exit "$STATUS"
+fi
+
+# grep exits 1 on no match, which is the good case here.
+REPORTED=$(grep -E '^[[:space:]]*error:' "$LOG" || true)
+if [ -n "$REPORTED" ]; then
+  echo "::error::\`bun install\` reported an error while exiting 0, so the dependency tree is incomplete. Re-run the job; this is usually transient." >&2
+  printf '%s\n' "$REPORTED" >&2
+  exit 1
+fi
+
+echo "bun install completed with no reported errors."

--- a/.github/scripts/bun-install.sh
+++ b/.github/scripts/bun-install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# `bun install`, with its output kept and judged rather than thrown away.
+#
+# Every install in CI goes through this. The reason is in assert-install-clean.sh:
+# bun has printed `error: Fail extracting tarball` and then exited 0, leaving a
+# package absent from the tree, and everything downstream then fails for a reason
+# that has nothing to do with the commit. Trusting the exit code alone is what
+# turns that into "N pre-existing errors" in somebody's report.
+#
+# Arguments are passed through to `bun install` (e.g. --frozen-lockfile).
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG="${RUNNER_TEMP:-/tmp}/bun-install.log"
+
+bun install "$@" 2>&1 | tee "$LOG"
+STATUS=${PIPESTATUS[0]}
+
+exec bash "$HERE/assert-install-clean.sh" "$LOG" "$STATUS"

--- a/.github/scripts/test-assert-install-clean.sh
+++ b/.github/scripts/test-assert-install-clean.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Mutation-tests assert-install-clean.sh against fixture logs.
+#
+# The case that matters is the one the exit code cannot see: an install that
+# printed `error:` and exited 0. If this check ever stops discriminating that from
+# a clean install, it reads as protection while providing none — and the symptom
+# it protects against (a package missing from node_modules) surfaces later as
+# "pre-existing type errors" that get believed.
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/assert-install-clean.sh"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/homiio-install-clean-test-XXXXXX")"
+FAILURES=0
+
+cleanup() {
+  trap - EXIT INT TERM
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT INT TERM
+
+expect() {
+  local label="$1" want_status="$2" want_fragment="$3" log="$4" status="$5"
+  local output got
+  output=$(bash "$SCRIPT" "$log" "$status" 2>&1)
+  got=$?
+  if [ "$got" != "$want_status" ]; then
+    echo "- $label: expected exit $want_status, got $got" >&2
+    echo "$output" >&2
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+  if [ -n "$want_fragment" ] && ! printf '%s' "$output" | grep -qF "$want_fragment"; then
+    echo "- $label: output did not contain '$want_fragment'" >&2
+    echo "$output" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+cat >"$WORKDIR/clean.log" <<'LOG'
+bun install v1.3.14 (0d9b296a)
++ typescript@6.0.3
+1605 packages installed [512.00ms]
+LOG
+
+# The real shape, taken from the incident: an error line, then exit 0.
+cat >"$WORKDIR/silent-failure.log" <<'LOG'
+bun install v1.3.14 (0d9b296a)
+error: Fail extracting tarball for "@homiio/shared-types"
+1604 packages installed [488.00ms]
+LOG
+
+# A word containing "error" that is not an error line must not trip it, or the
+# check becomes a thing people re-run until it passes.
+cat >"$WORKDIR/false-positive-bait.log" <<'LOG'
+bun install v1.3.14 (0d9b296a)
++ eslint-plugin-no-error-on-purpose@1.0.0
+warn: an error-handling package changed major versions
+1605 packages installed [512.00ms]
+LOG
+
+expect "clean install passes" 0 "no reported errors" "$WORKDIR/clean.log" 0
+expect "error line with exit 0 fails" 1 "reported an error while exiting 0" "$WORKDIR/silent-failure.log" 0
+expect "error line is named in the output" 1 'Fail extracting tarball' "$WORKDIR/silent-failure.log" 0
+expect "a nonzero exit fails" 7 "exited 7" "$WORKDIR/clean.log" 7
+expect "the word error elsewhere does not trip it" 0 "no reported errors" "$WORKDIR/false-positive-bait.log" 0
+expect "a missing log fails" 1 "does not exist" "$WORKDIR/nope.log" 0
+
+if [ "$FAILURES" -gt 0 ]; then
+  echo "Install-clean assertion tests failed: $FAILURES case(s)." >&2
+  exit 1
+fi
+echo "Install-clean check discriminated 6 case(s)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,9 @@
 #     for nobody, and a suite that runs zero tests exits 0, so every job that
 #     runs one carries a count floor.
 #   - A push to main still deployed to production ECS and to Cloudflare Pages
-#     regardless of this workflow. Both deploys now start from `workflow_run` on
-#     this workflow's success — see the header of each.
+#     regardless of this workflow. Both are gated on it now, by two different
+#     mechanisms and for a measured reason — see `deploy-backend` at the bottom
+#     of this file and the header of deploy-frontends.yml.
 name: CI
 
 on:
@@ -72,7 +73,7 @@ jobs:
       # install and therefore cannot share this one. Scripts stay enabled so the
       # root postinstall builds shared-types, which the steps below assume.
       - name: Install
-        run: bun install --frozen-lockfile
+        run: bash .github/scripts/bun-install.sh --frozen-lockfile
 
       # `shared-types` is built by the root postinstall; `listing-providers` is
       # not, and the backend typecheck resolves it through project references —
@@ -120,7 +121,7 @@ jobs:
       # The root postinstall builds shared-types, which these tests import by
       # package name and therefore resolve through its BUILT dist.
       - name: Install
-        run: bun install --frozen-lockfile
+        run: bash .github/scripts/bun-install.sh --frozen-lockfile
 
       - name: Test frontend
         run: >-
@@ -171,6 +172,7 @@ jobs:
           bash -n .github/scripts/*.sh
           bun scripts/test-check-lockfile-sync.mjs
           bun .github/scripts/test-assert-test-floor.mjs
+          bash .github/scripts/test-assert-install-clean.sh
           bash .github/scripts/test-deployment-scope.sh
 
   frontend-bundle:
@@ -184,7 +186,7 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install
-        run: bun install --frozen-lockfile
+        run: bash .github/scripts/bun-install.sh --frozen-lockfile
 
       # The same export deploy-frontends.yml runs, with the same environment, so a
       # broken web build fails on the pull request instead of after the merge that
@@ -195,3 +197,114 @@ jobs:
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
           NODE_ENV: production
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # OFF BY DEFAULT. Both of these are RED on main today, and a job that is red
+  # on every pull request from the day it lands is not a gate — it is a thing
+  # the next person disables. They are written, and left switched off, so that
+  # turning each one on is a repository-variable change rather than a design
+  # exercise, and so the debt is visible in the place the gate will live.
+  #
+  # To turn one on: fix the errors it reports, then set the repository variable
+  # to `ready` (Settings → Secrets and variables → Actions → Variables).
+  # ─────────────────────────────────────────────────────────────────────────
+
+  lint:
+    # Set HOMIIO_LINT_GATE=ready once `bun run lint` exits 0.
+    #
+    # Today it does not: backend 344 errors, listing-providers 15, frontend 14;
+    # shared-types is clean. #249 removed the noise that made this unreadable
+    # (jest globals, 3555 false `no-undef`s), so what remains is real: 272
+    # `no-require-imports` in a package that is deliberately "type":"commonjs",
+    # 57 unused-vars, and 10 genuine `no-undef`s. listing-providers' 15 include 6
+    # `no-undef` on DOM/undici types (RequestInit), which is the case #249's fix
+    # does not cover — its config still needs typescript-eslint's
+    # `eslint-recommended` to stop the base rule reporting TypeScript types.
+    #
+    # NOTHING IS BUILT IN THIS JOB, ON PURPOSE. `eslint .` in the backend has no
+    # `ignores`, and eslint 9's flat config does not skip `dist/` by default, so
+    # a build step before this would lint generated `.d.ts` output and add 214
+    # phantom errors. That is why `bun run lint` gives 344 on a clean checkout
+    # and 558 after `bun run build` — measured, both ways, on the same commit.
+    if: vars.HOMIIO_LINT_GATE == 'ready'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      # Scripts stay ENABLED so the root postinstall builds shared-types. Not for
+      # types — eslint does not typecheck — but because the frontend's config
+      # carries eslint-plugin-import, which resolves modules for real and would
+      # report @homiio/shared-types as unresolved without its dist. Building
+      # shared-types is safe here; what must not happen is building the BACKEND,
+      # per the note above.
+      - name: Install
+        run: bash .github/scripts/bun-install.sh --frozen-lockfile
+      - name: Lint every package
+        run: bun run lint
+
+  frontend-typecheck:
+    # Set HOMIIO_FRONTEND_TYPECHECK_GATE=ready once this exits 0.
+    #
+    # Nothing typechecks the frontend today: `expo export` compiles through
+    # Babel, which strips types without checking them, so the frontend-bundle job
+    # proves the bundle builds and nothing more. `tsc --noEmit` reports 10 errors
+    # — 9 real (a missing required `t` prop in two screens, `OfferingSummary`
+    # lacking `fallback` in two more, a `t` signature mismatch, and a locale code
+    # widened to `string`) and one environmental: @oxyhq/bloom's web portal wants
+    # @types/react-dom, which the frontend does not depend on.
+    #
+    # The install runs postinstall so shared-types is built — this project
+    # resolves it through a path mapping to ../shared-types/src, but its
+    # references still expect the built project.
+    if: vars.HOMIIO_FRONTEND_TYPECHECK_GATE == 'ready'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - name: Install
+        run: bash .github/scripts/bun-install.sh --frozen-lockfile
+      - name: Typecheck frontend
+        run: bun run --cwd packages/frontend typecheck
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # The backend deploy runs HERE, as a called workflow, rather than from its own
+  # `workflow_run` trigger like the frontend's.
+  #
+  # That asymmetry is not a preference, it is a measured failure. On `e94bd65`,
+  # deploy-aws.yml on `workflow_run` produced `conclusion: action_required` with
+  # ZERO jobs created, twice, with created_at == updated_at — concluded before
+  # scheduling anything, including its own ubuntu-latest scope job. The same
+  # trigger on deploy-frontends.yml, in the same repository and the same instant,
+  # ran to success. Ruled out by evidence: the YAML shape and `id-token: write`
+  # (CrowdSource runs an identical deploy-aws.yml on `workflow_run` and schedules
+  # fine), the ARM runner (this file's own push-triggered runs used it minutes
+  # earlier), rulesets, and environment protection rules (none exist). What is
+  # left is org-level Actions policy, which is not readable without admin:org.
+  #
+  # Calling the workflow removes the failing mechanism entirely and is a stronger
+  # gate besides: the deploy cannot start unless every job below it passed in
+  # THIS run, with no window in which main moves on between CI concluding and the
+  # deploy resolving a SHA. It also fails LOUDLY — a blocked deploy shows up
+  # inside the CI run on main, rather than in a separate run that quietly says
+  # action_required and that nobody is watching.
+  #
+  # deploy-frontends.yml is deliberately left on `workflow_run`: it demonstrably
+  # works, and rewiring a working production deploy for symmetry is risk with no
+  # return. If it ever exhibits the same conclusion, move it here too.
+  # ─────────────────────────────────────────────────────────────────────────
+  deploy-backend:
+    name: Deploy backend to AWS
+    needs: [backend, frontend, lockfile, frontend-bundle]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      id-token: write
+      contents: read
+    # The deploy syncs GitHub secrets to SSM with `toJSON(secrets)`, so it needs
+    # the caller's secrets; without `inherit` that object is empty and the sync
+    # silently writes nothing.
+    secrets: inherit
+    uses: ./.github/workflows/deploy-aws.yml

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -2,22 +2,25 @@
 # and substitute homiio (ecs service + ecr repo name) and packages/backend/Dockerfile (path).
 name: Deploy to AWS
 
-# GATED ON CI. This used to trigger directly on `push: main`, which meant a push
-# built an image and rolled it out to production ECS without the test suite ever
-# having run — nothing in this repository ran it. It now starts only after the CI
-# workflow concludes SUCCESSFULLY on main, so a red suite stops the rollout.
+# GATED ON CI, but CALLED rather than triggered. `ci.yml` invokes this with
+# `uses: ./.github/workflows/deploy-aws.yml` after every one of its jobs passes
+# on a push to main.
+#
+# It used to trigger on `push: main`, which rolled an image out to production ECS
+# without the test suite ever having run. The obvious replacement — `workflow_run`
+# on CI, which is what deploy-frontends.yml uses — was tried and DOES NOT WORK for
+# this workflow in this repository: it concluded `action_required` with zero jobs
+# created, twice, before scheduling anything. The full evidence and what it rules
+# out is in the `deploy-backend` comment in ci.yml. Do not "restore" the
+# workflow_run trigger without re-testing it on main; it fails silently, in a run
+# nobody looks at.
 #
 # `workflow_dispatch` is unchanged and remains the escape hatch: if CI itself
 # breaks, a deploy can still be forced by hand from any ref, and the scope filter
 # below does not apply to it.
-#
-# `workflow_run` supports no `paths-ignore`, so the old documentation-only filter
-# moved into the `scope` job. It fails open — see .github/scripts/deployment-scope.sh.
+
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
-    branches: [main]
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -36,21 +39,17 @@ env:
   APP: homiio
   CLUSTER: oxy-cluster
   DOCKERFILE: packages/backend/Dockerfile
-  # The commit CI actually judged, not whatever main has drifted to since. Falls
-  # back to the dispatched ref for a manual run, where there is no CI run to read.
-  DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+  # The commit CI judged. When called from ci.yml this IS that commit, because a
+  # called workflow runs inside the caller's run — there is no window in which
+  # main moves on underneath. Under workflow_dispatch it is the dispatched ref.
+  DEPLOY_SHA: ${{ github.sha }}
 
 jobs:
   scope:
-    # A CI run that failed, that was triggered by a pull request rather than a
-    # push, that came from a fork, or that ran on a branch other than main must
-    # not deploy anything.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_repository.full_name == github.repository &&
-      github.event.workflow_run.head_branch == 'main')
+    # No conclusion/branch/fork guard here any more, and none is needed: the only
+    # automatic caller is ci.yml's `deploy-backend`, which already requires every
+    # CI job to have passed on a push to refs/heads/main. Re-checking it here
+    # would be a second copy of a condition that can drift from the real one.
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -16,6 +16,7 @@
     "test": "jest --ci",
     "test:watch": "jest --watch",
     "lint": "expo lint",
+    "typecheck": "tsc --noEmit",
     "check:i18n": "bun scripts/check-locale-parity.ts",
     "clean": "rm -rf dist .expo"
   },


### PR DESCRIPTION
Follow-up to #251. **Split**: the `workflow_call` deploy fix that was originally in this branch has moved to its own PR on top of the mitigation (#255), so this one touches no deploy file at all.

Two things, neither of which can affect the deploy path.

## 1. Every install reads bun's output, not just its exit code

`~/Oxy/AGENTS.md`: `bun install` has printed `error: Fail extracting tarball for "<pkg>"` and then **exited 0**, leaving the package absent and producing dozens of phantom `TS2307`s that get reported as "N pre-existing errors" and believed. I applied this discipline to my local baseline but not to the workflow, which is the wrong way round — the local run is the one a human is watching.

`bun-install.sh` keeps the log; `assert-install-clean.sh` judges it and is allowed to disagree with the exit code. Six cases in `test-assert-install-clean.sh`, including a log containing the word "error" inside a package name that must **not** trip it — a gate that cries wolf gets disabled by whoever hits it next. Mutation-tested: disabling the scanner makes exactly two cases fail, and they name themselves.

## 2. `lint` and `frontend-typecheck`, written and left off

Both are red on `main` today, so both are gated on a repository variable (`HOMIIO_LINT_GATE`, `HOMIIO_FRONTEND_TYPECHECK_GATE`, each `== 'ready'`). A job that is red on every pull request from the day it lands is not a gate — it is a thing the next person disables. Written and switched off means turning either on is a variable change rather than a design exercise, and the debt is recorded in the place the gate will live.

Both were run locally so neither is an untested-forever job, and both show `skipped` in the green run on this PR. `packages/frontend` gains the `typecheck` script the second one calls.

**A `dist/` hazard to know before anyone arms the lint gate.** `eslint .` in the backend declares no `ignores`, and eslint 9's flat config does not skip `dist/` by default. So `bun run lint` reports **344 errors on a clean checkout and 558 after `bun run build`** — measured both ways on the same commit; the 214 difference is generated `.d.ts` output (all 171 `no-empty-object-type`, and a chunk of the `no-require-imports`). The job therefore builds nothing, and says so.

## Corrected numbers, and a corrected diagnosis

**My earlier report of 558 backend lint errors was wrong.** It was measured in a worktree where I had already run `bun run build`. On a clean tree the number is **344** — exactly what #249 reported. There was never a discrepancy between that figure and mine to explain; I created one.

| package | errors | warnings |
|---|---|---|
| backend | **344** | 275 |
| listing-providers | 15 | 0 |
| frontend | 14 | 33 |
| shared-types | 0 | 0 |

**And my diagnosis of the root cause was wrong; #249's was right.** I had claimed the three eslint configs never spread `typescript.configs['eslint-recommended'].rules`, leaving base `no-undef` enabled on TypeScript, and that this was the more fundamental cause. After #249, backend `no-undef` is **10 of 344** — the bulk really was jest globals, which is what #249 fixed. Worse, the fix I proposed would have disabled `no-undef` wholesale and **hidden those 10 genuine findings**. Telling the rule where the tests are is strictly better than switching the rule off.

The `eslint-recommended` point survives only for `listing-providers`: 6 of its 15 errors are `no-undef` on DOM/undici types like `RequestInit`, which jest globals do not cover. Six errors — an observation, not a sweeping finding, and it belongs to whoever owns that package.

Remaining backend breakdown: 272 `no-require-imports` (in a package that is deliberately `"type": "commonjs"`), 57 unused-vars, 10 `no-undef`, 5 others.

## Suite numbers

Backend **925 tests across 81 files** (up from 922 — #253 added three), frontend **40 across 4**, all passing. Floors of 850/38 unchanged and still correctly sized.

## One local-only trap, recorded because it cost me a measurement

`rm -rf packages/<pkg>/dist` without also removing `tsconfig.tsbuildinfo` leaves `tsc` believing the project is up to date: it emits nothing, **exits 0**, and every consumer then reports `TS6305 … has not been built from source file`. I did exactly this and briefly measured a tree where `listing-providers/dist` did not exist while its build had just reported success. `*.tsbuildinfo` is gitignored and none are tracked, so **CI is unaffected** — a fresh checkout has none. The correct local reset is `bun run --filter '*' clean`, which removes both.
