### PR TITLE
ProfileContext: drop the dead API the cascading render came from (−1)

### DIFF
--- a/packages/frontend/context/ProfileContext.tsx
+++ b/packages/frontend/context/ProfileContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useMemo, useCallback } from 'react';
+import React, { createContext, useContext, useEffect, useMemo } from 'react';
 import { useOxy } from '@oxyhq/services';
 import { useProfileStore } from '@/store/profileStore';
 import type { Profile } from '@/services/profileService';
@@ -6,64 +6,40 @@ import { logger } from '@/utils/logger';
 
 interface ProfileContextType {
   profile: Profile | null;
-  isLoading: boolean;
-  error: string | null;
   hasProfile: boolean;
-  refetch: () => void;
   canAccessRoommates: boolean;
-  refresh: () => Promise<void>;
-  isInitialized: boolean;
 }
 
 const ProfileContext = createContext<ProfileContextType | undefined>(undefined);
 
 export function ProfileProvider({ children }: { children: React.ReactNode }) {
   const { oxyServices, activeSessionId, isAuthenticated } = useOxy();
-  const {
-    profile,
-    isLoading,
-    error,
-    setProfile,
-    setError,
-    fetchProfile,
-  } = useProfileStore();
-
-  const [isInitialized, setIsInitialized] = React.useState(false);
-
-  const loadProfile = useCallback(async () => {
-    try {
-      await fetchProfile();
-      setIsInitialized(true);
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Failed to load profile';
-      setError(message);
-      setIsInitialized(true);
-    }
-  }, [fetchProfile, setError]);
-
-  const refresh = useCallback(async () => {
-    setIsInitialized(false);
-    await loadProfile();
-  }, [loadProfile]);
+  // SELECTORS, not `useProfileStore()`. Subscribing to the whole store re-renders
+  // this provider on every `set()` — including the `set({ isLoading: true })`
+  // that `fetchProfile` issues synchronously, which is the cascading render the
+  // effect below was reported for. Nothing here reads `isLoading`, so selecting
+  // only what is used removes the re-render rather than hiding it.
+  const profile = useProfileStore((s) => s.profile);
+  const setProfile = useProfileStore((s) => s.setProfile);
+  const fetchProfile = useProfileStore((s) => s.fetchProfile);
 
   useEffect(() => {
     let mounted = true;
 
     if (isAuthenticated && oxyServices && activeSessionId) {
-      loadProfile().catch((loadError) => {
+      fetchProfile().catch((loadError) => {
         if (mounted) {
-          logger.error('ProfileContext: loadProfile failed', loadError);
+          logger.error('ProfileContext: fetchProfile failed', loadError);
         }
       });
     } else if (!isAuthenticated) {
       setProfile(null);
-      setIsInitialized(false);
     }
 
     return () => {
       mounted = false;
     };
-  }, [isAuthenticated, oxyServices, activeSessionId, loadProfile, setProfile]);
+  }, [isAuthenticated, oxyServices, activeSessionId, fetchProfile, setProfile]);
 
   const hasProfile = profile !== null;
 
@@ -72,24 +48,9 @@ export function ProfileProvider({ children }: { children: React.ReactNode }) {
     [profile?.personalProfile?.settings?.roommate?.enabled],
   );
 
-  const refetch = useCallback(() => {
-    if (isAuthenticated && oxyServices && activeSessionId) {
-      loadProfile().catch(() => {});
-    }
-  }, [isAuthenticated, oxyServices, activeSessionId, loadProfile]);
-
   const contextValue = useMemo(
-    () => ({
-      profile,
-      isLoading,
-      error,
-      hasProfile,
-      refetch,
-      canAccessRoommates,
-      refresh,
-      isInitialized,
-    }),
-    [profile, isLoading, error, hasProfile, refetch, canAccessRoommates, refresh, isInitialized],
+    () => ({ profile, hasProfile, canAccessRoommates }),
+    [profile, hasProfile, canAccessRoommates],
   );
 
   return (


### PR DESCRIPTION
One provider, one PR. **−53 lines net.**

## A correction to what I told you

I reported that the rule was right because *"`fetchProfile` calls `set({ isLoading: true })` synchronously before its first `await`"*. That is true of the store, but **it is not what the rule was flagging.** `react-hooks/set-state-in-effect` tracks React state; a zustand `set()` is invisible to it.

The actual subject was **`setIsInitialized`** — a React `useState` setter reachable from the effect through `loadProfile`. I found that by experiment rather than by reading, and it changes the fix.

## `isInitialized` was dead API

All eight `useProfile()` call sites, checked individually:

| file | destructures |
|---|---|
| `components/SideBar/index.tsx` | `canAccessRoommates` |
| `app/reservations/[id].tsx` | `profile` |
| `app/roommates/index.tsx` | `profile, hasProfile` |
| `app/exchange/[id].tsx` | `profile` |
| `app/landlord/applications/[id].tsx` | `profile` |
| `app/roommates/preferences.tsx` | `profile, hasProfile` |
| `app/applications/[id].tsx` | `profile` |
| `app/contracts/[id].tsx` | `profile` |

**Nothing reads `isInitialized`, `isLoading`, `error`, `refetch` or `refresh`.** So the setState the rule flagged existed to feed a value nobody consumed. Removing it removes the finding at its cause, and `loadProfile`, `refresh` and `refetch` go with it — the effect calls `fetchProfile()` directly now.

## Selectors, separately — and a claim I am *not* making

The store reads are selectors now. `useProfileStore()` with no selector subscribes to the **whole store**, so this provider re-rendered on every `set()` including ones for state it never read.

**I could not measure that benefit and am not claiming it.** I instrumented both versions with a render counter, built and cold-started each: **both report 4 `ProfileProvider` renders**. That measurement is **vacuous** — with no session `isAuthenticated` is false, `fetchProfile` never runs, and the path in question never executes. It establishes no regression on an unauthenticated boot and nothing more. Verifying the reduction needs an authenticated session, which I do not have here.

## What I *did* verify: this is not a blinded analyzer

The obvious worry is that the error cleared only because `fetchProfile` is an opaque store action the rule cannot trace into — i.e. gaming the tool.

Tested directly: **kept the selectors but routed the call back through a traceable `useCallback` wrapper — the error did not come back.** It went away because the React setState went away, not because the analyzer lost sight of it.

## Verification

eslint clear on this file · `tsc --noEmit` 0 · 40 tests · production web export builds · real headed-browser cold start (fresh profile, `visibilityState === 'visible'` asserted): `/` renders **400 elements — identical to baseline**, `/roommates` renders 256, no console errors, no uncaught exceptions.

## Remaining after this and #269: 4

`app/_layout.tsx` (1) · `NotificationContext` (2) · `SindiExplanationBottomSheet:136` (1) — all `set-state-in-effect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)