### PR TITLE
Derive the root readiness gate instead of latching it in an effect (−1)

### DIFF
--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -218,7 +218,7 @@ function AppShell() {
 
 
 export default function RootLayout() {
-  const [appIsReady, setAppIsReady] = useState(false);
+
   // `startFade` is fully derived from initialization completing — there is no
   // other trigger — so we keep a single source of truth and derive the fade
   // flag instead of syncing it in an effect (which caused cascading renders).
@@ -247,28 +247,27 @@ export default function RootLayout() {
     setFadeComplete(true);
   }, []);
 
-  // NATIVE ONLY: once ready, hide the held OS splash. The shared helper is a
-  // no-op on web (the OS splash was never held; the custom overlay handles the
-  // transition there).
-  useHideNativeSplashWhenReady(appIsReady);
-
-  // Readiness gate.
+  // Readiness gate — DERIVED, for the same reason `startFade` above is.
   // - WEB keeps the fade-gated flow: the custom <AppSplashScreen> renders, fades
   //   out when init completes, and its `onFadeComplete` sets `fadeComplete`, so
   //   web readiness = init complete AND the custom splash finished fading.
   // - NATIVE renders NO custom splash (the held OS splash covers the screen), so
   //   `onFadeComplete` never fires; native readiness = init complete ONLY, else
   //   the OS splash would hang forever.
-  useEffect(() => {
-    if (appIsReady) return;
-    const ready =
-      Platform.OS === 'web'
-        ? initializationComplete && fadeComplete
-        : initializationComplete;
-    if (ready) {
-      setAppIsReady(true);
-    }
-  }, [initializationComplete, fadeComplete, appIsReady]);
+  //
+  // This was a `useState` latched by an effect. The latch could never differ
+  // from the expression: `setInitializationComplete` and `setFadeComplete` are
+  // each only ever called with `true` and neither is ever reset, so once the
+  // condition holds it holds forever. Deriving it drops a render — the splash
+  // used to persist for one extra commit while the effect caught up.
+  const appIsReady =
+    Platform.OS === 'web' ? initializationComplete && fadeComplete : initializationComplete;
+
+  // NATIVE ONLY: once ready, hide the held OS splash. The shared helper is a
+  // no-op on web (the OS splash was never held; the custom overlay handles the
+  // transition there).
+  useHideNativeSplashWhenReady(appIsReady);
+
 
   useEffect(() => {
     // React Query online manager using NetInfo


### PR DESCRIPTION
`app/_layout.tsx` is the boot gate — the one where a mistake is a white screen. It is also the **most provably-equivalent** change of this set.

## The latch could never differ from what it latched

```ts
const [appIsReady, setAppIsReady] = useState(false);
useEffect(() => {
  if (appIsReady) return;
  const ready = Platform.OS === 'web' ? initializationComplete && fadeComplete : initializationComplete;
  if (ready) setAppIsReady(true);
}, [initializationComplete, fadeComplete, appIsReady]);
```

Both inputs are **monotonic**, checked at every call site:

| setter | call sites | ever called with `false`? |
|---|---|---|
| `setInitializationComplete` | 2 (success + catch branches of the init effect) | no |
| `setFadeComplete` | 1 (`onFadeComplete` from the web splash) | no |

Neither is ever reset. Once the condition holds it holds forever — which is what a latch is *for*, and what makes this one redundant. So:

```ts
const appIsReady =
  Platform.OS === 'web' ? initializationComplete && fadeComplete : initializationComplete;
```

**The file already made this exact argument three lines above**, for `startFade`: *"we keep a single source of truth and derive the fade flag instead of syncing it in an effect (which caused cascading renders)"*. This finishes that work rather than introducing a new idea.

It also drops a render — the splash used to persist for one extra commit while the effect caught up.

## tsc caught my one mistake, and the bundle did not

The derivation initially landed *after* `useHideNativeSplashWhenReady(appIsReady)` used it — `TS2448`.

Worth flagging: **the production web bundle built successfully with that error present.** Expo compiles through Babel, which strips types without checking them. The `frontend-typecheck` job added in #261 is the only thing in CI that would have caught it. That is the second time this series the typecheck caught something every other gate waved through.

## Verification

Real headed Chromium, fresh profile, `document.visibilityState === 'visible'` asserted before any verdict. A stuck readiness gate presents as exactly the blank this harness exists to detect:

| route | elements | chars | vs baseline |
|---|---|---|---|
| `/` | 400 | 1231 | identical |
| `/properties` | 284 | 547 | identical |
| `/tips` | 289 | 848 | identical |

No console errors, no uncaught exceptions on any of them. Plus `tsc --noEmit` 0, eslint clear on the file, 40 tests pass.

(One route initially printed nothing in my summary — a truncated pipe, not a failure. Re-ran it with full output and exit code rather than letting an empty result read as a pass; it exits 0 at 284 elements. Third time this series an empty grep could have been mistaken for success.)

## Remaining: 3

`NotificationContext` (2) and `SindiExplanationBottomSheet:136` (1). See my message on the first of those — unlike `ProfileContext`, its `isLoading`/`error` are genuinely consumed by the inbox screen, so it is not a dead-API deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)