### PR TITLE
ci: restore the backend deploy path (revert to known-good trigger)

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -2,33 +2,32 @@
 # and substitute homiio (ecs service + ecr repo name) and packages/backend/Dockerfile (path).
 name: Deploy to AWS
 
-# GATED ON CI. This used to trigger directly on `push: main`, which meant a push
-# built an image and rolled it out to production ECS without the test suite ever
-# having run — nothing in this repository ran it. It now starts only after the CI
-# workflow concludes SUCCESSFULLY on main, so a red suite stops the rollout.
+# UNGATED AGAIN, DELIBERATELY AND TEMPORARILY. #251 moved this to `workflow_run`
+# on CI so a push could not reach production ECS untested. In this repository
+# that trigger does not merely gate the deploy — it BLOCKS it: both
+# workflow_run-triggered runs concluded `action_required` with ZERO jobs created,
+# before the scope job or anything else was scheduled. deploy-frontends.yml on
+# the identical trigger ran to success in the same instant, so the mechanism
+# works here in general; something about this workflow specifically does not.
 #
-# `workflow_dispatch` is unchanged and remains the escape hatch: if CI itself
-# breaks, a deploy can still be forced by hand from any ref, and the scope filter
-# below does not apply to it.
-#
-# `workflow_run` supports no `paths-ignore`, so the old documentation-only filter
-# moved into the `scope` job. It fails open — see .github/scripts/deployment-scope.sh.
+# This file is therefore restored byte-for-byte to its last known-good state
+# (2aca446), because a deploy path that is dead AND SILENT is worse than an
+# ungated one — the failure appears in a separate run nobody watches. A gate that
+# does not block deploys is coming back in a follow-up, as a workflow CALLED from
+# ci.yml rather than triggered by it. Do not re-add `workflow_run` here without
+# first proving on main that it schedules jobs.
+
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
+  push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   workflow_dispatch:
 
 permissions:
   id-token: write
   contents: read
-
-# Serialize production rollouts. Cancelling after `update-service` would leave an
-# unmonitored deployment running in ECS, so in-progress runs are never cancelled.
-concurrency:
-  group: deploy-homiio-backend
-  cancel-in-progress: false
 
 env:
   AWS_REGION: us-west-2
@@ -36,49 +35,12 @@ env:
   APP: homiio
   CLUSTER: oxy-cluster
   DOCKERFILE: packages/backend/Dockerfile
-  # The commit CI actually judged, not whatever main has drifted to since. Falls
-  # back to the dispatched ref for a manual run, where there is no CI run to read.
-  DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
 
 jobs:
-  scope:
-    # A CI run that failed, that was triggered by a pull request rather than a
-    # push, that came from a fork, or that ran on a branch other than main must
-    # not deploy anything.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_repository.full_name == github.repository &&
-      github.event.workflow_run.head_branch == 'main')
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      deploy: ${{ steps.filter.outputs.deploy }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ env.DEPLOY_SHA }}
-          # The scope diff reads <sha>^1..<sha>, so the parent has to be present.
-          fetch-depth: 2
-      - name: Detect backend deployment scope
-        id: filter
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "deploy=true" >>"$GITHUB_OUTPUT"
-            echo "manual dispatch: deploying regardless of what changed"
-          else
-            bash .github/scripts/deployment-scope.sh backend
-          fi
-
   deploy:
-    needs: scope
-    if: needs.scope.outputs.deploy == 'true'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ env.DEPLOY_SHA }}
 
       - name: Configure AWS credentials (OIDC, no stored keys)
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
**Mitigation. Merge this first, ahead of anything else.**

Homiio's backend cannot deploy. #251 moved `deploy-aws.yml` from `push: main` to `workflow_run` on CI so a push could not reach production ECS untested. In this repository that trigger does not gate the deploy — **it blocks it**, and silently.

```
20:56  workflow_run  action_required   jobs = 0
20:53  workflow_run  action_required   jobs = 0
20:51  push          success
20:31  push          success           (and every earlier run, all push)
```

Zero jobs, `created_at == updated_at == run_started_at` — concluded before the `scope` job or anything else was scheduled, so this is not an `if:` declining. `deploy-frontends.yml` on the identical trigger ran to `success` at 20:56 with both its jobs, so `workflow_run` works in this repository in general.

## Not an outage

**Production is running `2aca446`, and `e94bd65` changed only CI files — no backend code is missing from production.** This restores the ability to ship the *next* backend change, which is currently impossible.

## What this does

Restores `deploy-aws.yml` **byte-for-byte to `2aca446`**, its last known-good state, plus a comment saying why. Diff against known-good is the comment and nothing else.

Nothing novel, deliberately. This is configuration whose entire run history is successes. A new arrangement invented under time pressure is how the second outage happens — getting the path back is more urgent than getting it right.

## What it gives up

The backend half of the gate: a push to `main` will again build and roll out to production ECS without the suite having run. That is the state the repo was in this morning, and it is strictly better than a deploy path that is dead *and* silent.

**The frontend stays gated.** `deploy-frontends.yml` is untouched and demonstrably works.

## What comes next, separately

The gate returns as a workflow **called** from `ci.yml` (`uses: ./.github/workflows/deploy-aws.yml` with `needs:` on every CI job) rather than triggered by it. That removes the failing mechanism entirely and is a stronger gate besides — same run, no window in which `main` moves on between CI concluding and the deploy resolving a SHA — but the property that actually matters is that a blocked deploy would then appear **inside the CI run on `main`**, not in a separate run nobody watches. **Silence was the real defect here, more than the block.**

Merging this PR is itself the verification: it touches a non-documentation file, so the restored `push: main` trigger should schedule jobs and deploy. If it does, the trigger is confirmed as the variable.
