### PR TITLE
The wire contract is `id`, not `_id` — a clean cut

### DIFF
--- a/packages/backend/__tests__/integration/addressEndpoints.test.ts
+++ b/packages/backend/__tests__/integration/addressEndpoints.test.ts
@@ -6,7 +6,9 @@
  * (and back to `postal_code` in SQL), `land_plot` became three flat columns, and
  * the GeoJSON `coordinates` pair became two named scalars. None of that may
  * reach the frontend, so the shape assertions below are as load-bearing as the
- * query ones.
+ * query ones. An address serializes its identity as `id` only — the `_id` that
+ * used to ship beside it is gone, and the detail test asserts its ABSENCE, which
+ * is the only half that can catch it coming back.
  */
 
 import express, { type Express } from 'express';
@@ -74,8 +76,8 @@ describe('GET /api/addresses/:id', () => {
     const res = await request(app).get(`/api/addresses/${addressId}`).expect(200);
     const { address } = res.body;
 
-    expect(address._id).toBe(addressId);
     expect(address.id).toBe(addressId);
+    expect(address).not.toHaveProperty('_id');
     expect(address.postal_code).toBe('08013');
     expect(address).not.toHaveProperty('postalCode');
     // `[lng, lat]`, GeoJSON order — transposing this pins a Barcelona listing
@@ -108,7 +110,7 @@ describe('GET /api/addresses/search', () => {
 
     const res = await request(app).get('/api/addresses/search?query=mallor').expect(200);
 
-    expect(res.body.addresses.map((a: { _id: string }) => a._id)).toEqual([target]);
+    expect(res.body.addresses.map((a: { id: string }) => a.id)).toEqual([target]);
     expect(res.body.pagination.totalItems).toBe(1);
     expect(typeof res.body.pagination.totalItems).toBe('number');
   });
@@ -127,7 +129,7 @@ describe('GET /api/addresses/search', () => {
     const inCity = await seedAddress({ chain, street: 'Avinguda Diagonal' });
 
     const res = await request(app).get('/api/addresses/search?query=Barcelona').expect(200);
-    expect(res.body.addresses.map((a: { _id: string }) => a._id)).toEqual([inCity]);
+    expect(res.body.addresses.map((a: { id: string }) => a.id)).toEqual([inCity]);
   });
 
   it('matches on the REGION name and on the NEIGHBORHOOD name', async () => {
@@ -144,12 +146,12 @@ describe('GET /api/addresses/search', () => {
     await seedAddress({ chain: elsewhere, street: 'Rua Augusta' });
 
     const byRegion = await request(app).get('/api/addresses/search?query=catalonia').expect(200);
-    expect(byRegion.body.addresses.map((a: { _id: string }) => a._id).sort()).toEqual(
+    expect(byRegion.body.addresses.map((a: { id: string }) => a.id).sort()).toEqual(
       [inCatalonia, inGracia].sort(),
     );
 
     const byNeighborhood = await request(app).get('/api/addresses/search?query=gràcia').expect(200);
-    expect(byNeighborhood.body.addresses.map((a: { _id: string }) => a._id)).toEqual([inGracia]);
+    expect(byNeighborhood.body.addresses.map((a: { id: string }) => a.id)).toEqual([inGracia]);
   });
 
   it('ORs the street and geo matches — a street-only hit is never dropped', async () => {
@@ -169,7 +171,7 @@ describe('GET /api/addresses/search', () => {
 
     // Both, or the OR has quietly become an AND — or a join, which drops the
     // street-only row for exactly the same reason.
-    expect(res.body.addresses.map((a: { _id: string }) => a._id).sort()).toEqual(
+    expect(res.body.addresses.map((a: { id: string }) => a.id).sort()).toEqual(
       [streetOnly, geoOnly].sort(),
     );
     expect(res.body.pagination.totalItems).toBe(2);
@@ -196,7 +198,7 @@ describe('POST /api/addresses', () => {
     const first = await request(app).post('/api/addresses').send(BODY).expect(201);
     const second = await request(app).post('/api/addresses').send(BODY).expect(201);
 
-    expect(second.body.address._id).toBe(first.body.address._id);
+    expect(second.body.address.id).toBe(first.body.address.id);
     const rows = await getDb().select({ id: addresses.id }).from(addresses);
     expect(rows).toHaveLength(1);
   });
@@ -289,8 +291,8 @@ describe('GET /api/addresses/nearby', () => {
 
     // The far one is outside the radius; the two inside come back in distance
     // order, which is the assertion a "some rows came back" check would miss.
-    expect(res.body.addresses.map((a: { _id: string }) => a._id)).toEqual([near, mid]);
-    expect(res.body.addresses.map((a: { _id: string }) => a._id)).not.toContain(far);
+    expect(res.body.addresses.map((a: { id: string }) => a.id)).toEqual([near, mid]);
+    expect(res.body.addresses.map((a: { id: string }) => a.id)).not.toContain(far);
   });
 
   it('400s without coordinates', async () => {

--- a/packages/backend/__tests__/integration/cityEndpoints.test.ts
+++ b/packages/backend/__tests__/integration/cityEndpoints.test.ts
@@ -2,12 +2,13 @@
  * The ported `/api/cities*` endpoints, over real Postgres and the real router.
  *
  * Two things are asserted together on purpose: that the query answers correctly,
- * and that the RESPONSE SHAPE did not drift. Batch 10 owns the `_id` → `id` cut,
- * so every city body here must still carry both spellings, still nest its
- * country / region / cover image as objects with their own ids, and still report
- * the centre as `coordinates: { lat, lng }` even though the table holds named
- * scalar columns. A port that answers correctly and reshapes the body is a
- * broken frontend.
+ * and that the RESPONSE SHAPE did not drift. The `_id` → `id` cut landed, so
+ * every city body here carries `id` and NO `_id` — asserted in both directions,
+ * since only the negative half can catch the old spelling being reintroduced.
+ * It still nests its country / region / cover image as objects with their own
+ * ids, and still reports the centre as `coordinates: { lat, lng }` even though
+ * the table holds named scalar columns. A port that answers correctly and
+ * reshapes the body is a broken frontend.
  */
 
 import express, { type Express } from 'express';
@@ -69,20 +70,25 @@ describe('GET /api/cities', () => {
     expect(res.body.pagination.pages).toBe(1);
   });
 
-  it('keeps emitting BOTH id spellings, on the city and on its expanded refs', async () => {
+  it('emits `id` and never `_id`, on the city and on its expanded refs', async () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
 
     const res = await request(app).get('/api/cities').expect(200);
     const [city] = res.body.data;
 
-    expect(city._id).toBe(chain.cityId);
     expect(city.id).toBe(chain.cityId);
     expect(city.countryId).toEqual(
-      expect.objectContaining({ _id: chain.countryId, id: chain.countryId, name: 'Spain', code: 'ES' }),
+      expect.objectContaining({ id: chain.countryId, name: 'Spain', code: 'ES' }),
     );
     expect(city.regionId).toEqual(
-      expect.objectContaining({ _id: chain.regionId, id: chain.regionId, name: 'Catalonia' }),
+      expect.objectContaining({ id: chain.regionId, name: 'Catalonia' }),
     );
+    // The negative half. `objectContaining` above passes just as happily with an
+    // `_id` sitting beside the `id`, so without these the old dual-spelling
+    // shape would still satisfy every assertion in this test.
+    expect(city).not.toHaveProperty('_id');
+    expect(city.countryId).not.toHaveProperty('_id');
+    expect(city.regionId).not.toHaveProperty('_id');
   });
 
   it('reports the city centre as coordinates { lat, lng }', async () => {
@@ -156,7 +162,8 @@ describe('GET /api/cities/popular', () => {
     expect(res.body.data).toHaveLength(1);
     expect(res.body.data[0].name).toBe('Madrid');
     expect(res.body.data[0].coverImageId.urls.medium).toContain('medium.webp');
-    expect(res.body.data[0].coverImageId._id).toBe(coverId);
+    expect(res.body.data[0].coverImageId.id).toBe(coverId);
+    expect(res.body.data[0].coverImageId).not.toHaveProperty('_id');
   });
 
   it('excludes a city whose cover image has been deleted', async () => {
@@ -207,7 +214,7 @@ describe('GET /api/cities/lookup', () => {
     await seedGeoChain({ countryCode: 'VE', countryName: 'Venezuela', regionName: 'Valencia', cityName: 'Valencia' });
 
     const res = await request(app).get('/api/cities/lookup?name=Valencia&country=Spain&state=catalonia').expect(200);
-    expect(res.body.data._id).toBe(es.cityId);
+    expect(res.body.data.id).toBe(es.cityId);
   });
 
   it('404s when the narrowing country or region is unknown', async () => {

--- a/packages/backend/__tests__/integration/leaseOwnership.test.ts
+++ b/packages/backend/__tests__/integration/leaseOwnership.test.ts
@@ -10,11 +10,17 @@ import { createRentProperty, createLease } from '../helpers/factories';
 import leaseController from '../../controllers/leaseController';
 import { Lease } from '../../models';
 import { errorHandler } from '../../middlewares/errorHandler';
+import { serializeWireIds } from '../../middlewares/wireIds';
 import { assertFound } from '../helpers/assertFound';
 
 function buildApp(oxyUserId: string): Express {
   const app = express();
   app.use(express.json());
+  // Production mounts every one of these handlers behind `routes()`, whose
+  // first middleware is the wire-id serializer. Without it here the suite
+  // would assert a body shape the API no longer serves.
+  app.use(serializeWireIds);
+
   app.use((req, _res, next) => {
     const authed = req as unknown as { user: { id: string }; userId: string };
     authed.user = { id: oxyUserId };
@@ -86,7 +92,7 @@ describe('leaseController.createLease', () => {
       rentDetails: { monthlyRent: 1200, currency: 'EUR' },
     });
     expect(res.status).toBe(201);
-    const persisted = await Lease.findById(res.body.data.id ?? res.body.data._id);
+    const persisted = await Lease.findById(res.body.data.id);
     assertFound(persisted, 'persisted');
     expect(persisted.landlordOxyUserId).toBe('oxy-landlord');
     expect(persisted.status).toBe('draft');

--- a/packages/backend/__tests__/integration/moderationVisibility.test.ts
+++ b/packages/backend/__tests__/integration/moderationVisibility.test.ts
@@ -29,11 +29,17 @@ import {
 import { createAddress, models } from '../helpers/factories';
 
 import { errorHandler } from '../../middlewares/errorHandler';
+import { serializeWireIds } from '../../middlewares/wireIds';
 const { Property } = models;
 
 function buildApp(oxyUserId?: string): Express {
   const app = express();
   app.use(express.json());
+  // Production mounts every one of these handlers behind `routes()`, whose
+  // first middleware is the wire-id serializer. Without it here the suite
+  // would assert a body shape the API no longer serves.
+  app.use(serializeWireIds);
+
   app.use((req, _res, next) => {
     if (oxyUserId) {
       const authed = req as unknown as { user: { id: string }; userId: string };
@@ -71,7 +77,7 @@ describe('restricted listings and public reads', () => {
     const res = await request(buildApp()).get('/properties');
 
     expect(res.status).toBe(200);
-    const ids = (res.body.data as { _id: string }[]).map((item) => String(item._id));
+    const ids = (res.body.data as { id: string }[]).map((item) => String(item.id));
     expect(ids).toEqual([String(visible._id)]);
   });
 
@@ -89,7 +95,7 @@ describe('restricted listings and public reads', () => {
     expect((await Property.findById(legacy._id).lean())?.moderation).toBeUndefined();
 
     const res = await request(buildApp()).get('/properties');
-    expect((res.body.data as { _id: string }[]).map((item) => String(item._id))).toEqual([
+    expect((res.body.data as { id: string }[]).map((item) => String(item.id))).toEqual([
       String(legacy._id),
     ]);
   });

--- a/packages/backend/__tests__/integration/partnerCommission.test.ts
+++ b/packages/backend/__tests__/integration/partnerCommission.test.ts
@@ -30,6 +30,7 @@ import { createAddress, models } from '../helpers/factories';
 import partnerController from '../../controllers/partnerController';
 import roomController from '../../controllers/roomController';
 import { errorHandler } from '../../middlewares/errorHandler';
+import { serializeWireIds } from '../../middlewares/wireIds';
 import { assertFound } from '../helpers/assertFound';
 const { Partner, Commission, Property } = models;
 
@@ -37,6 +38,11 @@ const { Partner, Commission, Property } = models;
 function buildApp(oxyUserId: string): Express {
   const app = express();
   app.use(express.json());
+  // Production mounts every one of these handlers behind `routes()`, whose
+  // first middleware is the wire-id serializer. Without it here the suite
+  // would assert a body shape the API no longer serves.
+  app.use(serializeWireIds);
+
   app.use((req, _res, next) => {
     const authed = req as unknown as { user: { id: string }; userId: string };
     authed.user = { id: oxyUserId };
@@ -80,7 +86,7 @@ describe('partner earn close-deal loop', () => {
       .post('/properties')
       .send(await rentCreateBody(referralCode));
     expect(createRes.status).toBe(201);
-    const propertyId: string = createRes.body.data.id ?? createRes.body.data._id;
+    const propertyId: string = createRes.body.data.id;
 
     // The listing is attributed to the sourcing partner.
     const partner = await Partner.findOne({ referralCode });
@@ -123,13 +129,13 @@ describe('partner earn close-deal loop', () => {
     const createRes = await request(ownerApp)
       .post('/properties')
       .send(await rentCreateBody(referralCode));
-    const propertyId: string = createRes.body.data.id ?? createRes.body.data._id;
+    const propertyId: string = createRes.body.data.id;
 
     const first = await request(ownerApp)
       .post(`/properties/${propertyId}/mark-transacted`)
       .send({});
     expect(first.status).toBe(200);
-    const firstCommissionId = first.body.data.commission.id ?? first.body.data.commission._id;
+    const firstCommissionId = first.body.data.commission.id;
 
     // Close it a second time — must return the SAME commission, no new doc, no
     // extra points.
@@ -137,7 +143,7 @@ describe('partner earn close-deal loop', () => {
       .post(`/properties/${propertyId}/mark-transacted`)
       .send({});
     expect(second.status).toBe(200);
-    const secondCommissionId = second.body.data.commission.id ?? second.body.data.commission._id;
+    const secondCommissionId = second.body.data.commission.id;
     expect(String(secondCommissionId)).toBe(String(firstCommissionId));
 
     const commissions = await Commission.find({ propertyId });
@@ -153,7 +159,7 @@ describe('partner earn close-deal loop', () => {
     const createRes = await request(ownerApp)
       .post('/properties')
       .send(await rentCreateBody());
-    const propertyId: string = createRes.body.data.id ?? createRes.body.data._id;
+    const propertyId: string = createRes.body.data.id;
 
     const markRes = await request(ownerApp)
       .post(`/properties/${propertyId}/mark-transacted`)
@@ -223,7 +229,7 @@ describe('partner earn close-deal loop', () => {
     const createRes = await request(ownerApp)
       .post('/properties')
       .send(await rentCreateBody(referralCode));
-    const propertyId: string = createRes.body.data.id ?? createRes.body.data._id;
+    const propertyId: string = createRes.body.data.id;
 
     // A different, unrelated user cannot close the owner's deal.
     const intruderApp = buildApp('oxy-intruder');

--- a/packages/backend/__tests__/integration/propertyOwnership.test.ts
+++ b/packages/backend/__tests__/integration/propertyOwnership.test.ts
@@ -11,12 +11,18 @@ import { createProperty } from '../../controllers/property/create';
 import { createRentProperty, createAddress, models } from '../helpers/factories';
 
 import { errorHandler } from '../../middlewares/errorHandler';
+import { serializeWireIds } from '../../middlewares/wireIds';
 import { assertFound } from '../helpers/assertFound';
 const { Property } = models;
 
 function buildApp(oxyUserId: string): Express {
   const app = express();
   app.use(express.json());
+  // Production mounts every one of these handlers behind `routes()`, whose
+  // first middleware is the wire-id serializer. Without it here the suite
+  // would assert a body shape the API no longer serves.
+  app.use(serializeWireIds);
+
   app.use((req, _res, next) => {
     const authed = req as unknown as { user: { id: string }; userId: string };
     authed.user = { id: oxyUserId };
@@ -74,7 +80,7 @@ describe('property create ownership', () => {
   it('creates a listing owned by the authenticated user', async () => {
     const res = await request(buildApp('oxy-owner')).post('/properties').send(await validCreateBody());
     expect(res.status).toBe(201);
-    const persisted = await Property.findById(res.body.data.id ?? res.body.data._id);
+    const persisted = await Property.findById(res.body.data.id);
     assertFound(persisted, 'persisted');
     expect(persisted.oxyUserId).toBe('oxy-owner');
   });

--- a/packages/backend/__tests__/integration/roomOwnership.test.ts
+++ b/packages/backend/__tests__/integration/roomOwnership.test.ts
@@ -10,12 +10,18 @@ import { createRentProperty, models } from '../helpers/factories';
 
 import roomController from '../../controllers/roomController';
 import { errorHandler } from '../../middlewares/errorHandler';
+import { serializeWireIds } from '../../middlewares/wireIds';
 import { assertFound } from '../helpers/assertFound';
 const { Property } = models;
 
 function buildApp(oxyUserId: string): Express {
   const app = express();
   app.use(express.json());
+  // Production mounts every one of these handlers behind `routes()`, whose
+  // first middleware is the wire-id serializer. Without it here the suite
+  // would assert a body shape the API no longer serves.
+  app.use(serializeWireIds);
+
   app.use((req, _res, next) => {
     const authed = req as unknown as { user: { id: string }; userId: string };
     authed.user = { id: oxyUserId };
@@ -55,7 +61,7 @@ describe('roomController.createRoom', () => {
     const parent = await createRentProperty({ oxyUserId: 'oxy-owner' });
     const res = await request(buildApp('oxy-owner')).post('/rooms').send(await validRoomBody(parent._id));
     expect(res.status).toBe(201);
-    const persisted = await Property.findById(res.body.data.id ?? res.body.data._id);
+    const persisted = await Property.findById(res.body.data.id);
     assertFound(persisted, 'persisted');
     expect(persisted.oxyUserId).toBe('oxy-owner');
     expect(persisted.type).toBe(PropertyType.ROOM);

--- a/packages/backend/__tests__/integration/wireIdContract.test.ts
+++ b/packages/backend/__tests__/integration/wireIdContract.test.ts
@@ -1,0 +1,162 @@
+/**
+ * The `_id` → `id` wire contract, asserted on the real router.
+ *
+ * `@homiio/shared-types` names a document's identity `id` and nothing else, so
+ * every consumer now reads `id`. Mongo still stores `_id`, and
+ * `middlewares/wireIds.ts` is the one place that difference is resolved.
+ *
+ * This file exists because a typecheck cannot see any of it. The frontend
+ * compiles against the DTOs; the backend hands `res.json` a Mongoose document or
+ * a `.lean()` object, neither of which is typed as a DTO, so `tsc` is green
+ * whether the body carries `id`, `_id`, or both. Only a real request can tell
+ * those three apart.
+ *
+ * The NEGATIVE half of every assertion is the load-bearing one. Checking that
+ * `id` is present passes just as happily on the old dual-spelling body that also
+ * shipped `_id` — which is exactly the state this cut replaced — so each case
+ * asserts the absence too.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import mongoose from 'mongoose';
+
+import publicRoutes from '../../routes/public';
+import { errorHandler } from '../../middlewares/errorHandler';
+import { renameWireIds } from '../../middlewares/wireIds';
+import { Address, City, Country, Property, Region } from '../../models';
+import { OfferingType, PropertyStatus, PropertyType } from '@homiio/shared-types';
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  // The wiring production uses: `publicRoutes()` mounted at `/api`, exactly as
+  // server.ts does it, so the serializer under test is reached the same way.
+  app.use('/api', publicRoutes());
+  app.use(errorHandler);
+  return app;
+}
+
+describe('renameWireIds', () => {
+  it('moves `_id` to `id` and drops it', () => {
+    expect(renameWireIds({ _id: 'abc', name: 'x' })).toEqual({ name: 'x', id: 'abc' });
+  });
+
+  it('renames inside nested objects and arrays', () => {
+    const out = renameWireIds({
+      data: [{ _id: '1', address: { _id: '2' } }, { _id: '3' }],
+    }) as { data: Array<Record<string, unknown>> };
+
+    expect(out.data[0].id).toBe('1');
+    expect(out.data[0]).not.toHaveProperty('_id');
+    expect((out.data[0].address as Record<string, unknown>).id).toBe('2');
+    expect((out.data[0].address as Record<string, unknown>)).not.toHaveProperty('_id');
+    expect(out.data[1].id).toBe('3');
+  });
+
+  it('keeps an `id` that was already set and still drops `_id`', () => {
+    // A DTO mapper or a schema `toJSON` that set `id` made the more specific
+    // decision; overwriting it would silently undo, for example, toLeaseDTO.
+    expect(renameWireIds({ _id: 'raw', id: 'chosen' })).toEqual({ id: 'chosen' });
+  });
+
+  it('stringifies an ObjectId rather than emitting it as an object', () => {
+    const oid = new mongoose.Types.ObjectId();
+    const out = renameWireIds({ _id: oid }) as { id: unknown };
+
+    expect(out.id).toBe(oid.toString());
+    expect(typeof out.id).toBe('string');
+  });
+
+  it('leaves a Date alone', () => {
+    const when = new Date('2026-08-09T00:00:00.000Z');
+    expect((renameWireIds({ createdAt: when }) as { createdAt: Date }).createdAt).toEqual(when);
+  });
+
+  it('reduces a Mongoose document through its own toJSON first', async () => {
+    const country = await Country.create({ code: 'PT', name: 'Portugal', currency: 'EUR' });
+    const out = renameWireIds(country) as Record<string, unknown>;
+
+    expect(out).not.toHaveProperty('_id');
+    expect(out.id).toBe(country._id.toString());
+    expect(out.name).toBe('Portugal');
+    // The document itself is untouched — it is not this function's to edit, and
+    // the same object may be a cache entry or be saved after the response.
+    expect(country._id).toBeDefined();
+  });
+
+  it('passes primitives and null through', () => {
+    expect(renameWireIds(null)).toBeNull();
+    expect(renameWireIds('x')).toBe('x');
+    expect(renameWireIds(3)).toBe(3);
+  });
+});
+
+describe('the wire contract, over a real request', () => {
+  const app = buildApp();
+
+  /** Seed a published property in a city, and return the ids Mongo assigned. */
+  async function seedCityProperty(): Promise<{ cityId: string; propertyId: string }> {
+    const country = await Country.create({ code: 'ES', name: 'Spain', currency: 'EUR' });
+    const region = await Region.create({ countryId: country._id, name: 'Catalonia' });
+    const city = await City.create({
+      countryId: country._id,
+      regionId: region._id,
+      name: 'Barcelona',
+      currency: 'EUR',
+    });
+    const address = await Address.create({
+      countryId: country._id,
+      regionId: region._id,
+      cityId: city._id,
+      countryCode: 'ES',
+      street: 'Carrer de Mallorca',
+      postal_code: '08013',
+      coordinates: { type: 'Point', coordinates: [2.1734, 41.3851] },
+    });
+    const property = await Property.create({
+      addressId: address._id,
+      type: PropertyType.APARTMENT,
+      bedrooms: 2,
+      offerings: [OfferingType.LONG_TERM_RENT],
+      longTermRent: { monthlyAmount: 1800, currency: 'EUR' },
+      status: PropertyStatus.PUBLISHED,
+      isExternal: true,
+      source: 'fixture',
+      sourceId: 'wire-id-contract-1',
+      sourceUrl: 'https://fixtures.homiio.com/wire-id-contract',
+      images: [],
+    });
+
+    return { cityId: city._id.toString(), propertyId: property._id.toString() };
+  }
+
+  it('serializes a `.lean()` read as `id`, never `_id`, including nested documents', async () => {
+    const { cityId, propertyId } = await seedCityProperty();
+
+    const res = await request(app).get(`/api/cities/${cityId}/properties?limit=8`).expect(200);
+
+    const [property] = res.body.data.properties;
+    expect(property.id).toBe(propertyId);
+    expect(property).not.toHaveProperty('_id');
+    // The nested address arrives from `.populate()` inside the same lean result;
+    // a serializer that only renamed the top level would leave this one behind.
+    expect(property.address).toBeDefined();
+    expect(property.address).not.toHaveProperty('_id');
+    // And the city on the same body, which is a Mongoose DOCUMENT rather than a
+    // lean object — the other of the two paths that reach `res.json`.
+    expect(res.body.data.city.id).toBe(cityId);
+    expect(res.body.data.city).not.toHaveProperty('_id');
+  });
+
+  it('leaves no `_id` anywhere in the body, at any depth', async () => {
+    const { cityId } = await seedCityProperty();
+
+    const res = await request(app).get(`/api/cities/${cityId}/properties?limit=8`).expect(200);
+
+    // A whole-body scan rather than named fields: the point of a chokepoint is
+    // that nothing gets past it, and a per-field assertion only covers the
+    // fields somebody remembered.
+    expect(JSON.stringify(res.body)).not.toContain('"_id"');
+  });
+});

--- a/packages/backend/__tests__/unit/cityCoverSync.test.ts
+++ b/packages/backend/__tests__/unit/cityCoverSync.test.ts
@@ -458,7 +458,10 @@ describe('GET /api/cities/:id/properties', () => {
     expect(res.body.success).toBe(true);
     expect(res.body.data.city.name).toBe('London');
     expect(res.body.data.properties).toHaveLength(1);
-    expect(String(res.body.data.properties[0]._id)).toBe(String(property._id));
+    // Response side reads `id`; `property._id` is the Mongoose document the
+    // fixture created, which still has an `_id` because Mongo still stores one.
+    expect(String(res.body.data.properties[0].id)).toBe(String(property._id));
+    expect(res.body.data.properties[0]).not.toHaveProperty('_id');
     expect(res.body.data.pagination.total).toBe(1);
   });
 

--- a/packages/backend/controllers/addressController.ts
+++ b/packages/backend/controllers/addressController.ts
@@ -6,8 +6,8 @@
  * the geo chain to resolve the display names in the SAME statement rather than
  * populating four refs.
  *
- * The wire format is unchanged (batch 10 owns the `_id` → `id` cut): each
- * address still serializes with BOTH ids, its `coordinates` still leave as a
+ * Each address serializes with ONE id, `id` — these responses used to carry
+ * `_id` beside it and no longer do. Its `coordinates` still leave as a
  * GeoJSON `{ type: 'Point', coordinates: [lng, lat] }` pair even though the table
  * stores named `longitude` / `latitude` columns, and the Mongo field spellings
  * (`postal_code`, `building_name`, `address_lines`, `po_box`, `land_plot`) are
@@ -117,7 +117,7 @@ function serializeAddress(row: AddressRow | AddressWithGeoNames): Record<string,
   // `attachAddressGeoNames` derives the `location` label from the names above;
   // it is the one place that rule lives, shared with the property read path.
   attachAddressGeoNames(serialized);
-  return { _id: row.id, id: row.id, ...serialized };
+  return { id: row.id, ...serialized };
 }
 
 /**

--- a/packages/backend/controllers/cityController.ts
+++ b/packages/backend/controllers/cityController.ts
@@ -13,11 +13,11 @@
  * because a city read from one store and a property read from the other cannot
  * be joined by anything. They move with the property read path in batch 4.
  *
- * ## The wire format is unchanged
+ * ## The wire format
  *
- * Batch 10 owns the `_id` → `id` cut, so every response here still carries BOTH
- * (class B), still nests the country / region / cover image as objects with
- * their own `_id` + `id`, and still reports the city centre as
+ * A city serializes with ONE id, `id` — these responses used to carry `_id`
+ * beside it and no longer do. It still nests the country / region / cover image
+ * as objects with their own `id`, and still reports the city centre as
  * `coordinates: { lat, lng }` even though the table stores named `latitude` /
  * `longitude` columns. {@link serializeCity} is the single place that shape is
  * built, and it OMITS absent values rather than emitting `null`, because
@@ -119,9 +119,9 @@ function withoutAbsent(record: Record<string, unknown>): Record<string, unknown>
   return out;
 }
 
-/** Both id spellings, as every geo response has emitted since before the port. */
+/** An entity's id, ahead of its own fields, as every geo response emits it. */
 function withIds(id: string, rest: Record<string, unknown>): Record<string, unknown> {
-  return { _id: id, id, ...withoutAbsent(rest) };
+  return { id, ...withoutAbsent(rest) };
 }
 
 /** Build the city response object, including its expanded refs. */

--- a/packages/backend/middlewares/wireIds.ts
+++ b/packages/backend/middlewares/wireIds.ts
@@ -1,0 +1,118 @@
+/**
+ * The outbound id serializer — the ONE place `_id` stops being part of Homiio's
+ * wire contract.
+ *
+ * Every DTO in `@homiio/shared-types` names a document's identity `id`. Mongoose
+ * still stores `_id` underneath and will keep doing so until the Postgres port
+ * finishes, so something has to rename it on the way out. That rename cannot
+ * live in the models, because the two response paths this API uses reach
+ * `res.json` by different routes and only one of them passes through a model at
+ * all:
+ *
+ *   - `res.json(doc)` on a Mongoose document calls the schema's `toJSON`, so a
+ *     per-schema transform would cover it — and roughly a dozen schemas already
+ *     carry one.
+ *   - `res.json(await Query.lean())` does NOT. A lean result is a plain object
+ *     that never sees `toJSON`, and there are ~90 `.lean()` reads behind these
+ *     routers. Those emit `_id` and no `id` whatsoever.
+ *
+ * So the cut is made here, at the boundary both paths share, rather than in ~100
+ * call sites where the next `.lean()` added would silently reopen it.
+ *
+ * ## What it does, precisely
+ *
+ * Rebuilds the outgoing body and, on every object carrying `_id`, moves that
+ * value to `id` (stringified — an `ObjectId` reaching a consumer as an object
+ * rather than a string is the bug this exists to prevent) and drops `_id`. An
+ * `id` already present WINS: a schema transform or a DTO mapper that set one
+ * made the more specific decision and this must not overwrite it.
+ *
+ * It rebuilds rather than mutates. The input may be a cached object or a
+ * Mongoose document, and a serializer that edits its argument would corrupt the
+ * first and try to `delete` a schema path on the second.
+ *
+ * ## Why a whole-body walk is safe HERE and would not be in general
+ *
+ * Nothing this API returns is legitimately named `_id`. The one shape that could
+ * be — a raw `$group` result, whose `_id` is the grouping key and not an entity
+ * id — never reaches a client: every aggregation behind these routers maps its
+ * `_id` into a named field first (`analyticsController` emits `cityId` and
+ * `bucket`; `partnerController` folds it into a status total). If a future
+ * endpoint ever needs to pass a third-party payload through verbatim, it must
+ * not gain that property by accident — give it a route that serializes
+ * explicitly instead of widening this.
+ *
+ * ## Where it is mounted, and why not in `server.ts`
+ *
+ * At the top of `routes()` and `publicRoutes()`, the two routers that carry every
+ * `/api` response. NOT in `server.ts`, even though that is the one place the
+ * production app is assembled: the integration suites build their own `express()`
+ * and mount these routers directly, so a `server.ts`-only wrapper would be
+ * invisible to every test that asserts a response shape. The suite would then go
+ * on passing against a wire format production no longer serves — a gate that
+ * cannot see the thing it guards.
+ */
+
+import type { NextFunction, Request, Response } from 'express';
+
+/** Depth ceiling. Response bodies here nest a handful deep; this only stops a cycle. */
+const MAX_DEPTH = 16;
+
+interface JsonSerializable {
+  toJSON(): unknown;
+}
+
+/**
+ * Reduce a Mongoose document (or `ObjectId`, or anything else defining `toJSON`)
+ * to the value `JSON.stringify` would have produced for it, so the walk below
+ * only ever sees plain data. A `Date` is left alone — `res.json` renders it the
+ * same way and unwrapping it here would only lose the type earlier.
+ */
+function toPlain(value: object): unknown {
+  if (value instanceof Date || Buffer.isBuffer(value)) return value;
+  const candidate = value as Partial<JsonSerializable>;
+  return typeof candidate.toJSON === 'function' ? candidate.toJSON() : value;
+}
+
+/**
+ * Rebuild a response body with every `_id` renamed to `id`.
+ *
+ * Exported for direct use by tests and by any future non-router serialization
+ * point; the middleware below is the only production caller.
+ */
+export function renameWireIds(value: unknown, depth = 0): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (depth >= MAX_DEPTH) return value;
+
+  const plain = toPlain(value);
+  if (plain === null || typeof plain !== 'object') return plain;
+  if (plain instanceof Date || Buffer.isBuffer(plain)) return plain;
+
+  if (Array.isArray(plain)) {
+    return plain.map((entry) => renameWireIds(entry, depth + 1));
+  }
+
+  const record = plain as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(record)) {
+    if (key === '_id') continue;
+    out[key] = renameWireIds(entry, depth + 1);
+  }
+  if ('_id' in record && (out.id === undefined || out.id === null)) {
+    const raw = record._id;
+    out.id = raw === null || raw === undefined ? raw : String(raw);
+  }
+  return out;
+}
+
+/**
+ * Express middleware wrapping `res.json` so every body leaving these routers
+ * carries `id` and never `_id`.
+ */
+export function serializeWireIds(_req: Request, res: Response, next: NextFunction): void {
+  const json = res.json.bind(res);
+  res.json = (body: unknown) => json(renameWireIds(body));
+  next();
+}
+
+export default serializeWireIds;

--- a/packages/backend/routes/ai.ts
+++ b/packages/backend/routes/ai.ts
@@ -1044,7 +1044,6 @@ Return only the JSON array, no other text.`;
     const transformed = conversations.map((c: any) => {
       const o = c.toObject({ virtuals: true });
       return {
-        _id: o._id,
         id: o._id,
         title: o.title,
         status: o.status,
@@ -1102,7 +1101,7 @@ Return only the JSON array, no other text.`;
     return ok(res, {
       success: true,
       conversation: {
-        _id: saved._id,
+        id: saved._id,
         title: saved.title,
         messages: saved.messages,
         createdAt: saved.createdAt,

--- a/packages/backend/routes/index.ts
+++ b/packages/backend/routes/index.ts
@@ -16,6 +16,7 @@ import viewings from './viewings';
 import telegram from './telegram';
 import images from './images';
 import { asyncHandler } from '../middlewares';
+import { serializeWireIds } from '../middlewares/wireIds';
 import billing from './billing';
 import scraper from './scraper';
 import reviews from './reviews';
@@ -51,6 +52,11 @@ export default function() {
   const evictionRoutes = evictions();
 
   const router = express.Router();
+
+  // FIRST, so every body below leaves as `id` and never `_id`. See wireIds.ts:
+  // `.lean()` reads never pass through a schema `toJSON`, so a per-model
+  // transform cannot cover this router.
+  router.use(serializeWireIds);
 
   // Property availability (auth still required since mounted under oxy.auth() in server.ts).
   // Returns host availability windows + booked ranges (vacation flow).

--- a/packages/backend/routes/public.ts
+++ b/packages/backend/routes/public.ts
@@ -13,6 +13,7 @@ import telegramController from '../controllers/telegramController';
 import analyticsController from '../controllers/analyticsController';
 import * as reviewController from '../controllers/reviewController';
 import { asyncHandler } from '../middlewares';
+import { serializeWireIds } from '../middlewares/wireIds';
 import performanceMonitor from '../middlewares/performance';
 import { Conversation } from '../models';
 import * as profileController from '../controllers/profile';
@@ -42,6 +43,9 @@ function getPropertyAdjustmentFactor(propertyType: unknown): number {
 
 export default function () {
   const router = express.Router();
+
+  // FIRST, so every body below leaves as `id` and never `_id`. See wireIds.ts.
+  router.use(serializeWireIds);
 
   // Performance monitoring for all routes
   router.use(performanceMonitor);
@@ -255,7 +259,7 @@ export default function () {
 
       // Return conversation without sensitive user data, including status field
       const sharedConversation = {
-        _id: conversation._id,
+        id: conversation._id,
         title: conversation.title,
         messages: conversation.messages,
         createdAt: conversation.createdAt,

--- a/packages/backend/services/telegramService.ts
+++ b/packages/backend/services/telegramService.ts
@@ -647,7 +647,7 @@ ${t.__('telegram.hashtags.newProperty')}${cityHashtag} #${this.escapeMarkdown(pr
       {
         name: 'Property with no images',
         property: {
-          _id: 'test-no-images',
+          id: 'test-no-images',
           type: 'apartment',
           address: { city: 'Barcelona', state: 'Catalunya' },
           rent: { amount: 1200, currency: 'EUR', paymentFrequency: 'monthly' },
@@ -659,7 +659,7 @@ ${t.__('telegram.hashtags.newProperty')}${cityHashtag} #${this.escapeMarkdown(pr
       {
         name: 'Property with primary image',
         property: {
-          _id: 'test-primary-image',
+          id: 'test-primary-image',
           type: 'house',
           address: { city: 'Madrid', state: 'Madrid' },
           rent: { amount: 1500, currency: 'EUR', paymentFrequency: 'monthly' },
@@ -676,7 +676,7 @@ ${t.__('telegram.hashtags.newProperty')}${cityHashtag} #${this.escapeMarkdown(pr
       {
         name: 'Property with images but no primary',
         property: {
-          _id: 'test-no-primary',
+          id: 'test-no-primary',
           type: 'studio',
           address: { city: 'Valencia', state: 'Valencia' },
           rent: { amount: 800, currency: 'EUR', paymentFrequency: 'monthly' },
@@ -692,7 +692,7 @@ ${t.__('telegram.hashtags.newProperty')}${cityHashtag} #${this.escapeMarkdown(pr
       {
         name: 'Property with invalid image URLs',
         property: {
-          _id: 'test-invalid-urls',
+          id: 'test-invalid-urls',
           type: 'room',
           address: { city: 'Seville', state: 'Andalucia' },
           rent: { amount: 600, currency: 'EUR', paymentFrequency: 'monthly' },

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -298,7 +298,7 @@ export default function HomePage() {
         refetchCities(),
         ...nearbyCities.map((city) =>
           queryClient.invalidateQueries({
-            queryKey: cityQueryKeys.properties(city._id, 8),
+            queryKey: cityQueryKeys.properties(city.id, 8),
           }),
         ),
         loadSavedProperties(),
@@ -454,7 +454,7 @@ export default function HomePage() {
                 property={property}
                 variant="featured"
                 enableImageCarousel={false}
-                onPress={() => router.push(`/properties/${property._id || property.id}`)}
+                onPress={() => router.push(`/properties/${property.id}`)}
               />
             )}
           />
@@ -464,7 +464,7 @@ export default function HomePage() {
               <CityShowcaseSection
                 title={t('home.cityShowcase.title', { place: explorePlace })}
                 items={cities}
-                onPressCity={(city) => router.push(`/properties/city/${city._id}`)}
+                onPressCity={(city) => router.push(`/properties/city/${city.id}`)}
               />
             </Animated.View>
           ) : null}
@@ -475,7 +475,7 @@ export default function HomePage() {
                 title={featuredGridTitle}
                 items={gridProperties}
                 onPropertyPress={(property) =>
-                  router.push(`/properties/${property._id || property.id}`)
+                  router.push(`/properties/${property.id}`)
                 }
               />
             </Animated.View>
@@ -491,7 +491,7 @@ export default function HomePage() {
                   property={property}
                   variant="featured"
                   enableImageCarousel={false}
-                  onPress={() => router.push(`/properties/${property._id || property.id}`)}
+                  onPress={() => router.push(`/properties/${property.id}`)}
                 />
               )}
             />
@@ -507,14 +507,14 @@ export default function HomePage() {
                   property={property}
                   variant="featured"
                   enableImageCarousel={false}
-                  onPress={() => router.push(`/properties/${property._id || property.id}`)}
+                  onPress={() => router.push(`/properties/${property.id}`)}
                 />
               )}
             />
           ) : null}
 
           {nearbyCities.map((city) => (
-            <NearbyCityCarousel key={city._id} city={city} />
+            <NearbyCityCarousel key={city.id} city={city} />
           ))}
 
           {isWide ? (
@@ -582,7 +582,7 @@ export default function HomePage() {
                 <PropertyResultsGrid
                   properties={exploreProperties}
                   onPropertyPress={(property) =>
-                    router.push(`/properties/${property._id || property.id}`)
+                    router.push(`/properties/${property.id}`)
                   }
                 />
                 {exploreFeed.isFetchingNextPage ? (

--- a/packages/frontend/app/(tabs)/saved/[folderId]/edit.tsx
+++ b/packages/frontend/app/(tabs)/saved/[folderId]/edit.tsx
@@ -42,7 +42,7 @@ export default function EditFolderScreen() {
 
   const folders = foldersData?.folders || [];
 
-  const folder = useMemo(() => folders.find((f) => f._id === folderId), [folders, folderId]);
+  const folder = useMemo(() => folders.find((f) => f.id === folderId), [folders, folderId]);
   const [name, setName] = useState(folder?.name || '');
   const [emoji, setEmoji] = useState(folder?.icon || '📁');
   const [color, setColor] = useState(folder?.color || colors.primaryColor);

--- a/packages/frontend/app/(tabs)/saved/[folderId]/index.tsx
+++ b/packages/frontend/app/(tabs)/saved/[folderId]/index.tsx
@@ -62,7 +62,7 @@ export default function SavedFolderScreen() {
   const folders = foldersQuery.data?.folders ?? [];
 
   const folder = useMemo(
-    () => folders.find((f) => f._id === folderId),
+    () => folders.find((f) => f.id === folderId),
     [folders, folderId],
   );
   const propertiesInFolder = useMemo(
@@ -86,7 +86,7 @@ export default function SavedFolderScreen() {
   const notesById = useMemo(() => {
     const map = new Map<string, string>();
     propertiesInFolder.forEach((property) => {
-      const id = (property._id || property.id) as string | undefined;
+      const id = property.id as string | undefined;
       const note = property.notes?.trim();
       if (id && note) map.set(id, note);
     });
@@ -94,13 +94,13 @@ export default function SavedFolderScreen() {
   }, [propertiesInFolder]);
 
   const handlePropertyPress = useCallback((property: Property) => {
-    const id = (property._id || property.id) as string;
+    const id = property.id as string;
     if (id) router.push(`/properties/${id}`);
   }, []);
 
   const renderNoteFooter = useCallback(
     (property: Property) => {
-      const note = notesById.get((property._id || property.id) as string);
+      const note = notesById.get(property.id as string);
       if (!note) return undefined;
       return (
         <BloomText style={styles.noteText} numberOfLines={2}>

--- a/packages/frontend/app/(tabs)/saved/index.tsx
+++ b/packages/frontend/app/(tabs)/saved/index.tsx
@@ -198,7 +198,7 @@ export default function SavedPropertiesScreen() {
   // skipped entirely while signed out, so signing in changed the hook count
   // between renders — which React refuses to render through.
   const handlePropertyPress = useCallback((property: Property) => {
-    const id = (property._id || property.id) as string;
+    const id = property.id as string;
     if (id) router.push(`/properties/${id}`);
   }, []);
 
@@ -309,7 +309,7 @@ export default function SavedPropertiesScreen() {
       ) : tab === 'folders' ? (
         <FlatList
           data={filteredFolders}
-          keyExtractor={(folder) => folder._id}
+          keyExtractor={(folder) => folder.id}
           numColumns={2}
           columnWrapperStyle={styles.gridRow}
           contentContainerStyle={styles.gridContent}
@@ -393,8 +393,8 @@ interface FolderTileProps {
 
 const FolderTile: React.FC<FolderTileProps> = ({ folder }) => {
   const handlePress = useCallback(() => {
-    router.push(`/saved/${folder._id}`);
-  }, [folder._id]);
+    router.push(`/saved/${folder.id}`);
+  }, [folder.id]);
 
   return (
     <Pressable

--- a/packages/frontend/app/(tabs)/saved/notes.tsx
+++ b/packages/frontend/app/(tabs)/saved/notes.tsx
@@ -54,7 +54,7 @@ export default function NotesScreen() {
       bathrooms?: number;
     }[] = [];
     savedProperties.forEach((p) => {
-      const pid = (p._id || p.id) as string;
+      const pid = p.id as string;
       const notesArr = parseNotesString(p.notes);
       const title = getPropertyTitle(p) || p.address?.cityName || 'Property';
       const image = getPropertyImageSource(p);
@@ -95,10 +95,10 @@ export default function NotesScreen() {
     const targetPropId =
       propertyId ||
       selectedPropertyId ||
-      ((savedProperties[0]?._id || savedProperties[0]?.id) as string | undefined);
+      (savedProperties[0]?.id as string | undefined);
     if (!targetPropId) return;
     try {
-      const prop = savedProperties.find((p) => (p._id || p.id) === targetPropId);
+      const prop = savedProperties.find((p) => p.id === targetPropId);
       if (!prop) return;
       const currentNotes = parseNotesString(prop.notes);
       const updatedNotes = upsertNote(currentNotes, { id: note?.id, text });
@@ -117,7 +117,7 @@ export default function NotesScreen() {
   const handleDeleteNote = useCallback(
     async (propertyId: string, noteId: string) => {
       try {
-        const prop = savedProperties.find((p) => (p._id || p.id) === propertyId);
+        const prop = savedProperties.find((p) => p.id === propertyId);
         if (!prop) return;
         const updatedNotes = deleteNote(parseNotesString(prop.notes), noteId);
         const payload = serializeNotesArray(updatedNotes);
@@ -134,7 +134,7 @@ export default function NotesScreen() {
 
   const persistNotes = useCallback(
     async (propertyId: string, mutator: (arr: PropertyNote[]) => PropertyNote[]) => {
-      const prop = savedProperties.find((p) => (p._id || p.id) === propertyId);
+      const prop = savedProperties.find((p) => p.id === propertyId);
       if (!prop) return;
       const updated = mutator(parseNotesString(prop.notes));
       await updateNotesMutate({ propertyId, notes: serializeNotesArray(updated) });
@@ -289,7 +289,7 @@ export default function NotesScreen() {
                   <Text style={styles.pickerLabel}>{t('common.select')}</Text>
                   <ScrollView horizontal showsHorizontalScrollIndicator={false}>
                     {savedProperties.map((p) => {
-                      const pid = (p._id || p.id) as string;
+                      const pid = p.id as string;
                       const isSel = selectedPropertyId === pid;
                       return (
                         <TouchableOpacity

--- a/packages/frontend/app/(tabs)/sindi/shared/[token].tsx
+++ b/packages/frontend/app/(tabs)/sindi/shared/[token].tsx
@@ -20,7 +20,7 @@ interface ConversationMessage {
 }
 
 interface SharedConversation {
-  _id: string;
+  id: string;
   title: string;
   messages: ConversationMessage[];
   createdAt: Date;

--- a/packages/frontend/app/addresses/[id].tsx
+++ b/packages/frontend/app/addresses/[id].tsx
@@ -40,7 +40,7 @@ import { colors } from '@/styles/colors';
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 
 interface AddressData {
-  _id: string;
+  id: string;
   street: string;
   postal_code?: string;
   cityName?: string;
@@ -311,9 +311,9 @@ export default function AddressDetailsPage() {
                 <View style={styles.propertiesList}>
                   {properties.map((property) => (
                     <PropertyCard
-                      key={property._id}
+                      key={property.id}
                       property={property}
-                      onPress={() => router.push(`/properties/${property._id}`)}
+                      onPress={() => router.push(`/properties/${property.id}`)}
                       variant="compact"
                       orientation="horizontal"
                     />

--- a/packages/frontend/app/agency/[slug].tsx
+++ b/packages/frontend/app/agency/[slug].tsx
@@ -231,7 +231,7 @@ export default function AgencyProfileScreen() {
             <View>
               <PropertyResultsGrid
                 properties={properties}
-                onPropertyPress={(property) => router.push(`/properties/${property._id}`)}
+                onPropertyPress={(property) => router.push(`/properties/${property.id}`)}
               />
               <LoadMoreSentinel
                 onLoadMore={loadMoreProperties}

--- a/packages/frontend/app/explore/index.tsx
+++ b/packages/frontend/app/explore/index.tsx
@@ -241,7 +241,7 @@ export default function SearchScreen() {
 
   const handlePropertyPress = useCallback(
     (property: Property) => {
-      router.push(`/properties/${property._id || property.id}`);
+      router.push(`/properties/${property.id}`);
     },
     [router],
   );

--- a/packages/frontend/app/host/calendar.tsx
+++ b/packages/frontend/app/host/calendar.tsx
@@ -84,14 +84,14 @@ export default function HostCalendarScreen() {
     if (selectedPropertyId) return selectedPropertyId;
     const first = properties[0];
     if (!first) return null;
-    return first._id ?? first.id ?? null;
+    return first.id ?? null;
   }, [properties, selectedPropertyId]);
 
   const selectedProperty = useMemo<Property | null>(() => {
     if (!effectivePropertyId) return null;
     return (
       properties.find(
-        (item) => (item._id ?? item.id) === effectivePropertyId,
+        (item) => item.id === effectivePropertyId,
       ) ?? null
     );
   }, [effectivePropertyId, properties]);
@@ -317,7 +317,7 @@ export default function HostCalendarScreen() {
               <MenuContent>
                 <MenuGroup>
                   {properties.map((property) => {
-                    const id = property._id ?? property.id ?? '';
+                    const id = property.id ?? '';
                     return (
                       <MenuItem
                         key={id}

--- a/packages/frontend/app/insights/index.tsx
+++ b/packages/frontend/app/insights/index.tsx
@@ -273,7 +273,7 @@ export default function InsightsScreen() {
                             // Horizontal carousel row — keep one cover photo so the
                             // in-card pager doesn't fight the row swipe.
                             enableImageCarousel={false}
-                            onPress={() => router.push(`/properties/${property._id || property.id}`)}
+                            onPress={() => router.push(`/properties/${property.id}`)}
                         />
                     )}
                 />

--- a/packages/frontend/app/properties/[id]/book-viewing.tsx
+++ b/packages/frontend/app/properties/[id]/book-viewing.tsx
@@ -140,7 +140,7 @@ export default function BookViewingPage() {
     });
 
     return {
-      id: apiProperty._id || apiProperty.id || '',
+      id: apiProperty.id || '',
       title: generatedTitle,
       location: `${apiProperty.address?.cityName || ''}, ${apiProperty.address?.regionName || ''}`,
       landlordName: 'Property Owner',
@@ -162,7 +162,7 @@ export default function BookViewingPage() {
         );
 
         const viewings = Array.isArray(response?.data) ? response.data : [];
-        const viewing = viewings.find(v => v._id === modifyViewingIdString);
+        const viewing = viewings.find(v => v.id === modifyViewingIdString);
 
         if (viewing) {
           setExistingViewing(viewing);

--- a/packages/frontend/app/properties/[id]/index.tsx
+++ b/packages/frontend/app/properties/[id]/index.tsx
@@ -212,7 +212,7 @@ export default function PropertyDetailPage() {
   // Property view-model derived from the API payload.
   const property = useMemo<PropertyDetailViewModel | null>(() => {
     if (!apiProperty) return null;
-    const propertyId = apiProperty._id || apiProperty.id || '';
+    const propertyId = apiProperty.id || '';
 
     // Offering-aware headline price + location subtitle for the sticky header
     // and the right-column booking card. Centralised in `resolveHeadlinePrice`
@@ -259,7 +259,7 @@ export default function PropertyDetailPage() {
   // Track property view once per page load.
   useEffect(() => {
     if (apiProperty && !hasViewedRef.current) {
-      const propertyId = apiProperty._id || apiProperty.id;
+      const propertyId = apiProperty.id;
       const currentId = typeof id === 'string' ? id : undefined;
       if (propertyId && currentId && propertyId === currentId) {
         hasViewedRef.current = true;
@@ -356,7 +356,7 @@ export default function PropertyDetailPage() {
     // Homiio has no in-app messaging product, so "contact the owner" resolves to
     // the real enquiry surface: a viewing request for short-stay listings and a
     // tenant application otherwise. Never route to a non-existent chat screen.
-    const targetId = apiProperty?._id ?? apiProperty?.id ?? property?.id;
+    const targetId = apiProperty?.id ?? property?.id;
     if (!targetId) return;
     if (rentalMode === 'vacation') {
       router.push(`/properties/${targetId}/book-viewing`);
@@ -498,14 +498,14 @@ export default function PropertyDetailPage() {
       handleContact();
       return;
     }
-    if (apiProperty?._id || apiProperty?.id) {
-      router.push(`/properties/${apiProperty._id ?? apiProperty.id}/apply`);
+    if (apiProperty?.id) {
+      router.push(`/properties/${apiProperty.id}/apply`);
     }
   }, [apiProperty, rentalMode, router, handleContact, handlePublicHousingApply]);
 
   // Sale-listing primary CTA: open the existing viewing-request flow.
   const handleRequestViewing = useCallback(() => {
-    const targetId = apiProperty?._id ?? apiProperty?.id;
+    const targetId = apiProperty?.id;
     if (targetId) {
       router.push(`/properties/${targetId}/book-viewing`);
     }

--- a/packages/frontend/app/properties/city/[id].tsx
+++ b/packages/frontend/app/properties/city/[id].tsx
@@ -219,9 +219,9 @@ export default function CityPropertiesPage() {
 
   const handlePropertyPress = useCallback(
     (property: Property) => {
-      // The city-properties endpoint returns lean docs (only `_id`, no `id`
-      // virtual), so prefer `_id` for navigation.
-      const propertyId = property._id || property.id;
+      // The city-properties endpoint returns lean docs (only `id`, no `id`
+      // virtual), so prefer `id` for navigation.
+      const propertyId = property.id;
       if (propertyId) router.push(`/properties/${propertyId}`);
     },
     [router],

--- a/packages/frontend/app/properties/index.tsx
+++ b/packages/frontend/app/properties/index.tsx
@@ -129,7 +129,7 @@ export default function PropertiesScreen() {
 
   const handlePropertyPress = useCallback(
     (property: Property) => {
-      router.push(`/properties/${property._id || property.id}`);
+      router.push(`/properties/${property.id}`);
     },
     [router],
   );

--- a/packages/frontend/app/properties/my.tsx
+++ b/packages/frontend/app/properties/my.tsx
@@ -98,7 +98,7 @@ export default function MyPropertiesScreen() {
 
   const handlePropertyPress = useCallback(
     (property: Property) => {
-      router.push(`/properties/${property._id || property.id}`);
+      router.push(`/properties/${property.id}`);
     },
     [router],
   );
@@ -147,7 +147,7 @@ export default function MyPropertiesScreen() {
 
   const renderFooter = useCallback(
     (property: Property) => {
-      const propertyId = (property._id || property.id) as string;
+      const propertyId = property.id as string;
       const title = generatePropertyTitle({
         type: property.type,
         address: property.address,

--- a/packages/frontend/app/properties/recently-viewed.tsx
+++ b/packages/frontend/app/properties/recently-viewed.tsx
@@ -39,7 +39,7 @@ export default function RecentlyViewedScreen() {
 
   const handlePropertyPress = useCallback(
     (property: Property) => {
-      router.push(`/properties/${property._id || property.id}`);
+      router.push(`/properties/${property.id}`);
     },
     [router],
   );

--- a/packages/frontend/app/properties/type/[type].tsx
+++ b/packages/frontend/app/properties/type/[type].tsx
@@ -139,7 +139,7 @@ export default function PropertyTypeScreen() {
 
   const handlePropertyPress = useCallback(
     (property: Property) => {
-      router.push(`/properties/${property._id || property.id}`);
+      router.push(`/properties/${property.id}`);
     },
     [router],
   );

--- a/packages/frontend/app/viewings/index.tsx
+++ b/packages/frontend/app/viewings/index.tsx
@@ -229,7 +229,7 @@ export default function ViewingsPage() {
   const handleModify = (viewing: ViewingRequest) => {
     router.push({
       pathname: `/properties/${viewing.propertyId}/book-viewing`,
-      params: { modifyViewingId: viewing._id },
+      params: { modifyViewingId: viewing.id },
     });
   };
 
@@ -331,11 +331,11 @@ export default function ViewingsPage() {
             <View style={styles.listWrap}>
               {filteredViewings.map((viewing) => (
                 <ViewingCard
-                  key={viewing._id}
+                  key={viewing.id}
                   viewing={viewing}
                   cancelling={
                     cancelMutation.isPending &&
-                    cancelTarget?._id === viewing._id
+                    cancelTarget?.id === viewing.id
                   }
                   onCancel={() => setCancelTarget(viewing)}
                   onModify={() => handleModify(viewing)}
@@ -355,7 +355,7 @@ export default function ViewingsPage() {
           loading={cancelMutation.isPending}
           onCancel={() => setCancelTarget(null)}
           onConfirm={() => {
-            if (cancelTarget) cancelMutation.mutate(cancelTarget._id);
+            if (cancelTarget) cancelMutation.mutate(cancelTarget.id);
           }}
         />
       </SafeAreaView>

--- a/packages/frontend/components/BookingWidget.tsx
+++ b/packages/frontend/components/BookingWidget.tsx
@@ -67,7 +67,7 @@ export const BookingWidget: React.FC<BookingWidgetProps> = ({ property }) => {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { oxyServices, activeSessionId } = useOxy();
-  const propertyId = property._id || property.id || '';
+  const propertyId = property.id || '';
   const [sheet, setSheet] = useState<SheetVariant>(null);
   const [range, setRange] = useState<AvailabilityCalendarRange | null>(null);
   const [guests, setGuests] = useState<GuestCounts>(DEFAULT_GUESTS);

--- a/packages/frontend/components/CityShowcaseSection.tsx
+++ b/packages/frontend/components/CityShowcaseSection.tsx
@@ -130,7 +130,7 @@ export function CityShowcaseSection({ title, items, onPressCity }: CityShowcaseS
           <View className="flex-row gap-4">
             {items.map((city) => (
               <CityCard
-                key={city._id}
+                key={city.id}
                 city={city}
                 width={cardWidth}
                 height={cardHeight}

--- a/packages/frontend/components/NearbyCityCarousel.tsx
+++ b/packages/frontend/components/NearbyCityCarousel.tsx
@@ -15,7 +15,7 @@ interface NearbyCityCarouselProps {
 export function NearbyCityCarousel({ city }: NearbyCityCarouselProps) {
   const { t } = useTranslation();
   const router = useRouter();
-  const { data } = usePropertiesByCity(city._id, { limit: 8 });
+  const { data } = usePropertiesByCity(city.id, { limit: 8 });
   const cityProperties = (data?.properties as Property[] | undefined) ?? [];
 
   if (cityProperties.length === 0) return null;
@@ -30,7 +30,7 @@ export function NearbyCityCarousel({ city }: NearbyCityCarouselProps) {
           property={property}
           variant="featured"
           enableImageCarousel={false}
-          onPress={() => router.push(`/properties/${property._id || property.id}`)}
+          onPress={() => router.push(`/properties/${property.id}`)}
         />
       )}
     />

--- a/packages/frontend/components/PropertyCard.tsx
+++ b/packages/frontend/components/PropertyCard.tsx
@@ -210,7 +210,7 @@ export const PropertyCard = React.memo(function PropertyCard({
   // Define the callback function (using property parameter directly)
   const handlePressIn = useCallback(() => {
     if (!property) return;
-    const idToPrefetch = property._id || property.id;
+    const idToPrefetch = property.id;
     if (idToPrefetch) {
       prefetchProperty(queryClient, idToPrefetch as string);
       prefetchPropertyStats(queryClient, idToPrefetch as string);
@@ -275,7 +275,7 @@ export const PropertyCard = React.memo(function PropertyCard({
     // drive both the floating badges and the subtle "Also available" line.
     const otherOfferings = resolveOfferingSummaries(property, browseMode);
     const propertyData = {
-      id: property._id || property.id,
+      id: property.id,
       title: getPropertyTitle(property),
       location: getPropertyLocationLabel(property),
       price: primaryOffering.amount,

--- a/packages/frontend/components/RoomList.tsx
+++ b/packages/frontend/components/RoomList.tsx
@@ -39,7 +39,7 @@ const RoomCard = React.memo(({ property, matchScore }: RoomCardProps) => {
     const [hovered, setHovered] = useState(false);
 
     const handlePress = () => {
-        router.push(`/properties/${property._id}/`);
+        router.push(`/properties/${property.id}/`);
     };
 
     const isAvailable = propertyService.isPropertyAvailable(property);
@@ -318,7 +318,7 @@ export function RoomList({ filters, onFilterChange }: RoomListProps) {
             <FlatList
                 data={rooms}
                 renderItem={({ item }) => <RoomCard property={item} />}
-                keyExtractor={item => item._id}
+                keyExtractor={item => item.id}
                 contentContainerStyle={styles.listContainer}
                 showsVerticalScrollIndicator={false}
                 onEndReached={handleLoadMore}

--- a/packages/frontend/components/SaveButton.tsx
+++ b/packages/frontend/components/SaveButton.tsx
@@ -90,7 +90,7 @@ export function SaveButton({
   } = useSavedPropertiesContext();
 
   // Determine property ID
-  const propertyId = property?._id || property?.id;
+  const propertyId = property?.id;
 
   // Determine initial saved state from prop or property object
   const initialSavedState =

--- a/packages/frontend/components/SaveToFolderBottomSheet.tsx
+++ b/packages/frontend/components/SaveToFolderBottomSheet.tsx
@@ -125,7 +125,7 @@ export function SaveToFolderBottomSheet({
 
       // Save property to the new folder
       if (newFolder) {
-        await handleSaveToFolder(newFolder._id);
+        await handleSaveToFolder(newFolder.id);
       }
     } catch (error) {
       console.error('Failed to create folder:', error);
@@ -134,9 +134,9 @@ export function SaveToFolderBottomSheet({
 
   const renderFolderItem = (folder: SavedPropertyFolder) => (
     <TouchableOpacity
-      key={folder._id}
+      key={folder.id}
       style={styles.folderItem}
-      onPress={() => handleSaveToFolder(folder._id)}
+      onPress={() => handleSaveToFolder(folder.id)}
       disabled={isLoading || saveToFolderMutation.isPending}
     >
       <View style={[styles.folderIcon, { backgroundColor: folder.color }]}>

--- a/packages/frontend/components/SideBar/index.tsx
+++ b/packages/frontend/components/SideBar/index.tsx
@@ -362,7 +362,7 @@ export function SideBar() {
       .filter((folder) => !folder.isDefault && (folder.propertyCount ?? 0) > 0)
       .map((folder) => {
         const folderProperties = safeProps.filter(
-          (property) => property.folderId === folder._id,
+          (property) => property.folderId === folder.id,
         );
         const latestImages = [...folderProperties]
           .sort((a, b) => {
@@ -393,7 +393,7 @@ export function SideBar() {
           .filter((url): url is string => Boolean(url));
 
         return {
-          id: folder._id,
+          id: folder.id,
           name: folder.name,
           color: folder.color ?? colors.primaryColor,
           icon: folder.icon ?? 'folder',
@@ -411,7 +411,7 @@ export function SideBar() {
     const result: RecentEntry[] = [];
     for (const property of recentProperties ?? []) {
       if (!property) continue;
-      const id = property._id ?? property.id;
+      const id = property.id;
       if (!id) continue;
 
       const firstImage = Array.isArray(property.images)

--- a/packages/frontend/components/agent/PartnerDashboard.tsx
+++ b/packages/frontend/components/agent/PartnerDashboard.tsx
@@ -262,7 +262,7 @@ export const PartnerDashboard: React.FC<PartnerDashboardProps> = ({
           emptyText={t('agent.dashboard.noReferrals')}
         >
           {recentReferrals.map((property) => (
-            <View key={String(property._id ?? property.id)} style={styles.row}>
+            <View key={String(property.id)} style={styles.row}>
               <Ionicons
                 name="home-outline"
                 size={ICON_SIZES.md}

--- a/packages/frontend/components/exchange/ExchangeRequestBottomSheet.tsx
+++ b/packages/frontend/components/exchange/ExchangeRequestBottomSheet.tsx
@@ -51,7 +51,7 @@ const formatRange = (range: AvailabilityCalendarRange | null): string =>
     ? `${formatLocalized(range.checkIn, 'MMM d')} → ${formatLocalized(range.checkOut, 'MMM d')}`
     : '';
 
-const propertyId = (property: Property): string => property._id || property.id || '';
+const propertyId = (property: Property): string => property.id || '';
 
 const isExchangeEnabled = (property: Property): boolean =>
   hasOffering(property, OfferingType.EXCHANGE);

--- a/packages/frontend/components/property/ApplyToRentCTA.tsx
+++ b/packages/frontend/components/property/ApplyToRentCTA.tsx
@@ -49,7 +49,7 @@ export const ApplyToRentCTA: React.FC<ApplyToRentCTAProps> = ({ property }) => {
   const insets = useSafeAreaInsets();
   const { isAuthenticated } = useOxy();
 
-  const propertyId = String(property._id ?? property.id ?? '');
+  const propertyId = String(property.id ?? '');
 
   const activeApplicationQuery = useActiveApplicationForProperty(
     isAuthenticated ? propertyId : undefined,

--- a/packages/frontend/components/property/BookingCard.tsx
+++ b/packages/frontend/components/property/BookingCard.tsx
@@ -63,7 +63,7 @@ export const BookingCard: React.FC<BookingCardProps> = ({
   const [reportPressed, setReportPressed] = useState(false);
 
   const bookingMode = resolveBookingMode(property, rentalMode);
-  const propertyId = String(property._id ?? property.id ?? '');
+  const propertyId = String(property.id ?? '');
 
   // Rating from the same source the Reviews block reads (shared cache key).
   const { ratingSummary } = useAddressReviews(property);

--- a/packages/frontend/components/property/LandlordSection.tsx
+++ b/packages/frontend/components/property/LandlordSection.tsx
@@ -159,7 +159,7 @@ export const LandlordSection: React.FC<LandlordSectionProps> = ({
                                     <PropertyCard
                                         property={prop}
                                         variant="compact"
-                                        onPress={() => router.push(`/properties/${prop._id || prop.id}`)}
+                                        onPress={() => router.push(`/properties/${prop.id}`)}
                                         showSaveButton={false}
                                         showVerifiedBadge={false}
                                         showRating={false}

--- a/packages/frontend/components/property/LocationDisplay.tsx
+++ b/packages/frontend/components/property/LocationDisplay.tsx
@@ -70,7 +70,7 @@ export const LocationDisplay: React.FC<LocationDisplayProps> = ({ property }) =>
               initialCoordinates={coordinates}
               initialZoom={15}
               startFromCurrentLocation={false}
-              screenId={`property-location-${property?._id ?? property?.id ?? 'unknown'}`}
+              screenId={`property-location-${property?.id ?? 'unknown'}`}
             />
           </View>
         ) : null}

--- a/packages/frontend/components/property/LocationSection.tsx
+++ b/packages/frontend/components/property/LocationSection.tsx
@@ -51,7 +51,7 @@ export const LocationSection: React.FC<Props> = ({ property }) => {
                         style={{ height: 200 }}
                         initialCoordinates={coordinates as [number, number]}
                         initialZoom={property?.address?.coordinates?.type === 'Point' ? 15 : 12}
-                        screenId={`property-location-${property?._id || property?.id || 'unknown'}`}
+                        screenId={`property-location-${property?.id || 'unknown'}`}
                     />
                 </View>
             )}

--- a/packages/frontend/components/property/NeighborhoodInfo.tsx
+++ b/packages/frontend/components/property/NeighborhoodInfo.tsx
@@ -21,7 +21,7 @@ interface Props {
  */
 export const NeighborhoodInfo: React.FC<Props> = ({ property }) => {
   const { t } = useTranslation();
-  const propertyId = property?._id;
+  const propertyId = property?.id;
   const { data: neighborhood } = useNeighborhood({ propertyId });
 
   if (!neighborhood) return null;

--- a/packages/frontend/components/property/SimilarHomesSection.tsx
+++ b/packages/frontend/components/property/SimilarHomesSection.tsx
@@ -50,7 +50,7 @@ export const SimilarHomesSection: React.FC<SimilarHomesSectionProps> = ({
           enableImageCarousel={false}
           showSaveButton={false}
           showRating={false}
-          onPress={() => router.push(`/properties/${item._id || item.id}`)}
+          onPress={() => router.push(`/properties/${item.id}`)}
         />
       )}
     />

--- a/packages/frontend/components/property/SindiChatBottomSheet.tsx
+++ b/packages/frontend/components/property/SindiChatBottomSheet.tsx
@@ -46,7 +46,7 @@ export function SindiChatBottomSheet({ property, initialMessage }: SindiChatBott
         if (isInitialized.current || !oxyServices || !activeSessionId) return;
 
         // Validate required property data
-        if (!property._id && !property.id) {
+        if (!property.id) {
             logger.error('Property ID is required for Sindi chat');
             return;
         }
@@ -76,7 +76,7 @@ export function SindiChatBottomSheet({ property, initialMessage }: SindiChatBott
 
                     if (initialMessage) {
                         // Use the provided initial message (e.g., from suggestion chips)
-                        const propertyId = property._id || property.id;
+                        const propertyId = property.id;
                         messageToSend = `${initialMessage}
 
 <PROPERTIES_JSON>["${propertyId}"]</PROPERTIES_JSON>`;
@@ -92,7 +92,7 @@ export function SindiChatBottomSheet({ property, initialMessage }: SindiChatBott
                         const rent = longTerm?.monthlyAmount ?? shortTerm?.nightlyRate ?? 'unspecified';
                         const currency = longTerm?.currency || shortTerm?.currency || '';
                         const priceUnit = longTerm ? 'month' : shortTerm ? 'night' : 'month';
-                        const propertyId = property._id || property.id;
+                        const propertyId = property.id;
 
                         messageToSend = `I'm interested in this property: ${type} with ${bedrooms} bedrooms and ${bathrooms} bathrooms in ${location}. The rent is ${rent} ${currency}/${priceUnit}. Can you help me understand more about this property and my rental rights?
 

--- a/packages/frontend/components/property/StickyPropertyHeader.tsx
+++ b/packages/frontend/components/property/StickyPropertyHeader.tsx
@@ -106,7 +106,7 @@ export const StickyPropertyHeader: React.FC<StickyPropertyHeaderProps> = ({
           />
           {property ? (
             <SaveButton
-              property={property as Property & { _id: string }}
+              property={property}
               variant="heart"
               chrome="ghost"
               color={colors.COLOR_BLACK}

--- a/packages/frontend/components/search/SearchResultsView.tsx
+++ b/packages/frontend/components/search/SearchResultsView.tsx
@@ -98,7 +98,7 @@ function toMarkers(
           ? `€${Math.round(primary.amount).toLocaleString()}`
           : primary.label;
       return {
-        id: p._id,
+        id: p.id,
         coordinates: [coords[0], coords[1]] as [number, number],
         priceLabel,
       };
@@ -210,7 +210,7 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
   );
 
   const selectedProperty = useMemo(
-    () => (highlightedId ? properties.find((p) => p._id === highlightedId) ?? null : null),
+    () => (highlightedId ? properties.find((p) => p.id === highlightedId) ?? null : null),
     [highlightedId, properties],
   );
 

--- a/packages/frontend/components/sindi/ChatMessage.tsx
+++ b/packages/frontend/components/sindi/ChatMessage.tsx
@@ -41,7 +41,7 @@ const SearchResultCards: React.FC<{ content: string }> = ({ content }) => {
   return (
     <View style={sindiStyles.propertyCardsContainer}>
       {properties.map((property) => {
-        const key = property._id || property.id;
+        const key = property.id;
         return (
           <PropertyCard
             key={key}

--- a/packages/frontend/components/sindi/PropertiesFromIds.tsx
+++ b/packages/frontend/components/sindi/PropertiesFromIds.tsx
@@ -7,9 +7,9 @@ import { PropertyCard } from '@/components/PropertyCard';
 import { propertyService } from '@/services/propertyService';
 import { sindiStyles } from './styles';
 
-/** Resolve the routable ID for a property (DB `_id` or external `id`). */
+/** Resolve the routable ID for a property (DB `id` or external `id`). */
 function propertyKey(property: Property): string | undefined {
-  return property._id || property.id;
+  return property.id;
 }
 
 export interface PropertiesFromIdsProps {

--- a/packages/frontend/components/sindi/propertyParsing.ts
+++ b/packages/frontend/components/sindi/propertyParsing.ts
@@ -217,7 +217,6 @@ function toPropertyType(raw: string): PropertyType {
 function buildSyntheticProperty({ id, type, price, city }: SyntheticPropertyInput): Property {
   const now = new Date().toISOString();
   return {
-    _id: id,
     id,
     type: toPropertyType(type),
     // Synthetic search-line listings are long-term rentals — the only price the

--- a/packages/frontend/components/ui/PropertyResultsGrid.tsx
+++ b/packages/frontend/components/ui/PropertyResultsGrid.tsx
@@ -79,7 +79,7 @@ interface PropertyResultsGridProps {
   onPropertyPress: (property: Property) => void;
   highlightedPropertyId?: string | null;
   /**
-   * Web-only — fired when a pointer enters a card, with the card's `_id`. The
+   * Web-only — fired when a pointer enters a card, with the card's `id`. The
    * explore split view uses it to highlight the matching map price chip. Paired
    * with {@link onPropertyHoverOut}. Both are wired only on web (the list and
    * map are a toggle on native and never co-visible, so hover is moot there).
@@ -169,10 +169,10 @@ export const PropertyResultsGrid: React.FC<PropertyResultsGridProps> = ({
         onLayout={IS_WEB ? undefined : handleLayout}
       >
         {properties.map((property) => {
-          const isHighlighted = property._id === highlightedPropertyId;
+          const isHighlighted = property.id === highlightedPropertyId;
           return (
             <View
-              key={property._id}
+              key={property.id}
               style={[
                 styles.cell,
                 // WEB: CSS Grid sizes the track — no width style. NATIVE: explicit
@@ -192,10 +192,10 @@ export const PropertyResultsGrid: React.FC<PropertyResultsGridProps> = ({
               // on this View's own boundary: leave does NOT misfire when the
               // pointer moves over inner children, so it clears only when the
               // pointer truly exits the card. Gated to web (native shows list/map
-              // as a toggle, never together) and keyed on `_id` (the marker id).
+              // as a toggle, never together) and keyed on `id` (the marker id).
               onPointerEnter={
                 IS_WEB && onPropertyHoverIn
-                  ? () => onPropertyHoverIn(property._id)
+                  ? () => onPropertyHoverIn(property.id)
                   : undefined
               }
               onPointerLeave={

--- a/packages/frontend/components/widgets/FeaturedPropertiesWidget.tsx
+++ b/packages/frontend/components/widgets/FeaturedPropertiesWidget.tsx
@@ -96,7 +96,7 @@ function FeaturedProperties({ properties }: { properties: FeaturedProperty[] }) 
     <>
       {limited.map((property) => (
         <PropertyCard
-          key={property._id || property.id}
+          key={property.id}
           property={property}
           variant="compact"
           orientation="horizontal"
@@ -110,7 +110,7 @@ function FeaturedProperties({ properties }: { properties: FeaturedProperty[] }) 
           showSaveCount={true}
           saveCountDisplayMode="inline"
           style={styles.propertyCard}
-          onPress={() => router.push(`/properties/${property._id || property.id}`)}
+          onPress={() => router.push(`/properties/${property.id}`)}
         />
       ))}
       <Button

--- a/packages/frontend/components/widgets/PropertyPreviewWidget.tsx
+++ b/packages/frontend/components/widgets/PropertyPreviewWidget.tsx
@@ -255,7 +255,7 @@ export function PropertyPreviewWidget() {
       .join(', ');
 
     return {
-      _id: 'preview',
+      id: 'preview',
       address: {
         street: location.address ?? '',
         postal_code: location.postal_code ?? '',

--- a/packages/frontend/components/widgets/RecentlyViewedWidget.tsx
+++ b/packages/frontend/components/widgets/RecentlyViewedWidget.tsx
@@ -68,7 +68,7 @@ export function RecentlyViewedWidget() {
 
 
   const navigateToProperty = (property: Property) => {
-    router.push(`/properties/${property._id || property.id}`);
+    router.push(`/properties/${property.id}`);
   };
 
   // Hide widget completely if not authenticated
@@ -137,7 +137,7 @@ export function RecentlyViewedWidget() {
             </View>
           ) : (
             recentProperties.map((property) => (
-              <View key={property._id || property.id} style={styles.propertyCard}>
+              <View key={property.id} style={styles.propertyCard}>
                 <PropertyCard
                   property={property}
                   variant="featured"

--- a/packages/frontend/context/SavedPropertiesContext.tsx
+++ b/packages/frontend/context/SavedPropertiesContext.tsx
@@ -72,8 +72,8 @@ interface SavedPropertiesProviderProps {
   children: ReactNode;
 }
 
-const propertyKey = (property: Pick<SavedProperty, '_id' | 'id'>): string | undefined =>
-  property._id || property.id;
+const propertyKey = (property: Pick<SavedProperty, 'id' | 'id'>): string | undefined =>
+  property.id;
 
 export const SavedPropertiesProvider: React.FC<SavedPropertiesProviderProps> = ({ children }) => {
   const queryClient = useQueryClient();
@@ -186,7 +186,7 @@ export const SavedPropertiesProvider: React.FC<SavedPropertiesProviderProps> = (
         );
         queryClient.setQueryData<SavedPropertyFoldersResponse>(SAVED_FOLDERS_KEY, (prev) => ({
           folders: (prev?.folders ?? []).map((folder) =>
-            folder._id === folderId ? updatedFolder : folder,
+            folder.id === folderId ? updatedFolder : folder,
           ),
         }));
         toast.success(i18next.t('saved.toast.folderUpdated'));
@@ -208,7 +208,7 @@ export const SavedPropertiesProvider: React.FC<SavedPropertiesProviderProps> = (
 
         await savedPropertyFolderService.deleteSavedPropertyFolder(folderId);
         queryClient.setQueryData<SavedPropertyFoldersResponse>(SAVED_FOLDERS_KEY, (prev) => ({
-          folders: (prev?.folders ?? []).filter((folder) => folder._id !== folderId),
+          folders: (prev?.folders ?? []).filter((folder) => folder.id !== folderId),
         }));
         toast.success(i18next.t('saved.toast.folderDeleted'));
       } catch (error: unknown) {
@@ -231,7 +231,6 @@ export const SavedPropertiesProvider: React.FC<SavedPropertiesProviderProps> = (
         // Optimistic update to the query cache (drives `savedProperties` +
         // `savedPropertyIds` via the memos above).
         const optimistic: SavedProperty = {
-          _id: propertyId,
           id: propertyId,
           savedAt: new Date().toISOString(),
           folderId: folderId || undefined,
@@ -323,7 +322,7 @@ export const SavedPropertiesProvider: React.FC<SavedPropertiesProviderProps> = (
         if (removed?.folderId) {
           queryClient.setQueryData<SavedPropertyFoldersResponse>(SAVED_FOLDERS_KEY, (prev) => ({
             folders: (prev?.folders ?? []).map((folder) =>
-              folder._id === removed.folderId
+              folder.id === removed.folderId
                 ? { ...folder, propertyCount: Math.max(0, (folder.propertyCount || 0) - 1) }
                 : folder,
             ),
@@ -367,7 +366,7 @@ export const SavedPropertiesProvider: React.FC<SavedPropertiesProviderProps> = (
 
   const getFolderById = useCallback(
     (folderId: string) => {
-      return folders.find((folder) => folder._id === folderId);
+      return folders.find((folder) => folder.id === folderId);
     },
     [folders],
   );

--- a/packages/frontend/hooks/useAddressReviews.ts
+++ b/packages/frontend/hooks/useAddressReviews.ts
@@ -26,17 +26,13 @@ export interface ReviewRatingSummary {
 }
 
 /**
- * Pull a stable address id off a property. The id can land in a few shapes
- * depending on whether the property was hydrated from the list vs the detail
- * endpoint, so this mirrors the extraction both review sections already use.
+ * Pull a stable address id off a property. The list and detail endpoints both
+ * serialize the address id as `id`, but it is absent when the address ref was
+ * never expanded, so this still probes rather than reading it directly.
  */
 export function getReviewAddressId(property: Property | null | undefined): string | undefined {
   const address = property?.address;
   if (!address || typeof address !== 'object') return undefined;
-  if ('_id' in address) {
-    const id = (address as { _id?: unknown })._id;
-    if (typeof id === 'string') return id;
-  }
   if ('id' in address) {
     const id = (address as { id?: unknown }).id;
     if (typeof id === 'string') return id;

--- a/packages/frontend/hooks/useCityQueries.ts
+++ b/packages/frontend/hooks/useCityQueries.ts
@@ -50,10 +50,10 @@ export function usePopularCities(limit = 8, filters: CityFilters = {}) {
       if (!countryId && !regionId) return cities;
       return cities.filter((city) => {
         const cityCountryId = typeof city.countryId === 'object'
-          ? (city.countryId as { _id?: string })._id
+          ? (city.countryId as { id?: string }).id
           : city.countryId;
         const cityRegionId = typeof city.regionId === 'object'
-          ? (city.regionId as { _id?: string })._id
+          ? (city.regionId as { id?: string }).id
           : city.regionId;
         if (regionId && cityRegionId !== regionId) return false;
         if (countryId && cityCountryId !== countryId) return false;

--- a/packages/frontend/hooks/useCreatePropertyWizard.ts
+++ b/packages/frontend/hooks/useCreatePropertyWizard.ts
@@ -262,7 +262,7 @@ export function useCreatePropertyWizard(id: string | undefined) {
         : payload;
 
       const property = await propertyService.createProperty(createPayload);
-      return { property, redirectId: property?._id ?? null };
+      return { property, redirectId: property?.id ?? null };
     },
     onMutate: () => {
       setLoading(true);

--- a/packages/frontend/hooks/usePropertyCreateForm.ts
+++ b/packages/frontend/hooks/usePropertyCreateForm.ts
@@ -137,8 +137,8 @@ export function usePropertyCreateForm(id: string | undefined) {
   const hydratedPropertyIdRef = useRef<string | null>(null);
   useEffect(() => {
     if (!isEditMode || !property) return;
-    if (hydratedPropertyIdRef.current === property._id) return;
-    hydratedPropertyIdRef.current = property._id;
+    if (hydratedPropertyIdRef.current === property.id) return;
+    hydratedPropertyIdRef.current = property.id;
 
     setFormData('basicInfo', {
       propertyType: property.type || 'apartment',

--- a/packages/frontend/hooks/useRecentlyViewed.ts
+++ b/packages/frontend/hooks/useRecentlyViewed.ts
@@ -32,7 +32,7 @@ export function useRecentlyViewed() {
 
   // Add property to recently viewed
   const addProperty = useCallback(async (property: Property) => {
-    const propertyId = property._id || property.id;
+    const propertyId = property.id;
 
     if (!propertyId) return;
 

--- a/packages/frontend/hooks/useRecentlyViewedQueries.ts
+++ b/packages/frontend/hooks/useRecentlyViewedQueries.ts
@@ -33,7 +33,7 @@ export const useRecentlyViewedProperties = () => {
           // each property with a `viewedAt` timestamp that is not part of the
           // base Property type.
           const items = (response.data || []).map((property: Property & { viewedAt?: string }) => ({
-            id: property._id || property.id || '',
+            id: property.id || '',
             type: RecentlyViewedType.PROPERTY,
             data: property,
             viewedAt: property.viewedAt || new Date().toISOString(),

--- a/packages/frontend/hooks/useSavedNotes.ts
+++ b/packages/frontend/hooks/useSavedNotes.ts
@@ -23,7 +23,7 @@ export function useSavedNotesMutation() {
         const next = {
           ...previous,
           properties: previous.properties.map((p: any) => {
-            const id = p._id || p.id;
+            const id = p.id;
             if (id === propertyId) {
               return { ...p, notes };
             }

--- a/packages/frontend/hooks/useSavedProperties.ts
+++ b/packages/frontend/hooks/useSavedProperties.ts
@@ -32,7 +32,7 @@ export const useSavedProperties = (): UseSavedPropertiesReturn => {
 
   // Memoize saved property IDs for performance
   const savedPropertyIds = useMemo(() =>
-    savedProperties.map((property: any) => property._id || property.id).filter(Boolean),
+    savedProperties.map((property: any) => property.id).filter(Boolean),
     [savedProperties]
   );
 

--- a/packages/frontend/hooks/useSavedSearches.ts
+++ b/packages/frontend/hooks/useSavedSearches.ts
@@ -21,13 +21,12 @@ const EMPTY_SEARCHES: SavedSearch[] = [];
 
 /**
  * A saved search as it can arrive from the backend. The API has historically
- * used a few different field names (e.g. `title` vs `name`, `_id` vs `id`,
+ * used a few different field names (e.g. `title` vs `name`,
  * `notificationsEnabled` vs `notifications`), so every field is optional here
  * and normalised into a canonical {@link SavedSearch} before use.
  */
 interface RawSavedSearch {
   id?: string;
-  _id?: string;
   name?: string;
   title?: string;
   query?: string;
@@ -102,7 +101,7 @@ const extractSearchList = (payload: SavedSearchPayload): RawSavedSearch[] => {
 };
 
 const normalizeSearch = (raw: RawSavedSearch, defaults: Partial<SavedSearch> = {}): SavedSearch => ({
-  id: raw.id ?? raw._id ?? defaults.id ?? '',
+  id: raw.id ?? defaults.id ?? '',
   name: raw.name ?? raw.title ?? defaults.name ?? '',
   query: raw.query ?? raw.search ?? defaults.query ?? '',
   filters: raw.filters ?? raw.criteria ?? defaults.filters,

--- a/packages/frontend/hooks/useSindiSuggestions.ts
+++ b/packages/frontend/hooks/useSindiSuggestions.ts
@@ -40,7 +40,7 @@ export function useSindiSuggestions({ property, conversationContext }: UseSindiS
     const [error, setError] = useState<string | null>(null);
     const { oxyServices, activeSessionId } = useOxy();
 
-    const propertyId = property?._id || property?.id;
+    const propertyId = property?.id;
     const suggestions =
         fetched && fetched.propertyId === propertyId ? fetched.items : DEFAULT_SUGGESTIONS;
 

--- a/packages/frontend/services/addressService.ts
+++ b/packages/frontend/services/addressService.ts
@@ -7,7 +7,7 @@ import { API_URL } from '@/config';
 import { ApiResponse } from '../types/api';
 
 export interface AddressData {
-  _id: string;
+  id: string;
   street: string;
   city: string;
   state: string;

--- a/packages/frontend/services/evictionService.ts
+++ b/packages/frontend/services/evictionService.ts
@@ -14,13 +14,8 @@ import {
  *
  * Mirrors `exchangeService`: a thin class over `@/utils/api` (the Oxy-linked
  * client + `normalizeEnvelope` bridge) that reads the `{ success, data, … }`
- * envelope and normalises the persisted `_id` to `id`. Public reads
- * (`list`/`getById`/`listComments`) degrade to unauthenticated requests; every
- * write is auth-gated server-side.
- *
- * The backend already serialises `_id → id` in `toEvictionDTO`, so the local
- * `normalizeCase`/`normalizeComment` steps are defensive (never trust a raw
- * `_id` leak) rather than load-bearing.
+ * envelope. Public reads (`list`/`getById`/`listComments`) degrade to
+ * unauthenticated requests; every write is auth-gated server-side.
  */
 
 /** Public board filters. Omitting `status` lets the backend default to `upcoming`. */
@@ -56,32 +51,18 @@ export interface EvictionAttendResult {
   attendeeCount: number;
 }
 
-/** Backend records may carry `_id`; the frontend works with `id`. */
-type BackendEvictionCase = Omit<EvictionCase, 'id'> & { _id?: string; id?: string };
-type BackendEvictionComment = Omit<EvictionComment, 'id'> & { _id?: string; id?: string };
-
 /** Raw list envelope: the backend nests `pagination` and exposes flat aliases. */
 interface BackendEvictionListEnvelope {
-  evictions?: BackendEvictionCase[];
+  evictions?: EvictionCase[];
   pagination?: EvictionPagination;
   hasMore?: boolean;
 }
 
 interface BackendCommentListEnvelope {
-  comments?: BackendEvictionComment[];
+  comments?: EvictionComment[];
   pagination?: EvictionPagination;
   hasMore?: boolean;
 }
-
-const normalizeCase = (raw: BackendEvictionCase): EvictionCase => {
-  const id = raw.id ?? raw._id ?? '';
-  return { ...raw, id } as EvictionCase;
-};
-
-const normalizeComment = (raw: BackendEvictionComment): EvictionComment => {
-  const id = raw.id ?? raw._id ?? '';
-  return { ...raw, id } as EvictionComment;
-};
 
 const emptyPagination = (page: number, count: number): EvictionPagination => ({
   page,
@@ -104,42 +85,42 @@ class EvictionService {
       },
       requireAuth: false,
     });
-    const items = (response.data.evictions ?? []).map(normalizeCase);
+    const items = response.data.evictions ?? [];
     const pagination = response.data.pagination ?? emptyPagination(params.page ?? 1, items.length);
     return { items, pagination, hasMore: response.data.hasMore ?? false };
   }
 
   /** Public case detail. `isAttending`/`isOwner` are populated for a signed viewer. */
   async getById(id: string): Promise<EvictionCase> {
-    const response = await api.get<ApiResponse<BackendEvictionCase>>(
+    const response = await api.get<ApiResponse<EvictionCase>>(
       `${this.baseUrl}/${id}`,
       { requireAuth: false },
     );
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Eviction case not found');
     }
-    return normalizeCase(response.data.data);
+    return response.data.data;
   }
 
   /** Open a new case (authed). */
   async create(payload: CreateEvictionCaseData): Promise<EvictionCase> {
-    const response = await api.post<ApiResponse<BackendEvictionCase>>(this.baseUrl, payload);
+    const response = await api.post<ApiResponse<EvictionCase>>(this.baseUrl, payload);
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Could not create the eviction case');
     }
-    return normalizeCase(response.data.data);
+    return response.data.data;
   }
 
   /** Edit an owned case (authed, owner-only server-side). */
   async update(id: string, payload: UpdateEvictionCaseData): Promise<EvictionCase> {
-    const response = await api.put<ApiResponse<BackendEvictionCase>>(
+    const response = await api.put<ApiResponse<EvictionCase>>(
       `${this.baseUrl}/${id}`,
       payload,
     );
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Could not update the eviction case');
     }
-    return normalizeCase(response.data.data);
+    return response.data.data;
   }
 
   /** Delete an owned case (authed, owner-only server-side). */
@@ -160,14 +141,14 @@ class EvictionService {
 
   /** Owner-only: append a timeline update (reschedule / status change / note). */
   async createUpdate(id: string, payload: CreateEvictionUpdateData): Promise<EvictionCase> {
-    const response = await api.post<ApiResponse<BackendEvictionCase>>(
+    const response = await api.post<ApiResponse<EvictionCase>>(
       `${this.baseUrl}/${id}/updates`,
       payload,
     );
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Could not post the update');
     }
-    return normalizeCase(response.data.data);
+    return response.data.data;
   }
 
   /** Public coordination thread, newest-first, paginated. */
@@ -176,21 +157,21 @@ class EvictionService {
       `${this.baseUrl}/${id}/comments`,
       { params: { page, limit }, requireAuth: false },
     );
-    const items = (response.data.comments ?? []).map(normalizeComment);
+    const items = response.data.comments ?? [];
     const pagination = response.data.pagination ?? emptyPagination(page, items.length);
     return { items, pagination, hasMore: response.data.hasMore ?? false };
   }
 
   /** Post a comment on a case (authed). */
   async createComment(id: string, body: string): Promise<EvictionComment> {
-    const response = await api.post<ApiResponse<BackendEvictionComment>>(
+    const response = await api.post<ApiResponse<EvictionComment>>(
       `${this.baseUrl}/${id}/comments`,
       { body },
     );
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Could not post your comment');
     }
-    return normalizeComment(response.data.data);
+    return response.data.data;
   }
 
   /** Delete a comment (author or case owner, authed). */
@@ -208,7 +189,7 @@ class EvictionService {
     const response = await api.get<BackendEvictionListEnvelope>(`${this.baseUrl}/me/list`, {
       params: { page, limit },
     });
-    const items = (response.data.evictions ?? []).map(normalizeCase);
+    const items = response.data.evictions ?? [];
     const pagination = response.data.pagination ?? emptyPagination(page, items.length);
     return { items, pagination, hasMore: response.data.hasMore ?? false };
   }
@@ -218,7 +199,7 @@ class EvictionService {
     const response = await api.get<BackendEvictionListEnvelope>(`${this.baseUrl}/me/attending`, {
       params: { page, limit },
     });
-    const items = (response.data.evictions ?? []).map(normalizeCase);
+    const items = response.data.evictions ?? [];
     const pagination = response.data.pagination ?? emptyPagination(page, items.length);
     return { items, pagination, hasMore: response.data.hasMore ?? false };
   }

--- a/packages/frontend/services/exchangeService.ts
+++ b/packages/frontend/services/exchangeService.ts
@@ -12,9 +12,9 @@ import {
  * Home-exchange API client (swap + free hosting).
  *
  * Mirrors `reservationService`: a thin class over `@/utils/api` that unwraps the
- * backend's `{ data, pagination, meta }` envelope and normalises the persisted
- * `_id` to `id`. Distinct from reservations (paid vacation bookings) and viewing
- * requests (long-term-rent tours). Every endpoint is auth-gated server-side.
+ * backend's `{ data, pagination, meta }` envelope. Distinct from reservations
+ * (paid vacation bookings) and viewing requests (long-term-rent tours). Every
+ * endpoint is auth-gated server-side.
  */
 
 export interface ListExchangeRequestsParams {
@@ -54,27 +54,6 @@ export interface CreateExchangeReviewBody {
   categories?: ExchangeReviewCategories;
 }
 
-/** Backend records carry `_id`; the frontend works with `id`. */
-type BackendExchangeRequest = Omit<ExchangeRequest, 'id'> & {
-  _id?: string;
-  id?: string;
-};
-
-type BackendExchangeReview = Omit<ExchangeReview, 'id'> & {
-  _id?: string;
-  id?: string;
-};
-
-const normalizeRequest = (raw: BackendExchangeRequest): ExchangeRequest => {
-  const id = raw.id ?? raw._id ?? '';
-  return { ...raw, id } as ExchangeRequest;
-};
-
-const normalizeReview = (raw: BackendExchangeReview): ExchangeReview => {
-  const id = raw.id ?? raw._id ?? '';
-  return { ...raw, id } as ExchangeReview;
-};
-
 const emptyPagination = (count: number): ExchangePagination => ({
   page: 1,
   limit: count,
@@ -87,14 +66,14 @@ class ExchangeService {
 
   /** Propose a swap or hosting stay against an EXCHANGE listing. */
   async createRequest(payload: CreateExchangeRequestData): Promise<ExchangeRequest> {
-    const response = await api.post<ApiResponse<BackendExchangeRequest>>(
+    const response = await api.post<ApiResponse<ExchangeRequest>>(
       this.baseUrl,
       payload,
     );
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Exchange request failed');
     }
-    return normalizeRequest(response.data.data);
+    return response.data.data;
   }
 
   /**
@@ -105,7 +84,7 @@ class ExchangeService {
     params: ListExchangeRequestsParams = {},
   ): Promise<ExchangeRequestListResponse> {
     const response = await api.get<{
-      data?: BackendExchangeRequest[];
+      data?: ExchangeRequest[];
       pagination?: ExchangePagination;
     }>(this.baseUrl, {
       params: {
@@ -115,19 +94,19 @@ class ExchangeService {
         limit: params.limit,
       },
     });
-    const items = (response.data.data ?? []).map(normalizeRequest);
+    const items = response.data.data ?? [];
     const pagination = response.data.pagination ?? emptyPagination(items.length);
     return { items, pagination };
   }
 
   async getRequest(id: string): Promise<ExchangeRequest> {
-    const response = await api.get<ApiResponse<BackendExchangeRequest>>(
+    const response = await api.get<ApiResponse<ExchangeRequest>>(
       `${this.baseUrl}/${id}`,
     );
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Exchange request not found');
     }
-    return normalizeRequest(response.data.data);
+    return response.data.data;
   }
 
   /**
@@ -139,14 +118,14 @@ class ExchangeService {
     id: string,
     payload: UpdateExchangeRequestData,
   ): Promise<ExchangeRequest> {
-    const response = await api.patch<ApiResponse<BackendExchangeRequest>>(
+    const response = await api.patch<ApiResponse<ExchangeRequest>>(
       `${this.baseUrl}/${id}`,
       payload,
     );
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Exchange request update failed');
     }
-    return normalizeRequest(response.data.data);
+    return response.data.data;
   }
 
   /** Review the other party of a COMPLETED exchange (one review per reviewer). */
@@ -154,22 +133,22 @@ class ExchangeService {
     id: string,
     body: CreateExchangeReviewBody,
   ): Promise<ExchangeReview> {
-    const response = await api.post<ApiResponse<BackendExchangeReview>>(
+    const response = await api.post<ApiResponse<ExchangeReview>>(
       `${this.baseUrl}/${id}/reviews`,
       body,
     );
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Exchange review failed');
     }
-    return normalizeReview(response.data.data);
+    return response.data.data;
   }
 
   /** Both reviews tied to a single exchange (requester + host). */
   async getRequestReviews(id: string): Promise<ExchangeReview[]> {
-    const response = await api.get<ApiResponse<BackendExchangeReview[]>>(
+    const response = await api.get<ApiResponse<ExchangeReview[]>>(
       `${this.baseUrl}/${id}/reviews`,
     );
-    return (response.data.data ?? []).map(normalizeReview);
+    return response.data.data ?? [];
   }
 
   /**
@@ -181,13 +160,13 @@ class ExchangeService {
     params: { page?: number; limit?: number } = {},
   ): Promise<ProfileExchangeReviewsResponse> {
     const response = await api.get<{
-      data?: BackendExchangeReview[];
+      data?: ExchangeReview[];
       pagination?: ExchangePagination;
       meta?: Partial<ProfileExchangeReviewsMeta>;
     }>(`/api/profiles/oxy/${encodeURIComponent(oxyUserId)}/exchange-reviews`, {
       params: { page: params.page, limit: params.limit },
     });
-    const items = (response.data.data ?? []).map(normalizeReview);
+    const items = response.data.data ?? [];
     const pagination = response.data.pagination ?? emptyPagination(items.length);
     const meta: ProfileExchangeReviewsMeta = {
       averageRating: response.data.meta?.averageRating ?? 0,

--- a/packages/frontend/services/leaseService.ts
+++ b/packages/frontend/services/leaseService.ts
@@ -61,25 +61,15 @@ export interface UploadLeaseDocumentInput {
   type?: LeaseDocumentType;
 }
 
-interface BackendLease extends Omit<Lease, 'id'> {
-  _id?: string;
-  id?: string;
-}
-
-const normalizeLease = (raw: BackendLease): Lease => ({
-  ...(raw as Lease),
-  id: raw.id ?? raw._id ?? '',
-});
-
 const LEASE_BASE = '/api/leases';
 
 class LeaseService {
   async getLeases(filters?: LeaseFilters): Promise<LeaseListResponse> {
     const response = await api.get<{
-      data?: BackendLease[];
+      data?: Lease[];
       pagination?: { total: number; page: number; totalPages: number };
     }>(LEASE_BASE, { params: filters });
-    const leases = (response.data.data ?? []).map(normalizeLease);
+    const leases = response.data.data ?? [];
     const pagination = response.data.pagination;
     return {
       leases,
@@ -90,19 +80,19 @@ class LeaseService {
   }
 
   async getLease(leaseId: string): Promise<Lease> {
-    const response = await api.get<ApiResponse<BackendLease>>(`${LEASE_BASE}/${leaseId}`);
+    const response = await api.get<ApiResponse<Lease>>(`${LEASE_BASE}/${leaseId}`);
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Lease not found');
     }
-    return normalizeLease(response.data.data);
+    return response.data.data;
   }
 
   async createLease(data: CreateLeaseData): Promise<Lease> {
-    const response = await api.post<ApiResponse<BackendLease>>(LEASE_BASE, data);
+    const response = await api.post<ApiResponse<Lease>>(LEASE_BASE, data);
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Lease creation failed');
     }
-    return normalizeLease(response.data.data);
+    return response.data.data;
   }
 
   /**
@@ -110,21 +100,21 @@ class LeaseService {
    * The backend resolves all owner ids and lifecycle fields server-side.
    */
   async createLeaseFromApplication(applicationId: string): Promise<Lease> {
-    const response = await api.post<ApiResponse<BackendLease>>(
+    const response = await api.post<ApiResponse<Lease>>(
       `/api/applications/${applicationId}/create-lease`,
     );
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Could not create lease from application');
     }
-    return normalizeLease(response.data.data);
+    return response.data.data;
   }
 
   async updateLease(leaseId: string, data: UpdateLeaseData): Promise<Lease> {
-    const response = await api.put<ApiResponse<BackendLease>>(`${LEASE_BASE}/${leaseId}`, data);
+    const response = await api.put<ApiResponse<Lease>>(`${LEASE_BASE}/${leaseId}`, data);
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Lease update failed');
     }
-    return normalizeLease(response.data.data);
+    return response.data.data;
   }
 
   async deleteLease(leaseId: string): Promise<void> {
@@ -132,36 +122,36 @@ class LeaseService {
   }
 
   async signLease(leaseId: string, signature: string, acceptTerms: boolean): Promise<Lease> {
-    const response = await api.post<ApiResponse<BackendLease>>(`${LEASE_BASE}/${leaseId}/sign`, {
+    const response = await api.post<ApiResponse<Lease>>(`${LEASE_BASE}/${leaseId}/sign`, {
       signature,
       acceptTerms,
     });
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Lease signing failed');
     }
-    return normalizeLease(response.data.data);
+    return response.data.data;
   }
 
   async terminateLease(leaseId: string, data: TerminateLeaseData): Promise<Lease> {
-    const response = await api.post<ApiResponse<BackendLease>>(
+    const response = await api.post<ApiResponse<Lease>>(
       `${LEASE_BASE}/${leaseId}/terminate`,
       data,
     );
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Lease termination failed');
     }
-    return normalizeLease(response.data.data);
+    return response.data.data;
   }
 
   async renewLease(leaseId: string, data: RenewLeaseData): Promise<Lease> {
-    const response = await api.post<ApiResponse<BackendLease>>(
+    const response = await api.post<ApiResponse<Lease>>(
       `${LEASE_BASE}/${leaseId}/renew`,
       data,
     );
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Lease renewal failed');
     }
-    return normalizeLease(response.data.data);
+    return response.data.data;
   }
 
   async getLeasePayments(

--- a/packages/frontend/services/reservationService.ts
+++ b/packages/frontend/services/reservationService.ts
@@ -46,36 +46,23 @@ export interface ListReservationsParams {
   limit?: number;
 }
 
-interface BackendReservation extends Omit<Reservation, 'id'> {
-  _id?: string;
-  id?: string;
-}
-
-const normalizeReservation = (raw: BackendReservation): Reservation => {
-  const id = raw.id ?? raw._id ?? '';
-  return {
-    ...raw,
-    id,
-  } as Reservation;
-};
-
 export const reservationService = {
   async createReservation(payload: CreateReservationData): Promise<Reservation> {
-    const response = await api.post<ApiResponse<BackendReservation>>(
+    const response = await api.post<ApiResponse<Reservation>>(
       '/api/reservations',
       payload,
     );
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Reservation creation failed');
     }
-    return normalizeReservation(response.data.data);
+    return response.data.data;
   },
 
   async listReservations(
     params: ListReservationsParams = {},
   ): Promise<ReservationListResponse> {
     const response = await api.get<{
-      data?: BackendReservation[];
+      data?: Reservation[];
       pagination?: ReservationListResponse['pagination'];
     }>('/api/reservations', {
       params: {
@@ -85,7 +72,7 @@ export const reservationService = {
         limit: params.limit,
       },
     });
-    const items = (response.data.data ?? []).map(normalizeReservation);
+    const items = response.data.data ?? [];
     const pagination = response.data.pagination ?? {
       page: 1,
       limit: items.length,
@@ -96,27 +83,27 @@ export const reservationService = {
   },
 
   async getReservationById(id: string): Promise<Reservation> {
-    const response = await api.get<ApiResponse<BackendReservation>>(
+    const response = await api.get<ApiResponse<Reservation>>(
       `/api/reservations/${id}`,
     );
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Reservation not found');
     }
-    return normalizeReservation(response.data.data);
+    return response.data.data;
   },
 
   async updateReservation(
     id: string,
     payload: UpdateReservationData,
   ): Promise<Reservation> {
-    const response = await api.patch<ApiResponse<BackendReservation>>(
+    const response = await api.patch<ApiResponse<Reservation>>(
       `/api/reservations/${id}`,
       payload,
     );
     if (!response.data?.data) {
       throw new Error(response.data?.message || 'Reservation update failed');
     }
-    return normalizeReservation(response.data.data);
+    return response.data.data;
   },
 
   async getPropertyAvailability(

--- a/packages/frontend/services/savedPropertyFolderService.ts
+++ b/packages/frontend/services/savedPropertyFolderService.ts
@@ -1,7 +1,7 @@
 import { api } from '@/utils/api';
 
 export interface SavedPropertyFolder {
-  _id: string;
+  id: string;
   profileId: string;
   name: string;
   description: string;

--- a/packages/frontend/services/viewingService.ts
+++ b/packages/frontend/services/viewingService.ts
@@ -3,7 +3,7 @@ import { api, ApiResponse } from '@/utils/api';
 export type ViewingStatus = 'pending' | 'approved' | 'declined' | 'cancelled';
 
 export interface ViewingRequest {
-  _id: string;
+  id: string;
   propertyId: string;
   requesterOxyUserId: string;
   ownerOxyUserId: string;

--- a/packages/frontend/store/conversationStore.ts
+++ b/packages/frontend/store/conversationStore.ts
@@ -79,7 +79,7 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
         const data = await response.json();
         if (data.success && data.conversations) {
           const formattedConversations: Conversation[] = data.conversations.map((conv: any) => ({
-            id: conv._id,
+            id: conv.id,
             title: conv.title,
             messages: conv.messages || [],
             createdAt: new Date(conv.createdAt),
@@ -136,10 +136,10 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
           const apiConversation = data.conversation;
 
           const formattedConversation: Conversation = {
-            id: apiConversation._id || apiConversation.id,
+            id: apiConversation.id,
             title: apiConversation.title || 'Untitled Conversation',
             messages: (apiConversation.messages || []).map((msg: any) => ({
-              id: msg._id || msg.id || `msg_${Date.now()}_${Math.random()}`,
+              id: msg.id || `msg_${Date.now()}_${Math.random()}`,
               role: msg.role,
               content: msg.content || '',
               timestamp: new Date(msg.timestamp || Date.now()),
@@ -227,7 +227,7 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
           if (data.success && data.conversation) {
             const newConversation: Conversation = {
               ...conversation,
-              id: data.conversation._id,
+              id: data.conversation.id,
             };
             set({ currentConversation: newConversation });
 
@@ -313,9 +313,9 @@ export const useConversationStore = create<ConversationState>((set, get) => ({
         if (response.ok) {
           const data = await response.json();
 
-          if (data.success && data.conversation && data.conversation._id) {
+          if (data.success && data.conversation && data.conversation.id) {
             const newConversation: Conversation = {
-              id: data.conversation._id,
+              id: data.conversation.id,
               title: data.conversation.title || title,
               messages: data.conversation.messages || [],
               createdAt: new Date(data.conversation.createdAt),

--- a/packages/frontend/types/api.ts
+++ b/packages/frontend/types/api.ts
@@ -62,7 +62,7 @@ export interface CreateReviewRequest {
 }
 
 export interface Review extends CreateReviewRequest {
-  _id: string;
+  id: string;
   userId: string;
   livedForMonths: number;
   humanDuration: string;

--- a/packages/shared-types/src/address.ts
+++ b/packages/shared-types/src/address.ts
@@ -57,7 +57,6 @@ export interface Address {
 }
 
 export interface AddressDocument extends Address {
-  _id: string;
   id: string;
   normalizedKey: string;
   /** Populated when the country ref is expanded. */
@@ -103,10 +102,9 @@ export interface AddressGeoNames {
  * the populated `addressId` to `address`). It carries the building-level fields
  * and relational geo ids of an {@link Address}, plus the server-resolved geo
  * display names ({@link AddressGeoNames}) so consumers read location NAMES
- * directly. `_id`/`id` are present because the address is a persisted document.
+ * directly. `id` is present because the address is a persisted document.
  */
 export interface PropertyAddress extends Address, AddressGeoNames {
-  _id?: string;
   id?: string;
 }
 

--- a/packages/shared-types/src/geo.ts
+++ b/packages/shared-types/src/geo.ts
@@ -25,7 +25,7 @@ import type { ListingCurrency } from './currency';
 
 /**
  * A geo entity's cover-image reference as serialized by the API: the bare Image
- * `_id` (string) when un-populated, or the populated {@link Image} document when
+ * `id` (string) when un-populated, or the populated {@link Image} document when
  * the endpoint expands it (the `/api/cities*` routes populate
  * `coverImageId` → `{ urls, caption, width, height }`). Same Mongoose field,
  * either form — consumers read `urls` off the populated shape.
@@ -37,7 +37,7 @@ export type CoverImageRef = string | Image;
  * Keyed by its ISO-3166-1 alpha-2 code (e.g. `ES`, `US`, `GB`).
  */
 export interface Country {
-  _id: string;
+  id: string;
   /** ISO-3166-1 alpha-2 code, uppercase (e.g. `ES`). Unique. */
   code: string;
   /** Canonical English display name (e.g. `Spain`). */
@@ -59,8 +59,8 @@ export interface Country {
  * of the region's display name; references its country by id.
  */
 export interface Region {
-  _id: string;
-  /** The owning country's `_id`. */
+  id: string;
+  /** The owning country's `id`. */
   countryId: string;
   /**
    * Region code where one is well-defined (e.g. ISO-3166-2 subdivision code
@@ -70,8 +70,8 @@ export interface Region {
   /** Canonical display name (e.g. `Catalonia`). */
   name: string;
   /**
-   * The region's cover photo: the `_id` of an {@link Image} with
-   * `entityType: 'region'` and `entityId` equal to this region's `_id`.
+   * The region's cover photo: the `id` of an {@link Image} with
+   * `entityType: 'region'` and `entityId` equal to this region's `id`.
    * Populated to the {@link Image} document when an endpoint expands it. See
    * {@link CoverImageRef}.
    */
@@ -95,16 +95,16 @@ export interface Region {
  * because "which one is the cover" is a fact the relation does not carry.
  */
 export interface City {
-  _id: string;
+  id: string;
   name: string;
   /**
-   * The owning country's `_id`, or the populated {@link Country} document when an
+   * The owning country's `id`, or the populated {@link Country} document when an
    * endpoint expands it (the `/api/cities*` routes populate `countryId` →
    * `{ name, code, currency, flag }`).
    */
   countryId: string | Country;
   /**
-   * The owning region's `_id`, or the populated {@link Region} document when an
+   * The owning region's `id`, or the populated {@link Region} document when an
    * endpoint expands it (the `/api/cities*` routes populate `regionId` →
    * `{ name, code }`).
    */
@@ -116,8 +116,8 @@ export interface City {
   averageRent?: number;
   currency: ListingCurrency;
   /**
-   * The city's cover photo: the `_id` of an {@link Image} with
-   * `entityType: 'city'` and `entityId` equal to this city's `_id`. Set once at
+   * The city's cover photo: the `id` of an {@link Image} with
+   * `entityType: 'city'` and `entityId` equal to this city's `id`. Set once at
    * seed time (the curated city image is fetched, processed and stored in our own
    * object storage), so there is no live external image dependency at runtime.
    * Serialized as the populated {@link Image} (with `urls`) by the `/api/cities*`
@@ -142,8 +142,8 @@ export interface City {
  * Optional bounding box / centroid support map framing and reverse lookups.
  */
 export interface Neighborhood {
-  _id: string;
-  /** The owning city's `_id`. */
+  id: string;
+  /** The owning city's `id`. */
   cityId: string;
   name: string;
   /** Optional centroid for map framing. */

--- a/packages/shared-types/src/media.ts
+++ b/packages/shared-types/src/media.ts
@@ -8,7 +8,7 @@
  * Image document is the canonical record of those variants, their storage keys
  * and the source metadata.
  *
- * Consumers reference an Image by `_id` and read a ready-to-render `urls` map.
+ * Consumers reference an Image by `id` and read a ready-to-render `urls` map.
  * The legacy property `images[{ url, caption, isPrimary }]` shape is preserved
  * on the Property as a denormalized projection of these documents (its `url` is
  * the stored medium variant), so existing readers never break while the canonical
@@ -36,10 +36,10 @@ export type ImageVariantUrls = Record<ImageVariantName, string>;
  * it belongs to via `{ entityType, entityId }`.
  */
 export interface Image {
-  _id: string;
+  id: string;
   /** Which kind of entity this image belongs to. */
   entityType: ImageEntityType;
-  /** The owning entity's `_id` (Property / City / Region / Country / Profile). */
+  /** The owning entity's `id` (Property / City / Region / Country / Profile). */
   entityId: string;
   /** Object-storage keys (bucket-relative) for each processed variant. */
   keys: ImageVariantKeys;

--- a/packages/shared-types/src/profile.ts
+++ b/packages/shared-types/src/profile.ts
@@ -137,7 +137,6 @@ export interface PersonalProfile {
 
 export interface Profile {
   id: string;
-  _id?: string;
   oxyUserId: string;
   avatar?: string;
   personalProfile?: PersonalProfile;

--- a/packages/shared-types/src/property.ts
+++ b/packages/shared-types/src/property.ts
@@ -166,8 +166,7 @@ export interface PropertyCharacteristics {
 }
 
 export interface Property {
-  _id: string; // MongoDB ObjectId
-  id?: string; // Optional fallback
+  id: string;
   oxyUserId?: string;
   // External sourcing metadata
   source?: string; // Source name (e.g., 'fotocasa', 'internal')

--- a/packages/shared-types/src/review.ts
+++ b/packages/shared-types/src/review.ts
@@ -255,7 +255,7 @@ export interface Review {
 }
 
 /**
- * Serialized review returned by the API (`_id` → `id`, timestamps, derived
+ * Serialized review returned by the API (`id`, timestamps, derived
  * helpful counters, and the optional populated agency + address projections).
  */
 export interface ReviewDTO extends Review {
@@ -270,7 +270,7 @@ export interface ReviewDTO extends Review {
   agency?: AgencySummary;
   /** Populated address projection used by review lists / detail views. */
   populatedAddress?: {
-    _id: string;
+    id: string;
     street: string;
     city: string;
     state?: string;


### PR DESCRIPTION
Every DTO in `@homiio/shared-types` now names a document's identity `id`, and nothing on the wire carries `_id`. No dual field, no alias, no `@deprecated` shim — `_id` leaves the contract in one step and every consumer moves with it.

Doing this **while the backend still reads from Mongo is deliberate**: it decouples the rename from the datastore swap, so the Postgres cutover changes only where data comes from, not what the API returns. Mongoose keeps storing `_id` underneath; only the boundary moved.

This is the cut three files were already waiting on — `cityController.ts:18`, `addressController.ts:9` and `cityEndpoints.test.ts:5` each said "batch 10 owns the `_id` → `id` cut, so every response here still carries BOTH spellings". They now carry one.

## How the two categories were told apart

`_id` means two unrelated things in this repo, and only one of them is the wire. Every site was classified by **context, never by spelling**:

| Category | Verdict |
|---|---|
| DTO field declarations, response object literals, frontend reads of an API body | **changed** |
| Query filters (`find`/`findOne`/`updateOne`/`deleteOne`/`exists`) | untouched |
| `$group` / `$match` / `$lookup` / `$sort` keys | untouched |
| `{ _id: false }` / `{ _id: true }` subdocument options, index declarations | untouched |
| `ObjectId` construction and casts | untouched |
| `select('_id')`, `populate`, `foreignField`, sort paths | untouched |
| `documentTypes.ts` document / `.lean<>()` type declarations | untouched |
| `doc._id` reads that feed another query | untouched |

A broken `$group: { _id: … }` throws nothing — it silently changes what the aggregation returns — so none of this was left to a find-replace. Classification was scripted, then every ambiguous line was read; the six that looked like response shapes (`notificationController`, `savedFolders`, `savedProperties`, `savedSearches`, two in `roommateController`) turned out to be `findOne({ … })` filters whose opening call sat on the previous line.

### Site counts

**Changed:** 88 files — 11 DTO declarations in shared-types (+ their doc comments), ~150 frontend sites across 66 files, and the backend serialization boundary.

**Remaining, all Mongo-internal, all in `packages/backend`:** 1024 —
605 `doc._id` reads · 151 query filters · 84 document/lean type declarations · 73 comments describing the stored column · 45 `ObjectId` casts · 37 projection/populate paths · 34 aggregation keys · 26 schema definitions.

`packages/frontend`, `packages/shared-types` and `packages/listing-providers` are at **zero**. listing-providers needed no change at all: its 100 matches are compound snake_case names like `property_id` from portal payloads.

## The backend needed a serializer, not a rename

Grep cannot find where this API emits `_id`, because mostly it does not say so. Two paths reach `res.json` and **only one passes through a model**:

- `res.json(doc)` runs the schema's `toJSON` — about a dozen schemas already had a transform, most of which set `id` *without* deleting `_id`, which is why both spellings shipped.
- `res.json(await Query.lean())` does **not**. There are ~90 `.lean()` reads behind these routers and a lean object carries `_id` and no `id` whatsoever.

So the cut is made once, in `middlewares/wireIds.ts`, mounted first in `routes()` and `publicRoutes()` — the boundary both paths share — rather than in ~100 call sites where the next `.lean()` added would silently reopen it.

Two decisions worth reviewing:

- **Mounted in the routers, not `server.ts`.** The integration suites build their own `express()` and mount these routers directly, so a `server.ts`-only wrapper would be invisible to every test that asserts a response shape — the suite would keep passing against a format production no longer serves.
- **A whole-body walk is safe *here*** because nothing this API returns is legitimately named `_id`. The one shape that could be, a raw `$group` result, never reaches a client (`analyticsController` maps its group key into `cityId` and `bucket` first). An `id` already set by a DTO mapper or schema transform **wins**, so `toLeaseDTO`/`toReviewDTO`/`toEvictionDTO` are not overwritten. The doc comment says explicitly that a future passthrough endpoint must serialize explicitly rather than widen this.

Nothing was double-mapped: existing transforms that set `id` are left in place and the serializer defers to them.

## Verification

A typecheck cannot see any of this — the frontend compiles against the DTOs, but the backend hands `res.json` a Mongoose document or a lean object, neither typed as a DTO, so `tsc` is green whether the body carries `id`, `_id`, or both. `__tests__/integration/wireIdContract.test.ts` asserts the contract over a **real request** through the real router, on both a `.lean()` read and a Mongoose document, including nested populated documents and a whole-body scan for `"_id"` at any depth.

The **negative** assertions are the load-bearing half — checking that `id` is present passes just as happily on the old body that also shipped `_id`, which is exactly the state being replaced.

**Mutation-tested four ways**, each caught, each naming the offending case:

| Mutation | Result |
|---|---|
| stop deleting `_id` (emit both, the old shape) | 6 failed |
| drop the recursion (top level only) | 3 failed, naming the nested + whole-body cases |
| unmount the middleware from `publicRoutes` | 2 failed |
| let `_id` clobber a pre-existing `id` | 1 failed, naming the DTO-mapper case |

Restores were byte-verified against pristine copies (md5) rather than `git checkout`, which during mutation testing would have reverted the uncommitted work under test.

Five suites that mount controllers directly (`propertyOwnership`, `leaseOwnership`, `moderationVisibility`, `partnerCommission`, `roomOwnership`) now mount the serializer too, so they assert the shape production actually serves, and their `id ?? _id` fallbacks are gone.

## Gates

| Gate | Result |
|---|---|
| backend tsc | 0 errors |
| frontend tsc | 0 errors |
| backend jest | **1132/1132**, 99 suites (baseline 1123/98; floor 1100) |
| frontend jest | **40/40** (floor 38) |
| web bundle (`expo export`) | exported |
| lockfile sync | in sync |
| version pins | bun 1.3.14, node 22 consistent |
| migration phases | 3/3 declare a phase |
| CI gate self-tests | all 8 still discriminating |

Baseline was measured on `origin/main` **before** any edit: backend tsc 0, frontend tsc 0, jest 1123/1123 across 98 suites. No dependency changed, so `bun.lock` is untouched.

## One thing deliberately left alone

`hydrateDisplayNames` in `controllers/roommate/serialize.ts` reads `user?.id ?? user?._id` off the **Oxy API's** `/users/by-ids` response. That is a foreign service's contract, not Homiio's wire, so it is unchanged. Flag it if you disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
