### PR TITLE
Clear the frontend's mechanical lint debt, 70 → 20

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -176,6 +176,7 @@
         "eslint": "^9.39.5",
         "eslint-config-expo": "~56.0.4",
         "eslint-plugin-unused-imports": "^4.4.1",
+        "globals": "^17.7.0",
         "jest": "^29.7.0",
         "jest-expo": "~56.0.5",
         "prettier": "^3.9.5",

--- a/packages/frontend/__tests__/homiioWidgetsPlugin.test.ts
+++ b/packages/frontend/__tests__/homiioWidgetsPlugin.test.ts
@@ -8,7 +8,7 @@
  * a tap that opens nothing.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+ 
 const { assertBaseUrl } = require('../modules/homiio-widgets/app.plugin');
 
 describe('withHomiioWidgets origin validation', () => {

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -51,7 +51,7 @@ import {
 import { usePropertySearch } from '@/hooks/usePropertySearch';
 import { getCategoryFilters } from '@/store/getCategoryFilters';
 import type { HomeCategory } from '@/store/homeCategoryStore';
-import { DEFAULT_SEARCH_QUERY } from '@/store/searchQueryStore';
+import { DEFAULT_SEARCH_QUERY, useSearchQueryStore } from '@/store/searchQueryStore';
 import { PropertyResultsGrid } from '@/components/ui/PropertyResultsGrid';
 import { PropertyResultsGridSkeleton } from '@/components/ui/PropertyResultsGridSkeleton';
 import { LoadMoreSentinel } from '@/components/common/LoadMoreSentinel';
@@ -71,7 +71,6 @@ import { NearbyCityCarousel } from '@/components/NearbyCityCarousel';
 import { SearchSummaryBar } from '@/components/search/SearchSummaryBar';
 import { SearchPanel } from '@/components/search/SearchPanel';
 import type { SearchQuery, SearchStep } from '@/components/search/types';
-import { useSearchQueryStore } from '@/store/searchQueryStore';
 import { CityShowcaseSection } from '@/components/CityShowcaseSection';
 import { FeaturedGridSection } from '@/components/FeaturedGridSection';
 import { HostCtaBanner } from '@/components/HostCtaBanner';
@@ -117,7 +116,7 @@ function getDistance(lat1: number, lon1: number, lat2: number, lon2: number): nu
 function resolveExplorePlace(
   userLocation: { latitude: number; longitude: number } | null | undefined,
   cities: City[],
-  citiesByDistance: Array<{ city: City; distance: number }>,
+  citiesByDistance: { city: City; distance: number }[],
   queryPlace: string | undefined,
   defaultPlace: string,
 ): string {

--- a/packages/frontend/app/(tabs)/profile/edit.tsx
+++ b/packages/frontend/app/(tabs)/profile/edit.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, ScrollView } from 'react-native';
+import { ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button } from '@oxyhq/bloom/button';
 import { Header } from '@/components/Header';

--- a/packages/frontend/app/properties/[id]/apply.tsx
+++ b/packages/frontend/app/properties/[id]/apply.tsx
@@ -29,7 +29,7 @@ import {
   EmploymentStatus,
   ReferenceRelationship,
   TenantApplicationDocumentType,
-} from '@homiio/shared-types';
+ PropertyType } from '@homiio/shared-types';
 import { Header } from '@/components/Header';
 import { ThemedText } from '@/components/ThemedText';
 import { colors } from '@/styles/colors';
@@ -41,7 +41,6 @@ import {
 } from '@/services/applicationService';
 import { useOxy, openAccountDialog } from '@oxyhq/services';
 import { generatePropertyTitle } from '@/utils/propertyTitleGenerator';
-import { PropertyType } from '@homiio/shared-types';
 import { ApiError } from '@/utils/api';
 
 const MAX_DOCUMENTS = 10;

--- a/packages/frontend/app/properties/[id]/index.tsx
+++ b/packages/frontend/app/properties/[id]/index.tsx
@@ -22,7 +22,6 @@ import React, {
 } from 'react';
 import {
   Platform,
-  Pressable,
   StyleSheet,
   View,
 } from 'react-native';

--- a/packages/frontend/app/properties/[id]/report.tsx
+++ b/packages/frontend/app/properties/[id]/report.tsx
@@ -26,13 +26,12 @@ import { Button } from '@oxyhq/bloom/button';
 import { Chip } from '@oxyhq/bloom/chip';
 import { openAccountDialog, useOxy } from '@oxyhq/services';
 
-import { ListingReportReason } from '@homiio/shared-types';
+import { ListingReportReason, PropertyType } from '@homiio/shared-types';
 import { Header } from '@/components/Header';
 import { ThemedText } from '@/components/ThemedText';
 import { useProperty } from '@/hooks';
 import { useReportListingMutation } from '@/hooks/useReportMutation';
 import { generatePropertyTitle } from '@/utils/propertyTitleGenerator';
-import { PropertyType } from '@homiio/shared-types';
 import { ApiError } from '@/utils/api';
 import { toast } from '@oxyhq/bloom/toast';
 import { colors } from '@/styles/colors';

--- a/packages/frontend/assets/icons/analytics-icon.tsx
+++ b/packages/frontend/assets/icons/analytics-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon, Rect } from 'react-native-svg';
+import Svg, { Rect } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/bell-icon.tsx
+++ b/packages/frontend/assets/icons/bell-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/bookmark-icon.tsx
+++ b/packages/frontend/assets/icons/bookmark-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/comment-icon.tsx
+++ b/packages/frontend/assets/icons/comment-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/compose-icon.tsx
+++ b/packages/frontend/assets/icons/compose-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/feeds-icon.tsx
+++ b/packages/frontend/assets/icons/feeds-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/gear-icon.tsx
+++ b/packages/frontend/assets/icons/gear-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/handle-icon.tsx
+++ b/packages/frontend/assets/icons/handle-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/hashtag-icon.tsx
+++ b/packages/frontend/assets/icons/hashtag-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/heart-icon.tsx
+++ b/packages/frontend/assets/icons/heart-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/home-icon.tsx
+++ b/packages/frontend/assets/icons/home-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/list-icon.tsx
+++ b/packages/frontend/assets/icons/list-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/loading-icon.tsx
+++ b/packages/frontend/assets/icons/loading-icon.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import Svg, { Rect } from 'react-native-svg';
-import { ViewStyle } from 'react-native';
+import { ViewStyle, Animated, Easing } from 'react-native';
 import { colors } from '@/styles/colors';
 import { USE_NATIVE_DRIVER } from '@/utils/animation';
-import { Animated, Easing } from 'react-native';
 
 export const Loading = ({
   color = colors.primaryColor,

--- a/packages/frontend/assets/icons/location-icon.tsx
+++ b/packages/frontend/assets/icons/location-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/media-icon.tsx
+++ b/packages/frontend/assets/icons/media-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/plus-icon.tsx
+++ b/packages/frontend/assets/icons/plus-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/search-icon.tsx
+++ b/packages/frontend/assets/icons/search-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path, Line } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/assets/icons/video-icon.tsx
+++ b/packages/frontend/assets/icons/video-icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Svg, { Path, Line, Polygon } from 'react-native-svg';
+import Svg, { Path, Line } from 'react-native-svg';
 import { ViewStyle } from 'react-native';
 import { colors } from '@/styles/colors';
 

--- a/packages/frontend/components/agent/PartnerDashboard.tsx
+++ b/packages/frontend/components/agent/PartnerDashboard.tsx
@@ -184,7 +184,7 @@ export const PartnerDashboard: React.FC<PartnerDashboardProps> = ({
 
   // The 4-up summary grid. Counts render as-is; the two money figures are shown
   // in the ledger's own currency (no FX) via `formatCurrency`.
-  const summaryCells: ReadonlyArray<{ key: string; label: string; value: string }> = [
+  const summaryCells: readonly { key: string; label: string; value: string }[] = [
     {
       key: 'referrals',
       label: t('agent.dashboard.referrals'),

--- a/packages/frontend/components/property/LandlordSection.tsx
+++ b/packages/frontend/components/property/LandlordSection.tsx
@@ -2,18 +2,16 @@ import React from 'react';
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import { ThemedText } from '@/components/ThemedText';
 import { Section, SECTION_GUTTER } from '@/components/property/Section';
-import ProfileAvatar from '@/components/ProfileAvatar';
 import { Avatar } from '@oxyhq/bloom/avatar';
 import { Ionicons } from '@expo/vector-icons';
 import { colors } from '@/styles/colors';
 import { hairline, spacing } from '@/constants/styles';
 import { ActionButton } from '@/components/ui/ActionButton';
-import { FollowButton } from '@oxyhq/services';
+import { FollowButton, useOxy } from '@oxyhq/services';
 import type { Profile, Property } from '@homiio/shared-types';
 import { HomeCarouselSection } from '@/components/HomeCarouselSection';
 import { PropertyCard } from '@/components/PropertyCard';
 import { useRouter } from 'expo-router';
-import { useOxy } from '@oxyhq/services';
 import { useOxyAvatars } from '@/hooks/useOxyAvatars';
 
 interface LandlordSectionProps {

--- a/packages/frontend/context/MapStateContext.tsx
+++ b/packages/frontend/context/MapStateContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useRef, useCallback } from 'react';
+import React, { createContext, useContext, useRef, useCallback } from 'react';
 
 export interface MapState {
   center: [number, number];
@@ -9,11 +9,11 @@ export interface MapState {
     east: number;
     north: number;
   };
-  markers?: Array<{
+  markers?: {
     id: string;
     coordinates: [number, number];
     priceLabel: string;
-  }>;
+  }[];
   highlightedMarkerId?: string | null;
   filters?: {
     minPrice?: number;

--- a/packages/frontend/context/NotificationContext.tsx
+++ b/packages/frontend/context/NotificationContext.tsx
@@ -26,7 +26,6 @@ import {
     getNotificationsModule,
     NotificationData,
     NotificationContent,
-    NotificationCategory,
 } from '@/utils/notifications';
 import { notificationService, Notification } from '@/services/notificationService';
 import { useOxy } from '@oxyhq/services';

--- a/packages/frontend/eslint.config.js
+++ b/packages/frontend/eslint.config.js
@@ -3,6 +3,13 @@ const { defineConfig } = require('eslint/config');
 const expoConfig = require('eslint-config-expo/flat');
 
 module.exports = defineConfig([
+  {
+    // Standalone, so it is a GLOBAL ignore. Attached to a config object that
+    // also carries `rules`, `ignores` only exempts those files from THAT
+    // object. `dist/**` rather than `dist/*` for the same reason a single `*`
+    // stops at one level.
+    ignores: ['dist/**'],
+  },
   expoConfig,
   {
     plugins: {
@@ -22,6 +29,19 @@ module.exports = defineConfig([
         },
       ],
     },
-    ignores: ['dist/*'],
+  },
+  {
+    /**
+     * Jest's globals, in the only place they exist.
+     *
+     * `jest.setup.js` and the suites use `jest`, `describe`, `it` and `expect`,
+     * and nothing told eslint where the tests are — so `no-undef` reported six
+     * of them as undefined globals. The rule is right; the config had simply
+     * never been told. Same fix #249 applied to the backend.
+     */
+    files: ['jest.setup.js', '**/__tests__/**/*.{ts,tsx,js,jsx}', '**/*.test.{ts,tsx,js,jsx}'],
+    languageOptions: {
+      globals: require('globals').jest,
+    },
   },
 ]);

--- a/packages/frontend/hooks/profile/useProfileEditForm.ts
+++ b/packages/frontend/hooks/profile/useProfileEditForm.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Alert } from 'react-native';
 import i18next from 'i18next';
 import type { Profile, UpdateProfileData } from '@/services/profileService';

--- a/packages/frontend/hooks/useCurrency.ts
+++ b/packages/frontend/hooks/useCurrency.ts
@@ -4,7 +4,6 @@ import {
   formatCurrency,
   formatCurrencyWithCode,
   convertCurrency,
-  formatAmountInCurrency,
   getExchangeRateDisplay,
   Currency,
 } from '@/utils/currency';

--- a/packages/frontend/hooks/useOxyAvatars.ts
+++ b/packages/frontend/hooks/useOxyAvatars.ts
@@ -19,7 +19,7 @@ import type { User } from '@oxyhq/core';
  * the root layout): the resolver turns the file id into the canonical Oxy
  * media URL via `getFileDownloadUrl`, the single media chokepoint.
  */
-export function useOxyAvatars(oxyUserIds: ReadonlyArray<string | undefined | null>) {
+export function useOxyAvatars(oxyUserIds: readonly (string | undefined | null)[]) {
   const { oxyServices } = useOxy();
 
   // Stable, deduped list of non-empty ids; sorted so the query key is

--- a/packages/frontend/hooks/useProfile.ts
+++ b/packages/frontend/hooks/useProfile.ts
@@ -1,10 +1,9 @@
 import { useCallback } from 'react';
 import i18next from 'i18next';
 import { useProfileStore } from '@/store/profileStore';
-import { Profile, UpdateProfileData } from '@/services/profileService';
+import profileService, { UpdateProfileData } from '@/services/profileService';
 import { useOxy } from '@oxyhq/services';
 import { toast } from '@oxyhq/bloom/toast';
-import profileService from '@/services/profileService';
 
 export const useProfileActions = () => {
   const { profile, isLoading, error, setProfile, setLoading, setError } = useProfileStore();

--- a/packages/frontend/hooks/usePropertyQueries.ts
+++ b/packages/frontend/hooks/usePropertyQueries.ts
@@ -1,6 +1,6 @@
-import { useCallback, useState, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { usePropertyStore, usePropertySelectors } from '@/store/propertyStore';
-import { Property, PropertyFilters, propertyService } from '@/services/propertyService';
+import { PropertyFilters, propertyService } from '@/services/propertyService';
 import {
   CreatePropertyData,
   PropertyAreaInsights,

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -109,6 +109,7 @@
     "eslint": "^9.39.5",
     "eslint-config-expo": "~56.0.4",
     "eslint-plugin-unused-imports": "^4.4.1",
+    "globals": "^17.7.0",
     "jest": "^29.7.0",
     "jest-expo": "~56.0.5",
     "prettier": "^3.9.5",

--- a/packages/frontend/services/profileService.ts
+++ b/packages/frontend/services/profileService.ts
@@ -1,4 +1,4 @@
-import { api, ApiError } from '@/utils/api';
+import { api } from '@/utils/api';
 import {
   Profile,
   PersonalProfile,

--- a/packages/frontend/store/currencyStore.ts
+++ b/packages/frontend/store/currencyStore.ts
@@ -5,11 +5,11 @@ interface CurrencyState {
   // Data
   currentCurrency: string;
   exchangeRates: Record<string, number>;
-  currencies: Array<{
+  currencies: {
     code: string;
     name: string;
     symbol: string;
-  }>;
+  }[];
 
   // Loading states
   isLoading: boolean;

--- a/packages/frontend/store/locationStore.ts
+++ b/packages/frontend/store/locationStore.ts
@@ -13,11 +13,11 @@ interface LocationState {
     zipCode: string;
   } | null;
   searchResults: any[];
-  searchHistory: Array<{
+  searchHistory: {
     query: string;
     timestamp: string;
     results: any[];
-  }>;
+  }[];
 
   // Loading states
   isLoading: boolean;

--- a/packages/frontend/store/recentlyViewedStore.ts
+++ b/packages/frontend/store/recentlyViewedStore.ts
@@ -4,12 +4,12 @@ import { Property, RecentlyViewedType } from '@homiio/shared-types';
 // Recently Viewed State Interface
 interface RecentlyViewedState {
   // Data
-  items: Array<{
+  items: {
     id: string;
     type: RecentlyViewedType;
     data: any;
     viewedAt: string;
-  }>;
+  }[];
 
   // Loading states
   isLoading: boolean;

--- a/packages/frontend/utils/api.ts
+++ b/packages/frontend/utils/api.ts
@@ -16,7 +16,7 @@ const API_CONFIG = {
 // params). This adoption changes only the TRANSPORT (now the linked client),
 // not the consumer-facing types. eslint-disable kept narrow to these public
 // generics — no `any` is used in the request logic itself.
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 export interface ApiResponse<T = any> {
   success: boolean;
   message?: string;
@@ -219,7 +219,7 @@ export const api = {
     }
   },
 };
-/* eslint-enable @typescript-eslint/no-explicit-any */
+ 
 
 // Web-compatible alert function
 export function webAlert(

--- a/packages/frontend/utils/propertyTitleGenerator.ts
+++ b/packages/frontend/utils/propertyTitleGenerator.ts
@@ -182,13 +182,13 @@ export function previewPropertyTitle(propertyData: PropertyData, format: TitleFo
  */
 export function testPropertyTitleGeneration(language = 'en-US'): {
   success: boolean;
-  tests: Array<{
+  tests: {
     name: string;
     input: PropertyData;
     expected: string;
     actual: string;
     passed: boolean;
-  }>;
+  }[];
 } {
   const originalLanguage = i18next.language;
 
@@ -196,11 +196,11 @@ export function testPropertyTitleGeneration(language = 'en-US'): {
     // Set language for testing
     i18next.changeLanguage(language);
 
-    const testCases: Array<{
+    const testCases: {
       name: string;
       input: PropertyData;
       expected: string;
-    }> = [
+    }[] = [
       {
         name: 'Basic apartment with address',
         input: {


### PR DESCRIPTION
Independent of the backend stack (#260, #263). Leaves only the React Compiler findings, which are real refactors and belong in their own change.

**First a correction to the numbers:** the brief lists the frontend at 14 lint errors. On current `main` it is **70** — `main` has moved since that measurement.

## Config first, same order as #258

- **`jest.setup.js` reported six `no-undef` on `jest`.** The config had never been told where the tests are — the identical gap #249 closed for the backend. A `files`-scoped block supplies jest's globals; `no-undef` stays fully armed everywhere else. Not a code problem, and fixing the code around it would have been the wrong move.
- **`ignores: ['dist/*']` was not a global ignore.** It sat on the config object that also carries `rules`, where it only exempts those files from *that* object. It is a standalone entry now, and `dist/**` rather than `dist/*` — a single `*` stops at one level.

## Then the 44 mechanical ones

`unused-imports/no-unused-imports`, mostly `Line`/`Polygon` imported and never used across `assets/icons/*`. Autofixed.

The same pass also merged duplicate imports from one module (`import/no-duplicates`, also fixable), which left `{ A , B }` with a stray space in four files — cleaned up by hand rather than left as autofixer residue.

`globals` added as a devDependency for the jest block, with `bun.lock` in the same commit.

## What is deliberately left

**20 `react-hooks/*` errors:**

| count | rule |
|---|---|
| 6 | `set-state-in-effect` |
| 6 | `refs` (cannot access refs during render) |
| 6 | `immutability` |
| 1 | `rules-of-hooks` (a conditional `useCallback`) |
| 1 | `preserve-manual-memoization` |

In `app/_layout.tsx`, `NotificationContext`, `ProfileContext`, `PageScrollView`, `SindiExplanationBottomSheet`, `useCurrency` and `assets/icons/loading-icon.tsx`.

These are correctness findings about render behaviour in **boot-critical providers**, not lint noise. `app/_layout.tsx` in particular is where this repo has previously shipped a white-screen-on-cold-boot (see the provider-ordering note in `~/Oxy/AGENTS.md`), and the 40-test frontend suite would not catch a regression in any of them. They want their own PR, a real browser cold-start check, and a frontend reviewer.

**`bun run lint` at the workspace root cannot go green — and the lint gate cannot be armed — until those 20 are resolved.** Backend, listing-providers and shared-types are already at zero (#263).

## Verification

`tsc --noEmit` exits 0 · 40 frontend tests pass · the production web export builds (the same command the `frontend-bundle` job runs) · eslint reports 20 errors across 515 files, all of them the react-hooks set above · `check:lockfile` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)