### PR TITLE
Land the cold-start check as a repo script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,6 +327,76 @@ The worker reads these at startup; disabled providers are not registered.
 
 `packages/backend/worker.ts` is the worker entrypoint — same Docker image as the API, different start command. Run with a separate ECS task definition. Separate container only if Playwright memory becomes a concern.
 
+## Cold-Start Check (the only thing that sees a white screen)
+
+```bash
+bun run --cwd packages/frontend build          # produces dist/
+bun run --cwd packages/frontend check:cold-start / /properties
+bun run --cwd packages/frontend check:cold-start:test   # mutation-tests the check
+```
+
+`packages/frontend/scripts/check-cold-start.mjs` loads the exported web app in a
+REAL headed browser with a fresh profile and asserts it actually **rendered**.
+
+**Run it after touching anything in the boot path** — `app/_layout.tsx`, the
+providers under `context/`, the readiness/splash gate — and after any change the
+React Compiler lint rules prompt in those files.
+
+Why it exists: nothing else here can see a white-screen boot. `tsc` passes,
+`jest` passes, `expo export` succeeds, and the app still mounts nothing. A
+boot-mounted component calling a suspenseful hook deadlocks the render, so the
+init effect never runs and the promise never resolves — a blank page with ZERO
+console output. Provider ordering fails the same silent way (see `~/Oxy/AGENTS.md`,
+the `useTheme`/`BloomThemeProvider` rule).
+
+Three properties worth keeping if you edit it:
+
+- It asserts `document.visibilityState === 'visible'` **before** any verdict and
+  exits INCONCLUSIVE (3) otherwise. A backgrounded tab pauses
+  `requestAnimationFrame`, which presents exactly as "blank" — a false reading
+  that has cost this ecosystem a debugging session.
+- It asserts rendered CONTENT, not merely that nothing threw. "Nothing threw" is
+  not the property.
+- It carries a mutation test that breaks the entry bundle and requires the check
+  to notice, so it can tell "ran and found nothing" from "did not run".
+
+**Standing rule when reading its output, or any check's:** print the full output
+and the exit code. Do not ask a grep whether it matched — an empty match reads
+identically to a pass, and that mistake was made three separate times while
+building this.
+
+## Known react-hooks findings (frontend)
+
+`eslint-plugin-react-hooks` v7 runs the React Compiler's rules statically. **This
+app does not enable the compiler** (no `experiments.reactCompiler` in
+`app.config.js`), so separate the two kinds before "fixing" anything:
+`set-state-in-effect` and `rules-of-hooks` are genuine either way;
+`immutability`, `refs` and `preserve-manual-memoization` reason about a
+transformation that does not run here.
+
+`react-hooks/immutability` is switched off for
+`components/SindiExplanationBottomSheet.tsx` in `eslint.config.js`, with the
+premise and a revisit condition written there and beside `experiments` in
+`app.config.js`. Do not widen it.
+
+**Open, deliberately deferred — `context/NotificationContext.tsx` (2 findings).**
+`loadNotifications` opens with a synchronous
+`setState({ isLoading: true, error: null })` before its first `await`, called
+from an effect: a real cascading render on mount. Unlike `ProfileContext` (fixed
+by deleting dead API) this state is LIVE — `app/(tabs)/inbox/index.tsx` consumes
+`isLoading` and `error` — so the fix is to move the notifications list to React
+Query, which is already the design this file's own section describes
+(refetch-on-focus + invalidation); the hand-rolled `useState` is the drift.
+`notifications`/`unreadCount`/`isLoading`/`error` become query state;
+`preferences`/`hasPermission`/`badgeCount`/`scheduledNotifications` are device
+state and stay.
+
+**It was not done because it cannot be verified without an authenticated
+session** — unauthenticated, `loadNotifications` returns at its guard and the
+path never executes, so the cold-start check above cannot reach it. Get a session
+first; do not ship it on reasoning alone. The same applies to
+`SindiExplanationBottomSheet:136`.
+
 ## Layout Shell & Design Tokens (CRITICAL)
 
 ### ContentPanel (Bloom, Mention-shaped)

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -18,6 +18,8 @@
     "lint": "expo lint",
     "typecheck": "tsc --noEmit",
     "check:i18n": "bun scripts/check-locale-parity.ts",
+    "check:cold-start": "node scripts/check-cold-start.mjs",
+    "check:cold-start:test": "node scripts/test-check-cold-start.mjs",
     "clean": "rm -rf dist .expo"
   },
   "dependencies": {

--- a/packages/frontend/scripts/check-cold-start.mjs
+++ b/packages/frontend/scripts/check-cold-start.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * Cold-start check: does the exported web app actually RENDER on a fresh load?
+ *
+ * Usage:
+ *   bun run --cwd packages/frontend build     # produces dist/
+ *   bun run --cwd packages/frontend check:cold-start [route ...]
+ *
+ * WHY THIS EXISTS
+ *
+ * Nothing else in this repository can see a white-screen boot. `tsc` passes,
+ * `jest` passes, `expo export` succeeds — and the app still mounts nothing.
+ * The failure mode it guards is real and has shipped in this ecosystem before:
+ * a boot-mounted component calling a suspenseful hook deadlocks the render, so
+ * the init effect never runs, the promise never resolves, and you get a blank
+ * page with ZERO console output. Provider ordering (`~/Oxy/AGENTS.md`, the
+ * `useTheme`/`BloomThemeProvider` rule) fails the same silent way.
+ *
+ * Run it after touching anything in the boot path: `app/_layout.tsx`, the
+ * providers under `context/`, or the readiness/splash gate.
+ *
+ * WHAT IT ASSERTS, AND WHY EACH PART IS THERE
+ *
+ *  - A REAL browser, headed, on a real display — not jsdom. Jest reproduces
+ *    neither render races, navigation races nor layout.
+ *  - A FRESH `--user-data-dir` every run, so it is genuinely cold: no cache, no
+ *    storage, no service worker carried over from the previous run.
+ *  - `document.visibilityState === 'visible'` BEFORE any verdict. A backgrounded
+ *    tab pauses `requestAnimationFrame`, which presents exactly as "blank" — a
+ *    false reading that has cost this ecosystem a whole debugging session. If
+ *    the tab is not foregrounded this exits INCONCLUSIVE (3) rather than
+ *    passing or failing, because a blank reading would mean nothing.
+ *  - Content, not merely absence of errors. "Nothing threw" is not the property;
+ *    "the app rendered something" is.
+ *
+ * A STANDING RULE FOR CHANGING THIS FILE
+ *
+ * When you check its output, print the FULL output and the exit code. Do not
+ * ask a grep whether it matched: an empty match reads identically to a pass,
+ * and that mistake was made three separate times while building this. The
+ * accompanying `test-check-cold-start.mjs` mutation-tests exactly that — it
+ * breaks the bundle and requires this script to notice.
+ */
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DIST = process.env.COLD_START_DIST ?? join(HERE, '..', 'dist');
+const ROUTES = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+const BOOT_WAIT_MS = Number(process.env.COLD_START_WAIT_MS ?? 9000);
+const CHROME = process.env.COLD_START_CHROME ?? '/usr/bin/chromium';
+
+/** Below this many DOM nodes we call it blank; a mounted app is far above it. */
+const MIN_ELEMENTS = 20;
+
+if (!existsSync(DIST)) {
+  console.error(`No export at ${DIST}. Run \`bun run build\` in packages/frontend first.`);
+  process.exit(2);
+}
+if (!existsSync(CHROME)) {
+  console.error(`No browser at ${CHROME}. Set COLD_START_CHROME to one.`);
+  process.exit(2);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const teardown = [];
+function cleanup() {
+  for (const fn of teardown.splice(0).reverse()) {
+    try {
+      fn();
+    } catch {
+      // Teardown is best effort; a failure here must not mask the verdict.
+    }
+  }
+}
+process.on('exit', cleanup);
+process.on('SIGINT', () => {
+  cleanup();
+  process.exit(130);
+});
+
+const port = 8700 + Math.floor(Math.random() * 300);
+const debugPort = 9400 + Math.floor(Math.random() * 400);
+
+const server = spawn('bunx', ['--bun', 'serve', '-s', DIST, '-l', String(port)], {
+  stdio: ['ignore', 'ignore', 'ignore'],
+});
+teardown.push(() => server.kill('SIGKILL'));
+
+async function waitFor(fn, tries = 60) {
+  for (let i = 0; i < tries; i += 1) {
+    try {
+      const value = await fn();
+      if (value) return value;
+    } catch {
+      // Not up yet.
+    }
+    await sleep(500);
+  }
+  return null;
+}
+
+if (!(await waitFor(async () => (await fetch(`http://127.0.0.1:${port}/`)).ok))) {
+  console.error('static server never came up');
+  process.exit(2);
+}
+
+const profile = mkdtempSync(join(tmpdir(), 'homiio-cold-start-'));
+teardown.push(() => rmSync(profile, { recursive: true, force: true }));
+
+const chrome = spawn(
+  CHROME,
+  [
+    `--remote-debugging-port=${debugPort}`,
+    `--user-data-dir=${profile}`,
+    '--no-first-run',
+    '--no-default-browser-check',
+    '--window-size=1280,900',
+    'about:blank',
+  ],
+  { stdio: ['ignore', 'ignore', 'ignore'] },
+);
+teardown.push(() => chrome.kill('SIGKILL'));
+
+const wsUrl = await waitFor(async () => {
+  const res = await fetch(`http://127.0.0.1:${debugPort}/json/version`);
+  return (await res.json()).webSocketDebuggerUrl;
+});
+if (!wsUrl) {
+  console.error('browser devtools never came up');
+  process.exit(2);
+}
+
+const ws = new WebSocket(wsUrl);
+await new Promise((resolve, reject) => {
+  ws.onopen = resolve;
+  ws.onerror = reject;
+});
+teardown.push(() => ws.close());
+
+let nextId = 1;
+const pending = new Map();
+let consoleErrors = [];
+let pageErrors = [];
+
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data);
+  if (msg.id && pending.has(msg.id)) {
+    const { resolve, reject } = pending.get(msg.id);
+    pending.delete(msg.id);
+    if (msg.error) reject(new Error(JSON.stringify(msg.error)));
+    else resolve(msg.result);
+    return;
+  }
+  if (msg.method === 'Runtime.consoleAPICalled' && msg.params.type === 'error') {
+    consoleErrors.push(
+      msg.params.args.map((a) => a.value ?? a.description ?? a.type).join(' '),
+    );
+  }
+  if (msg.method === 'Runtime.exceptionThrown') {
+    const details = msg.params.exceptionDetails;
+    pageErrors.push(details.exception?.description ?? details.text);
+  }
+};
+
+function send(method, params = {}, sessionId) {
+  const id = nextId++;
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    ws.send(JSON.stringify({ id, method, params, sessionId }));
+  });
+}
+
+const { targetInfos } = await send('Target.getTargets');
+const pageTarget = targetInfos.find((t) => t.type === 'page');
+const { sessionId } = await send('Target.attachToTarget', {
+  targetId: pageTarget.targetId,
+  flatten: true,
+});
+const call = (method, params = {}) => send(method, params, sessionId);
+await call('Page.enable');
+await call('Runtime.enable');
+
+const PROBE = `(() => {
+  const root = document.getElementById('root') || document.body;
+  const text = (root.innerText || '').trim();
+  return {
+    visibility: document.visibilityState,
+    rootChildren: root.childElementCount,
+    elements: root.querySelectorAll('*').length,
+    renderedChars: text.length,
+    sample: text.slice(0, 120),
+  };
+})()`;
+
+let failures = 0;
+let inconclusive = 0;
+
+for (const route of ROUTES.length ? ROUTES : ['/']) {
+  consoleErrors = [];
+  pageErrors = [];
+  await call('Page.navigate', { url: `http://127.0.0.1:${port}${route}` });
+  await sleep(BOOT_WAIT_MS);
+
+  const { result } = await call('Runtime.evaluate', {
+    expression: PROBE,
+    returnByValue: true,
+    awaitPromise: true,
+  });
+  const probe = result.value;
+
+  console.log(JSON.stringify({ route, ...probe, consoleErrors, pageErrors }, null, 2));
+
+  if (probe.visibility !== 'visible') {
+    console.error(`INCONCLUSIVE ${route}: tab was not foregrounded, so "blank" would mean nothing.`);
+    inconclusive += 1;
+  } else if (probe.rootChildren === 0 || probe.elements < MIN_ELEMENTS) {
+    console.error(`FAIL ${route}: the app rendered nothing (${probe.elements} elements).`);
+    failures += 1;
+  } else if (pageErrors.length) {
+    console.error(`FAIL ${route}: uncaught exception during boot.`);
+    failures += 1;
+  } else {
+    console.error(`PASS ${route}: ${probe.elements} elements, visibility=${probe.visibility}.`);
+  }
+}
+
+cleanup();
+if (inconclusive) process.exit(3);
+process.exit(failures ? 1 : 0);

--- a/packages/frontend/scripts/test-check-cold-start.mjs
+++ b/packages/frontend/scripts/test-check-cold-start.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Mutation-tests check-cold-start.mjs against a deliberately broken export.
+ *
+ * The failure that costs something is the check PASSING on a blank app, because
+ * then it reads as boot coverage forever and nobody looks again. So this breaks
+ * the thing it guards — replaces the entry bundle with a `throw` — and requires
+ * the check to exit non-zero AND say the app rendered nothing.
+ *
+ * It asserts the clean case first, because a check that failed on every input
+ * would satisfy the non-zero half on its own.
+ *
+ * Note this deliberately reads the FULL output and the exit code rather than
+ * grepping for a pattern: an empty match is indistinguishable from a pass, which
+ * is the mistake this whole family of scripts exists to avoid.
+ */
+import { spawnSync } from 'node:child_process';
+import { cpSync, rmSync, mkdtempSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CHECK = join(HERE, 'check-cold-start.mjs');
+const DIST = join(HERE, '..', 'dist');
+
+if (!existsSync(DIST)) {
+  console.error('No export to test against. Run `bun run build` in packages/frontend first.');
+  process.exit(2);
+}
+
+const work = mkdtempSync(join(tmpdir(), 'homiio-cold-start-test-'));
+process.on('exit', () => rmSync(work, { recursive: true, force: true }));
+
+let failures = 0;
+
+/**
+ * Runs the check and returns { status, output }.
+ *
+ * `spawnSync` rather than `execFileSync` on purpose: the verdict lines go to
+ * STDERR (data on stdout, human verdict on stderr), and execFileSync returns
+ * only stdout on success — so the clean case looked like a check that had
+ * printed no verdict at all. Both streams, both outcomes, uniformly.
+ */
+function run(distDir) {
+  const result = spawnSync('node', [CHECK, '/'], {
+    encoding: 'utf8',
+    env: { ...process.env, COLD_START_DIST: distDir, COLD_START_WAIT_MS: '9000' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return {
+    status: result.status ?? 1,
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+  };
+}
+
+function expect(label, got, wantStatus, wantSubstring) {
+  if (got.status !== wantStatus) {
+    console.error(`FAIL ${label}: expected exit ${wantStatus}, got ${got.status}\n${got.output}`);
+    failures += 1;
+    return;
+  }
+  if (wantSubstring && !got.output.includes(wantSubstring)) {
+    console.error(
+      `FAIL ${label}: exit ${got.status} was right but the output never said ${JSON.stringify(wantSubstring)}\n${got.output}`,
+    );
+    failures += 1;
+    return;
+  }
+  console.log(`ok   ${label}`);
+}
+
+// 1. The clean export must PASS — otherwise "it fails on the mutant" proves nothing.
+expect('a working export passes', run(DIST), 0, 'PASS /');
+
+// 2. A broken entry bundle must FAIL, and say the app rendered nothing.
+const broken = join(work, 'dist-broken');
+cpSync(DIST, broken, { recursive: true });
+const jsDir = join(broken, '_expo', 'static', 'js', 'web');
+const entry = readdirSync(jsDir).find((f) => f.startsWith('entry-') && f.endsWith('.js'));
+if (!entry) {
+  console.error('FAIL: could not find the entry bundle to break — the check cannot pass vacuously');
+  process.exit(1);
+}
+writeFileSync(join(jsDir, entry), 'throw new Error("mutation probe: entry bundle broken");\n');
+expect('a broken bundle is caught and named', run(broken), 1, 'rendered nothing');
+
+if (failures) {
+  console.error(`\n${failures} mutation(s) went undetected.`);
+  process.exit(1);
+}
+console.log('\nAll mutations detected.');


### PR DESCRIPTION
It was living in my scratchpad, which is to say it did not exist.

```bash
bun run --cwd packages/frontend build
bun run --cwd packages/frontend check:cold-start / /properties
bun run --cwd packages/frontend check:cold-start:test   # mutation-tests the check
```

## What it is for

**Nothing else in this repository can see a white-screen boot.** `tsc` passes, `jest` passes, `expo export` succeeds, and the app still mounts nothing. A boot-mounted component calling a suspenseful hook deadlocks the render, so the init effect never runs and the promise never resolves — blank page, **zero console output**. Provider ordering fails the same silent way (`~/Oxy/AGENTS.md`, the `useTheme`/`BloomThemeProvider` rule).

It loads the export in a **real headed browser** with a fresh `--user-data-dir` (no cache, no storage, no service worker), waits, and asserts the app **rendered content** — not merely that nothing threw.

## Three load-bearing properties

1. **`document.visibilityState === 'visible'` is asserted before any verdict**, and it exits **INCONCLUSIVE (3)** otherwise. A backgrounded tab pauses `requestAnimationFrame` and presents exactly as "blank". A false blank is worse than no reading.
2. **Content, not absence of errors.** "Nothing threw" is not the property being checked.
3. **It carries a mutation test.** `test-check-cold-start.mjs` replaces the entry bundle with a `throw` and requires the check to exit non-zero *and* say the app rendered nothing — so it can tell "ran and found nothing" from "did not run". The clean case is asserted first, since a check that failed on everything would satisfy the non-zero half on its own.

## The mutation test caught a real defect in itself, first run

It used `execFileSync`, which returns **only stdout** on success — and the verdict lines go to stderr. So a perfectly good check looked like one that had printed no verdict at all, and the clean case failed. `spawnSync` now: both streams, both outcomes, uniformly.

Which is the same bug class as the standing rule the `AGENTS.md` entry records:

> Print the full output and the exit code. Do not ask a grep whether it matched — an empty match reads identically to a pass.

That mistake happened **three separate times** during this series, twice in my own tooling.

## Also documented: the deferred `NotificationContext` work

The `AGENTS.md` entry carries the diagnosis so nobody redoes it:

- `loadNotifications` opens with a synchronous `setState({ isLoading: true, error: null })` before its first `await`, called from an effect — a real cascading render on mount.
- Unlike `ProfileContext` (fixed by deleting dead API in #270), **this state is live**: `app/(tabs)/inbox/index.tsx` consumes `isLoading` and `error`.
- The fix is React Query for the notifications list — already the design that file's own `AGENTS.md` section describes (refetch-on-focus + invalidation); the hand-rolled `useState` is the drift. Which fields become query state and which stay device state is written out.
- **Why it was not done: verifying it needs an authenticated session** the cold-start check cannot reach — unauthenticated, `loadNotifications` returns at its guard and the path never executes.

That last line is the one that stops someone repeating the analysis and then shipping it unverified anyway.

## Verification

The check passes on the current export (`/` 400 elements, `/properties` 284, both `visibility=visible`, no console errors, no uncaught exceptions) and its mutation test exits 0 with **"All mutations detected."** `tsc --noEmit` 0; frontend lint unchanged at 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)