### PR TITLE
Fix the lint configs before the lint errors

### DIFF
--- a/packages/backend/eslint.config.mjs
+++ b/packages/backend/eslint.config.mjs
@@ -4,7 +4,34 @@ import typescriptParser from '@typescript-eslint/parser';
 import globals from 'globals';
 
 export default [
+  {
+    /**
+     * Compiled output, not source.
+     *
+     * This package lints `.` rather than `src`, and eslint 9's flat config does
+     * NOT skip `dist/` on its own. Without this the same commit reports 344
+     * errors on a clean tree and 606 after `bun run build` — 262 of them inside
+     * emitted `.js`/`.d.ts` that no one wrote. A gate whose verdict depends on
+     * whether somebody happened to build is a gate that gets switched off.
+     *
+     * Hand-written declarations under `types/` are deliberately NOT ignored;
+     * only generated output is.
+     */
+    ignores: ['dist/**'],
+  },
   js.configs.recommended,
+  /**
+   * Turns OFF the base rules TypeScript itself owns — `no-undef`, `no-redeclare`
+   * and friends — for TypeScript files only.
+   *
+   * `no-undef` cannot see a type, so it reports `RequestInfo`, `RequestInit`,
+   * `NodeJS` and the `Express` namespace as undefined globals. Scoping matters
+   * here and is the whole point: `scripts/migrate-addresses.js` has four
+   * genuinely undefined `Property` references, and this config leaves the rule
+   * fully armed on plain JavaScript so those stay reported. Switching `no-undef`
+   * off outright would have silenced them.
+   */
+  typescript.configs['flat/eslint-recommended'],
   {
     languageOptions: {
       globals: {

--- a/packages/listing-providers/eslint.config.mjs
+++ b/packages/listing-providers/eslint.config.mjs
@@ -4,7 +4,37 @@ import typescriptParser from '@typescript-eslint/parser';
 import globals from 'globals';
 
 export default [
+  {
+    /**
+     * Generated output, never source.
+     *
+     * `tsc` emits this package to `dist/`, but a misconfigured project elsewhere
+     * in the workspace can pull `src/*.ts` into ITS program and, being unable to
+     * map those files under its own `rootDir`, emit them right back next to the
+     * sources. That has happened often enough for `.gitignore` to carry an entry
+     * for it (see "Accidental tsc emit alongside listing-providers sources").
+     *
+     * Linting the result is never a real finding, and it makes the verdict
+     * depend on whether somebody happened to build: the same commit measured 15
+     * errors on a clean tree and 4,679 with those artifacts present. A gate that
+     * swings by three orders of magnitude on build state is a gate nobody
+     * believes.
+     */
+    ignores: ['dist/**', 'src/**/*.js', 'src/**/*.d.ts'],
+  },
   js.configs.recommended,
+  /**
+   * Turns OFF the base rules TypeScript itself owns — `no-undef`, `no-redeclare`,
+   * `no-dupe-class-members` and friends — and only for TypeScript files.
+   *
+   * Without it, `no-undef` from `js.configs.recommended` reports TYPES as
+   * undefined globals: `RequestInit` and `RequestInfo` in `proxy.ts` and
+   * `runtime.ts` accounted for 6 of this package's 15 errors, every one of them
+   * false. Turning the rule off wholesale would have been the wrong fix — this
+   * config is scoped to TypeScript files, so `no-undef` stays fully armed on
+   * plain JavaScript, where nothing else checks for an undefined name.
+   */
+  typescript.configs['flat/eslint-recommended'],
   {
     files: ['**/*.ts'],
     languageOptions: {

--- a/packages/shared-types/eslint.config.mjs
+++ b/packages/shared-types/eslint.config.mjs
@@ -4,7 +4,20 @@ import typescriptParser from '@typescript-eslint/parser';
 import globals from 'globals';
 
 export default [
+  {
+    /** Generated output — see the same block in listing-providers for why `src` is listed. */
+    ignores: ['dist/**', 'src/**/*.js', 'src/**/*.d.ts'],
+  },
   js.configs.recommended,
+  /**
+   * Turns off the base rules TypeScript owns (`no-undef`, `no-redeclare`, …) for
+   * TypeScript files only, so the rule keeps reporting on plain JavaScript where
+   * nothing else does. This package is clean either way today; it is here so the
+   * three near-identical configs stop drifting — one of them missing this line
+   * is exactly why `no-undef` was reporting `RequestInit` as an undefined global
+   * in listing-providers.
+   */
+  typescript.configs['flat/eslint-recommended'],
   {
     files: ['**/*.ts'],
     languageOptions: {


### PR DESCRIPTION
Config first, per the brief. Two things were wrong in the config, and between them they account for every `no-undef` on this repo's board plus the fact that the lint result changed depending on whether you had run a build.

## 1. `eslint-recommended` was missing from all three TypeScript configs

Not just `listing-providers` — `backend` and `shared-types` have the same gap. typescript-eslint's `eslint-recommended` exists to switch off the base ESLint rules TypeScript itself owns. Without it, `no-undef` — which cannot see a type — reports types as undefined globals:

| where | reported as undefined |
|---|---|
| `listing-providers/src/proxy.ts`, `runtime.ts` | `RequestInfo`, `RequestInit` ×6 |
| `backend/services/ingestion/ExternalMediaIngest.ts` | `RequestInfo`, `RequestInit` |
| `backend/middlewares/validation.ts` | `Express` |
| `backend/server.ts` | `NodeJS` |
| `backend/__tests__/…` | `RequestInfo`, `RequestInit` |

Plus a false `no-redeclare` on a TS declaration merge in `scripts/seedProperties.ts`.

**Scoping is the whole point, and is why turning `no-undef` off outright would have been wrong.** `eslint-recommended` disables it for **TypeScript files only**. `scripts/migrate-addresses.js` has four genuinely undefined `Property` references and an unused `crypto`. All five are still reported after this change — verified by listing them, not by assuming:

```
scripts/migrate-addresses.js 12:7   'crypto' is assigned a value but never used  [no-unused-vars]
scripts/migrate-addresses.js 34:30  'Property' is not defined                    [no-undef]
scripts/migrate-addresses.js 89:15  'Property' is not defined                    [no-undef]
scripts/migrate-addresses.js 116:49 'Property' is not defined                    [no-undef]
scripts/migrate-addresses.js 120:43 'Property' is not defined                    [no-undef]
```

It also turns four rules **on** — `no-var`, `prefer-const`, `prefer-rest-params`, `prefer-spread` — which line up with the house rules (`const` by default, never `var`) and surface 4 genuine `prefer-const` findings nothing was checking before.

### One correction to the brief

"Spread `typescript.configs['eslint-recommended']`" does not work as written. In `@typescript-eslint/eslint-plugin` 8.64.0 that key is still the **legacy eslintrc shape** — `{ overrides: [{ files: ['*.ts', …], rules: {…} }] }`, with basename-matching globs — and is not a valid flat-config entry. The flat one is a sibling key: `typescript.configs['flat/eslint-recommended']`, which is what this uses.

## 2. `ignores` for generated output

eslint 9's flat config does not skip generated output, and the backend lints `.` rather than `src`.

- **backend**: 344 errors clean, **606** after `bun run build` — 265 inside emitted `.js`/`.d.ts`. Now `dist/**` is ignored and both states read 341 across the same 313 files. Hand-written declarations under `types/` are deliberately still linted.
- **listing-providers**: worse, and worth flagging. A misconfigured `tsc` project *elsewhere in the workspace* pulls its `src/*.ts` into that program and, unable to map them under its own `rootDir`, emits them straight back next to the sources. `.gitignore` already carries an entry for this ("Accidental tsc emit alongside listing-providers sources"), so `git status` stays clean while `eslint src` climbs to **4,679** errors. Its own build is innocent — verified by deleting the artifacts and rebuilding. Now ignored.

## Counts

Clean tree = fresh checkout + `bun install`, so only `shared-types/dist` exists (the root postinstall builds it). File counts are included deliberately: **a config file that fails to parse reports zero errors and reads as clean.** That happened once while writing this PR — a `**/*.ts` inside a JSDoc block terminated the comment, `bun run lint` died, and a grep-based counter dutifully reported "0 errors" for two packages. The counter now asserts a nonzero file count.

| package | before | after | files linted |
|---|---|---|---|
| backend | 344 | **341** | 313 |
| listing-providers | 15 | **9** | 217 |
| shared-types | 0 | **0** | 21 |

Backend's −3 is −7 false (6 `no-undef` + 1 `no-redeclare`) and +4 genuine (`prefer-const`). The remaining 341 + 9 are the real debt and are the next PR.

## Verification

- Every one of the three configs is asserted to actually parse and load.
- The 5 genuine `.js` findings are enumerated above and still reported.
- Build-state invariance: backend reads 341 errors / 313 files both clean and built.
- **Mutation-tested:** a `var` + unused local appended to `listing-providers/src/proxy.ts` is caught (`no-var`, from the rule set this PR turns on, plus an extra `no-unused-vars`). Restored in place with `trap - EXIT INT TERM` first; md5 matches and `git diff` is empty.

Nothing is suppressed: no `eslint-disable` anywhere, and no rule is switched off outside `eslint-recommended`'s TypeScript-scoped set.

### One thing I did not change, for you to rule on

The three configs are near-identical copies, and that duplication is the direct cause of this bug — `#249` fixed the jest globals in `backend` only, and `eslint-recommended` was missing from all three. A shared base would prevent recurrence, but doing it properly means declaring `eslint`, `@eslint/js`, `@typescript-eslint/*` and `globals` a **fifth** time at the workspace root so the base file can resolve them, which trades one duplication for another. I left it alone rather than make that call unasked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)