### PR TITLE
ci: gate the backend deploy by CALLING it from CI, not triggering it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,9 @@
 #     for nobody, and a suite that runs zero tests exits 0, so every job that
 #     runs one carries a count floor.
 #   - A push to main still deployed to production ECS and to Cloudflare Pages
-#     regardless of this workflow. Both deploys now start from `workflow_run` on
-#     this workflow's success — see the header of each.
+#     regardless of this workflow. Both are gated on it now, by two DIFFERENT
+#     mechanisms and for a measured reason — see `deploy-backend` at the bottom
+#     of this file and the header of deploy-frontends.yml.
 name: CI
 
 on:
@@ -195,3 +196,42 @@ jobs:
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
           NODE_ENV: production
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # The backend deploy runs HERE, as a called workflow, rather than from its own
+  # `workflow_run` trigger like the frontend's.
+  #
+  # That asymmetry is not a preference, it is a measured failure. On e94bd65,
+  # deploy-aws.yml on `workflow_run` produced `conclusion: action_required` with
+  # ZERO jobs created, twice, `created_at == updated_at` — concluded before
+  # scheduling anything, including its own ubuntu-latest scope job, so it was not
+  # an `if:` declining. deploy-frontends.yml on the identical trigger, in the same
+  # repository and the same instant, ran to success. The full list of what that
+  # excludes is in deploy-aws.yml's header; the cause is NOT established.
+  #
+  # Calling the workflow removes the failing mechanism instead of working around
+  # it, and is a stronger gate besides: the deploy cannot start unless every job
+  # below passed in THIS run, with no window in which main moves on between CI
+  # concluding and the deploy resolving a SHA.
+  #
+  # The property that matters most, though, is that it fails LOUDLY. A blocked or
+  # failing deploy now appears as a job inside the CI run on main. The mechanism
+  # this replaces failed in a separate run that quietly said action_required and
+  # that nobody was watching — silence was the real defect, more than the block.
+  #
+  # deploy-frontends.yml is deliberately left on `workflow_run`: it demonstrably
+  # works, and rewiring a working production deploy for symmetry is risk taken for
+  # tidiness. If it ever shows the same conclusion, move it here too.
+  # ─────────────────────────────────────────────────────────────────────────
+  deploy-backend:
+    name: Deploy backend to AWS
+    needs: [backend, frontend, lockfile, frontend-bundle]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      id-token: write
+      contents: read
+    # The deploy syncs GitHub secrets to SSM with `toJSON(secrets)`, so it needs
+    # the caller's secrets; without `inherit` that object is empty and the sync
+    # silently writes nothing while reporting success.
+    secrets: inherit
+    uses: ./.github/workflows/deploy-aws.yml

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -2,32 +2,42 @@
 # and substitute homiio (ecs service + ecr repo name) and packages/backend/Dockerfile (path).
 name: Deploy to AWS
 
-# UNGATED AGAIN, DELIBERATELY AND TEMPORARILY. #251 moved this to `workflow_run`
-# on CI so a push could not reach production ECS untested. In this repository
-# that trigger does not merely gate the deploy — it BLOCKS it: both
-# workflow_run-triggered runs concluded `action_required` with ZERO jobs created,
-# before the scope job or anything else was scheduled. deploy-frontends.yml on
-# the identical trigger ran to success in the same instant, so the mechanism
-# works here in general; something about this workflow specifically does not.
+# GATED ON CI, but CALLED rather than triggered. `ci.yml` invokes this with
+# `uses: ./.github/workflows/deploy-aws.yml` once every one of its jobs has
+# passed on a push to main.
 #
-# This file is therefore restored byte-for-byte to its last known-good state
-# (2aca446), because a deploy path that is dead AND SILENT is worse than an
-# ungated one — the failure appears in a separate run nobody watches. A gate that
-# does not block deploys is coming back in a follow-up, as a workflow CALLED from
-# ci.yml rather than triggered by it. Do not re-add `workflow_run` here without
-# first proving on main that it schedules jobs.
+# WHY NOT `workflow_run`, WHICH IS THE OBVIOUS ANSWER AND IS WHAT
+# deploy-frontends.yml USES: it was tried, on main, and it does not gate this
+# workflow — it BLOCKS it. Both runs concluded `action_required` with ZERO jobs
+# created and `created_at == updated_at`, before the scope job or anything else
+# was scheduled, while every push-triggered run of the same file succeeded and
+# deploy-frontends.yml on the identical trigger ran to success in the same
+# instant. Excluded by evidence: the YAML shape and `id-token: write`
+# (CrowdSource runs an equivalent file on `workflow_run` and schedules fine),
+# the ARM runner (this file's own push runs use it), rulesets, environment
+# protection rules and deployment branch policies (none in either repo), and
+# repo-level Actions settings (byte-identical between the two repos). The cause
+# is NOT established. Do not re-add `workflow_run` here on the strength of an
+# argument; the only acceptable evidence is a green scheduled run on main.
+#
+# `workflow_dispatch` is unchanged and remains the escape hatch: if CI itself
+# breaks, a deploy can still be forced by hand from any ref, and the scope filter
+# below does not apply to it. It is NOT a test of this wiring — being unfiltered
+# by design, it bypasses the whole chain.
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
+  workflow_call:
   workflow_dispatch:
 
 permissions:
   id-token: write
   contents: read
+
+# Serialize production rollouts. Cancelling after `update-service` would leave an
+# unmonitored deployment running in ECS, so in-progress runs are never cancelled.
+concurrency:
+  group: deploy-homiio-backend
+  cancel-in-progress: false
 
 env:
   AWS_REGION: us-west-2
@@ -35,12 +45,51 @@ env:
   APP: homiio
   CLUSTER: oxy-cluster
   DOCKERFILE: packages/backend/Dockerfile
+  # The commit CI judged. When called from ci.yml this IS that commit, because a
+  # called workflow runs inside the caller's run — there is no window in which
+  # main moves on underneath. Under workflow_dispatch it is the dispatched ref.
+  DEPLOY_SHA: ${{ github.sha }}
 
 jobs:
+  # `workflow_call` carries no path filters, and neither did `workflow_run`, so
+  # the `paths-ignore: ['**.md', 'docs/**']` this workflow used to declare lives
+  # here now. It fails OPEN: every uncertainty deploys, because a needless
+  # rollout costs a rollout while a skipped one leaves production on old code
+  # under a green tick.
+  #
+  # No conclusion/branch/fork guard: the only automatic caller is ci.yml's
+  # `deploy-backend`, which already requires every CI job to have passed on a
+  # push to refs/heads/main. A second copy of that condition here could only
+  # drift from the real one.
+  scope:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      deploy: ${{ steps.filter.outputs.deploy }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+          # The scope diff reads <sha>^1..<sha>, so the parent has to be present.
+          fetch-depth: 2
+      - name: Detect backend deployment scope
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "deploy=true" >>"$GITHUB_OUTPUT"
+            echo "manual dispatch: deploying regardless of what changed"
+          else
+            bash .github/scripts/deployment-scope.sh backend
+          fi
+
   deploy:
+    needs: scope
+    if: needs.scope.outputs.deploy == 'true'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
 
       - name: Configure AWS credentials (OIDC, no stored keys)
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
**Stacked on #255 — merge that first.** This re-lands the gate #255 had to give up, by a mechanism that is not the one that broke.

## The mechanism, and why not the obvious one

`workflow_run` does not gate this workflow in this repository — **it blocks it.** Both runs concluded `action_required` with **zero jobs created** and `created_at == updated_at`, before the `scope` job or anything else was scheduled, so it was never an `if:` declining. Meanwhile `deploy-frontends.yml` on the identical trigger, same repo, same instant, ran to success with both its jobs.

**Excluded by evidence, not reasoning:**

| candidate | why not |
|---|---|
| the YAML shape / `workflow_run` itself | CrowdSource runs an equivalent `deploy-aws.yml` on `workflow_run`; all 8 recent runs schedule jobs (reaching `failure`/`skipped`). Same org, both repos public. |
| `permissions: id-token: write` | CrowdSource's has it. |
| `runs-on: ubuntu-24.04-arm` | this file's own push-triggered runs use it and succeed. |
| org-level Actions policy | would catch CrowdSource too, and doesn't. |
| repository rulesets | none. |
| environment protection rules / deployment branch policies | Homiio has three environments and CrowdSource one; `protection_rules: []` and `deployment_branch_policy: null` on every one of them. |
| repo-level Actions settings | `allowed_actions`, `sha_pinning_required`, `default_workflow_permissions`, `can_approve_pull_request_reviews` — **byte-identical** between the two repos. |

**The cause is not established, and this change does not claim to have found it.** The one structural difference left standing is that CrowdSource declares `workflow_run` alone while Homiio's declared `workflow_run` + `workflow_dispatch` — but Homiio's *frontend* deploy declares both and works, so that is an observation, not a diagnosis. I stopped there rather than keep guessing.

## What this does

`deploy-aws.yml` → `workflow_call` + `workflow_dispatch`. `ci.yml` calls it:

```yaml
  deploy-backend:
    needs: [backend, frontend, lockfile, frontend-bundle]
    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
    permissions: { id-token: write, contents: read }
    secrets: inherit
    uses: ./.github/workflows/deploy-aws.yml
```

This is a **stronger** gate than the `workflow_run` version it replaces:

- The deploy cannot start unless every CI job passed **in this run**. No parsing of another run's `conclusion`, and no window in which `main` moves on between CI concluding and the deploy resolving a SHA — `DEPLOY_SHA` is simply `github.sha`.
- **It fails loudly.** A blocked or failing deploy appears as a job inside the CI run on `main`. What #251 shipped failed in a *separate* run that quietly said `action_required`, which is why it took a merge plus someone actively watching to notice. **Silence was the real defect, more than the block.**
- `secrets: inherit` is required and easy to miss: the deploy syncs GitHub secrets to SSM via `toJSON(secrets)`, and without it that object is empty and the sync writes nothing while reporting success.

The old `paths-ignore: ['**.md','docs/**']` moves into the `scope` job (`.github/scripts/deployment-scope.sh`, already on `main`), which **fails open** — every uncertainty deploys, because a needless rollout costs a rollout while a skipped one leaves production on old code under a green tick. The `workflow_run` conclusion/branch/fork guard is gone: the only automatic caller already requires all-green on a push to `refs/heads/main`, and a second copy of that condition could only drift.

`concurrency` is restored so production rollouts serialize, with `cancel-in-progress: false` — cancelling after `update-service` would leave an unmonitored deployment running in ECS.

**`deploy-frontends.yml` stays on `workflow_run`.** It demonstrably works, and rewiring a working production deploy for symmetry is risk taken for tidiness.

## Verification

**Only observable after merge.** `deploy-backend` is `if: push && main`, so this PR's own run shows it as `skipped` — as it should. The proof is a real scheduled run on `main`.

`workflow_dispatch` is **not** a test of this wiring: it is unfiltered by design, so it bypasses the whole chain and would confirm the deploy job works while saying nothing about the trigger. Use it to ship, not to check.
