### PR TITLE
The react-hooks findings that are safe to fix without a browser (20 → 13)

### DIFF
--- a/packages/frontend/app/(tabs)/saved/index.tsx
+++ b/packages/frontend/app/(tabs)/saved/index.tsx
@@ -194,6 +194,14 @@ export default function SavedPropertiesScreen() {
     ]);
   }, [queryClient]);
 
+  // Above the `!isAuthed` early return below. Declared after it, this hook was
+  // skipped entirely while signed out, so signing in changed the hook count
+  // between renders — which React refuses to render through.
+  const handlePropertyPress = useCallback((property: Property) => {
+    const id = (property._id || property.id) as string;
+    if (id) router.push(`/properties/${id}`);
+  }, []);
+
   const isLoading = savedQuery.isPending || foldersQuery.isPending;
   const isError = savedQuery.isError || foldersQuery.isError;
   const isRefreshing = savedQuery.isFetching || foldersQuery.isFetching;
@@ -227,11 +235,6 @@ export default function SavedPropertiesScreen() {
   const renderFolder: ListRenderItem<SavedPropertyFolder> = ({ item }) => (
     <FolderTile folder={item} />
   );
-
-  const handlePropertyPress = useCallback((property: Property) => {
-    const id = (property._id || property.id) as string;
-    if (id) router.push(`/properties/${id}`);
-  }, []);
 
   return (
     <View style={styles.root}>

--- a/packages/frontend/assets/icons/loading-icon.tsx
+++ b/packages/frontend/assets/icons/loading-icon.tsx
@@ -13,7 +13,11 @@ export const Loading = ({
   size?: number;
   style?: ViewStyle;
 }) => {
-  const rotateAnim = React.useRef(new Animated.Value(0)).current;
+  // `useState` with a lazy initialiser, not `useRef(...).current`: reading a
+  // ref during render is what the compiler objects to, and the value is only
+  // ever created once either way. `interpolate` below has to run during
+  // render to build the style, so the ref form could not stay.
+  const [rotateAnim] = React.useState(() => new Animated.Value(0));
 
   React.useEffect(() => {
     const animation = Animated.loop(

--- a/packages/frontend/components/PageScrollView.tsx
+++ b/packages/frontend/components/PageScrollView.tsx
@@ -74,8 +74,12 @@ export function PageScrollView({
   const value = scrollY ?? fallbackScrollY;
 
   // Keep the latest `onEndReached` without regenerating the worklet handler.
+  // Assigned in an effect, not during render: the worklet reads it via
+  // `runOnJS` during a scroll, which is well after commit.
   const onEndReachedRef = useRef(onEndReached);
-  onEndReachedRef.current = onEndReached;
+  useEffect(() => {
+    onEndReachedRef.current = onEndReached;
+  }, [onEndReached]);
   const fireEndReached = useCallback(() => {
     onEndReachedRef.current?.();
   }, []);

--- a/packages/frontend/components/common/LoadMoreSentinel.tsx
+++ b/packages/frontend/components/common/LoadMoreSentinel.tsx
@@ -25,8 +25,12 @@ const SENTINEL_STYLE = { height: 1 } as const;
 export function LoadMoreSentinel({ onLoadMore, enabled, rootMargin = '600px' }: LoadMoreSentinelProps) {
   const viewRef = useRef<View>(null);
   // Keep the latest callback without re-subscribing the observer every render.
+  // Assigned in an effect, not during render: the observer only ever reads it
+  // from its own callback, which is well after commit.
   const onLoadMoreRef = useRef(onLoadMore);
-  onLoadMoreRef.current = onLoadMore;
+  useEffect(() => {
+    onLoadMoreRef.current = onLoadMore;
+  }, [onLoadMore]);
 
   useEffect(() => {
     if (Platform.OS !== 'web' || typeof window === 'undefined' || !('IntersectionObserver' in window)) {


### PR DESCRIPTION
Four files. The thirteen remaining errors are listed at the bottom rather than rushed.

## One is a genuine bug

**`app/(tabs)/saved/index.tsx` violates the rule of hooks.** `useCallback` was declared *after* the `if (!isAuthed) return` early return, so the hook was skipped entirely while signed out. **Signing in changes the hook count between renders**, which React refuses to render through — `Rendered more hooks than during the previous render`. Moved above the return; nothing else changes.

## Three are behaviour-preserving by construction

**`LoadMoreSentinel` and `PageScrollView`** both used the latest-callback-ref idiom with the write during render (`ref.current = cb`). The ref itself earns its keep — it is what stops the `IntersectionObserver` re-subscribing, and the Reanimated worklet handler regenerating, on every render — so the *write* moved into an effect rather than the ref going away. There is no gap on first render: `useRef(cb)` already initialises with the same value, and both readers (the observer callback, the worklet's `runOnJS`) fire well after commit.

**`assets/icons/loading-icon.tsx`** read `useRef(new Animated.Value(0)).current` during render. `interpolate` has to run during render to build the style, so the ref form could not stay; `useState` with a lazy initialiser gives the same create-once value without the render-time ref read.

## What is left, and why I stopped here

**13 errors**, in files where the fix is a *render-behaviour* change rather than a mechanical one:

| file | rule |
|---|---|
| `app/_layout.tsx:269` | `set-state-in-effect` |
| `context/NotificationContext.tsx:483,489` | `set-state-in-effect` |
| `context/ProfileContext.tsx:53` | `set-state-in-effect` |
| `hooks/useSindiSuggestions.ts:37` | `set-state-in-effect` |
| `components/SindiExplanationBottomSheet.tsx:136` | `set-state-in-effect` |
| `components/SindiExplanationBottomSheet.tsx:137,151,223,226,236` | `immutability` |
| `hooks/useCurrency.ts:21` | `immutability` |
| `app/tips/[slug].tsx:147` | `preserve-manual-memoization` |

Three reasons these are not in this PR:

1. **`app/_layout.tsx` and the two contexts are boot-critical providers.** This repo has previously shipped a white-screen-on-cold-boot from provider ordering (the `useTheme`/`BloomThemeProvider` rule in `~/Oxy/AGENTS.md`), and that class of bug passes `tsc`, passes the suite, and only shows up in a real browser on a cold start.
2. **The 40-test frontend suite would not catch a regression in any of them.**
3. **The `SindiExplanationBottomSheet` cluster is Reanimated.** Five of the six `immutability` errors are `sharedValue.value = …` writes, which the compiler objects to on principle because a shared value is external mutable state. Whether the right answer is to restructure the component or to scope the rule for that pattern is a judgement worth making deliberately — and per the brief, if a rule produces false positives on correct code the fix belongs in the config, with the reason.

**`bun run lint` at the root — and therefore `HOMIIO_LINT_GATE` — stays blocked on these 13.** Backend, listing-providers and shared-types are at zero.

## Verification

`tsc --noEmit` exits 0 · 40 tests pass · the production web export builds (same command as the `frontend-bundle` job) · eslint reports exactly the 13 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)