### PR TITLE
Derive the Sindi suggestions fallback instead of resetting it (−1)

### DIFF
--- a/packages/frontend/hooks/useSindiSuggestions.ts
+++ b/packages/frontend/hooks/useSindiSuggestions.ts
@@ -27,18 +27,27 @@ const DEFAULT_SUGGESTIONS: SindiSuggestion[] = [
 ];
 
 export function useSindiSuggestions({ property, conversationContext }: UseSindiSuggestionsProps = {}) {
-    const [suggestions, setSuggestions] = useState<SindiSuggestion[]>(DEFAULT_SUGGESTIONS);
+    // Keyed by the property it was fetched for, so the fallback below is DERIVED
+    // rather than reset by an effect. The effect used to call
+    // `setSuggestions(DEFAULT_SUGGESTIONS)` synchronously whenever it could not
+    // fetch — a cascading render, and on the very first pass a no-op, since that
+    // is already the initial value. Keying also fixes a real bug: suggestions
+    // fetched for one property stayed on screen while the next one loaded.
+    const [fetched, setFetched] = useState<{ propertyId: string; items: SindiSuggestion[] } | null>(
+        null,
+    );
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const { oxyServices, activeSessionId } = useOxy();
 
+    const propertyId = property?._id || property?.id;
+    const suggestions =
+        fetched && fetched.propertyId === propertyId ? fetched.items : DEFAULT_SUGGESTIONS;
+
     useEffect(() => {
-        if (!property || !oxyServices || !activeSessionId) {
-            setSuggestions(DEFAULT_SUGGESTIONS);
+        if (!property || !propertyId || !oxyServices || !activeSessionId) {
             return;
         }
-
-        const propertyId = property._id || property.id;
         
         const fetchSuggestions = async () => {
             setLoading(true);
@@ -65,32 +74,24 @@ export function useSindiSuggestions({ property, conversationContext }: UseSindiS
 
                 const data = response.data;
 
-                if (data.success && data.suggestions?.length > 0) {
-                    setSuggestions(data.suggestions);
-                } else {
-                    setSuggestions(DEFAULT_SUGGESTIONS);
-                }
+                setFetched({
+                    propertyId,
+                    items:
+                        data.success && data.suggestions?.length > 0
+                            ? data.suggestions
+                            : DEFAULT_SUGGESTIONS,
+                });
 
             } catch (err) {
                 setError(err instanceof Error ? err.message : 'Failed to load suggestions');
-                setSuggestions(DEFAULT_SUGGESTIONS);
+                setFetched({ propertyId, items: DEFAULT_SUGGESTIONS });
             } finally {
                 setLoading(false);
             }
         };
 
         fetchSuggestions();
-    }, [property, conversationContext, oxyServices, activeSessionId]);
+    }, [property, propertyId, conversationContext, oxyServices, activeSessionId]);
 
-    return {
-        suggestions,
-        loading,
-        error,
-        refetch: () => {
-            if (property && oxyServices && activeSessionId) {
-                // Trigger re-fetch by updating a dependency
-                setSuggestions(DEFAULT_SUGGESTIONS);
-            }
-        },
-    };
+    return { suggestions, loading, error };
 }


### PR DESCRIPTION
Second of the series, independent of #267.

## The finding

The effect called `setSuggestions(DEFAULT_SUGGESTIONS)` **synchronously** whenever it could not fetch — a cascading render, and on the very first pass a no-op, since that is already the initial state.

`useEffect` is the smell here rather than the fix (`~/AGENTS.md`: prefer derived state), so the fallback is derived now. The fetched list is held **keyed by the property it was fetched for**, and

```ts
fetched?.propertyId === propertyId ? fetched.items : DEFAULT_SUGGESTIONS
```

does what the reset was for. The only remaining state write is the async result, which is in a callback — exactly where the rule says it belongs.

## Keying it fixes a real bug, not just the lint error

Suggestions fetched for one property **stayed on screen while the next property's request was in flight**, because nothing cleared them on the way in. The old code only reset when it *couldn't* fetch; switching between two fetchable properties showed the previous one's suggestions until the new response landed. The key makes the stale set underivable.

## `refetch` removed

It claimed to *"trigger re-fetch by updating a dependency"* and set `suggestions` — which is **not a dependency of the effect**, so it reset the list and re-fetched nothing. The hook's one consumer (`components/property/SindiSection.tsx`) destructures `suggestions` alone and never called it. Dead and misleading, so it goes rather than getting a comment.

## Verification

Real headed Chromium, fresh profile, `document.visibilityState === 'visible'` asserted before any verdict (harness described in #267, and itself mutation-tested against a deliberately broken bundle):

| route | result |
|---|---|
| `/` | **PASS** — 400 elements, identical to baseline |
| `/properties` | **PASS** — 284 elements |

Zero console errors, zero uncaught exceptions on both. `tsc --noEmit` 0, 40 tests pass, production web export builds.

## Remaining: `app/_layout.tsx` (1) · `NotificationContext` (2) · `ProfileContext` (1) · `SindiExplanationBottomSheet` (6)

The last of those needs a ruling from you before I touch it — see my message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)