### PR TITLE
Make the frontend typecheck, then arm its gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,14 +200,17 @@ jobs:
           NODE_ENV: production
 
   # ─────────────────────────────────────────────────────────────────────────
-  # OFF BY DEFAULT. Both of these are RED on main today, and a job that is red
-  # on every pull request from the day it lands is not a gate — it is a thing
-  # the next person disables. They are written, and left switched off, so that
-  # turning each one on is a repository-variable change rather than a design
-  # exercise, and so the debt is visible in the place the gate will live.
+  # `lint` is still OFF BY DEFAULT. A job that is red on every pull request from
+  # the day it lands is not a gate — it is a thing the next person disables — so
+  # it stays behind a repository variable until `bun run lint` exits 0, and the
+  # debt stays visible in the place the gate will live.
   #
-  # To turn one on: fix the errors it reports, then set the repository variable
-  # to `ready` (Settings → Secrets and variables → Actions → Variables).
+  # `frontend-typecheck` was the other one and is now ARMED, below: it exits 0,
+  # so its switch was removed rather than left set to `ready`. A switch that
+  # nobody needs is a switch someone can flip the wrong way.
+  #
+  # To turn `lint` on: fix the errors it reports, then delete its `if:` — not
+  # set the variable. Same reasoning.
   # ─────────────────────────────────────────────────────────────────────────
 
   lint:
@@ -246,20 +249,23 @@ jobs:
         run: bun run lint
 
   frontend-typecheck:
-    # Set HOMIIO_FRONTEND_TYPECHECK_GATE=ready once this exits 0.
+    # ARMED. Nothing else typechecks the frontend: `expo export` compiles
+    # through Babel, which strips types without checking them, so the
+    # frontend-bundle job proves the bundle builds and nothing more.
     #
-    # Nothing typechecks the frontend today: `expo export` compiles through
-    # Babel, which strips types without checking them, so the frontend-bundle job
-    # proves the bundle builds and nothing more. `tsc --noEmit` reports 10 errors
-    # — 9 real (a missing required `t` prop in two screens, `OfferingSummary`
-    # lacking `fallback` in two more, a `t` signature mismatch, and a locale code
-    # widened to `string`) and one environmental: @oxyhq/bloom's web portal wants
-    # @types/react-dom, which the frontend does not depend on.
+    # It is armed unconditionally rather than behind a repository variable. A
+    # variable is the right shape for a job that is red on arrival and needs a
+    # human to decide when to switch it on; this one exits 0, and leaving the
+    # switch in place would only mean the next person to make it red can turn it
+    # off instead of fixing it.
+    #
+    # The ten errors it used to report were not stylistic. Two screens omitted a
+    # REQUIRED `t` prop, so `t(key)` was calling `undefined` — a crash on
+    # /applications and /stays that no test covers.
     #
     # The install runs postinstall so shared-types is built — this project
     # resolves it through a path mapping to ../shared-types/src, but its
     # references still expect the built project.
-    if: vars.HOMIIO_FRONTEND_TYPECHECK_GATE == 'ready'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -299,7 +305,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   deploy-backend:
     name: Deploy backend to AWS
-    needs: [backend, frontend, lockfile, frontend-bundle]
+    needs: [backend, frontend, frontend-typecheck, lockfile, frontend-bundle]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       id-token: write

--- a/bun.lock
+++ b/bun.lock
@@ -171,6 +171,7 @@
         "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^29.5.14",
         "@types/react": "~19.2.17",
+        "@types/react-dom": "~19.2.4",
         "babel-plugin-module-resolver": "^5.0.3",
         "eslint": "^9.39.5",
         "eslint-config-expo": "~56.0.4",
@@ -1055,6 +1056,8 @@
     "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.4", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw=="],
 
     "@types/react-test-renderer": ["@types/react-test-renderer@19.1.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ=="],
 

--- a/packages/frontend/app/applications/index.tsx
+++ b/packages/frontend/app/applications/index.tsx
@@ -197,7 +197,7 @@ export default function MyApplicationsScreen() {
       {header}
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>
         <ScrollView contentContainerStyle={styles.content}>
-          <FilterRow value={filter} onChange={setFilter} />
+          <FilterRow value={filter} onChange={setFilter} t={t} />
 
           {filtered.length === 0 ? (
             <View style={styles.emptyWrap}>

--- a/packages/frontend/app/properties/[id]/index.tsx
+++ b/packages/frontend/app/properties/[id]/index.tsx
@@ -894,7 +894,10 @@ export default function PropertyDetailPage() {
                 landlordProfile={landlordProfile}
                 ownerProperties={ownerProperties}
                 onApplyPublic={handlePublicHousingApply}
-                t={(k, d) => t(k, d ?? '') || (d ?? k)}
+                // LandlordSection only ever calls `t(key)`, so the second
+                // parameter was dead — with `d` always undefined this is the
+                // same expression it evaluated to.
+                t={(k: string) => t(k, '') || k}
               />
             </View>
           ) : null}

--- a/packages/frontend/app/settings/language.tsx
+++ b/packages/frontend/app/settings/language.tsx
@@ -31,12 +31,18 @@ interface LanguageOption {
   flag: string;
 }
 
-const LANGUAGES: LanguageOption[] = [
+// Annotated on the LITERAL, not on the result of `.filter`. Annotating the
+// result let each `code` widen to `string`, which both defeated the point of
+// `SupportedLanguageCode` — a typo here would have compiled — and made the
+// `includes` call below an error, since it takes the narrow union.
+const ALL_LANGUAGES: LanguageOption[] = [
   { code: 'en-US', label: 'English', description: 'English (United States)', flag: '🇺🇸' },
   { code: 'es-ES', label: 'Español', description: 'Español (España)', flag: '🇪🇸' },
   { code: 'ca-ES', label: 'Català', description: 'Català (Espanya)', flag: '🇪🇸' },
   { code: 'it-IT', label: 'Italiano', description: 'Italiano (Italia)', flag: '🇮🇹' },
-].filter((lang) => SUPPORTED_LANGUAGE_CODES.includes(lang.code));
+];
+
+const LANGUAGES = ALL_LANGUAGES.filter((lang) => SUPPORTED_LANGUAGE_CODES.includes(lang.code));
 
 export default function LanguageSettingsScreen() {
   const { t, i18n } = useTranslation();

--- a/packages/frontend/app/stays/index.tsx
+++ b/packages/frontend/app/stays/index.tsx
@@ -185,7 +185,7 @@ export default function StaysScreen() {
       {header}
       <SafeAreaView edges={['bottom']} style={styles.safeArea}>
         <ScrollView contentContainerStyle={styles.content}>
-          <FilterRow value={filter} onChange={setFilter} />
+          <FilterRow value={filter} onChange={setFilter} t={t} />
 
           {filteredGroups.length === 0 ? (
             <View style={styles.emptyWrap}>

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -104,6 +104,7 @@
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.14",
     "@types/react": "~19.2.17",
+    "@types/react-dom": "~19.2.4",
     "babel-plugin-module-resolver": "^5.0.3",
     "eslint": "^9.39.5",
     "eslint-config-expo": "~56.0.4",

--- a/packages/frontend/utils/propertyUtils.ts
+++ b/packages/frontend/utils/propertyUtils.ts
@@ -182,13 +182,20 @@ export function resolvePrimaryOffering(
 export interface OfferingSummary {
   offering: OfferingType;
   i18nKey: string;
+  /**
+   * English default for `t(i18nKey, fallback)`. Both consumers already passed
+   * this; without it here they were passing `undefined`, so a missing
+   * translation rendered the raw key instead of readable text — the same
+   * fallback every neighbouring `t()` call in those files supplies.
+   */
+  fallback: string;
 }
 
-const OFFERING_SUMMARY_META: Record<OfferingType, { i18nKey: string }> = {
-  [OfferingType.LONG_TERM_RENT]: { i18nKey: 'listing.offering.summary.longTerm' },
-  [OfferingType.SHORT_TERM_RENT]: { i18nKey: 'listing.offering.summary.nightly' },
-  [OfferingType.SALE]: { i18nKey: 'listing.offering.summary.sale' },
-  [OfferingType.EXCHANGE]: { i18nKey: 'listing.offering.summary.exchange' },
+const OFFERING_SUMMARY_META: Record<OfferingType, { i18nKey: string; fallback: string }> = {
+  [OfferingType.LONG_TERM_RENT]: { i18nKey: 'listing.offering.summary.longTerm', fallback: 'Monthly' },
+  [OfferingType.SHORT_TERM_RENT]: { i18nKey: 'listing.offering.summary.nightly', fallback: 'By night' },
+  [OfferingType.SALE]: { i18nKey: 'listing.offering.summary.sale', fallback: 'For sale' },
+  [OfferingType.EXCHANGE]: { i18nKey: 'listing.offering.summary.exchange', fallback: 'Exchange' },
 };
 
 /** Stable display order for the "Also available" summaries. */
@@ -216,6 +223,7 @@ export function resolveOfferingSummaries(
   ).map((offering) => ({
     offering,
     i18nKey: OFFERING_SUMMARY_META[offering].i18nKey,
+    fallback: OFFERING_SUMMARY_META[offering].fallback,
   }));
 }
 


### PR DESCRIPTION
Nothing typechecks the frontend today — `expo export` compiles through Babel, which strips types without checking them, so the `frontend-bundle` job proves the bundle builds and nothing more. `tsc --noEmit` reported **10 errors → 0**, and one of them was a crash.

## Two were real bugs, not type noise

**`/applications` and `/stays` crash on render.** `FilterRow` declares `t` as a **required** prop and both call sites omitted it, so `t(option.i18nKey)` was calling `undefined`. `t` was in scope at both call sites the whole time — it was simply never passed. Nothing covers those screens, so only a typechecker could have found this.

**A missing i18n fallback rendered raw keys.** `OfferingSummary` had no `fallback` field, but both consumers — the property detail screen and `PropertyCard` — pass `summary.fallback` as the i18n default value. It was `undefined`, so a missing translation rendered `listing.offering.summary.nightly` verbatim, in the middle of an expression where every neighbouring `t()` call supplies readable English. Added to the type and populated from the strings `en.json` already carries (`Monthly`, `By night`, `For sale`, `Exchange`).

## The rest were type-level

- **`LandlordSection`** takes `t: (k: string) => string` and only ever calls `t(key)`, but the detail screen passed a two-parameter wrapper. With the second argument always `undefined` the expression reduces to `t(k, '') || k`, which is what it passes now — one parameter, and the two implicit `any`s go with it.
- **`app/settings/language.tsx`** annotated `LanguageOption[]` on the **result** of `.filter`, so each `code` widened to `string` in the literal. That defeated `SupportedLanguageCode` — a typo in a locale code would have compiled — and made the `SUPPORTED_LANGUAGE_CODES.includes(...)` call an error, since it takes the narrow union. Annotating the literal instead fixes both. Note this **narrows** a type that had been widened by accident; nothing here is widened to make an error go away.

## The one environmental error

`@types/react-dom` added as a frontend devDependency at `~19.2.4`, matching the installed `react-dom` 19.2.3. `@oxyhq/bloom`'s web portal imports `react-dom` and the frontend did not depend on its types. **`bun.lock` is in the same commit**, and `bun run check:lockfile` is green (it correctly refused to run while the lockfile was uncommitted — worth knowing that check does that).

## Gate armed, and why the switch is gone rather than set

`HOMIIO_FRONTEND_TYPECHECK_GATE == 'ready'` is **removed**, not set to `ready`. A repository variable is the right shape for a job that is red on arrival and needs a human to pick the moment. Once the job is green, that switch only offers the next person a way to turn it off instead of fixing what they broke — and a job silently not running because a variable is unset is exactly the "reads as coverage but isn't" failure this workflow's own comments warn about. `lint` keeps its variable, because `lint` is still red (183 `no-require-imports`, see #260).

`deploy-backend` now `needs` it. The deploy is already gated on the frontend's tests and its web bundle, so gating it on the frontend's types is the same rule rather than a new one.

## Verification

- `bun run --cwd packages/frontend typecheck` exits 0 (was 10 errors).
- **Mutation-tested:** a `const mutationProbe: number = 'string'` appended to `utils/propertyUtils.ts` is caught and named (`TS2322` at line 509), then restored in place (`cat pristine > target`, `trap - EXIT INT TERM` first) — md5 matches, `git diff` empty.
- 40 frontend tests pass; `check:lockfile` green; the workflow YAML parses and `frontend-typecheck` has no `if:` while `lint` still does (asserted, not eyeballed).

No `as any`, no `@ts-ignore`, no `@ts-expect-error`, no `!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)