### PR TITLE
Give the Mongoose layer real types, not `any` (no-require-imports, part 1)

### DIFF
--- a/packages/backend/models/index.ts
+++ b/packages/backend/models/index.ts
@@ -1,17 +1,16 @@
 /**
- * Model registry.
+ * Model registry — the one place a Mongoose model is resolved.
  *
- * Source files under `models/schemas/*` are still CJS (`module.exports =
- * mongoose.model(...)`) — they remain untouched so existing tests keep working
- * via `require('../../models')`. This file gives the rest of the codebase
- * typed, named ES imports while still emitting a CJS `module.exports` for those
- * legacy callers.
+ * Every schema under `models/schemas/*` exports its model as a default export,
+ * and this file imports them and attaches the document interface that
+ * `mongoose.model()` cannot infer from a schema literal.
  *
  * Document interfaces live in `./documentTypes` (lightweight) or beside the
  * TS-native model files (`./Property`, `./Address`, `./Review`).
+ *
+ * The `module.exports` aggregate at the bottom is a bridge for the ~30 files
+ * that still do `require('../models')`; it goes when they do.
  */
-
-import type { Model } from 'mongoose';
 
 import type { IProperty, IPropertyModel } from './Property';
 import type { IAddress, IAddressModel } from './Address';
@@ -58,47 +57,85 @@ import type {
   IEvictionReport,
 } from './documentTypes';
 
-// Schemas are CJS — `require` them and cast to typed Mongoose Models.
+import PropertyModelDefault from './schemas/PropertySchema';
+import AddressModelDefault from './Address';
+import { Review as ReviewSource } from './Review';
+import LeaseModelDefault from './schemas/LeaseSchema';
+import RecentlyViewedModelDefault from './schemas/RecentlyViewedSchema';
+import ViewingRequestModelDefault from './schemas/ViewingRequestSchema';
+import SavedPropertyFolderModelDefault from './schemas/SavedPropertyFolderSchema';
+import SavedSearchModelDefault from './schemas/SavedSearchSchema';
+import ProfileModelDefault from './schemas/ProfileSchema';
+import ConversationModelDefault from './schemas/ConversationSchema';
+import CountryModelDefault from './schemas/CountrySchema';
+import RegionModelDefault from './schemas/RegionSchema';
+import CityModelDefault from './schemas/CitySchema';
+import NeighborhoodModelDefault from './schemas/NeighborhoodSchema';
+import SavedModelDefault from './schemas/SavedSchema';
+import BillingModelDefault from './schemas/BillingSchema';
+import ReservationModelDefault from './schemas/ReservationSchema';
+import TenantApplicationModelDefault from './schemas/TenantApplicationSchema';
+import NotificationModelDefault from './schemas/NotificationSchema';
+import ExchangeRequestModelDefault from './schemas/ExchangeRequestSchema';
+import ExchangeReviewModelDefault from './schemas/ExchangeReviewSchema';
+import ListingReportModelDefault from './schemas/ListingReportSchema';
+import AgencyModelDefault from './schemas/AgencySchema';
+import PartnerModelDefault from './schemas/PartnerSchema';
+import CommissionModelDefault from './schemas/CommissionSchema';
+import ImageModelDefault from './schemas/ImageSchema';
+import PlacePoiModelDefault from './schemas/PlacePoiSchema';
+import RoommateRequestModelDefault from './schemas/RoommateRequestSchema';
+import RoommateRelationshipModelDefault from './schemas/RoommateRelationshipSchema';
+import EvictionCaseModelDefault from './schemas/EvictionCaseSchema';
+import EvictionCommentModelDefault from './schemas/EvictionCommentSchema';
+import EvictionReportModelDefault from './schemas/EvictionReportSchema';
+import { ModerationReport as ModerationReportSource } from './ModerationReport';
+import { ModerationOutbox as ModerationOutboxSource } from './ModerationOutbox';
+import { ModerationEvent as ModerationEventSource } from './ModerationEvent';
+import { ModerationEnforcement as ModerationEnforcementSource } from './ModerationEnforcement';
 
-const PropertyModel = require('./schemas/PropertySchema') as IPropertyModel;
-const AddressModel = (require('./Address').default) as IAddressModel;
-const ReviewModel = (require('./Review').Review) as IReviewModel;
-const LeaseModel = require('./schemas/LeaseSchema') as ILeaseModel;
-const RecentlyViewedModel = require('./schemas/RecentlyViewedSchema') as Model<IRecentlyViewed>;
-const ViewingRequestModel = require('./schemas/ViewingRequestSchema') as Model<IViewingRequest>;
-const SavedPropertyFolderModel = require('./schemas/SavedPropertyFolderSchema') as Model<ISavedPropertyFolder>;
-const SavedSearchModel = require('./schemas/SavedSearchSchema') as Model<ISavedSearch>;
-const ProfileModel = require('./schemas/ProfileSchema') as IProfileModel;
-const ConversationModel = require('./schemas/ConversationSchema') as IConversationModel;
-const CountryModel = require('./schemas/CountrySchema') as Model<ICountry>;
-const RegionModel = require('./schemas/RegionSchema') as Model<IRegion>;
-const CityModel = require('./schemas/CitySchema') as ICityModel;
-const NeighborhoodModel = require('./schemas/NeighborhoodSchema') as Model<INeighborhood>;
-const SavedModel = require('./schemas/SavedSchema') as Model<ISaved>;
-const BillingModel = require('./schemas/BillingSchema') as IBillingModel;
-const ReservationModel = require('./schemas/ReservationSchema') as Model<IReservation>;
-const TenantApplicationModel = require('./schemas/TenantApplicationSchema') as Model<ITenantApplication>;
-const NotificationModel = require('./schemas/NotificationSchema') as Model<INotification>;
-const ExchangeRequestModel = require('./schemas/ExchangeRequestSchema') as Model<IExchangeRequest>;
-const ExchangeReviewModel = require('./schemas/ExchangeReviewSchema') as Model<IExchangeReview>;
-const ListingReportModel = require('./schemas/ListingReportSchema') as Model<IListingReport>;
-const AgencyModel = require('./schemas/AgencySchema') as IAgencyModel;
-const PartnerModel = require('./schemas/PartnerSchema') as Model<IPartner>;
-const CommissionModel = require('./schemas/CommissionSchema') as Model<ICommission>;
-const ImageModel = require('./schemas/ImageSchema') as Model<IImage>;
-const PlacePoiModel = require('./schemas/PlacePoiSchema') as Model<IPlacePoi>;
-const RoommateRequestModel = require('./schemas/RoommateRequestSchema') as Model<IRoommateRequest>;
-const RoommateRelationshipModel = require('./schemas/RoommateRelationshipSchema') as Model<IRoommateRelationship>;
-const EvictionCaseModel = require('./schemas/EvictionCaseSchema') as Model<IEvictionCase>;
-const EvictionCommentModel = require('./schemas/EvictionCommentSchema') as Model<IEvictionComment>;
-const EvictionReportModel = require('./schemas/EvictionReportSchema') as Model<IEvictionReport>;
+// The casts attach each document interface, which `mongoose.model()` cannot
+// infer from the schema literal on its own.
+
+const PropertyModel = PropertyModelDefault;
+const AddressModel = AddressModelDefault;
+const ReviewModel = ReviewSource;
+const LeaseModel = LeaseModelDefault;
+const RecentlyViewedModel = RecentlyViewedModelDefault;
+const ViewingRequestModel = ViewingRequestModelDefault;
+const SavedPropertyFolderModel = SavedPropertyFolderModelDefault;
+const SavedSearchModel = SavedSearchModelDefault;
+const ProfileModel = ProfileModelDefault;
+const ConversationModel = ConversationModelDefault;
+const CountryModel = CountryModelDefault;
+const RegionModel = RegionModelDefault;
+const CityModel = CityModelDefault;
+const NeighborhoodModel = NeighborhoodModelDefault;
+const SavedModel = SavedModelDefault;
+const BillingModel = BillingModelDefault;
+const ReservationModel = ReservationModelDefault;
+const TenantApplicationModel = TenantApplicationModelDefault;
+const NotificationModel = NotificationModelDefault;
+const ExchangeRequestModel = ExchangeRequestModelDefault;
+const ExchangeReviewModel = ExchangeReviewModelDefault;
+const ListingReportModel = ListingReportModelDefault;
+const AgencyModel = AgencyModelDefault;
+const PartnerModel = PartnerModelDefault;
+const CommissionModel = CommissionModelDefault;
+const ImageModel = ImageModelDefault;
+const PlacePoiModel = PlacePoiModelDefault;
+const RoommateRequestModel = RoommateRequestModelDefault;
+const RoommateRelationshipModel = RoommateRelationshipModelDefault;
+const EvictionCaseModel = EvictionCaseModelDefault;
+const EvictionCommentModel = EvictionCommentModelDefault;
+const EvictionReportModel = EvictionReportModelDefault;
+const ModerationReportModel = ModerationReportSource;
+const ModerationOutboxModel = ModerationOutboxSource;
+const ModerationEventModel = ModerationEventSource;
+const ModerationEnforcementModel = ModerationEnforcementSource;
 
 // CrowdSource moderation. TS-native models, required the same way as the rest so
 // they land on the aggregate `module.exports` below alongside them.
-const ModerationReportModel = (require('./ModerationReport').ModerationReport) as Model<IModerationReport>;
-const ModerationOutboxModel = (require('./ModerationOutbox').ModerationOutbox) as Model<IModerationOutbox>;
-const ModerationEventModel = (require('./ModerationEvent').ModerationEvent) as Model<IModerationEvent>;
-const ModerationEnforcementModel = (require('./ModerationEnforcement').ModerationEnforcement) as Model<IModerationEnforcement>;
 
 // Named ES exports — preferred for new code.
 export const Property = PropertyModel;
@@ -187,12 +224,12 @@ export type {
   IModerationEnforcement,
 };
 
-// Legacy CJS callers (`const models = require('../../models')` — used by the
-// Jest helpers and integration tests) need this aggregate as `module.exports`.
-// We assign it last so it overrides whatever the TS-emitted `exports.X = ...`
-// markers would have provided to require() consumers; named ES imports inside
-// this codebase still resolve to the same singletons because they read the
-// same keys off `module.exports`.
+// The remaining `require('../models')` callers (Jest helpers, integration
+// tests, a handful of controllers) need this aggregate as `module.exports`. It
+// is assigned last so it overrides the TS-emitted `exports.X = ...` markers;
+// named ES imports inside this codebase still resolve to the same singletons
+// because they read the same keys off it. Delete this block once the last
+// `require('../models')` is gone.
 module.exports = {
   Property: PropertyModel,
   Address: AddressModel,

--- a/packages/backend/models/schemas/AgencySchema.ts
+++ b/packages/backend/models/schemas/AgencySchema.ts
@@ -13,8 +13,10 @@
  * agency is addressed publicly by a URL-safe, collision-suffixed `slug`.
  */
 
-const mongoose = require('mongoose');
-const { normalizeAgencyName, slugifyAgencyName } = require('../../utils/agencyName');
+import mongoose from 'mongoose';
+import type { IAgencyModel } from '../documentTypes';
+import type { IAgency } from '../documentTypes';
+import { normalizeAgencyName, slugifyAgencyName } from '../../utils/agencyName';
 
 const MIN_NAME_LENGTH = 2;
 const MAX_NAME_LENGTH = 120;
@@ -99,4 +101,4 @@ agencySchema.statics.findOrCreateByName = async function findOrCreateByName(
   return this.create({ name, normalizedName, slug: `${baseSlug}-${Date.now()}` });
 };
 
-module.exports = mongoose.model('Agency', agencySchema);
+export default mongoose.model<IAgency, IAgencyModel>('Agency', agencySchema);

--- a/packages/backend/models/schemas/BillingSchema.ts
+++ b/packages/backend/models/schemas/BillingSchema.ts
@@ -1,7 +1,8 @@
 import type { Model } from 'mongoose';
 import type { IBilling } from '../documentTypes';
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { IBillingModel } from '../documentTypes';
 
 const billingSchema = new mongoose.Schema({
   oxyUserId: {
@@ -122,4 +123,4 @@ billingSchema.pre('save', async function(this: IBilling, next: (err?: Error) => 
   next();
 });
 
-module.exports = mongoose.model('Billing', billingSchema);
+export default mongoose.model<IBilling, IBillingModel>('Billing', billingSchema);

--- a/packages/backend/models/schemas/CitySchema.ts
+++ b/packages/backend/models/schemas/CitySchema.ts
@@ -8,8 +8,10 @@
  * filtered by `cityId` (no free-text `popularNeighborhoods` array).
  */
 
-const mongoose = require('mongoose');
-const { LISTING_CURRENCIES } = require('@homiio/shared-types');
+import mongoose from 'mongoose';
+import type { ICityModel } from '../documentTypes';
+import type { ICity } from '../documentTypes';
+import { LISTING_CURRENCIES } from '@homiio/shared-types';
 
 const citySchema = new mongoose.Schema({
   name: {
@@ -62,7 +64,7 @@ const citySchema = new mongoose.Schema({
   },
   currency: {
     type: String,
-    enum: LISTING_CURRENCIES,
+    enum: [...LISTING_CURRENCIES],
     default: 'EUR'
   },
   /**
@@ -143,4 +145,4 @@ citySchema.methods.updatePropertiesCount = async function() {
   return this.save();
 };
 
-module.exports = mongoose.model('City', citySchema);
+export default mongoose.model<ICity, ICityModel>('City', citySchema);

--- a/packages/backend/models/schemas/CommissionSchema.ts
+++ b/packages/backend/models/schemas/CommissionSchema.ts
@@ -14,7 +14,8 @@
  * deal has closed.
  */
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { ICommission } from '../documentTypes';
 
 const COMMISSION_STATUSES: ReadonlyArray<string> = ['pending', 'approved', 'paid', 'cancelled'];
 const COMMISSION_OFFERINGS: ReadonlyArray<string> = ['rent', 'sale', 'exchange'];
@@ -107,4 +108,4 @@ commissionSchema.index({ propertyId: 1 }, { unique: true });
 // Partner earnings-ledger lookups (newest first).
 commissionSchema.index({ partnerId: 1, createdAt: -1 });
 
-module.exports = mongoose.model('Commission', commissionSchema);
+export default mongoose.model<ICommission>('Commission', commissionSchema);

--- a/packages/backend/models/schemas/ConversationSchema.ts
+++ b/packages/backend/models/schemas/ConversationSchema.ts
@@ -1,6 +1,7 @@
 import type { IConversation, IConversationMessage } from '../documentTypes';
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { IConversationModel } from '../documentTypes';
 
 interface ConversationDoc extends IConversation {
   analytics: { messageCount: number; lastActivity: Date; totalTokens: number };
@@ -279,4 +280,4 @@ conversationSchema.set('toJSON', {
   virtuals: true, // Include virtual fields
 });
 
-module.exports = mongoose.model("Conversation", conversationSchema);
+export default mongoose.model<IConversation, IConversationModel>("Conversation", conversationSchema);

--- a/packages/backend/models/schemas/CountrySchema.ts
+++ b/packages/backend/models/schemas/CountrySchema.ts
@@ -7,8 +7,9 @@
  * `countryCode` for fast filtering.
  */
 
-const mongoose = require('mongoose');
-const { LISTING_CURRENCIES } = require('@homiio/shared-types');
+import mongoose from 'mongoose';
+import type { ICountry } from '../documentTypes';
+import { LISTING_CURRENCIES } from '@homiio/shared-types';
 
 const countrySchema = new mongoose.Schema({
   /** ISO-3166-1 alpha-2 code, uppercase (e.g. `ES`). Unique. */
@@ -35,7 +36,7 @@ const countrySchema = new mongoose.Schema({
   /** Default currency for the country. */
   currency: {
     type: String,
-    enum: LISTING_CURRENCIES,
+    enum: [...LISTING_CURRENCIES],
     default: 'EUR'
   },
   /** Optional emoji flag (e.g. `🇪🇸`). */
@@ -62,4 +63,4 @@ const countrySchema = new mongoose.Schema({
 
 countrySchema.index({ name: 'text' });
 
-module.exports = mongoose.model('Country', countrySchema);
+export default mongoose.model<ICountry>('Country', countrySchema);

--- a/packages/backend/models/schemas/EvictionCaseSchema.ts
+++ b/packages/backend/models/schemas/EvictionCaseSchema.ts
@@ -12,9 +12,10 @@
  * `updates` is an owner-authored timeline (reschedules, status changes, notes).
  */
 
-const mongoose = require('mongoose');
-const validator = require('validator');
-const { EvictionCaseStatus } = require('@homiio/shared-types');
+import mongoose from 'mongoose';
+import type { IEvictionCase } from '../documentTypes';
+import validator from 'validator';
+import { EvictionCaseStatus } from '@homiio/shared-types';
 
 const MAX_TITLE_LENGTH = 140;
 const MAX_DESCRIPTION_LENGTH = 8000;
@@ -183,4 +184,4 @@ evictionCaseSchema.index({ 'location.coordinates': '2dsphere' });
 // "My cases" lookups.
 evictionCaseSchema.index({ oxyUserId: 1, createdAt: -1 });
 
-module.exports = mongoose.model('EvictionCase', evictionCaseSchema);
+export default mongoose.model<IEvictionCase>('EvictionCase', evictionCaseSchema);

--- a/packages/backend/models/schemas/EvictionCommentSchema.ts
+++ b/packages/backend/models/schemas/EvictionCommentSchema.ts
@@ -6,7 +6,8 @@
  * cascade-deleted when their parent `EvictionCase` is removed.
  */
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { IEvictionComment } from '../documentTypes';
 
 const MAX_BODY_LENGTH = 2000;
 
@@ -43,4 +44,4 @@ const evictionCommentSchema = new mongoose.Schema({
 // Newest-first thread pagination per case.
 evictionCommentSchema.index({ caseId: 1, createdAt: -1 });
 
-module.exports = mongoose.model('EvictionComment', evictionCommentSchema);
+export default mongoose.model<IEvictionComment>('EvictionComment', evictionCommentSchema);

--- a/packages/backend/models/schemas/EvictionReportSchema.ts
+++ b/packages/backend/models/schemas/EvictionReportSchema.ts
@@ -7,12 +7,10 @@
  * internal review queue and carry no public visibility.
  */
 
-const mongoose = require('mongoose');
-const validator = require('validator');
-const {
-  ListingReportReason,
-  ListingReportStatus
-} = require('@homiio/shared-types');
+import mongoose from 'mongoose';
+import type { IEvictionReport } from '../documentTypes';
+import validator from 'validator';
+import { ListingReportReason, ListingReportStatus } from '@homiio/shared-types';
 
 const MAX_DETAILS_LENGTH = 4000;
 
@@ -80,4 +78,4 @@ evictionReportSchema.index(
   }
 );
 
-module.exports = mongoose.model('EvictionReport', evictionReportSchema);
+export default mongoose.model<IEvictionReport>('EvictionReport', evictionReportSchema);

--- a/packages/backend/models/schemas/ExchangeRequestSchema.ts
+++ b/packages/backend/models/schemas/ExchangeRequestSchema.ts
@@ -7,8 +7,9 @@
  * tour) and Lease (long-term contract). Mirrors ReservationSchema's structure.
  */
 
-const mongoose = require('mongoose');
-const { ExchangeMode, ExchangeRequestStatus } = require('@homiio/shared-types');
+import mongoose from 'mongoose';
+import type { IExchangeRequest } from '../documentTypes';
+import { ExchangeMode, ExchangeRequestStatus } from '@homiio/shared-types';
 
 // Half-open date range [start, end) for an exchange stay.
 const exchangeWindowSchema = new mongoose.Schema({
@@ -103,4 +104,4 @@ exchangeRequestSchema.pre('save', function(this: any, next: any) {
   next();
 });
 
-module.exports = mongoose.model('ExchangeRequest', exchangeRequestSchema);
+export default mongoose.model<IExchangeRequest>('ExchangeRequest', exchangeRequestSchema);

--- a/packages/backend/models/schemas/ExchangeReviewSchema.ts
+++ b/packages/backend/models/schemas/ExchangeReviewSchema.ts
@@ -6,7 +6,8 @@
  * stops a participant from reviewing the same exchange twice.
  */
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { IExchangeReview } from '../documentTypes';
 
 // Minimum / maximum allowed star rating (1-5).
 const MIN_RATING = 1;
@@ -67,4 +68,4 @@ exchangeReviewSchema.index({ subjectOxyUserId: 1, createdAt: -1 });
 // One review per reviewer per exchange.
 exchangeReviewSchema.index({ exchangeRequestId: 1, reviewerOxyUserId: 1 }, { unique: true });
 
-module.exports = mongoose.model('ExchangeReview', exchangeReviewSchema);
+export default mongoose.model<IExchangeReview>('ExchangeReview', exchangeReviewSchema);

--- a/packages/backend/models/schemas/ImageSchema.ts
+++ b/packages/backend/models/schemas/ImageSchema.ts
@@ -18,7 +18,8 @@
  * shape) — this collection remains the source of truth for variants and keys.
  */
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { IImage } from '../documentTypes';
 
 /** Entity kinds an image can belong to (mirrors `ImageEntityType` in shared-types). */
 const IMAGE_ENTITY_TYPES = ['property', 'city', 'region', 'country', 'profile'];
@@ -114,4 +115,4 @@ const imageSchema = new mongoose.Schema({
 // Primary access pattern: an entity's ordered photo list.
 imageSchema.index({ entityType: 1, entityId: 1, order: 1 });
 
-module.exports = mongoose.model('Image', imageSchema);
+export default mongoose.model<IImage>('Image', imageSchema);

--- a/packages/backend/models/schemas/LeaseSchema.ts
+++ b/packages/backend/models/schemas/LeaseSchema.ts
@@ -7,7 +7,8 @@ import type { Types } from 'mongoose';
 import { PAYMENT_CURRENCIES } from '@homiio/shared-types';
 import type { ILease } from '../documentTypes';
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { ILeaseModel } from '../documentTypes';
 
 interface LeaseDoc extends ILease {
   leaseTerms: {
@@ -557,4 +558,4 @@ leaseSchema.methods.scheduleInspection = function(this: LeaseDoc, inspectionData
   return this.save();
 };
 
-module.exports = mongoose.model('Lease', leaseSchema);
+export default mongoose.model<ILease, ILeaseModel>('Lease', leaseSchema);

--- a/packages/backend/models/schemas/ListingReportSchema.ts
+++ b/packages/backend/models/schemas/ListingReportSchema.ts
@@ -8,12 +8,10 @@
  * `Review` (public address rating).
  */
 
-const mongoose = require('mongoose');
-const validator = require('validator');
-const {
-  ListingReportReason,
-  ListingReportStatus
-} = require('@homiio/shared-types');
+import mongoose from 'mongoose';
+import type { IListingReport } from '../documentTypes';
+import validator from 'validator';
+import { ListingReportReason, ListingReportStatus } from '@homiio/shared-types';
 
 const MAX_DETAILS_LENGTH = 4000;
 
@@ -81,4 +79,4 @@ listingReportSchema.index(
   }
 );
 
-module.exports = mongoose.model('ListingReport', listingReportSchema);
+export default mongoose.model<IListingReport>('ListingReport', listingReportSchema);

--- a/packages/backend/models/schemas/NeighborhoodSchema.ts
+++ b/packages/backend/models/schemas/NeighborhoodSchema.ts
@@ -8,7 +8,8 @@
  * free-text array).
  */
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { INeighborhood } from '../documentTypes';
 
 const neighborhoodSchema = new mongoose.Schema({
   /** Owning city's `_id`. */
@@ -60,4 +61,4 @@ const neighborhoodSchema = new mongoose.Schema({
 neighborhoodSchema.index({ cityId: 1, name: 1 }, { unique: true });
 neighborhoodSchema.index({ cityId: 1 });
 
-module.exports = mongoose.model('Neighborhood', neighborhoodSchema);
+export default mongoose.model<INeighborhood>('Neighborhood', neighborhoodSchema);

--- a/packages/backend/models/schemas/NotificationSchema.ts
+++ b/packages/backend/models/schemas/NotificationSchema.ts
@@ -1,4 +1,5 @@
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { INotification } from '../documentTypes';
 
 /**
  * Notification Schema
@@ -84,5 +85,5 @@ notificationSchema.index({ recipientOxyUserId: 1, read: 1, createdAt: -1 });
 // Type-filtered listing (mailbox filter chips).
 notificationSchema.index({ recipientOxyUserId: 1, type: 1, createdAt: -1 });
 
-module.exports =
-  mongoose.models.Notification || mongoose.model('Notification', notificationSchema);
+export default
+  mongoose.models.Notification || mongoose.model<INotification>('Notification', notificationSchema);

--- a/packages/backend/models/schemas/PartnerSchema.ts
+++ b/packages/backend/models/schemas/PartnerSchema.ts
@@ -10,7 +10,8 @@
  * it (never stored) so the frontend and backend can never disagree.
  */
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { IPartner } from '../documentTypes';
 
 const PARTNER_STATUSES: ReadonlyArray<string> = ['active', 'inactive'];
 
@@ -58,4 +59,4 @@ const partnerSchema = new mongoose.Schema({
   toObject: { virtuals: true }
 });
 
-module.exports = mongoose.model('Partner', partnerSchema);
+export default mongoose.model<IPartner>('Partner', partnerSchema);

--- a/packages/backend/models/schemas/PlacePoiSchema.ts
+++ b/packages/backend/models/schemas/PlacePoiSchema.ts
@@ -16,7 +16,8 @@
  * names (consistent with the API contract).
  */
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { IPlacePoi } from '../documentTypes';
 
 /** Stable nearby-service category keys (mirrors `NearbyServiceKey` in shared-types). */
 const NEARBY_SERVICE_KEYS = [
@@ -124,4 +125,4 @@ placePoiSchema.index({ cellKey: 1 }, { unique: true });
 // means "expire exactly at the stored date").
 placePoiSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
-module.exports = mongoose.model('PlacePoi', placePoiSchema);
+export default mongoose.model<IPlacePoi>('PlacePoi', placePoiSchema);

--- a/packages/backend/models/schemas/ProfileSchema.ts
+++ b/packages/backend/models/schemas/ProfileSchema.ts
@@ -1,4 +1,6 @@
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { IProfileModel } from '../documentTypes';
+import type { IProfile } from '../documentTypes';
 const {
   EmploymentStatus,
   LeaseDuration,
@@ -402,4 +404,4 @@ profileSchema.set('toJSON', {
   }
 });
 
-module.exports = mongoose.model('Profile', profileSchema);
+export default mongoose.model<IProfile, IProfileModel>('Profile', profileSchema);

--- a/packages/backend/models/schemas/PropertySchema.ts
+++ b/packages/backend/models/schemas/PropertySchema.ts
@@ -7,23 +7,12 @@
 import type { IProperty } from '../Property';
 import type { Query, UpdateQuery } from 'mongoose';
 
-const mongoose = require('mongoose');
-const validator = require('validator');
-const { transformAddressFields } = require('../../utils/helpers');
-const { validateOfferings } = require('./offeringValidation');
-const {
-  PropertyType,
-  PropertyStatus,
-  HousingType,
-  LayoutType,
-  UtilitiesIncluded,
-  LeaseDuration,
-  AvailabilityWindowStatus,
-  CancellationPolicy,
-  OfferingType,
-  ExchangeMode,
-  LISTING_CURRENCIES
-} = require('@homiio/shared-types');
+import mongoose from 'mongoose';
+import type { IPropertyModel } from '../Property';
+import validator from 'validator';
+import { transformAddressFields } from '../../utils/helpers';
+import { validateOfferings } from './offeringValidation';
+import { PropertyType, PropertyStatus, HousingType, LayoutType, UtilitiesIncluded, LeaseDuration, AvailabilityWindowStatus, CancellationPolicy, OfferingType, ExchangeMode, LISTING_CURRENCIES } from '@homiio/shared-types';
 
 // Monthly-rent pricing block (offering: long_term_rent). Currency uses the shared
 // LISTING_CURRENCIES set (covers every ingested market). 'FAIR' is 4 chars so no
@@ -38,7 +27,7 @@ const longTermRentSchema = new mongoose.Schema({
     type: String,
     required: true,
     uppercase: true,
-    enum: LISTING_CURRENCIES,
+    enum: [...LISTING_CURRENCIES],
     default: 'EUR'
   },
   deposit: {
@@ -70,7 +59,7 @@ const shortTermRentSchema = new mongoose.Schema({
     type: String,
     required: true,
     uppercase: true,
-    enum: LISTING_CURRENCIES,
+    enum: [...LISTING_CURRENCIES],
     default: 'EUR'
   },
   cleaningFee: {
@@ -186,7 +175,7 @@ const saleSchema = new mongoose.Schema({
     // Shared LISTING_CURRENCIES set so rent/sale codes stay consistent and cover
     // every ingested market. Note 'FAIR' is 4 chars, so no minlength/maxlength
     // constraint (a length cap would wrongly reject 'FAIR').
-    enum: LISTING_CURRENCIES
+    enum: [...LISTING_CURRENCIES]
   },
   pricePerSqm: {
     type: Number,
@@ -264,7 +253,7 @@ const propertySchema = new mongoose.Schema({
   sourceUrl: {
     type: String,
     validate: {
-      validator: validator.isURL,
+      validator: (value: string) => validator.isURL(value),
       message: 'Invalid source URL'
     }
   },
@@ -530,7 +519,7 @@ const propertySchema = new mongoose.Schema({
     url: {
       type: String,
       validate: {
-        validator: validator.isURL,
+        validator: (value: string) => validator.isURL(value),
         message: 'Invalid image URL'
       }
     },
@@ -582,7 +571,7 @@ const propertySchema = new mongoose.Schema({
       type: String,
       required: true,
       validate: {
-        validator: validator.isURL,
+        validator: (value: string) => validator.isURL(value),
         message: 'Invalid document URL'
       }
     },
@@ -801,14 +790,23 @@ propertySchema.index({ hasImages: -1, createdAt: -1 });
  * the schema and the controllers. Attached to `offerings` so it runs on save
  * and on `findOneAndUpdate` with `runValidators`.
  */
+/**
+ * A mongoose validator's `this` is the document on save and a Query on
+ * `findOneAndUpdate`, so it cannot be declared as `IProperty` up front —
+ * `isModified` is what tells the two apart.
+ */
+function isPropertyDocument(value: unknown): value is IProperty {
+  return typeof (value as { isModified?: unknown } | null)?.isModified === 'function';
+}
+
 propertySchema.path('offerings').validate({
-  validator: function(this: IProperty): boolean {
+  validator: function(this: unknown): boolean {
     // Only the document context exposes every block as `this.*`. Update
     // validators (findOneAndUpdate + runValidators) run with a Query `this`
     // where sibling blocks are not visible, which would wrongly reject a
     // partial edit — the update controller's `applyOfferingRulesForUpdate`
     // already enforces full coherence there, so skip when not a document.
-    if (typeof (this as { isModified?: unknown }).isModified !== 'function') {
+    if (!isPropertyDocument(this)) {
       return true;
     }
     return validateOfferings(this) === null;
@@ -1206,4 +1204,4 @@ propertySchema.methods.getCoordinates = function(this: IProperty): { longitude: 
   return null;
 };
 
-module.exports = mongoose.model('Property', propertySchema);
+export default mongoose.model<IProperty, IPropertyModel>('Property', propertySchema);

--- a/packages/backend/models/schemas/RecentlyViewedSchema.ts
+++ b/packages/backend/models/schemas/RecentlyViewedSchema.ts
@@ -1,4 +1,5 @@
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { IRecentlyViewed } from '../documentTypes';
 
 const recentlyViewedSchema = new mongoose.Schema({
   oxyUserId: {
@@ -25,4 +26,4 @@ recentlyViewedSchema.index({ oxyUserId: 1, propertyId: 1 }, { unique: true });
 // Index for efficient queries by oxyUserId and viewedAt
 recentlyViewedSchema.index({ oxyUserId: 1, viewedAt: -1 });
 
-module.exports = mongoose.model('RecentlyViewed', recentlyViewedSchema); 
+export default mongoose.model<IRecentlyViewed>('RecentlyViewed', recentlyViewedSchema); 

--- a/packages/backend/models/schemas/RegionSchema.ts
+++ b/packages/backend/models/schemas/RegionSchema.ts
@@ -7,7 +7,8 @@
  * reference a Region by `_id`.
  */
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { IRegion } from '../documentTypes';
 
 const regionSchema = new mongoose.Schema({
   /** Owning country's `_id`. */
@@ -62,4 +63,4 @@ regionSchema.index({ countryId: 1, name: 1 }, { unique: true });
 regionSchema.index({ countryId: 1 });
 regionSchema.index({ name: 'text' });
 
-module.exports = mongoose.model('Region', regionSchema);
+export default mongoose.model<IRegion>('Region', regionSchema);

--- a/packages/backend/models/schemas/ReservationSchema.ts
+++ b/packages/backend/models/schemas/ReservationSchema.ts
@@ -5,8 +5,9 @@
  * Distinct from ViewingRequest (in-person tour) and Lease (long-term contract).
  */
 
-const mongoose = require('mongoose');
-const { ReservationStatus, CancellationPolicy } = require('@homiio/shared-types');
+import mongoose from 'mongoose';
+import type { IReservation } from '../documentTypes';
+import { ReservationStatus, CancellationPolicy } from '@homiio/shared-types';
 
 const reservationSchema = new mongoose.Schema({
   propertyId: {
@@ -138,4 +139,4 @@ reservationSchema.pre('save', function(this: any, next: any) {
   next();
 });
 
-module.exports = mongoose.model('Reservation', reservationSchema);
+export default mongoose.model<IReservation>('Reservation', reservationSchema);

--- a/packages/backend/models/schemas/RoommateRelationshipSchema.ts
+++ b/packages/backend/models/schemas/RoommateRelationshipSchema.ts
@@ -1,4 +1,5 @@
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { IRoommateRelationship } from '../documentTypes';
 
 /**
  * A confirmed roommate relationship between two personal profiles.
@@ -46,4 +47,4 @@ roommateRelationshipSchema.index(
   { unique: true, partialFilterExpression: { status: 'active' } }
 );
 
-module.exports = mongoose.model('RoommateRelationship', roommateRelationshipSchema);
+export default mongoose.model<IRoommateRelationship>('RoommateRelationship', roommateRelationshipSchema);

--- a/packages/backend/models/schemas/RoommateRequestSchema.ts
+++ b/packages/backend/models/schemas/RoommateRequestSchema.ts
@@ -1,4 +1,5 @@
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { IRoommateRequest } from '../documentTypes';
 
 const roommateRequestSchema = new mongoose.Schema({
   fromOxyUserId: {
@@ -32,4 +33,4 @@ roommateRequestSchema.index(
   { unique: true, partialFilterExpression: { status: 'pending' } }
 );
 
-module.exports = mongoose.model('RoommateRequest', roommateRequestSchema);
+export default mongoose.model<IRoommateRequest>('RoommateRequest', roommateRequestSchema);

--- a/packages/backend/models/schemas/SavedPropertyFolderSchema.ts
+++ b/packages/backend/models/schemas/SavedPropertyFolderSchema.ts
@@ -1,7 +1,7 @@
 import type { Types } from 'mongoose';
 import type { ISavedPropertyFolder, ISavedFolderEntry } from '../documentTypes';
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
 
 type ObjectIdLike = string | Types.ObjectId;
 type FolderEntry = ISavedFolderEntry & { notes?: string; savedAt?: Date };
@@ -151,4 +151,4 @@ savedPropertyFolderSchema.methods.updatePropertyNotes = async function(
   return false;
 };
 
-module.exports = mongoose.model('SavedPropertyFolder', savedPropertyFolderSchema); 
+export default mongoose.model<ISavedPropertyFolder>('SavedPropertyFolder', savedPropertyFolderSchema); 

--- a/packages/backend/models/schemas/SavedSchema.ts
+++ b/packages/backend/models/schemas/SavedSchema.ts
@@ -1,4 +1,5 @@
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { ISaved } from '../documentTypes';
 
 const savedSchema = new mongoose.Schema({
   oxyUserId: { type: String, required: true, index: true },
@@ -11,4 +12,4 @@ const savedSchema = new mongoose.Schema({
 
 savedSchema.index({ oxyUserId: 1, targetType: 1, targetId: 1 }, { unique: true });
 
-module.exports = mongoose.models.Saved || mongoose.model('Saved', savedSchema);
+export default mongoose.models.Saved || mongoose.model<ISaved>('Saved', savedSchema);

--- a/packages/backend/models/schemas/SavedSearchSchema.ts
+++ b/packages/backend/models/schemas/SavedSearchSchema.ts
@@ -1,8 +1,14 @@
 import type { Document, Model } from 'mongoose';
 
-const mongoose: typeof import('mongoose') = require('mongoose');
+import mongoose from 'mongoose';
 
-interface ISavedSearch extends Document {
+/**
+ * Exported because `models/index.ts` re-exports the model, and a declaration
+ * emit cannot name a type it cannot import. Note this is NOT the same shape as
+ * `documentTypes.ISavedSearch`, which omits `query`/`filters`/`notificationsEnabled`
+ * — the two should be unified.
+ */
+export interface ISavedSearch extends Document {
   oxyUserId: string;
   name: string;
   query: string;
@@ -12,7 +18,7 @@ interface ISavedSearch extends Document {
   updatedAt: Date;
 }
 
-type SavedSearchModel = Model<ISavedSearch>;
+export type SavedSearchModel = Model<ISavedSearch>;
 
 const savedSearchSchema = new mongoose.Schema<ISavedSearch, SavedSearchModel>({
   oxyUserId: {
@@ -66,4 +72,4 @@ savedSearchSchema.pre('save', function(this: ISavedSearch) {
   this.updatedAt = new Date();
 });
 
-module.exports = mongoose.model<ISavedSearch, SavedSearchModel>('SavedSearch', savedSearchSchema); 
+export default mongoose.model<ISavedSearch, SavedSearchModel>('SavedSearch', savedSearchSchema); 

--- a/packages/backend/models/schemas/TenantApplicationSchema.ts
+++ b/packages/backend/models/schemas/TenantApplicationSchema.ts
@@ -7,14 +7,10 @@
  * booking) and ViewingRequest (in-person tour).
  */
 
-const mongoose = require('mongoose');
-const validator = require('validator');
-const {
-  TenantApplicationStatus,
-  TenantApplicationDocumentType,
-  EmploymentStatus,
-  ReferenceRelationship
-} = require('@homiio/shared-types');
+import mongoose from 'mongoose';
+import type { ITenantApplication } from '../documentTypes';
+import validator from 'validator';
+import { TenantApplicationStatus, TenantApplicationDocumentType, EmploymentStatus, ReferenceRelationship } from '@homiio/shared-types';
 
 const referenceContactSchema = new mongoose.Schema({
   name: {
@@ -40,7 +36,7 @@ const referenceContactSchema = new mongoose.Schema({
     trim: true,
     lowercase: true,
     validate: {
-      validator: validator.isEmail,
+      validator: (value: string) => validator.isEmail(value),
       message: 'Invalid reference email'
     }
   }
@@ -56,7 +52,7 @@ const applicationDocumentSchema = new mongoose.Schema({
     type: String,
     required: [true, 'Document URL is required'],
     validate: {
-      validator: validator.isURL,
+      validator: (value: string) => validator.isURL(value),
       message: 'Invalid document URL'
     }
   },
@@ -163,4 +159,4 @@ tenantApplicationSchema.pre('save', function(this: any, next: any) {
   next();
 });
 
-module.exports = mongoose.model('TenantApplication', tenantApplicationSchema);
+export default mongoose.model<ITenantApplication>('TenantApplication', tenantApplicationSchema);

--- a/packages/backend/models/schemas/ViewingRequestSchema.ts
+++ b/packages/backend/models/schemas/ViewingRequestSchema.ts
@@ -1,4 +1,5 @@
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
+import type { IViewingRequest } from '../documentTypes';
 
 const viewingRequestSchema = new mongoose.Schema({
   propertyId: {
@@ -45,6 +46,6 @@ const viewingRequestSchema = new mongoose.Schema({
 viewingRequestSchema.index({ propertyId: 1, scheduledAt: 1, status: 1 });
 viewingRequestSchema.index({ ownerOxyUserId: 1, scheduledAt: 1, status: 1 });
 
-module.exports = mongoose.model('ViewingRequest', viewingRequestSchema);
+export default mongoose.model<IViewingRequest>('ViewingRequest', viewingRequestSchema);
 
 

--- a/packages/backend/scripts/cleanup-external-profileId.ts
+++ b/packages/backend/scripts/cleanup-external-profileId.ts
@@ -1,9 +1,9 @@
 // Script to remove profileId from existing external properties
 // Usage: ts-node --transpile-only scripts/cleanup-external-profileId.ts
 
-require('dotenv').config();
+import 'dotenv/config';
 import database from '../database/connection';
-const Property = require('../models/schemas/PropertySchema');
+import Property from '../models/schemas/PropertySchema';
 
 (async () => {
   try {

--- a/packages/backend/utils/helpers.ts
+++ b/packages/backend/utils/helpers.ts
@@ -34,6 +34,6 @@ const transformAddressFields = <T extends AddressTransformable>(obj: T): T => {
   return obj;
 };
 
-module.exports = {
+export {
   transformAddressFields
 };


### PR DESCRIPTION
> Stacked behind #259. Its 73 fixes are in this branch's history; merge #259 first and this diff reduces to its own 33 files.

## The decision you asked for

**`no-require-imports` genuinely applies to this package, and scoping it off would be wrong.** The package being `"type": "commonjs"` is not the question the rule is asking. Under `module: Node16` + `"type": "commonjs"`, TypeScript compiles `import` to `require()` anyway — the emitted JavaScript is identical either way. What differs is that **`require()` in a `.ts` file returns `any`**, and that is the rule's actual subject.

The evidence is not theoretical:

- #257 already showed it once: `const { City, Country, Region } = require('../../models')` in `cityGeoMigration.test.ts` made `City.collection.indexes()` an `any[]`, producing implicit-any errors that vanished the moment it became a named import.
- Converting **this** layer surfaced **55 type errors immediately** — and they are errors about the schemas, not about the conversion. `models/index.ts` was doing `require('./schemas/PropertySchema') as IPropertyModel`: thirty casts, every one of them from `any`, every one of them incapable of failing.

So: no rule scoped off, no `eslint-disable`. The requires get converted.

## What changed

- **30 `models/schemas/*Schema.ts`** — `require('mongoose')` → `import`, and `module.exports = mongoose.model(...)` → `export default mongoose.model<IDoc>(...)`, or `<IDoc, IModel>` for the seven that declare statics. The document interface is attached where the model is created instead of asserted two files away.
- **`models/index.ts`** — 36 requires → imports, and **all 30 casts deleted**. Five imports needed aliasing because the file re-exports under the name it imports.
- `utils/helpers.ts` → named exports; `scripts/cleanup-external-profileId.ts` → imports.

## Three latent defects came out of hiding

None introduced here; all were invisible while the module was `any`.

1. **`validator.isEmail` / `validator.isURL` were passed to mongoose directly.** Mongoose invokes a validator as `(value, props)` — so its validator-props object was arriving where validator.js expects its *options* argument. Five sites now wrap: `(value: string) => validator.isEmail(value)`.
2. **The `offerings` validator declared `this: IProperty`**, but a mongoose validator's `this` is the document on `save` and a Query on `findOneAndUpdate` — which the body already knew, since it sniffs for `isModified`. That sniff is now a real type predicate rather than an inline cast.
3. **`SavedSearchSchema` declares a local `ISavedSearch` that is not the one in `documentTypes`** — it has `query`/`filters`/`notificationsEnabled`, the shared one does not. Exported so the declaration emit can name it, with the divergence written down in the file. Unifying the two is its own job.

One **TS2589** ("type instantiation is excessively deep") appeared at `enum: LISTING_CURRENCIES` — mongoose's `enum` option type recurses over the members of a readonly tuple, and on a schema this size that trips the compiler's depth limit. Spread to a plain array at five sites; identical value at runtime.

## Counts

`@typescript-eslint/no-require-imports`: **268 → 183**. Nothing else is reported.

## Why this stops at 183

The rest needs `controllers/*` and `routes/*` off `module.exports` too, and that is a materially bigger change than this one. I ran it end to end to find out rather than guess: a full sweep reaches **~200 errors**, dominated by

- ~92 `TS18047`/`TS18048` null-narrowing in integration tests — `Model.findOne()` returns `T | null` and the tests dereference straight through, which `require()`'s `any` had been absorbing. These are real, and fixing them without `!` means a narrowing helper applied across a dozen files.
- `routes/profiles.ts` alone contributes 37, from `profileController` attaching its handlers dynamically and typing them `unknown`.

That is a genuine second PR, not a rounding error on this one. The `module.exports` aggregate at the bottom of `models/index.ts` stays until then, and the comment says exactly when it goes.

## Mutation-tested — including the part that failed

- **Dropping `IPropertyModel` from the model generic IS caught**: two errors naming `findNearby` and `findWithinRadius`. The model-interface generic is load-bearing.
- **Replacing the DOCUMENT generic with a bogus type on `Country` or `City` is NOT caught.** I expected it to be. Mongoose's filter/update types are permissive, and where a bespoke `IXModel extends Model<IX>` exists the *second* generic decides the public surface. So `mongoose.model<IDoc>` buys correct **return** types, not call-site enforcement — worth knowing before anyone leans on it.

Both probes restored in place (`cat pristine > target`, `trap - EXIT INT TERM` first); md5 matches.

## Verification

`tsc --noEmit` exits 0 · 925 backend tests in 81 suites pass · lint reports nothing but `no-require-imports` · counts from `--format json` with a nonzero-file-count assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)