### PR TITLE
Flush a child batch only after its parents, whatever the batch sizes are

### DIFF
--- a/packages/backend/__tests__/db/dataBackfill.test.ts
+++ b/packages/backend/__tests__/db/dataBackfill.test.ts
@@ -834,6 +834,63 @@ describe('data backfill — end to end', () => {
     expect(row.coverImageId).toBeNull();
   }, 60_000);
 
+  it('writes a child batch only after its parents, however the batch sizes fall', async () => {
+    // THE PRODUCTION FAILURE, as a fixture.
+    //
+    // The first copy against production died here: `images`, `addresses` and
+    // `agencies` were in, and the first `property_images` batch hit 23503
+    // because the `properties` rows it referenced were still buffered. Batch
+    // size is derived from column count, so `properties` (135 columns) fills at
+    // 370 rows while `property_images` (11) fills at 500 — and at roughly ten
+    // photos per listing the CHILD fills after about fifty documents, with the
+    // parent four fifths empty.
+    //
+    // Fifty properties × eleven photos = 550 child rows and 50 parent rows,
+    // which crosses the child's threshold and nowhere near the parent's. Every
+    // earlier fixture in this file has one or two properties, which is why none
+    // of them could ever have caught it.
+    const geo = await seedAndCopyGeo();
+    const database = mongoDatabase();
+    const address = addressDocument(geo, 'Barcelona', BARCELONA);
+    await database.collection('addresses').insertMany([
+      address,
+      addressDocument(geo, 'Madrid', MADRID, { street: 'Gran Vía' }),
+      addressDocument(geo, 'Paris', PARIS, { street: 'Rue de Rivoli', countryCode: 'FR' }),
+    ]);
+
+    const photos = Array.from({ length: 55 * 11 }, () => imageDocument());
+    await database.collection('images').insertMany(photos);
+
+    const listings = Array.from({ length: 55 }, (_, listing) =>
+      propertyDocument(address._id as mongoose.Types.ObjectId, {
+        images: photos.slice(listing * 11, listing * 11 + 11).map((photo, index) => ({
+          _id: oid(),
+          imageId: photo._id,
+          url: 'u/m',
+          isPrimary: index === 0,
+          order: index,
+        })),
+      }),
+    );
+    await database.collection('properties').insertMany(listings);
+
+    const report = await runDataBackfill({
+      mongo: database,
+      database: getDb(),
+      mode: 'copy',
+      sampleSize: 5,
+    });
+
+    expect(report.verified.every((entry) => entry.missing === 0)).toBe(true);
+
+    const [parents] = await getDb().select({ total: sql<number>`count(*)::int` }).from(properties);
+    const [children] = await getDb()
+      .select({ total: sql<number>`count(*)::int` })
+      .from(propertyImages);
+    expect(parents.total).toBe(55);
+    expect(children.total).toBe(55 * 11);
+  }, 120_000);
+
   it('writes both calendars into one table, under their own scopes', async () => {
     const geo = await seedAndCopyGeo();
     const database = mongoDatabase();

--- a/packages/backend/db/backfill/data.ts
+++ b/packages/backend/db/backfill/data.ts
@@ -232,10 +232,15 @@ export interface DataBackfillReport {
 /** A buffered, batched, `ON CONFLICT DO NOTHING` writer for one table. */
 interface TableWriter {
   push(row: CandidateRow): void;
-  /** Write the buffer if it has reached the table's batch size. */
-  flushIfFull(): Promise<void>;
   /** Write whatever is buffered. */
   flush(): Promise<void>;
+  /**
+   * Whether this table's buffer has reached its own batch size.
+   *
+   * ASKED rather than acted on, because the flush decision belongs to the plan:
+   * one full child means every table flushes, parent first. See the call site.
+   */
+  readonly isFull: boolean;
   readonly inserted: number;
 }
 
@@ -275,11 +280,11 @@ function createWriter(database: Database, table: PgTable, write: boolean): Table
     push(row) {
       buffer.push(row);
     },
-    async flushIfFull() {
-      if (buffer.length >= limit) await flush();
-    },
     async flush() {
       await flush();
+    },
+    get isFull() {
+      return buffer.length >= limit;
     },
     get inserted() {
       return inserted;
@@ -367,9 +372,24 @@ async function streamCollectionPass(
       if (writer) for (const row of rows) writer.push(row);
     }
 
-    // Parent table first — `property_images.property_id` is NOT NULL, so a
-    // child batch may never reach the server ahead of the row it references.
-    for (const table of plan.tables) await writers.get(table)?.flushIfFull();
+    // ALL OR NONE, parent first — never "each table when its own buffer fills".
+    //
+    // A child's foreign key is `NOT NULL`, so a `property_images` batch that
+    // reaches the server before the `properties` rows it references is a
+    // `23503`. Per-table thresholds guarantee exactly that: `properties` is 135
+    // columns wide and fills at 370 rows, `property_images` is 11 columns wide
+    // and fills at 500 — and each property carries about ten photos, so the
+    // CHILD fills after roughly fifty documents while the parent is still four
+    // fifths empty.
+    //
+    // Measured, not reasoned: the first production copy died here, on the first
+    // `property_images` batch, with `images`, `addresses` and `agencies` already
+    // written. No test caught it because no fixture had ever crossed a batch
+    // boundary — 50 properties is enough, and `writes a child batch only after
+    // its parents` is now that fixture.
+    if (plan.tables.some((table) => writers.get(table)?.isFull === true)) {
+      for (const table of plan.tables) await writers.get(table)?.flush();
+    }
 
     documents += 1;
     if (documents % PROGRESS_INTERVAL === 0) {


### PR DESCRIPTION
The first copy against production died on the first `property_images` batch with
`23503` — `images` (171,976), `addresses` (11,734) and `agencies` (2,627)
already written, `properties` still buffered.

## What went wrong

Batch size is derived from column count, which is right, and the consequence was
not thought through:

| table | columns | fills at | reached after |
|---|--:|--:|---|
| `properties` | 135 | 370 rows | 370 documents |
| `property_images` | 11 | 500 rows | ~50 documents (≈10 photos each) |

So the CHILD reaches its threshold while the parent is four fifths empty, and a
per-table *"flush when your own buffer is full"* sends the child's rows to a
server that has never seen their parents.

The flush decision belongs to the **plan**, not to the writer: one full table
means every table flushes, parent first. The writer now only answers `isFull`.

## The fixture is the production failure

55 properties × 11 photos = **605 child rows** (past the child's 500) and **55
parent rows** (nowhere near the parent's 370). Every earlier fixture in this file
has one or two properties, which is exactly why none of them could have caught
it — and it is the reason a batch-size-derived-from-columns design needs a test
that crosses a batch boundary at all.

**Mutation-tested, not assumed.** Restoring the per-table flush turns the new
case red with the exact production error:

```
PostgresError: insert or update on table "property_images"
violates foreign key constraint "property_images_property_id_properties_id_fk"
```

## Nothing needs undoing

The copy is idempotent — `ON CONFLICT DO NOTHING` over ids copied verbatim from
Mongo — so the re-run converges on what the failed one left behind.

The audit pass that preceded it passed clean against production, and every frozen
census figure matched exactly: `MODERATION_ABSENT` 17,642 · `LISTING_FLAGS_ABSENT`
9,594 · `EXTERNAL_CONTACT_ABSENT` 5,174 · `PRICE_ETHICS_ABSENT` 133 ·
`HAS_IMAGES_DISAGREED` 1. Zero constraint violations, zero dangling references,
zero duplicate unique keys across 171,976 images, 11,734 addresses, 2,627
agencies, 17,644 properties (169,223 photo refs) and 5 profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)