### PR TITLE
Scope react-hooks/immutability off for the Sindi sheet, with the premise (10 → 5)

### DIFF
--- a/packages/frontend/app.config.js
+++ b/packages/frontend/app.config.js
@@ -29,6 +29,18 @@ module.exports = function (config) {
       userInterfaceStyle: 'automatic',
       newArchEnabled: true,
       jsEngine: 'hermes',
+      // NOTE — `experiments.reactCompiler` is deliberately absent: the React
+      // Compiler does not run in this app. Two things depend on that being true,
+      // so read them before enabling it:
+      //
+      //  1. `eslint.config.js` switches `react-hooks/immutability` off for
+      //     `components/SindiExplanationBottomSheet.tsx`, on the grounds that the
+      //     rule guards a transformation that does not happen here. Enabling the
+      //     compiler flips that premise and the exemption must be re-argued.
+      //  2. `~/AGENTS.md` §"React Compiler + external mutable state" — with the
+      //     compiler on, READING external mutable state from a memoized position
+      //     freezes the first value forever. This app reads Reanimated shared
+      //     values and zustand stores in plenty of places.
       ios: {
         supportsTablet: true,
         bundleIdentifier: 'com.homiio.android',

--- a/packages/frontend/eslint.config.js
+++ b/packages/frontend/eslint.config.js
@@ -44,4 +44,48 @@ module.exports = defineConfig([
       globals: require('globals').jest,
     },
   },
+  {
+    /**
+     * `react-hooks/immutability` off for this ONE file, because its premise is
+     * not true here.
+     *
+     * The rule guards a React Compiler transformation. **This app does not run
+     * the React Compiler** — there is no `experiments.reactCompiler` in
+     * `app.config.js`, and the built web bundle contains no compiler output on
+     * Homiio's own code (the only `useMemoCache` references in it are React's
+     * internal `__COMPILER_RUNTIME` export and dispatcher table).
+     * `eslint-plugin-react-hooks` v7 runs the rule statically either way.
+     *
+     * What it reports here is five `sharedValue.value = …` writes. A
+     * `useSharedValue` handle is stable by design and mutating `.value` is
+     * Reanimated's documented API — and specifically the form
+     * `~/Oxy/AGENTS.md` PRESCRIBES: drive the shared value imperatively and let
+     * `useAnimatedStyle` only READ it, because returning `withTiming` from a
+     * mapper silently fails on web. Every shared-value write in this file (19 of
+     * them, checked) is inside a `useEffect`, a `useCallback` or a
+     * `useAnimatedScrollHandler` worklet; **none is during render**, and no
+     * `useAnimatedStyle` in the file writes.
+     *
+     * What this exemption does NOT cover, measured rather than assumed: the rule
+     * does not report render-phase shared-value writes in the first place. Its
+     * subject is "a value used previously in an effect function or as an effect
+     * dependency". A render-phase `sharedValue.value = …` added to this file
+     * with the rule ON produced no new error, and the same probe in
+     * `PageScrollView.tsx` produced none either. So switching it off here gives
+     * up the five prescribed-pattern findings and nothing else — do not read it
+     * as sanctioning a render-phase write, which no rule here is watching for.
+     *
+     * REVISIT IF THE COMPILER IS ENABLED. Turning on
+     * `experiments.reactCompiler` flips the premise and this exemption has to be
+     * re-argued from scratch — see the note beside `experiments` in
+     * `app.config.js`. Note also that `~/AGENTS.md`'s compiler hazard is about
+     * READING external mutable state from a memoized position, where the
+     * compiler freezes the first value forever. That is a different failure from
+     * writing, and this exemption must not be widened to cover it.
+     */
+    files: ['components/SindiExplanationBottomSheet.tsx'],
+    rules: {
+      'react-hooks/immutability': 'off',
+    },
+  },
 ]);


### PR DESCRIPTION
Your ruling (b), with the three conditions. **Config only — no component changes.**

## I checked WHERE before choosing

All **19** shared-value writes in `components/SindiExplanationBottomSheet.tsx`:

| context | count |
|---|---|
| `useEffect` | 9 |
| `useCallback` | 4 |
| `useAnimatedScrollHandler` (worklet) | 6 |
| **during render** | **0** |

And no `useAnimatedStyle` in the file writes — only reads. That is exactly the form `~/Oxy/AGENTS.md` **prescribes**: drive the shared value imperatively, let the mapper only read, because returning `withTiming` from a mapper silently fails on web.

## The premise

This app does not run the React Compiler — no `experiments.reactCompiler` in `app.config.js`, and I checked the **built bundle** rather than the config alone: the only `useMemoCache` references are React's internal `__COMPILER_RUNTIME` export and dispatcher table, not compiler output on Homiio's code. `eslint-plugin-react-hooks` v7 runs the rule statically either way. The rule guards a transformation that does not happen here.

## The three conditions

1. **Narrowest scope** — one file, one rule. Verified it is not a blanket: `set-state-in-effect` still reports in that same file (line 136 is still an error, and is in the remaining 5).
2. **The reason states the premise**, not the inconvenience — compiler not enabled, `useSharedValue` handles stable by design, rule guards a transformation that does not run. Not "the rule is wrong about Reanimated".
3. **Revisit condition in `app.config.js`**, beside where `experiments` would be added, because that is where someone enabling the compiler will be looking. It also points at `~/AGENTS.md`'s hazard and says explicitly that it is about **reading** external mutable state from a memoized position — a different failure from writing — so the exemption must not be widened to cover reads.

## A claim I had written and removed, because it was false

My first draft of the comment said a render-phase write "would be a real finding and is not exempted by anything here."

**It is not a finding of this rule at all.** A render-phase `sharedValue.value = …` added to this file with the rule ON produced **no new error**, and the same probe in `PageScrollView.tsx` produced none either — exit 0. The rule's subject is a value *used in an effect or as an effect dependency*, not write-phase.

I caught this because my first version of the check grepped for `immutability` in the output, found nothing, and I had labelled that "caught elsewhere" — an empty grep reading as a pass, which is the same failure shape as the eslint false-zero earlier in this series. Re-ran it printing full output and exit code.

The comment now states the measured behaviour, so nobody reads the exemption as sanctioning a render-phase write that nothing is actually watching for.

## Remaining: 5

All `set-state-in-effect`, all genuine: `app/_layout.tsx`, `NotificationContext` ×2, `ProfileContext`, and line 136 of the Sindi sheet. Carrying on with those one at a time.

## Verification

eslint **5** errors across 515 files · `tsc --noEmit` 0 · 40 tests pass · production web export builds. Both probe files restored in place (`cat pristine > target`, `trap - EXIT INT TERM` first), `git diff` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)