### PR TITLE
Move notifications, saved searches and the roommate handshake to Postgres (#281)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,9 +150,13 @@ jobs:
       # glob that stops matching all produce an empty green run, and that reads as
       # coverage forever because nothing contradicts it.
       #
-      # RAISED FROM 1150 TO 1190 by the geo backfill, which added 36 tests in
-      # `__tests__/db/geoBackfill.test.ts` (measured 1190 -> 1226). Before that
-      # it went 1100 -> 1150 for the remaining-schema batch (#281), which added
+      # RAISED FROM 1190 TO 1225 by the first zero-row domain port
+      # (notifications, saved searches, roommate requests/relationships), which
+      # added `savedSearches.test.ts` and rewrote two Mongo-seeded suites
+      # against the real Postgres — measured 1233 -> 1264. Before that it went
+      # 1150 -> 1190 for the geo backfill, which added 36 tests in
+      # `__tests__/db/geoBackfill.test.ts` (measured 1190 -> 1226); and
+      # 1100 -> 1150 for the remaining-schema batch (#281), which added
       # 54 tests across 4 files under `__tests__/db/` and took the measured
       # count 1123 -> 1177. Each step keeps roughly the headroom the previous
       # figure carried rather than pinning the exact total. The floor is a
@@ -162,7 +166,7 @@ jobs:
         if: always()
         run: >-
           bun .github/scripts/assert-test-floor.mjs
-          "$RUNNER_TEMP/backend-tests.json" packages/backend 1190
+          "$RUNNER_TEMP/backend-tests.json" packages/backend 1225
 
   frontend:
     runs-on: ubuntu-24.04

--- a/packages/backend/__tests__/integration/evictionBoard.test.ts
+++ b/packages/backend/__tests__/integration/evictionBoard.test.ts
@@ -9,13 +9,37 @@
 
 import express, { type Express } from 'express';
 import request from 'supertest';
+import { eq } from 'drizzle-orm';
 
 import { sendEvictionOutcomeReminders } from '../../services/evictionOutcomeReminderService';
 
 import * as eviction from '../../controllers/eviction';
-import { EvictionCase, EvictionComment, EvictionReport, Notification } from '../../models';
+import { EvictionCase, EvictionComment, EvictionReport } from '../../models';
+import { getDb } from '../../db/postgres';
+import { notifications } from '../../db/schema';
 import { errorHandler } from '../../middlewares/errorHandler';
 import { assertFound } from '../helpers/assertFound';
+
+/**
+ * The eviction domain is still Mongo; its NOTIFICATIONS are not.
+ *
+ * `notificationDispatchService` — the single chokepoint every domain event goes
+ * through — writes `notifications` in Postgres from this batch on, so the
+ * fan-out assertions below read that table. The Postgres side of the harness has
+ * no per-test cleanup (`__tests__/jest.setup.ts` clears the Mongo collections
+ * and deliberately leaves Postgres alone), so this file empties the rows it
+ * causes.
+ */
+async function notificationsOfType(type: string) {
+  return getDb()
+    .select()
+    .from(notifications)
+    .where(eq(notifications.type, type));
+}
+
+beforeEach(async () => {
+  await getDb().delete(notifications);
+});
 
 function buildApp(oxyUserId?: string): Express {
   const app = express();
@@ -181,8 +205,8 @@ describe('updateEviction — ownership', () => {
     expect(res.body.data.updates).toHaveLength(1);
     expect(res.body.data.updates[0].newScheduledAt).toBe(rescheduled);
 
-    const notes = await Notification.find({ type: 'eviction_update' });
-    const recipients = notes.map((n: { recipientOxyUserId: string }) => n.recipientOxyUserId).sort();
+    const notes = await notificationsOfType('eviction_update');
+    const recipients = notes.map((n) => n.recipientOxyUserId).sort();
     // Fan-out reaches every attendee EXCEPT the owner.
     expect(recipients).toEqual(['oxy-a', 'oxy-b']);
   });
@@ -203,7 +227,7 @@ describe('comments', () => {
     const res = await request(buildApp('oxy-commenter')).post(`/evictions/${id}/comments`).send({ body: 'Me apunto' });
     expect(res.status).toBe(201);
 
-    const notes = await Notification.find({ type: 'eviction_comment' });
+    const notes = await notificationsOfType('eviction_comment');
     expect(notes).toHaveLength(1);
     expect(notes[0].recipientOxyUserId).toBe('oxy-owner');
   });
@@ -374,10 +398,10 @@ describe('sendEvictionOutcomeReminders — honest stale-case handling', () => {
     const first = await sendEvictionOutcomeReminders();
     expect(first.processed).toBe(1);
 
-    const notes = await Notification.find({ type: 'eviction_outcome_reminder' });
+    const notes = await notificationsOfType('eviction_outcome_reminder');
     expect(notes).toHaveLength(1);
     expect(notes[0].recipientOxyUserId).toBe('oxy-owner');
-    expect(String(notes[0].data.evictionId)).toBe(String(id));
+    expect(String((notes[0].data as { evictionId?: unknown }).evictionId)).toBe(String(id));
 
     const claimed = await EvictionCase.findById(id).select('outcomeReminderSentAt');
     assertFound(claimed, 'claimed');
@@ -386,7 +410,7 @@ describe('sendEvictionOutcomeReminders — honest stale-case handling', () => {
     // A second run is a no-op — no duplicate reminder.
     const second = await sendEvictionOutcomeReminders();
     expect(second.processed).toBe(0);
-    expect(await Notification.countDocuments({ type: 'eviction_outcome_reminder' })).toBe(1);
+    expect(await notificationsOfType('eviction_outcome_reminder')).toHaveLength(1);
   });
 
   it('never reminds future or already-resolved cases', async () => {
@@ -397,6 +421,6 @@ describe('sendEvictionOutcomeReminders — honest stale-case handling', () => {
 
     const result = await sendEvictionOutcomeReminders();
     expect(result.processed).toBe(0);
-    expect(await Notification.countDocuments({ type: 'eviction_outcome_reminder' })).toBe(0);
+    expect(await notificationsOfType('eviction_outcome_reminder')).toHaveLength(0);
   });
 });

--- a/packages/backend/__tests__/integration/notificationOwnership.test.ts
+++ b/packages/backend/__tests__/integration/notificationOwnership.test.ts
@@ -1,19 +1,35 @@
 /**
  * Notification ownership (IDOR) enforcement.
  *
- * Uses the real NotificationController instance and Notification model on the
- * in-memory Mongo, mounted behind a fake-auth middleware. Every read/write is
- * scoped to `recipientOxyUserId`, so user A must never be able to read, mark,
+ * Uses the real NotificationController instance against the REAL Postgres this
+ * worker owns, mounted behind a fake-auth middleware. Every read/write is
+ * scoped to `recipient_oxy_user_id`, so user A must never be able to read, mark,
  * or delete user B's notifications, and the bulk routes (`read-all`,
  * `clear-all`) must only affect the caller's own mailbox.
+ *
+ * ## Why the persistence assertions read the TABLE and not the response
+ *
+ * A handler that answered 404 while still performing the write would pass every
+ * assertion made on its response body — the 404 is the thing being tested, so
+ * trusting it to also prove the row is untouched is a check that cannot tell
+ * success from failure. Each IDOR case therefore re-reads the row afterwards and
+ * asserts it did NOT move.
+ *
+ * `resetNotifications` runs in `beforeEach` because the Postgres side of the
+ * harness has no per-test cleanup: `__tests__/jest.setup.ts` clears the Mongo
+ * collections after every test and deliberately leaves Postgres alone, so a file
+ * that writes rows owns emptying them.
  */
 
 import express, { type Express } from 'express';
 import request from 'supertest';
+import { eq } from 'drizzle-orm';
 
 import notificationController from '../../controllers/notificationController';
-import { Notification } from '../../models';
+import { getDb } from '../../db/postgres';
+import { notifications } from '../../db/schema';
 import { errorHandler } from '../../middlewares/errorHandler';
+import { objectIdHex } from '../helpers/postgresGeoFixtures';
 
 function buildApp(oxyUserId: string): Express {
   const app = express();
@@ -31,70 +47,89 @@ function buildApp(oxyUserId: string): Express {
   return app;
 }
 
-async function createNotificationFor(recipientOxyUserId: string, overrides: Record<string, unknown> = {}) {
-  return Notification.create({
-    recipientOxyUserId,
-    type: 'system',
-    title: 'Hello',
-    message: 'A message',
-    read: false,
-    ...overrides,
-  });
+type NotificationRow = typeof notifications.$inferSelect;
+
+async function createNotificationFor(
+  recipientOxyUserId: string,
+  overrides: Partial<typeof notifications.$inferInsert> = {},
+): Promise<NotificationRow> {
+  const [row] = await getDb()
+    .insert(notifications)
+    .values({
+      recipientOxyUserId,
+      type: 'system',
+      title: 'Hello',
+      message: 'A message',
+      read: false,
+      ...overrides,
+    })
+    .returning();
+  return row;
 }
+
+async function findById(id: string): Promise<NotificationRow | undefined> {
+  const [row] = await getDb().select().from(notifications).where(eq(notifications.id, id)).limit(1);
+  return row;
+}
+
+beforeEach(async () => {
+  await getDb().delete(notifications);
+});
 
 describe('notificationController — mark as read (IDOR)', () => {
   it('lets the owner mark their own notification as read', async () => {
     const n = await createNotificationFor('oxy-a');
-    const res = await request(buildApp('oxy-a')).patch(`/notifications/${n._id}/read`);
+    const res = await request(buildApp('oxy-a')).patch(`/notifications/${n.id}/read`);
     expect(res.status).toBe(200);
     expect(res.body.data.read).toBe(true);
 
-    const persisted = await Notification.findById(n._id);
-    expect(persisted.read).toBe(true);
-    expect(persisted.readAt).toBeTruthy();
+    const persisted = await findById(n.id);
+    expect(persisted?.read).toBe(true);
+    expect(persisted?.readAt).toBeTruthy();
   });
 
   it("does not let user A mark user B's notification as read (404, stays unread)", async () => {
     const n = await createNotificationFor('oxy-b');
-    const res = await request(buildApp('oxy-a')).patch(`/notifications/${n._id}/read`);
+    const res = await request(buildApp('oxy-a')).patch(`/notifications/${n.id}/read`);
     expect(res.status).toBe(404);
     expect(res.body.error.code).toBe('NOT_FOUND');
 
-    const persisted = await Notification.findById(n._id);
-    expect(persisted.read).toBe(false);
+    const persisted = await findById(n.id);
+    expect(persisted?.read).toBe(false);
+    // The pair moves together, so a stray `read_at` on an unread row would be a
+    // half-applied write the `read` assertion alone cannot see.
+    expect(persisted?.readAt).toBeNull();
   });
 });
 
 describe('notificationController — get / delete (IDOR)', () => {
   it("does not let user A read user B's notification (404)", async () => {
     const n = await createNotificationFor('oxy-b');
-    const res = await request(buildApp('oxy-a')).get(`/notifications/${n._id}`);
+    const res = await request(buildApp('oxy-a')).get(`/notifications/${n.id}`);
     expect(res.status).toBe(404);
     expect(res.body.error.code).toBe('NOT_FOUND');
   });
 
   it("does not let user A delete user B's notification (404, still exists)", async () => {
     const n = await createNotificationFor('oxy-b');
-    const res = await request(buildApp('oxy-a')).delete(`/notifications/${n._id}`);
+    const res = await request(buildApp('oxy-a')).delete(`/notifications/${n.id}`);
     expect(res.status).toBe(404);
     expect(res.body.error.code).toBe('NOT_FOUND');
 
-    const persisted = await Notification.findById(n._id);
-    expect(persisted).not.toBeNull();
+    expect(await findById(n.id)).toBeDefined();
   });
 
   it('lets the owner delete their own notification', async () => {
     const n = await createNotificationFor('oxy-a');
-    const res = await request(buildApp('oxy-a')).delete(`/notifications/${n._id}`);
+    const res = await request(buildApp('oxy-a')).delete(`/notifications/${n.id}`);
     expect(res.status).toBe(200);
 
-    const persisted = await Notification.findById(n._id);
-    expect(persisted).toBeNull();
+    expect(await findById(n.id)).toBeUndefined();
   });
 });
 
 describe('notificationController — bulk routes are per-user', () => {
-  it('read-all only marks the caller\'s own notifications as read', async () => {
+  it("read-all only marks the caller's own notifications as read", async () => {
     const a1 = await createNotificationFor('oxy-a');
     const a2 = await createNotificationFor('oxy-a');
     const b1 = await createNotificationFor('oxy-b');
@@ -103,10 +138,32 @@ describe('notificationController — bulk routes are per-user', () => {
     expect(res.status).toBe(200);
     expect(res.body.data.modifiedCount).toBe(2);
 
-    expect((await Notification.findById(a1._id)).read).toBe(true);
-    expect((await Notification.findById(a2._id)).read).toBe(true);
+    expect((await findById(a1.id))?.read).toBe(true);
+    expect((await findById(a2.id))?.read).toBe(true);
     // B's notification is untouched.
-    expect((await Notification.findById(b1._id)).read).toBe(false);
+    expect((await findById(b1.id))?.read).toBe(false);
+  });
+
+  it('read-all counts only the rows that MOVED, and leaves an already-read row alone', async () => {
+    // The Mongo handler counted `modifiedCount`, which excludes rows the update
+    // matched but did not change. The Postgres predicate has to carry the same
+    // exclusion explicitly — without `read = false` every already-read row would
+    // be rewritten with a fresh `read_at`, restamping when the user read
+    // something days ago, and the count would silently include it.
+    const alreadyRead = await createNotificationFor('oxy-a', {
+      read: true,
+      readAt: new Date('2020-01-01T00:00:00.000Z'),
+    });
+    const unread = await createNotificationFor('oxy-a');
+
+    const res = await request(buildApp('oxy-a')).patch('/notifications/read-all');
+    expect(res.status).toBe(200);
+    expect(res.body.data.modifiedCount).toBe(1);
+
+    expect((await findById(unread.id))?.read).toBe(true);
+    expect((await findById(alreadyRead.id))?.readAt).toEqual(
+      new Date('2020-01-01T00:00:00.000Z'),
+    );
   });
 
   it("clear-all only deletes the caller's own notifications", async () => {
@@ -118,8 +175,41 @@ describe('notificationController — bulk routes are per-user', () => {
     expect(res.status).toBe(200);
     expect(res.body.data.deletedCount).toBe(2);
 
-    expect(await Notification.countDocuments({ recipientOxyUserId: 'oxy-a' })).toBe(0);
+    const remaining = await getDb()
+      .select({ id: notifications.id })
+      .from(notifications)
+      .where(eq(notifications.recipientOxyUserId, 'oxy-a'));
+    expect(remaining).toHaveLength(0);
     // B's mailbox is untouched.
-    expect(await Notification.findById(b1._id)).not.toBeNull();
+    expect(await findById(b1.id)).toBeDefined();
+  });
+});
+
+describe('notificationController — ids that are not ObjectId-shaped', () => {
+  /**
+   * The `CastError` branches are deleted rather than widened (`db/ids.ts`).
+   * Post-cutover every id minted by the application is a uuid v7, so a handler
+   * that still recognised only a 24-hex id would answer 400 for a perfectly
+   * valid one. Both shapes have to reach the query and both have to 404 when the
+   * row is not the caller's.
+   */
+  it('answers 404 for a uuid-shaped id that does not exist', async () => {
+    const res = await request(buildApp('oxy-a')).get(
+      '/notifications/0198f0a1-0000-7000-8000-000000000000',
+    );
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('answers 404 for an ObjectId-shaped id that does not exist', async () => {
+    const res = await request(buildApp('oxy-a')).get(`/notifications/${objectIdHex()}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('answers 404 for a plainly malformed id rather than 400 or 500', async () => {
+    const res = await request(buildApp('oxy-a')).get('/notifications/not-an-id');
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
   });
 });

--- a/packages/backend/__tests__/integration/roommateOwnership.test.ts
+++ b/packages/backend/__tests__/integration/roommateOwnership.test.ts
@@ -1,15 +1,36 @@
 /**
  * Roommate controller — profile resolution, preferences mass-assignment (IDOR),
- * relationship lifecycle, and relationship ownership.
+ * the request handshake, relationship lifecycle, and relationship ownership.
+ *
+ * ## This suite spans BOTH stores on purpose
+ *
+ * `roommate_requests` and `roommate_relationships` are on Postgres; `profiles`
+ * is still the Mongo model, because it belongs to another batch. The two need no
+ * transaction between them — a request row and a profile READ are independent,
+ * and nothing here writes both — so the split is a real intermediate state of
+ * the migration rather than a lost guarantee. When profiles move, only the
+ * `Profile.` calls in the controller change.
+ *
+ * ## What makes these tests non-vacuous
+ *
+ * Both tables were empty in production, so "insert one row and read it back"
+ * would pass against almost anything. Every case below targets a rule with a way
+ * to be wrong — and the two partial unique indexes are asserted on what they
+ * PERMIT as well as what they refuse, which `CONVENTIONS.md` names as the half
+ * that a plain (total) index would silently eat.
  */
 
 import express, { type Express } from 'express';
 import request from 'supertest';
+import { and, eq } from 'drizzle-orm';
 
 import roommateController from '../../controllers/roommateController';
+import { getDb } from '../../db/postgres';
+import { roommateRelationships, roommateRequests } from '../../db/schema';
+import { sortPair } from '../../db/roommates/roommateRepository';
 import { asyncHandler } from '../../middlewares';
 import { errorHandler } from '../../middlewares/errorHandler';
-import { Profile, RoommateRequest, RoommateRelationship } from '../../models';
+import { Profile } from '../../models';
 
 beforeAll(() => {
   (global as unknown as { fetch: jest.Mock }).fetch = jest.fn(async () => ({
@@ -17,6 +38,12 @@ beforeAll(() => {
     status: 200,
     json: async () => ({ data: [] }),
   }));
+});
+
+beforeEach(async () => {
+  // Relationships first: `request_id` references `roommate_requests`.
+  await getDb().delete(roommateRelationships);
+  await getDb().delete(roommateRequests);
 });
 
 function buildApp(oxyUserId: string): Express {
@@ -58,6 +85,31 @@ async function createRoommateProfile(
     },
     ...overrides,
   });
+}
+
+/** Insert a pending request directly, for cases that start from one. */
+async function seedPendingRequest(fromOxyUserId: string, toOxyUserId: string) {
+  const [row] = await getDb()
+    .insert(roommateRequests)
+    .values({ fromOxyUserId, toOxyUserId, status: 'pending' })
+    .returning();
+  return row;
+}
+
+async function activeRelationshipBetween(a: string, b: string) {
+  const [oxyUser1Id, oxyUser2Id] = sortPair(a, b);
+  const [row] = await getDb()
+    .select()
+    .from(roommateRelationships)
+    .where(
+      and(
+        eq(roommateRelationships.oxyUser1Id, oxyUser1Id),
+        eq(roommateRelationships.oxyUser2Id, oxyUser2Id),
+        eq(roommateRelationships.status, 'active'),
+      ),
+    )
+    .limit(1);
+  return row;
 }
 
 describe('roommateController.getRoommateProfiles — profile resolution', () => {
@@ -104,50 +156,236 @@ describe('roommateController.updateRoommatePreferences — mass-assignment guard
   });
 });
 
-describe('roommateController relationship lifecycle', () => {
-  it('accepting a request materializes a relationship', async () => {
+describe('sendRoommateRequest — the pending-pair rule', () => {
+  it('stores the request and notifies nobody but the recipient', async () => {
     await createRoommateProfile('oxy-a');
     await createRoommateProfile('oxy-b');
 
-    const pending = await RoommateRequest.create({
-      fromOxyUserId: 'oxy-a',
-      toOxyUserId: 'oxy-b',
-      status: 'pending',
-    });
+    const res = await request(buildApp('oxy-a')).post('/roommates/oxy-b/request').send({ message: 'hola' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.id).toEqual(expect.any(String));
+    expect(res.body.data.status).toBe('pending');
 
-    const res = await request(buildApp('oxy-b'))
-      .post(`/roommates/requests/${pending._id}/accept`);
-
-    expect(res.status).toBe(200);
-
-    const relationship = await RoommateRelationship.findOne({
-      $or: [
-        { oxyUser1Id: 'oxy-a', oxyUser2Id: 'oxy-b' },
-        { oxyUser1Id: 'oxy-b', oxyUser2Id: 'oxy-a' },
-      ],
-      status: 'active',
-    });
-    expect(relationship).toBeTruthy();
+    const rows = await getDb().select().from(roommateRequests);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].fromOxyUserId).toBe('oxy-a');
+    expect(rows[0].message).toBe('hola');
   });
 
+  it('refuses a second pending request in the SAME direction with 409', async () => {
+    await createRoommateProfile('oxy-a');
+    await createRoommateProfile('oxy-b');
+    const app = buildApp('oxy-a');
+
+    expect((await request(app).post('/roommates/oxy-b/request')).status).toBe(201);
+    const second = await request(app).post('/roommates/oxy-b/request');
+    expect(second.status).toBe(409);
+
+    expect(await getDb().select().from(roommateRequests)).toHaveLength(1);
+  });
+
+  it('refuses a pending request in the REVERSE direction with 409', async () => {
+    // The partial unique index is on the ORDERED pair, so it cannot see this
+    // one — the repository keeps an explicit read for it, and dropping that read
+    // would let two people hold two pending requests about each other.
+    await createRoommateProfile('oxy-a');
+    await createRoommateProfile('oxy-b');
+
+    expect((await request(buildApp('oxy-a')).post('/roommates/oxy-b/request')).status).toBe(201);
+    const reverse = await request(buildApp('oxy-b')).post('/roommates/oxy-a/request');
+    expect(reverse.status).toBe(409);
+
+    expect(await getDb().select().from(roommateRequests)).toHaveLength(1);
+  });
+
+  it('PERMITS a fresh request after the first was declined', async () => {
+    // The permit half. A plain `UNIQUE(from, to)` passes every refusal
+    // assertion above and silently eats this one — which is a person being
+    // unable to ask again, months later, with no error anybody can see.
+    await createRoommateProfile('oxy-a');
+    await createRoommateProfile('oxy-b');
+
+    const first = await request(buildApp('oxy-a')).post('/roommates/oxy-b/request');
+    expect(first.status).toBe(201);
+
+    const declined = await request(buildApp('oxy-b')).post(
+      `/roommates/requests/${first.body.data.id}/decline`,
+    );
+    expect(declined.status).toBe(200);
+
+    const again = await request(buildApp('oxy-a')).post('/roommates/oxy-b/request');
+    expect(again.status).toBe(201);
+
+    expect(await getDb().select().from(roommateRequests)).toHaveLength(2);
+  });
+
+  it('refuses a request to yourself with 400', async () => {
+    await createRoommateProfile('oxy-a');
+    const res = await request(buildApp('oxy-a')).post('/roommates/oxy-a/request');
+    expect(res.status).toBe(400);
+    expect(await getDb().select().from(roommateRequests)).toHaveLength(0);
+  });
+});
+
+describe('respondToRoommateRequest — only the recipient, only once', () => {
+  it('accepting a request materializes a relationship with a SORTED pair', async () => {
+    await createRoommateProfile('oxy-a');
+    await createRoommateProfile('oxy-b');
+
+    // Seeded from `oxy-b` to `oxy-a`, so the stored pair has to be REORDERED.
+    // Without the sort the row still inserts and every "a relationship exists"
+    // assertion passes — `roommate_relationships_sorted_pair_check` is what
+    // turns forgetting it into a loud failure, and this is the case that
+    // exercises it.
+    const pending = await seedPendingRequest('oxy-b', 'oxy-a');
+
+    const res = await request(buildApp('oxy-a')).post(`/roommates/requests/${pending.id}/accept`);
+    expect(res.status).toBe(200);
+
+    const relationship = await activeRelationshipBetween('oxy-a', 'oxy-b');
+    expect(relationship).toBeDefined();
+    expect(relationship?.oxyUser1Id).toBe('oxy-a');
+    expect(relationship?.oxyUser2Id).toBe('oxy-b');
+    expect(relationship?.requestId).toBe(pending.id);
+  });
+
+  it('is idempotent — a second accept of the same request 404s and creates nothing', async () => {
+    await createRoommateProfile('oxy-a');
+    await createRoommateProfile('oxy-b');
+    const pending = await seedPendingRequest('oxy-a', 'oxy-b');
+    const app = buildApp('oxy-b');
+
+    expect((await request(app).post(`/roommates/requests/${pending.id}/accept`)).status).toBe(200);
+    // The `pending` status is in the UPDATE's own predicate, so the second call
+    // matches no row rather than running the acceptance twice.
+    expect((await request(app).post(`/roommates/requests/${pending.id}/accept`)).status).toBe(404);
+
+    expect(await getDb().select().from(roommateRelationships)).toHaveLength(1);
+  });
+
+  it('converges when the pair is accepted from two different requests', async () => {
+    // `roommate_relationships_active_pair_key` is what makes this one row
+    // instead of two. The old upsert read first, which two concurrent accepts
+    // both passed.
+    await createRoommateProfile('oxy-a');
+    await createRoommateProfile('oxy-b');
+    const first = await seedPendingRequest('oxy-a', 'oxy-b');
+    const second = await seedPendingRequest('oxy-b', 'oxy-a');
+
+    expect((await request(buildApp('oxy-b')).post(`/roommates/requests/${first.id}/accept`)).status).toBe(200);
+    expect((await request(buildApp('oxy-a')).post(`/roommates/requests/${second.id}/accept`)).status).toBe(200);
+
+    expect(await getDb().select().from(roommateRelationships)).toHaveLength(1);
+  });
+
+  it('does not let a non-recipient accept (404, still pending)', async () => {
+    await createRoommateProfile('oxy-a');
+    await createRoommateProfile('oxy-b');
+    await createRoommateProfile('oxy-stranger');
+    const pending = await seedPendingRequest('oxy-a', 'oxy-b');
+
+    const res = await request(buildApp('oxy-stranger')).post(`/roommates/requests/${pending.id}/accept`);
+    expect(res.status).toBe(404);
+
+    const [row] = await getDb()
+      .select()
+      .from(roommateRequests)
+      .where(eq(roommateRequests.id, pending.id));
+    expect(row.status).toBe('pending');
+    expect(await getDb().select().from(roommateRelationships)).toHaveLength(0);
+  });
+
+  it('answers 404 for a malformed request id rather than 400 or 500', async () => {
+    // `ObjectId.isValid` is deleted rather than widened: post-cutover every id
+    // is a uuid v7, which that guard rejected.
+    await createRoommateProfile('oxy-b');
+    const res = await request(buildApp('oxy-b')).post('/roommates/requests/not-an-id/accept');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('getRoommateRequests', () => {
+  it('splits the caller\'s own sent and received requests', async () => {
+    await createRoommateProfile('oxy-me');
+    await seedPendingRequest('oxy-me', 'oxy-x');
+    await seedPendingRequest('oxy-y', 'oxy-me');
+    await seedPendingRequest('oxy-x', 'oxy-y');
+
+    const res = await request(buildApp('oxy-me')).get('/roommates/requests');
+    expect(res.status).toBe(200);
+    expect(res.body.data.sent).toHaveLength(1);
+    expect(res.body.data.received).toHaveLength(1);
+    expect(res.body.data.sent[0].receiverOxyUserId).toBe('oxy-x');
+    expect(res.body.data.received[0].senderOxyUserId).toBe('oxy-y');
+  });
+});
+
+describe('endRoommateRelationship — participant-scoped', () => {
   it('DELETE /relationships/:id is participant-scoped', async () => {
     await createRoommateProfile('oxy-a');
     await createRoommateProfile('oxy-b');
     await createRoommateProfile('oxy-outsider');
 
-    const relationship = await RoommateRelationship.create({
-      oxyUser1Id: 'oxy-a',
-      oxyUser2Id: 'oxy-b',
-      status: 'active',
-      startDate: new Date(),
-    });
+    const [relationship] = await getDb()
+      .insert(roommateRelationships)
+      .values({ oxyUser1Id: 'oxy-a', oxyUser2Id: 'oxy-b', status: 'active', startDate: new Date() })
+      .returning();
 
-    const res = await request(buildApp('oxy-outsider'))
-      .delete(`/roommates/relationships/${relationship._id}`);
-
+    const res = await request(buildApp('oxy-outsider')).delete(
+      `/roommates/relationships/${relationship.id}`,
+    );
     expect(res.status).toBe(404);
 
-    const stillActive = await RoommateRelationship.findById(relationship._id);
-    expect(stillActive?.status).toBe('active');
+    const [stillActive] = await getDb()
+      .select()
+      .from(roommateRelationships)
+      .where(eq(roommateRelationships.id, relationship.id));
+    expect(stillActive.status).toBe('active');
+    expect(stillActive.endDate).toBeNull();
+  });
+
+  it('lets a participant end it, and stamps an end date in the same statement', async () => {
+    await createRoommateProfile('oxy-a');
+    await createRoommateProfile('oxy-b');
+
+    const [relationship] = await getDb()
+      .insert(roommateRelationships)
+      .values({ oxyUser1Id: 'oxy-a', oxyUser2Id: 'oxy-b', status: 'active', startDate: new Date() })
+      .returning();
+
+    const res = await request(buildApp('oxy-b')).delete(`/roommates/relationships/${relationship.id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('ended');
+
+    const [ended] = await getDb()
+      .select()
+      .from(roommateRelationships)
+      .where(eq(roommateRelationships.id, relationship.id));
+    expect(ended.status).toBe('ended');
+    // An `ended` row with no end date is a relationship nobody can say when
+    // they left; the CHECK only constrains the two dates against each other.
+    expect(ended.endDate).not.toBeNull();
+  });
+
+  it('PERMITS the same pair rooming together again after they parted', async () => {
+    // The second permit half. `roommate_relationships_active_pair_key` is
+    // partial on `status = 'active'` precisely so this is possible; a total
+    // unique index refuses it, and passes every other assertion in this file.
+    await createRoommateProfile('oxy-a');
+    await createRoommateProfile('oxy-b');
+
+    const [first] = await getDb()
+      .insert(roommateRelationships)
+      .values({ oxyUser1Id: 'oxy-a', oxyUser2Id: 'oxy-b', status: 'active', startDate: new Date() })
+      .returning();
+    await request(buildApp('oxy-a')).delete(`/roommates/relationships/${first.id}`);
+
+    const pending = await seedPendingRequest('oxy-a', 'oxy-b');
+    const res = await request(buildApp('oxy-b')).post(`/roommates/requests/${pending.id}/accept`);
+    expect(res.status).toBe(200);
+
+    const all = await getDb().select().from(roommateRelationships);
+    expect(all).toHaveLength(2);
+    expect(all.filter((row) => row.status === 'active')).toHaveLength(1);
   });
 });

--- a/packages/backend/__tests__/integration/savedSearches.test.ts
+++ b/packages/backend/__tests__/integration/savedSearches.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Saved searches — ownership, the unique-name rule, and the `jsonb` filters.
+ *
+ * The real handlers against the REAL Postgres this worker owns, mounted behind a
+ * fake-auth middleware. The Mongo collection was empty in production, so nothing
+ * here asserts a preserved row; what it asserts is that the RULES the schema now
+ * carries actually hold, in both directions.
+ *
+ * ## What makes these tests non-vacuous
+ *
+ * `saved_searches` was empty, so a suite that only inserted one row and read it
+ * back would pass against almost any implementation. Each case below is written
+ * against a rule that has a way to be WRONG:
+ *
+ *  - the unique name is asserted per OWNER, so an index missing `oxy_user_id`
+ *    (which would reject two different people saving "Madrid") fails,
+ *  - the 409 is asserted to leave the FIRST row intact, so an upsert
+ *    masquerading as a create fails,
+ *  - `filters` is asserted to survive a shape the column would lose if it were
+ *    ever flattened into columns,
+ *  - every ownership case re-reads the row afterwards, because a handler that
+ *    404s and writes anyway passes any assertion made on the response alone.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { eq } from 'drizzle-orm';
+
+import * as savedSearches from '../../controllers/profile/savedSearches';
+import { getDb } from '../../db/postgres';
+import { savedSearches as savedSearchesTable } from '../../db/schema';
+import { errorHandler } from '../../middlewares/errorHandler';
+
+function buildApp(oxyUserId?: string): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (oxyUserId) {
+      (req as unknown as { user: { id: string } }).user = { id: oxyUserId };
+    }
+    next();
+  });
+  app.get('/saved-searches', (req, res, next) => savedSearches.getSavedSearches(req, res, next));
+  app.post('/saved-searches', (req, res, next) => savedSearches.saveSearch(req, res, next));
+  app.put('/saved-searches/:searchId', (req, res, next) => savedSearches.updateSavedSearch(req, res, next));
+  app.patch('/saved-searches/:searchId/notifications', (req, res, next) =>
+    savedSearches.toggleSearchNotifications(req, res, next),
+  );
+  app.delete('/saved-searches/:searchId', (req, res, next) => savedSearches.deleteSavedSearch(req, res, next));
+  app.use(errorHandler);
+  return app;
+}
+
+async function rowById(id: string) {
+  const [row] = await getDb()
+    .select()
+    .from(savedSearchesTable)
+    .where(eq(savedSearchesTable.id, id))
+    .limit(1);
+  return row;
+}
+
+beforeEach(async () => {
+  await getDb().delete(savedSearchesTable);
+});
+
+describe('saveSearch', () => {
+  it('stores the search and returns it with an `id`', async () => {
+    const res = await request(buildApp('oxy-a'))
+      .post('/saved-searches')
+      .send({ name: 'Madrid centro', query: 'madrid', filters: { minPrice: 500 } });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.id).toEqual(expect.any(String));
+    // The wire contract is `id`, not `_id` (PR #287's clean cut).
+    expect(res.body.data._id).toBeUndefined();
+
+    const persisted = await rowById(res.body.data.id);
+    expect(persisted?.oxyUserId).toBe('oxy-a');
+    expect(persisted?.name).toBe('Madrid centro');
+    expect(persisted?.notificationsEnabled).toBe(false);
+  });
+
+  it('trims the name and the query before storing them', async () => {
+    // Not cosmetic: the unique index is on the stored bytes, so an untrimmed
+    // name would make `'Madrid '` a second row and retire the rule below.
+    const res = await request(buildApp('oxy-a'))
+      .post('/saved-searches')
+      .send({ name: '  Madrid  ', query: '  madrid  ' });
+    expect(res.status).toBe(201);
+
+    const persisted = await rowById(res.body.data.id);
+    expect(persisted?.name).toBe('Madrid');
+    expect(persisted?.query).toBe('madrid');
+  });
+
+  it('rejects a blank name or query with 400', async () => {
+    const app = buildApp('oxy-a');
+    const blankName = await request(app).post('/saved-searches').send({ name: '   ', query: 'x' });
+    expect(blankName.status).toBe(400);
+    const missingQuery = await request(app).post('/saved-searches').send({ name: 'x' });
+    expect(missingQuery.status).toBe(400);
+  });
+
+  it('requires authentication', async () => {
+    const res = await request(buildApp()).post('/saved-searches').send({ name: 'x', query: 'y' });
+    expect(res.status).toBe(401);
+  });
+
+  it('answers 409 on a duplicate name and leaves the FIRST row untouched', async () => {
+    const app = buildApp('oxy-a');
+    const created = await request(app).post('/saved-searches').send({ name: 'Madrid', query: 'one' });
+    expect(created.status).toBe(201);
+
+    const second = await request(app).post('/saved-searches').send({ name: 'Madrid', query: 'two' });
+    expect(second.status).toBe(409);
+    expect(second.body.code).toBe('SEARCH_NAME_EXISTS');
+
+    // An upsert wearing a create's clothes would pass the 409 assertion only if
+    // it also failed — but a handler that returned 409 *after* overwriting would
+    // not, which is what this re-read is for.
+    const persisted = await rowById(created.body.data.id);
+    expect(persisted?.query).toBe('one');
+
+    const all = await getDb().select().from(savedSearchesTable);
+    expect(all).toHaveLength(1);
+  });
+
+  it('scopes the unique name to the OWNER — two people may both save "Madrid"', async () => {
+    // The index that would break this is a plain `UNIQUE(name)`, which passes
+    // every "rejects a duplicate" assertion above. This is the permit half that
+    // `CONVENTIONS.md` says a unique index has to be tested on.
+    const a = await request(buildApp('oxy-a')).post('/saved-searches').send({ name: 'Madrid', query: 'q' });
+    const b = await request(buildApp('oxy-b')).post('/saved-searches').send({ name: 'Madrid', query: 'q' });
+    expect(a.status).toBe(201);
+    expect(b.status).toBe(201);
+
+    const all = await getDb().select().from(savedSearchesTable);
+    expect(all).toHaveLength(2);
+  });
+
+  it('round-trips a nested `filters` object through jsonb', async () => {
+    // `filters` is one of the five columns that earned `jsonb`: its shape is
+    // whatever the search UI supported the day it was saved. A column set that
+    // flattened it would lose the nesting and the array silently.
+    const filters = {
+      priceRange: { min: 500, max: 1200 },
+      amenities: ['wifi', 'lift'],
+      furnished: false,
+      nested: { deep: { deeper: 'value' } },
+    };
+    const res = await request(buildApp('oxy-a'))
+      .post('/saved-searches')
+      .send({ name: 'Complex', query: 'q', filters });
+    expect(res.status).toBe(201);
+
+    const persisted = await rowById(res.body.data.id);
+    expect(persisted?.filters).toEqual(filters);
+
+    const listed = await request(buildApp('oxy-a')).get('/saved-searches');
+    expect(listed.body.data[0].filters).toEqual(filters);
+  });
+});
+
+describe('getSavedSearches', () => {
+  it("returns only the caller's own searches, newest first", async () => {
+    await request(buildApp('oxy-a')).post('/saved-searches').send({ name: 'first', query: 'q' });
+    await request(buildApp('oxy-a')).post('/saved-searches').send({ name: 'second', query: 'q' });
+    await request(buildApp('oxy-b')).post('/saved-searches').send({ name: 'other', query: 'q' });
+
+    const res = await request(buildApp('oxy-a')).get('/saved-searches');
+    expect(res.status).toBe(200);
+    const names = res.body.data.map((row: { name: string }) => row.name);
+    expect(names).toHaveLength(2);
+    expect(names).not.toContain('other');
+  });
+});
+
+describe('updateSavedSearch / toggleSearchNotifications — ownership', () => {
+  it('lets the owner rename their own search', async () => {
+    const created = await request(buildApp('oxy-a'))
+      .post('/saved-searches')
+      .send({ name: 'old', query: 'q' });
+
+    const res = await request(buildApp('oxy-a'))
+      .put(`/saved-searches/${created.body.data.id}`)
+      .send({ name: 'new' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.name).toBe('new');
+  });
+
+  it("does not let user B rename user A's search (404, unchanged)", async () => {
+    const created = await request(buildApp('oxy-a'))
+      .post('/saved-searches')
+      .send({ name: 'mine', query: 'q' });
+
+    const res = await request(buildApp('oxy-b'))
+      .put(`/saved-searches/${created.body.data.id}`)
+      .send({ name: 'hijacked' });
+    expect(res.status).toBe(404);
+
+    const persisted = await rowById(created.body.data.id);
+    expect(persisted?.name).toBe('mine');
+  });
+
+  it('answers 409 when a rename collides with another of the same owner\'s searches', async () => {
+    const app = buildApp('oxy-a');
+    await request(app).post('/saved-searches').send({ name: 'taken', query: 'q' });
+    const other = await request(app).post('/saved-searches').send({ name: 'free', query: 'q' });
+
+    const res = await request(app).put(`/saved-searches/${other.body.data.id}`).send({ name: 'taken' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('SEARCH_NAME_EXISTS');
+
+    const persisted = await rowById(other.body.data.id);
+    expect(persisted?.name).toBe('free');
+  });
+
+  it('toggles notifications for the owner and refuses a stranger', async () => {
+    const created = await request(buildApp('oxy-a'))
+      .post('/saved-searches')
+      .send({ name: 'alerts', query: 'q' });
+
+    const on = await request(buildApp('oxy-a'))
+      .patch(`/saved-searches/${created.body.data.id}/notifications`)
+      .send({ notificationsEnabled: true });
+    expect(on.status).toBe(200);
+    expect(on.body.data.notificationsEnabled).toBe(true);
+
+    const stranger = await request(buildApp('oxy-b'))
+      .patch(`/saved-searches/${created.body.data.id}/notifications`)
+      .send({ notificationsEnabled: false });
+    expect(stranger.status).toBe(404);
+
+    const persisted = await rowById(created.body.data.id);
+    expect(persisted?.notificationsEnabled).toBe(true);
+  });
+});
+
+describe('deleteSavedSearch — ownership', () => {
+  it('lets the owner delete their own search', async () => {
+    const created = await request(buildApp('oxy-a'))
+      .post('/saved-searches')
+      .send({ name: 'bye', query: 'q' });
+
+    const res = await request(buildApp('oxy-a')).delete(`/saved-searches/${created.body.data.id}`);
+    expect(res.status).toBe(200);
+    expect(await rowById(created.body.data.id)).toBeUndefined();
+  });
+
+  it("does not let user B delete user A's search (404, still there)", async () => {
+    const created = await request(buildApp('oxy-a'))
+      .post('/saved-searches')
+      .send({ name: 'keep', query: 'q' });
+
+    const res = await request(buildApp('oxy-b')).delete(`/saved-searches/${created.body.data.id}`);
+    expect(res.status).toBe(404);
+    expect(await rowById(created.body.data.id)).toBeDefined();
+  });
+
+  it('answers 404 for an id that never existed, whatever shape it is', async () => {
+    // Both id shapes are live in a `text` primary key after the cutover, so a
+    // handler that still recognised only a 24-hex ObjectId would answer 400 for
+    // a perfectly valid uuid v7.
+    const app = buildApp('oxy-a');
+    expect((await request(app).delete('/saved-searches/0198f0a1-0000-7000-8000-000000000000')).status).toBe(404);
+    expect((await request(app).delete('/saved-searches/507f1f77bcf86cd799439011')).status).toBe(404);
+    expect((await request(app).delete('/saved-searches/not-an-id')).status).toBe(404);
+  });
+});

--- a/packages/backend/controllers/notificationController.ts
+++ b/packages/backend/controllers/notificationController.ts
@@ -2,27 +2,64 @@
  * Notification Controller
  * Handles notification management operations.
  *
- * Notifications are persisted in MongoDB (see models/schemas/NotificationSchema)
- * and scoped to the authenticated Oxy user. The mailbox screen
+ * Notifications are persisted in PostgreSQL (`db/schema/notifications.ts`, read
+ * and written through `db/notifications/notificationRepository.ts`) and scoped
+ * to the authenticated Oxy user. The mailbox screen
  * (packages/frontend/app/mailbox.tsx, via context/NotificationContext +
  * services/notificationService) lists, reads, updates and deletes them through
  * these handlers.
+ *
+ * ## What the Mongo port changed, and what it deliberately did not
+ *
+ * The `CastError` branches are GONE, not widened. A `text` primary key takes any
+ * string, so a malformed id is simply a lookup that matches nothing and the
+ * handler answers the same 404 it always answered for an id that did not exist.
+ * `db/ids.ts` is explicit that these guards are deleted rather than ported, and
+ * that using `isLiveEntityId` as a query precondition would re-introduce the
+ * fail-open bug in a new costume.
+ *
+ * The `ValidationError` branch is gone for the same class of reason: the two
+ * things Mongoose validated here are `type`/`title`/`message` presence, which
+ * this handler checks itself and answers 400 for, and `priority`, which the
+ * handler narrows against the declared tuple before the insert can see it. What
+ * remains — a `NOT NULL` or a CHECK — is a programming error rather than a
+ * caller's, and it belongs in the error handler as a 500 rather than being
+ * relabelled a 400 the client cannot act on.
  */
 
 import type { Request, Response, NextFunction } from 'express';
 
-import { Notification } from '../models';
+import { getDb } from '../db/postgres';
+import {
+  createNotification,
+  deleteAllNotifications,
+  deleteNotification,
+  findNotificationForRecipient,
+  isNotificationPriority,
+  listNotifications,
+  markAllRead,
+  markRead,
+  toNotificationDTO,
+  updateNotification,
+  type NotificationPriority,
+} from '../db/notifications/notificationRepository';
 import { AppError, successResponse } from '../middlewares/errorHandler';
 import { logger } from '../middlewares/logging';
 
-const VALID_PRIORITIES = ['low', 'medium', 'high', 'urgent'];
+/**
+ * Resolve the mailbox owner from the session, in the shape the auth layer sets.
+ *
+ * `req.userId` is declared `string | null`, so the `||` chain widens to include
+ * `null` — coalesced away here rather than at each of the eight call sites,
+ * every one of which only ever asks "is there an owner?".
+ */
+function recipientOf(req: Request): string | undefined {
+  return req.user?.id || req.user?._id || req.userId || undefined;
+}
 
-function errorName(error: unknown): string | undefined {
-  if (error && typeof error === 'object' && 'name' in error) {
-    const name = (error as { name: unknown }).name;
-    return typeof name === 'string' ? name : undefined;
-  }
-  return undefined;
+/** The `?priority` filter, or `undefined` when absent or not a declared value. */
+function priorityFilter(value: unknown): NotificationPriority | undefined {
+  return isNotificationPriority(value) ? value : undefined;
 }
 
 class NotificationController {
@@ -36,7 +73,7 @@ class NotificationController {
    */
   async getNotifications(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
+      const oxyUserId = recipientOf(req);
       if (!oxyUserId) {
         return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
       }
@@ -51,35 +88,24 @@ class NotificationController {
 
       const pageNumber = Math.max(1, parseInt(String(page), 10) || 1);
       const limitNumber = Math.min(100, Math.max(1, parseInt(String(limit), 10) || 20));
-      const skip = (pageNumber - 1) * limitNumber;
 
-      const query: Record<string, unknown> = { recipientOxyUserId: oxyUserId };
-      if (String(unreadOnly) === 'true') {
-        query.read = false;
-      }
-      if (type) {
-        query.type = String(type);
-      }
-      if (priority && VALID_PRIORITIES.includes(String(priority))) {
-        query.priority = String(priority);
-      }
-
-      const [notifications, total, unreadCount] = await Promise.all([
-        Notification.find(query)
-          .sort({ createdAt: -1 })
-          .skip(skip)
-          .limit(limitNumber)
-          .lean({ virtuals: true }),
-        Notification.countDocuments(query),
-        Notification.countDocuments({ recipientOxyUserId: oxyUserId, read: false }),
-      ]);
+      const { rows, total, unreadCount } = await listNotifications(
+        getDb(),
+        {
+          recipientOxyUserId: oxyUserId,
+          unreadOnly: String(unreadOnly) === 'true',
+          type: type === undefined ? undefined : String(type),
+          priority: priorityFilter(priority === undefined ? undefined : String(priority)),
+        },
+        { limit: limitNumber, offset: (pageNumber - 1) * limitNumber },
+      );
 
       const totalPages = Math.ceil(total / limitNumber);
 
       res.json({
         success: true,
         message: 'Notifications retrieved successfully',
-        notifications,
+        notifications: rows.map(toNotificationDTO),
         unreadCount,
         total,
         page: pageNumber,
@@ -98,7 +124,7 @@ class NotificationController {
    */
   async createNotification(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
+      const oxyUserId = recipientOf(req);
       if (!oxyUserId) {
         return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
       }
@@ -111,27 +137,25 @@ class NotificationController {
         );
       }
 
-      const notification = await Notification.create({
+      const notification = await createNotification(getDb(), {
         recipientOxyUserId: oxyUserId,
         type: String(type),
         title: String(title),
         message: String(message),
-        app: app ? String(app) : undefined,
-        priority: priority && VALID_PRIORITIES.includes(String(priority))
-          ? String(priority)
-          : undefined,
+        // `undefined` rather than `null`: the column is `NOT NULL DEFAULT`, so
+        // omitting the key is what lets the default apply. See the repository
+        // header — this is the one place drizzle and mongoose disagree.
+        app: app === undefined ? undefined : String(app),
+        priority: priorityFilter(priority),
         data: data ?? {},
       });
 
-      logger.info('Notification created', { notificationId: notification._id, oxyUserId, type });
+      logger.info('Notification created', { notificationId: notification.id, oxyUserId, type });
 
       res.status(201).json(
-        successResponse(notification.toJSON(), 'Notification created successfully')
+        successResponse(toNotificationDTO(notification), 'Notification created successfully')
       );
     } catch (error) {
-      if (errorName(error) === 'ValidationError') {
-        return next(new AppError('Validation failed', 400, 'VALIDATION_ERROR'));
-      }
       next(error);
     }
   }
@@ -141,27 +165,22 @@ class NotificationController {
    */
   async getNotificationById(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
+      const oxyUserId = recipientOf(req);
       if (!oxyUserId) {
         return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
       }
 
       const notificationId = req.params.id || req.params.notificationId;
 
-      const notification = await Notification.findOne({
-        _id: notificationId,
-        recipientOxyUserId: oxyUserId,
-      });
-
+      const notification = await findNotificationForRecipient(getDb(), notificationId, oxyUserId);
       if (!notification) {
         return next(new AppError('Notification not found', 404, 'NOT_FOUND'));
       }
 
-      res.json(successResponse(notification.toJSON(), 'Notification retrieved successfully'));
+      res.json(
+        successResponse(toNotificationDTO(notification), 'Notification retrieved successfully')
+      );
     } catch (error) {
-      if (errorName(error) === 'CastError') {
-        return next(new AppError('Invalid notification ID', 400, 'VALIDATION_ERROR'));
-      }
       next(error);
     }
   }
@@ -172,7 +191,7 @@ class NotificationController {
    */
   async updateNotification(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
+      const oxyUserId = recipientOf(req);
       if (!oxyUserId) {
         return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
       }
@@ -180,23 +199,13 @@ class NotificationController {
       const notificationId = req.params.id || req.params.notificationId;
       const { read, title, message, priority, data } = req.body;
 
-      const update: Record<string, unknown> = {};
-      if (read !== undefined) {
-        update.read = Boolean(read);
-        update.readAt = read ? new Date() : null;
-      }
-      if (title !== undefined) update.title = String(title);
-      if (message !== undefined) update.message = String(message);
-      if (priority !== undefined && VALID_PRIORITIES.includes(String(priority))) {
-        update.priority = String(priority);
-      }
-      if (data !== undefined) update.data = data;
-
-      const notification = await Notification.findOneAndUpdate(
-        { _id: notificationId, recipientOxyUserId: oxyUserId },
-        { $set: update },
-        { new: true, runValidators: true }
-      );
+      const notification = await updateNotification(getDb(), notificationId, oxyUserId, {
+        read: read === undefined ? undefined : Boolean(read),
+        title: title === undefined ? undefined : String(title),
+        message: message === undefined ? undefined : String(message),
+        priority: priorityFilter(priority),
+        data,
+      });
 
       if (!notification) {
         return next(new AppError('Notification not found', 404, 'NOT_FOUND'));
@@ -204,14 +213,10 @@ class NotificationController {
 
       logger.info('Notification updated', { notificationId, oxyUserId });
 
-      res.json(successResponse(notification.toJSON(), 'Notification updated successfully'));
+      res.json(
+        successResponse(toNotificationDTO(notification), 'Notification updated successfully')
+      );
     } catch (error) {
-      if (errorName(error) === 'CastError') {
-        return next(new AppError('Invalid notification ID', 400, 'VALIDATION_ERROR'));
-      }
-      if (errorName(error) === 'ValidationError') {
-        return next(new AppError('Validation failed', 400, 'VALIDATION_ERROR'));
-      }
       next(error);
     }
   }
@@ -221,30 +226,22 @@ class NotificationController {
    */
   async markAsRead(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
+      const oxyUserId = recipientOf(req);
       if (!oxyUserId) {
         return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
       }
 
       const notificationId = req.params.id || req.params.notificationId;
 
-      const notification = await Notification.findOneAndUpdate(
-        { _id: notificationId, recipientOxyUserId: oxyUserId },
-        { $set: { read: true, readAt: new Date() } },
-        { new: true }
-      );
-
+      const notification = await markRead(getDb(), notificationId, oxyUserId);
       if (!notification) {
         return next(new AppError('Notification not found', 404, 'NOT_FOUND'));
       }
 
       logger.info('Notification marked as read', { notificationId, oxyUserId });
 
-      res.json(successResponse(notification.toJSON(), 'Notification marked as read'));
+      res.json(successResponse(toNotificationDTO(notification), 'Notification marked as read'));
     } catch (error) {
-      if (errorName(error) === 'CastError') {
-        return next(new AppError('Invalid notification ID', 400, 'VALIDATION_ERROR'));
-      }
       next(error);
     }
   }
@@ -254,19 +251,15 @@ class NotificationController {
    */
   async deleteNotification(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
+      const oxyUserId = recipientOf(req);
       if (!oxyUserId) {
         return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
       }
 
       const notificationId = req.params.id || req.params.notificationId;
 
-      const notification = await Notification.findOneAndDelete({
-        _id: notificationId,
-        recipientOxyUserId: oxyUserId,
-      });
-
-      if (!notification) {
+      const deleted = await deleteNotification(getDb(), notificationId, oxyUserId);
+      if (!deleted) {
         return next(new AppError('Notification not found', 404, 'NOT_FOUND'));
       }
 
@@ -274,9 +267,6 @@ class NotificationController {
 
       res.json(successResponse(null, 'Notification deleted successfully'));
     } catch (error) {
-      if (errorName(error) === 'CastError') {
-        return next(new AppError('Invalid notification ID', 400, 'VALIDATION_ERROR'));
-      }
       next(error);
     }
   }
@@ -286,26 +276,17 @@ class NotificationController {
    */
   async markAllAsRead(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
+      const oxyUserId = recipientOf(req);
       if (!oxyUserId) {
         return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
       }
 
-      const result = await Notification.updateMany(
-        { recipientOxyUserId: oxyUserId, read: false },
-        { $set: { read: true, readAt: new Date() } }
-      );
+      const modifiedCount = await markAllRead(getDb(), oxyUserId);
 
-      logger.info('All notifications marked as read', {
-        oxyUserId,
-        modifiedCount: result.modifiedCount,
-      });
+      logger.info('All notifications marked as read', { oxyUserId, modifiedCount });
 
       res.json(
-        successResponse(
-          { modifiedCount: result.modifiedCount ?? 0 },
-          'All notifications marked as read'
-        )
+        successResponse({ modifiedCount }, 'All notifications marked as read')
       );
     } catch (error) {
       next(error);
@@ -317,23 +298,17 @@ class NotificationController {
    */
   async clearAllNotifications(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
+      const oxyUserId = recipientOf(req);
       if (!oxyUserId) {
         return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
       }
 
-      const result = await Notification.deleteMany({ recipientOxyUserId: oxyUserId });
+      const deletedCount = await deleteAllNotifications(getDb(), oxyUserId);
 
-      logger.info('All notifications cleared', {
-        oxyUserId,
-        deletedCount: result.deletedCount,
-      });
+      logger.info('All notifications cleared', { oxyUserId, deletedCount });
 
       res.json(
-        successResponse(
-          { deletedCount: result.deletedCount ?? 0 },
-          'All notifications cleared successfully'
-        )
+        successResponse({ deletedCount }, 'All notifications cleared successfully')
       );
     } catch (error) {
       next(error);

--- a/packages/backend/controllers/profile/savedSearches.ts
+++ b/packages/backend/controllers/profile/savedSearches.ts
@@ -1,41 +1,72 @@
+/**
+ * Saved searches, on Postgres.
+ *
+ * Ported from the Mongo `SavedSearch` model to
+ * `db/saved/savedSearchRepository.ts`. The collection was empty in production,
+ * so no user-visible behaviour depends on any row this port had to preserve.
+ *
+ * ## Two things the port changed, both deliberately
+ *
+ * **The duplicate-name check is the INDEX now.** `saveSearch` used to read for
+ * the name and then insert, which two concurrent requests both pass. The 409 is
+ * unchanged; it is now raised from `saved_searches_owner_name_key`'s own
+ * `23505`. See the repository header.
+ *
+ * **The `Profile.findByOxyUserId` guard on delete / update / toggle is GONE.**
+ * It was not an authorisation check — every one of those statements is already
+ * scoped by `oxyUserId`, which is resolved from the session and never from the
+ * client — so its only effect was to answer 404 to somebody who owned the row
+ * but happened to have no profile document yet. Keeping it would have made this
+ * controller depend on `profiles`, a table another batch owns, in order to
+ * reproduce a check that protected nothing. It is dropped rather than ported,
+ * and the ownership predicate that does the real work is untouched.
+ */
+
+import type { NextFunction, Request, Response } from 'express';
+
+import { getDb } from '../../db/postgres';
 import {
-  Profile,
-  SavedSearch,
-  successResponse,
-  errorResponse,
-} from './shared';
+  createSavedSearch,
+  deleteSavedSearch as deleteSavedSearchRow,
+  listSavedSearches,
+  SavedSearchNameTakenError,
+  toSavedSearchDTO,
+  updateSavedSearch as updateSavedSearchRow,
+} from '../../db/saved/savedSearchRepository';
+import { errorResponse, successResponse } from './shared';
+
+/** Resolve the owner from the session, in the shape the auth layer sets. */
+function ownerOf(req: Request): string | undefined {
+  return req.user?.id || req.user?._id || undefined;
+}
 
 /**
- * Get saved searches for the current user's profile
+ * Get saved searches for the current user
  */
-export async function getSavedSearches(req: any, res: any, next: any) {
+export async function getSavedSearches(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
 
     if (!oxyUserId) {
       return res.status(401).json(
         errorResponse("Authentication required", "AUTHENTICATION_REQUIRED")
       );
     }
-// Get saved searches
-    const savedSearches = await SavedSearch.find({ oxyUserId })
-      .sort({ createdAt: -1 })
-      .lean();
 
-    const response = successResponse(savedSearches, "Saved searches retrieved successfully");
+    const rows = await listSavedSearches(getDb(), oxyUserId);
 
-    res.json(response);
+    res.json(successResponse(rows.map(toSavedSearchDTO), "Saved searches retrieved successfully"));
   } catch (error) {
     next(error);
   }
 }
 
 /**
- * Save a search for the current user's profile
+ * Save a search for the current user
  */
-export async function saveSearch(req: any, res: any, next: any) {
+export async function saveSearch(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
     const { name, query, filters, notificationsEnabled } = req.body;
 
     if (!oxyUserId) {
@@ -44,50 +75,45 @@ export async function saveSearch(req: any, res: any, next: any) {
       );
     }
 
-    if (!name || !query) {
+    if (typeof name !== 'string' || !name.trim() || typeof query !== 'string' || !query.trim()) {
       return res.status(400).json(
         errorResponse("Search name and query are required", "SEARCH_DATA_REQUIRED")
       );
     }
-// Check if search with same name already exists
-    const existingSearch = await SavedSearch.findOne({
-      oxyUserId,
-      name: name.trim()
-    });
 
-    if (existingSearch) {
-      return res.status(409).json(
-        errorResponse("A search with this name already exists", "SEARCH_NAME_EXISTS")
-      );
+    let savedSearch;
+    try {
+      savedSearch = await createSavedSearch(getDb(), {
+        oxyUserId,
+        // Trimmed HERE: mongoose's `trim` has no Postgres counterpart, and the
+        // unique index is on the stored bytes — an untrimmed name would make
+        // `'Madrid '` a second row and quietly retire the duplicate-name rule.
+        name: name.trim(),
+        query: query.trim(),
+        filters: filters ?? {},
+        notificationsEnabled: Boolean(notificationsEnabled),
+      });
+    } catch (error) {
+      if (error instanceof SavedSearchNameTakenError) {
+        return res.status(409).json(
+          errorResponse("A search with this name already exists", "SEARCH_NAME_EXISTS")
+        );
+      }
+      throw error;
     }
 
-    // Create new saved search
-    const savedSearch = new SavedSearch({
-      oxyUserId,
-      name: name.trim(),
-      query: query.trim(),
-      filters: filters || {},
-      notificationsEnabled: !!notificationsEnabled,
-      createdAt: new Date(),
-      updatedAt: new Date()
-    });
-
-    await savedSearch.save();
-
-    res.status(201).json(
-      successResponse(savedSearch, "Search saved successfully")
-    );
+    res.status(201).json(successResponse(toSavedSearchDTO(savedSearch), "Search saved successfully"));
   } catch (error) {
     next(error);
   }
 }
 
 /**
- * Delete a saved search for the current user's profile
+ * Delete a saved search for the current user
  */
-export async function deleteSavedSearch(req: any, res: any, next: any) {
+export async function deleteSavedSearch(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
     const { searchId } = req.params;
 
     if (!oxyUserId) {
@@ -102,41 +128,26 @@ export async function deleteSavedSearch(req: any, res: any, next: any) {
       );
     }
 
-    // Get the active profile for the current user
-    const activeProfile = await Profile.findByOxyUserId(oxyUserId);
+    const deleted = await deleteSavedSearchRow(getDb(), searchId, oxyUserId);
 
-    if (!activeProfile) {
+    if (!deleted) {
       return res.status(404).json(
         errorResponse("Saved search not found", "SAVED_SEARCH_NOT_FOUND")
       );
     }
 
-    // Remove saved search
-    const result = await SavedSearch.deleteOne({
-      _id: searchId,
-      oxyUserId
-    });
-
-    if (result.deletedCount === 0) {
-      return res.status(404).json(
-        errorResponse("Saved search not found", "SAVED_SEARCH_NOT_FOUND")
-      );
-    }
-
-    res.json(
-      successResponse(null, "Search deleted successfully")
-    );
+    res.json(successResponse(null, "Search deleted successfully"));
   } catch (error) {
     next(error);
   }
 }
 
 /**
- * Update a saved search for the current user's profile
+ * Update a saved search for the current user
  */
-export async function updateSavedSearch(req: any, res: any, next: any) {
+export async function updateSavedSearch(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
     const { searchId } = req.params;
     const { name, query, filters, notificationsEnabled } = req.body;
 
@@ -152,28 +163,23 @@ export async function updateSavedSearch(req: any, res: any, next: any) {
       );
     }
 
-    // Get the active profile for the current user
-    const activeProfile = await Profile.findByOxyUserId(oxyUserId);
-
-    if (!activeProfile) {
-      return res.status(404).json(
-        errorResponse("Saved search not found", "SAVED_SEARCH_NOT_FOUND")
-      );
+    let savedSearch;
+    try {
+      savedSearch = await updateSavedSearchRow(getDb(), searchId, oxyUserId, {
+        name: name === undefined ? undefined : String(name).trim(),
+        query: query === undefined ? undefined : String(query).trim(),
+        filters,
+        notificationsEnabled:
+          notificationsEnabled === undefined ? undefined : Boolean(notificationsEnabled),
+      });
+    } catch (error) {
+      if (error instanceof SavedSearchNameTakenError) {
+        return res.status(409).json(
+          errorResponse("A search with this name already exists", "SEARCH_NAME_EXISTS")
+        );
+      }
+      throw error;
     }
-
-    // Prepare update data
-    const updateData: any = { updatedAt: new Date() };
-    if (name !== undefined) updateData.name = name.trim();
-    if (query !== undefined) updateData.query = query.trim();
-    if (filters !== undefined) updateData.filters = filters;
-    if (notificationsEnabled !== undefined) updateData.notificationsEnabled = !!notificationsEnabled;
-
-    // Update saved search
-    const savedSearch = await SavedSearch.findOneAndUpdate(
-      { _id: searchId, oxyUserId },
-      updateData,
-      { new: true }
-    );
 
     if (!savedSearch) {
       return res.status(404).json(
@@ -181,9 +187,7 @@ export async function updateSavedSearch(req: any, res: any, next: any) {
       );
     }
 
-    res.json(
-      successResponse(savedSearch, "Search updated successfully")
-    );
+    res.json(successResponse(toSavedSearchDTO(savedSearch), "Search updated successfully"));
   } catch (error) {
     next(error);
   }
@@ -192,9 +196,9 @@ export async function updateSavedSearch(req: any, res: any, next: any) {
 /**
  * Toggle notifications for a saved search
  */
-export async function toggleSearchNotifications(req: any, res: any, next: any) {
+export async function toggleSearchNotifications(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
     const { searchId } = req.params;
     const { notificationsEnabled } = req.body;
 
@@ -210,24 +214,9 @@ export async function toggleSearchNotifications(req: any, res: any, next: any) {
       );
     }
 
-    // Get the active profile for the current user
-    const activeProfile = await Profile.findByOxyUserId(oxyUserId);
-
-    if (!activeProfile) {
-      return res.status(404).json(
-        errorResponse("Saved search not found", "SAVED_SEARCH_NOT_FOUND")
-      );
-    }
-
-    // Update notifications setting
-    const savedSearch = await SavedSearch.findOneAndUpdate(
-      { _id: searchId, oxyUserId },
-      {
-        notificationsEnabled: !!notificationsEnabled,
-        updatedAt: new Date()
-      },
-      { new: true }
-    );
+    const savedSearch = await updateSavedSearchRow(getDb(), searchId, oxyUserId, {
+      notificationsEnabled: Boolean(notificationsEnabled),
+    });
 
     if (!savedSearch) {
       return res.status(404).json(
@@ -236,7 +225,7 @@ export async function toggleSearchNotifications(req: any, res: any, next: any) {
     }
 
     res.json(
-      successResponse(savedSearch, "Search notifications updated successfully")
+      successResponse(toSavedSearchDTO(savedSearch), "Search notifications updated successfully")
     );
   } catch (error) {
     next(error);

--- a/packages/backend/controllers/profile/shared.ts
+++ b/packages/backend/controllers/profile/shared.ts
@@ -1,4 +1,4 @@
-import { Profile, Saved, SavedPropertyFolder, SavedSearch, RecentlyViewed, Property } from '../../models';
+import { Profile, Saved, SavedPropertyFolder, RecentlyViewed, Property } from '../../models';
 import { successResponse } from '../../middlewares/errorHandler';
 
 const errorResponse = (message = 'Error occurred', code = 'ERROR') => ({
@@ -83,7 +83,6 @@ export {
   Profile,
   Saved,
   SavedPropertyFolder,
-  SavedSearch,
   RecentlyViewed,
   Property,
   successResponse,

--- a/packages/backend/controllers/roommateController.ts
+++ b/packages/backend/controllers/roommateController.ts
@@ -4,37 +4,29 @@
  */
 
 import type { Request, Response } from 'express';
-import type { Types } from 'mongoose';
 import type { PopulatedProfileLike } from './roommate/serialize';
 import type { IProfile } from '../models/documentTypes';
 
-import { Profile, RoommateRequest, RoommateRelationship } from '../models';
+import { Profile } from '../models';
+import { getDb } from '../db/postgres';
+import {
+  createRoommateRequest,
+  endRoommateRelationship as endRelationshipRow,
+  ensureActiveRelationship,
+  clampMatchScore,
+  listRoommateRelationships,
+  listRoommateRequests,
+  PendingRoommateRequestExistsError,
+  respondToRoommateRequest as respondToRequestRow,
+  toRoommateRequestDTO,
+  type RoommateRelationshipRow,
+  type RoommateRequestRow,
+} from '../db/roommates/roommateRepository';
 import { logger } from '../middlewares/logging';
 import { notificationDispatchService } from '../services/notificationDispatchService';
 import { pickFields } from '../utils/pickFields';
 import { EDITABLE_ROOMMATE_PREFERENCE_FIELDS } from './roommate/editableFields';
 import { ROOMMATE_PROFILE_FIELDS, hydrateDisplayNames, serializeRoommateProfile } from './roommate/serialize';
-
-import { Types as MongooseTypes } from 'mongoose';
-
-interface RoommateRequestLean {
-  _id: unknown;
-  fromOxyUserId: unknown;
-  toOxyUserId: unknown;
-  status: unknown;
-  message?: unknown;
-  createdAt: unknown;
-}
-
-interface RoommateRelationshipLean {
-  _id: unknown;
-  oxyUser1Id: unknown;
-  oxyUser2Id: unknown;
-  status: unknown;
-  matchScore?: unknown;
-  startDate?: unknown;
-  endDate?: unknown;
-}
 
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -327,16 +319,9 @@ const toggleRoommateMatching = async (req: Request, res: Response): Promise<Resp
   }
 };
 
-/** Serialize a single request document with hydrated display names + score. */
+/** Serialize a single request row with hydrated display names + score. */
 const serializeRequest = (
-  request: {
-    _id: unknown;
-    fromOxyUserId: string;
-    toOxyUserId: string;
-    status: string;
-    message?: string;
-    createdAt: Date;
-  },
+  request: RoommateRequestRow,
   profileByOxyUserId: Map<string, PopulatedProfileLike>,
   displayNames: Map<string, string>,
 ) => {
@@ -347,7 +332,7 @@ const serializeRequest = (
     prefsOf(profileByOxyUserId.get(request.toOxyUserId)),
   );
   return {
-    id: String(request._id),
+    id: request.id,
     senderOxyUserId: request.fromOxyUserId,
     receiverOxyUserId: request.toOxyUserId,
     sender,
@@ -373,17 +358,11 @@ const getRoommateRequests = async (req: Request, res: Response): Promise<Respons
       return res.status(404).json({ error: 'Profile not found' });
     }
 
-    const [sent, received] = await Promise.all([
-      RoommateRequest.find({ fromOxyUserId: oxyUserId }).sort({ createdAt: -1 }).lean(),
-      RoommateRequest.find({ toOxyUserId: oxyUserId }).sort({ createdAt: -1 }).lean(),
-    ]);
+    const { sent, received } = await listRoommateRequests(getDb(), oxyUserId);
 
     const participantOxyUserIds = Array.from(
       new Set(
-        [...sent, ...received].flatMap((request) => [
-          String(request.fromOxyUserId),
-          String(request.toOxyUserId),
-        ]),
+        [...sent, ...received].flatMap((request) => [request.fromOxyUserId, request.toOxyUserId]),
       ),
     );
     const profiles = await Profile.find({ oxyUserId: { $in: participantOxyUserIds } })
@@ -396,22 +375,8 @@ const getRoommateRequests = async (req: Request, res: Response): Promise<Respons
 
     res.json({
       data: {
-        sent: sent.map((r: RoommateRequestLean) => serializeRequest({
-          _id: r._id,
-          fromOxyUserId: String(r.fromOxyUserId),
-          toOxyUserId: String(r.toOxyUserId),
-          status: String(r.status),
-          message: typeof r.message === 'string' ? r.message : undefined,
-          createdAt: r.createdAt instanceof Date ? r.createdAt : new Date(String(r.createdAt)),
-        }, profileByOxyUserId, displayNames)),
-        received: received.map((r: RoommateRequestLean) => serializeRequest({
-          _id: r._id,
-          fromOxyUserId: String(r.fromOxyUserId),
-          toOxyUserId: String(r.toOxyUserId),
-          status: String(r.status),
-          message: typeof r.message === 'string' ? r.message : undefined,
-          createdAt: r.createdAt instanceof Date ? r.createdAt : new Date(String(r.createdAt)),
-        }, profileByOxyUserId, displayNames)),
+        sent: sent.map((request) => serializeRequest(request, profileByOxyUserId, displayNames)),
+        received: received.map((request) => serializeRequest(request, profileByOxyUserId, displayNames)),
       },
     });
   } catch (error) {
@@ -453,82 +418,63 @@ const sendRoommateRequest = async (req: Request, res: Response): Promise<Respons
       return res.status(400).json({ error: 'Target user does not have roommate matching enabled' });
     }
 
-    const existingRequest = await RoommateRequest.findOne({
-      status: 'pending',
-      $or: [
-        { fromOxyUserId: oxyUserId, toOxyUserId: targetOxyUserId },
-        { fromOxyUserId: targetOxyUserId, toOxyUserId: oxyUserId },
-      ],
-    });
-
-    if (existingRequest) {
-      return res.status(409).json({ error: 'A pending roommate request already exists between these users' });
+    // The "already pending?" read is GONE in the forward direction: it was a
+    // read-then-write with a window, and `roommate_requests_pending_pair_key`
+    // is a real partial unique index. The repository raises the same 409 from
+    // the index's own `23505`, and still reads for the REVERSE direction, which
+    // no single-column index can express.
+    let request;
+    try {
+      request = await createRoommateRequest(getDb(), {
+        fromOxyUserId: oxyUserId,
+        toOxyUserId: targetOxyUserId,
+        message: typeof message === 'string' ? message : undefined,
+      });
+    } catch (error) {
+      if (error instanceof PendingRoommateRequestExistsError) {
+        return res.status(409).json({ error: 'A pending roommate request already exists between these users' });
+      }
+      throw error;
     }
-
-    const request = await RoommateRequest.create({
-      fromOxyUserId: oxyUserId,
-      toOxyUserId: targetOxyUserId,
-      message: typeof message === 'string' ? message : undefined,
-    });
 
     await notificationDispatchService.createForUser(targetOxyUserId, {
       type: 'roommate',
       title: 'New roommate request',
       message: 'Someone sent you a roommate request.',
       priority: 'high',
-      data: { requestId: request._id.toString(), screen: '/roommates' },
+      data: { requestId: request.id, screen: '/roommates' },
     });
 
     res.status(201).json({
       message: 'Roommate request sent successfully',
-      data: request,
+      data: toRoommateRequestDTO(request),
     });
   } catch (error) {
-    if (error && typeof error === 'object' && (error as { code?: number }).code === 11000) {
-      return res.status(409).json({ error: 'A pending roommate request already exists between these users' });
-    }
     logger.error('Failed to send roommate request', { error: errorMessage(error) });
     res.status(500).json({ error: 'Failed to send roommate request' });
   }
 };
 
 /**
- * Deterministically sort two profile ids so a pair maps to one canonical
- * relationship row (`oxyUser1Id` < `oxyUser2Id` by string).
- */
-const sortPair = (a: string, b: string): [string, string] =>
-  a < b ? [a, b] : [b, a];
-
-/**
  * Create (idempotently) the roommate relationship for an accepted request.
- * Returns the relationship document.
+ *
+ * The pair is sorted by the repository and the sort is enforced by
+ * `roommate_relationships_sorted_pair_check`, so a writer that skipped it fails
+ * loudly instead of producing a second, invisible row for the same two people.
  */
-const createRelationshipForAcceptedRequest = async (request: {
-  _id: Types.ObjectId;
-  fromOxyUserId: string;
-  toOxyUserId: string;
-}) => {
+const createRelationshipForAcceptedRequest = async (request: RoommateRequestRow) => {
   const [fromProfile, toProfile] = await Promise.all([
     Profile.findOne({ oxyUserId: request.fromOxyUserId }).select('personalProfile'),
     Profile.findOne({ oxyUserId: request.toOxyUserId }).select('personalProfile'),
   ]);
   const matchScore = calculateMatchPercentage(prefsOf(fromProfile), prefsOf(toProfile));
-  const [oxyUser1Id, oxyUser2Id] = sortPair(request.fromOxyUserId, request.toOxyUserId);
 
-  return RoommateRelationship.findOneAndUpdate(
-    { oxyUser1Id, oxyUser2Id, status: 'active' },
-    {
-      $setOnInsert: {
-        oxyUser1Id,
-        oxyUser2Id,
-        requestId: request._id,
-        matchScore,
-        status: 'active',
-        startDate: new Date(),
-      },
-    },
-    { upsert: true, new: true, setDefaultsOnInsert: true },
-  );
+  return ensureActiveRelationship(getDb(), {
+    requestId: request.id,
+    fromOxyUserId: request.fromOxyUserId,
+    toOxyUserId: request.toOxyUserId,
+    matchScore: clampMatchScore(matchScore),
+  });
 };
 
 // Respond to a roommate request (accept/decline) - only the recipient may respond
@@ -542,34 +488,23 @@ const respondToRoommateRequest = async (req: Request, res: Response, status: 'ac
       return res.status(401).json({ error: 'Authentication required' });
     }
 
-    if (!MongooseTypes.ObjectId.isValid(requestId)) {
-      return res.status(404).json({ error: 'Roommate request not found' });
-    }
-
-    const request = await RoommateRequest.findOne({
-      _id: requestId,
-      toOxyUserId: oxyUserId,
-      status: 'pending'
-    });
+    // The `ObjectId.isValid` guard is DELETED rather than widened (`db/ids.ts`):
+    // post-cutover every request id is a uuid v7, which that guard rejects. The
+    // `UPDATE` below already answers "no such pending request of yours" for a
+    // malformed id, an unknown one and somebody else's alike.
+    const request = await respondToRequestRow(getDb(), requestId, oxyUserId, status);
 
     if (!request) {
       return res.status(404).json({ error: 'Roommate request not found' });
     }
 
-    request.status = status;
-    await request.save();
-
-    // On accept, materialize the confirmed relationship (idempotent upsert).
+    // On accept, materialize the confirmed relationship (idempotent insert).
     if (status === 'accepted') {
-      await createRelationshipForAcceptedRequest({
-        _id: request._id as Types.ObjectId,
-        fromOxyUserId: String(request.fromOxyUserId),
-        toOxyUserId: String(request.toOxyUserId),
-      });
+      await createRelationshipForAcceptedRequest(request);
     }
 
     // Notify the original sender of the accept/decline decision.
-    await notificationDispatchService.createForUser(request.fromOxyUserId.toString(), {
+    await notificationDispatchService.createForUser(request.fromOxyUserId, {
       type: 'roommate',
       title: status === 'accepted' ? 'Roommate request accepted' : 'Roommate request declined',
       message:
@@ -577,12 +512,12 @@ const respondToRoommateRequest = async (req: Request, res: Response, status: 'ac
           ? 'Your roommate request was accepted.'
           : 'Your roommate request was declined.',
       priority: 'medium',
-      data: { requestId: request._id.toString(), screen: '/roommates' },
+      data: { requestId: request.id, screen: '/roommates' },
     });
 
     res.json({
       message: `Roommate request ${status} successfully`,
-      data: request
+      data: toRoommateRequestDTO(request),
     });
   } catch (error) {
     logger.error(`Failed to ${action} roommate request`, { error: errorMessage(error) });
@@ -600,30 +535,22 @@ const declineRoommateRequest = async (req: Request, res: Response): Promise<Resp
   return respondToRoommateRequest(req, res, 'declined');
 };
 
-/** Serialize a relationship document with hydrated display names. */
+/** Serialize a relationship row with hydrated display names. */
 const serializeRelationship = (
-  relationship: {
-    _id: unknown;
-    oxyUser1Id: string;
-    oxyUser2Id: string;
-    status: string;
-    matchScore?: number;
-    startDate?: Date;
-    endDate?: Date;
-  },
+  relationship: RoommateRelationshipRow,
   profileByOxyUserId: Map<string, PopulatedProfileLike>,
   displayNames: Map<string, string>,
 ) => {
   const profile1 = serializeRoommateProfile(profileByOxyUserId.get(relationship.oxyUser1Id), displayNames);
   const profile2 = serializeRoommateProfile(profileByOxyUserId.get(relationship.oxyUser2Id), displayNames);
   return {
-    id: String(relationship._id),
+    id: relationship.id,
     oxyUser1Id: relationship.oxyUser1Id,
     oxyUser2Id: relationship.oxyUser2Id,
     profile1,
     profile2,
     status: relationship.status,
-    matchScore: relationship.matchScore ?? 0,
+    matchScore: relationship.matchScore,
     startDate: relationship.startDate,
     endDate: relationship.endDate,
   };
@@ -644,43 +571,24 @@ const getRoommateRelationships = async (req: Request, res: Response): Promise<Re
       return res.status(404).json({ error: 'Profile not found' });
     }
 
-    const relationships = await RoommateRelationship.find({
-      $or: [{ oxyUser1Id: oxyUserId }, { oxyUser2Id: oxyUserId }],
-    })
-      .sort({ createdAt: -1 })
-      .lean();
+    const relationships = await listRoommateRelationships(getDb(), oxyUserId);
 
     const participantOxyUserIds = Array.from(
       new Set(
-        relationships.flatMap((relationship: Record<string, unknown>) => [
-          String(relationship.oxyUser1Id),
-          String(relationship.oxyUser2Id),
-        ]),
+        relationships.flatMap((relationship) => [relationship.oxyUser1Id, relationship.oxyUser2Id]),
       ),
     );
     const profiles = await Profile.find({ oxyUserId: { $in: participantOxyUserIds } })
       .select(ROOMMATE_PROFILE_FIELDS)
       .lean();
     const profileByOxyUserId = new Map<string, PopulatedProfileLike>(
-      profiles.map((profile: PopulatedProfileLike & { oxyUserId: string }) => [String(profile.oxyUserId), profile as PopulatedProfileLike]),
+      profiles.map((entry: PopulatedProfileLike & { oxyUserId: string }) => [String(entry.oxyUserId), entry as PopulatedProfileLike]),
     );
     const displayNames = await hydrateDisplayNames(participantOxyUserIds);
 
     res.json({
-      data: relationships.map((r: RoommateRelationshipLean) =>
-        serializeRelationship(
-          {
-            _id: r._id,
-            oxyUser1Id: String(r.oxyUser1Id),
-            oxyUser2Id: String(r.oxyUser2Id),
-            status: String(r.status),
-            matchScore: typeof r.matchScore === 'number' ? r.matchScore : undefined,
-            startDate: r.startDate instanceof Date ? r.startDate : undefined,
-            endDate: r.endDate instanceof Date ? r.endDate : undefined,
-          },
-          profileByOxyUserId,
-          displayNames,
-        ),
+      data: relationships.map((relationship) =>
+        serializeRelationship(relationship, profileByOxyUserId, displayNames),
       ),
     });
   } catch (error) {
@@ -699,10 +607,6 @@ const endRoommateRelationship = async (req: Request, res: Response): Promise<Res
       return res.status(401).json({ error: 'Authentication required' });
     }
 
-    if (!MongooseTypes.ObjectId.isValid(relationshipId)) {
-      return res.status(404).json({ error: 'Roommate relationship not found' });
-    }
-
     const profile = await Profile.findByOxyUserId(oxyUserId);
 
     if (!profile) {
@@ -710,37 +614,30 @@ const endRoommateRelationship = async (req: Request, res: Response): Promise<Res
     }
 
     // The caller must be one of the two participants; a non-participant sees the
-    // same 404 as a missing relationship (no existence leak).
-    const relationship = await RoommateRelationship.findOne({
-      _id: relationshipId,
-      status: 'active',
-      $or: [{ oxyUser1Id: oxyUserId }, { oxyUser2Id: oxyUserId }],
-    });
+    // same 404 as a missing relationship (no existence leak). Both facts are in
+    // the `UPDATE`'s predicate, so there is no window between the check and the
+    // write — and the `ObjectId.isValid` guard is deleted rather than widened,
+    // for the reason `db/ids.ts` gives.
+    const relationship = await endRelationshipRow(getDb(), relationshipId, oxyUserId);
 
     if (!relationship) {
       return res.status(404).json({ error: 'Roommate relationship not found' });
     }
 
-    relationship.status = 'ended';
-    relationship.endDate = new Date();
-    await relationship.save();
-
     const otherOxyUserId =
-      String(relationship.oxyUser1Id) === oxyUserId
-        ? String(relationship.oxyUser2Id)
-        : String(relationship.oxyUser1Id);
+      relationship.oxyUser1Id === oxyUserId ? relationship.oxyUser2Id : relationship.oxyUser1Id;
 
-    await notificationDispatchService.createForUser(String(otherOxyUserId), {
+    await notificationDispatchService.createForUser(otherOxyUserId, {
       type: 'roommate',
       title: 'Roommate relationship ended',
       message: 'A roommate relationship was ended.',
       priority: 'medium',
-      data: { relationshipId: relationship._id.toString(), screen: '/roommates' },
+      data: { relationshipId: relationship.id, screen: '/roommates' },
     });
 
     res.json({
       message: 'Roommate relationship ended successfully',
-      data: { id: relationship._id.toString(), status: relationship.status },
+      data: { id: relationship.id, status: relationship.status },
     });
   } catch (error) {
     logger.error('Failed to end roommate relationship', { error: errorMessage(error) });

--- a/packages/backend/db/notifications/notificationRepository.ts
+++ b/packages/backend/db/notifications/notificationRepository.ts
@@ -1,0 +1,345 @@
+/**
+ * `notifications` — the in-app mailbox, on Postgres.
+ *
+ * The Mongo collection was empty in production, so this port has no backfill and
+ * no consistency window: the first row this repository writes is the first row
+ * the table has ever held.
+ *
+ * ## Two Mongoose behaviours had to be absorbed rather than dropped
+ *
+ * **`type` and `priority` were coerced with `String(...)` at the controller and
+ * defaulted by the schema.** Mongoose applies a `default` at document
+ * CONSTRUCTION, so `app: undefined` stored `'homiio'` and `priority: undefined`
+ * stored `'medium'`. drizzle does the opposite — an explicit `undefined` in the
+ * values object is simply omitted, which lets the column DEFAULT apply, so the
+ * two agree here only because every optional column carries its default in the
+ * schema. Passing an explicit `null` would NOT agree, and would fail `NOT NULL`;
+ * {@link createNotification} therefore takes `undefined` and never `null`.
+ *
+ * **`read` and `read_at` move together.** Mongo let a row be `read: true` with
+ * no `readAt` and vice versa, because the controller wrote them as two
+ * independent `$set` keys. There is no CHECK for it — the pair is not one of the
+ * coherence rules `db/schema/CONVENTIONS.md` expresses — so it is enforced HERE
+ * instead, by {@link markRead} and {@link updateNotification} being the only
+ * writers of either column and always writing both.
+ */
+
+import { and, count, desc, eq } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+import type { DatabaseOrTransaction } from '../postgres';
+import { notifications } from '../schema';
+import { NOTIFICATION_PRIORITIES } from '../schema/notifications';
+
+/** A notification priority the schema's CHECK accepts. */
+export type NotificationPriority = (typeof NOTIFICATION_PRIORITIES)[number];
+
+/** A row as stored. Every column, since the mailbox DTO carries all of them. */
+export type NotificationRow = typeof notifications.$inferSelect;
+
+/**
+ * Whether `value` is one of the four declared priorities.
+ *
+ * Exported because the controller and the dispatch service both have to narrow
+ * an untrusted string BEFORE it reaches the insert — a value the CHECK refuses
+ * arrives as a `23514` from the driver, which is a 500 rather than the 400 the
+ * caller earned.
+ */
+export function isNotificationPriority(value: unknown): value is NotificationPriority {
+  return (
+    typeof value === 'string' &&
+    (NOTIFICATION_PRIORITIES as readonly string[]).includes(value)
+  );
+}
+
+export interface CreateNotificationInput {
+  readonly recipientOxyUserId: string;
+  readonly type: string;
+  readonly title: string;
+  readonly message: string;
+  /** Omitted (never `null`) to take the column default — see the header. */
+  readonly app?: string;
+  readonly priority?: NotificationPriority;
+  readonly data?: Record<string, unknown>;
+}
+
+/** Insert one notification and return it. */
+export async function createNotification(
+  db: DatabaseOrTransaction,
+  input: CreateNotificationInput,
+): Promise<NotificationRow> {
+  const [row] = await db
+    .insert(notifications)
+    .values({
+      recipientOxyUserId: input.recipientOxyUserId,
+      type: input.type,
+      title: input.title,
+      message: input.message,
+      app: input.app,
+      priority: input.priority,
+      data: input.data ?? {},
+    })
+    .returning();
+  return row;
+}
+
+export interface ListNotificationsFilter {
+  readonly recipientOxyUserId: string;
+  readonly unreadOnly?: boolean;
+  readonly type?: string;
+  readonly priority?: NotificationPriority;
+}
+
+export interface ListNotificationsResult {
+  readonly rows: readonly NotificationRow[];
+  readonly total: number;
+  /** Unread across the WHOLE mailbox, deliberately not narrowed by the filter. */
+  readonly unreadCount: number;
+}
+
+/**
+ * The filter shared by the page read and its `count(*)`.
+ *
+ * One expression rather than two, because a page and a total built from
+ * different predicates disagree in a way that only shows up as a last page that
+ * is empty or a `hasNext` that never clears.
+ */
+function listFilter(filter: ListNotificationsFilter): SQL {
+  const clauses: SQL[] = [eq(notifications.recipientOxyUserId, filter.recipientOxyUserId)];
+  if (filter.unreadOnly) clauses.push(eq(notifications.read, false));
+  if (filter.type !== undefined) clauses.push(eq(notifications.type, filter.type));
+  if (filter.priority !== undefined) clauses.push(eq(notifications.priority, filter.priority));
+  // `and` of a non-empty list is always defined; the cast states that rather
+  // than reaching for a non-null assertion.
+  return and(...clauses) as SQL;
+}
+
+/**
+ * One page of the mailbox, newest first, plus the two counts the badge needs.
+ *
+ * `unreadCount` is the whole mailbox's, matching the Mongo handler: the filter
+ * chips change what is LISTED and must not change the badge, or switching to
+ * "payments" would appear to clear every other unread notification.
+ */
+export async function listNotifications(
+  db: DatabaseOrTransaction,
+  filter: ListNotificationsFilter,
+  page: { readonly limit: number; readonly offset: number },
+): Promise<ListNotificationsResult> {
+  const where = listFilter(filter);
+  const [rows, [totalRow], [unreadRow]] = await Promise.all([
+    db
+      .select()
+      .from(notifications)
+      .where(where)
+      .orderBy(desc(notifications.createdAt))
+      .limit(page.limit)
+      .offset(page.offset),
+    db.select({ value: count() }).from(notifications).where(where),
+    db
+      .select({ value: count() })
+      .from(notifications)
+      .where(
+        and(
+          eq(notifications.recipientOxyUserId, filter.recipientOxyUserId),
+          eq(notifications.read, false),
+        ),
+      ),
+  ]);
+  return { rows, total: totalRow.value, unreadCount: unreadRow.value };
+}
+
+/**
+ * One notification, scoped to its recipient.
+ *
+ * The recipient is part of the predicate rather than checked afterwards: a
+ * lookup by id alone that is authorised in a second statement is an IDOR the
+ * moment somebody forgets the second statement.
+ */
+export async function findNotificationForRecipient(
+  db: DatabaseOrTransaction,
+  id: string,
+  recipientOxyUserId: string,
+): Promise<NotificationRow | undefined> {
+  const [row] = await db
+    .select()
+    .from(notifications)
+    .where(
+      and(
+        eq(notifications.id, id),
+        eq(notifications.recipientOxyUserId, recipientOxyUserId),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+export interface UpdateNotificationInput {
+  /** Writes `read_at` in the same statement — see the header. */
+  readonly read?: boolean;
+  readonly title?: string;
+  readonly message?: string;
+  readonly priority?: NotificationPriority;
+  readonly data?: Record<string, unknown>;
+}
+
+/**
+ * Apply a partial update, scoped to the recipient. Returns the row, or
+ * `undefined` when it does not exist or belongs to somebody else.
+ *
+ * A caller passing no changes still gets the row back rather than a no-op
+ * `UPDATE`: `updated_at` carries drizzle's `$onUpdate`, so an empty `set` would
+ * restamp the row with the moment of a request that changed nothing.
+ */
+export async function updateNotification(
+  db: DatabaseOrTransaction,
+  id: string,
+  recipientOxyUserId: string,
+  input: UpdateNotificationInput,
+): Promise<NotificationRow | undefined> {
+  const values: Partial<typeof notifications.$inferInsert> = {};
+  if (input.read !== undefined) {
+    values.read = input.read;
+    values.readAt = input.read ? new Date() : null;
+  }
+  if (input.title !== undefined) values.title = input.title;
+  if (input.message !== undefined) values.message = input.message;
+  if (input.priority !== undefined) values.priority = input.priority;
+  if (input.data !== undefined) values.data = input.data;
+
+  if (Object.keys(values).length === 0) {
+    return findNotificationForRecipient(db, id, recipientOxyUserId);
+  }
+
+  const [row] = await db
+    .update(notifications)
+    .set(values)
+    .where(
+      and(
+        eq(notifications.id, id),
+        eq(notifications.recipientOxyUserId, recipientOxyUserId),
+      ),
+    )
+    .returning();
+  return row;
+}
+
+/** Mark one notification read. Returns the row, or `undefined` if not theirs. */
+export async function markRead(
+  db: DatabaseOrTransaction,
+  id: string,
+  recipientOxyUserId: string,
+): Promise<NotificationRow | undefined> {
+  const [row] = await db
+    .update(notifications)
+    .set({ read: true, readAt: new Date() })
+    .where(
+      and(
+        eq(notifications.id, id),
+        eq(notifications.recipientOxyUserId, recipientOxyUserId),
+      ),
+    )
+    .returning();
+  return row;
+}
+
+/**
+ * Mark every unread notification read. Returns how many moved.
+ *
+ * The `read = false` predicate is what makes the count meaningful AND what keeps
+ * `read_at` honest: without it every already-read row would be rewritten with a
+ * new `read_at`, restamping when the user read something they read last week.
+ */
+export async function markAllRead(
+  db: DatabaseOrTransaction,
+  recipientOxyUserId: string,
+): Promise<number> {
+  const rows = await db
+    .update(notifications)
+    .set({ read: true, readAt: new Date() })
+    .where(
+      and(
+        eq(notifications.recipientOxyUserId, recipientOxyUserId),
+        eq(notifications.read, false),
+      ),
+    )
+    .returning({ id: notifications.id });
+  return rows.length;
+}
+
+/** Delete one notification, scoped to its recipient. */
+export async function deleteNotification(
+  db: DatabaseOrTransaction,
+  id: string,
+  recipientOxyUserId: string,
+): Promise<boolean> {
+  const rows = await db
+    .delete(notifications)
+    .where(
+      and(
+        eq(notifications.id, id),
+        eq(notifications.recipientOxyUserId, recipientOxyUserId),
+      ),
+    )
+    .returning({ id: notifications.id });
+  return rows.length > 0;
+}
+
+/** Delete the whole mailbox. Returns how many rows went. */
+export async function deleteAllNotifications(
+  db: DatabaseOrTransaction,
+  recipientOxyUserId: string,
+): Promise<number> {
+  const rows = await db
+    .delete(notifications)
+    .where(eq(notifications.recipientOxyUserId, recipientOxyUserId))
+    .returning({ id: notifications.id });
+  return rows.length;
+}
+
+/**
+ * The unread badge on its own.
+ *
+ * `count()` rather than reading the rows, so the partial
+ * `notifications_recipient_unread_idx` can answer it without touching the heap.
+ */
+export async function countUnread(
+  db: DatabaseOrTransaction,
+  recipientOxyUserId: string,
+): Promise<number> {
+  const [row] = await db
+    .select({ value: count() })
+    .from(notifications)
+    .where(
+      and(
+        eq(notifications.recipientOxyUserId, recipientOxyUserId),
+        eq(notifications.read, false),
+      ),
+    );
+  return row.value;
+}
+
+/**
+ * The wire shape the mailbox client reads.
+ *
+ * `id` and not `_id` — the wire contract this repository was written against is
+ * the one PR #287 made a clean cut to. Timestamps are `Date`s and `res.json`
+ * serialises them to ISO, which is what the Mongoose handler shipped; the
+ * `db/schema/CONVENTIONS.md` warning about raw strings applies to `db.execute`
+ * and not to a drizzle `select`, which runs the column mappers.
+ */
+export function toNotificationDTO(row: NotificationRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    recipientOxyUserId: row.recipientOxyUserId,
+    type: row.type,
+    title: row.title,
+    message: row.message,
+    app: row.app,
+    priority: row.priority,
+    read: row.read,
+    readAt: row.readAt,
+    data: row.data,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/packages/backend/db/roommates/roommateRepository.ts
+++ b/packages/backend/db/roommates/roommateRepository.ts
@@ -1,0 +1,308 @@
+/**
+ * `roommate_requests` and `roommate_relationships` — the roommate handshake, on
+ * Postgres.
+ *
+ * Both empty in production, so this port has no backfill and no consistency
+ * window.
+ *
+ * ## Three read-then-writes became indexes, and none is re-implemented
+ *
+ * **"Is there already a pending request between these two?"** was a `$or` over
+ * both directions followed by an insert — a window two concurrent requests both
+ * pass. `roommate_requests_pending_pair_key` is a PARTIAL unique index on the
+ * ORDERED pair, so the insert itself is the check. It only covers one direction,
+ * which is deliberate and is why {@link createRoommateRequest} still refuses a
+ * reverse-direction pending request explicitly: the two people asking each other
+ * simultaneously is a real state, and the index cannot express "in either
+ * direction" (a partial unique index has no expression form that normalises the
+ * pair without also collapsing the sender, which the sent/received lists need).
+ *
+ * **"Does this pair already have an active relationship?"** was a
+ * `findOneAndUpdate` upsert, which under concurrency inserts twice.
+ * `roommate_relationships_active_pair_key` is a partial unique index on the
+ * SORTED pair, so {@link acceptRoommateRequest} inserts and converges on `23505`.
+ *
+ * ## The pair is SORTED before it is written, and the CHECK is why that is safe
+ *
+ * `roommate_relationships_sorted_pair_check` enforces `oxy_user1_id <
+ * oxy_user2_id`. Mongo stated the ordering in a doc comment and enforced
+ * nothing, so a writer that skipped the sort produced a second, invisible row
+ * for the same pair — and the "at most one active relationship" rule silently
+ * stopped holding. {@link sortPair} is the one place the ordering is applied,
+ * and the CHECK is what makes forgetting it a loud `23514` rather than a quiet
+ * duplicate.
+ *
+ * The same CHECK rules out a self-relationship for free, since `x < x` is false.
+ */
+
+import { and, desc, eq, or } from 'drizzle-orm';
+import type { DatabaseOrTransaction } from '../postgres';
+import { roommateRelationships, roommateRequests } from '../schema';
+import { isUniqueViolation } from '../uniqueViolation';
+
+export type RoommateRequestRow = typeof roommateRequests.$inferSelect;
+export type RoommateRelationshipRow = typeof roommateRelationships.$inferSelect;
+
+/** A pending request already exists between these two people. */
+export class PendingRoommateRequestExistsError extends Error {
+  constructor() {
+    super('A pending roommate request already exists between these users.');
+    this.name = 'PendingRoommateRequestExistsError';
+  }
+}
+
+/**
+ * The canonical ordering for a relationship pair.
+ *
+ * Exported so a test can assert the stored row really is sorted rather than
+ * trusting that the writer remembered — the property the CHECK exists to make
+ * unforgettable.
+ */
+export function sortPair(a: string, b: string): readonly [string, string] {
+  return a < b ? [a, b] : [b, a];
+}
+
+/**
+ * Open a request.
+ *
+ * @throws {PendingRoommateRequestExistsError} When one is already pending
+ *   between the two, in EITHER direction. The forward direction comes from the
+ *   partial unique index's own `23505`; the reverse is a read, because no index
+ *   can express it — see the header.
+ */
+export async function createRoommateRequest(
+  db: DatabaseOrTransaction,
+  input: { readonly fromOxyUserId: string; readonly toOxyUserId: string; readonly message?: string },
+): Promise<RoommateRequestRow> {
+  const reverse = await findPendingRequestBetween(db, input.toOxyUserId, input.fromOxyUserId);
+  if (reverse) throw new PendingRoommateRequestExistsError();
+
+  try {
+    const [row] = await db
+      .insert(roommateRequests)
+      .values({
+        fromOxyUserId: input.fromOxyUserId,
+        toOxyUserId: input.toOxyUserId,
+        message: input.message,
+      })
+      .returning();
+    return row;
+  } catch (error) {
+    if (isUniqueViolation(error, 'roommate_requests_pending_pair_key')) {
+      throw new PendingRoommateRequestExistsError();
+    }
+    throw error;
+  }
+}
+
+/** The pending request from `fromOxyUserId` to `toOxyUserId`, if there is one. */
+export async function findPendingRequestBetween(
+  db: DatabaseOrTransaction,
+  fromOxyUserId: string,
+  toOxyUserId: string,
+): Promise<RoommateRequestRow | undefined> {
+  const [row] = await db
+    .select()
+    .from(roommateRequests)
+    .where(
+      and(
+        eq(roommateRequests.fromOxyUserId, fromOxyUserId),
+        eq(roommateRequests.toOxyUserId, toOxyUserId),
+        eq(roommateRequests.status, 'pending'),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+export interface RoommateRequestLists {
+  readonly sent: readonly RoommateRequestRow[];
+  readonly received: readonly RoommateRequestRow[];
+}
+
+/** Both sides of a person's request list, newest first. */
+export async function listRoommateRequests(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+): Promise<RoommateRequestLists> {
+  const [sent, received] = await Promise.all([
+    db
+      .select()
+      .from(roommateRequests)
+      .where(eq(roommateRequests.fromOxyUserId, oxyUserId))
+      .orderBy(desc(roommateRequests.createdAt)),
+    db
+      .select()
+      .from(roommateRequests)
+      .where(eq(roommateRequests.toOxyUserId, oxyUserId))
+      .orderBy(desc(roommateRequests.createdAt)),
+  ]);
+  return { sent, received };
+}
+
+/**
+ * Move a PENDING request to `accepted` or `declined`, and only if `oxyUserId` is
+ * its recipient.
+ *
+ * The recipient and the `pending` status are both in the `UPDATE`'s predicate
+ * rather than checked first: that is what makes a double-accept answer
+ * `undefined` for the second caller instead of running the acceptance twice.
+ */
+export async function respondToRoommateRequest(
+  db: DatabaseOrTransaction,
+  requestId: string,
+  recipientOxyUserId: string,
+  status: 'accepted' | 'declined',
+): Promise<RoommateRequestRow | undefined> {
+  const [row] = await db
+    .update(roommateRequests)
+    .set({ status })
+    .where(
+      and(
+        eq(roommateRequests.id, requestId),
+        eq(roommateRequests.toOxyUserId, recipientOxyUserId),
+        eq(roommateRequests.status, 'pending'),
+      ),
+    )
+    .returning();
+  return row;
+}
+
+/**
+ * The active relationship for an accepted request, created if it is not there.
+ *
+ * Idempotent by the partial unique index rather than by a preceding read: two
+ * concurrent accepts of two different requests between the same pair both
+ * insert, one gets `23505`, and both end up looking at the one row.
+ */
+export async function ensureActiveRelationship(
+  db: DatabaseOrTransaction,
+  input: {
+    readonly requestId: string;
+    readonly fromOxyUserId: string;
+    readonly toOxyUserId: string;
+    readonly matchScore: number;
+  },
+): Promise<RoommateRelationshipRow> {
+  const [oxyUser1Id, oxyUser2Id] = sortPair(input.fromOxyUserId, input.toOxyUserId);
+
+  try {
+    const [row] = await db
+      .insert(roommateRelationships)
+      .values({
+        oxyUser1Id,
+        oxyUser2Id,
+        requestId: input.requestId,
+        matchScore: input.matchScore,
+        status: 'active',
+        startDate: new Date(),
+      })
+      .returning();
+    return row;
+  } catch (error) {
+    if (!isUniqueViolation(error, 'roommate_relationships_active_pair_key')) throw error;
+    const existing = await findActiveRelationshipBetween(db, oxyUser1Id, oxyUser2Id);
+    if (!existing) {
+      // The index refused the insert, so a row satisfying it existed at that
+      // instant. Not finding it now means it was ended in between — a real
+      // state, and one the caller must not be handed a fabricated row for.
+      throw error;
+    }
+    return existing;
+  }
+}
+
+/** The active relationship between a SORTED pair, if there is one. */
+export async function findActiveRelationshipBetween(
+  db: DatabaseOrTransaction,
+  oxyUser1Id: string,
+  oxyUser2Id: string,
+): Promise<RoommateRelationshipRow | undefined> {
+  const [row] = await db
+    .select()
+    .from(roommateRelationships)
+    .where(
+      and(
+        eq(roommateRelationships.oxyUser1Id, oxyUser1Id),
+        eq(roommateRelationships.oxyUser2Id, oxyUser2Id),
+        eq(roommateRelationships.status, 'active'),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+/** Every relationship this person is a party to, either side, newest first. */
+export async function listRoommateRelationships(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+): Promise<readonly RoommateRelationshipRow[]> {
+  return db
+    .select()
+    .from(roommateRelationships)
+    .where(
+      or(
+        eq(roommateRelationships.oxyUser1Id, oxyUserId),
+        eq(roommateRelationships.oxyUser2Id, oxyUserId),
+      ),
+    )
+    .orderBy(desc(roommateRelationships.createdAt));
+}
+
+/**
+ * End an ACTIVE relationship, and only if `oxyUserId` is one of its two parties.
+ *
+ * `end_date` is written in the same statement as the status, because
+ * `roommate_relationships_order_check` only constrains the two against each
+ * other — nothing would stop an `ended` row with no end date, which is a
+ * relationship nobody can say when they left.
+ */
+export async function endRoommateRelationship(
+  db: DatabaseOrTransaction,
+  relationshipId: string,
+  oxyUserId: string,
+): Promise<RoommateRelationshipRow | undefined> {
+  const [row] = await db
+    .update(roommateRelationships)
+    .set({ status: 'ended', endDate: new Date() })
+    .where(
+      and(
+        eq(roommateRelationships.id, relationshipId),
+        eq(roommateRelationships.status, 'active'),
+        or(
+          eq(roommateRelationships.oxyUser1Id, oxyUserId),
+          eq(roommateRelationships.oxyUser2Id, oxyUserId),
+        ),
+      ),
+    )
+    .returning();
+  return row;
+}
+
+/**
+ * `match_score` clamped into the range `roommate_relationships_match_score_check`
+ * accepts.
+ *
+ * The scorer is a percentage by construction, but it is arithmetic over
+ * user-supplied preference data — and a value outside `[0, 100]` would be a
+ * `23514` that fails the ACCEPT of a request the recipient really made, over a
+ * number that is decoration on the row. Clamping keeps the constraint's promise
+ * while refusing to let it break the handshake.
+ */
+export function clampMatchScore(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(100, Math.max(0, value));
+}
+
+/** The wire shape the roommate screens read for a request. */
+export function toRoommateRequestDTO(row: RoommateRequestRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    fromOxyUserId: row.fromOxyUserId,
+    toOxyUserId: row.toOxyUserId,
+    message: row.message,
+    status: row.status,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/packages/backend/db/saved/savedSearchRepository.ts
+++ b/packages/backend/db/saved/savedSearchRepository.ts
@@ -1,0 +1,189 @@
+/**
+ * `saved_searches` — a person's stored search, on Postgres.
+ *
+ * Empty in production, so this port has no backfill and no consistency window.
+ *
+ * ## The duplicate-name check MOVED INTO THE INDEX, and is not re-implemented
+ *
+ * `saveSearch` read for an existing name and then inserted, which is a
+ * read-then-write with a window between the two: two requests from the same
+ * person with the same name both find nothing and both insert.
+ * `saved_searches_owner_name_key` is a real UNIQUE, so the correct port INSERTS
+ * and handles `23505` — `db/MIGRATION-CONTRACT.md` lists this class of change
+ * explicitly, and re-implementing the read would keep the race in a new costume
+ * while the index quietly made it impossible.
+ *
+ * {@link SavedSearchNameTakenError} is what the controller turns into the 409
+ * the Mongo handler returned, so the wire behaviour is unchanged and only the
+ * race is gone.
+ *
+ * ## `name` and `query` are trimmed at the CALL SITE
+ *
+ * `CONVENTIONS.md` says a mongoose `trim` becomes nothing in Postgres and is
+ * re-applied where the value enters. Both are trimmed by the controller before
+ * they reach here, which matters for more than tidiness: the unique index is on
+ * the stored bytes, so `'Madrid'` and `'Madrid '` would be two rows and the
+ * duplicate-name rule would silently stop holding.
+ */
+
+import { and, desc, eq } from 'drizzle-orm';
+import type { DatabaseOrTransaction } from '../postgres';
+import { savedSearches } from '../schema';
+import { isUniqueViolation } from '../uniqueViolation';
+
+export type SavedSearchRow = typeof savedSearches.$inferSelect;
+
+/** This person already has a saved search under that name. */
+export class SavedSearchNameTakenError extends Error {
+  constructor(readonly name: string) {
+    super(`A saved search named '${name}' already exists for this owner.`);
+    this.name = 'SavedSearchNameTakenError';
+  }
+}
+
+export interface CreateSavedSearchInput {
+  readonly oxyUserId: string;
+  readonly name: string;
+  readonly query: string;
+  readonly filters?: Record<string, unknown>;
+  readonly notificationsEnabled?: boolean;
+}
+
+/**
+ * Insert a saved search.
+ *
+ * @throws {SavedSearchNameTakenError} When the owner already has one by that
+ *   name — raised from the index's own `23505` rather than from a preceding
+ *   read, so two concurrent requests cannot both succeed.
+ */
+export async function createSavedSearch(
+  db: DatabaseOrTransaction,
+  input: CreateSavedSearchInput,
+): Promise<SavedSearchRow> {
+  try {
+    const [row] = await db
+      .insert(savedSearches)
+      .values({
+        oxyUserId: input.oxyUserId,
+        name: input.name,
+        query: input.query,
+        filters: input.filters ?? {},
+        notificationsEnabled: input.notificationsEnabled ?? false,
+      })
+      .returning();
+    return row;
+  } catch (error) {
+    if (isUniqueViolation(error, 'saved_searches_owner_name_key')) {
+      throw new SavedSearchNameTakenError(input.name);
+    }
+    throw error;
+  }
+}
+
+/** Every saved search this person owns, newest first. */
+export async function listSavedSearches(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+): Promise<readonly SavedSearchRow[]> {
+  return db
+    .select()
+    .from(savedSearches)
+    .where(eq(savedSearches.oxyUserId, oxyUserId))
+    .orderBy(desc(savedSearches.createdAt));
+}
+
+export interface UpdateSavedSearchInput {
+  readonly name?: string;
+  readonly query?: string;
+  readonly filters?: Record<string, unknown>;
+  readonly notificationsEnabled?: boolean;
+}
+
+/**
+ * Apply a partial update, scoped to the owner. `undefined` when the row does not
+ * exist or is somebody else's.
+ *
+ * The ownership predicate is part of the `UPDATE` rather than a check before it,
+ * for the reason `notificationRepository` states: an authorisation performed in
+ * a second statement is an IDOR the first time somebody forgets it.
+ *
+ * @throws {SavedSearchNameTakenError} When a rename collides with another of the
+ *   owner's searches.
+ */
+export async function updateSavedSearch(
+  db: DatabaseOrTransaction,
+  id: string,
+  oxyUserId: string,
+  input: UpdateSavedSearchInput,
+): Promise<SavedSearchRow | undefined> {
+  const values: Partial<typeof savedSearches.$inferInsert> = {};
+  if (input.name !== undefined) values.name = input.name;
+  if (input.query !== undefined) values.query = input.query;
+  if (input.filters !== undefined) values.filters = input.filters;
+  if (input.notificationsEnabled !== undefined) {
+    values.notificationsEnabled = input.notificationsEnabled;
+  }
+
+  if (Object.keys(values).length === 0) {
+    return findSavedSearch(db, id, oxyUserId);
+  }
+
+  try {
+    const [row] = await db
+      .update(savedSearches)
+      .set(values)
+      .where(and(eq(savedSearches.id, id), eq(savedSearches.oxyUserId, oxyUserId)))
+      .returning();
+    return row;
+  } catch (error) {
+    if (isUniqueViolation(error, 'saved_searches_owner_name_key')) {
+      throw new SavedSearchNameTakenError(input.name ?? '');
+    }
+    throw error;
+  }
+}
+
+/** One saved search, scoped to its owner. */
+export async function findSavedSearch(
+  db: DatabaseOrTransaction,
+  id: string,
+  oxyUserId: string,
+): Promise<SavedSearchRow | undefined> {
+  const [row] = await db
+    .select()
+    .from(savedSearches)
+    .where(and(eq(savedSearches.id, id), eq(savedSearches.oxyUserId, oxyUserId)))
+    .limit(1);
+  return row;
+}
+
+/** Delete one saved search, scoped to its owner. */
+export async function deleteSavedSearch(
+  db: DatabaseOrTransaction,
+  id: string,
+  oxyUserId: string,
+): Promise<boolean> {
+  const rows = await db
+    .delete(savedSearches)
+    .where(and(eq(savedSearches.id, id), eq(savedSearches.oxyUserId, oxyUserId)))
+    .returning({ id: savedSearches.id });
+  return rows.length > 0;
+}
+
+/**
+ * The wire shape the profile screen reads.
+ *
+ * `id`, never `_id` — the wire contract is the clean cut PR #287 made.
+ */
+export function toSavedSearchDTO(row: SavedSearchRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    oxyUserId: row.oxyUserId,
+    name: row.name,
+    query: row.query,
+    filters: row.filters,
+    notificationsEnabled: row.notificationsEnabled,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/packages/backend/db/uniqueViolation.ts
+++ b/packages/backend/db/uniqueViolation.ts
@@ -1,0 +1,106 @@
+/**
+ * Recognising a unique-index violation, by CONSTRAINT and not by message.
+ *
+ * ## Why this exists at all
+ *
+ * `db/MIGRATION-CONTRACT.md` records a class of change this migration makes
+ * repeatedly: idempotency that used to be a read-then-write with a window
+ * (`SavedPropertyFolder.addProperty`, `reviewController`'s `alreadyVoted` and
+ * `alreadyReported`, `evictionController`'s RSVP check,
+ * `Agency.findOrCreateByName`) is now a unique KEY, and the ported code should
+ * INSERT and handle `23505` rather than re-implement the read. That instruction
+ * only pays off if "handle `23505`" is done precisely — which is what this
+ * module is for.
+ *
+ * ## The two ways to get this wrong, and why the constraint name is required
+ *
+ * **Matching on the message.** `error.message` for a unique violation is
+ * `duplicate key value violates unique constraint "..."`, and it is a
+ * LOCALISED, version-dependent string. A `includes('duplicate key')` check
+ * passes today and stops matching the first time the server runs under a
+ * different `lc_messages` — silently, turning a converged idempotent write back
+ * into a 500.
+ *
+ * **Matching on the CODE alone.** `23505` says "some unique index refused this
+ * row", not "the index I was expecting refused it". A table with two unique
+ * indexes — `saved_property_folder_items` has one, `saved_property_folders` has
+ * another on `lower(name)`, and a write touches both — would report a
+ * name-collision as "already in this folder" and converge on a row the caller
+ * never asked for. Every caller here therefore names the constraint it is
+ * prepared to treat as idempotent, and any OTHER violation propagates as the
+ * genuine error it is.
+ *
+ * postgres.js surfaces both fields on the thrown error (`code`,
+ * `constraint_name`), which is why this can be a property check rather than a
+ * parse. Measured against this project's driver rather than assumed:
+ *
+ * ```
+ * code= "23505"  constraint_name= "probe_unique_a_key"
+ * keys= code,constraint_name,detail,file,line,name,routine,schema_name,…
+ * ```
+ *
+ * ## But drizzle does NOT rethrow that error — it WRAPS it
+ *
+ * The one thing here that cannot be guessed from the driver's documentation.
+ * drizzle-orm 0.45.2 throws a `DrizzleQueryError` whose own enumerable keys are
+ * `cause,params,query` — it carries **no `code` and no `constraint_name` of its
+ * own** — and the real `PostgresError` is its `cause`:
+ *
+ * ```
+ * ctor= DrizzleQueryError  code= undefined  cname= undefined
+ * causeCtor= PostgresError causeCode= 23505 causeCname= saved_searches_owner_name_key
+ * ```
+ *
+ * So a check written against the driver's shape — which is what the driver's own
+ * README describes — reads `undefined === '23505'`, answers `false` for every
+ * real violation, and the idempotent path it guards silently becomes a 500. That
+ * is not a hypothetical: the first version of this module did exactly that, and
+ * it was caught only because the suite asserts the 409 rather than merely
+ * asserting that the second insert failed somehow.
+ *
+ * The chain is therefore WALKED rather than unwrapped once, so this keeps
+ * working if drizzle adds a layer, and it is depth-bounded so a cyclic `cause`
+ * cannot spin.
+ */
+
+/** The SQLSTATE for `unique_violation`. */
+const UNIQUE_VIOLATION = '23505';
+
+/**
+ * How far down a `cause` chain to look.
+ *
+ * Two is enough for drizzle 0.45.2 (`DrizzleQueryError` → `PostgresError`); the
+ * extra levels cost nothing and mean a future wrapper does not silently turn
+ * every idempotent write back into a 500.
+ */
+const MAX_CAUSE_DEPTH = 5;
+
+interface PostgresErrorLike {
+  readonly code?: unknown;
+  readonly constraint_name?: unknown;
+  readonly cause?: unknown;
+}
+
+/**
+ * Whether `error`, or anything in its `cause` chain, is a `23505` raised by the
+ * NAMED constraint.
+ *
+ * @param constraintName The index or constraint the caller is prepared to treat
+ *   as an idempotent repeat. A violation of any other one is not matched, so it
+ *   keeps propagating.
+ */
+export function isUniqueViolation(error: unknown, constraintName: string): boolean {
+  let current = error;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
+    if (!current || typeof current !== 'object') return false;
+    const candidate = current as PostgresErrorLike;
+    if (
+      candidate.code === UNIQUE_VIOLATION &&
+      candidate.constraint_name === constraintName
+    ) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}

--- a/packages/backend/services/notificationDispatchService.ts
+++ b/packages/backend/services/notificationDispatchService.ts
@@ -3,13 +3,30 @@
  *
  * The single chokepoint for *producing* in-app notifications from domain
  * events (lease signed, viewing approved, roommate request received, …).
- * Controllers never call `Notification.create` directly for event-driven
+ * Controllers never insert into `notifications` directly for event-driven
  * notifications — they call `createForUser` here so that recipient
  * resolution, defaults and failure handling live in one place.
+ *
+ * ## A failed dispatch is swallowed, and that is the contract
+ *
+ * Every caller is a domain action that has already succeeded — a lease was
+ * signed, an RSVP was recorded. Rethrowing here would roll back or 500 a write
+ * the user completed because a mailbox row could not be inserted, which is a
+ * worse outcome than a missing notification. The failure is logged rather than
+ * hidden, and `null` is the answer.
+ *
+ * That is also why this function does NOT take a caller's transaction. It is
+ * called AFTER the domain write commits, deliberately: joining the caller's
+ * transaction would make a mailbox failure abort the domain write, which is the
+ * exact coupling the swallow exists to prevent.
  */
 
-import { Notification } from '../models';
-import type { INotification } from '../models';
+import { getDb } from '../db/postgres';
+import {
+  createNotification,
+  isNotificationPriority,
+  type NotificationRow,
+} from '../db/notifications/notificationRepository';
 import { logger } from '../middlewares/logging';
 
 export type NotificationPriority = 'low' | 'medium' | 'high' | 'urgent';
@@ -27,23 +44,27 @@ class NotificationDispatchService {
   async createForUser(
     recipientOxyUserId: string | undefined | null,
     payload: DispatchPayload,
-  ): Promise<INotification | null> {
+  ): Promise<NotificationRow | null> {
     if (!recipientOxyUserId) {
       return null;
     }
     try {
-      const notification = await Notification.create({
+      const notification = await createNotification(getDb(), {
         recipientOxyUserId: String(recipientOxyUserId),
         type: payload.type,
         title: payload.title,
         message: payload.message,
-        priority: payload.priority,
+        // Narrowed rather than passed through: an undeclared priority is
+        // refused by `notifications_priority_check` as a `23514`, which would
+        // turn a best-effort mailbox write into a logged error for a caller
+        // that merely mistyped a constant.
+        priority: isNotificationPriority(payload.priority) ? payload.priority : undefined,
         data: payload.data ?? {},
         app: payload.app,
       });
 
       logger.info('Notification dispatched', {
-        notificationId: notification._id?.toString(),
+        notificationId: notification.id,
         recipientOxyUserId: String(recipientOxyUserId),
         type: payload.type,
       });


### PR DESCRIPTION
The first of the **zero-row domains**. Every table here was empty in production, so there is no backfill, no consistency window, and no user-visible surface a wrong answer could regress — which is what makes it the right place to establish the repository shape the remaining domains follow.

`db/<domain>/<name>Repository.ts`, exporting plain functions that take a `DatabaseOrTransaction` first — the shape `db/hasImages.ts` already used, and the same `db/<domain>/` layout as the catalogue reads in #298, so the two batches meet without inventing a third convention.

## Three read-then-writes became indexes, and none is re-implemented

`db/MIGRATION-CONTRACT.md` records this class of change: idempotency that used to be a read followed by a write is now a unique KEY, and the ported code should INSERT and handle `23505`. Done for the duplicate saved-search name, the pending roommate pair, and the active roommate relationship. Each had a window two concurrent requests both passed; none has one now, and the wire behaviour (409, or convergence on one row) is unchanged.

### The finding that cannot be guessed from the driver's documentation

`db/uniqueViolation.ts` is what makes "handle `23505`" precise, and **drizzle 0.45.2 does not rethrow the driver's error — it WRAPS it.** Measured, not assumed:

```
ctor= DrizzleQueryError  code= undefined  cname= undefined  keys= cause,params,query
causeCtor= PostgresError causeCode= 23505 causeCname= saved_searches_owner_name_key
```

A check written against postgres.js's own documented shape reads `undefined === '23505'`, answers `false` for every real violation, and silently turns the idempotent path into a 500. The first version of that module did exactly that. It was caught only because the suite asserts the **409** rather than merely asserting that the second insert failed somehow.

The constraint NAME is required too, not just the code: `23505` says *some* unique index refused the row, not that the expected one did — and a table with two unique indexes would otherwise report a name collision as "already in this folder".

## Notifications, and the pair that has no CHECK

`notificationDispatchService` stays the single chokepoint and stays best-effort. It deliberately does **not** take a caller's transaction: joining one would let a mailbox failure abort the domain write that the swallow exists to protect.

`read` / `read_at` move together. There is no coherence CHECK for that pair, so the repository enforces it by being the only writer of either column. `markAllRead` keeps `read = false` in its predicate — without it every already-read row is rewritten with a fresh `read_at`, restamping when somebody read something last week, and the count stops meaning what `modifiedCount` meant.

## Guards deleted rather than widened

The `CastError` branches and the `ObjectId.isValid` guards are gone, per `db/ids.ts`: post-cutover every id is a uuid v7, which those reject. A `text` primary key takes any string, so a malformed id is a lookup that matches nothing and gets the same 404 an unknown id always got. Asserted for all three shapes (uuid v7, ObjectId hex, plain garbage).

`savedSearches`'s `Profile.findByOxyUserId` guard is dropped too, and that one is a judgement call worth stating: it was not an authorisation check — every statement there is already scoped by the session `oxyUserId` — so its only effect was a spurious 404 for somebody who owned the row and had no profile document yet. Porting it would have made this controller depend on `profiles`, a table another batch owns, to reproduce a check that protected nothing.

## Tests

**105 suites / 1233 tests → 106 / 1264**, all green. CI floor raised 1190 → 1225.

The two Mongo-seeded suites are rewritten against the **real Postgres** rather than mocked, and every ownership case re-reads the row afterwards — a handler that 404s and writes anyway passes any assertion made on its response alone.

Both partial unique indexes are asserted on what they **PERMIT** as well as what they refuse (a fresh request after a decline; the same pair rooming together again after they parted), which is the half a total index eats silently, months later.

`evictionBoard.test.ts` reads its notification assertions from Postgres now: the eviction domain is still Mongo, but the dispatch chokepoint it asserts on is not.

### Mutation-tested

Four load-bearing assertions, each broken in turn, restored in place, and the tree verified byte-clean against the commit afterwards:

| mutation | result |
|---|---|
| drop `sortPair` from `ensureActiveRelationship` | 2 tests red |
| drop the reverse-direction pending read | 1 test red |
| drop `read = false` from `markAllRead` | 1 test red |
| stop walking the `cause` chain in `isUniqueViolation` | 4 tests red |

## Deliberately NOT in this PR

Three of the assigned domains are blocked on work another batch owns, with the evidence:

- **Evictions** — `createEvictionReport` commits its `EvictionReport` row inside `withReportIntakeSession`, a Mongo transaction it shares with `createModerationReport`. Porting eviction cases makes `EvictionReport.caseId` (a Mongo `ObjectId`) unable to hold a uuid v7, so the reports must move too — and moving the intake means moving all **three** of its call sites atomically, one of which is `reviewController.ts`. Evictions therefore move with the moderation batch, not before it.
- **Saved items / folders / recently viewed** — the list handlers return hydrated property documents, which is #298's `db/properties/propertySerializer.ts`. Writing a second property serializer here would be work thrown away the day #298 merges.
- **Conversations** — the Postgres schema keys on `oxy_user_id` where Mongo keys on `profileId`, so the port changes the ownership key; and the message append lives inside the AI streaming route. Both belong with the profiles batch.

Tenancy (leases, applications, reservations, viewings, exchanges) is unblocked but was not reached; it needs a narrow property projection that #298 will supply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)