### PR TITLE
Pin the wire-id claim across endpoints, and say what the serializer touches

### DIFF
--- a/packages/backend/__tests__/integration/wireIdContract.test.ts
+++ b/packages/backend/__tests__/integration/wireIdContract.test.ts
@@ -25,6 +25,7 @@ import publicRoutes from '../../routes/public';
 import { errorHandler } from '../../middlewares/errorHandler';
 import { renameWireIds } from '../../middlewares/wireIds';
 import { Address, City, Country, Property, Region } from '../../models';
+import { resetGeoTables, seedGeoChain } from '../helpers/postgresGeoFixtures';
 import { OfferingType, PropertyStatus, PropertyType } from '@homiio/shared-types';
 
 function buildApp(): Express {
@@ -95,6 +96,10 @@ describe('renameWireIds', () => {
 describe('the wire contract, over a real request', () => {
   const app = buildApp();
 
+  beforeEach(async () => {
+    await resetGeoTables();
+  });
+
   /** Seed a published property in a city, and return the ids Mongo assigned. */
   async function seedCityProperty(): Promise<{ cityId: string; propertyId: string }> {
     const country = await Country.create({ code: 'ES', name: 'Spain', currency: 'EUR' });
@@ -158,5 +163,143 @@ describe('the wire contract, over a real request', () => {
     // that nothing gets past it, and a per-field assertion only covers the
     // fields somebody remembered.
     expect(JSON.stringify(res.body)).not.toContain('"_id"');
+  });
+
+  /**
+   * The sweep, and the reason it carries a vacuity floor.
+   *
+   * One endpoint proving the serializer works says nothing about the one added
+   * next week, and the claim this middleware rests on is about the WHOLE router:
+   * "nothing this API returns is legitimately named `_id`". That is checkable,
+   * so it is checked.
+   *
+   * A scan for `"_id"` over a body that came back `[]` or `500` passes for the
+   * wrong reason, and the first draft of this test did exactly that — 10 of its
+   * 16 paths returned an empty list, a 404, or an error, so it would have gone
+   * green with the serializer removed from most of them. Hence the split below:
+   * a path is only counted as COVERAGE once its body is asserted to contain
+   * real entity data, and the assertion names the path that failed.
+   *
+   * The city endpoints need Postgres seeded as well as Mongo — they were ported
+   * in an earlier batch and no longer read the Mongo `City` model — which is the
+   * concrete way that first draft was silently empty.
+   *
+   * ## What this deliberately does NOT catch, so nobody reads it as a hole
+   *
+   * Putting `_id` back into a CONTROLLER's own response literal fails nothing
+   * here — verified by mutation, not assumed. That is the chokepoint working:
+   * `middlewares/wireIds.ts` strips it downstream, so the wire is still correct
+   * and there is no regression to report. What these cases do catch is a hole in
+   * the serializer itself (mutated to skip property-shaped objects: three cases
+   * red, naming `/api/properties` and the city-properties path) and the
+   * serializer being unmounted altogether. The subject under test is the WIRE,
+   * not which layer happens to produce it.
+   */
+  it('emits no `_id` from any public endpoint that returns entities', async () => {
+    const { cityId } = await seedCityProperty();
+    const chain = await seedGeoChain({ cityName: 'Barcelona', propertiesCount: 3 });
+
+    const entityPaths = [
+      '/api/cities',
+      '/api/cities/search?q=Barc',
+      '/api/cities/lookup?name=Barcelona',
+      `/api/cities/${chain.cityId}`,
+      `/api/cities/${cityId}/properties?limit=8`,
+      '/api/properties',
+    ];
+    // Two public GETs are deliberately absent, and neither absence is laziness:
+    //   - `/api/analytics/stats` returns aggregates, not entities, so it has no
+    //     `id` to floor on. It has its own case below.
+    //   - `/api/properties/by-ids` filters `status: 'active'`, which is not a
+    //     value in `PropertyStatus` (draft/published/reserved/rented/sold/
+    //     inactive/archived), so it cannot return a row for any fixture. That is
+    //     a pre-existing bug in `controllers/property/batch.ts`, unrelated to
+    //     this contract; listing it here would only buy a permanently empty body
+    //     that passes the `_id` scan for the wrong reason.
+
+    const leaked: string[] = [];
+    const empty: string[] = [];
+    for (const path of entityPaths) {
+      const res = await request(app).get(path);
+      const body = JSON.stringify(res.body ?? null);
+      if (body.includes('"_id"')) leaked.push(`${path} (HTTP ${res.status})`);
+      // The floor. A body with no `"id":` in it exercised nothing, so treating it
+      // as a pass would be the bug this whole test exists to catch.
+      if (res.status !== 200 || !body.includes('"id":')) {
+        empty.push(`${path} (HTTP ${res.status}, ${body.slice(0, 60)})`);
+      }
+    }
+
+    // Naming the offending path is the difference between a gate that tells you
+    // where to look and one that tells you only that something is wrong.
+    expect(leaked).toEqual([]);
+    expect(empty).toEqual([]);
+  });
+
+  /**
+   * Failure bodies go through the transform too — `errorHandler` runs on a
+   * response whose `res.json` this middleware already replaced. They carry no
+   * `_id`, but they DO pass through, and the envelope has to survive the rebuild.
+   */
+  it('passes error bodies through intact and without `_id`', async () => {
+    const errorPaths = [
+      '/api/cities/000000000000000000000000',
+      '/api/cities/lookup?name=Atlantis&country=Nowhere',
+    ];
+
+    for (const path of errorPaths) {
+      const res = await request(app).get(path);
+      expect(res.status).toBe(404);
+      expect(JSON.stringify(res.body)).not.toContain('"_id"');
+      expect(res.body.success).toBe(false);
+      expect(typeof res.body.message).toBe('string');
+    }
+  });
+
+  it('leaves the envelope, the pagination block and a non-entity `id` intact', async () => {
+    const { cityId } = await seedCityProperty();
+
+    const res = await request(app).get(`/api/cities/${cityId}/properties?limit=8`).expect(200);
+
+    // The transform rebuilds every object it walks, so the envelope keys have to
+    // survive that rebuild — a serializer that dropped `pagination` would still
+    // pass every `_id` assertion in this file.
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.pagination).toEqual(
+      expect.objectContaining({ page: 1, limit: 8, total: 1, pages: 1 }),
+    );
+    expect(res.body.data.city.name).toBe('Barcelona');
+
+    // A NUMERIC `id` is what an Overpass/OSM element carries, and the one shape a
+    // "stringify the id" transform would quietly corrupt if it ever stopped
+    // deferring to an `id` already present.
+    expect(renameWireIds({ id: 42, tags: { amenity: 'cafe' } })).toEqual({
+      id: 42,
+      tags: { amenity: 'cafe' },
+    });
+  });
+
+  /**
+   * `analyticsController` is the one endpoint whose underlying data really does
+   * have an `_id` that is NOT an entity id — a `$group` key. It maps that into
+   * `cityId` and `bucket` BEFORE responding, which is the reason a whole-body
+   * strip is safe on this router at all. Pinning it here means the day someone
+   * returns a raw aggregation, this fails rather than the meaning of a field
+   * silently changing.
+   */
+  it('keeps aggregation group keys mapped to named fields, never `_id`', async () => {
+    await seedCityProperty();
+
+    const res = await request(app).get('/api/analytics/stats').expect(200);
+
+    expect(JSON.stringify(res.body)).not.toContain('"_id"');
+    for (const row of res.body.data.topCities ?? []) {
+      expect(row).toHaveProperty('cityId');
+      expect(row).not.toHaveProperty('id');
+    }
+    for (const row of res.body.data.priceBuckets ?? []) {
+      expect(row).toHaveProperty('bucket');
+      expect(row).not.toHaveProperty('id');
+    }
   });
 });

--- a/packages/backend/controllers/roommate/serialize.ts
+++ b/packages/backend/controllers/roommate/serialize.ts
@@ -5,6 +5,16 @@
 import config from '../../config';
 import { logger } from '../../middlewares/logging';
 
+/**
+ * A user as the OXY API returns it from `POST /users/by-ids`.
+ *
+ * The `_id` here is deliberate and must NOT be renamed by a sweep of Homiio's
+ * own `_id` → `id` cut. This is a foreign service's response shape, not Homiio's
+ * wire: Oxy decides what it sends, and editing this declaration would only make
+ * Homiio stop reading a field Oxy still emits. It is also never re-served — the
+ * payload is projected into {@link SerializedRoommateProfile} below and the raw
+ * object never reaches `res.json`.
+ */
 interface OxyPublicUser {
   id?: string;
   _id?: string;

--- a/packages/backend/middlewares/wireIds.ts
+++ b/packages/backend/middlewares/wireIds.ts
@@ -31,16 +31,52 @@
  * Mongoose document, and a serializer that edits its argument would corrupt the
  * first and try to `delete` a schema path on the second.
  *
+ * ## Exactly what it touches, and what it leaves alone
+ *
+ * The walk is RECURSIVE and reaches every object and array element in the body,
+ * at any depth. That breadth is the point — a nested populated document is
+ * precisely where a top-level-only rename leaves `_id` behind — but it is also
+ * the whole risk surface, so what it does to each kind of payload is stated
+ * rather than left to be discovered:
+ *
+ *   - **Entity documents, nested or not.** `_id` → `id`. This is the job.
+ *   - **Envelopes.** `successResponse` and `paginationResponse` wrap data in
+ *     `{ success, message, data, meta }` / `{ … pagination }`. Those keys carry
+ *     no `_id`, so the envelope is rebuilt field-for-field and reaches the client
+ *     unchanged; only the entities inside `data` are rewritten.
+ *   - **Error bodies.** `errorHandler` runs after these routers, on a response
+ *     whose `res.json` this middleware has already replaced, so error payloads
+ *     pass through it too. They carry no `_id` and are unaffected — but they DO
+ *     pass through, which is worth knowing before adding a field to one.
+ *   - **A non-entity `id`.** Never touched. Only `_id` is removed, and an `id`
+ *     already present always wins, whatever its type.
+ *   - **`Date` and `Buffer`.** Returned as-is rather than walked, so they still
+ *     serialize the way `res.json` would render them.
+ *
  * ## Why a whole-body walk is safe HERE and would not be in general
  *
- * Nothing this API returns is legitimately named `_id`. The one shape that could
- * be — a raw `$group` result, whose `_id` is the grouping key and not an entity
- * id — never reaches a client: every aggregation behind these routers maps its
- * `_id` into a named field first (`analyticsController` emits `cityId` and
- * `bucket`; `partnerController` folds it into a status total). If a future
- * endpoint ever needs to pass a third-party payload through verbatim, it must
- * not gain that property by accident — give it a route that serializes
- * explicitly instead of widening this.
+ * Nothing this API returns is legitimately named `_id` — checked, not assumed,
+ * and pinned by `__tests__/integration/wireIdContract.test.ts`, which sweeps the
+ * public endpoints and fails on `"_id"` anywhere in any body.
+ *
+ * The two shapes that could have been a problem are both absent:
+ *
+ *   - **A raw `$group` result**, whose `_id` is the grouping key and not an
+ *     entity id, never reaches a client. Every aggregation behind these routers
+ *     maps it into a named field first — `analyticsController` emits `cityId`
+ *     and `bucket`, `partnerController` folds it into a status total.
+ *   - **A third-party payload relayed verbatim.** There is none. The only
+ *     upstream bodies this service parses are Nominatim (`lat`/`lon`/
+ *     `display_name`), Overpass (`id`/`lat`/`lon`/`tags`) and Wikimedia
+ *     (`pageid`) — none of which uses `_id` — plus `routes/ai.ts` calling
+ *     Homiio's OWN `/api/properties*` endpoints, whose bodies this middleware
+ *     already serialized once, and on which a second pass is a no-op. Oxy's
+ *     `/users/by-ids` is read in `controllers/roommate/serialize.ts` but its
+ *     payload is projected into Homiio's own shape and never reaches `res.json`.
+ *
+ * If a future endpoint DOES need to relay a third-party payload verbatim, it
+ * must not acquire this behaviour by accident: give it a route that serializes
+ * explicitly, rather than widening this.
  *
  * ## Where it is mounted, and why not in `server.ts`
  *


### PR DESCRIPTION
Follow-up to #287, addressing both asks on the serializer. No behaviour change to the transform itself — this makes its central claim checkable, and states what it does to payloads that are not entities.

## 1. The negative claim is now pinned across endpoints

`middlewares/wireIds.ts` rests on *"nothing this API returns is legitimately named `_id`"*. That is checkable, so `wireIdContract.test.ts` now sweeps the public endpoints and fails on `"_id"` in any body — **naming the offending path**, so the gate says where to look rather than only that something is wrong.

### The sweep carries a vacuity floor, because the first draft needed one

The first version of this sweep was mostly measuring nothing, and I only found that by printing what each path actually returned. **10 of its 16 paths came back an empty list, a 404, or a 500** — it would have gone green with the serializer removed from most of them.

The concrete cause: the city endpoints read **Postgres** since an earlier batch and no longer touch the Mongo `City` model, so a Mongo-only fixture leaves them empty. They are seeded through `postgresGeoFixtures` now, and **a path only counts as coverage once its body is asserted to contain real entity data** (`HTTP 200` *and* a `"id":` in the body), with the failure listing every path that came back empty.

### Two public GETs are excluded on purpose, with the reason in the test

- `/api/analytics/stats` returns aggregates, not entities, so it has no `id` to floor on. It gets its own case instead, pinning that its `$group` keys stay mapped to `cityId` and `bucket` — the property that makes a whole-body strip safe on this router at all. The day someone returns a raw aggregation, that test fails instead of a field's meaning silently changing.
- `/api/properties/by-ids` filters `status: 'active'`, and **`active` is not a value in `PropertyStatus`** (`draft`/`published`/`reserved`/`rented`/`sold`/`inactive`/`archived`). It cannot return a row for any fixture. That is a **pre-existing bug in `controllers/property/batch.ts`** — the endpoint is effectively dead — surfaced by the floor. Left alone here: it is not this contract's to fix, and changing a status filter could un-hide listings.

### Mutation-tested, including the case that deliberately survives

| Mutation | Result |
|---|---|
| serializer skips property-shaped objects (a targeted hole) | **3 red**, naming `/api/properties` and the city-properties path |
| re-add `_id` to `cityController`'s own response literal | **0 red — and that is correct** |

The second one is recorded in the test so nobody later reads it as a gap: the chokepoint strips `_id` downstream, so the wire is still right and there is no regression to report. The subject under test is the **wire**, not which layer produced it. (#287 already mutation-tested the serializer being unmounted, not deleting `_id`, losing its recursion, and clobbering a pre-existing `id` — all caught.)

### Also pinned

- The **envelope and pagination block survive the rebuild** — a transform that dropped `pagination` would have passed every `_id` assertion in the file.
- **Error bodies** pass through intact and carry no `_id`. They *do* go through the transform: `errorHandler` runs on a response whose `res.json` the middleware already replaced.
- A **numeric `id`** — what an Overpass/OSM element carries — is returned untouched.

## 2. What the transform touches is stated, not discovered

The docblock now names the behaviour per payload kind: entity documents nested at any depth, envelopes, error bodies, a non-entity `id`, and `Date`/`Buffer`.

It also records the **passthrough audit**, since a recursive strip reaching into a payload Homiio merely relays is the failure mode worth ruling out explicitly. There is no such payload — every upstream body this service parses was checked:

| Upstream | Keys | Risk |
|---|---|---|
| Nominatim | `lat`, `lon`, `display_name`, `boundingbox` | none — no `_id` |
| Overpass / OSM | `id` (numeric), `lat`, `lon`, `tags` | none — `id` already present always wins |
| Wikimedia | `pageid` | none — no `_id` |
| `routes/ai.ts` → Homiio's own `/api/properties*` | already serialized once | no-op on a second pass |
| Oxy `/users/by-ids` | `id`, `_id` | never reaches `res.json` — projected into Homiio's own shape first |

That last row is the one worth guarding, so `controllers/roommate/serialize.ts` now says why `OxyPublicUser._id` stays: it is a **foreign service's response shape**, and renaming it would only make Homiio stop reading a field Oxy still emits — editing someone else's wire from the wrong side.

## On the ~12 schemas that set `ret.id = ret._id` without deleting `_id`

Naming it as asked, and explaining why it is **not** cleaned up here. Those transforms are no longer redundant-and-wrong, they are load-bearing for a second caller: `toLeaseDTO` / `toReviewDTO` / `toEvictionDTO` call `doc.toJSON()` and then read `id` off the resulting plain object. Removing the transforms would break the DTO mappers, which never touch HTTP. What the inconsistency *did* mean is worth recording: both spellings have been shipping for a long time, so some clients may already read `id` — which made the cut in #287 less risky than it looked.

## Gates

| Gate | Result |
|---|---|
| backend tsc | 0 errors |
| backend jest | **1136/1136**, 99 suites (was 1132; floor 1100) |
| lockfile sync | in sync |
| version pins | clean |
| migration phases | 3/3 |

`packages/frontend`, `packages/shared-types` and `packages/listing-providers` remain at **zero** `_id`. No dependency changed, so `bun.lock` is untouched.

> ⚠️ Unrelated to this PR: the backend ECS deploy has been failing since #286 with `tasks failed to start`, rolling back to `oxy-homiio:12`. Production still serves the pre-#286 image, and `deploy-frontends.yml` is gated on CI success so no frontend/backend skew is possible. Neither #287 nor this PR can fix or worsen it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
