### PR TITLE
ci(deploy): sync DATABASE_URL, and gate the allowlist against half-edits

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -121,11 +121,38 @@ jobs:
       # that other services read.
       #
       # The list covers BOTH task definitions rolled below — the `homiio` API and
-      # the `homiio-worker` listing worker. Adding a new secret means adding it
-      # here, or it never reaches SSM.
+      # the `homiio-worker` listing worker. **A secret added to either task
+      # definition has to be added here in the SAME change, or it silently never
+      # syncs**: this step reports success either way, because it only ever
+      # reports on the names it was given.
+      #
+      # That is not hypothetical. `DATABASE_URL` was added to the repository
+      # secrets and to both task definitions during the Postgres cutover on
+      # 2026-08-09 and NOT added here. `/oxy/homiio/DATABASE_URL` was written by
+      # hand, every deploy that followed synced the other six and reported
+      # success, and a rotation of that secret would have propagated to nothing.
+      # It cost seven hours of the parameter being unmanaged; it would have cost
+      # an outage the first time somebody rotated it and believed the green run.
+      #
+      # Re-derive the list from what the containers actually read, never from
+      # memory or from this comment:
+      #
+      #   AWS_PROFILE=oxy AWS_REGION=us-west-2 aws ecs describe-task-definition \
+      #     --task-definition oxy-homiio \
+      #     --query 'taskDefinition.containerDefinitions[0].secrets[].name'
+      #   # …and again for oxy-homiio-worker.
+      #
+      # `packages/backend/__tests__/unit/deploySecretSync.test.ts` pins the two
+      # spellings below against each other and against that derivation, so a
+      # half-edit fails the build rather than a deploy months later.
       - name: Sync GitHub secrets -> SSM (GitHub is the source of truth)
         env:
+          # Read by BOTH families. Postgres is the live datastore; MONGODB_URI
+          # stays until the write paths finish moving off it, and comes out of
+          # this list at the same time it comes out of the task definitions.
+          APP_DATABASE_URL: ${{ secrets.DATABASE_URL }}
           APP_MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          # API only.
           APP_JWT_SECRET: ${{ secrets.JWT_SECRET }}
           APP_JWT_REFRESH_SECRET: ${{ secrets.JWT_REFRESH_SECRET }}
           # Worker only.
@@ -144,6 +171,7 @@ jobs:
             echo "synced -> $path"
           }
 
+          sync_secret DATABASE_URL "$APP_DATABASE_URL" "/oxy/$APP/DATABASE_URL"
           sync_secret MONGODB_URI "$APP_MONGODB_URI" "/oxy/$APP/MONGODB_URI"
           sync_secret JWT_SECRET "$APP_JWT_SECRET" "/oxy/$APP/JWT_SECRET"
           sync_secret JWT_REFRESH_SECRET "$APP_JWT_REFRESH_SECRET" "/oxy/$APP/JWT_REFRESH_SECRET"

--- a/packages/backend/__tests__/unit/deploySecretSync.test.ts
+++ b/packages/backend/__tests__/unit/deploySecretSync.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The deploy workflow's SSM sync names every secret it copies, and the two
+ * places it names them cannot drift apart.
+ *
+ * ## Two different failures, one step
+ *
+ * **The pattern.** `.github/workflows/deploy-aws.yml` used to expand the whole
+ * `secrets` context with `toJSON(secrets)` and walk it into a shell loop. That
+ * shape is indistinguishable from an exfiltration payload, so GitHub's
+ * malicious-workflow detection holds every run of the workflow as
+ * `action_required` with ZERO jobs until a human clicks "Approve and run" in the
+ * UI — per run, and with no automatable escape (the REST approve endpoint only
+ * serves fork pull requests). Measured across the org on 2026-08-08: every repo
+ * carrying the pattern was held; the two using explicit allowlists never were.
+ * Nothing in a normal CI run reports it, because the runs never start. #283
+ * removed it here.
+ *
+ * **The half-edit.** An allowlist then has its own failure mode, and it is
+ * quieter: the step reports success on the names it was given, so a secret the
+ * task definition reads but the list omits is never written, and the deploy is
+ * green. That happened. `DATABASE_URL` was added to the repository secrets and
+ * to both task definitions during the Postgres cutover on 2026-08-09 and not
+ * added to the list; `/oxy/homiio/DATABASE_URL` was set by hand and every
+ * subsequent deploy synced the other six and said so.
+ *
+ * ## What these assertions are worth, and what they are not
+ *
+ * They are exact about the two spellings INSIDE the workflow — the `env:`
+ * bindings and the `sync_secret` calls — because that is the drift that
+ * actually happens and it is fully observable from the repository. A name bound
+ * but never synced reaches nothing; a name synced from an unbound variable is
+ * read as empty and skipped with a warning nobody sees until the deploy that
+ * needed it; a name written to the wrong namespace is invisible to the
+ * container, which reads the other one.
+ *
+ * They are NOT a check that the list matches the LIVE task definitions — that
+ * needs AWS, which this suite has no credentials for and should not. What
+ * `EXPECTED_SYNCED_SECRETS` buys instead is that widening the workflow forces a
+ * deliberate edit here, in a file whose docblock says where the truth lives.
+ * The derivation is in the workflow's own comment, next to the list.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** The repository root — four levels above `packages/backend/__tests__/unit`. */
+const REPOSITORY_ROOT = join(__dirname, '..', '..', '..', '..');
+const WORKFLOW_PATH = join(REPOSITORY_ROOT, '.github', 'workflows', 'deploy-aws.yml');
+const workflow = readFileSync(WORKFLOW_PATH, 'utf8');
+
+/**
+ * Every parameter the two live task definitions read as a `secret`, as of
+ * `oxy-homiio:23` and `oxy-homiio-worker:31` (2026-08-09).
+ *
+ * `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `REDIS_URL` live under
+ * `/oxy/_shared/`; the rest under `/oxy/homiio/`. The split is what the
+ * `SHARED_` and `APP_` prefixes encode, and it matters because a shared value
+ * written to the app namespace syncs successfully and reaches nothing.
+ */
+const EXPECTED_SYNCED_SECRETS = {
+  APP: ['DATABASE_URL', 'JWT_REFRESH_SECRET', 'JWT_SECRET', 'LISTING_RESIDENTIAL_PROXY_URL', 'MONGODB_URI'],
+  SHARED: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'REDIS_URL'],
+};
+
+/**
+ * The body of the sync step: from its `- name:` line to the next step at the
+ * same indentation. Scoping matters — the workflow has other steps with `env:`
+ * blocks, and assertions that read the whole file would pass on bindings that
+ * belong to the build or the rollout.
+ */
+const syncStep = ((): string => {
+  const start = workflow.indexOf('      - name: Sync GitHub secrets');
+  if (start === -1) return '';
+  const rest = workflow.slice(start + 1);
+  const end = rest.search(/^ {6}- name: /m);
+  return end === -1 ? rest : rest.slice(0, end);
+})();
+
+/** `PREFIX_NAME: ${{ secrets.NAME }}` bindings, as `[prefix, envName, secretName]`. */
+const envBindings = [...syncStep.matchAll(/^ {10}(APP|SHARED)_([A-Z0-9_]+): \$\{\{ secrets\.([A-Z0-9_]+) \}\}$/gm)];
+
+/** `sync_secret NAME "$VAR" "PATH"` calls, as `[name, variable, path]`. */
+const syncCalls = [...syncStep.matchAll(/^ *sync_secret ([A-Z0-9_]+) "\$([A-Z0-9_]+)" "([^"]+)"$/gm)];
+
+describe('the deploy workflow syncs an explicit allowlist', () => {
+  it('has a sync step with bindings and calls at all', () => {
+    // Vacuity floor. Every assertion below reads one of these three; an empty
+    // step or a regex that stopped matching would make them all trivially true,
+    // which is exactly how a gate stops gating without anyone noticing.
+    // An empty string here means the step was renamed or removed.
+    expect(syncStep).not.toBe('');
+    expect(syncStep).toContain('aws ssm put-parameter');
+    expect(envBindings.length).toBeGreaterThanOrEqual(8);
+    expect(syncCalls.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('never enumerates the whole secrets context', () => {
+    // Matched as an EXPRESSION, not as prose: the step's own comment explains
+    // the block by name, so a plain substring check would fail on the
+    // explanation rather than on the payload — and would then be "fixed" by
+    // deleting the explanation.
+    expect(workflow).not.toMatch(/\$\{\{[^}]*toJSON\s*\(\s*secrets\s*\)/);
+  });
+
+  it('binds each secret under a prefix, and never under its own name', () => {
+    // The prefix is not cosmetic. `aws-actions/configure-aws-credentials`
+    // exports AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY into the job
+    // environment, so a secret bound under its raw name shadows the assumed
+    // OIDC role and fails this step with UnrecognizedClientException.
+    const envBlock = syncStep.slice(syncStep.indexOf('env:'), syncStep.indexOf('run:'));
+    for (const line of envBlock.split('\n')) {
+      const binding = /^ {10}([A-Za-z0-9_]+):/.exec(line);
+      if (binding) expect(binding[1]).toMatch(/^(APP|SHARED)_/);
+    }
+    // The variable must be named after the secret it carries, or the loop below
+    // cannot tell which value a call is actually sending.
+    for (const [, , envName, secretName] of envBindings) {
+      expect(envName).toBe(secretName);
+    }
+  });
+
+  it('syncs exactly the secrets it binds, from the variables it binds them to', () => {
+    const bound = envBindings.map(([, prefix, name]) => `${prefix}_${name}`).sort();
+    const consumed = syncCalls.map(([, , variable]) => variable).sort();
+    expect(consumed).toEqual(bound);
+
+    // Three independent spellings of one name per call — the label the warning
+    // prints, the variable the value comes from, and the parameter SSM stores —
+    // cross-checked against each other and against the namespace in the path.
+    // A mismatch means a skipped secret is reported under another one's name, or
+    // a shared value written where nothing reads it.
+    for (const [, name, variable, path] of syncCalls) {
+      const namespace = path.startsWith('/oxy/_shared/') ? 'SHARED' : 'APP';
+      expect(variable).toBe(`${namespace}_${name}`);
+      expect(path.split('/').pop()).toBe(name);
+    }
+  });
+
+  it('routes the shared secrets to /oxy/_shared and the rest to the app namespace', () => {
+    // A name with no call at all returns the empty string, which fails the
+    // comparison naming the missing secret — the case this whole file exists for.
+    const pathFor = (name: string): string =>
+      syncCalls.find(([, candidate]) => candidate === name)?.[3] ?? '';
+    for (const name of EXPECTED_SYNCED_SECRETS.SHARED) expect(pathFor(name)).toBe(`/oxy/_shared/${name}`);
+    for (const name of EXPECTED_SYNCED_SECRETS.APP) expect(pathFor(name)).toBe(`/oxy/$APP/${name}`);
+  });
+
+  it('covers every secret both task definitions read, and nothing else', () => {
+    // Widening this list is the deliberate edit the workflow comment asks for.
+    // Narrowing it means a container reads a parameter no deploy maintains.
+    expect(syncCalls.map(([, name]) => name).sort()).toEqual(
+      [...EXPECTED_SYNCED_SECRETS.APP, ...EXPECTED_SYNCED_SECRETS.SHARED].sort(),
+    );
+  });
+
+  it('still refuses placeholders and a non-us-west-2 REDIS_URL', () => {
+    // Both guards predate the allowlist. A secret left empty or set to a single
+    // dash is a mistake, not an instruction to overwrite production with
+    // garbage: skipping leaves whatever SSM already holds.
+    expect(syncStep).toContain('[ "$value" = "-" ]');
+    // The ESCAPED spelling, because the guard is a `grep` regex — asserting the
+    // bare hostname passes on a workflow whose dots are unescaped wildcards.
+    expect(syncStep).toContain(String.raw`'\.usw2\.cache\.amazonaws\.com'`);
+  });
+});


### PR DESCRIPTION
## What was actually wrong

`toJSON(secrets)` is already gone from `deploy-aws.yml` — #283 removed it, and deploys on `main` run unheld (CI run `31299986170` deployed at 06:58 UTC today, and the `workflow_dispatch` run `31300105120` that looked held was queued behind the `deploy-homiio-backend` concurrency group, not the abuse gate; it created jobs and ran as soon as the group freed).

What is wrong is the allowlist's own failure mode, and it is quieter than the pattern it replaced: the step reports success on the names it was given, so a secret a task definition reads but the list omits is never written, and the deploy is green.

**`DATABASE_URL` is that secret.** It is read by BOTH families this workflow rolls, and it was never added to the sync:

| | `oxy-homiio:23` (API) | `oxy-homiio-worker:31` |
|---|---|---|
| `/oxy/homiio/` | `DATABASE_URL` ❌, `MONGODB_URI` ✅, `JWT_SECRET` ✅, `JWT_REFRESH_SECRET` ✅ | `DATABASE_URL` ❌, `MONGODB_URI` ✅, `LISTING_RESIDENTIAL_PROXY_URL` ✅ |
| `/oxy/_shared/` | `AWS_ACCESS_KEY_ID` ✅, `AWS_SECRET_ACCESS_KEY` ✅ | `AWS_ACCESS_KEY_ID` ✅, `AWS_SECRET_ACCESS_KEY` ✅, `REDIS_URL` ✅ |

(✅ = in the allowlist before this PR.)

The repo secret `DATABASE_URL` was created `2026-08-09T00:16:31Z` and `/oxy/homiio/DATABASE_URL` was written by hand one second later. The deploy at 06:58 UTC today touched `MONGODB_URI`, `JWT_SECRET`, `JWT_REFRESH_SECRET` and `LISTING_RESIDENTIAL_PROXY_URL` and left `DATABASE_URL` alone — so a rotation of that secret would have propagated to nothing, behind a green run.

## What this changes

- `DATABASE_URL` joins the allowlist, on the app namespace, bound as `APP_DATABASE_URL` (the prefix is load-bearing: a secret bound under its raw `AWS_ACCESS_KEY_ID` name would shadow the OIDC role the previous step assumes).
- The workflow comment now states the rule where whoever adds the next secret will be standing, names this instance so it reads as a measured cost rather than hygiene, and carries the `aws ecs describe-task-definition` derivation for both families.
- `packages/backend/__tests__/unit/deploySecretSync.test.ts` is the gate. It pins the `env:` bindings against the `sync_secret` calls, each call's variable prefix against the SSM namespace in its path, the label against the parameter name, and the whole set against the two task definitions' `secrets[]` — plus the `toJSON(secrets)` absence, matched as an EXPRESSION so the step's own explanation of the pattern doesn't trip it.

## Verification

- Both task definitions read live from AWS, not from memory: `oxy-homiio:23` and `oxy-homiio-worker:31`.
- Allowlist is a superset of both: 8 names, union of the two `secrets[]` lists exactly.
- Mutation-tested, each failing the test that names the defect — drop the `sync_secret DATABASE_URL` call (4 red), drop both halves of it (3 red, incl. "covers every secret both task definitions read"), route it to `/oxy/_shared` (2 red), restore `toJSON(secrets)` (2 red, incl. "never enumerates the whole secrets context"), rename the step (4 red, the vacuity floor). Workflow restored byte-identically afterwards (md5 + marker check).
- `bun x tsc --noEmit -p packages/backend/tsconfig.json` clean; the new suite passes 7/7; the workflow YAML parses; `bun install` left `bun.lock` byte-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)