### PR TITLE
docs: scope AGENTS.md to Homiio-specific knowledge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,28 @@
-# Homiio — Real Estate Platform
+# Homiio
 
-Expo/RN frontend + Express backend. Agent: `homiio`.
+Real estate platform. Expo/RN frontend plus an Express backend. Agent: `homiio`.
+
+> Org-wide engineering standards (package manager, TypeScript, React, naming,
+> error handling, security, testing, git and PR conventions) live in
+> <https://github.com/OxyHQ/engineering>. This file carries only what is true of
+> Homiio specifically. Versions are in `package.json`, never here.
 
 ## Deployment
 
-Homiio runs on **AWS ECS Fargate** — not DigitalOcean App Platform or droplets. Infra (ECS task defs, ALB, ECR, SSM, S3 bucket) lives in `~/Oxy/oxy-infra/terraform-uswest2/`.
+Homiio runs on **AWS ECS Fargate**, not DigitalOcean App Platform or droplets.
+Infra (ECS task definitions, ALB, ECR, SSM, the S3 bucket) lives in
+`~/Oxy/oxy-infra/terraform-uswest2/`.
 
-- **Port**: `4000` | **Domain**: `api.homiio.com` | **ECR**: `oxy/homiio` | **Region**: `us-west-2`
-- Build: `linux/arm64` Dockerfile in `packages/backend/`.
-- Deploy: push to `main` → `.github/workflows/deploy-aws.yml` (OIDC `oxy-github-deploy`, no AWS keys in GitHub).
-- Secrets: GitHub repo secrets → SSM `/oxy/homiio/*` and `/oxy/_shared/*` → injected by ECS at task launch.
-- Media: S3 bucket `oxy-homiio-media-usw2-237343248947` (set via `AWS_S3_BUCKET` in ECS env).
-- Worker: same ECR image, separate ECS service (`app-homiio-worker.tf`); entrypoint `packages/backend/worker.ts`.
+- Port `4000`, domain `api.homiio.com`, ECR `oxy/homiio`, region `us-west-2`.
+- Built from the `linux/arm64` Dockerfile in `packages/backend/`.
+- Deploy: push to `main`, then `.github/workflows/deploy-aws.yml` (OIDC
+  `oxy-github-deploy`, no AWS keys in GitHub).
+- Secrets: GitHub repo secrets to SSM `/oxy/homiio/*` and `/oxy/_shared/*`,
+  injected by ECS at task launch.
+- Media: S3 bucket `oxy-homiio-media-usw2-237343248947`, set via `AWS_S3_BUCKET`
+  in the ECS env.
+- Worker: the same ECR image, a separate ECS service (`app-homiio-worker.tf`),
+  entrypoint `packages/backend/worker.ts`.
 
 ## Commands
 
@@ -22,12 +33,16 @@ bun run dev:backend         # Backend only
 bun run build               # Build all
 bun run test                # Test all
 bun run lint                # Lint all
+bun run check:lockfile      # Two-layer lockfile sync check
 bun run clean               # Clean everything
 ```
 
 ## Workflow
 
-**Automated PR reviews (`listing-providers` + `backend`).** After opening a PR, address automated review comments (Gemini, Bugbot, CodeQL, Copilot) before merge — fix high-confidence security/correctness findings; defer bikeshed/docs-only unless trivial.
+**Automated PR reviews run on `listing-providers` and `backend`.** After opening a
+PR, address the automated review comments (Gemini, Bugbot, CodeQL, Copilot)
+before merge: fix high-confidence security and correctness findings, and defer
+bikeshed or docs-only ones unless trivial.
 
 ## Architecture
 
@@ -39,108 +54,193 @@ packages/
   listing-providers/  @homiio/listing-providers Plugin contract, FetchRuntime, provider plugins
 ```
 
-Version numbers live in each `package.json` — read them there, don't trust this block for exact pins.
+The production Dockerfile builds in dependency order: `shared-types`, then
+`listing-providers`, then `backend`. The API image includes
+`@homiio/listing-providers`, and the worker uses the same image with a different
+start command.
 
-The production Dockerfile builds in dependency order: `shared-types` → `listing-providers` → `backend`. The API image includes `@homiio/listing-providers` (worker uses the same image, different start command).
+## Key features
 
-## Key Features
-
-- **Properties**: Listings, search, saved, viewings
-- **Payments**: Stripe 16.11 (billing, subscriptions)
-- **AI**: `@ai-sdk/openai` for smart features
-- **Location**: `expo-location` for geolocation
-- **Messaging**: Telegram + WhatsApp integrations
-- **Media**: Image processing (Sharp), AWS S3 storage
-- **i18n**: i18next with locales
+Properties (listings, search, saved, viewings); payments through Stripe (billing,
+subscriptions); AI features via `@ai-sdk/openai`; geolocation via
+`expo-location`; Telegram and WhatsApp messaging integrations; image processing
+with Sharp into AWS S3; i18n with i18next.
 
 ## Routes
 
-**Frontend**: addresses, contracts, horizon, insights, profile, properties, reviews, roommates, saved, search, settings, sindi, tips, viewings
+**Frontend:** addresses, contracts, horizon, insights, profile, properties,
+reviews, roommates, saved, search, settings, sindi, tips, viewings.
 
-**Backend**: addresses, ai, analytics, billing, cities, images, leases, notifications, profiles, properties, public, reviews, roommates, rooms, scraper, telegram, tips, viewings
+**Backend:** addresses, ai, analytics, billing, cities, images, leases,
+notifications, profiles, properties, public, reviews, roommates, rooms, scraper,
+telegram, tips, viewings.
 
 ## Ownership (CRITICAL)
 
-Property/room/**lease** create and update use the session `oxyUserId` from `@oxyhq/core/server` (`requireSessionOxyUserId`) — never accept owner ids from the client. Writes use `Model.findOne({ _id, oxyUserId })` for updates/deletes (non-owner → 404). Profile is an optional RE sidecar keyed by `oxyUserId`, not an ownership authority.
+Property, room and **lease** create and update take the session `oxyUserId` from
+`@oxyhq/core/server` (`requireSessionOxyUserId`), never an owner id from the
+client. Updates and deletes go through `Model.findOne({ _id, oxyUserId })`, so a
+non-owner gets a 404. Profile is an optional real-estate sidecar keyed by
+`oxyUserId`, not an ownership authority.
 
-- Shared guard: `packages/backend/utils/pickFields.ts` (one implementation for every write controller).
-- Whitelists: `controllers/property/editableFields.ts` (property + room) and `controllers/lease/editableFields.ts` (`CREATABLE_LEASE_FIELDS`/`EDITABLE_LEASE_FIELDS`).
-- Rule: never `new Model(req.body)`, never `...req.body`, never a denylist — pick the allowlist, then set server-only fields explicitly. Keep whitelists in sync with the schemas.
+- Shared guard: `packages/backend/utils/pickFields.ts`, one implementation for
+  every write controller.
+- Whitelists: `controllers/property/editableFields.ts` (property and room) and
+  `controllers/lease/editableFields.ts` (`CREATABLE_LEASE_FIELDS`,
+  `EDITABLE_LEASE_FIELDS`). **Keep them in sync with the schemas**, and never use
+  a denylist.
 
-## Leases & Contracts
+## Leases and contracts
 
-Leases are first-class Mongoose documents; the schema is the authority and `controllers/lease/toLeaseDTO.ts` serializes `_id` → `id` plus optional populated `property`/`landlord`/`tenant` for the frontend.
+Leases are first-class Mongoose documents. The schema is the authority and
+`controllers/lease/toLeaseDTO.ts` serializes `_id` to `id` plus optional
+populated `property`, `landlord` and `tenant` for the frontend.
 
-- **Backend routes**: `/api/leases` — list (`?status=`, `?propertyId=`), CRUD, sub-resources (`/:id/payments`, `/:id/documents`), lifecycle (`/:id/sign`, `/:id/terminate`, `/:id/renew`). Static sub-routes are declared before `/:id`.
-- **Frontend screens**: `/contracts` (list), `/contracts/[id]` (detail/sign), `/contracts/new` (landlord draft from application).
-- **Create flow**: landlord-only bridge `POST /api/applications/:id/create-lease` resolves property, tenant, and rent server-side from an **approved** application and returns a draft lease. `/contracts/new?application=<id>` is the only create entry point — no standalone tenant picker or manual lease form.
-- **Writes**: same IDOR pattern — `CREATABLE_LEASE_FIELDS` / `EDITABLE_LEASE_FIELDS` in `controllers/lease/editableFields.ts`; `landlordProfileId` is server-resolved, never from `req.body`.
+- **Backend routes:** `/api/leases`, with list (`?status=`, `?propertyId=`),
+  CRUD, sub-resources (`/:id/payments`, `/:id/documents`) and lifecycle
+  (`/:id/sign`, `/:id/terminate`, `/:id/renew`). Static sub-routes are declared
+  before `/:id`.
+- **Frontend screens:** `/contracts` (list), `/contracts/[id]` (detail and sign),
+  `/contracts/new` (landlord draft from an application).
+- **Create flow:** the landlord-only bridge
+  `POST /api/applications/:id/create-lease` resolves property, tenant and rent
+  server side from an **approved** application and returns a draft lease.
+  `/contracts/new?application=<id>` is the only create entry point; there is no
+  standalone tenant picker and no manual lease form.
+- **Writes** follow the same IDOR pattern, and `landlordProfileId` is server
+  resolved, never taken from `req.body`.
 
 ## Notifications (CRITICAL)
 
-Event-driven in-app notifications have **one write chokepoint**: `services/notificationDispatchService.ts`. Controllers call `createForUser` for domain events (lease signed, viewing approved, roommate request, …) — never `Notification.create` directly. Dispatch is best-effort (swallow-and-log; domain action must succeed even if the mailbox write fails).
+Event-driven in-app notifications have **one write chokepoint**:
+`services/notificationDispatchService.ts`. Controllers call `createForUser` for
+domain events (lease signed, viewing approved, roommate request) and never
+`Notification.create` directly. Dispatch is best effort, swallowing and logging,
+because the domain action must succeed even if the mailbox write fails.
 
-The frontend has **no realtime socket client** for notifications. Mailbox refresh is refetch-on-focus + React Query invalidation after writes (`NotificationContext`, `services/notificationService.ts`). See `packages/frontend/docs/NOTIFICATIONS.md`.
+The frontend has **no realtime socket client** for notifications. Mailbox refresh
+is refetch-on-focus plus React Query invalidation after writes
+(`NotificationContext`, `services/notificationService.ts`). See
+`packages/frontend/docs/NOTIFICATIONS.md`.
 
-## No Admin / Moderator Surfaces (CRITICAL)
+## No admin or moderator surfaces (CRITICAL)
 
-Never build admin panels, moderator queues, or privileged moderation actions on user content — the user vetoed this explicitly (the admin moderation queue, PR #229, was reverted in PR #231). The one exception is `/api/scraper/*`'s `requireAdmin` (infra tooling, not content moderation). Community-level machinery is the only moderation: per-user `reports[]` on reviews with automatic `moderationStatus: under_review` at ≥3 reports, `EvictionReport`s, and owners cancelling/deleting their own content. The `removed` moderation status is intentionally unreachable. If a future need arises, ask the user first.
+Never build admin panels, moderator queues, or privileged moderation actions on
+user content. The user vetoed this explicitly: the admin moderation queue (PR
+#229) was reverted in PR #231. The one exception is `/api/scraper/*`'s
+`requireAdmin`, which is infra tooling, not content moderation.
+
+Community-level machinery is the only moderation: per-user `reports[]` on reviews
+with automatic `moderationStatus: under_review` at 3 or more reports,
+`EvictionReport`s, and owners cancelling or deleting their own content. The
+`removed` moderation status is intentionally unreachable. If a future need
+arises, ask the user first.
 
 ## Roommates
 
-Accepted roommate requests materialize a `RoommateRelationship` document (`models/schemas/RoommateRelationshipSchema.ts`). Routes: `GET /api/roommates/relationships`, `DELETE /api/roommates/relationships/:relationshipId`. Ownership and participant resolution use `Profile.findByOxyUserId` — same rule as property/lease writes.
+Accepted roommate requests materialize a `RoommateRelationship` document
+(`models/schemas/RoommateRelationshipSchema.ts`). Routes:
+`GET /api/roommates/relationships` and
+`DELETE /api/roommates/relationships/:relationshipId`. Ownership and participant
+resolution use `Profile.findByOxyUserId`, the same rule as property and lease
+writes.
 
-## Partner Commissions (mark-transacted)
+## Partner commissions (mark-transacted)
 
-Owner-only close endpoint: `POST /api/properties/:propertyId/mark-transacted` (`controllers/property/transact.ts`). Sets terminal status (`rented` | `sold`, inferred from offerings when omitted) and runs the idempotent `onPropertyTransacted` commission trigger. Re-marking never creates a second commission. Frontend: `useMarkPropertyTransacted` on `/properties/my`.
+Owner-only close endpoint:
+`POST /api/properties/:propertyId/mark-transacted`
+(`controllers/property/transact.ts`). It sets a terminal status (`rented` or
+`sold`, inferred from offerings when omitted) and runs the idempotent
+`onPropertyTransacted` commission trigger. Re-marking never creates a second
+commission. Frontend: `useMarkPropertyTransacted` on `/properties/my`.
 
-## External Listings & Deep Links
+## External listings and deep links
 
-External properties (`isExternal: true`) block in-app apply/viewing — never route them to Homiio enquiry flows. Guard missing `sourceUrl` with a user-facing error.
+External properties (`isExternal: true`) block in-app apply and viewing. Never
+route them to Homiio enquiry flows. Guard a missing `sourceUrl` with a
+user-facing error.
 
 - **Portal CTA:** always offer `Linking.openURL(sourceUrl)` as the fallback.
-- **Direct contact:** when ingest captured owner/agent contact from portal AJAX (phone, email, WhatsApp, agency name), show in-app direct contact actions too — not only the portal link. Never invent contacts.
+- **Direct contact:** when ingest captured owner or agent contact from portal
+  AJAX (phone, email, WhatsApp, agency name), show in-app direct contact actions
+  too, not only the portal link. Never invent contacts.
 
-## Neighborhood Widget
+## Neighborhood widget
 
-`NeighborhoodRatingWidget` renders **only real Homiio-derived metrics** (listing count, average rent, vs-city contrast). No invented walkability/transit/safety scores. When no neighborhood resolves or lookup errors, the widget renders nothing.
+`NeighborhoodRatingWidget` renders **only real Homiio-derived metrics** (listing
+count, average rent, vs-city contrast). No invented walkability, transit or
+safety scores. When no neighborhood resolves, or the lookup errors, the widget
+renders nothing.
 
-Gated by `EXPO_PUBLIC_NEIGHBORHOOD_WIDGET_ENABLED=true` (off by default) in `components/widgets/WidgetManager.tsx` — enable only when neighborhood data coverage is broad enough.
+It is gated by `EXPO_PUBLIC_NEIGHBORHOOD_WIDGET_ENABLED=true` (off by default) in
+`components/widgets/WidgetManager.tsx`. Enable it only when neighborhood data
+coverage is broad enough.
 
-## Backend Client (Live)
+## Backend client (live)
 
-The Oxy linked client is live in `packages/frontend/utils/api.ts` (`oxyClient.createLinkedClient({ baseURL })`). It owns auth: it mirrors the Oxy session token, delegates 401 refresh, and invalidates the session on refresh failure — apps must NOT add local token providers, auth interceptors, or manual `Authorization` headers.
+The Oxy linked client is live in `packages/frontend/utils/api.ts`
+(`oxyClient.createLinkedClient({ baseURL })`). It owns auth: it mirrors the Oxy
+session token, delegates 401 refresh, and invalidates the session on refresh
+failure. Do NOT add local token providers, auth interceptors or manual
+`Authorization` headers.
 
-- `normalizeEnvelope` in `utils/api.ts` is the INTENTIONAL bridge that re-wraps the linked client's auto-unwrapped payload back into the `{ success, data, … }` envelope Homiio's ~45 consumers read (`response.data.data`). It stays until those consumers migrate — do not "fix" or remove it piecemeal.
-- The only sanctioned `oxyServices.getAccessToken()` use is Sindi's streaming fetch (`hooks/useSindiAuthenticatedFetch.ts`): the linked client is JSON-only and cannot stream. Do not add new `getAccessToken` call sites.
+- `normalizeEnvelope` in `utils/api.ts` is the INTENTIONAL bridge that re-wraps
+  the linked client's auto-unwrapped payload back into the
+  `{ success, data, ... }` envelope Homiio's many consumers read
+  (`response.data.data`). It stays until those consumers migrate. Do not "fix" or
+  remove it piecemeal.
+- The only sanctioned `oxyServices.getAccessToken()` use is Sindi's streaming
+  fetch (`hooks/useSindiAuthenticatedFetch.ts`), because the linked client is
+  JSON-only and cannot stream. Do not add new `getAccessToken` call sites.
 
-## Listing Provider Plugins (Market Aggregator)
+## Listing provider plugins (market aggregator)
 
-Homiio aggregates external market listings (Idealista, Fotocasa, Habitaclia, Blueground, apartments.com, Zillow, …) as **first-party data** — never hotlinked, never live-proxied.
+Homiio aggregates external market listings (Idealista, Fotocasa, Habitaclia,
+Blueground, apartments.com, Zillow and more) as **first-party data**, never
+hotlinked and never live-proxied.
 
 ### Fetch strategy (CRITICAL)
 
-**JSON/AJAX first, HTML last.** Providers MUST prefer internal JSON/XHR/GraphQL/datalayer APIs — ideally after Playwright session warm. HTML parsing and embedded JSON-LD via `fetchListingViaLadder` are **fallback only** when no usable JSON endpoint exists.
+**JSON/AJAX first, HTML last.** Providers MUST prefer internal JSON, XHR, GraphQL
+or datalayer APIs, ideally after a Playwright session warm. HTML parsing and
+embedded JSON-LD via `fetchListingViaLadder` are **fallback only**, for when no
+usable JSON endpoint exists.
 
 ### AJAX-with-session pattern (Idealista is the reference)
 
-When a portal gates JSON behind DataDome/JS:
+When a portal gates JSON behind DataDome or JS:
 
-1. `runtime.openBrowserSession` / `warmSession` — warm cookies on a search/home page (residential proxy, asset blocking ON, poll for content / challenge clearance).
-2. `session.request` / `fetchAjaxInPage` / `fetchJsonInPage` — same-origin XHR with Referer + `X-Requested-With`.
+1. `runtime.openBrowserSession` / `warmSession`: warm cookies on a search or home
+   page (residential proxy, asset blocking ON, poll for content or challenge
+   clearance).
+2. `session.request` / `fetchAjaxInPage` / `fetchJsonInPage`: same-origin XHR with
+   Referer and `X-Requested-With`.
 3. Fall back to HTML JSON-LD only when AJAX fails or the session pool is absent.
 
-Sticky reuse: `LISTING_PROXY_STICKY=true` keeps `proxySessionId` + `storageState` across discover pages. Shared helpers live in `packages/listing-providers/src/session.ts` + `browserSession.ts`.
+Sticky reuse: `LISTING_PROXY_STICKY=true` keeps `proxySessionId` and
+`storageState` across discover pages. Shared helpers live in
+`packages/listing-providers/src/session.ts` and `browserSession.ts`.
 
 ### External listing contact (CRITICAL)
 
-**Capture owner/agent contact when the portal exposes it.** After listing fetch, call portal contact AJAX when available (e.g. Idealista `contact-phones`, `adContactInfo`). Persist phone, email, WhatsApp, and agency name on the external Property / `NormalizedListing` so the app can show direct contact — not only `sourceUrl`. Never invent or guess contacts. Classifieds housing-only filter still applies (see below).
+**Capture owner and agent contact when the portal exposes it.** After a listing
+fetch, call the portal contact AJAX when available (Idealista `contact-phones`,
+`adContactInfo`). Persist phone, email, WhatsApp and agency name on the external
+Property and `NormalizedListing` so the app can show direct contact, not only
+`sourceUrl`. Never invent or guess contacts. The classifieds housing-only filter
+still applies (see below).
 
 ### Model
-- External properties have `isExternal: true`, no `oxyUserId`, `status: 'published'`, and a mandatory `sourceUrl`.
-- Optional ingested contact fields (phone, email, WhatsApp, agency name) when the portal AJAX exposes them — see § External listing contact.
-- The frontend already handles these: source badge, blocked apply/viewing, portal CTA to `sourceUrl`, plus direct contact when ingested. Do not remove that differentiation.
-- Upsert key is `(source, sourceId)` — handled by `scraperService.upsertExternalListing`.
+
+- External properties have `isExternal: true`, no `oxyUserId`,
+  `status: 'published'`, and a mandatory `sourceUrl`.
+- Optional ingested contact fields (phone, email, WhatsApp, agency name) when the
+  portal AJAX exposes them.
+- The frontend already handles these: source badge, blocked apply and viewing,
+  portal CTA to `sourceUrl`, plus direct contact when ingested. Do not remove
+  that differentiation.
+- The upsert key is `(source, sourceId)`, handled by
+  `scraperService.upsertExternalListing`.
 
 ### Package layout
 
@@ -148,13 +248,14 @@ Sticky reuse: `LISTING_PROXY_STICKY=true` keeps `proxySessionId` + `storageState
 packages/
   listing-providers/   @homiio/listing-providers   Plugin contract, ProviderRegistry, FetchRuntime, plugins
   backend/
-    services/ingestion/IngestionService.ts          NormalizedListing → Property upsert + image pipeline
-    services/ingestion/ExternalMediaIngest.ts       fetch → Sharp → S3 → Image doc → PropertyImageRef
+    services/ingestion/IngestionService.ts          NormalizedListing to Property upsert + image pipeline
+    services/ingestion/ExternalMediaIngest.ts       fetch, Sharp, S3, Image doc, PropertyImageRef
     services/ingestion/queues.ts                    BullMQ queue definitions
-    worker.ts                                        Worker entrypoint (separate process, same image)
+    worker.ts                                       Worker entrypoint (separate process, same image)
 ```
 
-`shared-types` exports `NormalizedListing` — the handoff DTO from provider → ingest.
+`shared-types` exports `NormalizedListing`, the handoff DTO from provider to
+ingest.
 
 ### Plugin contract
 
@@ -169,165 +270,235 @@ interface ListingProvider {
 }
 ```
 
-`FetchRuntime` (shared, not per-plugin) owns: rate limiting, retries, circuit breaker, Playwright pool, proxy/managed ladder, challenge/CAPTCHA detection → requeue or escalate.
+`FetchRuntime` is shared, not per-plugin, and owns rate limiting, retries, the
+circuit breaker, the Playwright pool, the proxy and managed ladder, and
+challenge/CAPTCHA detection leading to requeue or escalation.
 
 ### Warm Playwright session (preferred portal ingest)
 
-For DataDome / JS-gated portals (Idealista georeach, Fotocasa AJAX, …), use the shared helpers in `@homiio/listing-providers` (`src/session.ts`):
+For DataDome and JS-gated portals (Idealista georeach, Fotocasa AJAX), use the
+shared helpers in `@homiio/listing-providers` (`src/session.ts`):
 
-1. **`warmBrowserPage(page, { warmUrl, contentSelector?, isChallenge? })`** — goto origin, poll until challenge clears / content selector appears.
-2. **`fetchJsonInPage(page | context, url, { headers?, referer?, timeoutMs? })`** — same-origin JSON via `page.request` (cookies ride along; XHR headers set automatically).
-3. **`exportStorageState(context)`** — optional sticky reuse: pass the snapshot into the next `openBrowserSession({ storageState })` call on the same proxy session id.
+1. **`warmBrowserPage(page, { warmUrl, contentSelector?, isChallenge? })`**: goto
+   origin, poll until the challenge clears or the content selector appears.
+2. **`fetchJsonInPage(page | context, url, { headers?, referer?, timeoutMs? })`**:
+   same-origin JSON via `page.request`, with cookies riding along and XHR headers
+   set automatically.
+3. **`exportStorageState(context)`**: optional sticky reuse, passing the snapshot
+   into the next `openBrowserSession({ storageState })` call on the same proxy
+   session id.
 
-Convenience path when you do not own a page: `runtime.openBrowserSession(options)` → `session.request(url)` / `session.exportStorageState()` → `session.close()`. Asset blocking (`LISTING_BROWSER_BLOCK_ASSETS`, default ON) and residential proxy (`LISTING_RESIDENTIAL_PROXY_URL`, sticky via `LISTING_PROXY_STICKY`) are wired in `PlaywrightSessionPool` — providers only supply `warmUrl`, challenge detectors, and portal-specific selectors.
+When you do not own a page: `runtime.openBrowserSession(options)`, then
+`session.request(url)` / `session.exportStorageState()`, then `session.close()`.
+Asset blocking (`LISTING_BROWSER_BLOCK_ASSETS`, default ON) and the residential
+proxy (`LISTING_RESIDENTIAL_PROXY_URL`, sticky via `LISTING_PROXY_STICKY`) are
+wired in `PlaywrightSessionPool`, so providers only supply `warmUrl`, challenge
+detectors and portal-specific selectors.
 
-- **Escalation tiers are WORKER-ONLY and env-gated (default OFF).** Build the worker runtime with `createListingFetchRuntimeFromEnv()` (never in the API). Browser tier: `LISTING_BROWSER_ENABLED=true` + Playwright installed (it is an OPTIONAL peer of `@homiio/listing-providers`, loaded via dynamic `import()`; absent → tier skipped, logged, CI still green). Managed tier: `LISTING_MANAGED_FETCH_URL` (+ optional `LISTING_MANAGED_FETCH_KEY`/`*_KEY_HEADER`/`*_KEY_PARAM`/`*_URL_PARAM`); unset → rung does not exist (never faked). The ladder keys tier availability off method presence, so an unprovisioned rung is skipped, not attempted-and-failed. Worker must `await runtimeHandle.shutdown()` to close the browser pool.
-- **Residential proxy (DIY anti-bot, not a scraping API).** Homiio's worker scrapes with Playwright/HTTP; `LISTING_RESIDENTIAL_PROXY_URL` (`http://user:pass@host:port`, DataImpulse-compatible) routes **listing HTML/JSON only** through a cheap residential proxy. Playwright blocks images/CSS/fonts by default (`LISTING_BROWSER_BLOCK_ASSETS`, default ON) and uses `domcontentloaded`. Listing photos stay on a **direct** fetch in `ExternalMediaIngest`; optional `LISTING_MEDIA_PROXY_FALLBACK=true` retries once via proxy on failure. Optional `LISTING_HTTP_USE_PROXY=true` proxies the HTTP tier; `LISTING_PROXY_STICKY=true` appends `-session-<id>` to the proxy username (DataImpulse sticky IP). Do not set proxy env in prod SSM until credentials exist.
+- **Escalation tiers are WORKER-ONLY and env-gated, default OFF.** Build the
+  worker runtime with `createListingFetchRuntimeFromEnv()`, never in the API. The
+  browser tier needs `LISTING_BROWSER_ENABLED=true` plus Playwright installed (an
+  OPTIONAL peer of `@homiio/listing-providers`, loaded via dynamic `import()`; if
+  absent the tier is skipped and logged, and CI stays green). The managed tier
+  needs `LISTING_MANAGED_FETCH_URL` (plus optional `LISTING_MANAGED_FETCH_KEY`,
+  `*_KEY_HEADER`, `*_KEY_PARAM`, `*_URL_PARAM`); unset means the rung does not
+  exist and is never faked. The ladder keys tier availability off method
+  presence, so an unprovisioned rung is skipped, not attempted and failed. The
+  worker must `await runtimeHandle.shutdown()` to close the browser pool.
+- **Residential proxy is DIY anti-bot, not a scraping API.** Homiio's worker
+  scrapes with Playwright and HTTP; `LISTING_RESIDENTIAL_PROXY_URL`
+  (`http://user:pass@host:port`, DataImpulse compatible) routes **listing HTML
+  and JSON only** through a cheap residential proxy. Playwright blocks images,
+  CSS and fonts by default (`LISTING_BROWSER_BLOCK_ASSETS`) and uses
+  `domcontentloaded`. Listing photos stay on a **direct** fetch in
+  `ExternalMediaIngest`; optional `LISTING_MEDIA_PROXY_FALLBACK=true` retries once
+  via proxy on failure. Optional `LISTING_HTTP_USE_PROXY=true` proxies the HTTP
+  tier; `LISTING_PROXY_STICKY=true` appends `-session-<id>` to the proxy username
+  for a DataImpulse sticky IP. Do not set proxy env in prod SSM until credentials
+  exist.
 
 ### BullMQ queues (Valkey via `REDIS_URL`)
 
 | Queue | Purpose |
-|-------|---------|
-| `listing-discover` | city/bbox + provider → produces `ExternalListingRef` batch |
-| `listing-fetch` | single `sourceId` → fetch + normalize → ingest |
-| `listing-media` | propertyId + remote URLs (if media is decoupled from upsert) |
+|---|---|
+| `listing-discover` | city/bbox plus provider, produces an `ExternalListingRef` batch |
+| `listing-fetch` | single `sourceId`, fetch and normalize, then ingest |
+| `listing-media` | propertyId plus remote URLs, when media is decoupled from upsert |
 
-- Queue names must NOT contain `:` (BullMQ + Valkey restriction).
-- Dedup job ids: sha256 of `(provider, sourceId)` — never pass raw values with colons as custom ids.
+- Queue names must NOT contain `:` (a BullMQ and Valkey restriction).
+- Dedup job ids are the sha256 of `(provider, sourceId)`. Never pass raw values
+  containing colons as custom ids.
 - BullMQ connections need `maxRetriesPerRequest: null`.
 
-### Ingest pipeline (no portal CDN hotlinks ever)
+### Ingest pipeline (no portal CDN hotlinks, ever)
 
-1. Validate `NormalizedListing`.
-2. `Address.findOrCreateCanonical` + geocode.
-3. Upsert Property with `isExternal: true`, `status: 'published'`, `sourceUrl`, `expiresAt` TTL.
-4. For each `remoteImages` entry: download → Sharp → `createImageForEntity('property', id, …)` → `PropertyImageRef`. Dedup by URL/hash stored in Image metadata; re-syncs add/remove refs.
+1. Validate the `NormalizedListing`.
+2. `Address.findOrCreateCanonical` plus geocode.
+3. Upsert the Property with `isExternal: true`, `status: 'published'`,
+   `sourceUrl` and an `expiresAt` TTL.
+4. For each `remoteImages` entry: download, Sharp,
+   `createImageForEntity('property', id, ...)`, `PropertyImageRef`. Dedup by URL
+   or hash stored in Image metadata; re-syncs add and remove refs.
 5. Never store a portal CDN URL as a runtime `images[].url`.
 
 ### How to add a new provider
 
-1. Create `packages/listing-providers/src/providers/<name>/index.ts` implementing `ListingProvider`.
+1. Create `packages/listing-providers/src/providers/<name>/index.ts` implementing
+   `ListingProvider`.
 2. Register it in `packages/listing-providers/src/registry.ts`.
-3. Gate it with a feature flag env var `PROVIDER_<NAME>_ENABLED=true` (see below).
-4. Add integration test: normalize fixture → upsert → Image refs with storage mock.
+3. It is gated automatically: see the feature-flag rule below.
+4. Add an integration test: normalize a fixture, upsert, and check Image refs
+   with a storage mock.
 
-**Shared parse modules (CRITICAL — no copy-paste):** new portals MUST import from `packages/listing-providers/src/parse/` (plus `session.ts` / `browserSession.ts`). Do **not** re-implement JSON-LD / `__NEXT_DATA__` / contact / classifieds / city-list parsers per portal.
+**Shared parse modules (CRITICAL, no copy-paste):** new portals MUST import from
+`packages/listing-providers/src/parse/` (plus `session.ts` and
+`browserSession.ts`). Do **not** re-implement JSON-LD, `__NEXT_DATA__`, contact,
+classifieds or city-list parsers per portal.
 
 | Module | Use for |
-|--------|---------|
-| `parse/jsonLd.ts` | schema.org LD+JSON (`extractEsSchemaListings` / `extractItSchemaListings` / `extractSchemaOrgListings`, `collectJsonLdNodes`) |
-| `parse/nextData.ts` | `__NEXT_DATA__` / `__PAGE_MODEL__` / `__PRELOADED_STATE__` |
-| `parse/contact.ts` | phone/email/whatsapp → `NormalizedListing.contact` |
-| `parse/classifieds.ts` | housing category allowlist + `assertHousingListing` |
-| `parse/cities.ts` | `LISTING_*_CITIES` env city lists + `providerCitiesFromEnv()` |
-| `parse/price.ts` + `parse/listing.ts` | monthly/sale price sanity + ingest validation |
-| `session.ts` / `browserSession.ts` | Idealista-like warm + AJAX |
+|---|---|
+| `parse/jsonLd.ts` | schema.org LD+JSON (`extractEsSchemaListings`, `extractItSchemaListings`, `extractSchemaOrgListings`, `collectJsonLdNodes`) |
+| `parse/nextData.ts` | `__NEXT_DATA__`, `__PAGE_MODEL__`, `__PRELOADED_STATE__` |
+| `parse/contact.ts` | phone, email, whatsapp to `NormalizedListing.contact` |
+| `parse/classifieds.ts` | housing category allowlist plus `assertHousingListing` |
+| `parse/cities.ts` | `LISTING_*_CITIES` env city lists plus `providerCitiesFromEnv()` |
+| `parse/price.ts` and `parse/listing.ts` | monthly/sale price sanity plus ingest validation |
+| `session.ts` / `browserSession.ts` | Idealista-like warm plus AJAX |
 
-Root shims (`contact.ts`, `classifieds.ts`, `jsonLd.ts`, `nextData.ts`, `cities.ts`) re-export `parse/` for short imports — prefer `parse/` for new code. Portal-specific AJAX URL builders stay under `providers/<name>/`.
+Root shims (`contact.ts`, `classifieds.ts`, `jsonLd.ts`, `nextData.ts`,
+`cities.ts`) re-export `parse/` for short imports; prefer `parse/` for new code.
+Portal-specific AJAX URL builders stay under `providers/<name>/`.
 
-**Discover city lists (CRITICAL):** use `citiesFromEnv(market)` / `DEFAULT_MARKET_CITIES` — never hardcode a tiny per-provider city allowlist that bypasses `LISTING_<MARKET>_CITIES` and silently excludes metros. Optional per-provider narrowing: `providerCitiesFromEnv('LISTING_<PROVIDER>_CITIES', market)` (falls back to the market list). Browser-heavy ES portals enqueue **one discover job per city** in `worker.ts`; queue fairness is handled there, not by shrinking defaults.
+**Discover city lists (CRITICAL):** use `citiesFromEnv(market)` or
+`DEFAULT_MARKET_CITIES`. Never hardcode a tiny per-provider city allowlist that
+bypasses `LISTING_<MARKET>_CITIES` and silently excludes metros. Optional
+per-provider narrowing is
+`providerCitiesFromEnv('LISTING_<PROVIDER>_CITIES', market)`, which falls back to
+the market list. Browser-heavy ES portals enqueue **one discover job per city**
+in `worker.ts`; queue fairness is handled there, not by shrinking defaults.
 
 ### General classifieds portals (CRITICAL)
 
-Homiio is real estate only. **General classifieds** — milanuncios, kleinanzeigen, subito, leboncoin (marketplace), olx.ro, vivanuncios — must **never** be site-wide crawled.
+Homiio is real estate only. **General classifieds** (milanuncios, kleinanzeigen,
+subito, leboncoin marketplace, olx.ro, vivanuncios) must **never** be site-wide
+crawled.
 
-- **`discover()`**: housing/rent/sale category URLs or API params only — explicit per-portal category allowlist (DE kleinanzeigen, IT subito, FR leboncoin, RO olx.ro, ES milanuncios, MX vivanuncios).
-- **`normalize()`**: reject non-housing listings (cars, jobs, furniture, …); ingest must skip, never upsert.
-- **Tests**: housing fixture passes normalize; non-housing category fixture is rejected.
+- **`discover()`**: housing, rent or sale category URLs or API params only, with
+  an explicit per-portal category allowlist (DE kleinanzeigen, IT subito, FR
+  leboncoin, RO olx.ro, ES milanuncios, MX vivanuncios).
+- **`normalize()`**: reject non-housing listings (cars, jobs, furniture). Ingest
+  must skip, never upsert.
+- **Tests**: a housing fixture passes normalize, and a non-housing category
+  fixture is rejected.
 
-Dedicated real-estate portals (Idealista, Fotocasa, Habitaclia, Immobiliare, …) are exempt — housing-native, no classifieds guard needed.
+Dedicated real-estate portals (Idealista, Fotocasa, Habitaclia, Immobiliare) are
+exempt: they are housing native and need no classifieds guard.
 
 ### Feature flags
 
-Each provider is opt-in via env:
+**Do not maintain a list of provider flags here or anywhere else.** The flag name
+is derived mechanically in `packages/listing-providers/src/index.ts`:
 
-```
-PROVIDER_IDEALISTA_ENABLED=true
-PROVIDER_FOTOCASA_ENABLED=true
-PROVIDER_HABITACLIA_ENABLED=true
-PROVIDER_BLUEGROUND_ENABLED=true
-PROVIDER_APARTMENTS_COM_ENABLED=true
-PROVIDER_ZILLOW_ENABLED=true
-PROVIDER_REALTOR_COM_ENABLED=true
-PROVIDER_HOTPADS_ENABLED=true
-PROVIDER_REDFIN_ENABLED=true
-PROVIDER_IMMOBILIENSCOUT24_ENABLED=true
-PROVIDER_IMMOWELT_ENABLED=true
-PROVIDER_KLEINANZEIGEN_ENABLED=true
-PROVIDER_STORIA_ENABLED=true
-PROVIDER_IMOBILIARE_RO_ENABLED=true
-PROVIDER_OLX_RO_ENABLED=true
-PROVIDER_MERCADOLIBRE_AR_ENABLED=true
-PROVIDER_ZONAPROP_ENABLED=true
-PROVIDER_ARGENPROP_ENABLED=true
-PROVIDER_PROPERATI_ENABLED=true
-PROVIDER_PLUSVALIA_ENABLED=true
-PROVIDER_MERCADOLIBRE_EC_ENABLED=true
-PROVIDER_PROPERATI_EC_ENABLED=true
-PROVIDER_INMUEBLES24_ENABLED=true
-PROVIDER_LAMUDI_ENABLED=true
-PROVIDER_VIVANUNCIOS_ENABLED=true
-PROVIDER_PROPIEDADES_ENABLED=true
-PROVIDER_MERCADOLIBRE_CO_ENABLED=true
-PROVIDER_METROCUADRADO_ENABLED=true
-PROVIDER_MERCADOLIBRE_CL_ENABLED=true
-PROVIDER_MERCADOLIBRE_PE_ENABLED=true
-PROVIDER_MERCADOLIBRE_MX_ENABLED=true
-PROVIDER_IDEALISTA_PT_ENABLED=true
-PROVIDER_REALTOR_CA_ENABLED=true
-PROVIDER_REALESTATE_COM_AU_ENABLED=true
-PROVIDER_BAYUT_ENABLED=true
-PROVIDER_DAFT_ENABLED=true
-PROVIDER_IMMOWEB_ENABLED=true
-PROVIDER_OTODOM_ENABLED=true
-PROVIDER_FUNDA_ENABLED=true
+```ts
+process.env[`PROVIDER_${id.toUpperCase()}_ENABLED`] === 'true'
 ```
 
-**Multi-country brand expansion (thin wrappers reuse shared factories — default OFF):** Idealista ES/IT/**PT** (regional hosts + georeach AJAX); MercadoLibre AR/EC/CO/CL/PE/**MX** (`createMercadolibreProvider` + `rentSegment` for renta/arriendo); Navent Zonaprop/Argenprop/Plusvalía/Inmuebles24/Metrocuadrado (`createNaventProvider`); Blueground global (`blueground` one plugin, per-market city slugs). **Backlog (not yet wired):** Idealista (none — trio complete); MercadoLibre UY/VE/BO; Properati CO/PE; Lamudi ID/TH/TR; OLX PT/PL; Immowelt AT; Blueground PT/GR/AE/HK; ImmobiliareScout24 AT.
+So every registered provider is opt-in as `PROVIDER_<ID>_ENABLED=true`, default
+OFF, with the id coming from the plugin itself. A new plugin is gated the moment
+it is registered, with no flag to add anywhere. `registry.ts` and the
+`providers/` tree are the only authorities for which providers exist; the worker
+reads the flags at startup and disabled providers are not registered.
 
-Canada (`LISTING_CA_CITIES`): Realtor.ca (`api2.realtor.ca` form JSON after Imperva session warm — OFF). Rentals.ca / Kijiji housing-only — defer (Cloudflare / thin Next.js cards).
+### Market status
 
-Australia (`LISTING_AU_CITIES`): realestate.com.au (`window.ArgonautExchange` JSON — Kasada, OFF until AU browser+residential). Domain.com.au — defer (Akamai). Shared parsers: `nextData` / `contact` / `session` / `strategy`.
+Per-market notes on which portals work and what blocks the rest. Everything below
+is default OFF unless it says otherwise.
 
-UAE (`LISTING_AE_CITIES`): Bayut (`__NEXT_DATA__` search + detail — hb-captcha, OFF until AE browser+residential). Property Finder — defer (CloudFront 403). Never use paid RapidAPI mirrors in the worker.
+**Multi-country brand expansion** uses thin wrappers over shared factories:
+Idealista ES/IT/PT (regional hosts plus georeach AJAX); MercadoLibre
+AR/EC/CO/CL/PE/MX (`createMercadolibreProvider` plus `rentSegment` for renta and
+arriendo); Navent Zonaprop, Argenprop, Plusvalía, Inmuebles24 and Metrocuadrado
+(`createNaventProvider`); Blueground global (one plugin, per-market city slugs).
+**Backlog, not yet wired:** MercadoLibre UY/VE/BO; Properati CO/PE; Lamudi
+ID/TH/TR; OLX PT/PL; Immowelt AT; Blueground PT/GR/AE/HK; ImmobiliareScout24 AT.
 
-Colombia (`LISTING_CO_CITIES`): MercadoLibre inmuebles (thin `createMercadolibreProvider` — housing-only, OFF until Playwright+proxy probe), Metrocuadrado (Navent `rplis-api` + `__PRELOADED_STATE__` — Cloudflare, OFF). Fincaraiz is the same Navent stack — add later if needed; do not duplicate parsers.
-
-Chile (`LISTING_CL_CITIES`): MercadoLibre inmuebles (uses `arriendo` rent segment via shared `mercadolibre` — OFF until probe). Portalinmobiliario/TocToc need bespoke parsers — defer.
-
-Peru (`LISTING_PE_CITIES`): MercadoLibre inmuebles (thin `createMercadolibreProvider` — housing-only, OFF until probe). Urbania/Adondevivir (same RE group, JSON-LD) — defer until cold HTTP verified.
-
-Argentina (`LISTING_AR_CITIES`): Zonaprop / Argenprop (Navent `rplis-api` + `__PRELOADED_STATE__` via shared `navent` / `naventProvider` — Cloudflare, keep OFF until sticky residential clears), MercadoLibre inmuebles (housing-only; cold HTML search+detail verified — enable), Properati (`__NEXT_DATA__` / JSON-LD via shared modules — Cloudflare, OFF). MercadoLibre uses shared `mercadolibre` / `mercadolibreProvider` (also EC). Never site-wide crawl ML.
-
-Mexico (`LISTING_MX_CITIES`): Inmuebles24 (Navent — Cloudflare, OFF), Lamudi (JSON-LD MONTH rent — best HTTP candidate, OFF until live discover), Vivanuncios (housing-only classifieds — OFF), Propiedades (JSON-LD — Akamai, OFF), MercadoLibre inmuebles (thin `createMercadolibreProvider`, `renta` segment — OFF until probe). EasyBroker inactive — skip. Reuse shared `navent` / `jsonLd` / `contact` / `classifieds` / `cities` / `mercadolibre`.
-
-Portugal (`LISTING_PT_CITIES`): Idealista.pt (thin regional clone of `idealista_it` — `/imovel/`, `/arrendar-casas/`, georeach + contact AJAX; OFF until Playwright+proxy probe). Imovirtual/Casa Sapo — defer (bespoke parsers).
-
-Ireland / Belgium / Poland / Netherlands (`LISTING_IE_CITIES`, `LISTING_BE_CITIES`, `LISTING_PL_CITIES`, `LISTING_NL_CITIES`): **Daft.ie** (`__NEXT_DATA__` search + detail — cold HTTP verified), **Immoweb** (GET `/en/search-results` + `/en/classified/get-result/{id}` JSON — cold HTTP verified), **Otodom** (OLX vertical `__NEXT_DATA__` — cold HTTP verified), **Funda** (mobile `*.funda.io` NDJSON search + tinyId detail — Akamai 403 from datacenter, keep OFF until `LISTING_HTTP_USE_PROXY` or browser tier). Pararius / OLX PL housing-only / Willhaben AT / Immowelt AT — defer.
-
-Ecuador (`LISTING_EC_CITIES`): Plusvalía (thin `createNaventProvider` — Cloudflare, OFF until sticky residential), MercadoLibre EC inmuebles (thin `createMercadolibreProvider` — housing-only, OFF until Playwright+proxy probe), Properati EC (JSON-LD fixtures — ALB 403, keep OFF). No duplicated parsers — reuse `session` / `jsonLd` / `nextData` / `contact` / `classifieds` / `navent` / `mercadolibre`. inmo.ec not viable.
-
-Romania (`LISTING_RO_CITIES`): Storia (`__NEXT_DATA__` + session), Imobiliare.ro (Inertia search + JSON-LD detail), OLX.ro (housing `/imobiliare/…` only). Shared parsers live in `@homiio/listing-providers` `src/parse/` (`jsonLd`, `nextData`, `contact`, `classifieds`, `cities`, `price`) plus root `html` / `slug` / `navent` / `mercadolibre` — providers must not duplicate them.
-
-Germany (`LISTING_DE_CITIES`): ImmobilienScout24 (mobile JSON), Immowelt (LZ SERP JSON + optional session), Kleinanzeigen (housing categories only — never site-wide). Same shared contact/html/classifieds chokepoints.
-
-United States (`LISTING_US_CITIES`): realtor.com (direct GraphQL HTTP), HotPads (public JSON API), Redfin (Playwright session + Stingray AJAX — requires `LISTING_BROWSER_ENABLED`). Skipped: rent.com (rate-limited), trulia.com (Zillow Group overlap).
-
-The worker reads these at startup; disabled providers are not registered.
+- **Spain / Italy:** Idealista, Fotocasa, Habitaclia and the rest of the ES trio
+  are the reference implementations for the warm-session AJAX pattern.
+- **United States** (`LISTING_US_CITIES`): realtor.com (direct GraphQL HTTP),
+  HotPads (public JSON API), Redfin (Playwright session plus Stingray AJAX,
+  requires `LISTING_BROWSER_ENABLED`). Skipped: rent.com (rate limited),
+  trulia.com (Zillow Group overlap).
+- **Germany** (`LISTING_DE_CITIES`): ImmobilienScout24 (mobile JSON), Immowelt
+  (LZ SERP JSON plus optional session), Kleinanzeigen (housing categories only,
+  never site-wide).
+- **Romania** (`LISTING_RO_CITIES`): Storia (`__NEXT_DATA__` plus session),
+  Imobiliare.ro (Inertia search plus JSON-LD detail), OLX.ro (housing
+  `/imobiliare/...` only).
+- **Ireland / Belgium / Poland / Netherlands**: Daft.ie (`__NEXT_DATA__` search
+  plus detail, cold HTTP verified), Immoweb (GET `/en/search-results` plus
+  `/en/classified/get-result/{id}` JSON, cold HTTP verified), Otodom (OLX
+  vertical `__NEXT_DATA__`, cold HTTP verified), Funda (mobile `*.funda.io`
+  NDJSON search plus tinyId detail, Akamai 403 from a datacenter, keep OFF until
+  `LISTING_HTTP_USE_PROXY` or the browser tier). Pararius, OLX PL housing-only,
+  Willhaben AT and Immowelt AT are deferred.
+- **Argentina** (`LISTING_AR_CITIES`): Zonaprop and Argenprop (Navent
+  `rplis-api` plus `__PRELOADED_STATE__`, Cloudflare, keep OFF until sticky
+  residential clears), MercadoLibre inmuebles (housing only, cold HTML search and
+  detail verified, enable), Properati (`__NEXT_DATA__` / JSON-LD, Cloudflare,
+  OFF). Never site-wide crawl MercadoLibre.
+- **Mexico** (`LISTING_MX_CITIES`): Inmuebles24 (Navent, Cloudflare, OFF), Lamudi
+  (JSON-LD MONTH rent, the best HTTP candidate, OFF until live discover),
+  Vivanuncios (housing-only classifieds, OFF), Propiedades (JSON-LD, Akamai,
+  OFF), MercadoLibre inmuebles (`renta` segment, OFF until probe). EasyBroker is
+  inactive, skip it.
+- **Colombia** (`LISTING_CO_CITIES`): MercadoLibre inmuebles (housing only, OFF
+  until a Playwright and proxy probe), Metrocuadrado (Navent `rplis-api` plus
+  `__PRELOADED_STATE__`, Cloudflare, OFF). Fincaraiz is the same Navent stack,
+  add it later if needed and do not duplicate parsers.
+- **Chile** (`LISTING_CL_CITIES`): MercadoLibre inmuebles (`arriendo` rent
+  segment, OFF until probe). Portalinmobiliario and TocToc need bespoke parsers,
+  deferred.
+- **Peru** (`LISTING_PE_CITIES`): MercadoLibre inmuebles (housing only, OFF until
+  probe). Urbania and Adondevivir (same RE group, JSON-LD) deferred until cold
+  HTTP is verified.
+- **Ecuador** (`LISTING_EC_CITIES`): Plusvalía (Navent, Cloudflare, OFF until
+  sticky residential), MercadoLibre EC inmuebles (housing only, OFF until a
+  Playwright and proxy probe), Properati EC (JSON-LD fixtures, ALB 403, keep
+  OFF). inmo.ec is not viable.
+- **Portugal** (`LISTING_PT_CITIES`): Idealista.pt (thin regional clone of
+  `idealista_it`: `/imovel/`, `/arrendar-casas/`, georeach plus contact AJAX, OFF
+  until a Playwright and proxy probe). Imovirtual and Casa Sapo deferred (bespoke
+  parsers).
+- **Canada** (`LISTING_CA_CITIES`): Realtor.ca (`api2.realtor.ca` form JSON after
+  an Imperva session warm, OFF). Rentals.ca and Kijiji housing-only are deferred
+  (Cloudflare, thin Next.js cards).
+- **Australia** (`LISTING_AU_CITIES`): realestate.com.au
+  (`window.ArgonautExchange` JSON, Kasada, OFF until an AU browser plus
+  residential proxy). Domain.com.au deferred (Akamai).
+- **UAE** (`LISTING_AE_CITIES`): Bayut (`__NEXT_DATA__` search plus detail,
+  hb-captcha, OFF until an AE browser plus residential proxy). Property Finder
+  deferred (CloudFront 403). **Never use paid RapidAPI mirrors in the worker.**
 
 ### Legacy retirement
 
-- The legacy Fotocasa 30-second cron scrape loop is **gone**. `services/cron.ts` now runs only health + TTL cleanup.
-- The `localhost:3000` sidecar dependency and `config/cron.ts` `scrapeSources` array are removed.
-- `/api/scraper/*` routes are admin-only (`middlewares/requireAdmin.ts`).
-- `scraperService` upsert helpers (`upsertExternalListing`, `getScraperHealth`, `cleanupExpiredProperties`) remain for TTL cleanup, health reporting, and manual admin runs.
-- See `packages/backend/services/scraper-notes.md` for the archived migration log.
+- The legacy Fotocasa 30-second cron scrape loop is **gone**. `services/cron.ts`
+  now runs only health checks and TTL cleanup.
+- The `localhost:3000` sidecar dependency and the `config/cron.ts` `scrapeSources`
+  array are removed.
+- `/api/scraper/*` routes are admin only (`middlewares/requireAdmin.ts`).
+- `scraperService` upsert helpers (`upsertExternalListing`, `getScraperHealth`,
+  `cleanupExpiredProperties`) remain for TTL cleanup, health reporting and manual
+  admin runs.
+- See `packages/backend/services/scraper-notes.md` for the archived migration
+  log.
 
 ### Worker deploy
 
-`packages/backend/worker.ts` is the worker entrypoint — same Docker image as the API, different start command. Run with a separate ECS task definition. Separate container only if Playwright memory becomes a concern.
+`packages/backend/worker.ts` is the worker entrypoint: the same Docker image as
+the API, a different start command. Run it with a separate ECS task definition.
+Use a separate container only if Playwright memory becomes a concern.
 
-## Cold-Start Check (the only thing that sees a white screen)
+## Cold-start check (the only thing that sees a white screen)
 
 ```bash
 bun run --cwd packages/frontend build          # produces dist/
@@ -338,39 +509,38 @@ bun run --cwd packages/frontend check:cold-start:test   # mutation-tests the che
 `packages/frontend/scripts/check-cold-start.mjs` loads the exported web app in a
 REAL headed browser with a fresh profile and asserts it actually **rendered**.
 
-**Run it after touching anything in the boot path** — `app/_layout.tsx`, the
-providers under `context/`, the readiness/splash gate — and after any change the
-React Compiler lint rules prompt in those files.
+**Run it after touching anything in the boot path**: `app/_layout.tsx`, the
+providers under `context/`, the readiness and splash gate, and after any change
+the React Compiler lint rules prompt in those files.
 
 Why it exists: nothing else here can see a white-screen boot. `tsc` passes,
 `jest` passes, `expo export` succeeds, and the app still mounts nothing. A
 boot-mounted component calling a suspenseful hook deadlocks the render, so the
-init effect never runs and the promise never resolves — a blank page with ZERO
-console output. Provider ordering fails the same silent way (see `~/Oxy/AGENTS.md`,
-the `useTheme`/`BloomThemeProvider` rule).
+init effect never runs and the promise never resolves: a blank page with ZERO
+console output. Provider ordering fails the same silent way.
 
 Three properties worth keeping if you edit it:
 
 - It asserts `document.visibilityState === 'visible'` **before** any verdict and
   exits INCONCLUSIVE (3) otherwise. A backgrounded tab pauses
-  `requestAnimationFrame`, which presents exactly as "blank" — a false reading
+  `requestAnimationFrame`, which presents exactly as "blank", a false reading
   that has cost this ecosystem a debugging session.
 - It asserts rendered CONTENT, not merely that nothing threw. "Nothing threw" is
   not the property.
 - It carries a mutation test that breaks the entry bundle and requires the check
   to notice, so it can tell "ran and found nothing" from "did not run".
 
-**Standing rule when reading its output, or any check's:** print the full output
-and the exit code. Do not ask a grep whether it matched — an empty match reads
-identically to a pass, and that mistake was made three separate times while
-building this.
+**Standing rule when reading its output, or any check's here: print the full
+output and the exit code.** Do not ask a grep whether it matched, because an
+empty match reads identically to a pass. That mistake was made three separate
+times while building this.
 
 ## Known react-hooks findings (frontend)
 
-`eslint-plugin-react-hooks` v7 runs the React Compiler's rules statically. **This
-app does not enable the compiler** (no `experiments.reactCompiler` in
-`app.config.js`), so separate the two kinds before "fixing" anything:
-`set-state-in-effect` and `rules-of-hooks` are genuine either way;
+`eslint-plugin-react-hooks` v7 runs the React Compiler's rules statically.
+**This app does not enable the compiler** (there is no `experiments.reactCompiler`
+in `app.config.js`), so separate the two kinds before "fixing" anything:
+`set-state-in-effect` and `rules-of-hooks` are genuine either way, while
 `immutability`, `refs` and `preserve-manual-memoization` reason about a
 transformation that does not run here.
 
@@ -379,68 +549,83 @@ transformation that does not run here.
 premise and a revisit condition written there and beside `experiments` in
 `app.config.js`. Do not widen it.
 
-**Open, deliberately deferred — `context/NotificationContext.tsx` (2 findings).**
+**Open, deliberately deferred: `context/NotificationContext.tsx`, 2 findings.**
 `loadNotifications` opens with a synchronous
 `setState({ isLoading: true, error: null })` before its first `await`, called
-from an effect: a real cascading render on mount. Unlike `ProfileContext` (fixed
-by deleting dead API) this state is LIVE — `app/(tabs)/inbox/index.tsx` consumes
-`isLoading` and `error` — so the fix is to move the notifications list to React
-Query, which is already the design this file's own section describes
-(refetch-on-focus + invalidation); the hand-rolled `useState` is the drift.
-`notifications`/`unreadCount`/`isLoading`/`error` become query state;
-`preferences`/`hasPermission`/`badgeCount`/`scheduledNotifications` are device
-state and stay.
+from an effect, which is a real cascading render on mount. Unlike `ProfileContext`
+(fixed by deleting dead API) this state is LIVE, since
+`app/(tabs)/inbox/index.tsx` consumes `isLoading` and `error`, so the fix is to
+move the notifications list to React Query, which is already the design this
+file's own notifications section describes (refetch-on-focus plus invalidation);
+the hand-rolled `useState` is the drift. `notifications`, `unreadCount`,
+`isLoading` and `error` become query state, while `preferences`,
+`hasPermission`, `badgeCount` and `scheduledNotifications` are device state and
+stay.
 
 **It was not done because it cannot be verified without an authenticated
-session** — unauthenticated, `loadNotifications` returns at its guard and the
-path never executes, so the cold-start check above cannot reach it. Get a session
+session.** Unauthenticated, `loadNotifications` returns at its guard and the path
+never executes, so the cold-start check above cannot reach it. Get a session
 first; do not ship it on reasoning alone. The same applies to
 `SindiExplanationBottomSheet:136`.
 
-## Layout Shell & Design Tokens (CRITICAL)
+## Layout shell and design tokens (CRITICAL)
 
 ### ContentPanel (Bloom, Mention-shaped)
 
-The center column uses Bloom `ContentPanel` (`framed` + `maskColor`) — **not** a flat `mainContentWrapper` or custom bleed-mask. Reference: Mention `app/(app)/_layout.tsx`.
+The center column uses Bloom `ContentPanel` (`framed` plus `maskColor`), **not** a
+flat `mainContentWrapper` or a custom bleed mask. Reference: Mention
+`app/(app)/_layout.tsx`.
 
-- `framed={Platform.OS === 'web' && isScreenNotMobile}` (≥500 px wide).
-- `maskColor={theme.colors.background}` (unscoped — matches page bg).
-- Native phone: `framed={false}` / full-bleed.
-- Explore is fixed-viewport: no page scroll; still wraps center in ContentPanel when framed.
-- **Never hand-roll a bleed-mask** — ContentPanel owns it.
+- `framed={Platform.OS === 'web' && isScreenNotMobile}` (500 px wide or more).
+- `maskColor={theme.colors.background}`, unscoped, matching the page background.
+- Native phone: `framed={false}`, full bleed.
+- Explore is fixed-viewport: no page scroll, but it still wraps the center in
+  ContentPanel when framed.
+- **Never hand-roll a bleed mask.** ContentPanel owns it.
 
 ### Scroll ownership (one owner per surface)
 
-Web default = **document scroll**. Do NOT wrap SideBar+Slot in a layout-level `Animated.ScrollView`. The layout is a static flex row; only the screen (or document on web) scrolls.
+Web default is **document scroll**. Do NOT wrap SideBar plus Slot in a
+layout-level `Animated.ScrollView`. The layout is a static flex row; only the
+screen (or the document on web) scrolls.
 
 | Surface | Owner |
-|---------|-------|
+|---|---|
 | Web (default) | Document |
 | Native tabs | Screen `Animated.ScrollView` (local SharedValue) |
 | Explore | Fixed shell (no page scroll) |
 
-Remove `LayoutScrollProvider` / layout scroll handler when not needed. No dual writers of `scrollY`. Sticky Header `top` = Bloom `PANEL_TOP_INSET` (8) when framed.
+Remove `LayoutScrollProvider` and the layout scroll handler when not needed. No
+dual writers of `scrollY`. Sticky header `top` is Bloom `PANEL_TOP_INSET` when
+framed.
 
 ### Section stacking (NativeWind gap)
 
-Use NativeWind `gap-6 md:gap-8` on the section container — **not** per-section `marginTop: sectionGap` or `resolveSectionSpacing()`. Bottom padding: `pb-14` (home) / `pb-20` (agent).
+Use NativeWind `gap-6 md:gap-8` on the section container, **not** per-section
+`marginTop: sectionGap` or `resolveSectionSpacing()`. Bottom padding is `pb-14`
+(home) or `pb-20` (agent).
 
-- Drop `HomeCarouselSection` outer `marginBottom`.
-- Wide CTA rows: `flex-row items-stretch gap-6 md:gap-8`.
+- Drop the `HomeCarouselSection` outer `marginBottom`.
+- Wide CTA rows use `flex-row items-stretch gap-6 md:gap-8`.
 
 ### Design-token CSS (no hand-copied radius)
 
-`@import "@oxyhq/bloom/design-tokens/theme.css"` in `packages/frontend/styles/global.css` after the Tailwind import. This provides `rounded-radius-28`, `p-space-8`, etc. without pasting anything locally.
+`@import "@oxyhq/bloom/design-tokens/theme.css"` in
+`packages/frontend/styles/global.css`, after the Tailwind import. That provides
+`rounded-radius-28`, `p-space-8` and the rest without pasting anything locally.
 
-- **Never declare `--radius-radius-*` or other Bloom scales in `global.css`** — the Bloom import is the sole authority.
-- Keep only Homiio-local color seeds / `:root` overrides in `global.css`.
-- Bump `@oxyhq/bloom` in `packages/frontend/package.json` + lockfile in the same commit when the import is added.
+- **Never declare `--radius-radius-*` or other Bloom scales in `global.css`.** The
+  Bloom import is the sole authority.
+- Keep only Homiio-local color seeds and `:root` overrides in `global.css`.
 
-## NativeWind — `Pressable` Function-Form `style`
+## NativeWind: `Pressable` function-form `style`
 
-The NativeWind css-interop (v4 `react-native-css-interop`, and the v5 preview / `react-native-css` this app now runs) does NOT support React Native's function-form `style={({ pressed }) => [...]}` — the function is swallowed and the `Pressable` renders with no style at all.
+The NativeWind css-interop (v4 `react-native-css-interop`, and the v5 preview /
+`react-native-css` this app now runs) does NOT support React Native's
+function-form `style={({ pressed }) => [...]}`. The function is swallowed and the
+`Pressable` renders with no style at all.
 
-**Fix:** static style array + `onPressIn`/`onPressOut` + `useState`:
+**Fix:** a static style array plus `onPressIn` / `onPressOut` plus `useState`:
 
 ```tsx
 const [pressed, setPressed] = useState(false);
@@ -451,45 +636,137 @@ const [pressed, setPressed] = useState(false);
 >
 ```
 
-- For web hover, use `onHoverIn`/`onHoverOut` + state instead of `({ hovered })`.
-- Hooks can't run inside `.map()` — extract a small component when a function-form `Pressable` lives in a list.
-- Canonical template: `packages/frontend/components/search/SearchSummaryBar.tsx`
+- For web hover, use `onHoverIn` / `onHoverOut` plus state instead of
+  `({ hovered })`.
+- Hooks cannot run inside `.map()`, so extract a small component when a
+  function-form `Pressable` lives in a list.
+- Canonical template:
+  `packages/frontend/components/search/SearchSummaryBar.tsx`.
 - Audit: `grep -rn "style={({" app components --include=*.tsx` must return ZERO.
 
 ## `pointerEvents: 'box-none'` / `'box-only'` in a STYLE is BROKEN on web
 
-`box-none`/`box-only` are React Native-ONLY values — they are NOT valid CSS `pointer-events`. Put them in a `style` object (`style={{ pointerEvents: 'box-none' }}`) and RN-Web **silently drops** them, leaving the element at `pointer-events: auto` — so a transparent, full-size overlay (a save layer, a scrim wrapper, a padded popover) **swallows every tap/hover beneath it** with no error. This hid the property-card carousel arrows and would freeze the whole mobile-web screen behind the closed sidebar drawer (PR #202 / the box-none sweep).
+`box-none` and `box-only` are React Native-ONLY values and are NOT valid CSS
+`pointer-events`. Put them in a `style` object
+(`style={{ pointerEvents: 'box-none' }}`) and RN-Web **silently drops** them,
+leaving the element at `pointer-events: auto`, so a transparent, full-size
+overlay (a save layer, a scrim wrapper, a padded popover) **swallows every tap
+and hover beneath it** with no error. This hid the property-card carousel arrows
+and would freeze the whole mobile-web screen behind the closed sidebar drawer
+(PR #202 and the box-none sweep).
 
-- **Fix / correct pattern:** split into a pass-through container `pointerEvents: 'none'` (valid CSS) + genuinely-interactive children that re-enable themselves with `pointerEvents: 'auto'` (valid CSS: a child `auto` inside a parent `none` IS hittable). That reproduces box-none semantics with values RN-Web actually applies.
-- The RN `pointerEvents` **PROP** (`<View pointerEvents="box-none">`) is fine — RN-Web maps it correctly. Only the STYLE form is broken. Prefer the none/auto split.
-- Audit: `grep -rn "pointerEvents: 'box-none'\|pointerEvents: 'box-only'" app components` should stay ZERO in style objects.
+- **Correct pattern:** split into a pass-through container with
+  `pointerEvents: 'none'` (valid CSS) plus genuinely interactive children that
+  re-enable themselves with `pointerEvents: 'auto'` (also valid CSS: a child
+  `auto` inside a parent `none` IS hittable). That reproduces box-none semantics
+  with values RN-Web actually applies.
+- The RN `pointerEvents` **PROP** (`<View pointerEvents="box-none">`) is fine,
+  because RN-Web maps it correctly. Only the STYLE form is broken. Prefer the
+  none/auto split.
+- Audit:
+  `grep -rn "pointerEvents: 'box-none'\|pointerEvents: 'box-only'" app components`
+  should stay ZERO in style objects.
 
-## Masked Image Zoom (ZoomableImage)
+## Masked image zoom (ZoomableImage)
 
-Cards NEVER scale on hover/press ("cutrada"). The app-wide Airbnb-2026 move is the **image zooming inside the card's rounded mask** — the photo scales, the card stays put, corners stay clipped. There is **one** primitive: `components/ui/ZoomableImage.tsx`.
+Cards NEVER scale on hover or press ("cutrada"). The app-wide move is the **image
+zooming inside the card's rounded mask**: the photo scales, the card stays put,
+and corners stay clipped. There is **one** primitive,
+`components/ui/ZoomableImage.tsx`.
 
-- Wrap the `<Image>` (not the card): `<ZoomableImage borderRadius aspectRatio active style>` renders a `overflow:'hidden'` mask around an inner wrapper that applies `transform:[{scale: active?1.05:1}]`. Overlays (badges, scrim, heart, price) stay **siblings of** `ZoomableImage` so they don't zoom.
-- **Hover source is the CARD, not the image.** `active` is CONTROLLED-first: when the caller passes `active`, it drives the zoom (external wins) and `ZoomableImage` attaches NO hover listeners of its own. Each card owns ONE `onPointerEnter/Leave` (web) — `onHoverIn/Out` on a `Pressable`, or `onPointerEnter/Leave` gated to `Platform.OS==='web'` on a plain `View`/`TouchableOpacity` — on its whole container → a `hovered` state, and passes `active={hovered || pressed}` down, so the photo zooms on hover ANYWHERE on the card (photo OR text/body), Airbnb-style. `onPointerEnter/Leave` fire on the container boundary and don't re-fire moving between children on RN-Web, so one handler covers the whole card. `pressed` (touch) drives the native zoom. When `active` is omitted, `ZoomableImage` falls back to owning its own web hover over the image (standalone use). It's its own component, so no hooks-in-`.map`; static style arrays only (§NativeWind Pressable).
-- The card-level hover must ONLY feed the image `active` — NEVER re-add a `transform:[{scale}]`/lift/shadow on the card itself (that's the "cutrada" removed in #164).
-- For the in-card carousel, thread `imageActive` through `PropertyImageCarousel` → each page's `ZoomableImage` (OR-ed with the page's own touch press).
-- Web transition + Safari corner-clip fix are baked in (web-cast `transitionProperty`/`willChange`, the sanctioned `as unknown as ViewStyle` web-CSS pattern). NEVER add a per-component variant — reuse this one.
-- Wired in: `PropertyImageCarousel` + `PropertyCard` (both paths), `CityShowcaseSection`, `Host/AgentCtaBanner`, tips `TipCard`, `RoomList`. Card/banner/tile surfaces are otherwise **flat** — no `transform:[{scale}]` card interaction anywhere (audit: `grep -rnE "transform.*scale" components app` shows only `ZoomableImage`'s image-zoom + genuinely animated worklets).
+- Wrap the `<Image>`, not the card:
+  `<ZoomableImage borderRadius aspectRatio active style>` renders an
+  `overflow:'hidden'` mask around an inner wrapper applying
+  `transform:[{scale: active?1.05:1}]`. Overlays (badges, scrim, heart, price)
+  stay **siblings of** `ZoomableImage` so they do not zoom.
+- **The hover source is the CARD, not the image.** `active` is CONTROLLED first:
+  when the caller passes `active` it drives the zoom (external wins) and
+  `ZoomableImage` attaches NO hover listeners of its own. Each card owns ONE
+  `onPointerEnter` / `onPointerLeave` on web (`onHoverIn` / `onHoverOut` on a
+  `Pressable`, or `onPointerEnter` / `onPointerLeave` gated to
+  `Platform.OS==='web'` on a plain `View` or `TouchableOpacity`) on its whole
+  container, feeding a `hovered` state, and passes `active={hovered || pressed}`
+  down, so the photo zooms on hover ANYWHERE on the card, photo or text.
+  `onPointerEnter` / `onPointerLeave` fire on the container boundary and do not
+  re-fire moving between children on RN-Web, so one handler covers the whole
+  card. `pressed` (touch) drives the native zoom. When `active` is omitted,
+  `ZoomableImage` falls back to owning its own web hover over the image, for
+  standalone use. It is its own component, so there are no hooks in `.map`, and
+  it uses static style arrays only.
+- The card-level hover must ONLY feed the image `active`. NEVER re-add a
+  `transform:[{scale}]`, lift or shadow on the card itself; that is the
+  "cutrada" removed in #164.
+- For the in-card carousel, thread `imageActive` through
+  `PropertyImageCarousel` to each page's `ZoomableImage`, OR-ed with the page's
+  own touch press.
+- The web transition and the Safari corner-clip fix are baked in (web-cast
+  `transitionProperty` and `willChange`, the sanctioned
+  `as unknown as ViewStyle` web-CSS pattern). NEVER add a per-component variant;
+  reuse this one.
+- Wired in: `PropertyImageCarousel` and `PropertyCard` (both paths),
+  `CityShowcaseSection`, `Host/AgentCtaBanner`, tips `TipCard`, `RoomList`. Card,
+  banner and tile surfaces are otherwise **flat**, with no
+  `transform:[{scale}]` card interaction anywhere (audit:
+  `grep -rnE "transform.*scale" components app` shows only `ZoomableImage`'s
+  image zoom plus genuinely animated worklets).
 
-## Icon Button (IconButton)
+## Icon button (IconButton)
 
-`components/ui/IconButton.tsx` is the ONE app-wide icon-button primitive — a circular button with pressed/hover state (static style arrays, no function-form `style`) and three chrome **variants**. Never hand-roll `<Pressable style={[barIconButton, pressed && barIconButtonPressed]}><Ionicons/></Pressable>` again.
+`components/ui/IconButton.tsx` is the ONE app-wide icon-button primitive: a
+circular button with pressed and hover state (static style arrays, no
+function-form `style`) and three chrome **variants**. Never hand-roll
+`<Pressable style={[barIconButton, pressed && barIconButtonPressed]}><Ionicons/></Pressable>`
+again.
 
-- Variants: `ghost` (flat transparent, `mutedSubtle` pressed tint — headers/bars, reuses the shared `barIconButton`/`barIconSize`/`barBackIconSize` tokens), `overlay` (frosted-white circle for on-photo use — the card save heart), `filled` (brand fill + `primaryForeground` glyph). Props: `icon`/`onPress`/`accessibilityLabel` + optional `variant`/`size`/`color`/`active`+`activeColor`/`onLongPress`/`disabled`/`loading`/`badge`/`style`.
-- **`SaveButton` is a stateful COMPOSITION of `IconButton`** — it owns save logic (mutation, optimistic toggle, count, long-press folder sheet) and passes `chrome` → `IconButton`'s `variant` (`ghost` in headers/bars, `overlay` on cards). There is no separate cream/shadow save chrome. Every SaveButton site inherits the shared button.
-- Wired in: `Header` back, `StickyPropertyHeader` back/share, property `[id]` floating host/share/viewings (checkmark via `badge`), and `SaveButton` everywhere. Future icon-button sites reuse `IconButton`.
+- Variants: `ghost` (flat transparent, `mutedSubtle` pressed tint, for headers
+  and bars, reusing the shared `barIconButton` / `barIconSize` /
+  `barBackIconSize` tokens), `overlay` (frosted white circle for on-photo use,
+  such as the card save heart), and `filled` (brand fill plus
+  `primaryForeground` glyph). Props: `icon`, `onPress`, `accessibilityLabel`,
+  plus optional `variant`, `size`, `color`, `active` and `activeColor`,
+  `onLongPress`, `disabled`, `loading`, `badge` and `style`.
+- **`SaveButton` is a stateful COMPOSITION of `IconButton`.** It owns save logic
+  (mutation, optimistic toggle, count, long-press folder sheet) and passes
+  `chrome` to `IconButton`'s `variant` (`ghost` in headers and bars, `overlay` on
+  cards). There is no separate cream or shadow save chrome. Every SaveButton site
+  inherits the shared button.
+- Wired in: `Header` back, `StickyPropertyHeader` back and share, property `[id]`
+  floating host/share/viewings (checkmark via `badge`), and `SaveButton`
+  everywhere. Future icon-button sites reuse `IconButton`.
 
-## Infinite Scroll / Pagination Primitive
+## Infinite scroll and pagination primitive
 
-Homiio has **one** reusable infinite-scroll primitive — never hand-roll `ScrollView.onScroll` distance math again. It respects the "one scroll owner per surface" rule above (web sentinel, native handler) rather than copying Mention's `FlatList.onEndReached`.
+Homiio has **one** reusable infinite-scroll primitive. Never hand-roll
+`ScrollView.onScroll` distance math again. It respects the "one scroll owner per
+surface" rule above (web sentinel, native handler) rather than copying Mention's
+`FlatList.onEndReached`.
 
-- **Web** (document scroll or nested `overflow:auto`): render `components/common/LoadMoreSentinel.tsx` at the list's end — a 1px `View` + `IntersectionObserver` (600px `rootMargin`), inert on native.
-- **Native** (the surface's own scroll owner): `hooks/useInfiniteScroll.ts` returns an `{ onScroll }` end-detect handler (0.7 threshold, re-arms on scroll-up) to spread onto the screen's `ScrollView`. The home page instead gets end-detection from `components/PageScrollView.tsx`'s Reanimated worklet (`runOnJS`) firing `onEndReached`/`onEndReachedThreshold`, sharing the same `END_REACHED_THRESHOLD` constant.
-- A screen wires **both** (sentinel + native handler); each platform only fires its own. The guarded loader (`if (hasNextPage && !isFetchingNextPage) fetchNextPage()`) stays in the consumer, not the primitive.
-- Canonical data hooks — reuse, don't write a new pagination engine: `hooks/usePropertySearch.ts` (search/browse/home feed) and `hooks/useInfiniteCityProperties.ts` (a city's listings), both `useInfiniteQuery`-based and page-based. Render results with `components/ui/PropertyResultsGrid.tsx` / `PropertyResultsGridSkeleton` — a `.map` grid that intentionally does not own scroll, for embedding in the single page scroller.
-- Wired in: home `app/(tabs)/index.tsx`, `components/search/SearchResultsView.tsx`, `app/properties/index.tsx`, `app/properties/type/[type].tsx`, `app/properties/city/[id].tsx`; `app/(tabs)/saved/index.tsx` does client-side incremental reveal (no backend pagination endpoint).
-- Backend list endpoints feeding an infinite grid should expose flat `hasMore`/`totalPages` aliases alongside the nested `pagination` object (keeps `normalizeEnvelope` intact) — see `/api/properties/search` and `cityController.getPropertiesByCity`.
+- **Web** (document scroll or a nested `overflow:auto`): render
+  `components/common/LoadMoreSentinel.tsx` at the list's end, a 1px `View` plus
+  `IntersectionObserver` (600px `rootMargin`), inert on native.
+- **Native** (the surface's own scroll owner): `hooks/useInfiniteScroll.ts`
+  returns an `{ onScroll }` end-detect handler (0.7 threshold, re-arms on scroll
+  up) to spread onto the screen's `ScrollView`. The home page instead gets end
+  detection from `components/PageScrollView.tsx`'s Reanimated worklet
+  (`runOnJS`) firing `onEndReached` and `onEndReachedThreshold`, sharing the same
+  `END_REACHED_THRESHOLD` constant.
+- A screen wires **both** (sentinel plus native handler), and each platform only
+  fires its own. The guarded loader
+  (`if (hasNextPage && !isFetchingNextPage) fetchNextPage()`) stays in the
+  consumer, not the primitive.
+- Canonical data hooks, to reuse rather than writing a new pagination engine:
+  `hooks/usePropertySearch.ts` (search, browse, home feed) and
+  `hooks/useInfiniteCityProperties.ts` (a city's listings), both
+  `useInfiniteQuery`-based and page based. Render results with
+  `components/ui/PropertyResultsGrid.tsx` and `PropertyResultsGridSkeleton`, a
+  `.map` grid that intentionally does not own scroll, for embedding in the single
+  page scroller.
+- Wired in: home `app/(tabs)/index.tsx`,
+  `components/search/SearchResultsView.tsx`, `app/properties/index.tsx`,
+  `app/properties/type/[type].tsx`, `app/properties/city/[id].tsx`.
+  `app/(tabs)/saved/index.tsx` does client-side incremental reveal, since there
+  is no backend pagination endpoint for it.
+- Backend list endpoints feeding an infinite grid should expose flat `hasMore`
+  and `totalPages` aliases alongside the nested `pagination` object, which keeps
+  `normalizeEnvelope` intact. See `/api/properties/search` and
+  `cityController.getPropertiesByCity`.


### PR DESCRIPTION
Audits `AGENTS.md` against the tree and against the new org-wide standards at [OxyHQ/engineering](https://github.com/OxyHQ/engineering).

Agents stack `AGENTS.md` from the repo root down, so this file should carry only its own delta. It now opens with a pointer to the org standards instead of restating what they cover.

## The main change: a hand-maintained list replaced by the rule that generates it

The file carried 39 hardcoded `PROVIDER_*_ENABLED` lines. The source resolves **49**, because the flag name is derived mechanically in `packages/listing-providers/src/index.ts`:

```ts
process.env[`PROVIDER_${id.toUpperCase()}_ENABLED`] === "true"
```

So the list was duplicating a derivation, had already drifted by ten entries, and would drift again with the next plugin. It is replaced by the rule plus a pointer to `registry.ts` and the `providers/` tree, which are the only authorities. A new plugin is now gated the moment it is registered, with no list to update.

The per-market notes are kept, because those carry real knowledge that is not in the code: which portals are verified over cold HTTP, which are blocked by Cloudflare, Akamai, Kasada or DataDome, and what each is waiting on.

## Duplication of the org standards removed

- The mass-assignment rule (`never new Model(req.body)`, `never ...req.body`, `never a denylist`) is stated verbatim upstream. Only the Homiio-specific pointers remain: `utils/pickFields.ts` and the two `editableFields.ts` whitelists, plus "keep them in sync with the schemas".
- "Version numbers live in each `package.json`" is the closing line of the org standards.

## Version pin removed from prose

`Stripe 16.11` was already stale against `package.json`. Removed rather than updated.

## Kept

Everything genuinely local: the ownership/IDOR pattern and its file pointers, the lease create bridge being the only entry point, the notification write chokepoint, the **no admin surfaces** veto and why, the linked-client `normalizeEnvelope` bridge, the whole listing-provider fetch ladder and shared-parse chokepoints, the cold-start check and the three properties worth preserving in it, the deferred react-hooks findings and why they cannot be verified without a session, and the UI primitives (`ZoomableImage`, `IconButton`, the infinite-scroll pair) with their audit greps.

No nested `AGENTS.md` in this repo. `CLAUDE.md` already contains only the `@AGENTS.md` import line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)