### PR TITLE
Move viewing requests and tenant applications to Postgres (#281)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,9 @@ jobs:
       # glob that stops matching all produce an empty green run, and that reads as
       # coverage forever because nothing contradicts it.
       #
-      # RAISED FROM 1225 TO 1310 by the lease port, which added
+      # RAISED FROM 1310 TO 1345 by the viewings + applications port, which
+      # added two real-database suites — measured 1352 -> 1389. Before that it
+      # went 1225 -> 1310 for the lease port, which added
       # `leasePaymentSchedule.test.ts` and rewrote `leaseOwnership.test.ts`
       # against the real Postgres — measured 1320 -> 1351. Before that it went
       # 1190 -> 1225 for the first zero-row domain port
@@ -169,7 +171,7 @@ jobs:
         if: always()
         run: >-
           bun .github/scripts/assert-test-floor.mjs
-          "$RUNNER_TEMP/backend-tests.json" packages/backend 1310
+          "$RUNNER_TEMP/backend-tests.json" packages/backend 1345
 
   frontend:
     runs-on: ubuntu-24.04

--- a/packages/backend/__tests__/integration/tenantApplications.test.ts
+++ b/packages/backend/__tests__/integration/tenantApplications.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Tenant applications — the lifecycle, the `decided_at` equivalence, and the
+ * children that commit with the parent. Against the REAL Postgres.
+ *
+ * ## What makes these tests non-vacuous
+ *
+ * `tenant_applications` was empty in production. The cases below target rules
+ * that have a way to be wrong:
+ *
+ *  - `tenant_applications_decided_at_check` is asserted in BOTH directions, and
+ *    on the transition that must NOT stamp (`reviewing`) as well as the three
+ *    that must,
+ *  - every refusal re-reads the row,
+ *  - the duplicate-application rule is asserted on what it PERMITS (re-applying
+ *    after a rejection) as well as what it refuses,
+ *  - the children are asserted to be ABSENT when the parent insert fails, which
+ *    is the only assertion that distinguishes one transaction from two.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { eq } from 'drizzle-orm';
+
+import applicationController from '../../controllers/applicationController';
+import { getDb } from '../../db/postgres';
+import {
+  leases,
+  properties,
+  tenantApplicationDocuments,
+  tenantApplicationReferences,
+  tenantApplications,
+} from '../../db/schema';
+import { errorHandler } from '../../middlewares/errorHandler';
+import { resetGeoTables, seedListingWithGeo } from '../helpers/postgresGeoFixtures';
+
+function buildApp(oxyUserId: string): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    const authed = req as unknown as { user: { id: string }; userId: string };
+    authed.user = { id: oxyUserId };
+    authed.userId = oxyUserId;
+    next();
+  });
+  app.post('/applications', (req, res, next) => applicationController.createApplication(req, res, next));
+  app.get('/applications', (req, res, next) => applicationController.listMyApplications(req, res, next));
+  app.get('/applications/:id', (req, res, next) => applicationController.getApplicationById(req, res, next));
+  app.patch('/applications/:id', (req, res, next) => applicationController.updateApplicationStatus(req, res, next));
+  app.post('/applications/:id/create-lease', (req, res, next) => applicationController.createLeaseFromApplication(req, res, next));
+  app.use(errorHandler);
+  return app;
+}
+
+/** A distinct ISO-3166 alpha-2 per geo chain — `countries_code_key` is UNIQUE. */
+let geoChainCounter = 0;
+function nextCountryCode(): string {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const index = geoChainCounter++;
+  return `${alphabet[Math.floor(index / 26) % 26]}${alphabet[index % 26]}`;
+}
+
+/** A listing offered for long-term rent, owned by `oxy-landlord`. */
+async function seedRentalProperty(oxyUserId = 'oxy-landlord'): Promise<string> {
+  const { propertyId } = await seedListingWithGeo({
+    countryCode: nextCountryCode(),
+    overrides: {
+      oxyUserId,
+      status: 'published',
+      isExternal: false,
+      // `properties_offerings_*` makes `offerings` exactly the set of present
+      // priced blocks, so the block has to be here for the offering to be.
+      offerings: ['long_term_rent'],
+      longTermRentMonthlyAmount: 1400,
+      longTermRentCurrency: 'EUR',
+    },
+  });
+  return propertyId;
+}
+
+function applicationBody(propertyId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    propertyId,
+    moveInDate: '2026-03-01T00:00:00.000Z',
+    leaseTermMonths: 12,
+    monthlyIncome: 45000,
+    employmentStatus: 'employed',
+    referenceContacts: [
+      { name: 'Ada Ref', relationship: 'employer', phone: '+34600000000', email: 'Ada@Example.TEST' },
+    ],
+    ...overrides,
+  };
+}
+
+async function createApplicationFor(
+  propertyId: string,
+  applicant = 'oxy-applicant',
+  overrides: Record<string, unknown> = {},
+): Promise<string> {
+  const res = await request(buildApp(applicant))
+    .post('/applications')
+    .send(applicationBody(propertyId, overrides));
+  expect(res.status).toBe(201);
+  return res.body.data.id;
+}
+
+async function applicationRow(id: string) {
+  const [row] = await getDb()
+    .select()
+    .from(tenantApplications)
+    .where(eq(tenantApplications.id, id))
+    .limit(1);
+  return row;
+}
+
+beforeEach(async () => {
+  await getDb().delete(leases);
+  await getDb().delete(tenantApplications);
+  await resetGeoTables();
+});
+
+afterAll(async () => {
+  // Leave the shared tables as this file found them — see the reproduced
+  // geoBackfill collision documented in `leaseOwnership.test.ts`.
+  await getDb().delete(leases);
+  await getDb().delete(tenantApplications);
+  await resetGeoTables();
+});
+
+describe('createApplication', () => {
+  it('stores the application with a server-resolved landlord and no decision', async () => {
+    const propertyId = await seedRentalProperty();
+    const res = await request(buildApp('oxy-applicant'))
+      .post('/applications')
+      // A forged landlord, status and decision must be ignored.
+      .send(applicationBody(propertyId, {
+        landlordOxyUserId: 'attacker',
+        status: 'approved',
+        decidedAt: '2020-01-01T00:00:00.000Z',
+      }));
+
+    expect(res.status).toBe(201);
+    const persisted = await applicationRow(res.body.data.id);
+    expect(persisted.landlordOxyUserId).toBe('oxy-landlord');
+    expect(persisted.applicantOxyUserId).toBe('oxy-applicant');
+    expect(persisted.status).toBe('submitted');
+    // The un-decided half of the equivalence.
+    expect(persisted.decidedAt).toBeNull();
+  });
+
+  it('stores the reference contacts in the SAME transaction, lowercasing the email', async () => {
+    const id = await createApplicationFor(await seedRentalProperty());
+    const references = await getDb()
+      .select()
+      .from(tenantApplicationReferences)
+      .where(eq(tenantApplicationReferences.applicationId, id));
+
+    expect(references).toHaveLength(1);
+    expect(references[0].relationship).toBe('employer');
+    // Mongoose `lowercase: true` has no Postgres counterpart and is re-applied
+    // at the call site.
+    expect(references[0].email).toBe('ada@example.test');
+  });
+
+  it('refuses an undeclared reference relationship with 400, before any insert', async () => {
+    // Narrowed in the controller rather than left to
+    // `tenant_application_references_relationship_check`: a `23514` would be a
+    // 500 where the caller earned a 400 naming the field.
+    const propertyId = await seedRentalProperty();
+    const res = await request(buildApp('oxy-applicant'))
+      .post('/applications')
+      .send(applicationBody(propertyId, {
+        referenceContacts: [
+          { name: 'X', relationship: 'astrologer', phone: '+34600000000', email: 'x@y.test' },
+        ],
+      }));
+
+    expect(res.status).toBe(400);
+    // Neither the parent NOR the children — the only assertion that
+    // distinguishes one transaction from two.
+    expect(await getDb().select().from(tenantApplications)).toHaveLength(0);
+    expect(await getDb().select().from(tenantApplicationReferences)).toHaveLength(0);
+  });
+
+  it('refuses an external listing, one not offered for long-term rent, and your own', async () => {
+    const external = (await seedListingWithGeo({
+      countryCode: nextCountryCode(),
+      overrides: { oxyUserId: 'oxy-landlord', isExternal: true, source: 'idealista', sourceUrl: 'https://x.test/1' },
+    })).propertyId;
+    expect((await request(buildApp('oxy-a')).post('/applications').send(applicationBody(external))).status).toBe(400);
+
+    const notOffered = (await seedListingWithGeo({
+      countryCode: nextCountryCode(),
+      overrides: { oxyUserId: 'oxy-landlord', status: 'published' },
+    })).propertyId;
+    expect((await request(buildApp('oxy-a')).post('/applications').send(applicationBody(notOffered))).status).toBe(400);
+
+    const own = await seedRentalProperty();
+    expect((await request(buildApp('oxy-landlord')).post('/applications').send(applicationBody(own))).status).toBe(403);
+
+    expect(await getDb().select().from(tenantApplications)).toHaveLength(0);
+  });
+
+  it('refuses a SECOND active application and PERMITS one after a rejection', async () => {
+    const propertyId = await seedRentalProperty();
+    const first = await createApplicationFor(propertyId);
+
+    const duplicate = await request(buildApp('oxy-applicant'))
+      .post('/applications')
+      .send(applicationBody(propertyId));
+    expect(duplicate.status).toBe(409);
+
+    // The permit half: a rule scoped to the pair WITHOUT the active statuses
+    // passes the refusal above and eats this.
+    expect(
+      (await request(buildApp('oxy-landlord')).patch(`/applications/${first}`).send({ status: 'rejected' })).status,
+    ).toBe(200);
+
+    const again = await request(buildApp('oxy-applicant'))
+      .post('/applications')
+      .send(applicationBody(propertyId));
+    expect(again.status).toBe(201);
+  });
+});
+
+describe('updateApplicationStatus — the `decided_at` equivalence', () => {
+  it('stamps decided_at on approve, reject and withdraw', async () => {
+    for (const [status, actor] of [
+      ['approved', 'oxy-landlord'],
+      ['rejected', 'oxy-landlord'],
+      ['withdrawn', 'oxy-applicant'],
+    ] as const) {
+      const id = await createApplicationFor(await seedRentalProperty());
+      const res = await request(buildApp(actor)).patch(`/applications/${id}`).send({ status });
+      expect(res.status).toBe(200);
+
+      const persisted = await applicationRow(id);
+      expect(persisted.status).toBe(status);
+      expect(persisted.decidedAt).not.toBeNull();
+    }
+  });
+
+  it('does NOT stamp decided_at on `reviewing`, which is not terminal', async () => {
+    // The half a "stamp on every transition" writer gets wrong, and the CHECK
+    // refuses: `reviewing` is still open, so a decision date on it would sort a
+    // live application as if it were closed.
+    const id = await createApplicationFor(await seedRentalProperty());
+    const res = await request(buildApp('oxy-landlord')).patch(`/applications/${id}`).send({ status: 'reviewing' });
+    expect(res.status).toBe(200);
+    expect((await applicationRow(id)).decidedAt).toBeNull();
+  });
+
+  it('REFUSES a terminal row with no decided_at, and a decided_at on an open one', async () => {
+    // The CHECK, both directions, against the shapes `findOneAndUpdate` used to
+    // produce by bypassing the `pre('save')` hook entirely.
+    const propertyId = await seedRentalProperty();
+    const base = {
+      propertyId,
+      applicantOxyUserId: 'oxy-a',
+      landlordOxyUserId: 'oxy-landlord',
+      moveInDate: new Date('2026-03-01T00:00:00.000Z'),
+      leaseTermMonths: 12,
+      monthlyIncome: 45000,
+      employmentStatus: 'employed' as const,
+      submittedAt: new Date(),
+    };
+
+    await expect(
+      getDb().insert(tenantApplications).values({ ...base, status: 'approved' }),
+    ).rejects.toThrow();
+
+    await expect(
+      getDb().insert(tenantApplications).values({ ...base, status: 'submitted', decidedAt: new Date() }),
+    ).rejects.toThrow();
+  });
+
+  it('lets only the landlord decide and only the applicant withdraw', async () => {
+    const propertyId = await seedRentalProperty();
+
+    const byApplicant = await createApplicationFor(propertyId);
+    expect((await request(buildApp('oxy-applicant')).patch(`/applications/${byApplicant}`).send({ status: 'approved' })).status).toBe(403);
+    expect((await applicationRow(byApplicant)).status).toBe('submitted');
+
+    expect((await request(buildApp('oxy-landlord')).patch(`/applications/${byApplicant}`).send({ status: 'withdrawn' })).status).toBe(403);
+    expect((await applicationRow(byApplicant)).status).toBe('submitted');
+
+    expect((await request(buildApp('oxy-stranger')).patch(`/applications/${byApplicant}`).send({ status: 'approved' })).status).toBe(403);
+  });
+
+  it('refuses a SECOND decision — the precondition is in the UPDATE', async () => {
+    const id = await createApplicationFor(await seedRentalProperty());
+    expect((await request(buildApp('oxy-landlord')).patch(`/applications/${id}`).send({ status: 'approved' })).status).toBe(200);
+    expect((await request(buildApp('oxy-landlord')).patch(`/applications/${id}`).send({ status: 'rejected' })).status).toBe(400);
+    expect((await applicationRow(id)).status).toBe('approved');
+  });
+
+  it('refuses an unsupported status', async () => {
+    const id = await createApplicationFor(await seedRentalProperty());
+    const res = await request(buildApp('oxy-landlord')).patch(`/applications/${id}`).send({ status: 'nonsense' });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('reads', () => {
+  it('shows an application only to its two parties', async () => {
+    const id = await createApplicationFor(await seedRentalProperty());
+    expect((await request(buildApp('oxy-applicant')).get(`/applications/${id}`)).status).toBe(200);
+    expect((await request(buildApp('oxy-landlord')).get(`/applications/${id}`)).status).toBe(200);
+    expect((await request(buildApp('oxy-stranger')).get(`/applications/${id}`)).status).toBe(403);
+  });
+
+  it('splits the applicant and landlord views', async () => {
+    const propertyId = await seedRentalProperty();
+    await createApplicationFor(propertyId, 'oxy-applicant');
+
+    const asApplicant = await request(buildApp('oxy-applicant')).get('/applications');
+    expect(asApplicant.body.data).toHaveLength(1);
+
+    const asLandlord = await request(buildApp('oxy-landlord')).get('/applications?asLandlord=true');
+    expect(asLandlord.body.data).toHaveLength(1);
+
+    // The landlord's APPLICANT view is empty — they filed nothing.
+    const landlordOwnView = await request(buildApp('oxy-landlord')).get('/applications');
+    expect(landlordOwnView.body.data).toHaveLength(0);
+  });
+
+  it('carries the reference contacts on the list response', async () => {
+    await createApplicationFor(await seedRentalProperty());
+    const res = await request(buildApp('oxy-applicant')).get('/applications');
+    expect(res.body.data[0].referenceContacts).toHaveLength(1);
+    expect(res.body.data[0].referenceContacts[0].name).toBe('Ada Ref');
+  });
+});
+
+describe('createLeaseFromApplication', () => {
+  it('drafts a lease from an APPROVED application, priced from the listing', async () => {
+    const propertyId = await seedRentalProperty();
+    const id = await createApplicationFor(propertyId);
+    await request(buildApp('oxy-landlord')).patch(`/applications/${id}`).send({ status: 'approved' });
+
+    const res = await request(buildApp('oxy-landlord')).post(`/applications/${id}/create-lease`);
+    expect(res.status).toBe(201);
+    expect(res.body.data.status).toBe('draft');
+    expect(res.body.data.rentDetails.monthlyRent).toBe(1400);
+    expect(res.body.data.rentDetails.currency).toBe('EUR');
+    expect(res.body.data.tenantOxyUserId).toBe('oxy-applicant');
+
+    const [lease] = await getDb().select().from(leases);
+    expect(lease.landlordOxyUserId).toBe('oxy-landlord');
+    // 12 months from the move-in date.
+    expect(lease.leaseTermsStartDate.toISOString()).toBe('2026-03-01T00:00:00.000Z');
+    expect(lease.leaseTermsEndDate.toISOString()).toBe('2027-03-01T00:00:00.000Z');
+  });
+
+  it('refuses an application that is not approved, and a non-landlord', async () => {
+    const propertyId = await seedRentalProperty();
+    const id = await createApplicationFor(propertyId);
+
+    expect((await request(buildApp('oxy-landlord')).post(`/applications/${id}/create-lease`)).status).toBe(400);
+    expect((await request(buildApp('oxy-applicant')).post(`/applications/${id}/create-lease`)).status).toBe(403);
+    expect(await getDb().select().from(leases)).toHaveLength(0);
+  });
+
+  it('refuses a second lease for the same tenant and property', async () => {
+    const propertyId = await seedRentalProperty();
+    const id = await createApplicationFor(propertyId);
+    await request(buildApp('oxy-landlord')).patch(`/applications/${id}`).send({ status: 'approved' });
+
+    expect((await request(buildApp('oxy-landlord')).post(`/applications/${id}/create-lease`)).status).toBe(201);
+    expect((await request(buildApp('oxy-landlord')).post(`/applications/${id}/create-lease`)).status).toBe(409);
+    expect(await getDb().select().from(leases)).toHaveLength(1);
+  });
+
+  it('cannot even be given a listing that is OFFERED for rent with no price', async () => {
+    // The 'Property has no long-term rent price' branch in
+    // `createLeaseFromApplication` is UNREACHABLE through a valid listing, and
+    // that is the `properties` schema working rather than dead code: the four
+    // `properties_offerings_*` CHECKs make `offerings` exactly the set of
+    // present priced blocks, so "offered for long-term rent" and "has a
+    // long-term rent amount" cannot disagree. Asserted here rather than
+    // deleted, because the guard is also what narrows `number | null` to
+    // `number` for the insert — and because a later change that relaxed the
+    // CHECK would make the branch live again without anybody noticing.
+    const propertyId = await seedRentalProperty();
+
+    await expect(
+      getDb()
+        .update(properties)
+        .set({ longTermRentMonthlyAmount: null })
+        .where(eq(properties.id, propertyId)),
+    ).rejects.toThrow();
+  });
+});
+
+describe('documents', () => {
+  it('stores declared documents and refuses an undeclared type', async () => {
+    const propertyId = await seedRentalProperty();
+    const id = await createApplicationFor(propertyId, 'oxy-applicant', {
+      documents: [{ type: 'income', url: 'https://x.test/payslip.pdf', filename: 'payslip.pdf' }],
+    });
+
+    const stored = await getDb()
+      .select()
+      .from(tenantApplicationDocuments)
+      .where(eq(tenantApplicationDocuments.applicationId, id));
+    expect(stored).toHaveLength(1);
+    expect(stored[0].type).toBe('income');
+
+    const other = await seedRentalProperty('oxy-landlord-2');
+    const bad = await request(buildApp('oxy-applicant'))
+      .post('/applications')
+      .send(applicationBody(other, {
+        documents: [{ type: 'passport', url: 'https://x.test/p.pdf', filename: 'p.pdf' }],
+      }));
+    expect(bad.status).toBe(400);
+  });
+});

--- a/packages/backend/__tests__/integration/viewingRequests.test.ts
+++ b/packages/backend/__tests__/integration/viewingRequests.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Viewing requests — the lifecycle, the two conflict rules, and the
+ * `cancelled_by` equivalence, against the REAL Postgres this worker owns.
+ *
+ * ## What makes these tests non-vacuous
+ *
+ * `viewing_requests` was empty in production. Every case below targets a rule
+ * with a way to be wrong:
+ *
+ *  - `viewing_requests_cancelled_by_status_check` is asserted in BOTH
+ *    directions — the shapes it refuses are the ones Mongo allowed,
+ *  - every refusal re-reads the row, because a handler that 403s and writes
+ *    anyway passes any assertion made on its response alone,
+ *  - the two conflict rules are asserted on what they PERMIT (a re-request
+ *    after a decline, the same slot on a different property) as well as what
+ *    they refuse — a rule scoped too widely passes every refusal test.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { eq } from 'drizzle-orm';
+
+import viewingController from '../../controllers/viewingController';
+import { getDb } from '../../db/postgres';
+import { viewingRequests } from '../../db/schema';
+import { errorHandler } from '../../middlewares/errorHandler';
+import { resetGeoTables, seedListingWithGeo } from '../helpers/postgresGeoFixtures';
+
+function buildApp(oxyUserId?: string): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (oxyUserId) {
+      const authed = req as unknown as { user: { id: string }; userId: string };
+      authed.user = { id: oxyUserId };
+      authed.userId = oxyUserId;
+    }
+    next();
+  });
+  app.post('/properties/:propertyId/viewings', (req, res, next) => viewingController.createViewingRequest(req, res, next));
+  app.get('/properties/:propertyId/viewings', (req, res, next) => viewingController.listPropertyViewingRequests(req, res, next));
+  app.get('/viewings', (req, res, next) => viewingController.listMyViewingRequests(req, res, next));
+  app.post('/viewings/:viewingId/approve', (req, res, next) => viewingController.approveViewingRequest(req, res, next));
+  app.post('/viewings/:viewingId/decline', (req, res, next) => viewingController.declineViewingRequest(req, res, next));
+  app.post('/viewings/:viewingId/cancel', (req, res, next) => viewingController.cancelViewingRequest(req, res, next));
+  app.put('/viewings/:viewingId', (req, res, next) => viewingController.updateViewingRequest(req, res, next));
+  app.use(errorHandler);
+  return app;
+}
+
+/**
+ * A distinct ISO-3166 alpha-2 per geo chain within a test.
+ *
+ * `countries_code_key` is UNIQUE, so two chains built with the fixture's default
+ * `ES` collide — and several cases below deliberately seed more than one listing
+ * (a draft, an external and an owned one; two properties for the same slot).
+ * The counter resets per file, and `resetGeoTables` runs between tests, so the
+ * codes never have to be globally unique — only unique within one test.
+ */
+let geoChainCounter = 0;
+function nextCountryCode(): string {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const index = geoChainCounter++;
+  return `${alphabet[Math.floor(index / 26) % 26]}${alphabet[index % 26]}`;
+}
+
+/** A PUBLISHED, internal listing owned by `oxy-owner`. */
+async function seedBookableProperty(oxyUserId = 'oxy-owner'): Promise<string> {
+  const { propertyId } = await seedListingWithGeo({
+    countryCode: nextCountryCode(),
+    overrides: { oxyUserId, status: 'published', isExternal: false },
+  });
+  return propertyId;
+}
+
+/** A date/time pair a fortnight out, in the shape the client sends. */
+function futureSlot(offsetDays = 14, time = '10:00'): { date: string; time: string } {
+  const day = new Date(Date.now() + offsetDays * 24 * 60 * 60 * 1000);
+  return { date: day.toISOString().slice(0, 10), time };
+}
+
+async function viewingRow(id: string) {
+  const [row] = await getDb()
+    .select()
+    .from(viewingRequests)
+    .where(eq(viewingRequests.id, id))
+    .limit(1);
+  return row;
+}
+
+async function createRequest(
+  propertyId: string,
+  requester = 'oxy-requester',
+  slot = futureSlot(),
+): Promise<string> {
+  const res = await request(buildApp(requester))
+    .post(`/properties/${propertyId}/viewings`)
+    .send(slot);
+  expect(res.status).toBe(201);
+  return res.body.data.id;
+}
+
+beforeEach(async () => {
+  await getDb().delete(viewingRequests);
+  await resetGeoTables();
+});
+
+afterAll(async () => {
+  // Leave the shared tables as this file found them — see the reproduced
+  // geoBackfill collision documented in `leaseOwnership.test.ts`.
+  await getDb().delete(viewingRequests);
+  await resetGeoTables();
+});
+
+describe('createViewingRequest', () => {
+  it('stores a pending request with a server-resolved owner', async () => {
+    const propertyId = await seedBookableProperty();
+    const res = await request(buildApp('oxy-requester'))
+      .post(`/properties/${propertyId}/viewings`)
+      // A forged owner and status must be ignored — both are resolved
+      // server-side from the listing and the transition.
+      .send({ ...futureSlot(), ownerOxyUserId: 'attacker', status: 'approved' });
+
+    expect(res.status).toBe(201);
+    const persisted = await viewingRow(res.body.data.id);
+    expect(persisted.ownerOxyUserId).toBe('oxy-owner');
+    expect(persisted.requesterOxyUserId).toBe('oxy-requester');
+    expect(persisted.status).toBe('pending');
+    expect(persisted.cancelledBy).toBeNull();
+  });
+
+  it('refuses an unpublished, an external and an owner-booked listing', async () => {
+    const draft = (await seedListingWithGeo({
+      countryCode: nextCountryCode(),
+      overrides: { oxyUserId: 'oxy-owner', status: 'draft' },
+    })).propertyId;
+    expect((await request(buildApp('oxy-r')).post(`/properties/${draft}/viewings`).send(futureSlot())).status).toBe(400);
+
+    const external = (await seedListingWithGeo({
+      countryCode: nextCountryCode(),
+      overrides: { oxyUserId: 'oxy-owner', status: 'published', isExternal: true, source: 'idealista', sourceUrl: 'https://x.test/1' },
+    })).propertyId;
+    expect((await request(buildApp('oxy-r')).post(`/properties/${external}/viewings`).send(futureSlot())).status).toBe(400);
+
+    const own = await seedBookableProperty();
+    expect((await request(buildApp('oxy-owner')).post(`/properties/${own}/viewings`).send(futureSlot())).status).toBe(403);
+
+    expect(await getDb().select().from(viewingRequests)).toHaveLength(0);
+  });
+
+  it('refuses a slot in the past', async () => {
+    const propertyId = await seedBookableProperty();
+    const res = await request(buildApp('oxy-requester'))
+      .post(`/properties/${propertyId}/viewings`)
+      .send(futureSlot(-1));
+    expect(res.status).toBe(400);
+  });
+
+  it('refuses a SECOND active request from the same person on the same property', async () => {
+    const propertyId = await seedBookableProperty();
+    await createRequest(propertyId);
+
+    const second = await request(buildApp('oxy-requester'))
+      .post(`/properties/${propertyId}/viewings`)
+      .send(futureSlot(20));
+    expect(second.status).toBe(409);
+    expect(await getDb().select().from(viewingRequests)).toHaveLength(1);
+  });
+
+  it('PERMITS a fresh request after the first was declined', async () => {
+    // The permit half. A rule that keyed on the person and property WITHOUT the
+    // active-status scope passes every refusal above and eats this one.
+    const propertyId = await seedBookableProperty();
+    const id = await createRequest(propertyId);
+    expect((await request(buildApp('oxy-owner')).post(`/viewings/${id}/decline`)).status).toBe(200);
+
+    const again = await request(buildApp('oxy-requester'))
+      .post(`/properties/${propertyId}/viewings`)
+      .send(futureSlot(20));
+    expect(again.status).toBe(201);
+  });
+
+  it('refuses a slot another person already holds, and PERMITS it on a different property', async () => {
+    const propertyId = await seedBookableProperty();
+    const slot = futureSlot();
+    await createRequest(propertyId, 'oxy-first', slot);
+
+    const clash = await request(buildApp('oxy-second'))
+      .post(`/properties/${propertyId}/viewings`)
+      .send(slot);
+    expect(clash.status).toBe(409);
+
+    // The same instant on a DIFFERENT listing is not a conflict — a rule that
+    // forgot the property scope would refuse this too.
+    const other = await seedBookableProperty('oxy-other-owner');
+    const elsewhere = await request(buildApp('oxy-second'))
+      .post(`/properties/${other}/viewings`)
+      .send(slot);
+    expect(elsewhere.status).toBe(201);
+  });
+});
+
+describe('approve / decline — owner only, pending only', () => {
+  it('approves a pending request and notifies nobody else', async () => {
+    const id = await createRequest(await seedBookableProperty());
+    const res = await request(buildApp('oxy-owner')).post(`/viewings/${id}/approve`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('approved');
+    // `cancelled_by` must stay NULL for any status but `cancelled`.
+    expect((await viewingRow(id)).cancelledBy).toBeNull();
+  });
+
+  it('refuses a non-owner approval and leaves the request pending', async () => {
+    const id = await createRequest(await seedBookableProperty());
+    const res = await request(buildApp('oxy-requester')).post(`/viewings/${id}/approve`);
+    expect(res.status).toBe(403);
+    expect((await viewingRow(id)).status).toBe('pending');
+  });
+
+  it('refuses a SECOND approval — the precondition is in the UPDATE', async () => {
+    const id = await createRequest(await seedBookableProperty());
+    expect((await request(buildApp('oxy-owner')).post(`/viewings/${id}/approve`)).status).toBe(200);
+    expect((await request(buildApp('oxy-owner')).post(`/viewings/${id}/approve`)).status).toBe(400);
+  });
+
+  it('refuses approving a second request for an instant already approved', async () => {
+    const propertyId = await seedBookableProperty();
+    const slot = futureSlot();
+    const first = await createRequest(propertyId, 'oxy-a', slot);
+    expect((await request(buildApp('oxy-owner')).post(`/viewings/${first}/approve`)).status).toBe(200);
+
+    // A second request at the same instant can only exist if it was created
+    // before the first was approved — seeded directly, since the create path
+    // refuses it.
+    const [second] = await getDb()
+      .insert(viewingRequests)
+      .values({
+        propertyId,
+        requesterOxyUserId: 'oxy-b',
+        ownerOxyUserId: 'oxy-owner',
+        scheduledAt: new Date(`${slot.date}T${slot.time}`),
+        status: 'pending',
+      })
+      .returning();
+
+    const res = await request(buildApp('oxy-owner')).post(`/viewings/${second.id}/approve`);
+    expect(res.status).toBe(409);
+    expect((await viewingRow(second.id)).status).toBe('pending');
+  });
+});
+
+describe('cancel — the `cancelled_by` equivalence', () => {
+  it('records WHICH side cancelled, in the same statement as the status', async () => {
+    const propertyId = await seedBookableProperty();
+
+    const byRequester = await createRequest(propertyId, 'oxy-requester');
+    expect((await request(buildApp('oxy-requester')).post(`/viewings/${byRequester}/cancel`)).status).toBe(200);
+    expect(await viewingRow(byRequester)).toMatchObject({ status: 'cancelled', cancelledBy: 'requester' });
+
+    const byOwner = await createRequest(propertyId, 'oxy-other', futureSlot(21));
+    expect((await request(buildApp('oxy-owner')).post(`/viewings/${byOwner}/cancel`)).status).toBe(200);
+    expect(await viewingRow(byOwner)).toMatchObject({ status: 'cancelled', cancelledBy: 'owner' });
+  });
+
+  it('refuses a non-party cancellation', async () => {
+    const id = await createRequest(await seedBookableProperty());
+    const res = await request(buildApp('oxy-stranger')).post(`/viewings/${id}/cancel`);
+    expect(res.status).toBe(403);
+    expect((await viewingRow(id)).status).toBe('pending');
+  });
+
+  it('is idempotent — a second cancel answers 200 and does not re-attribute', async () => {
+    const id = await createRequest(await seedBookableProperty());
+    expect((await request(buildApp('oxy-requester')).post(`/viewings/${id}/cancel`)).status).toBe(200);
+
+    // The OWNER cancels an already-cancelled request: the answer is the current
+    // state, and `cancelled_by` must still name the requester who really did it.
+    const second = await request(buildApp('oxy-owner')).post(`/viewings/${id}/cancel`);
+    expect(second.status).toBe(200);
+    expect((await viewingRow(id)).cancelledBy).toBe('requester');
+  });
+
+  it('REFUSES a cancelled row with no canceller, and a canceller on a pending row', async () => {
+    // The CHECK, in both directions. Mongo permitted each; the second is the
+    // damaging one — a cancellation neither party can be shown to have made.
+    const propertyId = await seedBookableProperty();
+    const base = {
+      propertyId,
+      requesterOxyUserId: 'oxy-r',
+      ownerOxyUserId: 'oxy-owner',
+      scheduledAt: new Date(Date.now() + 86_400_000),
+    };
+
+    await expect(
+      getDb().insert(viewingRequests).values({ ...base, status: 'cancelled' }),
+    ).rejects.toThrow();
+
+    await expect(
+      getDb().insert(viewingRequests).values({ ...base, status: 'pending', cancelledBy: 'owner' }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('reschedule — requester only, pending only', () => {
+  it('moves the instant and refuses a clash', async () => {
+    const propertyId = await seedBookableProperty();
+    const taken = futureSlot(15);
+    await createRequest(propertyId, 'oxy-other', taken);
+    const mine = await createRequest(propertyId, 'oxy-requester', futureSlot(16));
+
+    const clash = await request(buildApp('oxy-requester')).put(`/viewings/${mine}`).send(taken);
+    expect(clash.status).toBe(409);
+
+    const moved = await request(buildApp('oxy-requester')).put(`/viewings/${mine}`).send(futureSlot(17));
+    expect(moved.status).toBe(200);
+  });
+
+  it('refuses the owner and refuses a non-pending request', async () => {
+    const propertyId = await seedBookableProperty();
+    const id = await createRequest(propertyId);
+
+    expect((await request(buildApp('oxy-owner')).put(`/viewings/${id}`).send(futureSlot(18))).status).toBe(403);
+
+    await request(buildApp('oxy-owner')).post(`/viewings/${id}/approve`);
+    expect((await request(buildApp('oxy-requester')).put(`/viewings/${id}`).send(futureSlot(18))).status).toBe(400);
+  });
+});
+
+describe('listing — scope IS the authorisation', () => {
+  it('shows an owner every request and a requester only their own', async () => {
+    const propertyId = await seedBookableProperty();
+    await createRequest(propertyId, 'oxy-a', futureSlot(10));
+    await createRequest(propertyId, 'oxy-b', futureSlot(11));
+
+    const owner = await request(buildApp('oxy-owner')).get(`/properties/${propertyId}/viewings`);
+    expect(owner.body.data).toHaveLength(2);
+    expect(owner.body.pagination.total).toBe(2);
+
+    const requester = await request(buildApp('oxy-a')).get(`/properties/${propertyId}/viewings`);
+    expect(requester.body.data).toHaveLength(1);
+    expect(requester.body.pagination.total).toBe(1);
+    expect(requester.body.data[0].requesterOxyUserId).toBe('oxy-a');
+  });
+
+  it('lists my own requests across properties, soonest first', async () => {
+    const first = await seedBookableProperty('oxy-owner-1');
+    const second = await seedBookableProperty('oxy-owner-2');
+    await createRequest(second, 'oxy-me', futureSlot(20));
+    await createRequest(first, 'oxy-me', futureSlot(5));
+
+    const res = await request(buildApp('oxy-me')).get('/viewings');
+    expect(res.status).toBe(200);
+    expect(res.body.data.map((row: { propertyId: string }) => row.propertyId)).toEqual([first, second]);
+  });
+});

--- a/packages/backend/controllers/applicationController.ts
+++ b/packages/backend/controllers/applicationController.ts
@@ -14,8 +14,21 @@
 
 import type { Request, Response, NextFunction } from 'express';
 import { PAYMENT_CURRENCIES } from '@homiio/shared-types';
-import { Property, TenantApplication } from '../models';
 import { getDb } from '../db/postgres';
+import {
+  ACTIVE_APPLICATION_STATUSES,
+  createApplication,
+  decideApplication,
+  findActiveApplicationForApplicant,
+  findApplicationById,
+  isApplicationStatus,
+  listApplications,
+  serializeApplication,
+  type TenantApplicationStatusValue,
+} from '../db/applications/applicationReads';
+import { findPropertyBookingBasis } from '../db/properties/propertyBookingBasis';
+import { TENANT_APPLICATION_DOCUMENT_TYPES } from '../db/schema/applications';
+import { REFERENCE_RELATIONSHIPS } from '../db/schema/profiles';
 import {
   createLease,
   findLeaseForTenant,
@@ -29,7 +42,6 @@ import imageUploadService from '../services/imageUploadService';
 import { requireSessionOxyUserId } from '../utils/sessionUser';
 import {
   TenantApplicationStatus,
-  TenantApplicationDocumentType,
   OfferingType,
   LeaseStatus,
 } from '@homiio/shared-types';
@@ -42,20 +54,36 @@ const ACTIVE_LEASE_STATUSES: readonly LeaseStatusValue[] = [
   LeaseStatus.ACTIVE,
 ];
 
-const ALLOWED_DOCUMENT_TYPES = new Set<string>(Object.values(TenantApplicationDocumentType));
 const APPLICATION_DOCUMENTS_FOLDER = 'applications/documents';
 
 interface ParsedReferenceContact {
   name: string;
-  relationship: string;
+  relationship: (typeof REFERENCE_RELATIONSHIPS)[number];
   phone: string;
   email: string;
 }
 
 interface ParsedDocument {
-  type: string;
+  type: (typeof TENANT_APPLICATION_DOCUMENT_TYPES)[number];
   url: string;
   filename: string;
+}
+
+/** Whether `value` is one of the four declared referee relationships. */
+function isReferenceRelationship(
+  value: unknown,
+): value is (typeof REFERENCE_RELATIONSHIPS)[number] {
+  return typeof value === 'string' && (REFERENCE_RELATIONSHIPS as readonly string[]).includes(value);
+}
+
+/** Whether `value` is one of the four declared document types. */
+function isApplicationDocumentType(
+  value: unknown,
+): value is (typeof TENANT_APPLICATION_DOCUMENT_TYPES)[number] {
+  return (
+    typeof value === 'string' &&
+    (TENANT_APPLICATION_DOCUMENT_TYPES as readonly string[]).includes(value)
+  );
 }
 
 /**
@@ -81,9 +109,20 @@ function parseReferenceContacts(raw: unknown): ParsedReferenceContact[] {
     if (!ref?.name || !ref?.relationship || !ref?.phone || !ref?.email) {
       throw new AppError(`referenceContacts[${index}] is missing required fields`, 400, 'INVALID_REFERENCES');
     }
+    // Narrowed HERE rather than left to `tenant_application_references_
+    // relationship_check`: Mongoose validated this enum on `create`, and an
+    // undeclared value arriving as a `23514` would be a 500 where the caller
+    // earned a 400 naming the field.
+    if (!isReferenceRelationship(ref.relationship)) {
+      throw new AppError(
+        `referenceContacts[${index}] has invalid relationship "${String(ref.relationship)}"`,
+        400,
+        'INVALID_REFERENCES',
+      );
+    }
     return {
       name: String(ref.name).trim(),
-      relationship: String(ref.relationship),
+      relationship: ref.relationship,
       phone: String(ref.phone).trim(),
       email: String(ref.email).trim().toLowerCase()
     };
@@ -113,8 +152,8 @@ function parseDocumentsFromBody(raw: unknown): ParsedDocument[] {
     if (!doc?.type || !doc?.url || !doc?.filename) {
       throw new AppError(`documents[${index}] is missing required fields`, 400, 'INVALID_DOCUMENTS');
     }
-    if (!ALLOWED_DOCUMENT_TYPES.has(doc.type)) {
-      throw new AppError(`documents[${index}] has invalid type "${doc.type}"`, 400, 'INVALID_DOCUMENT_TYPE');
+    if (!isApplicationDocumentType(doc.type)) {
+      throw new AppError(`documents[${index}] has invalid type "${String(doc.type)}"`, 400, 'INVALID_DOCUMENT_TYPE');
     }
     return {
       type: doc.type,
@@ -128,7 +167,10 @@ function parseDocumentsFromBody(raw: unknown): ParsedDocument[] {
  * Parse a parallel `documentTypes[]` field (multipart shape) — one string per
  * uploaded file (e.g. ["id", "income", "reference"]).
  */
-function parseDocumentTypes(raw: unknown, count: number): string[] {
+function parseDocumentTypes(
+  raw: unknown,
+  count: number,
+): (typeof TENANT_APPLICATION_DOCUMENT_TYPES)[number][] {
   if (!raw && count === 0) return [];
   let value: unknown = raw;
   if (typeof value === 'string') {
@@ -151,7 +193,7 @@ function parseDocumentTypes(raw: unknown, count: number): string[] {
     );
   }
   return value.map((type, index) => {
-    if (typeof type !== 'string' || !ALLOWED_DOCUMENT_TYPES.has(type)) {
+    if (!isApplicationDocumentType(type)) {
       throw new AppError(`documentTypes[${index}] is not a valid document type`, 400, 'INVALID_DOCUMENT_TYPE');
     }
     return type;
@@ -161,7 +203,10 @@ function parseDocumentTypes(raw: unknown, count: number): string[] {
 /**
  * Upload each multer file to S3 and return parsed document entries.
  */
-async function uploadDocumentFiles(files: any[], types: string[]): Promise<ParsedDocument[]> {
+async function uploadDocumentFiles(
+  files: any[],
+  types: readonly (typeof TENANT_APPLICATION_DOCUMENT_TYPES)[number][],
+): Promise<ParsedDocument[]> {
   const uploaded: ParsedDocument[] = [];
   for (let i = 0; i < files.length; i += 1) {
     const file = files[i];
@@ -208,11 +253,11 @@ class ApplicationController {
         documentTypes
       } = req.body || {};
 
-      const property = await Property.findById(propertyId).lean();
+      const db = getDb();
+      const property = await findPropertyBookingBasis(db, String(propertyId));
       if (!property) return next(new AppError('Property not found', 404, 'NOT_FOUND'));
       if (property.isExternal) return next(new AppError('Cannot apply to external listings', 400, 'EXTERNAL_PROPERTY'));
-      const propertyOfferings = Array.isArray(property.offerings) ? property.offerings : [];
-      if (!propertyOfferings.includes(OfferingType.LONG_TERM_RENT)) {
+      if (!property.offerings.includes(OfferingType.LONG_TERM_RENT)) {
         return next(new AppError('This property is not offered for long-term rent and does not accept applications', 400, 'NOT_APPLICABLE'));
       }
 
@@ -222,12 +267,14 @@ class ApplicationController {
         return next(new AppError('You cannot apply to your own property', 403, 'FORBIDDEN'));
       }
 
-      // Prevent duplicate active applications by the same applicant.
-      const existingActive = await TenantApplication.findOne({
-        propertyId,
-        applicantOxyUserId: oxyUserId,
-        status: { $in: [TenantApplicationStatus.SUBMITTED, TenantApplicationStatus.REVIEWING] }
-      }).lean();
+      // Prevent duplicate active applications by the same applicant. A read
+      // rather than an index: "active" is a status SET, and a partial unique
+      // index over one would also forbid re-applying after a rejection.
+      const existingActive = await findActiveApplicationForApplicant(
+        db,
+        String(propertyId),
+        oxyUserId,
+      );
       if (existingActive) {
         return next(new AppError('You already have an active application for this property', 409, 'ALREADY_APPLIED'));
       }
@@ -249,28 +296,34 @@ class ApplicationController {
 
       const allDocuments = [...parsedDocumentsFromBody, ...uploadedDocs];
 
-      const application = await TenantApplication.create({
-        propertyId,
-        applicantOxyUserId: oxyUserId,
-        landlordOxyUserId,
-        moveInDate: moveInDateParsed,
-        leaseTermMonths: Number(leaseTermMonths),
-        monthlyIncome: Number(monthlyIncome),
-        employmentStatus,
-        referenceContacts: parsedReferences,
-        documents: allDocuments,
-        notes,
-        status: TenantApplicationStatus.SUBMITTED,
-        submittedAt: new Date()
-      });
+      // One transaction: an application that committed without its references
+      // is one a landlord judges on incomplete information.
+      const hydrated = await db.transaction((tx) =>
+        createApplication(tx, {
+          columns: {
+            propertyId: String(propertyId),
+            applicantOxyUserId: oxyUserId,
+            landlordOxyUserId,
+            moveInDate: moveInDateParsed,
+            leaseTermMonths: Number(leaseTermMonths),
+            monthlyIncome: Number(monthlyIncome),
+            employmentStatus,
+            notes,
+            status: TenantApplicationStatus.SUBMITTED,
+            submittedAt: new Date(),
+          },
+          references: parsedReferences,
+          documents: allDocuments,
+        }),
+      );
 
       logger.info('Tenant application created', {
-        applicationId: String(application._id),
+        applicationId: hydrated.application.id,
         propertyId: String(propertyId),
         applicantOxyUserId: oxyUserId
       });
 
-      res.status(201).json(successResponse(application.toJSON(), 'Application submitted'));
+      res.status(201).json(successResponse(serializeApplication(hydrated), 'Application submitted'));
     } catch (error) {
       next(error);
     }
@@ -285,28 +338,22 @@ class ApplicationController {
       const { page = 1, limit = 10, status, asLandlord } = req.query;
       const oxyUserId = requireSessionOxyUserId(req);
 
-      const query: Record<string, unknown> = {};
-      if (String(asLandlord) === 'true') {
-        query.landlordOxyUserId = oxyUserId;
-      } else {
-        query.applicantOxyUserId = oxyUserId;
-      }
-      if (status) query.status = status;
-
       const pageNumber = Math.max(1, parseInt(String(page)) || 1);
       const limitNumber = Math.min(100, Math.max(1, parseInt(String(limit)) || 10));
       const skip = (pageNumber - 1) * limitNumber;
 
-      const [items, total] = await Promise.all([
-        TenantApplication.find(query)
-          .sort({ submittedAt: -1 })
-          .skip(skip)
-          .limit(limitNumber)
-          .lean(),
-        TenantApplication.countDocuments(query)
-      ]);
+      const asLandlordView = String(asLandlord) === 'true';
+      const result = await listApplications(
+        getDb(),
+        {
+          applicantOxyUserId: asLandlordView ? undefined : oxyUserId,
+          landlordOxyUserId: asLandlordView ? oxyUserId : undefined,
+          status: isApplicationStatus(status) ? status : undefined,
+        },
+        { limit: limitNumber, offset: skip },
+      );
 
-      res.json(paginationResponse(items, pageNumber, limitNumber, total, 'Applications retrieved'));
+      res.json(paginationResponse(result.applications.map(serializeApplication), pageNumber, limitNumber, result.total, 'Applications retrieved'));
     } catch (error) {
       next(error);
     }
@@ -320,16 +367,16 @@ class ApplicationController {
       const { id } = req.params;
       const oxyUserId = requireSessionOxyUserId(req);
 
-      const application = await TenantApplication.findById(id).lean();
-      if (!application) return next(new AppError('Application not found', 404, 'NOT_FOUND'));
+      const hydrated = await findApplicationById(getDb(), id);
+      if (!hydrated) return next(new AppError('Application not found', 404, 'NOT_FOUND'));
 
-      const isApplicant = application.applicantOxyUserId === oxyUserId;
-      const isLandlord = application.landlordOxyUserId === oxyUserId;
+      const isApplicant = hydrated.application.applicantOxyUserId === oxyUserId;
+      const isLandlord = hydrated.application.landlordOxyUserId === oxyUserId;
       if (!isApplicant && !isLandlord) {
         return next(new AppError('Not authorized to view this application', 403, 'FORBIDDEN'));
       }
 
-      res.json(successResponse(application, 'Application retrieved'));
+      res.json(successResponse(serializeApplication(hydrated), 'Application retrieved'));
     } catch (error) {
       next(error);
     }
@@ -347,16 +394,21 @@ class ApplicationController {
 
       const oxyUserId = requireSessionOxyUserId(req);
 
-      const application = await TenantApplication.findById(id);
-      if (!application) return next(new AppError('Application not found', 404, 'NOT_FOUND'));
+      const db = getDb();
+      const existing = await findApplicationById(db, id);
+      if (!existing) return next(new AppError('Application not found', 404, 'NOT_FOUND'));
 
-      const isApplicant = application.applicantOxyUserId === oxyUserId;
-      const isLandlord = application.landlordOxyUserId === oxyUserId;
+      const isApplicant = existing.application.applicantOxyUserId === oxyUserId;
+      const isLandlord = existing.application.landlordOxyUserId === oxyUserId;
       if (!isApplicant && !isLandlord) {
         return next(new AppError('Not authorized to update this application', 403, 'FORBIDDEN'));
       }
 
-      const landlordTransitions = new Set([
+      if (!isApplicationStatus(nextStatus)) {
+        return next(new AppError('Unsupported status transition', 400, 'INVALID_STATE'));
+      }
+
+      const landlordTransitions = new Set<TenantApplicationStatusValue>([
         TenantApplicationStatus.REVIEWING,
         TenantApplicationStatus.APPROVED,
         TenantApplicationStatus.REJECTED
@@ -364,37 +416,45 @@ class ApplicationController {
 
       if (landlordTransitions.has(nextStatus)) {
         if (!isLandlord) return next(new AppError('Only the landlord can perform this transition', 403, 'FORBIDDEN'));
-        if (
-          application.status !== TenantApplicationStatus.SUBMITTED &&
-          application.status !== TenantApplicationStatus.REVIEWING
-        ) {
+        if (!ACTIVE_APPLICATION_STATUSES.includes(existing.application.status)) {
           return next(new AppError('Application is no longer pending review', 400, 'INVALID_STATE'));
         }
       } else if (nextStatus === TenantApplicationStatus.WITHDRAWN) {
         if (!isApplicant) return next(new AppError('Only the applicant can withdraw the application', 403, 'FORBIDDEN'));
-        if (
-          application.status !== TenantApplicationStatus.SUBMITTED &&
-          application.status !== TenantApplicationStatus.REVIEWING
-        ) {
+        if (!ACTIVE_APPLICATION_STATUSES.includes(existing.application.status)) {
           return next(new AppError('Application can no longer be withdrawn', 400, 'INVALID_STATE'));
         }
       } else {
         return next(new AppError('Unsupported status transition', 400, 'INVALID_STATE'));
       }
 
-      application.status = nextStatus;
-      if (typeof notes === 'string') application.notes = notes;
-      // decidedAt is stamped automatically by the pre-save hook in the schema.
-      await application.save();
+      // `decided_at` is stamped by the repository iff `nextStatus` is terminal —
+      // the `pre('save')` hook that used to do it was bypassed by every
+      // `findOneAndUpdate`, and `tenant_applications_decided_at_check` now makes
+      // the pair an equivalence the write cannot get wrong.
+      //
+      // The permitted FROM statuses are in the `UPDATE`'s own predicate, so two
+      // landlords deciding at once cannot both succeed; the read above chose the
+      // error message, this chooses whether the write happens.
+      const hydrated = await decideApplication(
+        db,
+        id,
+        nextStatus,
+        ACTIVE_APPLICATION_STATUSES,
+        { notes: typeof notes === 'string' ? notes : undefined },
+      );
+      if (!hydrated) {
+        return next(new AppError('Application is no longer pending review', 400, 'INVALID_STATE'));
+      }
 
       logger.info('Tenant application status updated', {
-        applicationId: String(application._id),
+        applicationId: hydrated.application.id,
         nextStatus,
         byLandlord: isLandlord,
         byApplicant: isApplicant
       });
 
-      res.json(successResponse(application.toJSON(), 'Application updated'));
+      res.json(successResponse(serializeApplication(hydrated), 'Application updated'));
     } catch (error) {
       next(error);
     }
@@ -414,8 +474,9 @@ class ApplicationController {
       const { id } = req.params;
       const oxyUserId = requireSessionOxyUserId(req);
 
-      const application = await TenantApplication.findById(id);
-      if (!application) return next(new AppError('Application not found', 404, 'NOT_FOUND'));
+      const hydratedApplication = await findApplicationById(getDb(), id);
+      if (!hydratedApplication) return next(new AppError('Application not found', 404, 'NOT_FOUND'));
+      const application = hydratedApplication.application;
 
       if (application.landlordOxyUserId !== oxyUserId) {
         return next(new AppError('Only the landlord can create a lease from this application', 403, 'FORBIDDEN'));
@@ -424,21 +485,20 @@ class ApplicationController {
         return next(new AppError('Application must be approved before creating a lease', 400, 'INVALID_STATE'));
       }
 
-      // The application is still a Mongo document and the LEASE is Postgres.
-      // Nothing here needs the two to commit together — the application is only
-      // READ, and the lease is a single write — so the split costs no atomicity.
-      // When applications move, only these two reads change.
+      // Both the application and the lease are Postgres now. The application is
+      // only READ here — the lease is the single write — so this needs no
+      // transaction spanning the two.
       const db = getDb();
       const property = await findPropertyLeaseBasis(db, String(application.propertyId));
       if (!property) return next(new AppError('Property not found', 404, 'NOT_FOUND'));
 
-      const existing = await findLeaseForTenant(
+      const existingLease = await findLeaseForTenant(
         db,
         String(application.propertyId),
         String(application.applicantOxyUserId),
         ACTIVE_LEASE_STATUSES,
       );
-      if (existing) {
+      if (existingLease) {
         return next(new AppError('A lease already exists for this tenant and property', 409, 'LEASE_ALREADY_EXISTS'));
       }
 
@@ -478,7 +538,7 @@ class ApplicationController {
       );
 
       logger.info('Lease draft created from application', {
-        applicationId: String(application._id),
+        applicationId: application.id,
         leaseId: hydrated.lease.id,
         landlordOxyUserId: oxyUserId
       });

--- a/packages/backend/controllers/viewingController.ts
+++ b/packages/backend/controllers/viewingController.ts
@@ -1,15 +1,75 @@
 /**
  * Viewing Controller
- * Handles viewing request lifecycle (create, list, approve, decline, cancel)
+ * Handles viewing request lifecycle (create, list, approve, decline, cancel).
+ *
+ * Persisted in PostgreSQL (`db/schema/bookings.ts`, read and written through
+ * `db/bookings/viewingReads.ts`).
+ *
+ * ## What the port changed
+ *
+ * **`cancelledBy` and `status` move in one statement.**
+ * `viewing_requests_cancelled_by_status_check` makes them an equivalence, so a
+ * cancellation that failed to record WHO cancelled is now a `23514` rather than
+ * a row nobody can attribute. The repository is the only writer of either.
+ *
+ * **Every transition carries its precondition in the `UPDATE`'s predicate.**
+ * The Mongoose version read the document, checked `status === 'pending'` in JS,
+ * assigned and saved — a window in which two owners could both approve. The
+ * read is still there, because it is what decides WHICH error the caller sees
+ * (404 vs 403 vs 400), but the write no longer trusts it.
+ *
+ * **The property read is a narrow projection**
+ * (`db/properties/propertyBookingBasis.ts`): the questions are "is this
+ * bookable?" and "who owns it?", and a viewing request is not a listing page.
  */
 
 import type { Request, Response, NextFunction } from 'express';
 
-import { Property, ViewingRequest } from '../models';
 import { PropertyStatus } from '@homiio/shared-types';
+import { getDb } from '../db/postgres';
+import {
+  cancelViewing,
+  createViewing,
+  decideViewing,
+  findActiveViewingForRequester,
+  findViewingAtInstant,
+  findViewingById,
+  isViewingStatus,
+  listViewings,
+  rescheduleViewing,
+  serializeViewing,
+} from '../db/bookings/viewingReads';
+import { findPropertyBookingBasis } from '../db/properties/propertyBookingBasis';
 import { logger } from '../middlewares/logging';
 import { AppError, successResponse, paginationResponse } from '../middlewares/errorHandler';
 import { notificationDispatchService } from '../services/notificationDispatchService';
+
+/** Resolve the caller from the session, in the shape the auth layer sets. */
+function callerOf(req: Request): string | undefined {
+  return req.user?.id || req.user?._id || req.userId || undefined;
+}
+
+function parsePagination(query: Request['query']): { page: number; limit: number; skip: number } {
+  const page = parseInt(String(query.page ?? ''), 10) || 1;
+  const limit = parseInt(String(query.limit ?? ''), 10) || 10;
+  return { page, limit, skip: (page - 1) * limit };
+}
+
+/**
+ * Build the scheduled instant from a `YYYY-MM-DD` date and an `HH:mm` time.
+ *
+ * `new Date('2026-01-01T10:00')` — no zone suffix — is parsed in the SERVER's
+ * local zone. That is what the Mongoose handler did and it is preserved, which
+ * is the opposite call to the lease payment schedule and deliberately so: there,
+ * the zone silently changed a COMPUTED series of instalments; here it fixes one
+ * instant a human picked, nothing is derived from it, and re-anchoring it to UTC
+ * would move every appointment by the server's offset.
+ */
+function toScheduledAt(date: unknown, time: unknown): Date | undefined {
+  if (typeof date !== 'string' || typeof time !== 'string') return undefined;
+  const parsed = new Date(`${date}T${time}`);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
 
 class ViewingController {
   /**
@@ -20,70 +80,59 @@ class ViewingController {
       const { propertyId } = req.params;
       const { date, time, message } = req.body;
 
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
+      const oxyUserId = callerOf(req);
       if (!oxyUserId) {
         return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
       }
 
-      const property = await Property.findById(propertyId).lean();
+      const db = getDb();
+      const property = await findPropertyBookingBasis(db, propertyId);
       if (!property) return next(new AppError('Property not found', 404, 'NOT_FOUND'));
       if (property.status !== PropertyStatus.PUBLISHED) return next(new AppError('Property is not active', 400, 'PROPERTY_INACTIVE'));
       if (property.isExternal) return next(new AppError('Cannot book viewings for external properties', 400, 'EXTERNAL_PROPERTY'));
+
       const requesterOxyUserId = oxyUserId;
-const ownerOxyUserId = property.oxyUserId;
+      const ownerOxyUserId = property.oxyUserId;
       if (!ownerOxyUserId) return next(new AppError('Property has no owner', 400, 'INVALID_PROPERTY'));
 
       // Prevent booking own property
       if (ownerOxyUserId === oxyUserId) {
         return next(new AppError('You cannot book a viewing for your own property', 403, 'FORBIDDEN'));
       }
-// Build scheduledAt from date (YYYY-MM-DD) and time (HH:mm)
-      // Create date in local timezone first
-      const localDate = new Date(`${date}T${time}`);
-      // Convert to UTC ISO string
-      const scheduledAtString = localDate.toISOString();
-      const scheduledAt = new Date(scheduledAtString);
-      if (Number.isNaN(scheduledAt.getTime())) {
+
+      const scheduledAt = toScheduledAt(date, time);
+      if (!scheduledAt) {
         return next(new AppError('Invalid date or time', 400, 'INVALID_DATETIME'));
       }
-
-      const now = new Date();
-      if (scheduledAt.getTime() <= now.getTime()) {
+      if (scheduledAt.getTime() <= Date.now()) {
         return next(new AppError('Scheduled time must be in the future', 400, 'TIME_IN_PAST'));
       }
 
-      // Prevent multiple active (pending/approved) viewing requests for the same property by the same profile
-      const existingActiveForProfile = await ViewingRequest.findOne({
+      // One active request per person per property.
+      const existingActiveForProfile = await findActiveViewingForRequester(
+        db,
         propertyId,
         requesterOxyUserId,
-        status: { $in: ['pending', 'approved'] },
-      }).lean();
-
+      );
       if (existingActiveForProfile) {
         return next(new AppError('You already have an active viewing request for this property', 409, 'ALREADY_REQUESTED'));
       }
 
-      // Check for conflicts for the same property/time with non-cancelled/declined status
-      const conflict = await ViewingRequest.findOne({
-        propertyId,
-        scheduledAt,
-        status: { $in: ['pending', 'approved'] },
-      }).lean();
-
+      // One active request per property per instant.
+      const conflict = await findViewingAtInstant(db, propertyId, scheduledAt);
       if (conflict) {
         return next(new AppError('Time slot is no longer available', 409, 'TIME_CONFLICT'));
       }
 
-      const viewing = await ViewingRequest.create({
+      const viewing = await createViewing(db, {
         propertyId,
         requesterOxyUserId,
         ownerOxyUserId,
         scheduledAt,
-        message,
-        status: 'pending',
+        message: typeof message === 'string' ? message : undefined,
       });
 
-      logger.info('Viewing request created', { viewingId: viewing._id, propertyId, requesterOxyUserId, ownerOxyUserId });
+      logger.info('Viewing request created', { viewingId: viewing.id, propertyId, requesterOxyUserId, ownerOxyUserId });
 
       // Notify the property owner that someone requested a viewing.
       await notificationDispatchService.createForUser(ownerOxyUserId, {
@@ -91,10 +140,10 @@ const ownerOxyUserId = property.oxyUserId;
         title: 'New viewing request',
         message: 'Someone requested a viewing for your property.',
         priority: 'high',
-        data: { viewingId: viewing._id.toString(), propertyId: String(propertyId), screen: '/viewings' },
+        data: { viewingId: viewing.id, propertyId, screen: '/viewings' },
       });
 
-      res.status(201).json(successResponse(viewing.toJSON(), 'Viewing request created'));
+      res.status(201).json(successResponse(serializeViewing(viewing), 'Viewing request created'));
     } catch (error) {
       next(error);
     }
@@ -105,27 +154,22 @@ const ownerOxyUserId = property.oxyUserId;
    */
   async listMyViewingRequests(req: Request, res: Response, next: NextFunction): Promise<void | Response> {
     try {
-      const { page = 1, limit = 10, status } = req.query;
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
+      const oxyUserId = callerOf(req);
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      const query: Record<string, unknown> = { requesterOxyUserId: oxyUserId };
-      if (status) query.status = status;
+      const { status } = req.query;
+      const { page, limit, skip } = parsePagination(req.query);
 
-      const pageNumber = parseInt(String(page), 10) || 1;
-      const limitNumber = parseInt(String(limit), 10) || 10;
-      const skip = (pageNumber - 1) * limitNumber;
+      const result = await listViewings(
+        getDb(),
+        {
+          requesterOxyUserId: oxyUserId,
+          status: isViewingStatus(status) ? status : undefined,
+        },
+        { limit, offset: skip },
+      );
 
-      const [items, total] = await Promise.all([
-        ViewingRequest.find(query)
-          .sort({ scheduledAt: 1 })
-          .skip(skip)
-          .limit(limitNumber)
-          .lean(),
-        ViewingRequest.countDocuments(query),
-      ]);
-
-      res.json(paginationResponse(items, pageNumber, limitNumber, total, 'Viewing requests retrieved'));
+      res.json(paginationResponse(result.rows.map(serializeViewing), page, limit, result.total, 'Viewing requests retrieved'));
     } catch (error) {
       next(error);
     }
@@ -139,35 +183,31 @@ const ownerOxyUserId = property.oxyUserId;
   async listPropertyViewingRequests(req: Request, res: Response, next: NextFunction): Promise<void | Response> {
     try {
       const { propertyId } = req.params;
-      const { page = 1, limit = 10, status } = req.query;
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
+      const oxyUserId = callerOf(req);
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      const property = await Property.findById(propertyId).lean();
+      const db = getDb();
+      const property = await findPropertyBookingBasis(db, propertyId);
       if (!property) return next(new AppError('Property not found', 404, 'NOT_FOUND'));
 
       const isOwner = property.oxyUserId === oxyUserId;
+      const { status } = req.query;
+      const { page, limit, skip } = parsePagination(req.query);
 
-      const query: Record<string, unknown> = { propertyId };
-      if (!isOwner) {
-        query.requesterOxyUserId = oxyUserId;
-      }
-      if (status) query.status = status;
+      const result = await listViewings(
+        db,
+        {
+          propertyId,
+          // A non-owner sees only their own requests — the scope IS the
+          // authorisation, so it belongs in the predicate rather than in a
+          // filter applied to the results.
+          requesterOxyUserId: isOwner ? undefined : oxyUserId,
+          status: isViewingStatus(status) ? status : undefined,
+        },
+        { limit, offset: skip },
+      );
 
-      const pageNumber = parseInt(String(page), 10) || 1;
-      const limitNumber = parseInt(String(limit), 10) || 10;
-      const skip = (pageNumber - 1) * limitNumber;
-
-      const [items, total] = await Promise.all([
-        ViewingRequest.find(query)
-          .sort({ scheduledAt: 1 })
-          .skip(skip)
-          .limit(limitNumber)
-          .lean(),
-        ViewingRequest.countDocuments(query),
-      ]);
-
-      res.json(paginationResponse(items, pageNumber, limitNumber, total, 'Viewing requests retrieved'));
+      res.json(paginationResponse(result.rows.map(serializeViewing), page, limit, result.total, 'Viewing requests retrieved'));
     } catch (error) {
       next(error);
     }
@@ -177,45 +217,44 @@ const ownerOxyUserId = property.oxyUserId;
   async approveViewingRequest(req: Request, res: Response, next: NextFunction): Promise<void | Response> {
     try {
       const { viewingId } = req.params;
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
+      const oxyUserId = callerOf(req);
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      const viewing = await ViewingRequest.findById(viewingId);
+      const db = getDb();
+      const viewing = await findViewingById(db, viewingId);
       if (!viewing) return next(new AppError('Viewing request not found', 404, 'NOT_FOUND'));
 
-      if (String(viewing.ownerOxyUserId) !== String(oxyUserId)) {
+      if (viewing.ownerOxyUserId !== oxyUserId) {
         return next(new AppError('Only the property owner can approve', 403, 'FORBIDDEN'));
       }
       if (viewing.status !== 'pending') {
         return next(new AppError('Only pending requests can be approved', 400, 'INVALID_STATE'));
       }
 
-      // Ensure no other approved request exists for same property/time
-      const conflict = await ViewingRequest.findOne({
-        _id: { $ne: viewing._id },
-        propertyId: viewing.propertyId,
-        scheduledAt: viewing.scheduledAt,
-        status: 'approved',
-      }).lean();
+      // No OTHER approved request may already hold this instant.
+      const conflict = await findViewingAtInstant(db, viewing.propertyId, viewing.scheduledAt, {
+        excludeId: viewing.id,
+        statuses: ['approved'],
+      });
       if (conflict) return next(new AppError('Time slot already approved for another request', 409, 'TIME_CONFLICT'));
 
-      viewing.status = 'approved';
-      await viewing.save();
+      const approved = await decideViewing(db, viewingId, oxyUserId, 'approved');
+      if (!approved) return next(new AppError('Only pending requests can be approved', 400, 'INVALID_STATE'));
 
       // Notify the requester that their viewing was approved.
-      await notificationDispatchService.createForUser(String(viewing.requesterOxyUserId), {
+      await notificationDispatchService.createForUser(approved.requesterOxyUserId, {
         type: 'property',
         title: 'Viewing approved',
         message: 'Your viewing request was approved.',
         priority: 'high',
         data: {
-          viewingId: viewing._id.toString(),
-          propertyId: String(viewing.propertyId),
+          viewingId: approved.id,
+          propertyId: approved.propertyId,
           screen: '/viewings',
         },
       });
 
-      res.json(successResponse(viewing.toJSON(), 'Viewing request approved'));
+      res.json(successResponse(serializeViewing(approved), 'Viewing request approved'));
     } catch (error) {
       next(error);
     }
@@ -225,36 +264,37 @@ const ownerOxyUserId = property.oxyUserId;
   async declineViewingRequest(req: Request, res: Response, next: NextFunction): Promise<void | Response> {
     try {
       const { viewingId } = req.params;
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
+      const oxyUserId = callerOf(req);
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      const viewing = await ViewingRequest.findById(viewingId);
+      const db = getDb();
+      const viewing = await findViewingById(db, viewingId);
       if (!viewing) return next(new AppError('Viewing request not found', 404, 'NOT_FOUND'));
 
-      if (String(viewing.ownerOxyUserId) !== String(oxyUserId)) {
+      if (viewing.ownerOxyUserId !== oxyUserId) {
         return next(new AppError('Only the property owner can decline', 403, 'FORBIDDEN'));
       }
       if (viewing.status !== 'pending') {
         return next(new AppError('Only pending requests can be declined', 400, 'INVALID_STATE'));
       }
 
-      viewing.status = 'declined';
-      await viewing.save();
+      const declined = await decideViewing(db, viewingId, oxyUserId, 'declined');
+      if (!declined) return next(new AppError('Only pending requests can be declined', 400, 'INVALID_STATE'));
 
       // Notify the requester that their viewing was declined.
-      await notificationDispatchService.createForUser(String(viewing.requesterOxyUserId), {
+      await notificationDispatchService.createForUser(declined.requesterOxyUserId, {
         type: 'property',
         title: 'Viewing declined',
         message: 'Your viewing request was declined.',
         priority: 'medium',
         data: {
-          viewingId: viewing._id.toString(),
-          propertyId: String(viewing.propertyId),
+          viewingId: declined.id,
+          propertyId: declined.propertyId,
           screen: '/viewings',
         },
       });
 
-      res.json(successResponse(viewing.toJSON(), 'Viewing request declined'));
+      res.json(successResponse(serializeViewing(declined), 'Viewing request declined'));
     } catch (error) {
       next(error);
     }
@@ -264,29 +304,36 @@ const ownerOxyUserId = property.oxyUserId;
   async cancelViewingRequest(req: Request, res: Response, next: NextFunction): Promise<void | Response> {
     try {
       const { viewingId } = req.params;
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
+      const oxyUserId = callerOf(req);
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      const viewing = await ViewingRequest.findById(viewingId);
+      const db = getDb();
+      const viewing = await findViewingById(db, viewingId);
       if (!viewing) return next(new AppError('Viewing request not found', 404, 'NOT_FOUND'));
 
-      const isRequester = String(viewing.requesterOxyUserId) === String(oxyUserId);
-      const isOwner = String(viewing.ownerOxyUserId) === String(oxyUserId);
+      const isRequester = viewing.requesterOxyUserId === oxyUserId;
+      const isOwner = viewing.ownerOxyUserId === oxyUserId;
       if (!isRequester && !isOwner) return next(new AppError('Not authorized to cancel this request', 403, 'FORBIDDEN'));
 
       if (viewing.status === 'cancelled') {
-        return res.json(successResponse(viewing.toJSON(), 'Viewing request already cancelled'));
+        return res.json(successResponse(serializeViewing(viewing), 'Viewing request already cancelled'));
       }
 
-      viewing.status = 'cancelled';
-      viewing.cancelledBy = isOwner ? 'owner' : 'requester';
-      await viewing.save();
+      // Both columns in one statement — the CHECK is an equivalence.
+      const cancelled = await cancelViewing(db, viewingId, isOwner ? 'owner' : 'requester');
+      if (!cancelled) {
+        // Somebody else cancelled between the read and the write; the outcome
+        // the caller asked for already holds, so this is not an error.
+        const current = await findViewingById(db, viewingId);
+        if (!current) return next(new AppError('Viewing request not found', 404, 'NOT_FOUND'));
+        return res.json(successResponse(serializeViewing(current), 'Viewing request already cancelled'));
+      }
 
       // Notify the counterparty that the viewing was cancelled.
-      const cancelRecipientProfileId = isOwner
-        ? String(viewing.requesterOxyUserId)
-        : String(viewing.ownerOxyUserId);
-      await notificationDispatchService.createForUser(cancelRecipientProfileId, {
+      const cancelRecipientOxyUserId = isOwner
+        ? cancelled.requesterOxyUserId
+        : cancelled.ownerOxyUserId;
+      await notificationDispatchService.createForUser(cancelRecipientOxyUserId, {
         type: 'property',
         title: 'Viewing cancelled',
         message: isOwner
@@ -294,13 +341,13 @@ const ownerOxyUserId = property.oxyUserId;
           : 'A viewing request for your property was cancelled.',
         priority: 'medium',
         data: {
-          viewingId: viewing._id.toString(),
-          propertyId: String(viewing.propertyId),
+          viewingId: cancelled.id,
+          propertyId: cancelled.propertyId,
           screen: '/viewings',
         },
       });
 
-      res.json(successResponse(viewing.toJSON(), 'Viewing request cancelled'));
+      res.json(successResponse(serializeViewing(cancelled), 'Viewing request cancelled'));
     } catch (error) {
       next(error);
     }
@@ -311,13 +358,14 @@ const ownerOxyUserId = property.oxyUserId;
     try {
       const { viewingId } = req.params;
       const { date, time, message } = req.body;
-      const oxyUserId = req.user?.id || req.user?._id || req.userId;
-      
+      const oxyUserId = callerOf(req);
+
       if (!oxyUserId) {
         return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
       }
 
-      const viewing = await ViewingRequest.findById(viewingId);
+      const db = getDb();
+      const viewing = await findViewingById(db, viewingId);
       if (!viewing) return next(new AppError('Viewing request not found', 404, 'NOT_FOUND'));
 
       // Only allow updating pending requests
@@ -325,47 +373,34 @@ const ownerOxyUserId = property.oxyUserId;
         return next(new AppError('Can only modify pending viewing requests', 400, 'CANNOT_MODIFY'));
       }
 
-      // Get active profile for requester
       // Only allow requester to modify
-      const isRequester = String(viewing.requesterOxyUserId) === String(oxyUserId);
-      if (!isRequester) {
+      if (viewing.requesterOxyUserId !== oxyUserId) {
         return next(new AppError('Not authorized to modify this viewing request', 403, 'FORBIDDEN'));
       }
 
-      // Build scheduledAt from date (YYYY-MM-DD) and time (HH:mm)
-      // Create date in local timezone first
-      const localDate = new Date(`${date}T${time}`);
-      // Convert to UTC ISO string
-      const scheduledAtString = localDate.toISOString();
-      const scheduledAt = new Date(scheduledAtString);
-      if (Number.isNaN(scheduledAt.getTime())) {
+      const scheduledAt = toScheduledAt(date, time);
+      if (!scheduledAt) {
         return next(new AppError('Invalid date or time', 400, 'INVALID_DATETIME'));
       }
-
-      const now = new Date();
-      if (scheduledAt.getTime() <= now.getTime()) {
+      if (scheduledAt.getTime() <= Date.now()) {
         return next(new AppError('Scheduled time must be in the future', 400, 'TIME_IN_PAST'));
       }
 
-      // Check for conflicts for the same property/time with non-cancelled/declined status, excluding this request
-      const conflict = await ViewingRequest.findOne({
-        _id: { $ne: viewingId }, // Exclude this request
-        propertyId: viewing.propertyId,
-        scheduledAt,
-        status: { $in: ['pending', 'approved'] },
-      }).lean();
-
+      const conflict = await findViewingAtInstant(db, viewing.propertyId, scheduledAt, {
+        excludeId: viewingId,
+      });
       if (conflict) {
         return next(new AppError('Time slot is no longer available', 409, 'TIME_CONFLICT'));
       }
 
-      // Update the viewing request
-      viewing.scheduledAt = scheduledAt;
-      if (message !== undefined) viewing.message = message;
-      await viewing.save();
+      const updated = await rescheduleViewing(db, viewingId, oxyUserId, {
+        scheduledAt,
+        message: typeof message === 'string' ? message : undefined,
+      });
+      if (!updated) return next(new AppError('Can only modify pending viewing requests', 400, 'CANNOT_MODIFY'));
 
       logger.info('Viewing request updated', { viewingId, scheduledAt });
-      res.json(successResponse(viewing.toJSON(), 'Viewing request updated'));
+      res.json(successResponse(serializeViewing(updated), 'Viewing request updated'));
     } catch (error) {
       next(error);
     }
@@ -373,5 +408,3 @@ const ownerOxyUserId = property.oxyUserId;
 }
 
 export default new ViewingController();
-
-

--- a/packages/backend/db/applications/applicationReads.ts
+++ b/packages/backend/db/applications/applicationReads.ts
@@ -1,0 +1,314 @@
+/**
+ * `tenant_applications` and its two child tables — the long-term rent
+ * application, on Postgres.
+ *
+ * Empty in production, so this port has no backfill and no consistency window.
+ *
+ * ## `decided_at` was a HOOK and is now an EQUIVALENCE
+ *
+ * `TenantApplication.pre('save')` stamped `decidedAt` on the first move into a
+ * terminal status — and it is a SAVE hook, so `findOneAndUpdate` bypassed it
+ * entirely. That is how a `rejected` application with no `decided_at` reached a
+ * landlord's dashboard sorted as if it were still open.
+ *
+ * `tenant_applications_decided_at_check` now states
+ * `(status in terminal) = (decided_at is not null)`, so {@link decideApplication}
+ * has to write both together — and CANNOT write a stamp for `reviewing`, which
+ * the hook would happily have left behind on a later transition back. The
+ * terminal set is `TENANT_APPLICATION_TERMINAL_STATUSES`, declared in the schema
+ * precisely so the constraint and the writer name the same list.
+ *
+ * ## The children are inserted with the parent, in one transaction
+ *
+ * `reference_contacts[]` and `documents[]` were `{ _id: false }` subdocuments —
+ * they had no ids and the backfill mints them (`db/MIGRATION-CONTRACT.md`). An
+ * application that committed without its references is one a landlord judges on
+ * incomplete information, so they are not a follow-up write.
+ */
+
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+import type { DatabaseOrTransaction } from '../postgres';
+import {
+  tenantApplicationDocuments,
+  tenantApplicationReferences,
+  tenantApplications,
+} from '../schema';
+import {
+  TENANT_APPLICATION_STATUSES,
+  TENANT_APPLICATION_TERMINAL_STATUSES,
+} from '../schema/applications';
+
+/** An application status the CHECK accepts. */
+export type TenantApplicationStatusValue = (typeof TENANT_APPLICATION_STATUSES)[number];
+
+export type ApplicationRow = typeof tenantApplications.$inferSelect;
+export type ApplicationReferenceRow = typeof tenantApplicationReferences.$inferSelect;
+export type ApplicationDocumentRow = typeof tenantApplicationDocuments.$inferSelect;
+
+/** The statuses an application can still be acted on from. */
+export const ACTIVE_APPLICATION_STATUSES: readonly TenantApplicationStatusValue[] = [
+  'submitted',
+  'reviewing',
+];
+
+/** Whether `value` is one of the five declared statuses. */
+export function isApplicationStatus(value: unknown): value is TenantApplicationStatusValue {
+  return (
+    typeof value === 'string' &&
+    (TENANT_APPLICATION_STATUSES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Whether a status is one the CHECK requires a `decided_at` for.
+ *
+ * Reads the schema's own tuple rather than restating the three values, so the
+ * writer and `tenant_applications_decided_at_check` cannot drift.
+ */
+export function isTerminalApplicationStatus(status: TenantApplicationStatusValue): boolean {
+  return (TENANT_APPLICATION_TERMINAL_STATUSES as readonly string[]).includes(status);
+}
+
+/** One application plus the children a response carries. */
+export interface HydratedApplication {
+  application: ApplicationRow;
+  references: readonly ApplicationReferenceRow[];
+  documents: readonly ApplicationDocumentRow[];
+}
+
+/** Attach the children of `rows`, preserving the query's ordering. */
+async function hydrate(
+  db: DatabaseOrTransaction,
+  rows: readonly ApplicationRow[],
+): Promise<HydratedApplication[]> {
+  const ids = rows.map((row) => row.id);
+  if (ids.length === 0) return [];
+
+  const [references, documents] = await Promise.all([
+    db
+      .select()
+      .from(tenantApplicationReferences)
+      .where(inArray(tenantApplicationReferences.applicationId, ids)),
+    db
+      .select()
+      .from(tenantApplicationDocuments)
+      .where(inArray(tenantApplicationDocuments.applicationId, ids)),
+  ]);
+
+  const group = <T extends { applicationId: string }>(child: readonly T[]): Map<string, T[]> => {
+    const grouped = new Map<string, T[]>();
+    for (const row of child) {
+      const existing = grouped.get(row.applicationId);
+      if (existing) existing.push(row);
+      else grouped.set(row.applicationId, [row]);
+    }
+    return grouped;
+  };
+
+  const referencesByApplication = group(references);
+  const documentsByApplication = group(documents);
+
+  return rows.map((application) => ({
+    application,
+    references: referencesByApplication.get(application.id) ?? [],
+    documents: documentsByApplication.get(application.id) ?? [],
+  }));
+}
+
+/** One application, hydrated. No ownership predicate — the caller decides. */
+export async function findApplicationById(
+  db: DatabaseOrTransaction,
+  id: string,
+): Promise<HydratedApplication | undefined> {
+  const [row] = await db
+    .select()
+    .from(tenantApplications)
+    .where(eq(tenantApplications.id, id))
+    .limit(1);
+  if (!row) return undefined;
+  const [hydrated] = await hydrate(db, [row]);
+  return hydrated;
+}
+
+/** Does this applicant already hold an active application on this property? */
+export async function findActiveApplicationForApplicant(
+  db: DatabaseOrTransaction,
+  propertyId: string,
+  applicantOxyUserId: string,
+): Promise<ApplicationRow | undefined> {
+  const [row] = await db
+    .select()
+    .from(tenantApplications)
+    .where(
+      and(
+        eq(tenantApplications.propertyId, propertyId),
+        eq(tenantApplications.applicantOxyUserId, applicantOxyUserId),
+        inArray(tenantApplications.status, [...ACTIVE_APPLICATION_STATUSES]),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+export interface CreateApplicationInput {
+  readonly columns: typeof tenantApplications.$inferInsert;
+  readonly references: readonly Omit<
+    typeof tenantApplicationReferences.$inferInsert,
+    'id' | 'applicationId'
+  >[];
+  readonly documents: readonly Omit<
+    typeof tenantApplicationDocuments.$inferInsert,
+    'id' | 'applicationId'
+  >[];
+}
+
+/** Insert an application with its references and documents, in one transaction. */
+export async function createApplication(
+  db: DatabaseOrTransaction,
+  input: CreateApplicationInput,
+): Promise<HydratedApplication> {
+  const [row] = await db.insert(tenantApplications).values(input.columns).returning();
+
+  if (input.references.length > 0) {
+    await db
+      .insert(tenantApplicationReferences)
+      .values(input.references.map((reference) => ({ ...reference, applicationId: row.id })));
+  }
+  if (input.documents.length > 0) {
+    await db
+      .insert(tenantApplicationDocuments)
+      .values(input.documents.map((document) => ({ ...document, applicationId: row.id })));
+  }
+
+  const [hydrated] = await hydrate(db, [row]);
+  return hydrated;
+}
+
+export interface ListApplicationsFilter {
+  readonly applicantOxyUserId?: string;
+  readonly landlordOxyUserId?: string;
+  readonly status?: TenantApplicationStatusValue;
+}
+
+/** The predicate shared by the page and its `count(*)`, so the two agree. */
+function listFilter(filter: ListApplicationsFilter): SQL {
+  const clauses: SQL[] = [];
+  if (filter.applicantOxyUserId !== undefined) {
+    clauses.push(eq(tenantApplications.applicantOxyUserId, filter.applicantOxyUserId));
+  }
+  if (filter.landlordOxyUserId !== undefined) {
+    clauses.push(eq(tenantApplications.landlordOxyUserId, filter.landlordOxyUserId));
+  }
+  if (filter.status !== undefined) clauses.push(eq(tenantApplications.status, filter.status));
+  return clauses.length > 0 ? (and(...clauses) as SQL) : sql`true`;
+}
+
+export interface ListApplicationsResult {
+  readonly applications: readonly HydratedApplication[];
+  readonly total: number;
+}
+
+/** One page of applications, newest submission first. */
+export async function listApplications(
+  db: DatabaseOrTransaction,
+  filter: ListApplicationsFilter,
+  page: { readonly limit: number; readonly offset: number },
+): Promise<ListApplicationsResult> {
+  const where = listFilter(filter);
+  const [rows, [totalRow]] = await Promise.all([
+    db
+      .select()
+      .from(tenantApplications)
+      .where(where)
+      .orderBy(desc(tenantApplications.submittedAt))
+      .limit(page.limit)
+      .offset(page.offset),
+    db
+      .select({ value: sql<number>`count(*)::int` })
+      .from(tenantApplications)
+      .where(where),
+  ]);
+  return { applications: await hydrate(db, rows), total: totalRow.value };
+}
+
+/**
+ * Move an application to `nextStatus`, stamping `decided_at` iff that status is
+ * terminal.
+ *
+ * `fromStatuses` is the precondition, carried in the `UPDATE`'s own predicate so
+ * two landlords cannot both decide — the read that precedes this in the
+ * controller chooses the ERROR, this chooses whether the write happens.
+ *
+ * The `decided_at` value is written on the terminal transition and cleared
+ * otherwise, which is what the equivalence CHECK demands. Clearing matters: a
+ * `submitted → reviewing` move on a row that somehow carries a stamp would be a
+ * `23514` rather than a silent inconsistency.
+ */
+export async function decideApplication(
+  db: DatabaseOrTransaction,
+  id: string,
+  nextStatus: TenantApplicationStatusValue,
+  fromStatuses: readonly TenantApplicationStatusValue[],
+  options: { readonly notes?: string } = {},
+): Promise<HydratedApplication | undefined> {
+  const values: Partial<typeof tenantApplications.$inferInsert> = {
+    status: nextStatus,
+    decidedAt: isTerminalApplicationStatus(nextStatus) ? new Date() : null,
+  };
+  if (options.notes !== undefined) values.notes = options.notes;
+
+  const [row] = await db
+    .update(tenantApplications)
+    .set(values)
+    .where(
+      and(
+        eq(tenantApplications.id, id),
+        inArray(tenantApplications.status, [...fromStatuses]),
+      ),
+    )
+    .returning();
+  if (!row) return undefined;
+  const [hydrated] = await hydrate(db, [row]);
+  return hydrated;
+}
+
+/**
+ * The wire shape the applications screens read.
+ *
+ * The Mongoose handlers returned `application.toJSON()` — every field, with the
+ * two arrays inline — so this rebuilds that shape from the child tables. `id`,
+ * never `_id`.
+ */
+export function serializeApplication(hydrated: HydratedApplication): Record<string, unknown> {
+  const row = hydrated.application;
+  return {
+    id: row.id,
+    propertyId: row.propertyId,
+    applicantOxyUserId: row.applicantOxyUserId,
+    landlordOxyUserId: row.landlordOxyUserId,
+    moveInDate: row.moveInDate,
+    leaseTermMonths: row.leaseTermMonths,
+    monthlyIncome: row.monthlyIncome,
+    employmentStatus: row.employmentStatus,
+    status: row.status,
+    notes: row.notes,
+    submittedAt: row.submittedAt,
+    decidedAt: row.decidedAt,
+    referenceContacts: hydrated.references.map((reference) => ({
+      id: reference.id,
+      name: reference.name,
+      relationship: reference.relationship,
+      phone: reference.phone,
+      email: reference.email,
+    })),
+    documents: hydrated.documents.map((document) => ({
+      id: document.id,
+      type: document.type,
+      url: document.url,
+      filename: document.filename,
+    })),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/packages/backend/db/bookings/viewingReads.ts
+++ b/packages/backend/db/bookings/viewingReads.ts
@@ -1,0 +1,292 @@
+/**
+ * `viewing_requests` — the in-person tour, on Postgres.
+ *
+ * Empty in production, so this port has no backfill and no consistency window.
+ *
+ * ## `cancelled_by` is now an EQUIVALENCE, and it is the database's
+ *
+ * `viewing_requests_cancelled_by_status_check` states
+ * `(status = 'cancelled') = (cancelled_by is not null)`. Mongo allowed a
+ * `pending` request to name a canceller and — the damaging half — a `cancelled`
+ * one to name nobody, which is a cancellation neither party can be shown to have
+ * made. {@link cancelViewing} therefore writes both columns in ONE statement, and
+ * {@link approveViewing} / {@link declineViewing} cannot reach a state where one
+ * is set without the other.
+ *
+ * ## Two conflict rules, and why neither is a unique index
+ *
+ * "One active request per person per property" and "one active request per
+ * property per instant" are both scoped to the ACTIVE statuses
+ * (`pending`, `approved`), and Postgres has no partial unique index over a
+ * status SET that also permits the historical rows — a declined request and a
+ * cancelled one must not block a re-request. They stay reads, and the
+ * `viewing_requests_property_scheduled_status_idx` compound is what serves them.
+ *
+ * That is a genuine difference from `roommate_requests`, where the active set is
+ * the single value `pending` and the rule IS an index. The distinction is the
+ * cardinality of the predicate, not a preference.
+ */
+
+import { and, asc, eq, inArray, ne, sql } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+import type { DatabaseOrTransaction } from '../postgres';
+import { viewingRequests } from '../schema';
+import {
+  VIEWING_REQUEST_CANCELLERS,
+  VIEWING_REQUEST_STATUSES,
+} from '../schema/bookings';
+
+/** A viewing status the CHECK accepts. */
+export type ViewingStatusValue = (typeof VIEWING_REQUEST_STATUSES)[number];
+
+/** Which side cancelled. */
+export type ViewingCancellerValue = (typeof VIEWING_REQUEST_CANCELLERS)[number];
+
+export type ViewingRow = typeof viewingRequests.$inferSelect;
+
+/**
+ * The statuses that occupy a slot.
+ *
+ * Declared once because THREE reads share it — the per-person guard, the
+ * per-instant guard, and the approval re-check — and two of them disagreeing
+ * about what "active" means is how a double-booking arrives.
+ */
+export const ACTIVE_VIEWING_STATUSES: readonly ViewingStatusValue[] = ['pending', 'approved'];
+
+/** Whether `value` is one of the four declared statuses. */
+export function isViewingStatus(value: unknown): value is ViewingStatusValue {
+  return (
+    typeof value === 'string' && (VIEWING_REQUEST_STATUSES as readonly string[]).includes(value)
+  );
+}
+
+/** One viewing request by id. */
+export async function findViewingById(
+  db: DatabaseOrTransaction,
+  id: string,
+): Promise<ViewingRow | undefined> {
+  const [row] = await db
+    .select()
+    .from(viewingRequests)
+    .where(eq(viewingRequests.id, id))
+    .limit(1);
+  return row;
+}
+
+/** Does this person already hold an active request on this property? */
+export async function findActiveViewingForRequester(
+  db: DatabaseOrTransaction,
+  propertyId: string,
+  requesterOxyUserId: string,
+): Promise<ViewingRow | undefined> {
+  const [row] = await db
+    .select()
+    .from(viewingRequests)
+    .where(
+      and(
+        eq(viewingRequests.propertyId, propertyId),
+        eq(viewingRequests.requesterOxyUserId, requesterOxyUserId),
+        inArray(viewingRequests.status, [...ACTIVE_VIEWING_STATUSES]),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+/**
+ * Is this instant already taken on this property?
+ *
+ * @param excludeId A request to ignore — the one being rescheduled, or the one
+ *   being approved. Without it a request would conflict with itself.
+ */
+export async function findViewingAtInstant(
+  db: DatabaseOrTransaction,
+  propertyId: string,
+  scheduledAt: Date,
+  options: { readonly excludeId?: string; readonly statuses?: readonly ViewingStatusValue[] } = {},
+): Promise<ViewingRow | undefined> {
+  const clauses: SQL[] = [
+    eq(viewingRequests.propertyId, propertyId),
+    eq(viewingRequests.scheduledAt, scheduledAt),
+    inArray(viewingRequests.status, [...(options.statuses ?? ACTIVE_VIEWING_STATUSES)]),
+  ];
+  if (options.excludeId !== undefined) clauses.push(ne(viewingRequests.id, options.excludeId));
+
+  const [row] = await db
+    .select()
+    .from(viewingRequests)
+    .where(and(...clauses) as SQL)
+    .limit(1);
+  return row;
+}
+
+export interface CreateViewingInput {
+  readonly propertyId: string;
+  readonly requesterOxyUserId: string;
+  readonly ownerOxyUserId: string;
+  readonly scheduledAt: Date;
+  readonly message?: string;
+}
+
+/** Open a viewing request. Always `pending`, never from the body. */
+export async function createViewing(
+  db: DatabaseOrTransaction,
+  input: CreateViewingInput,
+): Promise<ViewingRow> {
+  const [row] = await db
+    .insert(viewingRequests)
+    .values({
+      propertyId: input.propertyId,
+      requesterOxyUserId: input.requesterOxyUserId,
+      ownerOxyUserId: input.ownerOxyUserId,
+      scheduledAt: input.scheduledAt,
+      message: input.message,
+      status: 'pending',
+    })
+    .returning();
+  return row;
+}
+
+export interface ListViewingsFilter {
+  readonly requesterOxyUserId?: string;
+  readonly propertyId?: string;
+  readonly status?: ViewingStatusValue;
+}
+
+/** The predicate shared by the page and its `count(*)`, so the two agree. */
+function listFilter(filter: ListViewingsFilter): SQL {
+  const clauses: SQL[] = [];
+  if (filter.requesterOxyUserId !== undefined) {
+    clauses.push(eq(viewingRequests.requesterOxyUserId, filter.requesterOxyUserId));
+  }
+  if (filter.propertyId !== undefined) {
+    clauses.push(eq(viewingRequests.propertyId, filter.propertyId));
+  }
+  if (filter.status !== undefined) clauses.push(eq(viewingRequests.status, filter.status));
+  // Every caller supplies at least one clause; `sql\`true\`` is the honest
+  // identity rather than a cast that pretends an empty `and` is an SQL.
+  return clauses.length > 0 ? (and(...clauses) as SQL) : sql`true`;
+}
+
+export interface ListViewingsResult {
+  readonly rows: readonly ViewingRow[];
+  readonly total: number;
+}
+
+/** One page of viewing requests, soonest first. */
+export async function listViewings(
+  db: DatabaseOrTransaction,
+  filter: ListViewingsFilter,
+  page: { readonly limit: number; readonly offset: number },
+): Promise<ListViewingsResult> {
+  const where = listFilter(filter);
+  const [rows, [totalRow]] = await Promise.all([
+    db
+      .select()
+      .from(viewingRequests)
+      .where(where)
+      .orderBy(asc(viewingRequests.scheduledAt))
+      .limit(page.limit)
+      .offset(page.offset),
+    db
+      .select({ value: sql<number>`count(*)::int` })
+      .from(viewingRequests)
+      .where(where),
+  ]);
+  return { rows, total: totalRow.value };
+}
+
+/**
+ * Move a PENDING request to `approved` or `declined`, owner-scoped.
+ *
+ * The owner and the `pending` status are both in the `UPDATE`'s predicate, so a
+ * second approval matches no row instead of re-running the transition — and two
+ * concurrent approvals cannot both succeed.
+ *
+ * `cancelled_by` is deliberately not written: it is NULL already, and the CHECK
+ * requires it to stay that way for any status but `cancelled`.
+ */
+export async function decideViewing(
+  db: DatabaseOrTransaction,
+  id: string,
+  ownerOxyUserId: string,
+  status: Extract<ViewingStatusValue, 'approved' | 'declined'>,
+): Promise<ViewingRow | undefined> {
+  const [row] = await db
+    .update(viewingRequests)
+    .set({ status })
+    .where(
+      and(
+        eq(viewingRequests.id, id),
+        eq(viewingRequests.ownerOxyUserId, ownerOxyUserId),
+        eq(viewingRequests.status, 'pending'),
+      ),
+    )
+    .returning();
+  return row;
+}
+
+/**
+ * Cancel a request, recording WHICH side did it.
+ *
+ * Both columns move in one statement — the CHECK is an equivalence, so writing
+ * the status alone is a `23514` and writing the canceller alone is one too.
+ */
+export async function cancelViewing(
+  db: DatabaseOrTransaction,
+  id: string,
+  cancelledBy: ViewingCancellerValue,
+): Promise<ViewingRow | undefined> {
+  const [row] = await db
+    .update(viewingRequests)
+    .set({ status: 'cancelled', cancelledBy })
+    .where(and(eq(viewingRequests.id, id), ne(viewingRequests.status, 'cancelled')))
+    .returning();
+  return row;
+}
+
+/** Reschedule a PENDING request, requester-scoped. */
+export async function rescheduleViewing(
+  db: DatabaseOrTransaction,
+  id: string,
+  requesterOxyUserId: string,
+  input: { readonly scheduledAt: Date; readonly message?: string },
+): Promise<ViewingRow | undefined> {
+  const values: Partial<typeof viewingRequests.$inferInsert> = { scheduledAt: input.scheduledAt };
+  if (input.message !== undefined) values.message = input.message;
+
+  const [row] = await db
+    .update(viewingRequests)
+    .set(values)
+    .where(
+      and(
+        eq(viewingRequests.id, id),
+        eq(viewingRequests.requesterOxyUserId, requesterOxyUserId),
+        eq(viewingRequests.status, 'pending'),
+      ),
+    )
+    .returning();
+  return row;
+}
+
+/**
+ * The wire shape the viewings screen reads.
+ *
+ * `id`, never `_id` — the wire contract is PR #287's clean cut. The Mongoose
+ * handlers returned `viewing.toJSON()`, i.e. every field, so this carries every
+ * column; there is nothing on this table that is not the requester's to see.
+ */
+export function serializeViewing(row: ViewingRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    propertyId: row.propertyId,
+    requesterOxyUserId: row.requesterOxyUserId,
+    ownerOxyUserId: row.ownerOxyUserId,
+    scheduledAt: row.scheduledAt,
+    message: row.message,
+    status: row.status,
+    cancelledBy: row.cancelledBy,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/packages/backend/db/properties/propertyBookingBasis.ts
+++ b/packages/backend/db/properties/propertyBookingBasis.ts
@@ -1,0 +1,77 @@
+/**
+ * The property columns every booking path asks about.
+ *
+ * `is this listing bookable at all?` (`status`, `is_external`, `offerings`) and
+ * `who owns it?` (`oxy_user_id`) — asked by `viewingController`,
+ * `applicationController` and `reservationController` before they will create
+ * anything.
+ *
+ * ## Why this is not `findPropertyById`
+ *
+ * `db/properties/propertyReads.ts` hydrates a listing with its address, geo
+ * names, photos, documents and calendar, because it exists to build a listing
+ * RESPONSE. A booking path builds no such response — it answers a yes/no and
+ * then writes its own row — so hydrating one would make every viewing request
+ * pay for a page render it discards.
+ *
+ * It is equally NOT a second serializer, which is the line that matters: nothing
+ * here reshapes a property for the wire, so
+ * `db/properties/propertySerializer.ts` stays the single authority on what a
+ * listing looks like to a client. A booking path that needs to SHOW a listing
+ * must go through that module, not widen this one.
+ *
+ * It lives under `db/properties/` rather than beside its callers because the
+ * columns are the property domain's, and one projection three controllers share
+ * is what stops three of them drifting on what "bookable" means.
+ */
+
+import { eq } from 'drizzle-orm';
+import type { DatabaseOrTransaction } from '../postgres';
+import { properties } from '../schema';
+
+/** The booking-relevant facts about a listing. */
+export interface PropertyBookingBasis {
+  readonly id: string;
+  /** `PropertyStatus`; a booking path compares it against `published`. */
+  readonly status: string;
+  /** External listings have no in-app apply, viewing or booking. */
+  readonly isExternal: boolean;
+  /**
+   * The owner, or NULL.
+   *
+   * Nullable because the `pre('save')` hook that sets `expires_at` on an
+   * external listing STRIPS the owner — so "external" and "ownerless" are
+   * closely related states, and a caller has to handle the null rather than
+   * assume a listing has somebody behind it.
+   */
+  readonly oxyUserId: string | null;
+  /**
+   * Which markets the listing is offered in (`long_term_rent`, …).
+   *
+   * `applicationController` refuses an application to a listing that is not
+   * offered for long-term rent, and `reservationController` asks the same
+   * question about short-term. The `properties_offerings_*` CHECKs make this
+   * exactly the set of present priced blocks, so it is a reliable answer rather
+   * than a hint.
+   */
+  readonly offerings: readonly string[];
+}
+
+/** The booking-relevant columns of one listing, or `undefined`. */
+export async function findPropertyBookingBasis(
+  db: DatabaseOrTransaction,
+  propertyId: string,
+): Promise<PropertyBookingBasis | undefined> {
+  const [row] = await db
+    .select({
+      id: properties.id,
+      status: properties.status,
+      isExternal: properties.isExternal,
+      oxyUserId: properties.oxyUserId,
+      offerings: properties.offerings,
+    })
+    .from(properties)
+    .where(eq(properties.id, propertyId))
+    .limit(1);
+  return row;
+}


### PR DESCRIPTION
Two more of the tenancy tables, both empty in production, both carrying a coherence CHECK the Mongoose hook could not enforce.

`db/bookings/viewingReads.ts` and `db/applications/applicationReads.ts`, plus `db/properties/propertyBookingBasis.ts` — **one** narrow projection (`status`, `is_external`, `oxy_user_id`, `offerings`) shared by every booking path, so three controllers cannot drift on what "bookable" means. It is deliberately **not** a second serializer: nothing in it reshapes a property for the wire, so `db/properties/propertySerializer.ts` stays the single authority on that, and a path that needs to *show* a listing must go through it.

## Two hooks became equivalences the database enforces

**`viewing_requests_cancelled_by_status_check`** — Mongo allowed a `pending` request to name a canceller and, worse, a `cancelled` one to name nobody, which is a cancellation neither party can be shown to have made. Both columns now move in one statement.

**`tenant_applications_decided_at_check`** — `pre('save')` stamped `decidedAt` on a terminal transition, and being a SAVE hook it was bypassed by every `findOneAndUpdate`. That is how a `rejected` application with no `decided_at` reached a landlord's dashboard sorted as if it were still open. The repository stamps **iff** the next status is terminal, reading the schema's own `TENANT_APPLICATION_TERMINAL_STATUSES` so the writer and the constraint cannot name different sets — and CLEARS it otherwise, which is what makes `reviewing` representable at all.

## Preconditions moved into the `UPDATE`

Every transition read the document, checked the status in JS, assigned and saved — a window two owners could both pass. The read stays, because it decides *which* error the caller sees (404 vs 403 vs 400); the write no longer trusts it.

## Vocabularies narrowed in the controller, not left to the CHECK

`referenceContacts[].relationship` was never validated on the way in — Mongoose's enum ran on `create`, and this port would otherwise have surfaced an undeclared value as a `23514`, i.e. a 500 where the caller earned a 400 naming the field. Same for the two document-type paths, which were already validated but untyped.

## A branch that is now UNREACHABLE, asserted rather than deleted

`createLeaseFromApplication`'s *"Property has no long-term rent price"* cannot be reached through a valid listing: the four `properties_offerings_*` CHECKs make `offerings` exactly the set of present priced blocks, so "offered for long-term rent" and "has a long-term rent amount" cannot disagree. The test asserts the **constraint** refuses that state. The guard stays because it is also what narrows `number | null` for the insert, and because relaxing the CHECK later would make it live again with nobody noticing.

`createLeaseFromApplication` also reads its application from Postgres now — the whole table has moved, so the Mongo read it carried since #303 would find nothing.

## Tests

**109 suites / 1352 tests → 111 / 1389**, green. CI floor 1310 → 1345.

Mutation-tested, restored in place, tree verified byte-clean afterwards:

| mutation | result |
|---|---|
| `decideApplication` always stamps `decided_at` | 1 red (the `reviewing` case) |
| `decideApplication` never stamps | 4 red |
| `cancelViewing` writes only the status | 2 red |

Both new suites carry an `afterAll` truncation for the geoBackfill collision documented in `leaseOwnership.test.ts`, and each geo chain takes a **distinct country code** — `countries_code_key` is UNIQUE, so two chains on the fixture's default `ES` collide, which several cases here need (a draft, an external and an owned listing; two properties for one slot).

Both conflict rules are asserted on what they **PERMIT** as well as what they refuse: a re-request after a decline, a re-application after a rejection, and the same instant on a different property. A rule scoped too widely passes every refusal test and eats exactly those.

## Still deferred

`reservations`, `exchange_requests` and `exchange_reviews` are the remainder of tenancy. `middlewares/validation.ts` still carries five `isMongoId()` sites (viewing ×2, review ×2, roommate request) that would 400 a uuid v7 — **none is wired to a route today**, so they are latent rather than live; `requireEntityId` is already there for whoever wires one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)