### PR TITLE
Name all three `resolveGeoFilterAddressIds` callers, not two

### DIFF
--- a/packages/backend/services/geoQueryService.ts
+++ b/packages/backend/services/geoQueryService.ts
@@ -152,12 +152,22 @@ export async function resolveNeighborhoodId(
  *  - `controllers/roomController.getRooms` — rooms are `properties` rows, but
  *    this controller also CREATES and UPDATES them, and writes stay on Mongo for
  *    the dual-run.
+ *  - `controllers/telegramController.sendBulkNotifications` — resolves a city
+ *    filter to `Property.find({ addressId: { $in: … } })` for a broadcast.
  *  - `models/schemas/PropertySchema.statics.search` — part of the Mongoose model
  *    itself.
  *
- * Both move with the property WRITE path, and this function goes with them. Do
- * not add a caller: for anything reading Postgres properties, the predicates in
- * `db/properties/propertyFilters` are the replacement.
+ * All three move with the property WRITE path, and this function goes with them.
+ * Do not add a caller: for anything reading Postgres properties, the predicates
+ * in `db/properties/propertyFilters` are the replacement.
+ *
+ * **The list above is load-bearing and was wrong once already.** It shipped in
+ * #298 naming two of the three — `telegramController` was missed — and an
+ * inventory that under-counts is worse than none, because the whole point of it
+ * is to tell the next reader when the function is finally safe to delete. If
+ * you change this list, `git grep -n resolveGeoFilterAddressIds` is the check;
+ * ignore the two doc-comment mentions in `controllers/property/{list,search}.ts`
+ * and `db/schema/geo.ts`, which name it only to say it is no longer used there.
  *
  * **Its one non-Property caller is gone.** `addressController.searchAddresses`
  * used it to turn a search term into an address-id list and then match


### PR DESCRIPTION
#298 moved every catalogue read off `resolveGeoFilterAddressIds` and left an inventory of what still calls it, so whoever finally deletes it knows when that is safe. **The inventory named two callers and there are three** — `controllers/telegramController.sendBulkNotifications` resolves a city filter into `Property.find({ addressId: { $in: … } })` for a broadcast, and was missed.

An inventory that under-counts is worse than none: its whole purpose is to answer "is anything still using this?", and it answers "no" one caller early. Nothing contradicts it — the function is exported, the caller compiles, and the list is a comment.

The correction therefore carries its own check (`git grep -n resolveGeoFilterAddressIds`, plus which mentions to ignore: three doc comments name it only to say it is *not* used there) and states outright that the list has been wrong once.

Found by `homiio-catalogue-2` reviewing #298 after merge. Comment-only, no behaviour change.