### PR TITLE
ci: name the seven secrets the deploy syncs, and correct the record on why

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,11 +300,23 @@ jobs:
   # ZERO jobs created, twice, with created_at == updated_at — concluded before
   # scheduling anything, including its own ubuntu-latest scope job. The same
   # trigger on deploy-frontends.yml, in the same repository and the same instant,
-  # ran to success. Ruled out by evidence: the YAML shape and `id-token: write`
-  # (CrowdSource runs an identical deploy-aws.yml on `workflow_run` and schedules
-  # fine), the ARM runner (this file's own push-triggered runs used it minutes
-  # earlier), rulesets, and environment protection rules (none exist). What is
-  # left is org-level Actions policy, which is not readable without admin:org.
+  # ran to success. Ruled out by evidence: the ARM runner (this file's own
+  # push-triggered runs used it minutes earlier), rulesets, and environment
+  # protection rules (none exist).
+  #
+  # The cause was in the YAML shape after all, and the two observations taken to
+  # rule that out did not: deploy-aws.yml expanded the whole `secrets` context
+  # with `toJSON(secrets)` and walked it into a shell loop, which GitHub's abuse
+  # detection reads as an exfiltration payload and holds pending a human click.
+  # deploy-frontends.yml has no such step, and the "identical" CrowdSource
+  # deploy-aws.yml is not identical — it syncs from an explicit
+  # `SSM_SECRET_ALLOWLIST` and never builds the blob. Both "controls" differ from
+  # this file in precisely that line. It is not org-level Actions policy.
+  #
+  # deploy-aws.yml no longer builds that blob, so the `workflow_run` trigger is
+  # very likely usable again. It is deliberately NOT restored here: being called
+  # is the stronger gate for the reasons below, and re-testing a production
+  # deploy trigger is a separate change from removing the pattern.
   #
   # Calling the workflow removes the failing mechanism entirely and is a stronger
   # gate besides: the deploy cannot start unless every job below it passed in
@@ -324,8 +336,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    # The deploy syncs GitHub secrets to SSM with `toJSON(secrets)`, so it needs
-    # the caller's secrets; without `inherit` that object is empty and the sync
-    # silently writes nothing.
+    # The deploy syncs named GitHub secrets to SSM, so it needs the caller's
+    # secrets; without `inherit` every one of them reads as empty and the sync
+    # silently writes nothing. Still required now that the step enumerates them
+    # by name rather than expanding the whole context.
     secrets: inherit
     uses: ./.github/workflows/deploy-aws.yml

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -85,25 +85,70 @@ jobs:
           role-to-assume: arn:aws:iam::237343248947:role/oxy-github-deploy
           aws-region: ${{ env.AWS_REGION }}
 
+      # The secrets are enumerated one at a time, on purpose.
+      #
+      # This step used to expand the entire `secrets` context with
+      # `toJSON(secrets)`. That expression is what made this workflow conclude
+      # `action_required` with zero jobs on `workflow_run` — the failure the
+      # comment above, and the `deploy-backend` comment in ci.yml, record as
+      # unexplained. A workflow that walks every repository secret into a shell
+      # loop is shaped exactly like an exfiltration payload, so GitHub's abuse
+      # detection holds the run until a human clicks "Approve and run" in the
+      # UI. The REST approve endpoint only serves fork pull requests, so it
+      # cannot be automated, and the approval is per run.
+      #
+      # The two observations that were taken to rule this out do not: the
+      # "identical" CrowdSource deploy-aws.yml that schedules fine is not
+      # identical — it syncs from an explicit `SSM_SECRET_ALLOWLIST` and never
+      # builds the blob — and deploy-frontends.yml, which runs on `workflow_run`
+      # in this repository without trouble, has no such step at all.
+      #
+      # Enumerating is also least privilege. The old loop copied every secret
+      # visible to the repo, so the org-wide CI credentials (NPM_TOKEN,
+      # CLOUDFLARE_API_TOKEN, ADD_TO_PROJECT_TOKEN) ended up in this app's SSM
+      # namespace, and this repo could overwrite the /oxy/_shared/* parameters
+      # that other services read.
+      #
+      # The list covers BOTH task definitions rolled below — the `homiio` API and
+      # the `homiio-worker` listing worker. Adding a new secret means adding it
+      # here, or it never reaches SSM.
       - name: Sync GitHub secrets -> SSM (GitHub is the source of truth)
         env:
-          SECRETS_JSON: ${{ toJSON(secrets) }}
+          APP_MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          APP_JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          APP_JWT_REFRESH_SECRET: ${{ secrets.JWT_REFRESH_SECRET }}
+          # Worker only.
+          APP_LISTING_RESIDENTIAL_PROXY_URL: ${{ secrets.LISTING_RESIDENTIAL_PROXY_URL }}
+          SHARED_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          SHARED_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SHARED_REDIS_URL: ${{ secrets.REDIS_URL }}
         run: |
-          SHARED="AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY REDIS_URL LIVEKIT_API_KEY LIVEKIT_API_SECRET"
-          echo "$SECRETS_JSON" | jq -r 'to_entries[] | select((.key|ascii_upcase) as $k | ($k=="GITHUB_TOKEN" or ($k|startswith("ACTIONS_")))|not) | [.key,.value]|@tsv' | \
-          while IFS=$'\t' read -r k v; do
-            [ -z "$k" ] && continue
-            if [ -z "$v" ] || [ "$v" = "-" ]; then
-              echo "::warning::skip empty/placeholder secret $k; SSM unchanged"
-              continue
+          sync_secret() {
+            name="$1"; value="$2"; path="$3"
+            if [ -z "$value" ] || [ "$value" = "-" ]; then
+              echo "::warning::skip empty/placeholder secret $name; SSM unchanged"
+              return 0
             fi
-            if [ "$k" = "REDIS_URL" ] && [ "$AWS_REGION" = "us-west-2" ] && ! printf '%s' "$v" | grep -q '\.usw2\.cache\.amazonaws\.com'; then
-              echo "::warning::skip REDIS_URL because it does not point at the us-west-2 Valkey endpoint; SSM unchanged"
-              continue
-            fi
-            case " $SHARED " in *" $k "*) path="/oxy/_shared/$k";; *) path="/oxy/$APP/$k";; esac
-            aws ssm put-parameter --name "$path" --value "$v" --type SecureString --overwrite >/dev/null && echo "synced -> $path"
-          done
+            aws ssm put-parameter --name "$path" --value "$value" --type SecureString --overwrite >/dev/null
+            echo "synced -> $path"
+          }
+
+          sync_secret MONGODB_URI "$APP_MONGODB_URI" "/oxy/$APP/MONGODB_URI"
+          sync_secret JWT_SECRET "$APP_JWT_SECRET" "/oxy/$APP/JWT_SECRET"
+          sync_secret JWT_REFRESH_SECRET "$APP_JWT_REFRESH_SECRET" "/oxy/$APP/JWT_REFRESH_SECRET"
+          sync_secret LISTING_RESIDENTIAL_PROXY_URL "$APP_LISTING_RESIDENTIAL_PROXY_URL" "/oxy/$APP/LISTING_RESIDENTIAL_PROXY_URL"
+          sync_secret AWS_ACCESS_KEY_ID "$SHARED_AWS_ACCESS_KEY_ID" "/oxy/_shared/AWS_ACCESS_KEY_ID"
+          sync_secret AWS_SECRET_ACCESS_KEY "$SHARED_AWS_SECRET_ACCESS_KEY" "/oxy/_shared/AWS_SECRET_ACCESS_KEY"
+
+          # Valkey lives in the cluster's region; a URL from another region
+          # leaves the worker silently without a cache, so it is rejected.
+          if [ -n "$SHARED_REDIS_URL" ] && [ "$SHARED_REDIS_URL" != "-" ] &&
+             [ "$AWS_REGION" = "us-west-2" ] &&
+             ! printf '%s' "$SHARED_REDIS_URL" | grep -q '\.usw2\.cache\.amazonaws\.com'; then
+            echo "::warning::skip REDIS_URL because it does not point at the us-west-2 Valkey endpoint; SSM unchanged"
+          else
+            sync_secret REDIS_URL "$SHARED_REDIS_URL" "/oxy/_shared/REDIS_URL"
+          fi
 
       - name: Login to ECR
         uses: aws-actions/amazon-ecr-login@v2


### PR DESCRIPTION
The `Sync GitHub secrets -> SSM` step expanded the whole `secrets` context with
`toJSON(secrets)` and walked it into a shell loop piped to `aws ssm put-parameter`.
That is structurally identical to a secret-exfiltration payload, so GitHub's abuse
detection holds the workflow: the run is created with conclusion `action_required`
and **zero jobs** until a human clicks "Approve and run" in the UI. The REST approve
endpoint only serves fork pull requests, so it cannot be automated, and approval is
**per run**. The gate re-fires whenever the workflow file changes.

Measured across the org on 2026-08-08 — repos **with** the pattern: Mercaria (held all
day), Syra (held since its Postgres merge), **Homiio** (`action_required` runs on
2026-07-30). Repos **without** it: Mention and OxyHQServices, both deployed unheld
(20:12Z, 20:59Z). 3/3 held vs 0/2. Allo removed the pattern on 2026-08-06 and every
deploy since (2026-08-07 12:32Z, 13:39Z, 13:54Z) completed without a hold.

## This repository already measured the bug and mis-attributed it

The `deploy-backend` comment in `ci.yml` records `deploy-aws.yml` on `workflow_run`
concluding `action_required` with **zero jobs created, twice**, `created_at ==
updated_at`, and ends: *"What is left is org-level Actions policy, which is not readable
without admin:org."* That conclusion rests on two controls, and **neither control holds**:

- *"CrowdSource runs an identical deploy-aws.yml on `workflow_run` and schedules fine"* —
  it is not identical. CrowdSource's sync step reads
  `SSM_SECRET_ALLOWLIST: MONGODB_URI WEBHOOK_SECRET_ENCRYPTION_KEY` and never builds the
  blob.
- *"The same trigger on deploy-frontends.yml, in the same repository and the same instant,
  ran to success"* — `deploy-frontends.yml` has no secret-sync step at all.

Both files differ from this one in precisely the `toJSON(secrets)` line, which makes that
line the discriminator rather than the thing ruled out. The workaround adopted then
(calling the workflow instead of triggering it) sidestepped the symptom; this PR removes
the cause. Both `ci.yml` comments are corrected to say so.

**The `workflow_run` trigger is deliberately NOT restored here.** Being called from CI is
the stronger gate for the reasons the existing comment gives, and re-testing a production
deploy trigger is a separate change. `secrets: inherit` stays — the step still references
named secrets, which are empty without it.

## The allowlist, and where each name comes from

Ground truth is **both live task definitions**, since this workflow rolls two ECS services
from one image: `oxy-homiio:11` (service `homiio`) and `oxy-homiio-worker:23` (service
`homiio-worker`, whose task definition is declared outside the shared module). Each name
is synced to the exact SSM path a `valueFrom` already points at.

| Secret | SSM path | Task definition | Provenance |
|---|---|---|---|
| `MONGODB_URI` | `/oxy/homiio/MONGODB_URI` | both | read by the backend; exists as a repo secret |
| `JWT_SECRET` | `/oxy/homiio/JWT_SECRET` | API | exists as a repo secret |
| `JWT_REFRESH_SECRET` | `/oxy/homiio/JWT_REFRESH_SECRET` | API | exists as a repo secret |
| `LISTING_RESIDENTIAL_PROXY_URL` | `/oxy/homiio/LISTING_RESIDENTIAL_PROXY_URL` | **worker only** | read by the listing scrapers; exists as a repo secret |
| `AWS_ACCESS_KEY_ID` | `/oxy/_shared/AWS_ACCESS_KEY_ID` | both | shared path; exists as a repo secret |
| `AWS_SECRET_ACCESS_KEY` | `/oxy/_shared/AWS_SECRET_ACCESS_KEY` | both | shared path; exists as a repo secret |
| `REDIS_URL` | `/oxy/_shared/REDIS_URL` | **worker only** | shared path; BullMQ queues; exists as a repo secret |

That is the union of both task definitions' secret lists — nothing either service consumes
stops being synced. All seven exist as repo secrets today, so every one of them is a real
sync that keeps working. Covering the worker matters: `LISTING_RESIDENTIAL_PROXY_URL` and
`REDIS_URL` appear in **no** API task definition, so an allowlist derived from the API
alone would have silently stopped syncing them.

## Deliberately not in the list

- `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET` — in the old `SHARED` variable, but neither task
  definition consumes them and neither is a repo secret. Dropping them means this repo can
  no longer overwrite `/oxy/_shared/*` parameters that **other** services depend on.
- `CLOUDFLARE_ACCOUNT_ID` and the org-wide `NPM_TOKEN`, `CLOUDFLARE_API_TOKEN`,
  `ADD_TO_PROJECT_TOKEN` — CI credentials belonging to other workflows. The old loop
  copied them into `/oxy/homiio/*`, where all four are still sitting as leftovers.
- `DATABASE_URL`, `OPENAI_API_KEY`, `STRIPE_SECRET_KEY`, `TELEGRAM_BOT_TOKEN`,
  `EMAIL_PASSWORD`, `CROWDSOURCE_*` and the rest of the backend's env surface — read by
  the code, but absent from both task definitions and not repo secrets, so syncing them
  would write parameters nothing reads. If any becomes real runtime config it needs adding
  to the task definition and to this list in the same change.
- `EXPO_PUBLIC_OXY_CLIENT_ID` — a client build-time value already in SSM, in neither task
  definition and not a repo secret.

## Behaviour preserved

The empty/placeholder guard (skip on empty or `-`) is unchanged, now in a `sync_secret`
helper. The Valkey endpoint check on `REDIS_URL` keeps its `AWS_REGION = us-west-2`
condition exactly as this repo had it. Values reach the shell through `env:` and are
quoted, so nothing is interpolated into `run:`.

## Verification

- Both `deploy-aws.yml` and `ci.yml` parse (`yaml.safe_load`); the sync step's `env:` keys
  are exactly the seven names above, and `ci.yml`'s `deploy-backend` still carries
  `secrets: inherit`.
- `SECRETS_JSON` is gone from `.github/` entirely, and `${{ toJSON(secrets) }}` no longer
  appears as an expression; the remaining textual occurrences are the two explanatory
  comments — the same shape Allo has been deploying with unheld since 2026-08-06.
- No job logic changed, so the repo's CI gates (`backend`, `frontend`,
  `frontend-typecheck`, `lockfile`, `frontend-bundle`) run on this PR unmodified.
