### PR TITLE
Copy the rest of the data — images, addresses, agencies, properties, profiles

### DIFF
--- a/packages/backend/__tests__/db/dataBackfill.test.ts
+++ b/packages/backend/__tests__/db/dataBackfill.test.ts
@@ -1,0 +1,868 @@
+/**
+ * The data backfill, against a real Mongo and a real Postgres.
+ *
+ * Both stores are genuine — the in-memory replica set `jest.setup.ts` starts,
+ * and this worker's own throwaway, fully-migrated Postgres database — and the
+ * end-to-end cases drive `runDataBackfill`, the SAME function the production
+ * one-shot calls. That is the point: the properties under test are a real
+ * `ON CONFLICT DO NOTHING`, real foreign keys, real CHECKs, a real GENERATED
+ * PostGIS column and a real `$in`. A mocked `insert` accepts any statement,
+ * including one the server rejects outright.
+ *
+ * The end-to-end cases run the GEO copy first, because that is the real
+ * ordering: `addresses.city_id` is `NOT NULL` with `ON DELETE RESTRICT`, so the
+ * geo hierarchy has to exist before an address can. Seeding Postgres directly
+ * instead would test a state production never passes through.
+ */
+
+import mongoose from 'mongoose';
+import { eq, sql } from 'drizzle-orm';
+
+import { getDb } from '../../db/postgres';
+import {
+  addresses,
+  agencies,
+  cities,
+  profiles,
+  properties,
+  propertyAvailabilityWindows,
+  propertyImages,
+} from '../../db/schema';
+import { runGeoBackfill } from '../../db/backfill/geo';
+import {
+  checkGeometry,
+  linkCoverImages,
+  readOnly,
+  runDataBackfill,
+} from '../../db/backfill/data';
+import {
+  DATA_COPY_ORDER,
+  DATA_PLANS,
+  DATA_RESOLUTIONS,
+  toAddressRow,
+  toAgencyRow,
+  toProfileChatMessageRows,
+  toProfileRow,
+  toPropertyImageRows,
+  toPropertyRow,
+  toPropertyWindowRows,
+} from '../../db/backfill/dataPlan';
+import { RowAuditor, UniqueKeyAuditor, type CandidateRow } from '../../db/backfill/rowAudit';
+import { ResolutionLog } from '../../db/backfill/geoPlan';
+
+/** The property rules, reached through the PLAN so the test cannot drift from it. */
+const PROPERTY_RULES = DATA_PLANS.properties.rules.properties ?? [];
+
+const oid = () => new mongoose.Types.ObjectId();
+
+/** The Mongo handle `jest.setup.ts` connected, narrowed once. */
+function mongoDatabase() {
+  const database = mongoose.connection.db;
+  if (!database) throw new Error('The test Mongo connection published no database handle.');
+  return database;
+}
+
+// ── fixtures ───────────────────────────────────────────────────────
+//
+// Real coordinates, because the geometry check measures a real distance. A
+// fixture at (0,0) would pass "the column is populated" and prove nothing about
+// the one bug that column exists to make impossible.
+
+const BARCELONA = { lng: 2.1686, lat: 41.3985 };
+const MADRID = { lng: -3.7038, lat: 40.4168 };
+const PARIS = { lng: 2.3522, lat: 48.8566 };
+
+interface GeoFixture {
+  readonly countryId: mongoose.Types.ObjectId;
+  readonly regionId: mongoose.Types.ObjectId;
+  readonly cityIds: Readonly<Record<string, mongoose.Types.ObjectId>>;
+}
+
+/** Countries / regions / cities for the three cities the distance check names. */
+async function seedGeo(): Promise<GeoFixture> {
+  const database = mongoDatabase();
+  const countryId = oid();
+  const regionId = oid();
+  const cityIds: Record<string, mongoose.Types.ObjectId> = {
+    Barcelona: oid(),
+    Madrid: oid(),
+    Paris: oid(),
+  };
+
+  await database.collection('countries').insertOne({
+    _id: countryId,
+    code: 'ES',
+    name: 'Spain',
+    currency: 'EUR',
+    isActive: true,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  });
+  await database.collection('regions').insertOne({
+    _id: regionId,
+    countryId,
+    name: 'Catalonia',
+    isActive: true,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  });
+  for (const [name, id] of Object.entries(cityIds)) {
+    const point = name === 'Barcelona' ? BARCELONA : name === 'Madrid' ? MADRID : PARIS;
+    await database.collection('cities').insertOne({
+      _id: id,
+      name,
+      countryId,
+      regionId,
+      coordinates: { lat: point.lat, lng: point.lng },
+      currency: 'EUR',
+      isActive: true,
+      propertiesCount: 0,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+  }
+  await database.collection('neighborhoods').insertOne({
+    _id: oid(),
+    cityId: cityIds.Barcelona,
+    name: 'Gràcia',
+    bbox: [],
+    isActive: true,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  });
+
+  return { countryId, regionId, cityIds };
+}
+
+function imageDocument(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    _id: oid(),
+    entityType: 'property',
+    entityId: oid(),
+    // Distinct per variant on purpose: four copies of one string cannot tell a
+    // correct flattening from one that writes `small` into `large`.
+    keys: { original: 'k/o', small: 'k/s', medium: 'k/m', large: 'k/l' },
+    urls: { original: 'u/o', small: 'u/s', medium: 'u/m', large: 'u/l' },
+    width: 1200,
+    height: 800,
+    format: 'jpeg',
+    bytes: 45678,
+    isPrimary: false,
+    order: 0,
+    createdAt: new Date('2026-01-02T03:04:05.000Z'),
+    updatedAt: new Date('2026-02-03T04:05:06.000Z'),
+    ...overrides,
+  };
+}
+
+function addressDocument(
+  geo: GeoFixture,
+  city: keyof GeoFixture['cityIds'],
+  point: { lng: number; lat: number },
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    _id: oid(),
+    countryId: geo.countryId,
+    regionId: geo.regionId,
+    cityId: geo.cityIds[city],
+    countryCode: 'ES',
+    street: 'Carrer de Verdi',
+    postal_code: '08012',
+    number: '42',
+    address_lines: [],
+    land_plot: {},
+    extras: { portal: 'idealista', floorRaw: '3º' },
+    coordinates: { type: 'Point', coordinates: [point.lng, point.lat] },
+    normalizedKey: `key-${Math.random().toString(36).slice(2)}`,
+    createdAt: new Date('2026-03-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-03-02T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function propertyDocument(
+  addressId: mongoose.Types.ObjectId,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    _id: oid(),
+    source: 'idealista',
+    sourceId: `ext-${Math.random().toString(36).slice(2)}`,
+    sourceUrl: 'https://www.idealista.com/inmueble/1/',
+    isExternal: true,
+    addressId,
+    type: 'apartment',
+    status: 'published',
+    offerings: ['long_term_rent'],
+    longTermRent: { monthlyAmount: 1200, currency: 'EUR' },
+    amenities: ['lift', 'balcony'],
+    availability: { isAvailable: true, availableFrom: new Date('2026-04-01T00:00:00.000Z') },
+    rules: { pets: false, smoking: false, parties: false, guests: true, maxOccupancy: 2 },
+    rating: { average: 0, count: 0 },
+    createdAt: new Date('2026-03-10T00:00:00.000Z'),
+    updatedAt: new Date('2026-03-11T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+/** Seed a coherent source and copy the geo half, as production did. */
+async function seedAndCopyGeo(): Promise<GeoFixture> {
+  const geo = await seedGeo();
+  await runGeoBackfill({ mongo: mongoDatabase(), database: getDb(), mode: 'copy', sampleSize: 5 });
+  return geo;
+}
+
+/** Every collection these fixtures write, cleared between cases. */
+const SOURCE_COLLECTIONS = [
+  'countries',
+  'regions',
+  'cities',
+  'neighborhoods',
+  'images',
+  'addresses',
+  'agencies',
+  'properties',
+  'profiles',
+] as const;
+
+/**
+ * Empty BOTH stores, before every case AND after the last one.
+ *
+ * Neither is cleaned for us. `jest.setup.ts`'s `afterEach` walks
+ * `mongoose.connection.collections`, which lists only collections mongoose knows
+ * through a MODEL — these fixtures are written through the raw driver, so
+ * mongoose has never heard of them and they survive. Postgres has no hook at
+ * all.
+ *
+ * `beforeEach` protects THIS file: left to accumulate, every `seedGeo` adds
+ * another country with code `ES`, `countries_code_key` absorbs it under
+ * `ON CONFLICT DO NOTHING`, and its regions then dangle — a fair demonstration
+ * of the hazard `UniqueKeyAuditor` exists for, and a useless thing to spend a
+ * test run on.
+ *
+ * `afterEach` protects everyone ELSE, and it is not redundant: jest runs test
+ * FILES sequentially in one worker against one database, so rows this file
+ * leaves behind are rows the next file starts with. Without it `geoBackfill`
+ * fails ten cases for reasons entirely inside this one — and only when the two
+ * run together, which is the hardest kind of failure to attribute.
+ *
+ * `CASCADE` because the FK graph is the point of these tables; this is the
+ * worker's OWN throwaway database, created and dropped by `db/testDatabase.ts`.
+ */
+async function emptyBothStores(): Promise<void> {
+  await Promise.all(
+    SOURCE_COLLECTIONS.map((name) => mongoDatabase().collection(name).deleteMany({})),
+  );
+  await getDb().execute(sql`
+    truncate table
+      property_availability_windows, property_documents, property_images, properties,
+      profile_chat_messages, profile_roommate_history, profile_preferred_locations,
+      profile_rental_history, profile_references, profiles,
+      addresses, agencies, neighborhoods, cities, regions, countries, images
+    cascade
+  `);
+}
+
+beforeEach(emptyBothStores);
+afterEach(emptyBothStores);
+
+// ── argument guards ────────────────────────────────────────────────
+
+describe('data backfill — argument guards', () => {
+  it('defaults --only to every collection, in copy order', () => {
+    expect(readOnly([])).toEqual([...DATA_COPY_ORDER]);
+  });
+
+  it('refuses an --only naming a collection that does not exist', () => {
+    // A typo silently running nothing is a successful-looking no-op, which is
+    // the failure the whole entrypoint is built against.
+    expect(() => readOnly(['--only=propertys'])).toThrow(/propertys/);
+    expect(readOnly(['--only=images,profiles'])).toEqual(['images', 'profiles']);
+  });
+});
+
+// ── the mappers ────────────────────────────────────────────────────
+
+describe('data backfill — the mappers', () => {
+  const log = () => new ResolutionLog();
+
+  it('carries an id verbatim, as the 24-char hex, minting nothing', () => {
+    const id = oid();
+    const row = toAgencyRow({ _id: id, name: 'Finques', normalizedName: 'finques', slug: 'finques' }, log());
+    expect(row.id).toBe(id.toHexString());
+  });
+
+  it('splits the coordinate pair into NAMED columns, and does not transpose it', () => {
+    const row = toAddressRow(
+      { _id: oid(), coordinates: { type: 'Point', coordinates: [BARCELONA.lng, BARCELONA.lat] } },
+      log(),
+    );
+    expect(row.longitude).toBe(BARCELONA.lng);
+    expect(row.latitude).toBe(BARCELONA.lat);
+  });
+
+  it('PRESERVES a coordinate array of the wrong length instead of salvaging it', () => {
+    // Salvaging a one-element array would silently produce a row at longitude 0
+    // — a valid point in the Gulf of Guinea. The audit has to see the shape.
+    const row = toAddressRow(
+      { _id: oid(), coordinates: { type: 'Point', coordinates: [1] } },
+      log(),
+    );
+    expect(row.longitude).toEqual([1]);
+  });
+
+  it('writes an empty normalizedKey as NULL, and counts it', () => {
+    const resolutions = log();
+    const row = toAddressRow({ _id: oid(), normalizedKey: '' }, resolutions);
+    expect(row.normalizedKey).toBeNull();
+    expect(resolutions.toRecord()[DATA_RESOLUTIONS.NORMALIZED_KEY_EMPTY]).toBe(1);
+  });
+
+  it('derives moderation_restricted = false when the sub-object is absent, and counts it', () => {
+    const resolutions = log();
+    const row = toPropertyRow(propertyDocument(oid()), resolutions);
+    expect(row.moderationRestricted).toBe(false);
+    expect(resolutions.toRecord()[DATA_RESOLUTIONS.MODERATION_ABSENT]).toBe(1);
+  });
+
+  it('leaves listingFlags NULL rather than false — they are THREE-state', () => {
+    // `false` would manufacture a claim about 9,594 listings nobody made: the
+    // classifier having looked and said no is not the same as it never running.
+    const resolutions = log();
+    const row = toPropertyRow(propertyDocument(oid()), resolutions);
+    expect(row.listingFlagsStudentsOnly).toBeNull();
+    expect(row.listingFlagsNoPets).toBeNull();
+    expect(resolutions.toRecord()[DATA_RESOLUTIONS.LISTING_FLAGS_ABSENT]).toBe(1);
+  });
+
+  it('reads listingFlags.noDSS into listing_flags_no_dss', () => {
+    const row = toPropertyRow(
+      propertyDocument(oid(), { listingFlags: { noDSS: true, studentsOnly: false } }),
+      log(),
+    );
+    expect(row.listingFlagsNoDss).toBe(true);
+    expect(row.listingFlagsStudentsOnly).toBe(false);
+  });
+
+  it('counts a stored hasImages that disagrees with its own array', () => {
+    const resolutions = log();
+    toPropertyRow(propertyDocument(oid(), { hasImages: false, images: [{ _id: oid() }] }), resolutions);
+    expect(resolutions.toRecord()[DATA_RESOLUTIONS.HAS_IMAGES_DISAGREED]).toBe(1);
+  });
+
+  it('never carries hasImages into the row — it is derived, not copied', () => {
+    const row = toPropertyRow(propertyDocument(oid(), { hasImages: true }), log());
+    expect(row).not.toHaveProperty('hasImages');
+  });
+
+  it('keeps an embedded image subdocument id, and mints one for a calendar window', () => {
+    // `Property.images[]` is an implicit `{ _id: true }` subdocument;
+    // `availabilityWindowSchema` declares `{ _id: false }`, so there is no id to
+    // preserve and one is minted. Asking the DOCUMENT is what makes that right
+    // without trusting a hand-written list of which arrays are which.
+    const imageId = oid();
+    const embeddedId = oid();
+    const resolutions = log();
+    const document = propertyDocument(oid(), {
+      images: [{ _id: embeddedId, imageId, url: 'u/m', isPrimary: true, order: 0 }],
+      availabilityWindows: [
+        { start: new Date('2026-05-01T00:00:00.000Z'), end: new Date('2026-05-08T00:00:00.000Z'), status: 'available' },
+      ],
+    });
+
+    const [image] = toPropertyImageRows(document, resolutions);
+    expect(image.id).toBe(embeddedId.toHexString());
+    expect(image.imageId).toBe(imageId.toHexString());
+
+    const [window] = toPropertyWindowRows(document, resolutions);
+    expect(window.id).toEqual(expect.stringMatching(/^[0-9a-f-]{36}$/));
+    expect(window.scope).toBe('listing');
+    expect(resolutions.toRecord()[DATA_RESOLUTIONS.SUBDOCUMENT_ID_MINTED]).toBe(1);
+  });
+
+  it('tags exchange windows with their own scope, in one table', () => {
+    const document = propertyDocument(oid(), {
+      offerings: ['exchange'],
+      longTermRent: undefined,
+      exchange: {
+        mode: 'swap',
+        availabilityWindows: [
+          { start: new Date('2026-06-01T00:00:00.000Z'), end: new Date('2026-06-08T00:00:00.000Z'), status: 'available' },
+        ],
+      },
+    });
+    const rows = toPropertyWindowRows(document, log());
+    expect(rows).toHaveLength(1);
+    expect(rows[0].scope).toBe('exchange');
+  });
+
+  it('numbers chat messages by ARRAY INDEX, not by timestamp', () => {
+    // `timestamp` defaults to `Date.now` at millisecond resolution, so two
+    // messages appended in one tick sort arbitrarily. The index is the meaning.
+    const sameInstant = new Date('2026-07-01T00:00:00.000Z');
+    const rows = toProfileChatMessageRows(
+      {
+        _id: oid(),
+        personalProfile: {
+          chatHistory: [
+            { _id: oid(), role: 'user', content: 'first', timestamp: sameInstant },
+            { _id: oid(), role: 'assistant', content: 'second', timestamp: sameInstant },
+          ],
+        },
+      },
+      log(),
+    );
+    expect(rows.map((row) => [row.position, row.content])).toEqual([
+      [0, 'first'],
+      [1, 'second'],
+    ]);
+  });
+
+  it('drops the personalProfile wrapper from every column name', () => {
+    const row = toProfileRow(
+      {
+        _id: oid(),
+        oxyUserId: 'oxy-1',
+        personalProfile: {
+          settings: { roommate: { preferences: { lifestyle: { cleanliness: 'very_clean' } } } },
+        },
+      },
+      log(),
+    );
+    // 51 bytes. With the wrapper it would be 68, and Postgres truncates an
+    // identifier at 63 SILENTLY.
+    expect(row.settingsRoommatePreferencesLifestyleCleanliness).toBe('very_clean');
+  });
+});
+
+// ── the audit ──────────────────────────────────────────────────────
+
+describe('data backfill — the audit', () => {
+  const log = () => new ResolutionLog();
+
+  function auditProperty(edit: (row: CandidateRow) => void) {
+    const row = toPropertyRow(propertyDocument(oid()), log());
+    edit(row);
+    const auditor = new RowAuditor(properties, PROPERTY_RULES);
+    auditor.add([row]);
+    return auditor.drain();
+  }
+
+  it('passes a coherent row — the floor that stops every refusal below being vacuous', () => {
+    expect(auditProperty(() => undefined)).toEqual([]);
+  });
+
+  it('refuses a value outside a CHECK vocabulary, naming it', () => {
+    const violations = auditProperty((row) => {
+      row.type = 'submarine';
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0].reason).toMatch(/not one of/);
+  });
+
+  it('refuses offerings that name a block the row does not carry', () => {
+    const violations = auditProperty((row) => {
+      row.offerings = ['long_term_rent', 'sale'];
+    });
+    expect(violations.map((violation) => violation.column)).toContain(
+      'properties_offering_sale_check',
+    );
+  });
+
+  it('refuses a priced block populated without its discriminator', () => {
+    // `sale: { currency: 'EUR' }` with `offerings: []` is rejected by Mongo and
+    // INVISIBLE to the coherence check, which only sees `false = false`.
+    const violations = auditProperty((row) => {
+      row.saleCurrency = 'EUR';
+    });
+    expect(violations.map((violation) => violation.column)).toContain('properties_sale_block_check');
+  });
+
+  it('refuses an external listing with no source_url', () => {
+    const violations = auditProperty((row) => {
+      row.sourceUrl = null;
+    });
+    expect(violations.map((violation) => violation.column)).toContain(
+      'properties_external_source_url_check',
+    );
+  });
+
+  it('refuses a text[] whose ELEMENT is not a string', () => {
+    // The geo tables carry no array column at all, so this path was unreachable
+    // until this batch — and an unaudited column kind is one whose bad values
+    // reach the insert.
+    const violations = auditProperty((row) => {
+      row.amenities = ['lift', 7];
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0].reason).toMatch(/element 1/);
+  });
+
+  it('refuses a coordinate pair outside the range PostGIS would silently coerce', () => {
+    const row = toAddressRow(
+      { _id: oid(), coordinates: { type: 'Point', coordinates: [0, 100] } },
+      log(),
+    );
+    const auditor = new RowAuditor(addresses, [
+      {
+        name: 'addresses_coordinates_range_check',
+        reason: 'out of range',
+        holds: (candidate) => typeof candidate.latitude !== 'number' || candidate.latitude <= 90,
+      },
+    ]);
+    auditor.add([row]);
+    expect(auditor.drain().map((violation) => violation.column)).toContain(
+      'addresses_coordinates_range_check',
+    );
+  });
+
+  it('reports two rows sharing a unique key, which ON CONFLICT DO NOTHING would ABSORB', () => {
+    const auditor = new UniqueKeyAuditor('agencies_normalized_name_key', (row) =>
+      typeof row.normalizedName === 'string' ? row.normalizedName : null,
+    );
+    auditor.add([
+      { id: 'a', normalizedName: 'finques' },
+      { id: 'b', normalizedName: 'finques' },
+    ]);
+    const violations = auditor.drain();
+    expect(violations).toHaveLength(1);
+    expect(violations[0].rows).toBe(1);
+    expect(violations[0].reason).toMatch(/without raising/);
+  });
+
+  it('does NOT report rows a PARTIAL unique index leaves uncovered', () => {
+    const auditor = new UniqueKeyAuditor('addresses_normalized_key_key', (row) =>
+      typeof row.normalizedKey === 'string' ? row.normalizedKey : null,
+    );
+    auditor.add([
+      { id: 'a', normalizedKey: null },
+      { id: 'b', normalizedKey: null },
+    ]);
+    expect(auditor.drain()).toEqual([]);
+  });
+
+  it('counts what it audited, so an empty report cannot be read as a clean one', () => {
+    const auditor = new RowAuditor(agencies, []);
+    expect(auditor.audited).toBe(0);
+    auditor.add([toAgencyRow({ _id: oid(), name: 'F', normalizedName: 'f', slug: 'f' }, log())]);
+    expect(auditor.audited).toBe(1);
+  });
+});
+
+// ── end to end ─────────────────────────────────────────────────────
+
+describe('data backfill — end to end', () => {
+  it('copies every collection, derives has_images and passes its own verification', async () => {
+    const geo = await seedAndCopyGeo();
+    const database = mongoDatabase();
+
+    const barcelona = addressDocument(geo, 'Barcelona', BARCELONA);
+    const madrid = addressDocument(geo, 'Madrid', MADRID, { street: 'Gran Vía', postal_code: '28013' });
+    const paris = addressDocument(geo, 'Paris', PARIS, { street: 'Rue de Rivoli', postal_code: '75001', countryCode: 'FR' });
+    await database.collection('addresses').insertMany([barcelona, madrid, paris]);
+
+    const agency = { _id: oid(), name: 'Finques Verdi', normalizedName: 'finques verdi', slug: 'finques-verdi', createdAt: new Date(), updatedAt: new Date() };
+    await database.collection('agencies').insertOne(agency);
+
+    const photo = imageDocument();
+    await database.collection('images').insertOne(photo);
+
+    const withPhoto = propertyDocument(barcelona._id as mongoose.Types.ObjectId, {
+      agencyId: agency._id,
+      images: [{ _id: oid(), imageId: photo._id, url: 'u/m', isPrimary: true, order: 0 }],
+      documents: [{ _id: oid(), name: 'Lease', url: 'https://example.test/lease.pdf', type: 'lease' }],
+      // The stored flag is WRONG on purpose: the copy must derive it, and
+      // production holds exactly this shape.
+      hasImages: false,
+    });
+    const withoutPhoto = propertyDocument(madrid._id as mongoose.Types.ObjectId, { hasImages: true });
+    const parisian = propertyDocument(paris._id as mongoose.Types.ObjectId);
+    await database.collection('properties').insertMany([withPhoto, withoutPhoto, parisian]);
+
+    await database.collection('profiles').insertOne({
+      _id: oid(),
+      oxyUserId: 'oxy-tenant-1',
+      personalProfile: {
+        personalInfo: { bio: 'Quiet tenant', annualIncome: 42000 },
+        references: [{ _id: oid(), name: 'Ana', relationship: 'landlord', verified: true }],
+        rentalHistory: [
+          { _id: oid(), address: 'Carrer Gran 1', startDate: new Date('2024-01-01'), endDate: new Date('2025-01-01'), verified: false },
+        ],
+        chatHistory: [{ _id: oid(), role: 'user', content: 'hello', timestamp: new Date() }],
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const report = await runDataBackfill({
+      mongo: database,
+      database: getDb(),
+      mode: 'copy',
+      sampleSize: 10,
+    });
+
+    expect(report.mode).toBe('copy');
+    expect(report.verified.every((entry) => entry.missing === 0)).toBe(true);
+    expect(report.verified.every((entry) => entry.mismatches.length === 0)).toBe(true);
+    expect(report.hasImagesDisagreements).toBe(0);
+
+    const db = getDb();
+    const [listing] = await db
+      .select({ hasImages: properties.hasImages, agencyId: properties.agencyId })
+      .from(properties)
+      .where(eq(properties.id, String(withPhoto._id)));
+    // DERIVED, not copied: the source said `false` and the photo row says
+    // otherwise.
+    expect(listing.hasImages).toBe(true);
+    expect(listing.agencyId).toBe(String(agency._id));
+
+    const [empty] = await db
+      .select({ hasImages: properties.hasImages })
+      .from(properties)
+      .where(eq(properties.id, String(withoutPhoto._id)));
+    expect(empty.hasImages).toBe(false);
+
+    const [photoRow] = await db
+      .select({ imageId: propertyImages.imageId, isPrimary: propertyImages.isPrimary })
+      .from(propertyImages)
+      .where(eq(propertyImages.propertyId, String(withPhoto._id)));
+    expect(photoRow.imageId).toBe(String(photo._id));
+    expect(photoRow.isPrimary).toBe(true);
+
+    // `extras` is the one jsonb column in the migration, and Postgres reorders
+    // its keys on the way in — the comparison the verifier makes has to survive
+    // that, and this asserts the value really round-tripped.
+    const [address] = await db
+      .select({ extras: addresses.extras, level: addresses.addressLevel })
+      .from(addresses)
+      .where(eq(addresses.id, String(barcelona._id)));
+    expect(address.extras).toEqual({ portal: 'idealista', floorRaw: '3º' });
+    // GENERATED from the identifying fields — `number` is set, `floor` is not.
+    expect(address.level).toBe('BUILDING');
+
+    const [profile] = await db.select({ oxyUserId: profiles.oxyUserId }).from(profiles);
+    expect(profile.oxyUserId).toBe('oxy-tenant-1');
+  }, 60_000);
+
+  it('measures a REAL distance, so a transposed coordinate pair cannot pass', async () => {
+    const geo = await seedAndCopyGeo();
+    const database = mongoDatabase();
+    await database.collection('addresses').insertMany([
+      addressDocument(geo, 'Barcelona', BARCELONA),
+      addressDocument(geo, 'Madrid', MADRID, { street: 'Gran Vía' }),
+      addressDocument(geo, 'Paris', PARIS, { street: 'Rue de Rivoli', countryCode: 'FR' }),
+    ]);
+
+    await runDataBackfill({
+      mongo: database,
+      database: getDb(),
+      mode: 'copy',
+      sampleSize: 5,
+      only: ['images', 'addresses'],
+    });
+
+    const geometry = await checkGeometry(getDb());
+    expect(geometry.centroidSamples).toBe(3);
+    expect(geometry.centroidOverLimit).toBe(0);
+
+    const [toMadrid, toParis] = geometry.pairs;
+    expect(toMadrid.withinTolerance).toBe(true);
+    expect(toMadrid.measuredMetres).toBeGreaterThan(400_000);
+    expect(toMadrid.measuredMetres).toBeLessThan(600_000);
+    expect(toParis.withinTolerance).toBe(true);
+    expect(toParis.measuredMetres).toBeGreaterThan(700_000);
+  }, 60_000);
+
+  it('a TRANSPOSED pair lands thousands of kilometres from its own city', async () => {
+    // The check the verifier runs, run against the defect it exists to catch —
+    // otherwise "centroidOverLimit is 0" is a number nobody has seen move.
+    const geo = await seedAndCopyGeo();
+    const database = mongoDatabase();
+    await database.collection('addresses').insertOne(
+      addressDocument(geo, 'Barcelona', BARCELONA, {
+        coordinates: { type: 'Point', coordinates: [BARCELONA.lat, BARCELONA.lng] },
+      }),
+    );
+
+    // The run's OWN verification must refuse it — that is the point of the
+    // check. The rows are already copied by then, so the measurement below reads
+    // what a transposition actually looks like rather than what it would.
+    await expect(
+      runDataBackfill({
+        mongo: database,
+        database: getDb(),
+        mode: 'copy',
+        sampleSize: 5,
+        only: ['images', 'addresses'],
+      }),
+    ).rejects.toThrow(/geometry/);
+
+    const geometry = await checkGeometry(getDb());
+    expect(geometry.centroidOverLimit).toBe(1);
+    expect(geometry.centroidMaxMetres).toBeGreaterThan(1_000_000);
+  }, 60_000);
+
+  it('refuses to write anything when the audit finds a violation', async () => {
+    const geo = await seedAndCopyGeo();
+    const database = mongoDatabase();
+    const address = addressDocument(geo, 'Barcelona', BARCELONA);
+    await database.collection('addresses').insertOne(address);
+    await database.collection('properties').insertOne(
+      propertyDocument(address._id as mongoose.Types.ObjectId, { type: 'submarine' }),
+    );
+
+    await expect(
+      runDataBackfill({ mongo: database, database: getDb(), mode: 'copy', sampleSize: 5 }),
+    ).rejects.toThrow(/Audit refused/);
+
+    const [row] = await getDb().select({ total: sql<number>`count(*)::int` }).from(properties);
+    expect(row.total).toBe(0);
+  }, 60_000);
+
+  it('refuses an audit that examined ZERO rows rather than reporting it clean', async () => {
+    // "No violations" and "nothing was checked" are the same report. The source
+    // guard proves the collections exist; this proves something was read.
+    await seedAndCopyGeo();
+    await mongoDatabase().collection('profiles').deleteMany({});
+
+    await expect(
+      runDataBackfill({
+        mongo: mongoDatabase(),
+        database: getDb(),
+        mode: 'audit-only',
+        only: ['profiles'],
+      }),
+    ).rejects.toThrow(/ZERO rows/);
+  }, 60_000);
+
+  it('is idempotent: a second copy inserts nothing and still verifies', async () => {
+    const geo = await seedAndCopyGeo();
+    const database = mongoDatabase();
+    const address = addressDocument(geo, 'Barcelona', BARCELONA);
+    // Madrid and Paris too: full verification demands at least one measurable
+    // real-world distance, and one city cannot supply one.
+    await database.collection('addresses').insertMany([
+      address,
+      addressDocument(geo, 'Madrid', MADRID, { street: 'Gran Vía' }),
+      addressDocument(geo, 'Paris', PARIS, { street: 'Rue de Rivoli', countryCode: 'FR' }),
+    ]);
+    await database.collection('properties').insertOne(
+      propertyDocument(address._id as mongoose.Types.ObjectId),
+    );
+
+    const first = await runDataBackfill({ mongo: database, database: getDb(), mode: 'copy', sampleSize: 5 });
+    const second = await runDataBackfill({ mongo: database, database: getDb(), mode: 'copy', sampleSize: 5 });
+
+    const inserted = (report: typeof first, collection: string) =>
+      report.copied.find((entry) => entry.collection === collection)?.inserted ?? {};
+    expect(inserted(first, 'addresses').addresses).toBe(3);
+    // `ON CONFLICT DO NOTHING` still reports the batch it SENT; what proves
+    // convergence is that verification passes and the table did not grow.
+    expect(second.verified.every((entry) => entry.missing === 0)).toBe(true);
+
+    const [row] = await getDb().select({ total: sql<number>`count(*)::int` }).from(addresses);
+    expect(row.total).toBe(3);
+  }, 90_000);
+
+  it('links a geo cover image once images exist, and never restamps updated_at', async () => {
+    const geo = await seedAndCopyGeo();
+    const database = mongoDatabase();
+
+    const cover = imageDocument({ entityType: 'city', entityId: geo.cityIds.Barcelona });
+    await database.collection('images').insertOne(cover);
+    await database.collection('cities').updateOne(
+      { _id: geo.cityIds.Barcelona },
+      { $set: { coverImageId: cover._id } },
+    );
+
+    await runDataBackfill({
+      mongo: database,
+      database: getDb(),
+      mode: 'copy',
+      sampleSize: 5,
+      only: ['images'],
+    });
+
+    const before = await getDb()
+      .select({ updatedAt: cities.updatedAt })
+      .from(cities)
+      .where(eq(cities.id, String(geo.cityIds.Barcelona)));
+
+    const reports = await linkCoverImages(getDb(), database);
+    const citiesReport = reports.find((entry) => entry.table === 'cities');
+    expect(citiesReport?.linked).toBe(1);
+
+    const [after] = await getDb()
+      .select({ coverImageId: cities.coverImageId, updatedAt: cities.updatedAt })
+      .from(cities)
+      .where(eq(cities.id, String(geo.cityIds.Barcelona)));
+    expect(after.coverImageId).toBe(String(cover._id));
+    // The only UPDATE in the backfill, and drizzle's `$onUpdate` would otherwise
+    // replace history with the migration's own clock.
+    expect(after.updatedAt.getTime()).toBe(before[0].updatedAt.getTime());
+  }, 60_000);
+
+  it('refuses to put a PROPERTY photo on a city, even though the FK would accept it', async () => {
+    const geo = await seedAndCopyGeo();
+    const database = mongoDatabase();
+
+    const listingPhoto = imageDocument({ entityType: 'property' });
+    await database.collection('images').insertOne(listingPhoto);
+    await database.collection('cities').updateOne(
+      { _id: geo.cityIds.Madrid },
+      { $set: { coverImageId: listingPhoto._id } },
+    );
+
+    await runDataBackfill({
+      mongo: database,
+      database: getDb(),
+      mode: 'copy',
+      sampleSize: 5,
+      only: ['images'],
+    });
+
+    const reports = await linkCoverImages(getDb(), database);
+    const citiesReport = reports.find((entry) => entry.table === 'cities');
+    expect(citiesReport?.notAGeoImage).toBe(1);
+    expect(citiesReport?.linked).toBe(0);
+
+    const [row] = await getDb()
+      .select({ coverImageId: cities.coverImageId })
+      .from(cities)
+      .where(eq(cities.id, String(geo.cityIds.Madrid)));
+    expect(row.coverImageId).toBeNull();
+  }, 60_000);
+
+  it('writes both calendars into one table, under their own scopes', async () => {
+    const geo = await seedAndCopyGeo();
+    const database = mongoDatabase();
+    const address = addressDocument(geo, 'Barcelona', BARCELONA);
+    await database.collection('addresses').insertMany([
+      address,
+      addressDocument(geo, 'Madrid', MADRID, { street: 'Gran Vía' }),
+      addressDocument(geo, 'Paris', PARIS, { street: 'Rue de Rivoli', countryCode: 'FR' }),
+    ]);
+    await database.collection('properties').insertOne(
+      propertyDocument(address._id as mongoose.Types.ObjectId, {
+        offerings: ['long_term_rent', 'exchange'],
+        exchange: {
+          mode: 'swap',
+          availabilityWindows: [
+            { start: new Date('2026-06-01T00:00:00.000Z'), end: new Date('2026-06-08T00:00:00.000Z'), status: 'available' },
+          ],
+        },
+        availabilityWindows: [
+          { start: new Date('2026-05-01T00:00:00.000Z'), end: new Date('2026-05-08T00:00:00.000Z'), status: 'blocked' },
+        ],
+      }),
+    );
+
+    await runDataBackfill({ mongo: database, database: getDb(), mode: 'copy', sampleSize: 5 });
+
+    const windows = await getDb()
+      .select({ scope: propertyAvailabilityWindows.scope, status: propertyAvailabilityWindows.status })
+      .from(propertyAvailabilityWindows);
+    expect(windows.map((row) => row.scope).sort()).toEqual(['exchange', 'listing']);
+  }, 60_000);
+});

--- a/packages/backend/db/backfill/data.ts
+++ b/packages/backend/db/backfill/data.ts
@@ -1,0 +1,1171 @@
+/**
+ * Copy the rest of the data — images, addresses, agencies, properties and
+ * profiles — from Mongo to Postgres.
+ *
+ * The second of two one-shots, run exactly like `db/migrate.ts` and compiled
+ * into the same image (`dist/db/backfill/data.js`). The runtime image has no
+ * ts-node, so a script that is not compiled cannot be run in production at all;
+ * `db/` is what `tsconfig.build.json` emits and `scripts/` is deliberately
+ * excluded from it.
+ *
+ *   node packages/backend/dist/db/backfill/data.js \
+ *     --source-database=homiio-production --target-database=homiio
+ *
+ *   …--audit-only     measure every row against the target, write nothing
+ *   …--verify-only    compare an already-copied target against the source
+ *   …--sample=<n>     rows per table in the field-by-field comparison (default 200)
+ *   …--only=a,b       a subset of collections (see the warning it prints)
+ *
+ * ## What it adds to `geo.ts`, and why it is a separate file
+ *
+ * `geo.ts` loads all five geo collections into memory before mapping any of
+ * them, which is right for under eight thousand documents and impossible for
+ * 171,976 images and 17,644 properties with their embedded arrays. So this
+ * STREAMS, and everything that follows is a consequence of that:
+ *
+ *  - **Two passes in `copy` mode.** The audit reads the whole source and writes
+ *    nothing; only then does the copy read it again and insert. That keeps the
+ *    property `geo.ts` advertises — *it never runs an insert the audit has not
+ *    seen* — which a single streaming pass cannot: it would refuse at the first
+ *    bad batch with every earlier batch already committed.
+ *  - **`RowAuditor` rather than `auditRows`.** Auditing per batch with the
+ *    one-shot function would produce one grouped report per batch, three hundred
+ *    of them, each saying "1 row". The grouping is what makes a report readable.
+ *  - **Foreign keys resolved against BOTH stores.** `geo.ts` checks a reference
+ *    against the ids its own run will insert, which works when every row is in
+ *    memory. Here a parent may be in Postgres already (the geo rows) or about to
+ *    be written by this run (`properties.address_id`), so the question asked is
+ *    the one `23503` will actually answer: does this id exist in the target
+ *    table, or in the source collection this run copies from?
+ *
+ * ## Two things happen only AFTER the copy, and both would be wrong before it
+ *
+ * `properties.has_images` is re-derived from `property_images` by
+ * `db/hasImages.ts`, the column's one writer — deriving it against a half-loaded
+ * child table would set every listing to `false`, which is not a visible failure
+ * but a feed that quietly ranks everything the same. And the geo cover images
+ * are filled in, because `cities.cover_image_id` could not be written while
+ * `images` was empty.
+ *
+ * ## Idempotent, so a re-run converges
+ *
+ * Every insert is `ON CONFLICT DO NOTHING` over ids copied verbatim from Mongo.
+ * A run that dies at document 90,000 is a position, not a mess. What makes that
+ * safe rather than lossy is the verify step, which asks whether every source row
+ * is PRESENT rather than trusting an insert count — `DO NOTHING` with no
+ * conflict target also absorbs a unique-index collision, which is why the audit
+ * checks for those separately.
+ */
+
+import mongoose from 'mongoose';
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { and, count, eq, getTableColumns, inArray, isNull, sql } from 'drizzle-orm';
+import type { PgTable } from 'drizzle-orm/pg-core';
+import { assertMigrationTarget, readTargetDatabase } from '@oxyhq/db/migrate';
+
+import { Logger } from '../../utils/logger';
+import { DATABASE_CASING } from '../casing';
+import { findHasImagesDisagreements, syncAllHasImages } from '../hasImages';
+import type { Database } from '../postgres';
+import * as schema from '../schema';
+import { cities, images, regions } from '../schema';
+import { GEO_IMAGE_ENTITY_TYPES, ResolutionLog, type SourceDocument } from './geoPlan';
+import {
+  DATA_COPY_ORDER,
+  DATA_PLANS,
+  DATA_TABLES,
+  type DataCollectionName,
+  type DataCollectionPlan,
+  type ReferenceSpec,
+} from './dataPlan';
+import { columnNames, foreignKeyRule } from './geoPlan';
+import {
+  describeViolations,
+  RowAuditor,
+  UniqueKeyAuditor,
+  type AuditViolation,
+  type CandidateRow,
+} from './rowAudit';
+import {
+  assertMigrationSource,
+  canonicalJson,
+  DEFAULT_SAMPLE_ROWS,
+  presentIds,
+  readMode,
+  readSampleSize,
+  readSourceDatabase,
+  sameValue,
+  type MongoDatabase,
+  type Mode,
+} from './geo';
+
+const logger = new Logger('DataBackfill');
+
+/**
+ * The collection shape id lookups are typed against.
+ *
+ * `_id` is the UNION of both stored shapes rather than the driver's default:
+ * Homiio's ids are permanently two-shaped, so `find({ _id: { $in: [...] } })`
+ * with a mix of ObjectIds and uuid v7 strings does not compile against an
+ * untyped collection handle.
+ */
+interface IdentifiedDocument {
+  _id: mongoose.Types.ObjectId | string;
+  [field: string]: unknown;
+}
+
+/** Seconds to wait for in-flight queries before forcing the socket shut. */
+const CLOSE_TIMEOUT_SECONDS = 5;
+
+/** Documents fetched per network round trip while streaming. */
+const CURSOR_BATCH_SIZE = 500;
+
+/** Rows per multi-row `INSERT`, before the per-table column count narrows it. */
+const INSERT_BATCH_ROWS = 500;
+
+/**
+ * Bind parameters allowed in one statement.
+ *
+ * Postgres accepts 65,535; 50,000 leaves headroom that costs a few extra round
+ * trips on a run measured in minutes. It matters because `properties` has 135
+ * columns — a fixed batch of 500 rows there would be 67,500 parameters and a
+ * hard protocol error, on the largest table, after the smaller ones had already
+ * succeeded.
+ */
+const MAX_BIND_PARAMETERS = 50_000;
+
+/** Ids resolved per `$in` when checking a foreign key's parents in Mongo. */
+const MONGO_LOOKUP_BATCH = 1_000;
+
+/** How often a streaming pass reports progress, in source documents. */
+const PROGRESS_INTERVAL = 25_000;
+
+/** Ids listed in a report when something is missing. Enough to grep for. */
+const MAX_REPORTED_IDS = 5;
+
+/**
+ * How far an address may sit from its own city's centroid before it is
+ * reported.
+ *
+ * 300 km is generous for a centroid and nowhere near a transposition: swapping
+ * Barcelona's pair (2.1686, 41.3985) lands the point off Somalia, ~5,000 km
+ * away. Loose on purpose — a check that cries wolf on a coarse centroid is a
+ * check somebody switches off.
+ */
+const CITY_CENTROID_LIMIT_METRES = 300_000;
+
+/** How far a measured city-pair distance may sit from the real-world figure. */
+const CITY_PAIR_TOLERANCE = 0.25;
+
+/**
+ * Real-world distances between city centres, for the named half of the geometry
+ * check.
+ *
+ * The addresses are anywhere within their cities, so this is not measuring town
+ * hall to town hall — ±25% distinguishes "these are the right two cities" from
+ * "one of them is in the wrong hemisphere", which is the only question a
+ * transposition check has to answer.
+ */
+const CITY_PAIRS = [
+  { from: 'Barcelona', to: 'Madrid', metres: 505_000 },
+  { from: 'Barcelona', to: 'Paris', metres: 830_000 },
+] as const;
+
+/** Per-collection outcome of the copy. */
+export interface CopyReport {
+  readonly collection: DataCollectionName;
+  readonly documents: number;
+  readonly inserted: Readonly<Record<string, number>>;
+}
+
+/** Per-table outcome of the verification. */
+export interface VerifyReport {
+  readonly table: string;
+  readonly sourceDocuments: number;
+  readonly targetRows: number;
+  readonly missing: number;
+  readonly missingIds: readonly string[];
+  readonly compared: number;
+  readonly mismatches: readonly string[];
+}
+
+/** What the geometry checks measured. */
+export interface GeometryReport {
+  readonly centroidSamples: number;
+  readonly centroidMaxMetres: number | null;
+  readonly centroidOverLimit: number;
+  readonly pairs: readonly {
+    readonly from: string;
+    readonly to: string;
+    readonly expectedMetres: number;
+    readonly measuredMetres: number | null;
+    readonly withinTolerance: boolean | null;
+  }[];
+}
+
+/** What the cover-image step did, per geo level. */
+export interface CoverReport {
+  readonly table: 'cities' | 'regions';
+  readonly claimed: number;
+  readonly linked: number;
+  readonly alreadySet: number;
+  readonly unresolvable: number;
+  readonly notAGeoImage: number;
+}
+
+/** What one run did, whichever mode it ran in. */
+export interface DataBackfillReport {
+  readonly mode: Mode;
+  readonly resolutions: Readonly<Record<string, number>>;
+  readonly audited: Readonly<Record<string, number>>;
+  readonly copied: readonly CopyReport[];
+  readonly hasImagesRederived: number | null;
+  readonly covers: readonly CoverReport[];
+  readonly verified: readonly VerifyReport[];
+  readonly geometry: GeometryReport | null;
+  readonly hasImagesDisagreements: number | null;
+}
+
+// ── the streaming pass ─────────────────────────────────────────────
+
+/** A buffered, batched, `ON CONFLICT DO NOTHING` writer for one table. */
+interface TableWriter {
+  push(row: CandidateRow): void;
+  /** Write the buffer if it has reached the table's batch size. */
+  flushIfFull(): Promise<void>;
+  /** Write whatever is buffered. */
+  flush(): Promise<void>;
+  readonly inserted: number;
+}
+
+/**
+ * Rows per statement for a table, derived from its column count.
+ *
+ * Derived rather than chosen so that a table added later cannot reintroduce the
+ * parameter-limit failure, and so no per-table tuning table has to be kept
+ * correct.
+ */
+function batchRows(table: PgTable): number {
+  const columns = Object.keys(getTableColumns(table)).length;
+  return Math.max(1, Math.min(INSERT_BATCH_ROWS, Math.floor(MAX_BIND_PARAMETERS / columns)));
+}
+
+function createWriter(database: Database, table: PgTable, write: boolean): TableWriter {
+  const limit = batchRows(table);
+  const buffer: CandidateRow[] = [];
+  let inserted = 0;
+
+  const flush = async (): Promise<void> => {
+    if (buffer.length === 0) return;
+    const batch = buffer.splice(0, buffer.length);
+    if (!write) return;
+    // The rows arrive loosely typed because the AUDIT is what proves their
+    // shape — it reads the target's own column metadata, so a row that survives
+    // it is one Postgres accepts. This narrowing is that proof cashed in, and it
+    // is the same one `geo.ts` makes for the same reason.
+    await database
+      .insert(table)
+      .values(batch as PgTable['$inferInsert'][])
+      .onConflictDoNothing();
+    inserted += batch.length;
+  };
+
+  return {
+    push(row) {
+      buffer.push(row);
+    },
+    async flushIfFull() {
+      if (buffer.length >= limit) await flush();
+    },
+    async flush() {
+      await flush();
+    },
+    get inserted() {
+      return inserted;
+    },
+  };
+}
+
+/** Every document in a collection, in `_id` order, streamed. */
+async function* streamCollection(
+  mongo: MongoDatabase,
+  collection: string,
+): AsyncIterable<SourceDocument> {
+  const cursor = mongo
+    .collection(collection)
+    .find({}, { batchSize: CURSOR_BATCH_SIZE, sort: { _id: 1 } });
+  try {
+    for await (const document of cursor) yield document as SourceDocument;
+  } finally {
+    await cursor.close();
+  }
+}
+
+/** What one streaming pass over one collection produced. */
+interface PassResult {
+  readonly documents: number;
+  readonly inserted: Readonly<Record<string, number>>;
+  readonly violations: readonly AuditViolation[];
+  /** Rows audited per table — the vacuity floor for an empty violation list. */
+  readonly audited: Readonly<Record<string, number>>;
+}
+
+/**
+ * Stream one collection: map every document, audit every row it produces, and —
+ * when `write` is set — insert them in batches.
+ *
+ * The audit runs in BOTH modes and on every row. In `audit` mode the writers
+ * simply do not write, so the rows the audit inspects are, batch for batch, the
+ * rows the copy would have inserted. An audit built from a separate "check the
+ * document" pass could pass on a document whose MAPPER produces something else,
+ * which is the failure mode that makes a pre-flight check worth less than none.
+ */
+async function streamCollectionPass(
+  database: Database,
+  mongo: MongoDatabase,
+  plan: DataCollectionPlan,
+  log: ResolutionLog,
+  write: boolean,
+): Promise<PassResult> {
+  const writers = new Map<string, TableWriter>();
+  const auditors = new Map<string, RowAuditor>();
+  const referenced = new Map<ReferenceSpec, Set<string>>();
+  const uniqueAuditors = plan.uniqueKeys.map((spec) => ({
+    spec,
+    auditor: new UniqueKeyAuditor(spec.constraint, spec.key),
+  }));
+
+  for (const table of plan.tables) {
+    const target = requireTable(table);
+    writers.set(table, createWriter(database, target, write));
+    auditors.set(table, new RowAuditor(target, plan.rules[table] ?? []));
+  }
+  for (const spec of plan.references) referenced.set(spec, new Set<string>());
+
+  let documents = 0;
+  for await (const document of streamCollection(mongo, plan.sourceCollection)) {
+    const mapped = plan.map(document, log);
+
+    for (const table of plan.tables) {
+      const rows = mapped[table] ?? [];
+      if (rows.length === 0) continue;
+      auditors.get(table)?.add(rows);
+      for (const entry of uniqueAuditors) {
+        if (entry.spec.table === table) entry.auditor.add(rows);
+      }
+      for (const spec of plan.references) {
+        if (spec.table !== table) continue;
+        const collected = referenced.get(spec);
+        if (collected === undefined) continue;
+        for (const row of rows) {
+          const value = row[spec.column];
+          if (typeof value === 'string') collected.add(value);
+        }
+      }
+      const writer = writers.get(table);
+      if (writer) for (const row of rows) writer.push(row);
+    }
+
+    // Parent table first — `property_images.property_id` is NOT NULL, so a
+    // child batch may never reach the server ahead of the row it references.
+    for (const table of plan.tables) await writers.get(table)?.flushIfFull();
+
+    documents += 1;
+    if (documents % PROGRESS_INTERVAL === 0) {
+      logger.info(`${plan.name}: ${documents} documents`, {
+        inserted: insertedCounts(plan, writers),
+      });
+    }
+  }
+
+  for (const table of plan.tables) await writers.get(table)?.flush();
+
+  const violations: AuditViolation[] = [];
+  const audited: Record<string, number> = {};
+  for (const table of plan.tables) {
+    const auditor = auditors.get(table);
+    if (auditor === undefined) continue;
+    audited[table] = auditor.audited;
+    violations.push(...auditor.drain());
+  }
+  for (const entry of uniqueAuditors) violations.push(...entry.auditor.drain());
+
+  // Once per collection rather than per document: the question is SET membership
+  // over hundreds of thousands of ids, and asking it one id at a time is the
+  // difference between seconds and hours.
+  violations.push(...(await resolveReferences(database, mongo, plan, referenced)));
+
+  return { documents, inserted: insertedCounts(plan, writers), violations, audited };
+}
+
+function insertedCounts(
+  plan: DataCollectionPlan,
+  writers: ReadonlyMap<string, TableWriter>,
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const table of plan.tables) counts[table] = writers.get(table)?.inserted ?? 0;
+  return counts;
+}
+
+/**
+ * Resolve every collected foreign key against BOTH stores.
+ *
+ * A parent may legitimately live in either: `addresses.city_id` points at geo
+ * rows already in Postgres, `properties.address_id` at rows this very run is
+ * about to write. Checking only Postgres would report every property as an
+ * orphan; checking only Mongo would miss a geo row that never arrived. The union
+ * is the only question worth asking — "will this reference resolve by the time
+ * the row is inserted?"
+ */
+async function resolveReferences(
+  database: Database,
+  mongo: MongoDatabase,
+  plan: DataCollectionPlan,
+  referenced: ReadonlyMap<ReferenceSpec, ReadonlySet<string>>,
+): Promise<AuditViolation[]> {
+  const violations: AuditViolation[] = [];
+
+  for (const [spec, ids] of referenced) {
+    if (ids.size === 0) continue;
+    const wanted = [...ids];
+
+    const inTarget = await presentIds(database, requireTable(spec.parentTable), wanted);
+    const stillMissing = wanted.filter((id) => !inTarget.has(id));
+    const resolvable = new Set(inTarget);
+
+    if (stillMissing.length > 0 && spec.parentCollection !== null) {
+      for (const id of await presentInMongo(mongo, spec.parentCollection, stillMissing)) {
+        resolvable.add(id);
+      }
+    }
+
+    // Re-checked through the SAME rule the geo copy uses, so a dangling
+    // reference is reported in one vocabulary across both halves of the
+    // migration rather than two.
+    const rule = foreignKeyRule(spec.constraint, spec.column, resolvable, spec.nullable);
+    const offenders = wanted.filter((id) => !resolvable.has(id));
+    if (offenders.length === 0) continue;
+
+    violations.push({
+      column: rule.name,
+      reason: `${rule.reason} — no ${spec.parentTable} row and no ${spec.parentCollection ?? '(no source collection)'} document holds it`,
+      rows: offenders.length,
+      examples: offenders.slice(0, MAX_REPORTED_IDS).map((id) => ({ id: plan.name, value: id })),
+    });
+  }
+
+  return violations;
+}
+
+/** Which of these ids the source collection holds. Batched — see the audit's cost. */
+async function presentInMongo(
+  mongo: MongoDatabase,
+  collection: string,
+  ids: readonly string[],
+): Promise<ReadonlySet<string>> {
+  const present = new Set<string>();
+  for (let start = 0; start < ids.length; start += MONGO_LOOKUP_BATCH) {
+    const batch = ids.slice(start, start + MONGO_LOOKUP_BATCH);
+    // Both id shapes are live and permanently so (24-char ObjectId hex before
+    // the cutover, uuid v7 after), and `isValid` decides only the SPELLING of
+    // the lookup — never whether an id is acceptable. The collection is typed
+    // through `IdentifiedDocument` so the union is expressible; the untyped
+    // handle assumes `ObjectId` and would not compile.
+    const keys = batch.map((id) =>
+      mongoose.Types.ObjectId.isValid(id) ? new mongoose.Types.ObjectId(id) : id,
+    );
+    const found = await mongo
+      .collection<IdentifiedDocument>(collection)
+      .find({ _id: { $in: keys } }, { projection: { _id: 1 } })
+      .toArray();
+    for (const document of found) present.add(String(document._id));
+  }
+  return present;
+}
+
+// ── after the copy ─────────────────────────────────────────────────
+
+/**
+ * Fill `cities.cover_image_id` / `regions.cover_image_id` where they are NULL.
+ *
+ * The geo copy could only link a cover whose image it CARRIED (`city`, `region`
+ * and `country` photos), and it wrote NULL for anything else rather than fail a
+ * real foreign key. Now that every image exists, the remainder can be filled.
+ *
+ * Three rules, and each is a decision rather than a mechanism:
+ *
+ *  - **Only NULL covers are touched.** A cover the application has since set for
+ *    itself (`cityCoverSyncService` writes this column at runtime) is left
+ *    exactly as it is — a backfill that reverted live work would be a copy
+ *    fighting the system it is copying into. It is also what makes a re-run a
+ *    no-op.
+ *  - **A cover naming a PROPERTY photo is refused, not linked.** The foreign key
+ *    would accept it and the result would be a listing's photo on a city, which
+ *    `db/MIGRATION-CONTRACT.md` records as wrong by construction — it is the bug
+ *    `cityCoverSyncService.forceReplaceListingCovers` exists to undo.
+ *  - **`updated_at` is assigned FROM ITSELF.** This is the only UPDATE in the
+ *    whole backfill, and drizzle applies `$onUpdate` to any column not named in
+ *    `.set()` — so the obvious spelling would restamp every row with the
+ *    backfill's own clock and destroy the historical value. In an `UPDATE … SET`
+ *    the right-hand side reads the OLD row, so this is an explicit no-op that
+ *    displaces the automatic one.
+ */
+export async function linkCoverImages(
+  database: Database,
+  mongo: MongoDatabase,
+): Promise<CoverReport[]> {
+  const reports: CoverReport[] = [];
+  for (const level of [
+    { table: 'cities' as const, collection: 'cities', target: cities },
+    { table: 'regions' as const, collection: 'regions', target: regions },
+  ]) {
+    const claims = new Map<string, string>();
+    for await (const document of streamCollection(mongo, level.collection)) {
+      const id = String(document._id);
+      const cover = document.coverImageId;
+      if (cover === undefined || cover === null) continue;
+      claims.set(id, String(cover));
+    }
+
+    // One query for every referenced cover, with its entity type, rather than a
+    // lookup per row: 1,230 covers over 1,660 cities.
+    const wanted = [...new Set(claims.values())];
+    const geoImages = new Set<string>();
+    const anyImage = new Set<string>();
+    for (let start = 0; start < wanted.length; start += MONGO_LOOKUP_BATCH) {
+      const batch = wanted.slice(start, start + MONGO_LOOKUP_BATCH);
+      const rows = await database
+        .select({ id: images.id, entityType: images.entityType })
+        .from(images)
+        .where(inArray(images.id, batch));
+      for (const row of rows) {
+        anyImage.add(row.id);
+        if ((GEO_IMAGE_ENTITY_TYPES as readonly string[]).includes(row.entityType)) {
+          geoImages.add(row.id);
+        }
+      }
+    }
+
+    let linked = 0;
+    let alreadySet = 0;
+    let unresolvable = 0;
+    let notAGeoImage = 0;
+    for (const [rowId, coverId] of claims) {
+      if (!anyImage.has(coverId)) {
+        unresolvable += 1;
+        continue;
+      }
+      if (!geoImages.has(coverId)) {
+        notAGeoImage += 1;
+        continue;
+      }
+      const updated = await database
+        .update(level.target)
+        .set({ coverImageId: coverId, updatedAt: sql`${level.target.updatedAt}` })
+        .where(and(eq(level.target.id, rowId), isNull(level.target.coverImageId)))
+        .returning({ id: level.target.id });
+      if (updated.length > 0) linked += 1;
+      else alreadySet += 1;
+    }
+
+    const report: CoverReport = {
+      table: level.table,
+      claimed: claims.size,
+      linked,
+      alreadySet,
+      unresolvable,
+      notAGeoImage,
+    };
+    logger.info(`Cover images for ${level.table}`, report);
+    reports.push(report);
+  }
+  return reports;
+}
+
+// ── verifying ──────────────────────────────────────────────────────
+
+/**
+ * Counts, completeness by ID, and a field-by-field sample — per collection.
+ *
+ * Completeness is by ID rather than by count because equal counts can hide a
+ * copy that dropped forty rows and gained forty others: `ON CONFLICT DO NOTHING`
+ * absorbing a unique collision while the ingestion worker inserted new listings
+ * is exactly that shape, and a count comparison reports it as perfect.
+ *
+ * Fidelity RE-RUNS the mapper against the live source document. Reading back
+ * what was written and checking it is what was written is a check that cannot
+ * fail.
+ */
+async function verifyCollection(
+  database: Database,
+  mongo: MongoDatabase,
+  plan: DataCollectionPlan,
+  sampleSize: number,
+): Promise<VerifyReport[]> {
+  const parentTable = plan.tables[0];
+  const target = requireTable(parentTable);
+
+  const ids: string[] = [];
+  let missing = 0;
+  const missingIds: string[] = [];
+  let pending: string[] = [];
+
+  const drain = async (): Promise<void> => {
+    if (pending.length === 0) return;
+    const present = await presentIds(database, target, pending);
+    for (const id of pending) {
+      if (present.has(id)) continue;
+      missing += 1;
+      if (missingIds.length < MAX_REPORTED_IDS) missingIds.push(id);
+    }
+    pending = [];
+  };
+
+  for await (const document of streamCollection(mongo, plan.sourceCollection)) {
+    const id = String(document._id);
+    ids.push(id);
+    pending.push(id);
+    if (pending.length >= MONGO_LOOKUP_BATCH) await drain();
+  }
+  await drain();
+
+  const [totals] = await database.select({ total: count() }).from(target);
+  const { compared, mismatches } = await compareSample(database, mongo, plan, sampleSize);
+
+  const report: VerifyReport = {
+    table: parentTable,
+    sourceDocuments: ids.length,
+    targetRows: totals?.total ?? 0,
+    missing,
+    missingIds,
+    compared,
+    mismatches: mismatches.slice(0, MAX_REPORTED_IDS),
+  };
+  logger.info(`Verified ${plan.name}`, report);
+  return [report];
+}
+
+/**
+ * Re-map a sample of source documents and compare every column against what is
+ * stored.
+ *
+ * `$sample` rather than the first N: `_id` order is creation order, so the front
+ * of `properties` is its OLDEST rows — the cohort least likely to carry the
+ * sub-objects added later, which are exactly the fields a fidelity check most
+ * needs to exercise.
+ *
+ * A column the mapper left `undefined` is SKIPPED only where the column has a
+ * default; where it has none, `undefined` must have stored NULL and that IS
+ * checked — the difference between "the schema filled this in" and "the copy
+ * lost it".
+ */
+async function compareSample(
+  database: Database,
+  mongo: MongoDatabase,
+  plan: DataCollectionPlan,
+  sampleSize: number,
+): Promise<{ compared: number; mismatches: string[] }> {
+  const documents = (await mongo
+    .collection(plan.sourceCollection)
+    .aggregate([{ $sample: { size: sampleSize } }])
+    .toArray()) as SourceDocument[];
+
+  const log = new ResolutionLog();
+  const mismatches: string[] = [];
+  let compared = 0;
+
+  for (const document of documents) {
+    const mapped = plan.map(document, log);
+    for (const table of plan.tables) {
+      const rows = mapped[table] ?? [];
+      if (rows.length === 0) continue;
+      const target = requireTable(table);
+      const columns = getTableColumns(target);
+
+      if (plan.mintsIds.includes(table)) {
+        compared += rows.length;
+        mismatches.push(...(await compareMintedRows(database, plan, table, rows)));
+        continue;
+      }
+
+      const rowIds = rows.map((row) => String(row.id));
+      const stored = await database
+        .select()
+        .from(target)
+        .where(inArray(getTableColumns(target).id, rowIds));
+      const byId = new Map(
+        stored.map((row) => [String((row as CandidateRow).id), row as CandidateRow]),
+      );
+
+      for (const expected of rows) {
+        compared += 1;
+        const actual = byId.get(String(expected.id));
+        if (actual === undefined) {
+          mismatches.push(`${table}/${String(expected.id)}: absent from the target`);
+          continue;
+        }
+        for (const column of columnNames(target)) {
+          // GENERATED ALWAYS columns are not the copy's to produce — `geo`,
+          // `address_level` and `search_vector` are derived by the DATABASE from
+          // columns that were copied, and writing one raises 428C9. Comparing
+          // them would report a mismatch on every row of a perfect copy.
+          if (columns[column]?.generated !== undefined) continue;
+          const want = expected[column];
+          // `undefined` means the mapper omitted the key, so the column's own
+          // DEFAULT decided the stored value and there is nothing to compare it
+          // against. Where there is no default, NULL is the only legal outcome
+          // and it is checked.
+          if (want === undefined) {
+            if (columns[column]?.hasDefault) continue;
+            if (actual[column] === null) continue;
+            mismatches.push(
+              `${table}/${String(expected.id)}.${column}: expected NULL, stored ${JSON.stringify(actual[column])}`,
+            );
+            continue;
+          }
+          if (!sameValue(want, actual[column])) {
+            mismatches.push(
+              `${table}/${String(expected.id)}.${column}: expected ${JSON.stringify(want)}, stored ${JSON.stringify(actual[column])}`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  return { compared, mismatches };
+}
+
+/**
+ * Compare rows whose ids were MINTED, as a set, with the id excluded.
+ *
+ * A re-map mints new ids, so there is nothing to match on — and nothing to
+ * check either: the id is the one value the copy invented rather than carried.
+ * Everything else IS checked, against every stored row for the same parent, so a
+ * lost field or a wrong one still fails.
+ *
+ * Matching by parent rather than globally keeps the comparison meaningful on a
+ * table that will hold millions of rows.
+ */
+async function compareMintedRows(
+  database: Database,
+  plan: DataCollectionPlan,
+  table: string,
+  rows: readonly CandidateRow[],
+): Promise<string[]> {
+  const target = requireTable(table);
+  const columns = getTableColumns(target);
+  const parentColumn = plan.references.find((spec) => spec.table === table)?.column;
+  if (parentColumn === undefined || rows.length === 0) return [];
+
+  const parents = [...new Set(rows.map((row) => String(row[parentColumn])))];
+  const stored = await database
+    .select()
+    .from(target)
+    .where(inArray(columns[parentColumn], parents));
+
+  const fingerprint = (row: CandidateRow): string =>
+    canonicalJson(
+      Object.fromEntries(
+        Object.keys(columns)
+          .filter((column) => column !== 'id' && columns[column]?.generated === undefined)
+          .map((column) => [column, row[column] ?? null]),
+      ),
+    );
+
+  const available = new Map<string, number>();
+  for (const row of stored) {
+    const key = fingerprint(row as CandidateRow);
+    available.set(key, (available.get(key) ?? 0) + 1);
+  }
+
+  const mismatches: string[] = [];
+  for (const expected of rows) {
+    const key = fingerprint(expected);
+    const remaining = available.get(key) ?? 0;
+    if (remaining === 0) {
+      mismatches.push(`${table}: no stored row matches ${key}`);
+      continue;
+    }
+    available.set(key, remaining - 1);
+  }
+  return mismatches;
+}
+
+/**
+ * The geometry checks — the only ones that can see a transposed coordinate pair.
+ *
+ * `addresses.geo` is GENERATED from `longitude`/`latitude`, so it is never null
+ * and never disagrees with its columns. That makes "the column is populated" a
+ * check which passes just as happily on a pair swapped end for end: the result
+ * is a valid point in the wrong hemisphere, indexable, queryable, and wrong.
+ * Only a DISTANCE can tell.
+ *
+ * Both halves are needed. The centroid sweep covers EVERY address and catches a
+ * transposition anywhere in the table; the named pairs are an independent
+ * real-world anchor that would catch an error the sweep cannot see, because both
+ * sides of the sweep's comparison come from the same migration.
+ */
+export async function checkGeometry(database: Database): Promise<GeometryReport> {
+  const [centroid] = await database.execute<{
+    samples: string;
+    max_metres: number | null;
+    over_limit: string;
+  }>(sql`
+    select
+      count(*)::text as samples,
+      max(distance) as max_metres,
+      count(*) filter (where distance > ${CITY_CENTROID_LIMIT_METRES})::text as over_limit
+    from (
+      select ST_Distance(a.geo, ST_MakePoint(c.longitude, c.latitude)::geography) as distance
+      from addresses a
+      join cities c on c.id = a.city_id
+      where c.longitude is not null and c.latitude is not null
+    ) measured
+  `);
+
+  const pairs: GeometryReport['pairs'][number][] = [];
+  for (const pair of CITY_PAIRS) {
+    const [row] = await database.execute<{ metres: number | null }>(sql`
+      select ST_Distance(
+        (select a.geo from addresses a join cities c on c.id = a.city_id
+          where lower(c.name) = lower(${pair.from}) limit 1),
+        (select a.geo from addresses a join cities c on c.id = a.city_id
+          where lower(c.name) = lower(${pair.to}) limit 1)
+      ) as metres
+    `);
+    const measuredMetres = row?.metres ?? null;
+    pairs.push({
+      from: pair.from,
+      to: pair.to,
+      expectedMetres: pair.metres,
+      measuredMetres,
+      // `null` rather than `false` when a city has no address: "nothing in
+      // Paris" is not a failed distance check, and reporting it as one would
+      // make an honest gap indistinguishable from a transposition. The CALLER
+      // decides what to do with it — and treats it as not-passed, so an absent
+      // city can never be read as a pass either.
+      withinTolerance:
+        measuredMetres === null
+          ? null
+          : Math.abs(measuredMetres - pair.metres) <= pair.metres * CITY_PAIR_TOLERANCE,
+    });
+  }
+
+  return {
+    centroidSamples: Number(centroid?.samples ?? 0),
+    centroidMaxMetres: centroid?.max_metres ?? null,
+    centroidOverLimit: Number(centroid?.over_limit ?? 0),
+    pairs,
+  };
+}
+
+// ── the run ────────────────────────────────────────────────────────
+
+/**
+ * Audit, copy and verify — on connections the caller already opened and already
+ * checked.
+ *
+ * Exported so the test suite drives the SAME function production does, against a
+ * real Mongo and a real Postgres, rather than a re-assembled imitation of it.
+ * The two database-name guards are deliberately NOT in here: they belong to
+ * whoever opened the connections, and {@link main} runs both before calling
+ * this. A test's throwaway database has no such names to check.
+ *
+ * @throws {Error} When the audit refuses any row (nothing is written), or when
+ *   verification finds a source row missing from the target, a column whose
+ *   stored value differs from what the mappers produce, a `has_images`
+ *   disagreement, or a geometry check that did not pass.
+ */
+export async function runDataBackfill(options: {
+  readonly mongo: MongoDatabase;
+  readonly database: Database;
+  readonly mode: Mode;
+  readonly sampleSize?: number;
+  readonly only?: readonly DataCollectionName[];
+}): Promise<DataBackfillReport> {
+  const { mongo, database, mode } = options;
+  const sampleSize = options.sampleSize ?? DEFAULT_SAMPLE_ROWS;
+  const selected = options.only ?? DATA_COPY_ORDER;
+  const plans = DATA_COPY_ORDER.filter((name) => selected.includes(name)).map(
+    (name) => DATA_PLANS[name],
+  );
+  const partial = plans.length !== DATA_COPY_ORDER.length;
+
+  const log = new ResolutionLog();
+  const audited: Record<string, number> = {};
+
+  // ── the audit pass ──
+  //
+  // A full read that writes nothing, in BOTH `audit-only` and `copy` mode. The
+  // second is the point: it is what keeps "never run an insert the audit has not
+  // seen" true for a streaming copy, which a single pass cannot — it would
+  // refuse at the first bad batch with every earlier batch already committed.
+  if (mode !== 'verify-only') {
+    const violations: AuditViolation[] = [];
+    for (const plan of plans) {
+      const pass = await streamCollectionPass(database, mongo, plan, log, false);
+      Object.assign(audited, pass.audited);
+      violations.push(...pass.violations);
+      logger.info(`Audited ${plan.name}`, { documents: pass.documents, rows: pass.audited });
+    }
+
+    if (violations.length > 0) {
+      for (const line of describeViolations('audit', violations)) logger.error(line);
+      throw new Error(
+        `Audit refused ${violations.length} constraint violation(s); nothing was written. ` +
+        'Every line above names a column, the reason the target would refuse it, ' +
+        'how many rows carry it and example ids.',
+      );
+    }
+
+    // The VACUITY FLOOR. "No violations" and "nothing was checked" are the same
+    // report, and a streaming audit can produce the second one for a dozen
+    // boring reasons. Refusing here is what stops an empty pass being read as a
+    // clean one — the source guard already proved the collections exist, so zero
+    // rows audited means something between them and here went wrong.
+    const totalAudited = Object.values(audited).reduce((sum, rows) => sum + rows, 0);
+    if (totalAudited === 0) {
+      throw new Error(
+        'The audit examined ZERO rows across every selected collection. That is ' +
+        'not a clean audit — it is an audit that ran against nothing, and it ' +
+        'reports identically to one that passed. Nothing was written.',
+      );
+    }
+    logger.info('Audit passed', { rows: audited, resolutions: log.toRecord() });
+  }
+
+  if (mode === 'audit-only') {
+    return {
+      mode,
+      resolutions: log.toRecord(),
+      audited,
+      copied: [],
+      hasImagesRederived: null,
+      covers: [],
+      verified: [],
+      geometry: null,
+      hasImagesDisagreements: null,
+    };
+  }
+
+  // ── the copy pass ──
+  const copied: CopyReport[] = [];
+  if (mode === 'copy') {
+    for (const plan of plans) {
+      const pass = await streamCollectionPass(database, mongo, plan, log, true);
+      const report: CopyReport = {
+        collection: plan.name,
+        documents: pass.documents,
+        inserted: pass.inserted,
+      };
+      logger.info(`Copied ${plan.name}`, report);
+      copied.push(report);
+    }
+  }
+
+  // ── after the copy ──
+  //
+  // Both steps read tables a SCOPED run may not have populated, and running them
+  // against a partial copy writes a wrong answer rather than no answer: deriving
+  // `has_images` from a half-loaded `property_images` sets every listing to
+  // `false`, and linking covers before `images` is loaded records every one of
+  // them as unresolvable.
+  let hasImagesRederived: number | null = null;
+  let covers: CoverReport[] = [];
+  if (mode === 'copy' && !partial) {
+    hasImagesRederived = await syncAllHasImages(database);
+    logger.info('properties.has_images re-derived from property_images', { hasImagesRederived });
+    covers = await linkCoverImages(database, mongo);
+  } else if (mode === 'copy') {
+    logger.warn(
+      'Scoped run (--only): has_images derivation and geo cover linking were SKIPPED. ' +
+      'Both read tables this run may not have populated.',
+    );
+  }
+
+  // ── verification ──
+  const verified: VerifyReport[] = [];
+  for (const plan of plans) {
+    verified.push(...(await verifyCollection(database, mongo, plan, sampleSize)));
+  }
+
+  const geometry = selected.includes('addresses') ? await checkGeometry(database) : null;
+  const hasImagesDisagreements = partial ? null : (await findHasImagesDisagreements(database)).length;
+
+  logger.info('Verification measurements', {
+    geometry,
+    hasImagesDisagreements,
+    resolutions: log.toRecord(),
+  });
+
+  const failures: string[] = [];
+  for (const report of verified) {
+    if (report.missing > 0) {
+      failures.push(`${report.table}: ${report.missing} source row(s) missing from the target`);
+    }
+    if (report.mismatches.length > 0) {
+      failures.push(`${report.table}: ${report.mismatches.length} column(s) differ from the source`);
+    }
+    // The vacuity floor, and it has to be conditional: a collection that is
+    // legitimately empty compares nothing and that is the correct answer. What
+    // must never pass is a collection with documents whose sample compared none
+    // of them — "no mismatches" and "nothing was compared" read identically.
+    if (report.compared === 0 && report.sourceDocuments > 0) {
+      failures.push(
+        `${report.table}: ${report.sourceDocuments} source document(s) and the ` +
+        'field-by-field sample compared NOTHING',
+      );
+    }
+  }
+  if (geometry !== null) {
+    if (geometry.centroidSamples === 0) {
+      failures.push('geometry: no address could be compared against its city centroid');
+    }
+    if (geometry.centroidOverLimit > 0) {
+      failures.push(
+        `geometry: ${geometry.centroidOverLimit} address(es) sit more than ` +
+        `${CITY_CENTROID_LIMIT_METRES / 1000} km from their own city — the shape a transposed pair makes`,
+      );
+    }
+    // A pair with no address in one of its cities was NOT MEASURED, which is not
+    // the same as measured-and-wrong: reporting it as a failure would make an
+    // honest gap indistinguishable from a transposition. What must not happen is
+    // every pair going unmeasured and the check reporting a pass — so the
+    // vacuity floor is that at least one real-world distance was obtained.
+    const measured = geometry.pairs.filter((pair) => pair.measuredMetres !== null);
+    if (measured.length === 0) {
+      failures.push(
+        'geometry: not one named city pair could be measured, so nothing anchored ' +
+        `the coordinates to a real-world distance (tried ${geometry.pairs.map((pair) => `${pair.from}→${pair.to}`).join(', ')})`,
+      );
+    }
+    for (const pair of measured) {
+      if (pair.withinTolerance === true) continue;
+      failures.push(
+        `geometry: ${pair.from}→${pair.to} measured ${pair.measuredMetres} m ` +
+        `against an expected ${pair.expectedMetres} m`,
+      );
+    }
+  }
+  if (hasImagesDisagreements !== null && hasImagesDisagreements > 0) {
+    failures.push(
+      `has_images: ${hasImagesDisagreements} listing(s) disagree with their own photo rows`,
+    );
+  }
+
+  if (failures.length > 0) {
+    for (const failure of failures) logger.error(failure);
+    throw new Error(`Verification failed:\n  ${failures.join('\n  ')}`);
+  }
+
+  return {
+    mode,
+    resolutions: log.toRecord(),
+    audited,
+    copied,
+    hasImagesRederived,
+    covers,
+    verified,
+    geometry,
+    hasImagesDisagreements,
+  };
+}
+
+/**
+ * The `--only=a,b` argument, or every collection.
+ *
+ * @throws {Error} When it names a collection that does not exist. A typo
+ *   silently running nothing would be a successful-looking no-op, which is the
+ *   failure this whole file is built against.
+ */
+export function readOnly(argv: readonly string[]): readonly DataCollectionName[] {
+  const prefix = '--only=';
+  const flag = argv.find((argument) => argument.startsWith(prefix));
+  if (flag === undefined) return DATA_COPY_ORDER;
+
+  const names = flag.slice(prefix.length).split(',').map((name) => name.trim()).filter(Boolean);
+  const unknown = names.filter(
+    (name) => !(DATA_COPY_ORDER as readonly string[]).includes(name),
+  );
+  if (unknown.length > 0) {
+    throw new Error(
+      `--only names ${unknown.join(', ')}, which this backfill does not know. ` +
+      `Valid names: ${DATA_COPY_ORDER.join(', ')}.`,
+    );
+  }
+  return names as readonly DataCollectionName[];
+}
+
+/** The drizzle table a SQL name refers to. */
+function requireTable(name: string): PgTable {
+  const table = DATA_TABLES[name];
+  if (table === undefined) {
+    throw new Error(
+      `No table named ${JSON.stringify(name)} is registered in DATA_TABLES. Refusing ` +
+      'rather than skipping it: a pass that cannot find its table audits nothing ' +
+      'and reports success exactly as loudly as one that passed.',
+    );
+  }
+  return table;
+}
+
+// ── entrypoint ─────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  // Argument validation first, before either connection string is read and
+  // before anything opens a socket: an operator who forgot a flag should learn
+  // it instantly rather than after two connection attempts.
+  const argv = process.argv.slice(2);
+  const target = readTargetDatabase(argv);
+  const source = readSourceDatabase(argv);
+  const mode = readMode(argv);
+  const sampleSize = readSampleSize(argv);
+  const only = readOnly(argv);
+
+  const mongoUrl = process.env.MONGODB_URI;
+  if (!mongoUrl) throw new Error('MONGODB_URI is not set; there is nothing to copy from.');
+  const postgresUrl = process.env.DATABASE_URL;
+  if (!postgresUrl) throw new Error('DATABASE_URL is not set; there is nowhere to copy to.');
+
+  logger.info('Data backfill starting', { source, target, mode, sampleSize, only });
+
+  await mongoose.connect(mongoUrl);
+  const client = postgres(postgresUrl, { max: 1 });
+  try {
+    const mongo = mongoose.connection.db;
+    if (!mongo) throw new Error('Mongo connected but published no database handle.');
+
+    // Both guards before anything is read and long before anything is written.
+    await assertMigrationSource(
+      mongo,
+      source,
+      only.map((name) => DATA_PLANS[name].sourceCollection),
+    );
+    await assertMigrationTarget(client, target);
+
+    const database = drizzle(client, { schema, casing: DATABASE_CASING });
+    const report = await runDataBackfill({ mongo, database, mode, sampleSize, only });
+    logger.info('Data backfill complete', {
+      source,
+      target,
+      mode,
+      resolutions: report.resolutions,
+    });
+  } finally {
+    await client.end({ timeout: CLOSE_TIMEOUT_SECONDS });
+    await mongoose.disconnect();
+  }
+}
+
+// `require.main === module` rather than an unconditional call: this file is both
+// a CLI entrypoint and a module the tests import for its exported pieces.
+if (require.main === module) {
+  main().catch((error: unknown) => {
+    logger.error('Data backfill failed', error);
+    // Not `process.exit`: it would truncate the very message that says what went
+    // wrong. The event loop is free once both connections are closed.
+    process.exitCode = 1;
+  });
+}

--- a/packages/backend/db/backfill/dataPlan.ts
+++ b/packages/backend/db/backfill/dataPlan.ts
@@ -1,0 +1,1283 @@
+/**
+ * The rest of the data — images, addresses, agencies, properties and profiles —
+ * mapped from Mongo documents to candidate rows.
+ *
+ * The geo reference data landed first (`geoPlan.ts`) to close a live regression.
+ * This is everything else: 171,976 images, 11,734 addresses, 2,627 agencies,
+ * 17,644 properties with three child tables, and the five profiles.
+ *
+ * Same rules as `geoPlan`, and they are not restated here: ids travel verbatim,
+ * a value of the wrong shape is PRESERVED so `rowAudit` refuses it rather than
+ * being coerced away, and every departure from what the source holds is a NAMED,
+ * COUNTED resolution.
+ *
+ * ## The order is a foreign key graph, not a preference
+ *
+ * `images` → `property_images.image_id` (NOT NULL, RESTRICT) and
+ * `cities/regions.cover_image_id`; `addresses` → `properties.address_id`
+ * (NOT NULL, RESTRICT); `agencies` → `properties.agency_id`. **`agencies` before
+ * `properties` is the edge that is easy to miss**, because the issue and the
+ * census both list agencies after properties by row count — migration 0003
+ * promoted `agency_id` from the deferred-foreign-key ledger to a real reference,
+ * which is what turned a harmless ordering into a fatal one. 8,374 listings
+ * carry an agency.
+ *
+ * `profiles` is last, and its position carries no FK argument at all: nothing
+ * references a profile and a profile references nothing (Oxy owns identity, so
+ * `oxy_user_id` has no foreign key by design). It is last because it is the only
+ * IRREPLACEABLE data here — properties, addresses and images are regenerable by
+ * the ingestion worker from the portals — so it runs once every mechanical
+ * failure the other four could expose has been exposed.
+ *
+ * ## What is NOT copied, and why each is deliberate
+ *
+ * | field | reason |
+ * |---|---|
+ * | `properties.hasImages` | DERIVED after the copy by `db/hasImages.ts`, the column's one writer. Production holds a row whose stored flag disagrees with its own array, so copying it would import a known-wrong answer into the primary sort key of every discovery feed. |
+ * | `properties.coverImageIndex` | `-1` on all 17,644 rows; the meaning moved to `property_images.is_primary`. |
+ * | `properties.title` / `views` | Absent from `PropertySchema`, so mongoose strict mode has been dropping them from every write. There is nothing to copy — see `schema/unmappedColumns.ts`. |
+ * | `Region.imageIds[]` / `City.imageIds[]` | Dropped with the column: the relation already exists as `images.(entity_type, entity_id)`. |
+ */
+
+import { uuidv7 } from '@oxyhq/db';
+import type { PgTable } from 'drizzle-orm/pg-core';
+import {
+  addresses,
+  agencies,
+  cities,
+  countries,
+  images,
+  neighborhoods,
+  partners,
+  regions,
+  profileChatMessages,
+  profilePreferredLocations,
+  profileReferences,
+  profileRentalHistory,
+  profileRoommateHistory,
+  profiles,
+  properties,
+  propertyAvailabilityWindows,
+  propertyDocuments,
+  propertyImages,
+} from '../schema';
+import { OFFERING_TYPES } from '../schema/properties';
+import {
+  createdAtValue,
+  idValue,
+  optional,
+  readPath,
+  ResolutionLog,
+  toImageRow,
+  updatedAtValue,
+  withSchemaDefault,
+  type SourceDocument,
+} from './geoPlan';
+import type { CandidateRow, RowRule } from './rowAudit';
+
+/**
+ * Every rule under which this copy writes something other than what the source
+ * holds, with the production figure the census froze it at.
+ *
+ * Reported and compared, never enforced: production moves between the census and
+ * the window (external listings carry a TTL that reaps them continuously), so a
+ * drifting count is information and an equal count is confirmation. Neither is a
+ * reason to refuse.
+ */
+export const DATA_RESOLUTIONS = {
+  /**
+   * The `moderation` sub-object is absent → `moderation_restricted` is `false`.
+   *
+   * Frozen at **17,642 of 17,644**. The column is `NOT NULL DEFAULT false`, so
+   * this could have been an omission — it is written explicitly because a
+   * decision that is counted is a decision somebody can audit, and this one
+   * rests on three measured facts rather than on convenience: the field was
+   * added to `PropertySchema` after the newest document was created, re-ingesting
+   * does not add it (the rows WITHOUT it have a later max `updatedAt` than the
+   * two with it), and `moderation.restricted` is written only by
+   * `ModerationEnforcementService`, which is switched off in production. Absent
+   * therefore means "no jury has restricted this listing".
+   */
+  MODERATION_ABSENT: 'MODERATION_ABSENT',
+  /**
+   * `listingFlags` is absent → all eleven columns NULL.
+   *
+   * Frozen at **9,594 of 17,644**, and this one must NOT copy
+   * {@link MODERATION_ABSENT}'s answer. Those booleans are THREE-state: `true`
+   * (the classifier fired), `false` (it looked and said no), NULL (it never
+   * ran). Defaulting 9,594 rows to `false` would manufacture a claim about them
+   * that nobody made.
+   */
+  LISTING_FLAGS_ABSENT: 'LISTING_FLAGS_ABSENT',
+  /** `externalContact` is absent → all six columns NULL. Frozen at **5,174**. */
+  EXTERNAL_CONTACT_ABSENT: 'EXTERNAL_CONTACT_ABSENT',
+  /** `priceEthics` is absent → all eight columns NULL. Frozen at **133**. */
+  PRICE_ETHICS_ABSENT: 'PRICE_ETHICS_ABSENT',
+  /**
+   * The stored `hasImages` disagreed with its own `images[]` — counted, and the
+   * stored value discarded either way.
+   *
+   * Census: **1 row** (`6a515dd9c196de4ad2a8550e`, `hasImages: false` with
+   * twelve images). The flag is re-derived for the whole table after the copy,
+   * so this count is not a correction — it is the evidence that deriving rather
+   * than copying was the right call. That id carries `expiresAt: 2026-08-09`, so
+   * the TTL may have reaped it; a count of zero here is expected once it has.
+   */
+  HAS_IMAGES_DISAGREED: 'HAS_IMAGES_DISAGREED',
+  /**
+   * `normalizedKey` was stored as an EMPTY STRING → written NULL.
+   *
+   * The unique index is partial on `normalized_key is not null`, and an empty
+   * string is a VALUE: two unkeyed addresses would collide for real, and under
+   * `ON CONFLICT DO NOTHING` one of them would silently never arrive. Mongo's
+   * `sparse: true` had the same requirement and the same trap.
+   */
+  NORMALIZED_KEY_EMPTY: 'NORMALIZED_KEY_EMPTY',
+  /**
+   * An embedded subdocument had no `_id` → a uuid v7 was minted for its row.
+   *
+   * Not a remap: there was no id to preserve and nothing references these rows.
+   * `availabilityWindowSchema` declares `{ _id: false }`, so every calendar
+   * window is one of these; `Property.images[]`, `documents[]` and the five
+   * profile arrays keep their own ids.
+   */
+  SUBDOCUMENT_ID_MINTED: 'SUBDOCUMENT_ID_MINTED',
+} as const;
+
+/** The Mongo collection each copy step reads. */
+export const DATA_SOURCE_COLLECTIONS = {
+  images: 'images',
+  addresses: 'addresses',
+  agencies: 'agencies',
+  properties: 'properties',
+  profiles: 'profiles',
+} as const;
+
+export type DataCollectionName = keyof typeof DATA_SOURCE_COLLECTIONS;
+
+/** Copy in this order or fail `23503`. See the module doc for every edge. */
+export const DATA_COPY_ORDER = [
+  'images',
+  'addresses',
+  'agencies',
+  'properties',
+  'profiles',
+] as const satisfies readonly DataCollectionName[];
+
+/** A foreign key this copy must resolve before it writes the child row. */
+export interface ReferenceSpec {
+  /** The SQL table the child row goes into. */
+  readonly table: string;
+  /** The constraint's own name, so a finding is greppable against the schema. */
+  readonly constraint: string;
+  /** The column on the child row. */
+  readonly column: string;
+  /** The Postgres table it references. */
+  readonly parentTable: string;
+  /**
+   * The Mongo collection the parents come from, or `null` when the parents live
+   * ONLY in Postgres.
+   *
+   * A parent may legitimately be in either store: `addresses.city_id` points at
+   * geo rows already copied, `properties.address_id` at rows THIS run is about
+   * to write. Resolving against only one of them is wrong in both directions —
+   * Postgres alone reports every property as an orphan, Mongo alone misses a geo
+   * row that never arrived.
+   */
+  readonly parentCollection: string | null;
+  /** Whether NULL is acceptable. */
+  readonly nullable: boolean;
+}
+
+/** A unique index `ON CONFLICT DO NOTHING` would absorb rather than report. */
+export interface UniqueKeySpec {
+  readonly table: string;
+  readonly constraint: string;
+  /** The composite key, or `null` for a row a PARTIAL index does not cover. */
+  readonly key: (row: CandidateRow) => string | null;
+}
+
+/** One collection's copy: what it reads, what it writes, and what must hold. */
+export interface DataCollectionPlan {
+  readonly name: DataCollectionName;
+  readonly sourceCollection: string;
+  /** Target tables, PARENT FIRST — a child's FK must resolve against a row already in. */
+  readonly tables: readonly string[];
+  /** One document → the rows it becomes, keyed by SQL table name. */
+  readonly map: (
+    document: SourceDocument,
+    log: ResolutionLog,
+  ) => Readonly<Record<string, readonly CandidateRow[]>>;
+  /** Table-level CHECKs the column metadata cannot express, keyed by table. */
+  readonly rules: Readonly<Record<string, readonly RowRule[]>>;
+  /**
+   * Tables whose rows carry a MINTED id, so a re-map produces a different one.
+   *
+   * The verifier re-runs the mapper against the live source document and matches
+   * what it produces against what is stored — by id, because that is the only
+   * thing the two share. For a row minted from a `{ _id: false }` subdocument
+   * there IS no shared id: `uuidv7()` returns something new every call, so an
+   * id-matched comparison reports every such row as "absent from the target" on
+   * a flawless copy. Those tables are compared as a SET of rows with the id
+   * excluded instead, which checks every field that was actually copied and
+   * claims nothing about the one that was not.
+   */
+  readonly mintsIds: readonly string[];
+  readonly uniqueKeys: readonly UniqueKeySpec[];
+  readonly references: readonly ReferenceSpec[];
+}
+
+// ── images ─────────────────────────────────────────────────────────
+
+/**
+ * `images` ← the WHOLE collection this time.
+ *
+ * The geo copy took only `city`/`region`/`country` photos; `property_images
+ * .image_id` is `NOT NULL` with `ON DELETE RESTRICT`, so every one of the
+ * 169,223 referenced property photos has to be here before a listing is written.
+ *
+ * `entity_id` gets no reference rule and never will: one column referencing five
+ * tables cannot be a foreign key, which is why it is the one permanent entry in
+ * `deferredForeignKeys.ts`'s `ID_COLUMNS_WITHOUT_FOREIGN_KEY`. A dangling one is
+ * also not a copy failure — the census found 948 orphaned image documents left
+ * behind by the `properties` TTL, and refusing to migrate because of a defect
+ * the migration did not cause would be refusing for the wrong reason.
+ */
+const imagesPlan: DataCollectionPlan = {
+  mintsIds: [],
+  name: 'images',
+  sourceCollection: DATA_SOURCE_COLLECTIONS.images,
+  tables: ['images'],
+  map: (document, log) => ({ images: [toImageRow(document, log)] }),
+  rules: {},
+  uniqueKeys: [],
+  references: [],
+};
+
+// ── addresses ──────────────────────────────────────────────────────
+
+/**
+ * `addresses` ← `models/Address.ts`. MANY-TO-ONE with properties, 0.67 per
+ * listing, and that ratio is the point: `findOrCreateCanonical` collapses
+ * listings onto a canonical building by `normalizedKey`. The copy preserves that
+ * mapping by copying ids verbatim and nothing else — it never regenerates a key,
+ * never dedupes, and never creates an address a property points at.
+ *
+ * ## The coordinate pair is the most dangerous read in the whole backfill
+ *
+ * Mongo stores `coordinates: { type: 'Point', coordinates: [lng, lat] }` — a
+ * POSITIONAL pair, and transposing it produces a valid point in the wrong
+ * hemisphere with no error at any layer: still two numbers, still inside the
+ * range CHECK for most European latitudes, still indexable. The target removes
+ * the class of bug permanently (named columns, `geo` GENERATED from them), so
+ * this function is the last place the order still matters — and the verifier
+ * measures a real-world DISTANCE rather than asserting the column is non-null,
+ * because non-null is exactly what a transposed pair also is.
+ *
+ * ## `normalized_key` is copied verbatim, and `''` becomes NULL
+ *
+ * Verbatim because the `pre('save')` hook that derives it has already changed
+ * shape once, so recomputing during the copy would re-key every building and
+ * break the dedup `findOrCreateCanonical` depends on.
+ */
+const addressesPlan: DataCollectionPlan = {
+  mintsIds: [],
+  name: 'addresses',
+  sourceCollection: DATA_SOURCE_COLLECTIONS.addresses,
+  tables: ['addresses'],
+  map: (document, log) => ({ addresses: [toAddressRow(document, log)] }),
+  rules: {
+    addresses: [
+      {
+        // Mongo REJECTED an out-of-range pair on the way in, so this holds on
+        // every stored row — and it is checked anyway because PostGIS does NOT
+        // enforce it: `ST_MakePoint(0, 100)::geography` raises a NOTICE, coerces
+        // latitude 100 to **80**, and the insert SUCCEEDS. A bad pair becomes a
+        // different, entirely plausible place rather than an error.
+        name: 'addresses_coordinates_range_check',
+        reason:
+          'longitude must be within ±180 and latitude within ±90 (23514) — ' +
+          'PostGIS would COERCE an out-of-range pair into a plausible wrong place ' +
+          'rather than refuse it',
+        holds: (row) =>
+          inRange(row.longitude, -180, 180) && inRange(row.latitude, -90, 90),
+        offendingValue: (row) => [row.longitude, row.latitude],
+      },
+    ],
+  },
+  uniqueKeys: [
+    {
+      table: 'addresses',
+      constraint: 'addresses_normalized_key_key',
+      // PARTIAL: `where normalized_key is not null`. Two unkeyed addresses do
+      // not collide, and treating them as if they did would report thousands of
+      // findings on a healthy collection.
+      key: (row) => (typeof row.normalizedKey === 'string' ? row.normalizedKey : null),
+    },
+  ],
+  references: [
+    reference('addresses', 'addresses_country_id_countries_id_fk', 'countryId', 'countries', 'countries', false),
+    reference('addresses', 'addresses_region_id_regions_id_fk', 'regionId', 'regions', 'regions', false),
+    reference('addresses', 'addresses_city_id_cities_id_fk', 'cityId', 'cities', 'cities', false),
+    reference('addresses', 'addresses_neighborhood_id_neighborhoods_id_fk', 'neighborhoodId', 'neighborhoods', 'neighborhoods', true),
+  ],
+};
+
+/** `addresses` ← `models/Address.ts`. */
+export function toAddressRow(document: SourceDocument, log: ResolutionLog): CandidateRow {
+  const createdAt = createdAtValue(document, log);
+
+  // `[longitude, latitude]`, written out because the ORDER is the entire
+  // meaning. Anything that is not exactly two elements is handed to the audit
+  // UNCHANGED rather than salvaged: a one-element array or a `{ lat, lng }`
+  // object would otherwise silently produce a row at longitude 0.
+  const pair = readPath(document, 'coordinates.coordinates');
+  const point = Array.isArray(pair) && pair.length === 2 ? pair : null;
+
+  const normalizedKey = readPath(document, 'normalizedKey');
+  if (normalizedKey === '') log.applied(DATA_RESOLUTIONS.NORMALIZED_KEY_EMPTY);
+
+  return {
+    id: idValue(document._id),
+
+    countryId: idValue(readPath(document, 'countryId')),
+    regionId: idValue(readPath(document, 'regionId')),
+    cityId: idValue(readPath(document, 'cityId')),
+    neighborhoodId: idValue(readPath(document, 'neighborhoodId')),
+    countryCode: optional(document, 'countryCode'),
+
+    street: optional(document, 'street'),
+    postalCode: optional(document, 'postal_code'),
+    number: optional(document, 'number'),
+    buildingName: optional(document, 'building_name'),
+    block: optional(document, 'block'),
+    entrance: optional(document, 'entrance'),
+    floor: optional(document, 'floor'),
+    unit: optional(document, 'unit'),
+    subunit: optional(document, 'subunit'),
+    district: optional(document, 'district'),
+    addressLines: withSchemaDefault(document, 'address_lines', [], log),
+    poBox: optional(document, 'po_box'),
+    reference: optional(document, 'reference'),
+
+    landPlotBlock: optional(document, 'land_plot.block'),
+    landPlotLot: optional(document, 'land_plot.lot'),
+    landPlotParcel: optional(document, 'land_plot.parcel'),
+
+    extras: withSchemaDefault(document, 'extras', {}, log),
+
+    longitude: point === null ? (pair ?? null) : point[0],
+    latitude: point === null ? (pair ?? null) : point[1],
+    // `geo` and `address_level` are GENERATED ALWAYS. Writing either raises
+    // 428C9 — which is the point of generating them: no write path, this copy
+    // included, can produce a row whose point disagrees with its pair.
+
+    normalizedKey: normalizedKey === '' ? null : (normalizedKey ?? null),
+
+    createdAt,
+    updatedAt: updatedAtValue(document, createdAt, log),
+  };
+}
+
+// ── agencies ───────────────────────────────────────────────────────
+
+/**
+ * `agencies` ← `models/schemas/AgencySchema.ts`. 2,627 rows, and it MUST land
+ * before `properties`.
+ *
+ * `normalizedName` and `slug` are copied VERBATIM and never recomputed:
+ * `utils/agencyName` is ordinary application code that can change, and
+ * recomputing during the copy would re-key every existing agency and split
+ * reviews across two rows that used to be one. Same rule, same reason, as
+ * `addresses.normalized_key`.
+ *
+ * Both unique keys are declared because `ON CONFLICT DO NOTHING` would ABSORB a
+ * collision rather than raise it — and the 8,374 listings pointing at the loser
+ * would then fail their own foreign key later, in a different table, with
+ * nothing connecting the two facts.
+ */
+const agenciesPlan: DataCollectionPlan = {
+  mintsIds: [],
+  name: 'agencies',
+  sourceCollection: DATA_SOURCE_COLLECTIONS.agencies,
+  tables: ['agencies'],
+  map: (document, log) => ({ agencies: [toAgencyRow(document, log)] }),
+  rules: {
+    agencies: [
+      notEmptyRule('agencies_normalized_name_not_empty_check', 'normalizedName'),
+      notEmptyRule('agencies_slug_not_empty_check', 'slug'),
+    ],
+  },
+  uniqueKeys: [
+    {
+      table: 'agencies',
+      constraint: 'agencies_normalized_name_key',
+      key: (row) => (typeof row.normalizedName === 'string' ? row.normalizedName : null),
+    },
+    {
+      table: 'agencies',
+      constraint: 'agencies_slug_key',
+      key: (row) => (typeof row.slug === 'string' ? row.slug : null),
+    },
+  ],
+  references: [],
+};
+
+/** `agencies` ← `models/schemas/AgencySchema.ts`. */
+export function toAgencyRow(document: SourceDocument, log: ResolutionLog): CandidateRow {
+  const createdAt = createdAtValue(document, log);
+  return {
+    id: idValue(document._id),
+    name: optional(document, 'name'),
+    normalizedName: optional(document, 'normalizedName'),
+    slug: optional(document, 'slug'),
+    createdAt,
+    updatedAt: updatedAtValue(document, createdAt, log),
+  };
+}
+
+/**
+ * `('<offering>' = any(offerings)) = (<discriminator> is not null)`, per
+ * offering.
+ *
+ * Written per-offering rather than as one combined constraint so a violation
+ * NAMES which offering is incoherent; a single check would report the same
+ * constraint for any of the four and say nothing a reader could act on. Each
+ * direction catches a different bug: `offerings` naming a block that is not
+ * there (a listing advertising a price it does not have), and a block present
+ * without its offering (a price nothing can find).
+ */
+const OFFERING_COHERENCE_RULES: readonly RowRule[] = [
+  offeringRule('long_term_rent', 'longTermRentMonthlyAmount'),
+  offeringRule('short_term_rent', 'shortTermRentNightlyRate'),
+  offeringRule('sale', 'salePrice'),
+  offeringRule('exchange', 'exchangeMode'),
+];
+
+function offeringRule(offering: string, discriminator: string): RowRule {
+  return {
+    name: `properties_offering_${offering}_check`,
+    reason:
+      `offerings must name '${offering}' exactly when ${discriminator} is set (23514)`,
+    holds: (row) => {
+      // A non-array `offerings` is already refused by the column scan; reporting
+      // it here too would double-count one defect under two names.
+      if (!Array.isArray(row.offerings)) return true;
+      return row.offerings.includes(offering) === !isAbsent(row[discriminator]);
+    },
+    offendingValue: (row) => ({ offerings: row.offerings, [discriminator]: row[discriminator] }),
+  };
+}
+
+/**
+ * The four block-INTEGRITY CHECKs: a satellite column may only be populated when
+ * its block's discriminator is.
+ *
+ * The coherence rules above are written over PRICE null-ness;
+ * `offeringValidation.ts` writes the same invariant over BLOCK PRESENCE, and the
+ * two diverge in exactly one direction — `sale: { currency: 'EUR' }` with
+ * `offerings: []` is rejected by Mongo and invisible to a coherence check, which
+ * only sees `false = false`.
+ */
+const BLOCK_INTEGRITY_RULES: readonly RowRule[] = [
+  blockRule('long_term_rent', 'longTermRentMonthlyAmount', [
+    'longTermRentCurrency',
+    'longTermRentDeposit',
+    'longTermRentApplicationFee',
+    'longTermRentLateFee',
+    'longTermRentUtilities',
+  ]),
+  blockRule('short_term_rent', 'shortTermRentNightlyRate', [
+    'shortTermRentCurrency',
+    'shortTermRentCleaningFee',
+    'shortTermRentServiceFee',
+    'shortTermRentTaxesPercent',
+    'shortTermRentMinNights',
+    'shortTermRentMaxNights',
+    'shortTermRentInstantBook',
+    'shortTermRentDeposit',
+  ]),
+  blockRule('sale', 'salePrice', [
+    'saleCurrency',
+    'salePricePerSqm',
+    'saleEstimatedYield',
+    'saleIsPriceReduced',
+    'saleChainStatus',
+  ]),
+  blockRule('exchange', 'exchangeMode', [
+    'exchangeMinStay',
+    'exchangeMaxStay',
+    'exchangeWelcomeNote',
+    'exchangeLanguages',
+    'exchangeMealsIncluded',
+    'exchangeRequiresReciprocity',
+  ]),
+];
+
+function blockRule(
+  block: string,
+  discriminator: string,
+  satellites: readonly string[],
+): RowRule {
+  return {
+    name: `properties_${block}_block_check`,
+    reason: `a ${block} column may only be set when ${discriminator} is (23514)`,
+    holds: (row) =>
+      !isAbsent(row[discriminator]) || satellites.every((column) => isAbsent(row[column])),
+    offendingValue: (row) => satellites.filter((column) => !isAbsent(row[column])),
+  };
+}
+
+// ── properties ─────────────────────────────────────────────────────
+
+/**
+ * `properties` ← `models/schemas/PropertySchema.ts`, plus its three child
+ * tables. 135 columns and the last table in the dependency order.
+ *
+ * ## Four absent sub-objects, four different answers
+ *
+ * Flattening an optional sub-document makes every one of its columns nullable,
+ * so "the block was absent" has to be represented by the columns themselves.
+ * Only `moderation` gets a VALUE, and it is the only one that can — see
+ * {@link DATA_RESOLUTIONS} for the measured reason each of the four differs.
+ *
+ * ## The offering CHECKs are the largest correctness win in this port
+ *
+ * `models/schemas/offeringValidation.ts` states one invariant — `offerings`
+ * equals exactly the set of present priced blocks — and Mongo has TWO
+ * enforcement paths for it that do not agree: the path validator runs on
+ * `save()`, and EXPLICITLY SKIPS ITSELF on `findOneAndUpdate` (a Query `this`
+ * cannot see sibling blocks), while `scraperService.ts:285` reaches the
+ * collection through `updateOne` with no `runValidators` at all — the
+ * steady-state path for all 17,644 external listings. Here it is one rule the
+ * database enforces on every write path there is or will be, which is exactly
+ * why the audit has to check it before the copy: a row that has drifted is a
+ * `23514` mid-run otherwise.
+ */
+const propertiesPlan: DataCollectionPlan = {
+  // `availabilityWindowSchema` declares `{ _id: false }`; `Property.images[]`
+  // and `documents[]` are implicit `{ _id: true }` subdocuments and keep theirs.
+  mintsIds: ['property_availability_windows'],
+  name: 'properties',
+  sourceCollection: DATA_SOURCE_COLLECTIONS.properties,
+  tables: ['properties', 'property_images', 'property_documents', 'property_availability_windows'],
+  map: (document, log) => ({
+    properties: [toPropertyRow(document, log)],
+    property_images: toPropertyImageRows(document, log),
+    property_documents: toPropertyDocumentRows(document, log),
+    property_availability_windows: toPropertyWindowRows(document, log),
+  }),
+  rules: {
+    properties: [
+      ...OFFERING_COHERENCE_RULES,
+      ...BLOCK_INTEGRITY_RULES,
+      {
+        name: 'properties_offerings_check',
+        reason: `every element must be one of ${OFFERING_TYPES.join(', ')} (23514)`,
+        holds: (row) =>
+          !Array.isArray(row.offerings) ||
+          row.offerings.every((offering) =>
+            (OFFERING_TYPES as readonly string[]).includes(String(offering)),
+          ),
+        offendingValue: (row) => row.offerings,
+      },
+      {
+        // One-directional on purpose: an internal listing MAY carry a source
+        // URL, so only the external half is asserted. A blanket `NOT NULL` would
+        // encode the external path — `source_url` is absent from both
+        // `CREATABLE_PROPERTY_FIELDS` and `EDITABLE_PROPERTY_FIELDS`, so no
+        // user-created listing can ever have one.
+        name: 'properties_external_source_url_check',
+        reason: 'an external listing must carry the source_url it came from (23514)',
+        holds: (row) => row.isExternal !== true || !isAbsent(row.sourceUrl),
+        offendingValue: (row) => row.sourceUrl,
+      },
+    ],
+    property_availability_windows: [
+      {
+        name: 'property_availability_windows_order_check',
+        reason: 'ends_at must be after starts_at (23514)',
+        holds: (row) =>
+          !(row.startsAt instanceof Date) ||
+          !(row.endsAt instanceof Date) ||
+          row.endsAt.getTime() > row.startsAt.getTime(),
+        offendingValue: (row) => [row.startsAt, row.endsAt],
+      },
+    ],
+  },
+  uniqueKeys: [
+    {
+      table: 'properties',
+      constraint: 'properties_source_source_id_key',
+      // Mongo's partial unique `{ source, sourceId }`. `source` is `NOT NULL
+      // DEFAULT 'internal'`, so the default is spelled out here: a row that
+      // omits it still occupies the `internal` key space.
+      //
+      // `JSON.stringify` rather than a separator character. A composite key
+      // needs one neither half can contain, and both halves are portal-supplied
+      // strings — the obvious unambiguous choice is a NUL byte, which is what
+      // #296 removed from this directory: a single NUL makes git classify the
+      // file as BINARY, and a binary file has no diff for anyone to review.
+      key: (row) =>
+        typeof row.sourceId === 'string'
+          ? JSON.stringify([typeof row.source === 'string' ? row.source : 'internal', row.sourceId])
+          : null,
+    },
+    {
+      table: 'property_images',
+      constraint: 'property_images_one_primary_key',
+      // PARTIAL: `where is_primary`. A plain unique on
+      // `(property_id, is_primary)` would also permit only one NON-primary photo
+      // per listing, which is the opposite of a photo list.
+      key: (row) => (row.isPrimary === true ? String(row.propertyId) : null),
+    },
+  ],
+  references: [
+    reference('properties', 'properties_address_id_addresses_id_fk', 'addressId', 'addresses', 'addresses', false),
+    reference('properties', 'properties_agency_id_agencies_id_fk', 'agencyId', 'agencies', 'agencies', true),
+    reference('properties', 'properties_sourced_by_partner_id_partners_id_fk', 'sourcedByPartnerId', 'partners', 'partners', true),
+    reference('properties', 'properties_parent_property_id_properties_id_fk', 'parentPropertyId', 'properties', 'properties', true),
+    reference('property_images', 'property_images_property_id_properties_id_fk', 'propertyId', 'properties', 'properties', false),
+    reference('property_images', 'property_images_image_id_images_id_fk', 'imageId', 'images', 'images', false),
+    reference('property_documents', 'property_documents_property_id_properties_id_fk', 'propertyId', 'properties', 'properties', false),
+    reference('property_availability_windows', 'property_availability_windows_property_id_properties_id_fk', 'propertyId', 'properties', 'properties', false),
+  ],
+};
+
+/** `properties` ← `models/schemas/PropertySchema.ts`. */
+export function toPropertyRow(document: SourceDocument, log: ResolutionLog): CandidateRow {
+  const createdAt = createdAtValue(document, log);
+
+  if (readPath(document, 'moderation') === undefined) {
+    log.applied(DATA_RESOLUTIONS.MODERATION_ABSENT);
+  }
+  if (readPath(document, 'listingFlags') === undefined) {
+    log.applied(DATA_RESOLUTIONS.LISTING_FLAGS_ABSENT);
+  }
+  if (readPath(document, 'externalContact') === undefined) {
+    log.applied(DATA_RESOLUTIONS.EXTERNAL_CONTACT_ABSENT);
+  }
+  if (readPath(document, 'priceEthics') === undefined) {
+    log.applied(DATA_RESOLUTIONS.PRICE_ETHICS_ABSENT);
+  }
+  // The stored flag is never written — `db/hasImages.ts` re-derives the column
+  // for the whole table after the copy. Counting where the two disagree is what
+  // makes "deriving was the right call" a measurement rather than an assertion.
+  const embedded = subdocuments(document, 'images');
+  if (readPath(document, 'hasImages') !== (embedded.length > 0)) {
+    log.applied(DATA_RESOLUTIONS.HAS_IMAGES_DISAGREED);
+  }
+
+  return {
+    id: idValue(document._id),
+    oxyUserId: optional(document, 'oxyUserId'),
+
+    source: withSchemaDefault(document, 'source', 'internal', log),
+    sourceId: optional(document, 'sourceId'),
+    sourceUrl: optional(document, 'sourceUrl'),
+    isExternal: withSchemaDefault(document, 'isExternal', false, log),
+    expiresAt: optional(document, 'expiresAt'),
+
+    // RENAMED from Mongo's `sourcedByPartner`: the old name was invisible to
+    // `idShapedColumns`, whose `_id` suffix test classifies every id-shaped
+    // column in the schema, and a column no gate can see is one that ships
+    // unconstrained.
+    sourcedByPartnerId: idValue(readPath(document, 'sourcedByPartner')),
+    sourcedByReferralCode: optional(document, 'sourcedByReferralCode'),
+    agencyId: idValue(readPath(document, 'agencyId')),
+
+    externalContactPhone: optional(document, 'externalContact.phone'),
+    externalContactEmail: optional(document, 'externalContact.email'),
+    externalContactWhatsapp: optional(document, 'externalContact.whatsapp'),
+    externalContactName: optional(document, 'externalContact.name'),
+    externalContactAgencyName: optional(document, 'externalContact.agencyName'),
+    externalContactKind: optional(document, 'externalContact.kind'),
+
+    listingFlagsStudentsOnly: optional(document, 'listingFlags.studentsOnly'),
+    listingFlagsRoomNotFullUnit: optional(document, 'listingFlags.roomNotFullUnit'),
+    listingFlagsTemporaryOnly: optional(document, 'listingFlags.temporaryOnly'),
+    listingFlagsGenderRestricted: optional(document, 'listingFlags.genderRestricted'),
+    listingFlagsWorkersOnly: optional(document, 'listingFlags.workersOnly'),
+    listingFlagsAgencyFeePayable: optional(document, 'listingFlags.agencyFeePayable'),
+    listingFlagsNoPets: optional(document, 'listingFlags.noPets'),
+    listingFlagsNoSmoking: optional(document, 'listingFlags.noSmoking'),
+    listingFlagsNoCouples: optional(document, 'listingFlags.noCouples'),
+    // `noDSS` in Mongo, `no_dss` here — the one place in this mapping where the
+    // source spelling and the column name differ by more than case.
+    listingFlagsNoDss: optional(document, 'listingFlags.noDSS'),
+    listingFlagsDetectedLanguage: optional(document, 'listingFlags.detectedLanguage'),
+
+    description: optional(document, 'description'),
+
+    addressId: idValue(readPath(document, 'addressId')),
+    showAddressNumber: withSchemaDefault(document, 'showAddressNumber', true, log),
+
+    type: withSchemaDefault(document, 'type', 'apartment', log),
+    housingType: withSchemaDefault(document, 'housingType', 'private', log),
+    layoutType: withSchemaDefault(document, 'layoutType', 'traditional', log),
+
+    bedrooms: withSchemaDefault(document, 'bedrooms', 0, log),
+    bathrooms: withSchemaDefault(document, 'bathrooms', 0, log),
+    squareFootage: withSchemaDefault(document, 'squareFootage', 0, log),
+    floor: withSchemaDefault(document, 'floor', 0, log),
+    yearBuilt: optional(document, 'yearBuilt'),
+
+    hasElevator: withSchemaDefault(document, 'hasElevator', false, log),
+    hasBalcony: withSchemaDefault(document, 'hasBalcony', false, log),
+    hasGarden: withSchemaDefault(document, 'hasGarden', false, log),
+    utilitiesIncluded: withSchemaDefault(document, 'utilitiesIncluded', false, log),
+    petFriendly: withSchemaDefault(document, 'petFriendly', false, log),
+    proximityToTransport: withSchemaDefault(document, 'proximityToTransport', false, log),
+    proximityToSchools: withSchemaDefault(document, 'proximityToSchools', false, log),
+    proximityToShopping: withSchemaDefault(document, 'proximityToShopping', false, log),
+    isVerified: withSchemaDefault(document, 'isVerified', false, log),
+    isEcoFriendly: withSchemaDefault(document, 'isEcoFriendly', false, log),
+
+    offerings: withSchemaDefault(document, 'offerings', [], log),
+    amenities: withSchemaDefault(document, 'amenities', [], log),
+
+    furnishedStatus: withSchemaDefault(document, 'furnishedStatus', 'not_specified', log),
+    petPolicy: withSchemaDefault(document, 'petPolicy', 'not_specified', log),
+    petFee: withSchemaDefault(document, 'petFee', 0, log),
+    parkingType: withSchemaDefault(document, 'parkingType', 'none', log),
+    parkingSpaces: withSchemaDefault(document, 'parkingSpaces', 0, log),
+    leaseTerm: withSchemaDefault(document, 'leaseTerm', 'monthly', log),
+    cancellationPolicy: optional(document, 'cancellationPolicy'),
+
+    // Carried ALONGSIDE `availability_available_from`, which DISAGREES with it
+    // on 1,630 of 17,644 rows while both are present on every one. They are read
+    // by different filter paths, so collapsing them would silently change what a
+    // filter matches for those listings.
+    availableFrom: withSchemaDefault(document, 'availableFrom', createdAt, log),
+
+    smokingAllowed: withSchemaDefault(document, 'smokingAllowed', false, log),
+    partiesAllowed: withSchemaDefault(document, 'partiesAllowed', false, log),
+    guestsAllowed: withSchemaDefault(document, 'guestsAllowed', true, log),
+    maxGuests: withSchemaDefault(document, 'maxGuests', 1, log),
+
+    longTermRentMonthlyAmount: optional(document, 'longTermRent.monthlyAmount'),
+    longTermRentCurrency: optional(document, 'longTermRent.currency'),
+    longTermRentDeposit: optional(document, 'longTermRent.deposit'),
+    longTermRentApplicationFee: optional(document, 'longTermRent.applicationFee'),
+    longTermRentLateFee: optional(document, 'longTermRent.lateFee'),
+    longTermRentUtilities: optional(document, 'longTermRent.utilities'),
+
+    shortTermRentNightlyRate: optional(document, 'shortTermRent.nightlyRate'),
+    shortTermRentCurrency: optional(document, 'shortTermRent.currency'),
+    shortTermRentCleaningFee: optional(document, 'shortTermRent.cleaningFee'),
+    shortTermRentServiceFee: optional(document, 'shortTermRent.serviceFee'),
+    shortTermRentTaxesPercent: optional(document, 'shortTermRent.taxesPercent'),
+    shortTermRentMinNights: optional(document, 'shortTermRent.minNights'),
+    shortTermRentMaxNights: optional(document, 'shortTermRent.maxNights'),
+    shortTermRentInstantBook: optional(document, 'shortTermRent.instantBook'),
+    shortTermRentDeposit: optional(document, 'shortTermRent.deposit'),
+
+    salePrice: optional(document, 'sale.price'),
+    saleCurrency: optional(document, 'sale.currency'),
+    salePricePerSqm: optional(document, 'sale.pricePerSqm'),
+    saleEstimatedYield: optional(document, 'sale.estimatedYield'),
+    saleIsPriceReduced: optional(document, 'sale.isPriceReduced'),
+    saleChainStatus: optional(document, 'sale.chainStatus'),
+
+    exchangeMode: optional(document, 'exchange.mode'),
+    exchangeMinStay: optional(document, 'exchange.minStay'),
+    exchangeMaxStay: optional(document, 'exchange.maxStay'),
+    exchangeWelcomeNote: optional(document, 'exchange.welcomeNote'),
+    exchangeLanguages: optional(document, 'exchange.languages'),
+    exchangeMealsIncluded: optional(document, 'exchange.mealsIncluded'),
+    exchangeRequiresReciprocity: optional(document, 'exchange.requiresReciprocity'),
+
+    accommodationDetailsSleepingArrangement: optional(document, 'accommodationDetails.sleepingArrangement'),
+    accommodationDetailsHostelRoomType: optional(document, 'accommodationDetails.hostelRoomType'),
+    accommodationDetailsCampsiteType: optional(document, 'accommodationDetails.campsiteType'),
+    accommodationDetailsMaxStay: optional(document, 'accommodationDetails.maxStay'),
+    accommodationDetailsMinAge: optional(document, 'accommodationDetails.minAge'),
+    accommodationDetailsMaxAge: optional(document, 'accommodationDetails.maxAge'),
+    accommodationDetailsCulturalExchange: withSchemaDefault(document, 'accommodationDetails.culturalExchange', false, log),
+    accommodationDetailsMealsIncluded: withSchemaDefault(document, 'accommodationDetails.mealsIncluded', false, log),
+    // PROTECTED — `schema/protectedColumns.ts`. A credential for a real network,
+    // on the most-read table in the product; mongoose hid it only by accident.
+    accommodationDetailsWifiPassword: optional(document, 'accommodationDetails.wifiPassword'),
+    accommodationDetailsRoommatePreferences: withSchemaDefault(document, 'accommodationDetails.roommatePreferences', [], log),
+    accommodationDetailsColivingFeatures: withSchemaDefault(document, 'accommodationDetails.colivingFeatures', [], log),
+    accommodationDetailsLanguages: withSchemaDefault(document, 'accommodationDetails.languages', [], log),
+    accommodationDetailsHouseRules: withSchemaDefault(document, 'accommodationDetails.houseRules', [], log),
+
+    availabilityIsAvailable: withSchemaDefault(document, 'availability.isAvailable', true, log),
+    availabilityAvailableFrom: withSchemaDefault(document, 'availability.availableFrom', createdAt, log),
+    availabilityMinimumStay: withSchemaDefault(document, 'availability.minimumStay', 1, log),
+    availabilityMaximumStay: withSchemaDefault(document, 'availability.maximumStay', 12, log),
+
+    rulesPets: withSchemaDefault(document, 'rules.pets', false, log),
+    rulesSmoking: withSchemaDefault(document, 'rules.smoking', false, log),
+    rulesParties: withSchemaDefault(document, 'rules.parties', false, log),
+    rulesGuests: withSchemaDefault(document, 'rules.guests', true, log),
+    rulesMaxOccupancy: withSchemaDefault(document, 'rules.maxOccupancy', 1, log),
+
+    // The `NOT NULL` column of the four absent sub-objects, and the only one
+    // that gets a value. See DATA_RESOLUTIONS.MODERATION_ABSENT.
+    moderationRestricted: withSchemaDefault(document, 'moderation.restricted', false, log),
+    moderationRestrictedAt: optional(document, 'moderation.restrictedAt'),
+    moderationRestrictedByDecisionId: optional(document, 'moderation.restrictedByDecisionId'),
+
+    priceEthicsEthicalSuggested: optional(document, 'priceEthics.ethicalSuggested'),
+    priceEthicsEthicalMax: optional(document, 'priceEthics.ethicalMax'),
+    priceEthicsWithinEthical: optional(document, 'priceEthics.withinEthical'),
+    priceEthicsMarketVerdict: optional(document, 'priceEthics.marketVerdict'),
+    priceEthicsPercentDiffFromAvg: optional(document, 'priceEthics.percentDiffFromAvg'),
+    priceEthicsIsFairPrice: optional(document, 'priceEthics.isFairPrice'),
+    priceEthicsFairnessScore: optional(document, 'priceEthics.fairnessScore'),
+    priceEthicsScoredAt: optional(document, 'priceEthics.scoredAt'),
+
+    ratingAverage: withSchemaDefault(document, 'rating.average', 0, log),
+    ratingCount: withSchemaDefault(document, 'rating.count', 0, log),
+
+    lastSaved: withSchemaDefault(document, 'lastSaved', createdAt, log),
+    parentPropertyId: idValue(readPath(document, 'parentPropertyId')),
+    status: withSchemaDefault(document, 'status', 'draft', log),
+    deletedAt: optional(document, 'deletedAt'),
+
+    createdAt,
+    updatedAt: updatedAtValue(document, createdAt, log),
+  };
+}
+
+/** `property_images` ← `Property.images[]`. */
+export function toPropertyImageRows(
+  document: SourceDocument,
+  log: ResolutionLog,
+): readonly CandidateRow[] {
+  const propertyId = idValue(document._id);
+  return subdocuments(document, 'images').map((child) => ({
+    id: mintedSubdocumentId(child, log),
+    propertyId,
+    imageId: idValue(readPath(child, 'imageId')),
+    url: optional(child, 'url'),
+    caption: optional(child, 'caption'),
+    isPrimary: withSchemaDefault(child, 'isPrimary', false, log),
+    order: withSchemaDefault(child, 'order', 0, log),
+    // The `urls` sub-document, flattened. Nullable because Mongo declared it
+    // `default: undefined` precisely so pre-Image entries still validate.
+    urlsOriginal: optional(child, 'urls.original'),
+    urlsSmall: optional(child, 'urls.small'),
+    urlsMedium: optional(child, 'urls.medium'),
+    urlsLarge: optional(child, 'urls.large'),
+  }));
+}
+
+/** `property_documents` ← `Property.documents[]`. */
+export function toPropertyDocumentRows(
+  document: SourceDocument,
+  log: ResolutionLog,
+): readonly CandidateRow[] {
+  const propertyId = idValue(document._id);
+  return subdocuments(document, 'documents').map((child) => ({
+    id: mintedSubdocumentId(child, log),
+    propertyId,
+    name: optional(child, 'name'),
+    url: optional(child, 'url'),
+    type: withSchemaDefault(child, 'type', 'other', log),
+  }));
+}
+
+/**
+ * `property_availability_windows` ← BOTH calendars.
+ *
+ * Mongo declared `availabilityWindowSchema` twice — on the listing and inside
+ * the exchange block — so "does anything overlap this range?" had to be asked
+ * against two arrays with two sets of indexes. One table plus a `scope`
+ * discriminator makes it one question answered by one GiST index over
+ * `tstzrange(starts_at, ends_at)`.
+ *
+ * Every window here mints its id: the sub-schema declares `{ _id: false }`, so
+ * there is none to preserve.
+ */
+export function toPropertyWindowRows(
+  document: SourceDocument,
+  log: ResolutionLog,
+): readonly CandidateRow[] {
+  const propertyId = idValue(document._id);
+  const windows = (path: string, scope: 'listing' | 'exchange') =>
+    subdocuments(document, path).map((child) => ({
+      id: mintedSubdocumentId(child, log),
+      propertyId,
+      scope,
+      // Mongo's `start` / `end`. Renamed because `end` is a reserved word and
+      // the pair reads better together.
+      startsAt: optional(child, 'start'),
+      endsAt: optional(child, 'end'),
+      status: withSchemaDefault(child, 'status', 'available', log),
+    }));
+
+  return [
+    ...windows('availabilityWindows', 'listing'),
+    ...windows('exchange.availabilityWindows', 'exchange'),
+  ];
+}
+
+// ── profiles ───────────────────────────────────────────────────────
+
+/**
+ * `profiles` ← `models/schemas/ProfileSchema.ts`. Five rows, and the ONLY
+ * irreplaceable data in this backfill.
+ *
+ * Properties, addresses and images are regenerable — the ingestion worker
+ * rebuilds them from the portals. A tenant's profile is not: nobody re-enters an
+ * income, a rental history, a set of references or a Sindi transcript, and there
+ * is no upstream to re-scrape it from. Five rows is small enough that `data.ts`
+ * verifies them exhaustively rather than by sample.
+ *
+ * ## The `personalProfile` wrapper is DROPPED from every column name
+ *
+ * A hard limit, not a style choice:
+ * `personalProfile.settings.roommate.preferences.lifestyle.cleanliness` spells
+ * out to 68 bytes and Postgres truncates an identifier at 63 SILENTLY, so two
+ * paths differing only past byte 63 would collide into one column.
+ *
+ * ## Every column is NULLABLE, including the ones with a Mongoose default
+ *
+ * `personalProfile` is declared with no `default`, so mongoose never
+ * materialises it and none of its defaults are ever written. Column nullness is
+ * the only representation of the block being absent once it is flattened away —
+ * which is why nothing here uses `withSchemaDefault`.
+ */
+const profilesPlan: DataCollectionPlan = {
+  // Every profile array is an implicit `{ _id: true }` subdocument.
+  mintsIds: [],
+  name: 'profiles',
+  sourceCollection: DATA_SOURCE_COLLECTIONS.profiles,
+  tables: [
+    'profiles',
+    'profile_references',
+    'profile_rental_history',
+    'profile_preferred_locations',
+    'profile_roommate_history',
+    'profile_chat_messages',
+  ],
+  map: (document, log) => ({
+    profiles: [toProfileRow(document, log)],
+    profile_references: toProfileReferenceRows(document, log),
+    profile_rental_history: toProfileRentalHistoryRows(document, log),
+    profile_preferred_locations: toProfilePreferredLocationRows(document, log),
+    profile_roommate_history: toProfileRoommateHistoryRows(document, log),
+    profile_chat_messages: toProfileChatMessageRows(document, log),
+  }),
+  rules: {
+    profile_rental_history: [dateOrderRule('profile_rental_history_order_check')],
+    profile_roommate_history: [dateOrderRule('profile_roommate_history_order_check')],
+  },
+  uniqueKeys: [
+    {
+      table: 'profiles',
+      constraint: 'profiles_oxy_user_id_key',
+      key: (row) => (typeof row.oxyUserId === 'string' ? row.oxyUserId : null),
+    },
+  ],
+  references: [
+    reference('profile_references', 'profile_references_profile_id_profiles_id_fk', 'profileId', 'profiles', 'profiles', false),
+    reference('profile_rental_history', 'profile_rental_history_profile_id_profiles_id_fk', 'profileId', 'profiles', 'profiles', false),
+    reference('profile_preferred_locations', 'profile_preferred_locations_profile_id_profiles_id_fk', 'profileId', 'profiles', 'profiles', false),
+    reference('profile_roommate_history', 'profile_roommate_history_profile_id_profiles_id_fk', 'profileId', 'profiles', 'profiles', false),
+    reference('profile_chat_messages', 'profile_chat_messages_profile_id_profiles_id_fk', 'profileId', 'profiles', 'profiles', false),
+  ],
+};
+
+/** `profiles` ← `models/schemas/ProfileSchema.ts`, wrapper dropped. */
+export function toProfileRow(document: SourceDocument, log: ResolutionLog): CandidateRow {
+  const createdAt = createdAtValue(document, log);
+  const field = (path: string) => optional(document, `personalProfile.${path}`);
+
+  return {
+    id: idValue(document._id),
+    oxyUserId: optional(document, 'oxyUserId'),
+
+    personalInfoBio: field('personalInfo.bio'),
+    personalInfoOccupation: field('personalInfo.occupation'),
+    personalInfoEmployer: field('personalInfo.employer'),
+    // PROTECTED — `schema/protectedColumns.ts`. `showIncome` defaults to false,
+    // so this has never been part of a public profile.
+    personalInfoAnnualIncome: field('personalInfo.annualIncome'),
+    personalInfoEmploymentStatus: field('personalInfo.employmentStatus'),
+    personalInfoMoveInDate: field('personalInfo.moveInDate'),
+    personalInfoLeaseDuration: field('personalInfo.leaseDuration'),
+
+    preferencesPropertyTypes: field('preferences.propertyTypes'),
+    preferencesMaxRent: field('preferences.maxRent'),
+    preferencesPriceUnit: field('preferences.priceUnit'),
+    preferencesMinBedrooms: field('preferences.minBedrooms'),
+    preferencesMinBathrooms: field('preferences.minBathrooms'),
+    preferencesPreferredAmenities: field('preferences.preferredAmenities'),
+    preferencesPetFriendly: field('preferences.petFriendly'),
+    preferencesSmokingAllowed: field('preferences.smokingAllowed'),
+    preferencesFurnished: field('preferences.furnished'),
+    preferencesParkingRequired: field('preferences.parkingRequired'),
+    preferencesAccessibility: field('preferences.accessibility'),
+
+    verificationIdentity: field('verification.identity'),
+    verificationIncome: field('verification.income'),
+    verificationBackground: field('verification.background'),
+    verificationRentalHistory: field('verification.rentalHistory'),
+    verificationReferences: field('verification.references'),
+
+    settingsNotificationsEmail: field('settings.notifications.email'),
+    settingsNotificationsPush: field('settings.notifications.push'),
+    settingsNotificationsSms: field('settings.notifications.sms'),
+    settingsNotificationsPropertyAlerts: field('settings.notifications.propertyAlerts'),
+    settingsNotificationsViewingReminders: field('settings.notifications.viewingReminders'),
+    settingsNotificationsLeaseUpdates: field('settings.notifications.leaseUpdates'),
+
+    settingsPrivacyProfileVisibility: field('settings.privacy.profileVisibility'),
+    settingsPrivacyShowContactInfo: field('settings.privacy.showContactInfo'),
+    settingsPrivacyShowIncome: field('settings.privacy.showIncome'),
+    settingsPrivacyShowRentalHistory: field('settings.privacy.showRentalHistory'),
+    settingsPrivacyShowReferences: field('settings.privacy.showReferences'),
+
+    settingsRoommateEnabled: field('settings.roommate.enabled'),
+    settingsRoommatePreferencesAgeRangeMin: field('settings.roommate.preferences.ageRange.min'),
+    settingsRoommatePreferencesAgeRangeMax: field('settings.roommate.preferences.ageRange.max'),
+    settingsRoommatePreferencesGender: field('settings.roommate.preferences.gender'),
+    settingsRoommatePreferencesLifestyleSmoking: field('settings.roommate.preferences.lifestyle.smoking'),
+    settingsRoommatePreferencesLifestylePets: field('settings.roommate.preferences.lifestyle.pets'),
+    settingsRoommatePreferencesLifestylePartying: field('settings.roommate.preferences.lifestyle.partying'),
+    settingsRoommatePreferencesLifestyleCleanliness: field('settings.roommate.preferences.lifestyle.cleanliness'),
+    settingsRoommatePreferencesLifestyleSchedule: field('settings.roommate.preferences.lifestyle.schedule'),
+    settingsRoommatePreferencesBudgetMin: field('settings.roommate.preferences.budget.min'),
+    settingsRoommatePreferencesBudgetMax: field('settings.roommate.preferences.budget.max'),
+    settingsRoommatePreferencesMoveInDate: field('settings.roommate.preferences.moveInDate'),
+    settingsRoommatePreferencesLeaseDuration: field('settings.roommate.preferences.leaseDuration'),
+
+    settingsLanguage: field('settings.language'),
+    settingsTimezone: field('settings.timezone'),
+    settingsCurrency: field('settings.currency'),
+
+    createdAt,
+    updatedAt: updatedAtValue(document, createdAt, log),
+  };
+}
+
+/** `profile_references` ← `personalProfile.references[]`. */
+export function toProfileReferenceRows(
+  document: SourceDocument,
+  log: ResolutionLog,
+): readonly CandidateRow[] {
+  const profileId = idValue(document._id);
+  return subdocuments(document, 'personalProfile.references').map((child) => ({
+    id: mintedSubdocumentId(child, log),
+    profileId,
+    name: optional(child, 'name'),
+    relationship: optional(child, 'relationship'),
+    phone: optional(child, 'phone'),
+    email: optional(child, 'email'),
+    verified: withSchemaDefault(child, 'verified', false, log),
+  }));
+}
+
+/** `profile_rental_history` ← `personalProfile.rentalHistory[]`. */
+export function toProfileRentalHistoryRows(
+  document: SourceDocument,
+  log: ResolutionLog,
+): readonly CandidateRow[] {
+  const profileId = idValue(document._id);
+  return subdocuments(document, 'personalProfile.rentalHistory').map((child) => ({
+    id: mintedSubdocumentId(child, log),
+    profileId,
+    address: optional(child, 'address'),
+    startDate: optional(child, 'startDate'),
+    endDate: optional(child, 'endDate'),
+    monthlyRent: optional(child, 'monthlyRent'),
+    reasonForLeaving: optional(child, 'reasonForLeaving'),
+    landlordContactName: optional(child, 'landlordContact.name'),
+    landlordContactPhone: optional(child, 'landlordContact.phone'),
+    landlordContactEmail: optional(child, 'landlordContact.email'),
+    verified: withSchemaDefault(child, 'verified', false, log),
+  }));
+}
+
+/**
+ * `profile_preferred_locations` ← `personalProfile.preferences.preferredLocations[]`.
+ *
+ * `radius` keeps Mongo's units, which are MILES (the validator reads "Radius
+ * must be at least 1 mile"). Nothing converts it and the column does not claim
+ * otherwise.
+ */
+export function toProfilePreferredLocationRows(
+  document: SourceDocument,
+  log: ResolutionLog,
+): readonly CandidateRow[] {
+  const profileId = idValue(document._id);
+  return subdocuments(document, 'personalProfile.preferences.preferredLocations').map((child) => ({
+    id: mintedSubdocumentId(child, log),
+    profileId,
+    city: optional(child, 'city'),
+    state: optional(child, 'state'),
+    radius: optional(child, 'radius'),
+  }));
+}
+
+/** `profile_roommate_history` ← `personalProfile.settings.roommate.history[]`. */
+export function toProfileRoommateHistoryRows(
+  document: SourceDocument,
+  log: ResolutionLog,
+): readonly CandidateRow[] {
+  const profileId = idValue(document._id);
+  return subdocuments(document, 'personalProfile.settings.roommate.history').map((child) => ({
+    id: mintedSubdocumentId(child, log),
+    profileId,
+    startDate: optional(child, 'startDate'),
+    endDate: optional(child, 'endDate'),
+    location: optional(child, 'location'),
+    roommateCount: optional(child, 'roommateCount'),
+    reason: optional(child, 'reason'),
+  }));
+}
+
+/**
+ * `profile_chat_messages` ← `personalProfile.chatHistory[]`.
+ *
+ * `position` is the ARRAY INDEX, and it is the transcript's meaning. `timestamp`
+ * cannot substitute: it defaults to `Date.now` at millisecond resolution, so two
+ * messages appended in the same tick sort arbitrarily.
+ */
+export function toProfileChatMessageRows(
+  document: SourceDocument,
+  log: ResolutionLog,
+): readonly CandidateRow[] {
+  const profileId = idValue(document._id);
+  return subdocuments(document, 'personalProfile.chatHistory').map((child, position) => ({
+    id: mintedSubdocumentId(child, log),
+    profileId,
+    role: optional(child, 'role'),
+    content: optional(child, 'content'),
+    timestamp: withSchemaDefault(child, 'timestamp', createdAtValue(document, log), log),
+    position,
+  }));
+}
+
+// ── the plans, and the rules that could not be derived ─────────────
+
+/** Every collection, in the ONE order that satisfies the foreign-key graph. */
+export const DATA_PLANS: Readonly<Record<DataCollectionName, DataCollectionPlan>> = {
+  images: imagesPlan,
+  addresses: addressesPlan,
+  agencies: agenciesPlan,
+  properties: propertiesPlan,
+  profiles: profilesPlan,
+};
+
+/**
+ * The drizzle table each SQL name refers to.
+ *
+ * It carries the PARENT tables too — `countries`, `regions`, `cities`,
+ * `neighborhoods`, `partners` — even though nothing here writes them. The
+ * foreign-key audit resolves a reference against the parent table by name, so a
+ * parent missing from this map is not a silent skip: `requireTable` refuses,
+ * because a reference check that cannot find its table resolves nothing and
+ * reports success exactly as loudly as one that passed.
+ */
+export const DATA_TABLES: Readonly<Record<string, PgTable>> = {
+  countries,
+  regions,
+  cities,
+  neighborhoods,
+  partners,
+  images,
+  addresses,
+  agencies,
+  properties,
+  property_images: propertyImages,
+  property_documents: propertyDocuments,
+  property_availability_windows: propertyAvailabilityWindows,
+  profiles,
+  profile_references: profileReferences,
+  profile_rental_history: profileRentalHistory,
+  profile_preferred_locations: profilePreferredLocations,
+  profile_roommate_history: profileRoommateHistory,
+  profile_chat_messages: profileChatMessages,
+};
+
+/** `end is null or end >= start`, as both profile history tables spell it. */
+function dateOrderRule(constraint: string): RowRule {
+  return {
+    name: constraint,
+    reason: 'end_date must be null or on/after start_date (23514)',
+    holds: (row) => {
+      const start = row.startDate;
+      const end = row.endDate;
+      if (!(start instanceof Date) || !(end instanceof Date)) return true;
+      return end.getTime() >= start.getTime();
+    },
+    offendingValue: (row) => [row.startDate, row.endDate],
+  };
+}
+
+/** `length(x) > 0`. An absent value fails NOT NULL first, and is not re-reported. */
+function notEmptyRule(constraint: string, column: string): RowRule {
+  return {
+    name: constraint,
+    reason: `${column} must not be an empty string (23514)`,
+    holds: (row) => typeof row[column] !== 'string' || row[column].length > 0,
+    offendingValue: (row) => row[column],
+  };
+}
+
+function reference(
+  table: string,
+  constraint: string,
+  column: string,
+  parentTable: string,
+  parentCollection: string | null,
+  nullable: boolean,
+): ReferenceSpec {
+  return { table, constraint, column, parentTable, parentCollection, nullable };
+}
+
+/** A column that will be NULL in Postgres. */
+function isAbsent(value: unknown): boolean {
+  return value === undefined || value === null;
+}
+
+/**
+ * A present value within bounds.
+ *
+ * An ABSENT one passes: it fails `NOT NULL` instead, which the column scan
+ * reports — and one defect reported under two names reads as two defects.
+ */
+function inRange(value: unknown, low: number, high: number): boolean {
+  if (typeof value !== 'number') return true;
+  return value >= low && value <= high;
+}
+
+/**
+ * The elements of an embedded array, or none.
+ *
+ * A non-array is handed to the audit rather than salvaged, exactly as every
+ * other reader here does: the mappers PRESERVE what was stored so `rowAudit`
+ * reports it.
+ */
+function subdocuments(document: SourceDocument, path: string): readonly SourceDocument[] {
+  const value = readPath(document, path);
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (element): element is SourceDocument =>
+      typeof element === 'object' && element !== null && !Array.isArray(element),
+  );
+}
+
+/**
+ * A subdocument's id, counting the mint.
+ *
+ * `uuidv7` comes from `@oxyhq/db`, which is where `generatedId()`'s own default
+ * comes from — so a minted row id and an application-created one are the same
+ * shape by construction rather than by two implementations agreeing.
+ */
+function mintedSubdocumentId(child: SourceDocument, log: ResolutionLog): unknown {
+  const stored = child._id;
+  if (stored !== undefined && stored !== null) return idValue(stored);
+  // Not a remap: there was no id to preserve, and nothing references these rows.
+  // The DOCUMENT is asked rather than a hand-written list of which arrays
+  // declare `{ _id: false }` — that is one word in a schema file, and
+  // `availabilityWindowSchema` carries it while `MIGRATION-CONTRACT.md`'s table
+  // does not list it.
+  log.applied(DATA_RESOLUTIONS.SUBDOCUMENT_ID_MINTED);
+  return uuidv7();
+}

--- a/packages/backend/db/backfill/geo.ts
+++ b/packages/backend/db/backfill/geo.ts
@@ -120,7 +120,7 @@ const INSERT_BATCH_ROWS = 500;
 const LOOKUP_BATCH_IDS = 1000;
 
 /** Rows per table compared field by field, unless `--sample=` says otherwise. */
-const DEFAULT_SAMPLE_ROWS = 200;
+export const DEFAULT_SAMPLE_ROWS = 200;
 
 /** Ids listed in a report when something is missing. Enough to grep for. */
 const MAX_REPORTED_IDS = 5;
@@ -273,6 +273,7 @@ export function readSampleSize(argv: readonly string[]): number {
 export async function assertMigrationSource(
   database: MongoDatabase,
   expected: string,
+  required: readonly string[] = Object.values(GEO_SOURCE_COLLECTIONS),
 ): Promise<void> {
   const actual = database.databaseName;
   if (actual !== expected) {
@@ -285,7 +286,7 @@ export async function assertMigrationSource(
   }
 
   const present = new Set((await database.listCollections().toArray()).map((entry) => entry.name));
-  const missing = Object.values(GEO_SOURCE_COLLECTIONS).filter((name) => !present.has(name));
+  const missing = required.filter((name) => !present.has(name));
   if (missing.length > 0) {
     throw new Error(
       `Refusing to copy: ${JSON.stringify(actual)} has no ${missing.join(', ')} ` +
@@ -594,7 +595,7 @@ async function reconcilePlan(
 // ── verifying ──────────────────────────────────────────────────────
 
 /** Which of `ids` the target already holds. */
-async function presentIds(
+export async function presentIds(
   database: Database,
   table: PgTable,
   ids: readonly string[],
@@ -612,11 +613,22 @@ async function presentIds(
 /**
  * Whether a stored value equals the value the mapper produced.
  *
- * `Date` by instant rather than by identity — postgres.js hands back a new
- * `Date` for every read, so `===` would report every timestamp as a mismatch and
- * the comparison would be worthless in exactly the way that looks thorough.
+ * Not `===`, and every exception below is a real storage property rather than a
+ * loosening. Each would otherwise report a mismatch on a PERFECT copy — the way
+ * a comparison fails that looks most thorough, until somebody stops believing
+ * the verifier:
+ *
+ *  - **`Date`.** postgres.js hands back a NEW `Date` object for every read, so
+ *    identity always differs; only the instant is the fact.
+ *  - **Arrays.** Same — a new array per read, so a `text[]` column has to be
+ *    compared element by element. No geo table has one; `properties.offerings`,
+ *    `amenities` and `addresses.address_lines` all do.
+ *  - **`jsonb`.** Postgres REORDERS object keys on the way in (it stores a
+ *    parsed representation, not the text), so `{a:1,b:2}` reads back as
+ *    `{b:2,a:1}`. Any comparison that respects key order is wrong about
+ *    `addresses.extras` on every row carrying more than one key.
  */
-function sameValue(expected: unknown, actual: unknown): boolean {
+export function sameValue(expected: unknown, actual: unknown): boolean {
   if (expected instanceof Date || actual instanceof Date) {
     return (
       expected instanceof Date &&
@@ -624,7 +636,39 @@ function sameValue(expected: unknown, actual: unknown): boolean {
       expected.getTime() === actual.getTime()
     );
   }
+  if (Array.isArray(expected) || Array.isArray(actual)) {
+    return (
+      Array.isArray(expected) &&
+      Array.isArray(actual) &&
+      expected.length === actual.length &&
+      expected.every((element, index) => sameValue(element, actual[index]))
+    );
+  }
+  if (isPlainObject(expected) || isPlainObject(actual)) {
+    return canonicalJson(expected) === canonicalJson(actual);
+  }
   return expected === actual;
+}
+
+/** JSON with object keys SORTED, so `jsonb`'s own ordering cannot matter. */
+export function canonicalJson(value: unknown): string {
+  if (value === null || value === undefined) return 'null';
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value instanceof Date) return JSON.stringify(value.toISOString());
+  if (typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+  const entries = Object.entries(value).sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  );
+  return `{${entries.map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`).join(',')}}`;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    !(value instanceof Date)
+  );
 }
 
 /**

--- a/packages/backend/db/backfill/geoPlan.ts
+++ b/packages/backend/db/backfill/geoPlan.ts
@@ -167,11 +167,18 @@ export const GEO_RESOLUTIONS = {
 
 export type GeoResolution = (typeof GEO_RESOLUTIONS)[keyof typeof GEO_RESOLUTIONS];
 
-/** Counts of each named resolution actually applied, for the run report. */
+/**
+ * Counts of each named resolution actually applied, for the run report.
+ *
+ * Keyed by plain `string` rather than by one copy's resolution union: the geo
+ * copy and the data copy name different resolutions, and a log that accepts only
+ * one set forces the other to invent a second counter — which is how two halves
+ * of one migration end up reporting in two formats.
+ */
 export class ResolutionLog {
-  private readonly counts = new Map<GeoResolution, number>();
+  private readonly counts = new Map<string, number>();
 
-  applied(resolution: GeoResolution): void {
+  applied(resolution: string): void {
     this.counts.set(resolution, (this.counts.get(resolution) ?? 0) + 1);
   }
 
@@ -193,6 +200,13 @@ export interface CoverContext {
 }
 
 // ── reading a Mongo value without changing it ──────────────────────
+//
+// EXPORTED, and shared with `dataPlan.ts`. They started private here and stayed
+// here when the second batch of collections needed them: two copies of "how do
+// we read a stored value" is two answers to the question this backfill's whole
+// audit is built on. Nothing about them is geo-specific except the file they
+// happen to live in, which is a move somebody can make later without changing a
+// line of behaviour.
 
 /**
  * Whether a value is an ObjectId, decided by DUCK TYPING rather than
@@ -240,13 +254,13 @@ export function toObjectIdHex(value: unknown): string | null {
  * where the real fault is a shape nobody expected, and would quietly erase a
  * foreign key on a nullable column.
  */
-function idValue(value: unknown): unknown {
+export function idValue(value: unknown): unknown {
   if (value === undefined || value === null) return null;
   return isObjectId(value) ? value.toHexString() : value;
 }
 
 /** A dotted path (`coordinates.lat`), or `undefined` where any level is absent. */
-function readPath(document: SourceDocument, path: string): unknown {
+export function readPath(document: SourceDocument, path: string): unknown {
   let current: unknown = document;
   for (const segment of path.split('.')) {
     if (typeof current !== 'object' || current === null) return undefined;
@@ -256,7 +270,7 @@ function readPath(document: SourceDocument, path: string): unknown {
 }
 
 /** A value that may legitimately be absent, normalised to an explicit `null`. */
-function optional(document: SourceDocument, path: string): unknown {
+export function optional(document: SourceDocument, path: string): unknown {
   const value = readPath(document, path);
   return value === undefined ? null : value;
 }
@@ -269,7 +283,7 @@ function optional(document: SourceDocument, path: string): unknown {
  * in the target, so a stored `null` is the same "the document does not say" a
  * missing key is — and Mongoose would hydrate both to the default.
  */
-function withSchemaDefault(
+export function withSchemaDefault(
   document: SourceDocument,
   path: string,
   fallback: unknown,
@@ -282,7 +296,7 @@ function withSchemaDefault(
 }
 
 /** `created_at` — the stored value, or the id's own embedded creation instant. */
-function createdAtValue(document: SourceDocument, log: ResolutionLog): unknown {
+export function createdAtValue(document: SourceDocument, log: ResolutionLog): unknown {
   const stored = readPath(document, 'createdAt');
   if (stored !== undefined && stored !== null) return stored;
   const id = document._id;
@@ -296,7 +310,7 @@ function createdAtValue(document: SourceDocument, log: ResolutionLog): unknown {
 }
 
 /** `updated_at` — the stored value, else whatever `created_at` resolved to. */
-function updatedAtValue(document: SourceDocument, createdAt: unknown, log: ResolutionLog): unknown {
+export function updatedAtValue(document: SourceDocument, createdAt: unknown, log: ResolutionLog): unknown {
   const stored = readPath(document, 'updatedAt');
   if (stored !== undefined && stored !== null) return stored;
   log.applied(GEO_RESOLUTIONS.TIMESTAMP_FROM_OBJECT_ID);

--- a/packages/backend/db/backfill/rowAudit.ts
+++ b/packages/backend/db/backfill/rowAudit.ts
@@ -36,7 +36,7 @@
  */
 
 import { getTableColumns } from 'drizzle-orm';
-import type { PgTable } from 'drizzle-orm/pg-core';
+import type { PgColumn, PgTable } from 'drizzle-orm/pg-core';
 
 /**
  * A candidate row, before it is known to fit its target.
@@ -123,20 +123,66 @@ class ViolationCollector {
 }
 
 /**
+ * What {@link refusalReason} needs from a column.
+ *
+ * A structural shape rather than drizzle's `PgColumn`, because the array case
+ * recurses into `baseColumn` — a real `PgColumn` — while the object the caller
+ * assembles is not one. Naming the fields lets the recursion type-check without
+ * either side pretending to be the other.
+ */
+interface AuditableColumn {
+  readonly notNull: boolean;
+  readonly hasDefault: boolean;
+  readonly dataType: string;
+  readonly columnType: string;
+  readonly enumValues?: readonly string[] | undefined;
+  readonly baseColumn?: AuditableColumn | undefined;
+}
+
+/**
+ * A drizzle column as the audit reads it.
+ *
+ * `enumValues` and `baseColumn` are declared on some column classes and not
+ * others, so both are read with an `in` test rather than assumed present — the
+ * alternative is `undefined.includes` firing at the moment the audit is supposed
+ * to be explaining a data defect.
+ */
+function auditableColumn(column: PgColumn): AuditableColumn {
+  const base = 'baseColumn' in column ? column.baseColumn : undefined;
+  return {
+    notNull: column.notNull,
+    hasDefault: column.hasDefault,
+    dataType: column.dataType,
+    columnType: column.columnType,
+    enumValues: 'enumValues' in column ? column.enumValues : undefined,
+    baseColumn: isPgColumn(base) ? auditableColumn(base) : undefined,
+  };
+}
+
+/**
+ * Whether a value is a drizzle column.
+ *
+ * `PgArray.baseColumn` is typed loosely enough that TypeScript will not accept
+ * it as a `PgColumn` on its own, and a structural test is the honest way to say
+ * "this is a column if it declares what a column declares" — the alternative is
+ * asserting a type the compiler has already said it cannot verify.
+ */
+function isPgColumn(value: unknown): value is PgColumn {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'dataType' in value &&
+    'columnType' in value &&
+    'notNull' in value
+  );
+}
+
+/**
  * Check one value against one column's declared type.
  *
  * @returns The reason it would be refused, or `null` when it fits.
  */
-function refusalReason(
-  value: unknown,
-  column: {
-    notNull: boolean;
-    hasDefault: boolean;
-    dataType: string;
-    columnType: string;
-    enumValues?: readonly string[] | undefined;
-  },
-): string | null {
+function refusalReason(value: unknown, column: AuditableColumn): string | null {
   // `undefined` means the row omits the key, so the column's DEFAULT applies.
   // That is only legal where one exists; without a default an omitted NOT NULL
   // column is the same `23502` a null would be.
@@ -166,6 +212,13 @@ function refusalReason(
         if (!Number.isInteger(value)) return 'expected an integer, got a fraction';
         if (value < INT32_MIN || value > INT32_MAX) return 'outside the `integer` range (22003)';
       }
+      // `bigint({ mode: 'number' })` hands JavaScript a `number`, so its real
+      // ceiling is `Number.MAX_SAFE_INTEGER` rather than the column's 64 bits —
+      // past that the VALUE is already wrong before Postgres ever sees it.
+      if (column.columnType === 'PgBigInt53') {
+        if (!Number.isInteger(value)) return 'expected an integer, got a fraction';
+        if (!Number.isSafeInteger(value)) return 'outside the safe-integer range';
+      }
       return null;
     }
     case 'boolean':
@@ -173,6 +226,32 @@ function refusalReason(
     case 'date':
       if (!(value instanceof Date)) return `expected a Date, got ${typeName(value)}`;
       return Number.isNaN(value.getTime()) ? 'an Invalid Date' : null;
+    case 'array': {
+      // No geo table has an array column, so this arm was unreachable until the
+      // second batch — and an unaudited column kind is one whose bad values
+      // reach the insert, which is what this module exists to prevent. The
+      // ELEMENTS are checked against the base column, which carries any element
+      // vocabulary: a `text({ enum }).array()` generates its CHECK from the same
+      // tuple, so recursing here IS that CHECK rather than a restatement.
+      if (!Array.isArray(value)) return `expected an array, got ${typeName(value)}`;
+      const base = column.baseColumn;
+      if (base === undefined) return null;
+      for (const [index, element] of value.entries()) {
+        const reason = refusalReason(element, base);
+        if (reason !== null) return `element ${index}: ${reason}`;
+      }
+      return null;
+    }
+    case 'json': {
+      // `jsonb` takes anything JSON can carry, which is nearly everything — so
+      // the only refusal worth making is the one that would SUCCEED and be
+      // wrong. A `Date` serialises to an ISO string, so it stores fine and reads
+      // back as text, silently changing the value's type.
+      if (value instanceof Date) {
+        return 'a Date in a jsonb column — it would store as a string and read back as one';
+      }
+      return null;
+    }
     default:
       // A dataType this module has not been taught about. Reported rather than
       // waved through: a column kind nobody checked is a column kind whose bad
@@ -188,6 +267,128 @@ function typeName(value: unknown): string {
   if (Array.isArray(value)) return 'an array';
   if (value instanceof Date) return 'a Date';
   return `a ${typeof value}`;
+}
+
+/**
+ * An audit that accumulates across many calls.
+ *
+ * {@link auditRows} loads a whole table's rows before checking any of them,
+ * which is right for the geo copy (under eight thousand documents) and
+ * impossible for the rest: 171,976 images and 17,644 properties with their
+ * embedded arrays do not fit in memory at once, so `data.ts` STREAMS and audits
+ * batch by batch.
+ *
+ * Auditing per batch with the one-shot function would produce one grouped report
+ * PER BATCH — three hundred of them, each saying "1 row" — and the grouping is
+ * what makes a report readable. So the collector has to outlive the batch.
+ */
+export class RowAuditor {
+  private readonly collector = new ViolationCollector();
+  private readonly columns: ReturnType<typeof getTableColumns>;
+  private readonly known: ReadonlySet<string>;
+  private rowsSeen = 0;
+
+  constructor(
+    table: PgTable,
+    private readonly rules: readonly RowRule[] = [],
+  ) {
+    this.columns = getTableColumns(table);
+    this.known = new Set(Object.keys(this.columns));
+  }
+
+  /** Audit one batch. */
+  add(rows: readonly CandidateRow[]): void {
+    for (const row of rows) {
+      this.rowsSeen += 1;
+
+      // A key the target has no column for is a mapper bug. drizzle would throw
+      // on the insert — but only after the audit had reported green, which is
+      // precisely the shape this module exists to rule out.
+      for (const key of Object.keys(row)) {
+        if (!this.known.has(key)) {
+          this.collector.record(key, 'no such column on the target table', row.id, row[key]);
+        }
+      }
+
+      for (const [name, column] of Object.entries(this.columns)) {
+        const reason = refusalReason(row[name], auditableColumn(column));
+        if (reason !== null) this.collector.record(name, reason, row.id, row[name]);
+      }
+
+      for (const rule of this.rules) {
+        if (!rule.holds(row)) {
+          this.collector.record(rule.name, rule.reason, row.id, rule.offendingValue?.(row));
+        }
+      }
+    }
+  }
+
+  /**
+   * How many rows have been audited.
+   *
+   * The VACUITY FLOOR. "No violations" and "nothing was checked" are the same
+   * report, and a streaming audit produces the second for a dozen boring reasons
+   * — a collection name that matches nothing, a filter that excludes everything,
+   * a cursor that closed early. A caller acting on an empty report without
+   * reading this is trusting a check it never ran.
+   */
+  get audited(): number {
+    return this.rowsSeen;
+  }
+
+  /** Every violation so far, grouped by column and reason. */
+  drain(): AuditViolation[] {
+    return this.collector.drain();
+  }
+}
+
+/**
+ * Rows colliding on a unique index — a defect `ON CONFLICT DO NOTHING` ABSORBS.
+ *
+ * Not the same check as a foreign key or a CHECK, and the one the copy's own
+ * idempotence creates. Every insert is `ON CONFLICT DO NOTHING` with NO conflict
+ * target, which covers the primary key AND every unique index: two source rows
+ * carrying one `agencies.normalized_name` do not raise `23505`, they become one
+ * row. Silently. The 8,374 listings pointing at the loser then fail their own
+ * foreign key later, in a different table, with nothing connecting the two
+ * facts.
+ *
+ * `key` composes the value the index sees and returns `null` for a row the index
+ * does not cover — a PARTIAL unique index (`where normalized_key is not null`)
+ * genuinely does not constrain those rows, and treating them as colliding would
+ * report thousands of findings on a healthy collection.
+ */
+export class UniqueKeyAuditor {
+  private readonly seen = new Map<string, unknown>();
+  private readonly collector = new ViolationCollector();
+
+  constructor(
+    private readonly constraint: string,
+    private readonly key: (row: CandidateRow) => string | null,
+  ) {}
+
+  add(rows: readonly CandidateRow[]): void {
+    for (const row of rows) {
+      const value = this.key(row);
+      if (value === null) continue;
+      const owner = this.seen.get(value);
+      if (owner === undefined) {
+        this.seen.set(value, row.id);
+        continue;
+      }
+      this.collector.record(
+        this.constraint,
+        'two rows share one unique key — ON CONFLICT DO NOTHING would drop one ' +
+        'of them without raising (23505 never fires)',
+        row.id,
+        `${value} (already held by ${String(owner)})`,
+      );
+    }
+  }
+
+  drain(): AuditViolation[] {
+    return this.collector.drain();
+  }
 }
 
 /**
@@ -207,42 +408,9 @@ export function auditRows(
   rows: readonly CandidateRow[],
   rules: readonly RowRule[] = [],
 ): AuditViolation[] {
-  const columns = getTableColumns(table);
-  const collector = new ViolationCollector();
-
-  // A key the target has no column for is a mapper bug, and it is checked once
-  // rather than per row: drizzle would throw on the insert, but only after the
-  // audit had reported green — which is precisely the shape this module exists
-  // to rule out.
-  const known = new Set(Object.keys(columns));
-  for (const row of rows) {
-    for (const key of Object.keys(row)) {
-      if (!known.has(key)) {
-        collector.record(key, 'no such column on the target table', row.id, row[key]);
-      }
-    }
-  }
-
-  for (const row of rows) {
-    for (const [name, column] of Object.entries(columns)) {
-      const reason = refusalReason(row[name], {
-        notNull: column.notNull,
-        hasDefault: column.hasDefault,
-        dataType: column.dataType,
-        columnType: column.columnType,
-        enumValues: 'enumValues' in column ? column.enumValues : undefined,
-      });
-      if (reason !== null) collector.record(name, reason, row.id, row[name]);
-    }
-
-    for (const rule of rules) {
-      if (!rule.holds(row)) {
-        collector.record(rule.name, rule.reason, row.id, rule.offendingValue?.(row));
-      }
-    }
-  }
-
-  return collector.drain();
+  const auditor = new RowAuditor(table, rules);
+  auditor.add(rows);
+  return auditor.drain();
 }
 
 /** Render violations as the lines an operator reads in a task log. */

--- a/packages/backend/db/hasImages.ts
+++ b/packages/backend/db/hasImages.ts
@@ -165,11 +165,29 @@ export async function findHasImagesDisagreements(
 export async function syncAllHasImages(db: DatabaseOrTransaction): Promise<number> {
   const rows = await db
     .update(properties)
-    .set({ hasImages: hasPhotoRow() })
-    // Touch only the rows that are actually wrong: `updated_at` carries
-    // `$onUpdate`, so an unconditional rewrite would restamp every listing in
-    // the table with the migration's own clock and destroy the ordering the
-    // historical value carries.
+    .set({
+      hasImages: hasPhotoRow(),
+      // `updated_at` ASSIGNED FROM ITSELF, and it is load-bearing rather than
+      // decorative — the trap `CONVENTIONS.md` §Timestamps was corrected to name.
+      // drizzle applies `$onUpdate` to any column NOT in `.set()`, so the obvious
+      // spelling stamps every row this touches with the caller's clock. The
+      // callers here are a backfill and a drift repair; neither is a change to
+      // the listing, and narrowing the `where` bounds how many rows are damaged
+      // without making any of them right.
+      //
+      // On a first copy that is not a rounding error: the column defaults to
+      // `false` on insert, so this fires on every image-bearing listing (16,585
+      // of 17,644 at the census) and would replace their real `updated_at`
+      // wholesale. In an `UPDATE … SET` the right-hand side reads the OLD row,
+      // so this is an explicit no-op that displaces the automatic one.
+      //
+      // {@link syncHasImages} deliberately does NOT do this: it is called from a
+      // photo write, where the listing really did change.
+      updatedAt: sql`${properties.updatedAt}`,
+    })
+    // Touch only the rows that are actually wrong — fewer rows rewritten, and a
+    // returned count that means "how many were repaired" rather than "how many
+    // exist".
     .where(ne(properties.hasImages, hasPhotoRow()))
     .returning({ id: properties.id });
 


### PR DESCRIPTION
Closes #292.

The geo half landed in #293/#294. This is everything else: **171,976 images →
11,734 addresses → 2,627 agencies → 17,644 properties** (with three child
tables) **→ 5 profiles**, plus the `cities.cover_image_id` /
`regions.cover_image_id` links the geo copy had to leave NULL because `images`
was empty and every value would have dangled.

```
node packages/backend/dist/db/backfill/data.js \
  --source-database=homiio-production --target-database=homiio [--audit-only]
```

## It STREAMS, and the three differences from `geo.ts` all follow from that

`loadSource` reads five collections into memory — right for under eight thousand
documents, impossible for 172,000 images and 17,644 properties with their
embedded arrays.

- **Two passes in copy mode.** The audit reads the whole source and writes
  nothing; only then does the copy read it again and insert. That keeps the
  property `geo.ts` advertises — *it never runs an insert the audit has not
  seen* — which a single streaming pass cannot: it would refuse at the first bad
  batch with every earlier batch already committed.
- **`RowAuditor` rather than `auditRows`.** Auditing per batch with the one-shot
  function produces one grouped report PER BATCH, three hundred of them, each
  saying "1 row". `auditRows` is now one call to a class that accumulates. It
  also exposes `audited`, and the runner **refuses a pass that examined zero
  rows** — "no violations" and "nothing was checked" are the same report.
- **Foreign keys resolved against BOTH stores.** A parent may be in Postgres
  already (geo) or about to be written by this run (`properties.address_id`), so
  the question asked is the one `23503` actually answers.

## `agencies` before `properties`

Migration 0003 promoted `agency_id` to a real foreign key and 8,374 listings
carry one, so the order the issue lists by row count fails `23503` tens of
thousands of rows in.

## Three audit capabilities the geo tables never needed

No geo table has an array or a jsonb column, so `refusalReason` reported every
one of them as an *unaudited column kind* — `properties.offerings`, `amenities`
and `addresses.extras` would have reached the insert unchecked.

- **Arrays** recurse into the base column, which is where an element vocabulary
  lives, so this IS the CHECK rather than a restatement of it.
- **jsonb** refuses only the value that would SUCCEED and be wrong: a `Date`,
  which stores as a string and reads back as one.
- **`bigint({mode:'number'})`** is bounded by `MAX_SAFE_INTEGER` rather than the
  column's 64 bits — past that the value is already wrong before Postgres sees
  it.

## `UniqueKeyAuditor` — the defect this copy's own idempotence creates

Every insert is `ON CONFLICT DO NOTHING` with no target, which covers the primary
key **and every unique index**: two source rows sharing one
`agencies.normalized_name` do not raise `23505`, they become one row, and the
8,374 listings pointing at the loser fail their own foreign key later, in a
different table, with nothing connecting the two facts.

## A bug the verifier found: `syncAllHasImages` restamped `updated_at`

The trap #297 documented, met a third time. `properties.has_images` defaults to
`false` on insert, so the post-copy derivation fires on every image-bearing
listing (**16,585 of 17,644** at the census) — and drizzle's `$onUpdate` applies
to any column not named in `.set()`, so each of those rows would have had its
real `updated_at` replaced by the migration's clock. Narrowing the `where` bounds
how many rows are damaged without making any of them right. `updated_at` is now
assigned from itself; `syncHasImages` deliberately keeps the old behaviour,
because it is called from a photo write where the listing did change.

Found by the field-by-field verifier, not by review.

## Verification measures a real DISTANCE

`addresses.geo` is GENERATED from the coordinate pair, so it is never null and
never disagrees with its columns — which makes "the column is populated" a check
that passes just as happily on a transposed pair. Instead:

- every address is measured against **its own city's centroid** (>300 km is
  reported);
- **Barcelona→Madrid (~505 km)** and **Barcelona→Paris (~830 km)** against real
  figures, ±25%;
- a pair that cannot be measured is reported as *unmeasured*, never as a pass,
  and a run where none could be measured **fails**;
- a test transposes Barcelona and confirms the check moves — 5,000 km, refused.

**Completeness is by ID, not by count.** Equal counts hide a copy that dropped
forty rows and gained forty others, which is exactly what `DO NOTHING` absorbing
a collision while the ingestion worker inserts new listings looks like.
**Fidelity re-runs the mapper** against the live source document; reading back
what was written and checking it is what was written is a check that cannot fail.
Rows whose ids were MINTED (`availabilityWindowSchema` declares `{_id: false}`)
are compared as a set with the id excluded — there is nothing to match on, and
nothing to check either.

## Six named resolutions, each counted against its frozen census figure

`MODERATION_ABSENT` (17,642) · `LISTING_FLAGS_ABSENT` (9,594) ·
`EXTERNAL_CONTACT_ABSENT` (5,174) · `PRICE_ETHICS_ABSENT` (133) ·
`HAS_IMAGES_DISAGREED` (1) · `NORMALIZED_KEY_EMPTY` · `SUBDOCUMENT_ID_MINTED`.

`listingFlags` deliberately does **not** copy `moderation`'s answer: those
booleans are three-state (`true` / `false` / never-classified), and defaulting
9,594 rows to `false` would manufacture a claim nobody made.

## On the shared vocabulary

`geoPlan`'s readers, `geo`'s `sameValue`/`presentIds` and the argument guards are
now EXPORTED and shared by both copies rather than relocated. Moving them into a
neutral module is a behaviour-free refactor, and it is best done when nobody is
mid-flight in this directory — happy to follow up with it.

`sameValue` did have to learn arrays and jsonb: Postgres reorders jsonb keys, so
a comparison that respects order is wrong about `addresses.extras` on every row
with more than one key.

## Gates

- **106 suites, 1267 tests, all green.** Baseline on this commit's parent
  (`b5ef0b1`): 105 suites, 1233 tests — so the delta is exactly the new suite.
- Typecheck, eslint, the NUL-byte gate and `tsc -p tsconfig.build.json` clean
  (`dist/db/backfill/data.js` is what the one-shot runs).
- No dependency change, so no lockfile change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)