### PR TITLE
Record the `$onUpdate` restamp trap beside the column helper that carries it

### DIFF
--- a/packages/backend/db/schema/CONVENTIONS.md
+++ b/packages/backend/db/schema/CONVENTIONS.md
@@ -210,6 +210,29 @@ Mongoose. Deliberately not a trigger: a trigger is invisible in the schema file,
 and it would fire during backfill and overwrite the historical value the
 migration exists to preserve.
 
+> **That last sentence is the trap, not the reassurance it reads as.** Rejecting
+> the trigger did not remove the hazard — it moved it from "always" to "unless
+> you name the column". `$onUpdate` fires on **every `db.update()` that does not
+> set `updated_at` explicitly**, so a repair touching one wrong column restamps
+> the row with the migration's clock and destroys exactly the value the trigger
+> was rejected for destroying. Any backfill, reconcile or one-shot repair must
+> either write the source's `updated_at` explicitly or write the whole row.
+>
+> Not hypothetical, and not one person's slip: during the geo backfill
+> (2026-08-09) two independent repairs of the SAME 1,213 city covers each met it
+> from a different direction and each had to defend against it by hand. A hazard
+> two people meet independently belongs to the column helper, not to the task —
+> which is why it is recorded here beside the helper rather than in either
+> script.
+>
+> Writing the whole row is the more robust of the two defences, because it does
+> not depend on remembering. A test that pins it needs a fixture where
+> `updated_at` is ALREADY correct and some other column is wrong: with both
+> wrong, "write the columns that differ" and "write every column" produce the
+> same result and the weaker one passes. Reference:
+> `__tests__/db/geoBackfill.test.ts`, "repairs a row whose ONLY wrong column is
+> the cover, without stamping updated_at".
+
 Where Mongo kept a SECOND, application-written timestamp beside
 `timestamps: true` — `cities.last_updated` — both are ported. They are two
 different facts: one moves on any write, the other only when the count is


### PR DESCRIPTION
Per the suggestion on #296 — checked whether it was already in `CONVENTIONS.md`, and it isn't. What's there points the *wrong way*, which is why this is a correction rather than an addition.

## The existing text reads as reassurance and is a trap

`db/schema/CONVENTIONS.md` §Timestamps currently says:

> **`updated_at` is maintained by the application** (`$onUpdate`), matching Mongoose. Deliberately not a trigger: a trigger is invisible in the schema file, and it would fire during backfill and overwrite the historical value the migration exists to preserve.

Read by someone about to write a repair, that says the backfill hazard was designed out. It wasn't. Rejecting the trigger moved it from **"always"** to **"unless you name the column"**:

`$onUpdate` fires on every `db.update()` that does not set `updated_at` explicitly. So a repair touching one wrong column restamps the row with the migration's clock — destroying precisely the value the trigger was rejected for destroying. The paragraph is most misleading to the one reader who most needs it.

## Why it belongs on the helper, not in a script

During the geo backfill (2026-08-09) **two independent repairs of the same 1,213 city covers each met this from a different direction** — one from a reconcile pass that would have rewritten all 1,213, one from a manual cover repair that would have done the same — and each defended against it by hand, separately.

A hazard two people meet independently isn't a property of either task. It's a property of the column helper, so it's recorded beside the helper.

## Also records what it takes to TEST

Writing the **whole row** is the stronger of the two defences, because it doesn't depend on remembering.

Pinning it needs a fixture where `updated_at` is **already correct** and some other column is wrong. With both wrong — the obvious fixture — "write the columns that differ" and "write every column" produce identical results and the weaker implementation passes. That mutation survived once here before the fixture was sharpened, so the note names the shape rather than just the rule.

The doc points at `__tests__/db/geoBackfill.test.ts`, "repairs a row whose ONLY wrong column is the cover, without stamping updated_at" — verified present.

## Testing

Documentation only; no code path changes. Suite unchanged: **105 suites, 1233 tests**, all green. Confirmed the new text carries no NUL byte, which #296 now gates anyway.