### PR TITLE
Pin bun and node in the backend image, and check the pins

### DIFF
--- a/.github/scripts/check-version-pins.sh
+++ b/.github/scripts/check-version-pins.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Fails when a toolchain version is pinned in two places that have drifted.
+#
+# `packages/backend/Dockerfile` used to install bun with a bare
+# `npm install -g bun`, which is not a pin at all: the image built today and the
+# image built next month could resolve different bun versions from the same
+# commit. That matters more here than anywhere else in the repository, because
+# this Dockerfile narrows `workspaces` and deliberately never copies `bun.lock`
+# — with no lockfile, the bun version is the only thing deciding how the
+# dependency ranges resolve.
+#
+# Pinning it introduces the problem the ci.yml header was avoiding: a third copy
+# of a version number to keep in step. This script is the answer to that. It is
+# cheap, it runs on every pull request, and it turns silent drift into a red job
+# that names both files.
+#
+# Node is checked the same way against `engines.node`, which is what everything
+# else in the repository reads to decide which runtime it is targeting.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DOCKERFILE="$ROOT/packages/backend/Dockerfile"
+CI="$ROOT/.github/workflows/ci.yml"
+PKG="$ROOT/package.json"
+FAILURES=0
+
+fail() {
+  printf '::error::%s\n' "$1"
+  FAILURES=$((FAILURES + 1))
+}
+
+# --- bun --------------------------------------------------------------------
+ci_bun="$(sed -nE "s/^[[:space:]]*BUN_VERSION:[[:space:]]*'([^']+)'.*/\1/p" "$CI" | head -1)"
+docker_bun="$(sed -nE 's/^ARG BUN_VERSION=(.+)$/\1/p' "$DOCKERFILE" | head -1)"
+
+if [[ -z "$ci_bun" ]]; then
+  fail "could not read BUN_VERSION from $CI — the check cannot pass vacuously"
+elif [[ -z "$docker_bun" ]]; then
+  fail "could not read 'ARG BUN_VERSION=' from $DOCKERFILE — the check cannot pass vacuously"
+elif [[ "$ci_bun" != "$docker_bun" ]]; then
+  fail "bun pin drift: ci.yml says '$ci_bun', packages/backend/Dockerfile says '$docker_bun'"
+else
+  printf 'bun pinned to %s in both ci.yml and packages/backend/Dockerfile\n' "$ci_bun"
+fi
+
+# Every `npm install -g bun` must carry the pin; one that does not is unpinned
+# however carefully the ARG above is maintained.
+#
+# Matched on RUN lines only. Matching the bare phrase anywhere in the file
+# reported the comment above this Dockerfile's own install step — a check that
+# fires on prose about itself is the kind that gets deleted rather than fixed.
+run_installs=0
+while IFS= read -r line; do
+  run_installs=$((run_installs + 1))
+  [[ "$line" == *'bun@${BUN_VERSION}'* ]] && continue
+  fail "unpinned bun install in $DOCKERFILE: $line"
+done < <(grep -nE '^[[:space:]]*RUN .*npm install -g bun' "$DOCKERFILE" || true)
+
+if [[ "$run_installs" -eq 0 ]]; then
+  fail "no 'RUN … npm install -g bun' found in $DOCKERFILE — the check cannot pass vacuously"
+fi
+
+# --- node -------------------------------------------------------------------
+engines_major="$(sed -nE 's/.*"node":[[:space:]]*"([0-9]+)\..*/\1/p' "$PKG" | head -1)"
+if [[ -z "$engines_major" ]]; then
+  fail "could not read engines.node from $PKG — the check cannot pass vacuously"
+fi
+
+from_lines="$(grep -c '^FROM node:' "$DOCKERFILE" || true)"
+if [[ "$from_lines" -eq 0 ]]; then
+  fail "no 'FROM node:' stages found in $DOCKERFILE — the check cannot pass vacuously"
+fi
+
+while IFS= read -r line; do
+  stage_major="$(printf '%s' "$line" | sed -nE 's/^FROM node:([0-9]+).*/\1/p')"
+  if [[ -z "$stage_major" ]]; then
+    fail "could not read a node major from: $line"
+  elif [[ -n "$engines_major" && "$stage_major" != "$engines_major" ]]; then
+    fail "node pin drift: package.json engines.node is ${engines_major}.x, Dockerfile has '$line'"
+  fi
+done < <(grep '^FROM node:' "$DOCKERFILE")
+
+if [[ "$FAILURES" -eq 0 ]]; then
+  printf 'node pinned to %s across %s stage(s), matching engines.node\n' "$engines_major" "$from_lines"
+  exit 0
+fi
+exit 1

--- a/.github/scripts/test-check-version-pins.sh
+++ b/.github/scripts/test-check-version-pins.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Mutation-tests check-version-pins.sh against throwaway copies of the files.
+#
+# The failure that costs something is a check that passes on drift, so every
+# assertion below breaks exactly one pin and requires the script to (a) exit
+# non-zero and (b) NAME the thing it is complaining about. A check that failed
+# for every input would satisfy (a) alone, which is why the clean case is
+# asserted first and why the messages are matched rather than just the status.
+
+set -uo pipefail
+
+SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPTS/../.." && pwd)"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/homiio-pins-test-XXXXXX")"
+FAILURES=0
+
+cleanup() {
+  trap - EXIT INT TERM
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT INT TERM
+
+# A fixture tree the script can run against without touching the real one.
+seed() {
+  rm -rf "$WORKDIR/tree"
+  mkdir -p "$WORKDIR/tree/.github/scripts" "$WORKDIR/tree/.github/workflows" "$WORKDIR/tree/packages/backend"
+  cp "$SCRIPTS/check-version-pins.sh" "$WORKDIR/tree/.github/scripts/"
+  cp "$REPO/.github/workflows/ci.yml" "$WORKDIR/tree/.github/workflows/"
+  cp "$REPO/packages/backend/Dockerfile" "$WORKDIR/tree/packages/backend/"
+  cp "$REPO/package.json" "$WORKDIR/tree/"
+}
+
+# expect <label> <expected-status> <substring-that-must-appear>
+expect() {
+  local label="$1" want="$2" needle="${3:-}" out status
+  out="$(bash "$WORKDIR/tree/.github/scripts/check-version-pins.sh" 2>&1)"
+  status=$?
+  if [[ "$status" -ne "$want" ]]; then
+    printf 'FAIL %s: expected exit %d, got %d\n%s\n' "$label" "$want" "$status" "$out"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+  if [[ -n "$needle" && "$out" != *"$needle"* ]]; then
+    printf 'FAIL %s: exit %d was right but the output never mentioned %q\n%s\n' \
+      "$label" "$status" "$needle" "$out"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+  printf 'ok   %s\n' "$label"
+}
+
+seed
+expect "clean tree passes" 0 "bun pinned to"
+
+seed
+sed -i 's/^ARG BUN_VERSION=.*/ARG BUN_VERSION=9.9.9/' "$WORKDIR/tree/packages/backend/Dockerfile"
+expect "bun drift is caught and named" 1 "bun pin drift"
+
+seed
+sed -i 's/npm install -g bun@${BUN_VERSION}/npm install -g bun/' "$WORKDIR/tree/packages/backend/Dockerfile"
+expect "an unpinned bun install is caught" 1 "unpinned bun install"
+
+seed
+sed -i 's/^FROM node:[0-9]*/FROM node:18/' "$WORKDIR/tree/packages/backend/Dockerfile"
+expect "node drift is caught and named" 1 "node pin drift"
+
+seed
+sed -i 's/^ARG BUN_VERSION=.*/ARG NOT_THE_PIN=1.0.0/' "$WORKDIR/tree/packages/backend/Dockerfile"
+expect "a missing bun pin fails instead of passing vacuously" 1 "cannot pass vacuously"
+
+seed
+sed -i "s/  BUN_VERSION: '.*'/  NOT_BUN_VERSION: 'x'/" "$WORKDIR/tree/.github/workflows/ci.yml"
+expect "a missing ci.yml pin fails instead of passing vacuously" 1 "cannot pass vacuously"
+
+if [[ "$FAILURES" -ne 0 ]]; then
+  printf '\n%d mutation(s) went undetected.\n' "$FAILURES"
+  exit 1
+fi
+printf '\nAll mutations detected.\n'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,17 @@ permissions:
   contents: read
 
 env:
-  # Same bun as deploy-frontends.yml. A lockfile read by two different bun
-  # versions is how `lockfile had changes, but lockfile is frozen` arrives in a
-  # deploy that changed nothing. `packages/backend/Dockerfile` is deliberately not
-  # a third pin to keep in step: it narrows `workspaces` and does not copy
-  # bun.lock at all, resolving fresh from the version ranges.
+  # Same bun as deploy-frontends.yml AND packages/backend/Dockerfile. A lockfile
+  # read by two different bun versions is how `lockfile had changes, but lockfile
+  # is frozen` arrives in a deploy that changed nothing.
+  #
+  # The Dockerfile used to be exempt on the grounds that it narrows `workspaces`
+  # and never copies bun.lock, resolving fresh from the version ranges. That is
+  # true and it is the argument FOR pinning it, not against: with no lockfile the
+  # bun version is the only thing deciding how those ranges resolve, so an
+  # unpinned install lets an identical commit produce different images. It is a
+  # third pin now, and `.github/scripts/check-version-pins.sh` is what keeps the
+  # three in step instead of goodwill.
   BUN_VERSION: '1.3.14'
 
 jobs:
@@ -168,6 +174,12 @@ jobs:
       # Every gate in this repository carries a mutation test that breaks what it
       # guards and fails if the guard still passes. Running them is what keeps a
       # gate that has silently stopped discriminating from reading as coverage.
+      # Toolchain versions are pinned in three files (this one, the backend
+      # Dockerfile, package.json's engines). Drift between them is silent by
+      # nature, so it is checked rather than remembered.
+      - name: Verify the toolchain pins have not drifted
+        run: bash .github/scripts/check-version-pins.sh
+
       - name: Verify the CI and deploy gates can still fail
         run: |
           bash -n .github/scripts/*.sh
@@ -175,6 +187,7 @@ jobs:
           bun .github/scripts/test-assert-test-floor.mjs
           bash .github/scripts/test-assert-install-clean.sh
           bash .github/scripts/test-deployment-scope.sh
+          bash .github/scripts/test-check-version-pins.sh
 
   frontend-bundle:
     runs-on: ubuntu-24.04

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -32,7 +32,12 @@
 ##
 
 # ── Build stage ───────────────────────────────────────────────────
-FROM node:20-bookworm-slim AS builder
+# Kept in step with `BUN_VERSION` in .github/workflows/ci.yml by
+# .github/scripts/check-version-pins.sh, which fails CI if the two drift.
+ARG BUN_VERSION=1.3.14
+
+FROM node:22-bookworm-slim AS builder
+ARG BUN_VERSION
 
 # Toolchain for any node-gyp fallback (sharp ships arm64 glibc prebuilds, but
 # keep the compiler available so a source build never fails the image).
@@ -46,7 +51,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PUPPETEER_SKIP_DOWNLOAD=true \
     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
-RUN npm install -g bun
+# Pinned, and pinned to the SAME version as CI and deploy-frontends.
+#
+# The usual argument for pinning bun — one lockfile read by two versions — does
+# NOT apply here: this stage narrows `workspaces` and deliberately never copies
+# bun.lock. That makes the pin MORE load-bearing, not less. With no lockfile,
+# the bun version is the only thing deciding how the version ranges below
+# resolve, so an unpinned `npm install -g bun` means the image built today and
+# the image built next month can install different dependency graphs from an
+# identical commit.
+RUN npm install -g bun@${BUN_VERSION}
 
 WORKDIR /app
 
@@ -91,7 +105,8 @@ RUN bun run --filter @homiio/backend build
 RUN cp -r packages/backend/locales packages/backend/dist/locales
 
 # ── Production stage ──────────────────────────────────────────────
-FROM node:20-bookworm-slim
+FROM node:22-bookworm-slim
+ARG BUN_VERSION
 
 # Runtime deps: tini as PID 1; Playwright OS libs installed via
 # `playwright install-deps` below (Chromium needs a full set of shared libs).
@@ -111,7 +126,7 @@ ENV NODE_ENV=production \
     # Playwright browsers land under this path (owned by root, readable by node).
     PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
-RUN npm install -g bun
+RUN npm install -g bun@${BUN_VERSION}
 
 WORKDIR /app
 


### PR DESCRIPTION
`packages/backend/Dockerfile` installed bun with a bare `npm install -g bun` in **both** stages while CI and `deploy-frontends.yml` pin `1.3.14`, and built on `node:20` while `engines.node` says `22.x`.

## Why the bun pin matters more here, not less

ci.yml's header exempted this file, and the reason it gave is correct but points the other way:

> `packages/backend/Dockerfile` is deliberately not a third pin to keep in step: it narrows `workspaces` and does not copy bun.lock at all, resolving fresh from the version ranges.

With **no lockfile**, the bun version is the only thing deciding how those version ranges resolve. An unpinned install means the image built today and the image built next month can install different dependency graphs from an identical commit — which is a stronger reason to pin than the lockfile argument that applies elsewhere. The comment is updated to say so.

## The third pin is checked, not remembered

Pinning does introduce exactly what the exemption was avoiding: a third copy of a version number that can drift silently. `.github/scripts/check-version-pins.sh` runs in the `lockfile` job and:

- compares the Dockerfile's `ARG BUN_VERSION` against ci.yml's `BUN_VERSION`;
- requires **every** `RUN … npm install -g bun` to carry the pin (an `ARG` maintained perfectly still helps nobody if one stage ignores it);
- compares each `FROM node:` major against `package.json` `engines.node`.

It carries a mutation test, per the convention every other gate in this repo follows — six cases, each breaking exactly one pin, each asserting the check exits non-zero **and names what broke**. Two are vacuity floors: a missing `ARG BUN_VERSION` or a missing `BUN_VERSION:` must *fail*, not pass by comparing nothing to nothing.

**The first version of the check had a false positive** — it grepped the whole Dockerfile for `npm install -g bun` and flagged the comment *above* the install explaining the pin. Fixed before landing rather than after. A check that fires on prose about itself is one the next person deletes rather than fixes.

## Verified against a real image

Not by reading the Dockerfile:

| check | result |
|---|---|
| `docker build --target builder` | succeeds |
| `docker build` (full image) | succeeds |
| `node --version` inside it | **v22.22.3** |
| `bun --version` inside it | **1.3.14** |
| Playwright Chromium | present in `/ms-playwright` |
| `node packages/backend/dist/server.js` | **boots** — loads every module, mounts the routes, and fails only at `connect ECONNREFUSED 127.0.0.1:27017` |
| `dist` contents | `server.js` + `worker.js`, **no `__tests__`** |

That last row also confirms #257's `tsconfig.build.json` behaves the same inside the image as it does locally.

The server-boot result is the one that matters: it means node 22 runs this code, rather than that node 22 was installed.

## One thing I noticed but did not touch

The boot log carries a pre-existing mongoose warning — `Duplicate schema index on {"propertyId":1}`, from an index declared both with `index: true` and `schema.index()`. Unrelated to this PR, harmless, and worth someone's five minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)