### PR TITLE
ci: invoke wrangler directly, not through cloudflare/wrangler-action

### DIFF
--- a/.github/workflows/deploy-frontends.yml
+++ b/.github/workflows/deploy-frontends.yml
@@ -91,9 +91,35 @@ jobs:
           # VARIABLE, not a secret: the id ships inside the bundle, so it is
           # public by construction and a secret would only hide it from the UI.
           EXPO_PUBLIC_OXY_CLIENT_ID: ${{ vars.EXPO_PUBLIC_OXY_CLIENT_ID }}
+      # `bunx wrangler` DIRECTLY, never `cloudflare/wrangler-action`.
+      #
+      # The action does not just run wrangler, it PROVISIONS it: it probes with
+      # `bun run wrangler --version`, finds nothing (wrangler is not a dependency
+      # of this repo), and installs it itself. That install is the single point
+      # of failure in the only workflow that ships the frontend, and on
+      # 2026-08-09 it took the frontend down with it — run 31292337344 died with
+      # `error: Fail extracting tarball for "wrangler"` after `Script not found
+      # "wrangler"`, published nothing, and left production serving a bundle from
+      # the previous day while the API had already moved to the new wire format.
+      #
+      # This is the same class of failure `~/Oxy/Mercaria/AGENTS.md` records —
+      # "Do NOT use `cloudflare/wrangler-action`: its `npm i wrangler` chokes on
+      # the monorepo's `workspace:*` deps. Run `bunx wrangler` directly" — and
+      # Mercaria's deploy-cloudflare.yml has run this shape since. Do not
+      # "modernise" this back to the action.
+      #
+      # `wrangler@4` is PINNED. An unpinned `bunx wrangler` re-resolves the
+      # latest major on every deploy, which is how a deploy path changes
+      # behaviour with no diff to show for it.
+      #
+      # NOTE this is `pages deploy`, not `deploy`: Homiio's frontend is a
+      # Cloudflare PAGES project (`homiio-frontend`, SPA routing via
+      # `packages/frontend/public/_redirects`). Mercaria serves a Worker with
+      # Static Assets and needs a `wrangler.jsonc` plus `public/.assetsignore`;
+      # none of that applies here and none of it should be copied over — the
+      # shared part is how wrangler is INVOKED, not which product it targets.
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy packages/frontend/dist --project-name=homiio-frontend --branch=main
+        run: bunx wrangler@4 pages deploy packages/frontend/dist --project-name=homiio-frontend --branch=main
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/packages/backend/__tests__/integration/wireIdContract.test.ts
+++ b/packages/backend/__tests__/integration/wireIdContract.test.ts
@@ -25,6 +25,7 @@ import publicRoutes from '../../routes/public';
 import { errorHandler } from '../../middlewares/errorHandler';
 import { renameWireIds } from '../../middlewares/wireIds';
 import { Address, City, Country, Property, Region } from '../../models';
+import { resetGeoTables, seedGeoChain } from '../helpers/postgresGeoFixtures';
 import { OfferingType, PropertyStatus, PropertyType } from '@homiio/shared-types';
 
 function buildApp(): Express {
@@ -95,6 +96,10 @@ describe('renameWireIds', () => {
 describe('the wire contract, over a real request', () => {
   const app = buildApp();
 
+  beforeEach(async () => {
+    await resetGeoTables();
+  });
+
   /** Seed a published property in a city, and return the ids Mongo assigned. */
   async function seedCityProperty(): Promise<{ cityId: string; propertyId: string }> {
     const country = await Country.create({ code: 'ES', name: 'Spain', currency: 'EUR' });
@@ -158,5 +163,143 @@ describe('the wire contract, over a real request', () => {
     // that nothing gets past it, and a per-field assertion only covers the
     // fields somebody remembered.
     expect(JSON.stringify(res.body)).not.toContain('"_id"');
+  });
+
+  /**
+   * The sweep, and the reason it carries a vacuity floor.
+   *
+   * One endpoint proving the serializer works says nothing about the one added
+   * next week, and the claim this middleware rests on is about the WHOLE router:
+   * "nothing this API returns is legitimately named `_id`". That is checkable,
+   * so it is checked.
+   *
+   * A scan for `"_id"` over a body that came back `[]` or `500` passes for the
+   * wrong reason, and the first draft of this test did exactly that — 10 of its
+   * 16 paths returned an empty list, a 404, or an error, so it would have gone
+   * green with the serializer removed from most of them. Hence the split below:
+   * a path is only counted as COVERAGE once its body is asserted to contain
+   * real entity data, and the assertion names the path that failed.
+   *
+   * The city endpoints need Postgres seeded as well as Mongo — they were ported
+   * in an earlier batch and no longer read the Mongo `City` model — which is the
+   * concrete way that first draft was silently empty.
+   *
+   * ## What this deliberately does NOT catch, so nobody reads it as a hole
+   *
+   * Putting `_id` back into a CONTROLLER's own response literal fails nothing
+   * here — verified by mutation, not assumed. That is the chokepoint working:
+   * `middlewares/wireIds.ts` strips it downstream, so the wire is still correct
+   * and there is no regression to report. What these cases do catch is a hole in
+   * the serializer itself (mutated to skip property-shaped objects: three cases
+   * red, naming `/api/properties` and the city-properties path) and the
+   * serializer being unmounted altogether. The subject under test is the WIRE,
+   * not which layer happens to produce it.
+   */
+  it('emits no `_id` from any public endpoint that returns entities', async () => {
+    const { cityId } = await seedCityProperty();
+    const chain = await seedGeoChain({ cityName: 'Barcelona', propertiesCount: 3 });
+
+    const entityPaths = [
+      '/api/cities',
+      '/api/cities/search?q=Barc',
+      '/api/cities/lookup?name=Barcelona',
+      `/api/cities/${chain.cityId}`,
+      `/api/cities/${cityId}/properties?limit=8`,
+      '/api/properties',
+    ];
+    // Two public GETs are deliberately absent, and neither absence is laziness:
+    //   - `/api/analytics/stats` returns aggregates, not entities, so it has no
+    //     `id` to floor on. It has its own case below.
+    //   - `/api/properties/by-ids` filters `status: 'active'`, which is not a
+    //     value in `PropertyStatus` (draft/published/reserved/rented/sold/
+    //     inactive/archived), so it cannot return a row for any fixture. That is
+    //     a pre-existing bug in `controllers/property/batch.ts`, unrelated to
+    //     this contract; listing it here would only buy a permanently empty body
+    //     that passes the `_id` scan for the wrong reason.
+
+    const leaked: string[] = [];
+    const empty: string[] = [];
+    for (const path of entityPaths) {
+      const res = await request(app).get(path);
+      const body = JSON.stringify(res.body ?? null);
+      if (body.includes('"_id"')) leaked.push(`${path} (HTTP ${res.status})`);
+      // The floor. A body with no `"id":` in it exercised nothing, so treating it
+      // as a pass would be the bug this whole test exists to catch.
+      if (res.status !== 200 || !body.includes('"id":')) {
+        empty.push(`${path} (HTTP ${res.status}, ${body.slice(0, 60)})`);
+      }
+    }
+
+    // Naming the offending path is the difference between a gate that tells you
+    // where to look and one that tells you only that something is wrong.
+    expect(leaked).toEqual([]);
+    expect(empty).toEqual([]);
+  });
+
+  /**
+   * Failure bodies go through the transform too — `errorHandler` runs on a
+   * response whose `res.json` this middleware already replaced. They carry no
+   * `_id`, but they DO pass through, and the envelope has to survive the rebuild.
+   */
+  it('passes error bodies through intact and without `_id`', async () => {
+    const errorPaths = [
+      '/api/cities/000000000000000000000000',
+      '/api/cities/lookup?name=Atlantis&country=Nowhere',
+    ];
+
+    for (const path of errorPaths) {
+      const res = await request(app).get(path);
+      expect(res.status).toBe(404);
+      expect(JSON.stringify(res.body)).not.toContain('"_id"');
+      expect(res.body.success).toBe(false);
+      expect(typeof res.body.message).toBe('string');
+    }
+  });
+
+  it('leaves the envelope, the pagination block and a non-entity `id` intact', async () => {
+    const { cityId } = await seedCityProperty();
+
+    const res = await request(app).get(`/api/cities/${cityId}/properties?limit=8`).expect(200);
+
+    // The transform rebuilds every object it walks, so the envelope keys have to
+    // survive that rebuild — a serializer that dropped `pagination` would still
+    // pass every `_id` assertion in this file.
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.pagination).toEqual(
+      expect.objectContaining({ page: 1, limit: 8, total: 1, pages: 1 }),
+    );
+    expect(res.body.data.city.name).toBe('Barcelona');
+
+    // A NUMERIC `id` is what an Overpass/OSM element carries, and the one shape a
+    // "stringify the id" transform would quietly corrupt if it ever stopped
+    // deferring to an `id` already present.
+    expect(renameWireIds({ id: 42, tags: { amenity: 'cafe' } })).toEqual({
+      id: 42,
+      tags: { amenity: 'cafe' },
+    });
+  });
+
+  /**
+   * `analyticsController` is the one endpoint whose underlying data really does
+   * have an `_id` that is NOT an entity id — a `$group` key. It maps that into
+   * `cityId` and `bucket` BEFORE responding, which is the reason a whole-body
+   * strip is safe on this router at all. Pinning it here means the day someone
+   * returns a raw aggregation, this fails rather than the meaning of a field
+   * silently changing.
+   */
+  it('keeps aggregation group keys mapped to named fields, never `_id`', async () => {
+    await seedCityProperty();
+
+    const res = await request(app).get('/api/analytics/stats').expect(200);
+
+    expect(JSON.stringify(res.body)).not.toContain('"_id"');
+    for (const row of res.body.data.topCities ?? []) {
+      expect(row).toHaveProperty('cityId');
+      expect(row).not.toHaveProperty('id');
+    }
+    for (const row of res.body.data.priceBuckets ?? []) {
+      expect(row).toHaveProperty('bucket');
+      expect(row).not.toHaveProperty('id');
+    }
   });
 });

--- a/packages/backend/controllers/roommate/serialize.ts
+++ b/packages/backend/controllers/roommate/serialize.ts
@@ -5,6 +5,16 @@
 import config from '../../config';
 import { logger } from '../../middlewares/logging';
 
+/**
+ * A user as the OXY API returns it from `POST /users/by-ids`.
+ *
+ * The `_id` here is deliberate and must NOT be renamed by a sweep of Homiio's
+ * own `_id` → `id` cut. This is a foreign service's response shape, not Homiio's
+ * wire: Oxy decides what it sends, and editing this declaration would only make
+ * Homiio stop reading a field Oxy still emits. It is also never re-served — the
+ * payload is projected into {@link SerializedRoommateProfile} below and the raw
+ * object never reaches `res.json`.
+ */
 interface OxyPublicUser {
   id?: string;
   _id?: string;

--- a/packages/backend/middlewares/wireIds.ts
+++ b/packages/backend/middlewares/wireIds.ts
@@ -31,16 +31,52 @@
  * Mongoose document, and a serializer that edits its argument would corrupt the
  * first and try to `delete` a schema path on the second.
  *
+ * ## Exactly what it touches, and what it leaves alone
+ *
+ * The walk is RECURSIVE and reaches every object and array element in the body,
+ * at any depth. That breadth is the point — a nested populated document is
+ * precisely where a top-level-only rename leaves `_id` behind — but it is also
+ * the whole risk surface, so what it does to each kind of payload is stated
+ * rather than left to be discovered:
+ *
+ *   - **Entity documents, nested or not.** `_id` → `id`. This is the job.
+ *   - **Envelopes.** `successResponse` and `paginationResponse` wrap data in
+ *     `{ success, message, data, meta }` / `{ … pagination }`. Those keys carry
+ *     no `_id`, so the envelope is rebuilt field-for-field and reaches the client
+ *     unchanged; only the entities inside `data` are rewritten.
+ *   - **Error bodies.** `errorHandler` runs after these routers, on a response
+ *     whose `res.json` this middleware has already replaced, so error payloads
+ *     pass through it too. They carry no `_id` and are unaffected — but they DO
+ *     pass through, which is worth knowing before adding a field to one.
+ *   - **A non-entity `id`.** Never touched. Only `_id` is removed, and an `id`
+ *     already present always wins, whatever its type.
+ *   - **`Date` and `Buffer`.** Returned as-is rather than walked, so they still
+ *     serialize the way `res.json` would render them.
+ *
  * ## Why a whole-body walk is safe HERE and would not be in general
  *
- * Nothing this API returns is legitimately named `_id`. The one shape that could
- * be — a raw `$group` result, whose `_id` is the grouping key and not an entity
- * id — never reaches a client: every aggregation behind these routers maps its
- * `_id` into a named field first (`analyticsController` emits `cityId` and
- * `bucket`; `partnerController` folds it into a status total). If a future
- * endpoint ever needs to pass a third-party payload through verbatim, it must
- * not gain that property by accident — give it a route that serializes
- * explicitly instead of widening this.
+ * Nothing this API returns is legitimately named `_id` — checked, not assumed,
+ * and pinned by `__tests__/integration/wireIdContract.test.ts`, which sweeps the
+ * public endpoints and fails on `"_id"` anywhere in any body.
+ *
+ * The two shapes that could have been a problem are both absent:
+ *
+ *   - **A raw `$group` result**, whose `_id` is the grouping key and not an
+ *     entity id, never reaches a client. Every aggregation behind these routers
+ *     maps it into a named field first — `analyticsController` emits `cityId`
+ *     and `bucket`, `partnerController` folds it into a status total.
+ *   - **A third-party payload relayed verbatim.** There is none. The only
+ *     upstream bodies this service parses are Nominatim (`lat`/`lon`/
+ *     `display_name`), Overpass (`id`/`lat`/`lon`/`tags`) and Wikimedia
+ *     (`pageid`) — none of which uses `_id` — plus `routes/ai.ts` calling
+ *     Homiio's OWN `/api/properties*` endpoints, whose bodies this middleware
+ *     already serialized once, and on which a second pass is a no-op. Oxy's
+ *     `/users/by-ids` is read in `controllers/roommate/serialize.ts` but its
+ *     payload is projected into Homiio's own shape and never reaches `res.json`.
+ *
+ * If a future endpoint DOES need to relay a third-party payload verbatim, it
+ * must not acquire this behaviour by accident: give it a route that serializes
+ * explicitly, rather than widening this.
  *
  * ## Where it is mounted, and why not in `server.ts`
  *


### PR DESCRIPTION
Replaces `cloudflare/wrangler-action@v3` with a direct, pinned `bunx wrangler@4 pages deploy` in the only workflow that ships the frontend.

> **Not an emergency any more.** The failed deploy was re-run and succeeded, and production is consistent again (verified below). This is the hardening so the next deploy is not a coin flip.

## What happened

The action does not merely *run* wrangler, it **provisions** it: it probes with `bun run wrangler --version`, finds nothing — wrangler is not a dependency of this repo — and installs it itself. That install is the single point of failure in the one workflow that ships the frontend, and on 2026-08-09 it took the frontend down:

```
🔍 Checking for existing Wrangler installation
/home/runner/.bun/bin/bun run wrangler --version
error: Script not found "wrangler"
⚠️ Wrangler not found or version is incompatible. Installing...
error: Fail extracting tarball for "wrangler"
##[error]The process '/home/runner/.bun/bin/bun' failed with exit code 1
```

Run `31292337344` published **nothing** — the live entry bundle hash was unchanged afterwards — while the API had already moved to the `id` wire format (#287). Production served a frontend from the previous day reading `_id` against a backend that no longer emits it: **43 unguarded `._id` reads** across saved folders, viewings, the home-screen city sections, room lists, address and agency pages.

The failure was silent unless somebody checked the deployed bundle rather than the workflow's dispatch — the workflow *ran*, `scope` passed, and only the deploy step died.

## Why this shape, and why not the action

`~/Oxy/Mercaria/AGENTS.md` already records this class of failure:

> Do NOT use `cloudflare/wrangler-action`: its `npm i wrangler` chokes on the monorepo's `workspace:*` deps. Run `bunx wrangler` directly.

Mercaria's `deploy-cloudflare.yml` has run the direct shape since. Homiio has the same monorepo shape and had not moved. **The reasoning is now in the workflow itself**, so nobody "modernises" it back to the action later.

`wrangler@4` is **pinned**: an unpinned `bunx wrangler` re-resolves the latest major on every deploy, which is how a deploy path changes behaviour with no diff to show for it.

## Deliberately still `pages deploy`, not `deploy`

Homiio's frontend is a Cloudflare **Pages** project (`homiio-frontend`, SPA routing via `packages/frontend/public/_redirects`). It has no `wrangler.jsonc`, no `_worker.js` and no `public/.assetsignore` — **and needs none**. Mercaria serves a Worker with Static Assets and needs all three.

What the two repos share is how wrangler is *invoked*, not which product it targets. Copying Mercaria's Workers conventions here would be a platform migration wearing a bugfix's clothes, so this PR does not.

## Credentials and injection surface

Credentials move from the action's `apiToken`/`accountId` inputs to the `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` environment variables wrangler reads natively — the same way Mercaria passes them. The `run:` string is **fully static**: no `${{ }}` interpolation, so this adds no workflow-injection surface.

## Verification

The workflow parses, the deploy step no longer carries a `uses:`, and `.github/scripts/test-deployment-scope.sh` still discriminates 8 cases (the `scope` job is untouched).

Production, checked after the successful re-run — and checked on the artefact, not the exit code:

| | before | after |
|---|---|---|
| live entry bundle | `entry-a8469b5c…` | `entry-1a222fd3…` (11,395,437 B) |
| `._id` reads in the deployed bundle | 137 | **21** |
| `GET /api/properties?limit=2` | — | **0 `_id`, 47 `id`** |

The 21 remaining are all bundled **Oxy SDK** code reading Oxy's own API shape (`resolveUserId(n){return n.id??n._id}`, `getNormalizedUserHandle`, `blockedId._id`, `restrictedId._id`, `memberId`), plus one unrelated `this._id = 0` counter in a library class. Homiio's own frontend source is at zero — that is a foreign service's contract and is correctly left alone, the same call made for `OxyPublicUser._id` in #289.

> One caution on that measurement, since it nearly fooled me: an intermediate fetch returned **1825 bytes** with zero `._id`, which reads as a clean pass. It was the SPA HTML fallback served during propagation, not the bundle. Any check of a deployed asset needs to assert it got the artefact it thinks it did — hence the byte count and the `.id` floor above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
