### PR TITLE
Two react-hooks findings outside the provider tree (13 → 11)

### DIFF
--- a/packages/frontend/app/tips/[slug].tsx
+++ b/packages/frontend/app/tips/[slug].tsx
@@ -144,17 +144,24 @@ export default function TipArticleScreen() {
     enabled: Boolean(slug) && tipQuery.isSuccess,
   });
 
+  // Hoisted to locals so the dependency expressions are plain identifiers. The
+  // array said `allTipsQuery.data?.data` while the body read
+  // `allTipsQuery.data.data` — the same value, but two different expressions,
+  // which is what "inferred different dependency than source" was reporting.
+  const allTips = allTipsQuery.data?.data;
+  const currentTipTags = tipQuery.data?.tags;
+
   const relatedTips = useMemo(() => {
-    if (!slug || !allTipsQuery.data?.data) return [];
-    const current = allTipsQuery.data.data.filter((entry) => entry.slug !== slug);
-    const currentTags = new Set(tipQuery.data?.tags ?? []);
+    if (!slug || !allTips) return [];
+    const current = allTips.filter((entry) => entry.slug !== slug);
+    const currentTags = new Set(currentTipTags ?? []);
     const scored = current.map((entry) => {
       const overlap = entry.tags.filter((tag) => currentTags.has(tag)).length;
       return { entry, overlap };
     });
     scored.sort((a, b) => b.overlap - a.overlap);
     return scored.map((item) => item.entry).slice(0, 3);
-  }, [allTipsQuery.data?.data, slug, tipQuery.data?.tags]);
+  }, [allTips, slug, currentTipTags]);
 
   if (!slug) {
     return (

--- a/packages/frontend/hooks/useCurrency.ts
+++ b/packages/frontend/hooks/useCurrency.ts
@@ -16,24 +16,30 @@ export const useCurrency = () => {
   const { currentCurrency, isLoading, error, setCurrentCurrency, setLoading, setError } =
     useCurrencyStore();
 
-  // Load saved currency on app start
+  // Load the saved currency once on mount. Inlined into the effect: it was a
+  // `const` arrow declared BELOW this effect and called from inside it, so the
+  // effect closed over whichever instance the first render happened to make.
+  // It is used nowhere else and is not returned from the hook, so there is
+  // nothing for it to be a named function for.
   useEffect(() => {
-    loadSavedCurrency();
-  }, []);
-
-  const loadSavedCurrency = async () => {
-    try {
-      setLoading(true);
-      const savedCurrencyCode = await AsyncStorage.getItem(CURRENCY_STORAGE_KEY);
-      if (savedCurrencyCode) {
-        setCurrentCurrency(savedCurrencyCode);
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        const savedCurrencyCode = await AsyncStorage.getItem(CURRENCY_STORAGE_KEY);
+        if (!cancelled && savedCurrencyCode) {
+          setCurrentCurrency(savedCurrencyCode);
+        }
+      } catch {
+        if (!cancelled) setError('Failed to load saved currency');
+      } finally {
+        if (!cancelled) setLoading(false);
       }
-    } catch (error) {
-      setError('Failed to load saved currency');
-    } finally {
-      setLoading(false);
-    }
-  };
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [setCurrentCurrency, setError, setLoading]);
 
   const changeCurrency = async (currencyCode: string) => {
     try {


### PR DESCRIPTION
First of the series. Both are leaf-level and neither touches a provider, so they go together and ahead of the boot-critical ones.

## `hooks/useCurrency.ts`

`loadSavedCurrency()` was called from a `useEffect` declared **three lines above** the `const` arrow that defines it. It works at runtime — effects run after render, by which point the binding is assigned — but the effect closed over whichever instance the first render happened to create, and the rule is right that reading a value before its declaration means the earlier access can never see a later one.

It is used nowhere else and is not returned from the hook, so there was nothing for it to be a named function for. Inlined into the effect, with a `cancelled` flag so unmounting mid-read cannot set state on a gone component.

Its deps are the three zustand setters it calls. **I checked those are stable** — `create()` builds the store object once, so the setter identities never change and the effect still runs exactly once. Listing them is honest, where `[]` would have needed a disable.

## `app/tips/[slug].tsx`

The dependency array said `allTipsQuery.data?.data` while the body read `allTipsQuery.data.data`. Same value, two different expressions — which is exactly what *"inferred different dependency than source"* reports. Hoisted both to locals so the dependencies are plain identifiers; the memo body is otherwise unchanged.

## No inline disables

I added one to `useCurrency` while working and took it back out. The deps it was silencing turned out to be correct once written down — which is usually the case, and is why the rule against them is a good one.

## Verification — a real headed browser, cold start

Built a harness for this series rather than eyeballing it. Each run launches **headed Chromium on a real X display with a fresh `--user-data-dir`** (so: no cache, no storage, no service worker — a genuine cold start), waits 9s, and asserts `document.visibilityState === 'visible'` before reporting any verdict. That last part matters: a backgrounded tab pauses `requestAnimationFrame`, which reads as "blank" and has cost this ecosystem a phantom debugging session. If the tab is not foregrounded the harness exits **inconclusive** rather than passing or failing.

**The harness is itself mutation-tested**: pointed at a copy of `dist` with the entry bundle replaced by `throw new Error(...)`, it reports 0 elements, captures the exception, and exits 1. It can tell "it ran and found nothing wrong" from "it did not run".

| route | result |
|---|---|
| `/` | **PASS** — 400 elements, 1231 chars, **identical to the pre-change baseline** |
| `/tips` | **PASS** — 289 elements, 848 chars |

Zero console errors and zero uncaught exceptions on both. Plus `tsc --noEmit` 0, 40 tests pass, production web export builds.

## Remaining after this: 11

`app/_layout.tsx` (1) · `NotificationContext` (2) · `ProfileContext` (1) · `useSindiSuggestions` (1) · `SindiExplanationBottomSheet` (6). One PR each, in that reverse order of risk. **The `SindiExplanationBottomSheet` six need a ruling from you before I touch them** — evidence in the next message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)