### PR TITLE
Gate NUL bytes repository-wide, not just under `db/`

### DIFF
--- a/packages/backend/__tests__/db/geoBackfill.test.ts
+++ b/packages/backend/__tests__/db/geoBackfill.test.ts
@@ -14,8 +14,6 @@
  * together.
  */
 
-import { readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import mongoose from 'mongoose';
 import { eq, inArray, getTableName, sql } from 'drizzle-orm';
 import { alias, getTableConfig, type PgTable } from 'drizzle-orm/pg-core';
@@ -421,40 +419,6 @@ describe('geo backfill — the copy order', () => {
         expect(position.get(parent)!).toBeLessThan(position.get(getTableName(table))!);
       }
     }
-  });
-});
-
-describe('db/ sources are text, not binary', () => {
-  /**
-   * A single NUL byte makes git classify a source file as BINARY, and from then
-   * on it has no diff: `git show`, `git log -p` and every pull-request review
-   * print `Bin 0 -> N bytes` instead of the code. Nothing else notices — tsc,
-   * eslint, jest and CI all passed on a `db/backfill/rowAudit.ts` that carried
-   * two of them, and the only thing that ever said so was `git show --stat`
-   * after the merge.
-   *
-   * That is the shape this repository gates rather than remembers: a wrong
-   * thing nothing trips over. Scoped to `db/` because that is where the
-   * migration code lives; widen it if the class recurs elsewhere.
-   */
-  const roots = [join(__dirname, '..', '..', 'db'), __dirname];
-
-  function typescriptFiles(directory: string): string[] {
-    return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-      const path = join(directory, entry.name);
-      if (entry.isDirectory()) return typescriptFiles(path);
-      return entry.isFile() && path.endsWith('.ts') ? [path] : [];
-    });
-  }
-
-  it('contains no NUL byte in any db/ TypeScript file', () => {
-    const files = roots.flatMap(typescriptFiles);
-    // Vacuity floor: a traversal that silently stopped matching would otherwise
-    // report "no offenders" forever, which is the same failure in a new costume.
-    expect(files.length).toBeGreaterThan(30);
-
-    const offenders = files.filter((path) => readFileSync(path).includes(0));
-    expect(offenders).toEqual([]);
   });
 });
 

--- a/packages/backend/__tests__/unit/sourceFilesAreText.test.ts
+++ b/packages/backend/__tests__/unit/sourceFilesAreText.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Every tracked source file is TEXT, not binary — repository-wide.
+ *
+ * ## The hole this closes, which passes every other gate by construction
+ *
+ * A single NUL byte makes git classify a file as binary, and a binary file has
+ * **no diff**: `git show`, `git log -p` and every pull-request review print
+ * `Bin 0 -> N bytes` where the code should be. Nobody reviewing that pull
+ * request can see a line of it.
+ *
+ * Nothing else notices. `packages/backend/db/backfill/rowAudit.ts` shipped in
+ * PR #293 carrying two of them, inside a template literal used as a map key:
+ * TypeScript compiled it, eslint passed it, its own 36 tests passed, and every
+ * CI job was green. The only thing that ever said so was `git show --stat`
+ * after the merge, which nobody has a reason to run.
+ *
+ * So this is a REVIEWABILITY property, not a correctness one, and it cannot be
+ * caught by a tool that reads the file as text — every one of them decodes the
+ * NUL happily. It has to be asserted on the bytes.
+ *
+ * ## Repository-wide, deliberately
+ *
+ * This started scoped to `packages/backend/db/`, where the defect happened. That
+ * is the wrong scope: the hazard belongs to the REPOSITORY (git's classification
+ * and what a reviewer can see), not to any package, and a file written anywhere
+ * by anyone has the same problem. Living in the backend suite is a compromise —
+ * it is the suite CI always runs — and it costs about 10 MB of reads.
+ *
+ * `git ls-files` rather than a directory walk: it is the exact set git will
+ * classify, so the check cannot disagree with the thing it is checking, and
+ * `node_modules`, `dist` and every build output are excluded for free rather
+ * than by a hand-maintained ignore list that would rot.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** The repository root — two levels above this package. */
+const REPOSITORY_ROOT = join(__dirname, '..', '..', '..', '..');
+
+/**
+ * Extensions a human reads in a diff.
+ *
+ * Not "everything git tracks": fonts, images and lockfile binaries are
+ * legitimately binary, and listing what must be TEXT is the affirmative form —
+ * a new binary asset type cannot silently widen it.
+ */
+const TEXT_EXTENSIONS = [
+  '*.ts',
+  '*.tsx',
+  '*.js',
+  '*.jsx',
+  '*.mjs',
+  '*.cjs',
+  '*.json',
+  '*.md',
+  '*.yml',
+  '*.yaml',
+  '*.sql',
+];
+
+/**
+ * Floor on the number of files scanned.
+ *
+ * A traversal that silently stopped matching — a moved root, a renamed
+ * extension, a `git ls-files` that returned nothing because the working
+ * directory was wrong — would otherwise report "no offenders" forever, which is
+ * the same class of failure this file exists to catch. Measured at 1,212 on
+ * 2026-08-09; set well below it so ordinary deletion cannot trip it.
+ */
+const MINIMUM_FILES_SCANNED = 800;
+
+function trackedTextFiles(): string[] {
+  const output = execFileSync('git', ['ls-files', '-z', '--', ...TEXT_EXTENSIONS], {
+    cwd: REPOSITORY_ROOT,
+    encoding: 'buffer',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return output
+    .toString('utf8')
+    .split('\0')
+    .filter((path) => path.length > 0);
+}
+
+describe('tracked source files are text, not binary', () => {
+  it('contains no NUL byte, so every file has a reviewable diff', () => {
+    const files = trackedTextFiles();
+    expect(files.length).toBeGreaterThan(MINIMUM_FILES_SCANNED);
+
+    const offenders = files.filter((path) =>
+      readFileSync(join(REPOSITORY_ROOT, path)).includes(0),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('can actually detect one — the check is not vacuous', () => {
+    // The assertion above is `[] === []` on a clean tree, which is exactly what
+    // a broken scan also produces. This pins the predicate itself against a
+    // buffer holding the byte, so "no offenders" means the scan looked.
+    expect(Buffer.from('const key = `a\0b`;', 'utf8').includes(0)).toBe(true);
+    expect(Buffer.from('const key = `a b`;', 'utf8').includes(0)).toBe(false);
+  });
+});

--- a/packages/backend/db/backfill/geo.ts
+++ b/packages/backend/db/backfill/geo.ts
@@ -311,6 +311,14 @@ export interface SourceData {
  * cover the WHOLE plan — every table, every foreign key — before the first
  * insert. The volume makes that free: 7 countries, 211 regions, 1,660 cities,
  * 4,521 neighborhoods and 1,297 geo images is under eight thousand documents.
+ *
+ * **That shape is bounded by THIS batch and does not generalise — do not copy it
+ * into a larger one.** The task this runs on is 512 CPU / 1024 MB, and the rest
+ * of the migration is two orders of magnitude bigger: 170,679 property images
+ * and 17,644 properties each carrying an embedded `images[]`. Loading those
+ * before mapping is an OOM, not a slow run. A large batch has to stream with a
+ * cursor and keep only the parent-id SETS the foreign-key rules need, in two
+ * passes, so that "audit the whole plan before the first insert" still holds.
  */
 export async function loadSource(database: MongoDatabase): Promise<SourceData> {
   const read = async (collection: string, filter: Record<string, unknown> = {}) =>


### PR DESCRIPTION
Answering the question on #294: **the scanner was scoped to `packages/backend/db/`.** Widening it, as suggested — it is cheap insurance and the narrow scope was wrong on principle.

## Why this is worth a gate at all

A single NUL byte makes git classify a file as **binary**, and a binary file has no diff: `git show`, `git log -p` and every pull-request review print `Bin 0 -> N bytes` where the code should be. Nobody reviewing that PR can see a line of it.

`db/backfill/rowAudit.ts` shipped in #293 carrying two of them, inside a template literal used as a map key. tsc compiled it, eslint passed it, its own 36 tests passed, and every CI job was green. The only thing that ever said so was `git show --stat` after the merge, which nobody has a reason to run.

It is a **reviewability** hole that passes every gate by construction, and no tool that reads the file as text can catch it — they all decode the NUL happily. It has to be asserted on the bytes.

## What changes

`packages/backend/__tests__/unit/sourceFilesAreText.test.ts` replaces the `db/`-scoped block in `geoBackfill.test.ts`. It scans **every tracked source file in the monorepo** — 1,212 files, ~10 MB, ~60 ms.

- **`git ls-files`, not a directory walk.** It is the exact set git classifies, so the check cannot disagree with the thing it is checking — and `node_modules`, `dist` and every build output are excluded for free rather than by a hand-maintained ignore list that would rot.
- **The extension list is affirmative** (what must be TEXT: `.ts .tsx .js .jsx .mjs .cjs .json .md .yml .yaml .sql`) rather than "everything git tracks minus known binaries". Fonts and images are legitimately binary; a new binary asset type cannot silently widen the rule.
- **It lives in the backend suite** as a compromise: the property belongs to the repository, not to any package, and that is the suite CI always runs.

## Two defences against it going vacuous

`expect(offenders).toEqual([])` on a clean tree is exactly what a *broken* scan also produces — the failure mode this file exists to catch, in the file itself.

1. A floor on the number of files scanned (1,212 measured, 800 asserted), so a moved root or a `git ls-files` run from the wrong directory cannot pass as "no offenders".
2. A case pinning the predicate against a buffer that holds the byte, so the detection itself is proven and not assumed.

**Mutation-tested**: injecting a NUL into `packages/frontend/package.json` — a different package entirely, which the old `db/` scanner could never have seen — turns it red and names the path.

## Also

Documents that `loadSource`'s load-everything-then-map shape in `db/backfill/geo.ts` is **bounded by the geo batch and does not generalise**. It is free at under eight thousand documents and an OOM at 170,679 property images on a 512 CPU / 1024 MB task. The note sits where somebody would otherwise copy it into a large batch; the full-backfill agent has been told directly as well.

## Testing

**105 suites, 1233 tests**, all green locally (104 / 1232 before). typecheck clean, 0 lint errors. No dependency or migration change.