### PR TITLE
Saved properties, folders and recently-viewed on Postgres (#281)

### DIFF
--- a/packages/backend/__tests__/integration/recentlyViewed.test.ts
+++ b/packages/backend/__tests__/integration/recentlyViewed.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Recently-viewed listings — the unique key, the ordering, and the 90-day
+ * retention sweep that is the table's ONLY bound.
+ *
+ * The real handlers against the REAL Postgres this worker owns. The Mongo
+ * collection was empty in production because BOTH of its write paths were
+ * broken (see `db/saved/recentlyViewedRepository.ts`), so nothing here asserts a
+ * preserved row.
+ *
+ * ## The retention sweep is tested through `CleanupService`, not the repository
+ *
+ * This is the append-heavy table in the domain — it grows on READS rather than
+ * on deliberate user action — so the thing that actually has to hold is that the
+ * scheduled job still prunes it after the store changed underneath it.
+ * `cleanupOldData` is what cron calls; testing `pruneRecentlyViewedBefore`
+ * alone would pass just as happily with the service still wired to a Mongoose
+ * model that no longer receives any rows.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { eq } from 'drizzle-orm';
+
+import * as recentlyViewedController from '../../controllers/profile/recentlyViewed';
+import { getDb } from '../../db/postgres';
+import { properties as propertiesTable, recentlyViewed } from '../../db/schema';
+import { errorHandler } from '../../middlewares/errorHandler';
+import { CleanupService } from '../../services/cleanupService';
+import { resetGeoTables, seedListingWithGeo, seedProperty } from '../helpers/postgresGeoFixtures';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function buildApp(oxyUserId?: string): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (oxyUserId) {
+      (req as unknown as { user: { id: string } }).user = { id: oxyUserId };
+    }
+    next();
+  });
+  app.get('/recent-properties', (req, res, next) =>
+    recentlyViewedController.getRecentProperties(req, res, next),
+  );
+  app.post('/recent-properties/:propertyId', (req, res, next) =>
+    recentlyViewedController.trackPropertyView(req, res, next),
+  );
+  app.delete('/recent-properties', (req, res, next) =>
+    recentlyViewedController.clearRecentProperties(req, res, next),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+let listingA: string;
+let listingB: string;
+let listingC: string;
+let addressId: string;
+
+async function viewsOf(oxyUserId: string) {
+  return getDb().select().from(recentlyViewed).where(eq(recentlyViewed.oxyUserId, oxyUserId));
+}
+
+/** Backdate a stored view, so the retention window has something to act on. */
+async function backdateView(oxyUserId: string, propertyId: string, daysAgo: number) {
+  await getDb()
+    .update(recentlyViewed)
+    .set({ viewedAt: new Date(Date.now() - daysAgo * DAY_MS) })
+    .where(eq(recentlyViewed.oxyUserId, oxyUserId));
+  return propertyId;
+}
+
+beforeEach(async () => {
+  await getDb().delete(recentlyViewed);
+  await resetGeoTables();
+
+  const seeded = await seedListingWithGeo({ cityName: 'Madrid' });
+  addressId = seeded.addressId;
+  listingA = seeded.propertyId;
+  listingB = await seedProperty({ addressId });
+  listingC = await seedProperty({ addressId });
+});
+
+/**
+ * Leave the database as this file found it — see the identical hook in
+ * `savedProperties.test.ts` for the measured consequence of not doing so.
+ */
+afterAll(async () => {
+  await getDb().delete(recentlyViewed);
+  await resetGeoTables();
+});
+
+describe('trackPropertyView', () => {
+  it('records a view', async () => {
+    const res = await request(buildApp('oxy-a')).post(`/recent-properties/${listingA}`);
+    expect(res.status).toBe(200);
+
+    const views = await viewsOf('oxy-a');
+    expect(views).toHaveLength(1);
+    expect(views[0].propertyId).toBe(listingA);
+  });
+
+  it('moves `viewed_at` on a repeat instead of adding a second row', async () => {
+    const app = buildApp('oxy-a');
+    await request(app).post(`/recent-properties/${listingA}`);
+    const first = (await viewsOf('oxy-a'))[0];
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await request(app).post(`/recent-properties/${listingA}`);
+
+    const views = await viewsOf('oxy-a');
+    expect(views).toHaveLength(1);
+    expect(views[0].viewedAt.getTime()).toBeGreaterThan(first.viewedAt.getTime());
+    // `created_at` is when the listing was FIRST opened and must not move with
+    // it — the two are different facts and the read orders by the latter.
+    expect(views[0].createdAt.getTime()).toBe(first.createdAt.getTime());
+  });
+
+  it('scopes the unique key to the OWNER — two people may both view one listing', async () => {
+    // The index that breaks this is `UNIQUE(property_id)`, which passes the
+    // "no duplicate row" assertion above just as happily.
+    await request(buildApp('oxy-a')).post(`/recent-properties/${listingA}`);
+    await request(buildApp('oxy-b')).post(`/recent-properties/${listingA}`);
+
+    expect(await viewsOf('oxy-a')).toHaveLength(1);
+    expect(await viewsOf('oxy-b')).toHaveLength(1);
+  });
+
+  it('answers 404 for a listing that does not exist, and stores nothing', async () => {
+    const res = await request(buildApp('oxy-a')).post('/recent-properties/507f1f77bcf86cd799439011');
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('PROPERTY_NOT_FOUND');
+    expect(await viewsOf('oxy-a')).toHaveLength(0);
+  });
+
+  it('requires authentication', async () => {
+    expect((await request(buildApp()).post(`/recent-properties/${listingA}`)).status).toBe(401);
+  });
+});
+
+describe('getRecentProperties', () => {
+  it('returns hydrated listings, most recently viewed first', async () => {
+    const app = buildApp('oxy-a');
+    await request(app).post(`/recent-properties/${listingA}`);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await request(app).post(`/recent-properties/${listingB}`);
+
+    const res = await request(app).get('/recent-properties');
+    expect(res.status).toBe(200);
+    expect(res.body.data.map((row: { id: string }) => row.id)).toEqual([listingB, listingA]);
+    // Hydrated through the catalogue serializer, address join included.
+    expect(res.body.data[0].address).toBeDefined();
+    expect(res.body.data[0].viewedAt).toEqual(expect.any(String));
+    expect(res.body.data[0]._id).toBeUndefined();
+  });
+
+  it("returns only the caller's own history", async () => {
+    await request(buildApp('oxy-a')).post(`/recent-properties/${listingA}`);
+    await request(buildApp('oxy-b')).post(`/recent-properties/${listingB}`);
+
+    const res = await request(buildApp('oxy-a')).get('/recent-properties');
+    expect(res.body.data.map((row: { id: string }) => row.id)).toEqual([listingA]);
+  });
+
+  it('honours `?limit` and keeps the NEWEST rows', async () => {
+    const app = buildApp('oxy-a');
+    for (const listing of [listingA, listingB, listingC]) {
+      await request(app).post(`/recent-properties/${listing}`);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+
+    const res = await request(app).get('/recent-properties?limit=2');
+    // A `limit` applied AFTER the ordering, not before: the two most recent are
+    // C and B, and an implementation that limited first would be free to return
+    // A.
+    expect(res.body.data.map((row: { id: string }) => row.id)).toEqual([listingC, listingB]);
+  });
+
+  it('caps an absurd `?limit` rather than hydrating whatever was asked for', async () => {
+    // Mongo's `parseInt(limit)` was unbounded, and hydration here is a catalogue
+    // read with four joins plus three batched child queries per page.
+    const app = buildApp('oxy-a');
+    await request(app).post(`/recent-properties/${listingA}`);
+
+    const res = await request(app).get('/recent-properties?limit=1000000');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+  });
+
+  it('drops a view when its listing is deleted — the foreign key CASCADEs', async () => {
+    await request(buildApp('oxy-a')).post(`/recent-properties/${listingA}`);
+    await getDb().delete(propertiesTable).where(eq(propertiesTable.id, listingA));
+
+    expect(await viewsOf('oxy-a')).toHaveLength(0);
+    const res = await request(buildApp('oxy-a')).get('/recent-properties');
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('requires authentication', async () => {
+    expect((await request(buildApp()).get('/recent-properties')).status).toBe(401);
+  });
+});
+
+describe('clearRecentProperties', () => {
+  it("clears the caller's history and reports the count, leaving other people alone", async () => {
+    await request(buildApp('oxy-a')).post(`/recent-properties/${listingA}`);
+    await request(buildApp('oxy-a')).post(`/recent-properties/${listingB}`);
+    await request(buildApp('oxy-b')).post(`/recent-properties/${listingA}`);
+
+    const res = await request(buildApp('oxy-a')).delete('/recent-properties');
+    expect(res.status).toBe(200);
+    expect(res.body.data.deletedCount).toBe(2);
+
+    expect(await viewsOf('oxy-a')).toHaveLength(0);
+    expect(await viewsOf('oxy-b')).toHaveLength(1);
+  });
+
+  it('succeeds for a caller who has no profile document — the guard is gone', async () => {
+    // The Mongo handler required `Profile.findByOxyUserId` and answered 404
+    // without one. That was never an authorisation check: the delete is scoped
+    // by `oxyUserId` from the session either way. Nothing in this suite creates
+    // a profile, so a restored guard would fail every case above too — this one
+    // states the rule rather than relying on that.
+    const res = await request(buildApp('oxy-nobody')).delete('/recent-properties');
+    expect(res.status).toBe(200);
+    expect(res.body.data.deletedCount).toBe(0);
+  });
+
+  it('requires authentication', async () => {
+    expect((await request(buildApp()).delete('/recent-properties')).status).toBe(401);
+  });
+});
+
+describe('the 90-day retention sweep', () => {
+  it('deletes views older than the window and keeps the rest, across ALL users', async () => {
+    // The table's only bound. It runs from cron via `cleanupOldData`, which is
+    // what this calls — a test of the repository alone would still pass with the
+    // service wired to the Mongoose model that no longer receives rows.
+    await request(buildApp('oxy-a')).post(`/recent-properties/${listingA}`);
+    await backdateView('oxy-a', listingA, 91);
+    await request(buildApp('oxy-b')).post(`/recent-properties/${listingB}`);
+    await backdateView('oxy-b', listingB, 120);
+
+    // Inside the window, and belonging to a THIRD person, so a sweep that
+    // deleted everything or scoped itself to one owner both fail.
+    await request(buildApp('oxy-c')).post(`/recent-properties/${listingC}`);
+
+    const result = await new CleanupService().cleanupOldData();
+    expect(result.errors).toBe(0);
+    expect(result.deleted).toBe(2);
+
+    expect(await viewsOf('oxy-a')).toHaveLength(0);
+    expect(await viewsOf('oxy-b')).toHaveLength(0);
+    expect(await viewsOf('oxy-c')).toHaveLength(1);
+  });
+
+  it('keeps a view that is inside the window by a day', async () => {
+    // The boundary, so an off-by-one in the cutoff arithmetic is visible rather
+    // than being absorbed by a fixture that is months old.
+    await request(buildApp('oxy-a')).post(`/recent-properties/${listingA}`);
+    await backdateView('oxy-a', listingA, 89);
+
+    await new CleanupService().cleanupOldData();
+    expect(await viewsOf('oxy-a')).toHaveLength(1);
+  });
+});

--- a/packages/backend/__tests__/integration/savedProperties.test.ts
+++ b/packages/backend/__tests__/integration/savedProperties.test.ts
@@ -1,0 +1,515 @@
+/**
+ * Saved properties and their folders — ownership, the composite uniques, and the
+ * two referential rules that replaced application code.
+ *
+ * The real handlers against the REAL Postgres this worker owns, mounted behind a
+ * fake-auth middleware. Both Mongo collections were empty in production, so
+ * nothing here asserts a preserved row; what it asserts is that the rules the
+ * schema now carries actually hold, in BOTH directions.
+ *
+ * ## Why a mocked drizzle could not have caught any of this
+ *
+ * Every load-bearing case below is a statement a mock accepts and a server
+ * refuses, or a behaviour the SERVER performs and no application code does:
+ *
+ *  - `saved_items_owner_target_key` and `saved_property_folders_owner_name_key`
+ *    are composite uniques. A mocked `insert` returns whatever it was told to,
+ *    so the "two people may both save this" half — the half a plain
+ *    `UNIQUE(target_id)` would break while still passing every "rejects a
+ *    duplicate" assertion — is invisible without a real index.
+ *  - `saved_items.folder_id` is `ON DELETE SET NULL`, which is what now re-files
+ *    a deleted folder's saves. The Mongo handler did that with an explicit
+ *    `updateMany`; the port deleted that statement, so if the constraint were
+ *    wrong the saves would vanish with the folder and no unit test would know.
+ *  - `saved_items.target_id` is `ON DELETE CASCADE` against a real foreign key.
+ *    Both the 404 on saving a listing that does not exist and the disappearance
+ *    of a save when its listing is reaped are the server's behaviour, not the
+ *    controller's.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { and, eq } from 'drizzle-orm';
+
+import * as savedFolders from '../../controllers/profile/savedFolders';
+import * as savedProperties from '../../controllers/profile/savedProperties';
+import { getDb } from '../../db/postgres';
+import {
+  properties as propertiesTable,
+  savedItems,
+  savedPropertyFolders,
+} from '../../db/schema';
+import { errorHandler } from '../../middlewares/errorHandler';
+import { resetGeoTables, seedListingWithGeo, seedProperty } from '../helpers/postgresGeoFixtures';
+
+function buildApp(oxyUserId?: string): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (oxyUserId) {
+      (req as unknown as { user: { id: string } }).user = { id: oxyUserId };
+    }
+    next();
+  });
+  app.get('/saved-properties', (req, res, next) => savedProperties.getSavedProperties(req, res, next));
+  app.post('/save-property', (req, res, next) => savedProperties.saveProperty(req, res, next));
+  app.delete('/saved-properties/:propertyId', (req, res, next) =>
+    savedProperties.unsaveProperty(req, res, next),
+  );
+  app.patch('/saved-properties/:propertyId/notes', (req, res, next) =>
+    savedProperties.updateSavedPropertyNotes(req, res, next),
+  );
+  app.get('/folders', (req, res, next) => savedFolders.getSavedPropertyFolders(req, res, next));
+  app.post('/folders', (req, res, next) => savedFolders.createSavedPropertyFolder(req, res, next));
+  app.put('/folders/:folderId', (req, res, next) =>
+    savedFolders.updateSavedPropertyFolder(req, res, next),
+  );
+  app.delete('/folders/:folderId', (req, res, next) =>
+    savedFolders.deleteSavedPropertyFolder(req, res, next),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+/** Two listings, so "the right one" is distinguishable from "the only one". */
+let listingA: string;
+let listingB: string;
+let addressId: string;
+
+async function savesOf(oxyUserId: string) {
+  return getDb().select().from(savedItems).where(eq(savedItems.oxyUserId, oxyUserId));
+}
+
+async function foldersOf(oxyUserId: string) {
+  return getDb()
+    .select()
+    .from(savedPropertyFolders)
+    .where(eq(savedPropertyFolders.oxyUserId, oxyUserId));
+}
+
+beforeEach(async () => {
+  const db = getDb();
+  // Saves and folders first: `saved_items` CASCADEs from `properties`, so
+  // `resetGeoTables` would take them anyway — but folders do NOT reference a
+  // listing, so a folder from the previous test would survive and make the
+  // duplicate-name cases fail for the wrong reason.
+  await db.delete(savedItems);
+  await db.delete(savedPropertyFolders);
+  await resetGeoTables();
+
+  const seeded = await seedListingWithGeo({ cityName: 'Barcelona' });
+  addressId = seeded.addressId;
+  listingA = seeded.propertyId;
+  listingB = await seedProperty({ addressId });
+});
+
+/**
+ * Leave the database as this file found it.
+ *
+ * Truncating in `beforeEach` protects THIS file and leaves the last test's
+ * fixtures behind for whatever runs next on the same worker — which shares one
+ * database with it. That residue is not inert: `countries_code_key` is a UNIQUE
+ * index on `code`, and `db/backfill/geo.ts` copies with
+ * `ON CONFLICT DO NOTHING`, so a leftover `ES` country makes the backfill skip
+ * inserting its OWN country and then fail the `regions` foreign key. Measured:
+ * `jest --runInBand --runTestsByPath <this file> __tests__/db/geoBackfill.test.ts`
+ * fails 10 cases in that suite without this hook and passes with it.
+ */
+afterAll(async () => {
+  const db = getDb();
+  await db.delete(savedItems);
+  await db.delete(savedPropertyFolders);
+  await resetGeoTables();
+});
+
+describe('saveProperty', () => {
+  it('saves a listing into a default folder it creates on first use', async () => {
+    const res = await request(buildApp('oxy-a')).post('/save-property').send({ propertyId: listingA });
+
+    expect(res.status).toBe(200);
+    const folders = await foldersOf('oxy-a');
+    expect(folders).toHaveLength(1);
+    expect(folders[0].isDefault).toBe(true);
+    expect(folders[0].name).toBe('Favorites');
+    expect(res.body.data.folderId).toBe(folders[0].id);
+
+    const saved = await savesOf('oxy-a');
+    expect(saved).toHaveLength(1);
+    expect(saved[0].targetId).toBe(listingA);
+    expect(saved[0].targetType).toBe('property');
+    expect(saved[0].folderId).toBe(folders[0].id);
+  });
+
+  it('reuses the default folder on the next save rather than creating a second', async () => {
+    // The half that fails if `ensureDefaultFolder` inserts unconditionally: the
+    // unique index would raise, and a caller would get a 500 on their second
+    // save.
+    const app = buildApp('oxy-a');
+    await request(app).post('/save-property').send({ propertyId: listingA });
+    await request(app).post('/save-property').send({ propertyId: listingB });
+
+    expect(await foldersOf('oxy-a')).toHaveLength(1);
+    expect(await savesOf('oxy-a')).toHaveLength(2);
+  });
+
+  it('is idempotent per listing — a repeat save updates rather than duplicating', async () => {
+    const app = buildApp('oxy-a');
+    await request(app).post('/save-property').send({ propertyId: listingA, notes: 'first' });
+    const second = await request(app)
+      .post('/save-property')
+      .send({ propertyId: listingA, notes: 'second' });
+    expect(second.status).toBe(200);
+
+    const saved = await savesOf('oxy-a');
+    expect(saved).toHaveLength(1);
+    expect(saved[0].notes).toBe('second');
+  });
+
+  it('scopes the save to the OWNER — two people may both save one listing', async () => {
+    // The index that breaks this is `UNIQUE(target_type, target_id)`, which
+    // passes every "rejects a duplicate" assertion above. This is the permit
+    // half `CONVENTIONS.md` requires a unique index to be tested on.
+    const a = await request(buildApp('oxy-a')).post('/save-property').send({ propertyId: listingA });
+    const b = await request(buildApp('oxy-b')).post('/save-property').send({ propertyId: listingA });
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+
+    expect(await savesOf('oxy-a')).toHaveLength(1);
+    expect(await savesOf('oxy-b')).toHaveLength(1);
+  });
+
+  it('answers 404 for a listing that does not exist, and stores nothing', async () => {
+    // Mongo stored a bare string with nothing behind it, so this used to
+    // succeed. The foreign key refuses it; without the `23503` handler the
+    // caller would get a 500 instead.
+    const res = await request(buildApp('oxy-a'))
+      .post('/save-property')
+      .send({ propertyId: '507f1f77bcf86cd799439011' });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('PROPERTY_NOT_FOUND');
+    expect(await savesOf('oxy-a')).toHaveLength(0);
+  });
+
+  it('requires authentication and a property id', async () => {
+    expect((await request(buildApp()).post('/save-property').send({ propertyId: listingA })).status).toBe(401);
+    expect((await request(buildApp('oxy-a')).post('/save-property').send({})).status).toBe(400);
+  });
+
+  it("refuses to file a save into somebody else's folder", async () => {
+    const folder = await request(buildApp('oxy-b')).post('/folders').send({ name: 'B private' });
+    expect(folder.status).toBe(201);
+
+    const res = await request(buildApp('oxy-a'))
+      .post('/save-property')
+      .send({ propertyId: listingA, folderId: folder.body.data.id });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('FOLDER_NOT_FOUND');
+
+    // A handler that 404s and writes anyway passes any assertion made on the
+    // response alone.
+    expect(await savesOf('oxy-a')).toHaveLength(0);
+  });
+
+  it('stores a blank note as NULL and puts an empty string on the wire', async () => {
+    // The two Mongo writers disagreed — one stored `null`, the other `''`. The
+    // column is nullable with no default, so absence has one spelling now.
+    await request(buildApp('oxy-a'))
+      .post('/save-property')
+      .send({ propertyId: listingA, notes: '   ' });
+
+    const saved = await savesOf('oxy-a');
+    expect(saved[0].notes).toBeNull();
+
+    const listed = await request(buildApp('oxy-a')).get('/saved-properties');
+    expect(listed.body.data[0].notes).toBe('');
+  });
+});
+
+describe('getSavedProperties', () => {
+  it('returns the hydrated listing, newest save first, with the saved fields merged', async () => {
+    const app = buildApp('oxy-a');
+    await request(app).post('/save-property').send({ propertyId: listingA });
+    await request(app).post('/save-property').send({ propertyId: listingB, notes: 'second' });
+
+    const res = await request(app).get('/saved-properties');
+    expect(res.status).toBe(200);
+    expect(res.body.data.map((row: { id: string }) => row.id)).toEqual([listingB, listingA]);
+
+    // Hydrated through the catalogue serializer, not a bare row: the address is
+    // the join `findProperties` performs.
+    expect(res.body.data[0].address).toBeDefined();
+    expect(res.body.data[0].savedAt).toEqual(expect.any(String));
+    expect(res.body.data[0].notes).toBe('second');
+    // The wire contract is `id`, not `_id` (PR #287's clean cut).
+    expect(res.body.data[0]._id).toBeUndefined();
+  });
+
+  it("returns only the caller's own saves", async () => {
+    await request(buildApp('oxy-a')).post('/save-property').send({ propertyId: listingA });
+    await request(buildApp('oxy-b')).post('/save-property').send({ propertyId: listingB });
+
+    const res = await request(buildApp('oxy-a')).get('/saved-properties');
+    expect(res.body.data.map((row: { id: string }) => row.id)).toEqual([listingA]);
+  });
+
+  it('drops a save when its listing is deleted — the foreign key CASCADEs', async () => {
+    await request(buildApp('oxy-a')).post('/save-property').send({ propertyId: listingA });
+    expect(await savesOf('oxy-a')).toHaveLength(1);
+
+    await getDb().delete(propertiesTable).where(eq(propertiesTable.id, listingA));
+
+    // The Mongo handler needed an application-side `if (!prop) return null` for
+    // exactly this case, because its `targetId` pointed at nothing. Here the row
+    // is already gone.
+    expect(await savesOf('oxy-a')).toHaveLength(0);
+    const res = await request(buildApp('oxy-a')).get('/saved-properties');
+    expect(res.body.data).toEqual([]);
+  });
+});
+
+describe('unsaveProperty / updateSavedPropertyNotes — ownership', () => {
+  it('lets the owner unsave, and refuses a stranger without deleting', async () => {
+    await request(buildApp('oxy-a')).post('/save-property').send({ propertyId: listingA });
+
+    const stranger = await request(buildApp('oxy-b')).delete(`/saved-properties/${listingA}`);
+    expect(stranger.status).toBe(404);
+    expect(await savesOf('oxy-a')).toHaveLength(1);
+
+    const owner = await request(buildApp('oxy-a')).delete(`/saved-properties/${listingA}`);
+    expect(owner.status).toBe(200);
+    expect(await savesOf('oxy-a')).toHaveLength(0);
+  });
+
+  it("does not let user B rewrite user A's note", async () => {
+    await request(buildApp('oxy-a'))
+      .post('/save-property')
+      .send({ propertyId: listingA, notes: 'mine' });
+
+    const res = await request(buildApp('oxy-b'))
+      .patch(`/saved-properties/${listingA}/notes`)
+      .send({ notes: 'hijacked' });
+    expect(res.status).toBe(404);
+
+    const saved = await savesOf('oxy-a');
+    expect(saved[0].notes).toBe('mine');
+  });
+
+  it('lets the owner replace and clear their own note', async () => {
+    const app = buildApp('oxy-a');
+    await request(app).post('/save-property').send({ propertyId: listingA, notes: 'first' });
+
+    const updated = await request(app)
+      .patch(`/saved-properties/${listingA}/notes`)
+      .send({ notes: 'second' });
+    expect(updated.status).toBe(200);
+    expect(updated.body.data.notes).toBe('second');
+
+    const cleared = await request(app).patch(`/saved-properties/${listingA}/notes`).send({ notes: '' });
+    expect(cleared.status).toBe(200);
+    expect((await savesOf('oxy-a'))[0].notes).toBeNull();
+  });
+
+  it('answers 404 for a listing this person never saved', async () => {
+    const res = await request(buildApp('oxy-a'))
+      .patch(`/saved-properties/${listingA}/notes`)
+      .send({ notes: 'x' });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('SAVED_PROPERTY_NOT_FOUND');
+  });
+});
+
+describe('saved-property folders', () => {
+  it('creates a folder and returns it with an `id` and a zero count', async () => {
+    const res = await request(buildApp('oxy-a'))
+      .post('/folders')
+      .send({ name: '  Barcelona  ', description: '  by the sea  ' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.id).toEqual(expect.any(String));
+    expect(res.body.data._id).toBeUndefined();
+    expect(res.body.data.propertyCount).toBe(0);
+    // Trimmed at the call site: the unique index is on `lower(name)` over the
+    // stored bytes, so an untrimmed name would retire the duplicate rule.
+    expect(res.body.data.name).toBe('Barcelona');
+    expect(res.body.data.description).toBe('by the sea');
+    // Column defaults, not mongoose document defaults.
+    expect(res.body.data.color).toBe('#3B82F6');
+    expect(res.body.data.icon).toBe('folder-outline');
+  });
+
+  it('stores a blank description as NULL rather than as an empty string', async () => {
+    const res = await request(buildApp('oxy-a')).post('/folders').send({ name: 'Plain', description: '  ' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.description).toBeNull();
+  });
+
+  it('answers 409 on a duplicate name IGNORING CASE, leaving the first intact', async () => {
+    const app = buildApp('oxy-a');
+    const first = await request(app).post('/folders').send({ name: 'Beach', color: '#111111' });
+    expect(first.status).toBe(201);
+
+    const second = await request(app).post('/folders').send({ name: 'bEaCh', color: '#222222' });
+    expect(second.status).toBe(409);
+    expect(second.body.code).toBe('FOLDER_NAME_EXISTS');
+
+    const folders = await foldersOf('oxy-a');
+    expect(folders).toHaveLength(1);
+    expect(folders[0].color).toBe('#111111');
+  });
+
+  it('scopes the unique name to the OWNER — two people may both have "Beach"', async () => {
+    const a = await request(buildApp('oxy-a')).post('/folders').send({ name: 'Beach' });
+    const b = await request(buildApp('oxy-b')).post('/folders').send({ name: 'Beach' });
+    expect(a.status).toBe(201);
+    expect(b.status).toBe(201);
+  });
+
+  it('counts saves per folder, from `saved_items` and scoped to the owner', async () => {
+    const app = buildApp('oxy-a');
+    const beach = await request(app).post('/folders').send({ name: 'Beach' });
+    // Created but never filled: a folder with no saves must report 0 rather
+    // than being absent from the response, which is what the `?? 0` in the
+    // controller supplies (the count map omits empty folders).
+    await request(app).post('/folders').send({ name: 'City' });
+
+    await request(app).post('/save-property').send({ propertyId: listingA, folderId: beach.body.data.id });
+    await request(app).post('/save-property').send({ propertyId: listingB, folderId: beach.body.data.id });
+    // Another person's save in their OWN folder must not be counted here.
+    await request(buildApp('oxy-b')).post('/save-property').send({ propertyId: listingA });
+
+    const res = await request(app).get('/folders');
+    expect(res.status).toBe(200);
+    const counts = Object.fromEntries(
+      res.body.data.folders.map((f: { name: string; propertyCount: number }) => [f.name, f.propertyCount]),
+    );
+    expect(counts).toEqual({ Beach: 2, City: 0 });
+  });
+
+  it('lists the default folder first, then oldest first', async () => {
+    const app = buildApp('oxy-a');
+    await request(app).post('/folders').send({ name: 'Alpha' });
+    await request(app).post('/folders').send({ name: 'Beta' });
+    // Creates the default folder LAST, so a query that merely ordered by
+    // `created_at` would put it at the end.
+    await request(app).post('/save-property').send({ propertyId: listingA });
+
+    const res = await request(app).get('/folders');
+    expect(res.body.data.folders.map((f: { name: string }) => f.name)).toEqual([
+      'Favorites',
+      'Alpha',
+      'Beta',
+    ]);
+  });
+
+  it("returns only the caller's own folders", async () => {
+    await request(buildApp('oxy-a')).post('/folders').send({ name: 'Mine' });
+    await request(buildApp('oxy-b')).post('/folders').send({ name: 'Theirs' });
+
+    const res = await request(buildApp('oxy-a')).get('/folders');
+    expect(res.body.data.folders.map((f: { name: string }) => f.name)).toEqual(['Mine']);
+  });
+
+  it('refuses to update or delete the DEFAULT folder', async () => {
+    const app = buildApp('oxy-a');
+    await request(app).post('/save-property').send({ propertyId: listingA });
+    const defaultFolder = (await foldersOf('oxy-a'))[0];
+
+    const updated = await request(app).put(`/folders/${defaultFolder.id}`).send({ name: 'Renamed' });
+    expect(updated.status).toBe(400);
+    expect(updated.body.code).toBe('CANNOT_UPDATE_DEFAULT_FOLDER');
+
+    const deleted = await request(app).delete(`/folders/${defaultFolder.id}`);
+    expect(deleted.status).toBe(400);
+    expect(deleted.body.code).toBe('CANNOT_DELETE_DEFAULT_FOLDER');
+
+    expect((await foldersOf('oxy-a'))[0].name).toBe('Favorites');
+  });
+
+  it("does not let user B rename or delete user A's folder", async () => {
+    const created = await request(buildApp('oxy-a')).post('/folders').send({ name: 'Mine' });
+
+    const renamed = await request(buildApp('oxy-b'))
+      .put(`/folders/${created.body.data.id}`)
+      .send({ name: 'Hijacked' });
+    expect(renamed.status).toBe(404);
+
+    const deleted = await request(buildApp('oxy-b')).delete(`/folders/${created.body.data.id}`);
+    expect(deleted.status).toBe(404);
+
+    const folders = await foldersOf('oxy-a');
+    expect(folders).toHaveLength(1);
+    expect(folders[0].name).toBe('Mine');
+  });
+
+  it('answers 409 when a rename collides with another of the same owner\'s folders', async () => {
+    const app = buildApp('oxy-a');
+    await request(app).post('/folders').send({ name: 'Taken' });
+    const other = await request(app).post('/folders').send({ name: 'Free' });
+
+    const res = await request(app).put(`/folders/${other.body.data.id}`).send({ name: 'TAKEN' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('FOLDER_NAME_EXISTS');
+
+    const folders = await foldersOf('oxy-a');
+    expect(folders.map((f) => f.name).sort()).toEqual(['Free', 'Taken']);
+  });
+
+  it('KEEPS the saves when their folder is deleted, un-filing them', async () => {
+    // The load-bearing case of this port. The Mongo handler ran an explicit
+    // `Saved.updateMany({ folderId }, { folderId: null })` before deleting; that
+    // statement is GONE, and `ON DELETE SET NULL` is what replaced it. If the
+    // constraint were CASCADE — or absent — a person would lose every saved
+    // listing by tidying up a folder.
+    const app = buildApp('oxy-a');
+    const folder = await request(app).post('/folders').send({ name: 'Temporary' });
+    await request(app).post('/save-property').send({ propertyId: listingA, folderId: folder.body.data.id });
+    await request(app).post('/save-property').send({ propertyId: listingB, folderId: folder.body.data.id });
+
+    const res = await request(app).delete(`/folders/${folder.body.data.id}`);
+    expect(res.status).toBe(200);
+
+    const saved = await savesOf('oxy-a');
+    expect(saved).toHaveLength(2);
+    expect(saved.every((row) => row.folderId === null)).toBe(true);
+
+    const listed = await request(app).get('/saved-properties');
+    expect(listed.body.data).toHaveLength(2);
+    expect(listed.body.data.every((row: { folderId: null }) => row.folderId === null)).toBe(true);
+  });
+
+  it('answers 404 for a folder id that never existed, whatever shape it is', async () => {
+    // Both id shapes are live in a `text` primary key after the cutover, so a
+    // handler that recognised only a 24-hex ObjectId would answer 400 for a
+    // perfectly valid uuid v7.
+    const app = buildApp('oxy-a');
+    expect((await request(app).delete('/folders/0198f0a1-0000-7000-8000-000000000000')).status).toBe(404);
+    expect((await request(app).delete('/folders/507f1f77bcf86cd799439011')).status).toBe(404);
+    expect((await request(app).delete('/folders/not-an-id')).status).toBe(404);
+  });
+
+  it('requires authentication on every folder route', async () => {
+    const app = buildApp();
+    expect((await request(app).get('/folders')).status).toBe(401);
+    expect((await request(app).post('/folders').send({ name: 'x' })).status).toBe(401);
+    expect((await request(app).put('/folders/abc').send({ name: 'x' })).status).toBe(401);
+    expect((await request(app).delete('/folders/abc')).status).toBe(401);
+  });
+});
+
+describe('the folder membership table has no writer', () => {
+  it('files a save through `saved_items.folder_id` and never `saved_property_folder_items`', async () => {
+    // The Mongo document carried BOTH a `Saved.folderId` pointer and a
+    // `SavedPropertyFolder.properties[]` array — two representations of one
+    // fact, kept in step by a best-effort `try {} catch {}`. Only the pointer
+    // survives; this pins that the port did not quietly start maintaining both.
+    const app = buildApp('oxy-a');
+    const folder = await request(app).post('/folders').send({ name: 'Beach' });
+    await request(app).post('/save-property').send({ propertyId: listingA, folderId: folder.body.data.id });
+
+    const filed = await getDb()
+      .select()
+      .from(savedItems)
+      .where(and(eq(savedItems.oxyUserId, 'oxy-a'), eq(savedItems.folderId, folder.body.data.id)));
+    expect(filed).toHaveLength(1);
+  });
+});

--- a/packages/backend/controllers/profile/recentlyViewed.ts
+++ b/packages/backend/controllers/profile/recentlyViewed.ts
@@ -1,57 +1,110 @@
+/**
+ * Recently-viewed listings, on Postgres.
+ *
+ * Ported from the Mongo `RecentlyViewed` collection to
+ * `db/saved/recentlyViewedRepository.ts`. The collection held 0 documents in
+ * production — and, unlike the rest of this domain, that is not because nobody
+ * used the feature. See the repository header: the client posted to a route no
+ * router served, so every view was a swallowed 404.
+ *
+ * ## Three things the port changed, all deliberate
+ *
+ * **The `Profile.findByOxyUserId` guard on `clearRecentProperties` is GONE.** It
+ * was not an authorisation check — the delete is already scoped by `oxyUserId`,
+ * which is resolved from the session and never from the client — so its only
+ * effect was to answer 404 to somebody who owned rows but happened to have no
+ * profile document yet. The same guard was dropped from `savedSearches` for the
+ * same reason, and the ownership predicate that does the real work is untouched.
+ *
+ * **The de-duplicating `Map` is gone.** The handler read every view, then folded
+ * them into a `Map` keyed by property id, keeping the newest of each. A second
+ * row for one `(owner, listing)` pair is unrepresentable under
+ * `recently_viewed_owner_property_key`, so the fold could only ever be a no-op —
+ * and it was applied AFTER `limit`, which meant a duplicate would have silently
+ * shortened the page rather than being corrected.
+ *
+ * **`debugRecentProperties` is DELETED**, with its route. Every fact it reported
+ * was either a `populate()` artefact with no Postgres counterpart
+ * (`hasPopulatedProperty`, `populatedKeys`) or already answered by
+ * `GET /me/recent-properties`; its `propertyChecks` — "does this property still
+ * exist?" — is a question `ON DELETE CASCADE` now answers "yes" by construction.
+ * It had no consumer anywhere in the repo.
+ */
+
+import type { NextFunction, Request, Response } from 'express';
+import { inArray } from 'drizzle-orm';
+
+import { getDb } from '../../db/postgres';
+import { properties } from '../../db/schema';
+import { findProperties } from '../../db/properties/propertyReads';
+import { serializeProperty } from '../../db/properties/propertySerializer';
 import {
-  Profile,
-  RecentlyViewed,
-  Property,
-  successResponse,
-  errorResponse,
-} from './shared';
+  clearRecentlyViewed,
+  listRecentlyViewed,
+  trackPropertyView as trackPropertyViewRow,
+  ViewedPropertyNotFoundError,
+} from '../../db/saved/recentlyViewedRepository';
+import { getQueryInteger } from '../queryParams';
+import { errorResponse, successResponse } from './shared';
+
+/** What `GET /me/recent-properties` returns when the caller names no limit. */
+const DEFAULT_RECENT_LIMIT = 10;
+
+/**
+ * The most rows one request may ask for.
+ *
+ * Mongo's `parseInt(limit)` was unbounded, so `?limit=1000000` hydrated a
+ * million listings — and hydration here is a catalogue read with four joins and
+ * three batched child queries, not a `find()`. The cap is the response's bound;
+ * the TABLE's bound is the 90-day retention sweep (see the repository header).
+ */
+const MAX_RECENT_LIMIT = 100;
+
+/** Resolve the owner from the session, in the shape the auth layer sets. */
+function ownerOf(req: Request): string | undefined {
+  return req.user?.id || req.user?._id || undefined;
+}
 
 /**
  * Get recently viewed properties for the current user's profile
  */
-export async function getRecentProperties(req: any, res: any, next: any) {
+export async function getRecentProperties(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
-    const { limit = 10 } = req.query;
+    const oxyUserId = ownerOf(req);
 
     if (!oxyUserId) {
       return res.status(401).json(
         errorResponse("Authentication required", "AUTHENTICATION_REQUIRED")
       );
     }
-// Get recently viewed properties
-    const recentViews = await RecentlyViewed.find({ oxyUserId })
-      .sort({ viewedAt: -1 })
-      .limit(parseInt(limit))
-      .populate({
-        path: 'propertyId',
-        populate: {
-          path: 'addressId',
-          model: 'Address'
-        }
-      })
-      .lean();
 
-    // Map and filter properties, ensuring no duplicates by property ID
-    const propertiesMap = new Map();
-    recentViews.forEach(view => {
-      if (view.propertyId && view.propertyId._id) {
-        const propertyId = view.propertyId._id.toString();
-        // Only keep the most recent view for each property
-        if (!propertiesMap.has(propertyId) || view.viewedAt > propertiesMap.get(propertyId).viewedAt) {
-          propertiesMap.set(propertyId, {
-            ...view.propertyId,
-            viewedAt: view.viewedAt
-          });
-        }
-      }
+    // `getQueryInteger` already floors at 1 by falling back on a non-positive
+    // value, so only the ceiling has to be applied here.
+    const limit = Math.min(
+      getQueryInteger(req.query.limit, DEFAULT_RECENT_LIMIT),
+      MAX_RECENT_LIMIT,
+    );
+
+    const views = await listRecentlyViewed(getDb(), oxyUserId, limit);
+    if (views.length === 0) {
+      return res.json(successResponse([], "Recent properties retrieved successfully"));
+    }
+
+    const hydrated = await findProperties({
+      where: inArray(properties.id, views.map((view) => view.propertyId)),
+    });
+    const byId = new Map(hydrated.map((entry) => [entry.property.id, entry]));
+
+    // Ordered by `views`, not by the catalogue read: most recently opened first.
+    const recent = views.flatMap((view) => {
+      const listing = byId.get(view.propertyId);
+      // Only reachable if a listing is deleted BETWEEN the two statements above;
+      // the foreign key rules out every other case.
+      if (!listing) return [];
+      return [{ ...serializeProperty(listing), viewedAt: view.viewedAt }];
     });
 
-    const properties = Array.from(propertiesMap.values());
-
-    res.json(
-      successResponse(properties, "Recent properties retrieved successfully")
-    );
+    res.json(successResponse(recent, "Recent properties retrieved successfully"));
   } catch (error) {
     next(error);
   }
@@ -60,9 +113,9 @@ export async function getRecentProperties(req: any, res: any, next: any) {
 /**
  * Track property view for the current user's profile
  */
-export async function trackPropertyView(req: any, res: any, next: any) {
+export async function trackPropertyView(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
     const { propertyId } = req.params;
 
     if (!oxyUserId) {
@@ -76,29 +129,19 @@ export async function trackPropertyView(req: any, res: any, next: any) {
         errorResponse("Property ID is required", "PROPERTY_ID_REQUIRED")
       );
     }
-// Check if view already exists
-    const existingView = await RecentlyViewed.findOne({
-      oxyUserId,
-      propertyId
-    });
 
-    if (existingView) {
-      // Update existing view timestamp
-      existingView.viewedAt = new Date();
-      await existingView.save();
-    } else {
-      // Create new view record
-      const propertyView = new RecentlyViewed({
-        oxyUserId,
-        propertyId,
-        viewedAt: new Date()
-      });
-      await propertyView.save();
+    try {
+      await trackPropertyViewRow(getDb(), oxyUserId, propertyId);
+    } catch (error) {
+      if (error instanceof ViewedPropertyNotFoundError) {
+        return res.status(404).json(
+          errorResponse("Property not found", "PROPERTY_NOT_FOUND")
+        );
+      }
+      throw error;
     }
 
-    res.json(
-      successResponse(null, "Property view tracked successfully")
-    );
+    res.json(successResponse(null, "Property view tracked successfully"));
   } catch (error) {
     next(error);
   }
@@ -107,9 +150,9 @@ export async function trackPropertyView(req: any, res: any, next: any) {
 /**
  * Clear recently viewed properties for the current user's profile
  */
-export async function clearRecentProperties(req: any, res: any, next: any) {
+export async function clearRecentProperties(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
 
     if (!oxyUserId) {
       return res.status(401).json(
@@ -117,106 +160,9 @@ export async function clearRecentProperties(req: any, res: any, next: any) {
       );
     }
 
-    // Get the active profile for the current user
-    const activeProfile = await Profile.findByOxyUserId(oxyUserId);
+    const deletedCount = await clearRecentlyViewed(getDb(), oxyUserId);
 
-    if (!activeProfile) {
-      return res.status(404).json(
-        errorResponse("Profile not found", "PROFILE_NOT_FOUND")
-      );
-    }
-
-    // Clear all recently viewed properties for this profile
-    const result = await RecentlyViewed.deleteMany({
-      oxyUserId
-    });
-
-    res.json(
-      successResponse({ deletedCount: result.deletedCount }, "Recently viewed properties cleared successfully")
-    );
-  } catch (error) {
-    next(error);
-  }
-}
-
-/**
- * Debug endpoint to check recently viewed data
- */
-export async function debugRecentProperties(req: any, res: any, next: any) {
-  try {
-    const oxyUserId = req.user?.id || req.user?._id;
-
-    if (!oxyUserId) {
-      return res.status(401).json(
-        errorResponse("Authentication required", "AUTHENTICATION_REQUIRED")
-      );
-    }
-
-    // Get the active profile for the current user
-    const activeProfile = await Profile.findByOxyUserId(oxyUserId);
-
-    if (!activeProfile) {
-      return res.json(
-        successResponse({
-          error: "No active profile found",
-          oxyUserId,
-          debugInfo: "User needs to create a profile first"
-        }, "Debug info retrieved")
-      );
-    }
-
-    // Get recently viewed records WITHOUT population
-    const rawRecentViews = await RecentlyViewed.find({ oxyUserId })
-      .sort({ viewedAt: -1 })
-      .lean();
-
-    // Get recently viewed records WITH population
-    const populatedRecentViews = await RecentlyViewed.find({ oxyUserId })
-      .sort({ viewedAt: -1 })
-      .populate({
-        path: 'propertyId',
-        populate: {
-          path: 'addressId',
-          model: 'Address'
-        }
-      })
-      .lean();
-
-    // Check if properties exist
-    const propertyChecks = await Promise.all(
-      rawRecentViews.map(async (view) => {
-        const exists = await Property.findById(view.propertyId);
-        return {
-          propertyId: view.propertyId,
-          exists: !!exists,
-          propertyTitle: exists?.type || 'No title',
-          propertyStatus: exists?.status || 'unknown'
-        };
-      })
-    );
-
-    // Get total count
-    const totalCount = await RecentlyViewed.countDocuments({ oxyUserId });
-
-    res.json(
-      successResponse({
-        oxyUserId,
-        totalCount,
-        rawRecentViews: rawRecentViews.map(view => ({
-          propertyId: view.propertyId,
-          viewedAt: view.viewedAt,
-          createdAt: view.createdAt,
-          updatedAt: view.updatedAt
-        })),
-        populatedRecentViews: populatedRecentViews.map(view => ({
-          propertyId: view.propertyId ? (typeof view.propertyId === 'object' ? view.propertyId._id : view.propertyId) : null,
-          hasPopulatedProperty: !!view.propertyId && typeof view.propertyId === 'object',
-          viewedAt: view.viewedAt,
-          populatedKeys: view.propertyId && typeof view.propertyId === 'object' ? Object.keys(view.propertyId) : []
-        })),
-        propertyChecks
-      }, "Debug info retrieved successfully")
-    );
+    res.json(successResponse({ deletedCount }, "Recently viewed properties cleared successfully"));
   } catch (error) {
     next(error);
   }

--- a/packages/backend/controllers/profile/savedFolders.ts
+++ b/packages/backend/controllers/profile/savedFolders.ts
@@ -1,49 +1,75 @@
+/**
+ * Saved-property folders, on Postgres.
+ *
+ * Ported from the Mongo `SavedPropertyFolder` collection to
+ * `db/saved/savedFolderRepository.ts`. The collection held 0 documents in
+ * production, so no user-visible behaviour depends on a preserved row.
+ *
+ * ## Three things the port changed, all deliberate
+ *
+ * **The duplicate-name check is the INDEX.** Both handlers built a case-insensitive
+ * `RegExp` from the submitted name and searched with it before writing. That was
+ * a read-then-write two concurrent requests both pass, and the regex was
+ * unescaped user input besides — a folder named `.*` matched every existing name,
+ * so the 409 fired against a folder the caller had never seen. The 409 is
+ * unchanged and now comes from `saved_property_folders_owner_name_key`'s own
+ * `23505`.
+ *
+ * **Deleting a folder no longer re-files its saves in application code.**
+ * `saved_items.folder_id` is `ON DELETE SET NULL`, so the saves return to "not in
+ * a folder" in the same statement that drops the folder.
+ *
+ * **`propertyCount` is computed from `saved_items`**, which is where folder
+ * membership lives. It was a Mongoose virtual over the folder's own
+ * `properties[]` array on the WRITE side and a `Saved` aggregation on the READ
+ * side — two answers to one question. Only the second was ever correct, and it
+ * is the one that survives.
+ */
+
+import type { NextFunction, Request, Response } from 'express';
+
+import { getDb } from '../../db/postgres';
+import { countSavedPropertiesByFolder } from '../../db/saved/savedPropertyRepository';
 import {
-  Saved,
-  SavedPropertyFolder,
-  successResponse,
-  errorResponse,
-} from './shared';
+  createSavedFolder,
+  deleteSavedFolder as deleteSavedFolderRow,
+  findSavedFolder,
+  listSavedFolders,
+  SavedFolderNameTakenError,
+  toSavedFolderDTO,
+  updateSavedFolder as updateSavedFolderRow,
+} from '../../db/saved/savedFolderRepository';
+import { errorResponse, successResponse } from './shared';
+
+/** Resolve the owner from the session, in the shape the auth layer sets. */
+function ownerOf(req: Request): string | undefined {
+  return req.user?.id || req.user?._id || undefined;
+}
 
 /**
  * Get saved property folders for the current user's profile
  */
-export async function getSavedPropertyFolders(req: any, res: any, next: any) {
+export async function getSavedPropertyFolders(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
 
     if (!oxyUserId) {
       return res.status(401).json(
         errorResponse("Authentication required", "AUTHENTICATION_REQUIRED")
       );
     }
-// Get all folders for this profile
-    const folders = await SavedPropertyFolder.find({ oxyUserId })
-      .sort({ isDefault: -1, createdAt: 1 })
-      .lean();
 
-    // Calculate property count using unified Saved collection
-    const folderIds = folders.map((f: any) => f._id);
-    let countsByFolder: Record<string, number> = {};
-    if (folderIds.length > 0) {
-      const counts = await Saved.aggregate([
-        { $match: { oxyUserId, targetType: 'property', folderId: { $in: folderIds } } },
-        { $group: { _id: '$folderId', count: { $sum: 1 } } },
-      ]);
-      countsByFolder = counts.reduce((acc: any, row: any) => {
-        acc[String(row._id)] = row.count;
-        return acc;
-      }, {} as Record<string, number>);
-    }
-
-    const foldersWithCount = folders.map((folder: any) => ({
-      ...folder,
-      propertyCount: countsByFolder[String(folder._id)] || 0,
-    }));
-
-    res.json(
-      successResponse({ folders: foldersWithCount }, "Saved property folders retrieved successfully")
+    const folders = await listSavedFolders(getDb(), oxyUserId);
+    const counts = await countSavedPropertiesByFolder(
+      getDb(),
+      oxyUserId,
+      folders.map((folder) => folder.id),
     );
+
+    res.json(successResponse(
+      { folders: folders.map((folder) => toSavedFolderDTO(folder, counts.get(folder.id) ?? 0)) },
+      "Saved property folders retrieved successfully",
+    ));
   } catch (error) {
     next(error);
   }
@@ -52,9 +78,9 @@ export async function getSavedPropertyFolders(req: any, res: any, next: any) {
 /**
  * Create a new saved property folder
  */
-export async function createSavedPropertyFolder(req: any, res: any, next: any) {
+export async function createSavedPropertyFolder(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
     const { name, description, color, icon } = req.body;
 
     if (!oxyUserId) {
@@ -63,38 +89,35 @@ export async function createSavedPropertyFolder(req: any, res: any, next: any) {
       );
     }
 
-    if (!name || !name.trim()) {
+    if (typeof name !== 'string' || !name.trim()) {
       return res.status(400).json(
         errorResponse("Folder name is required", "FOLDER_NAME_REQUIRED")
       );
     }
-// Check if folder with same name already exists
-    const existingFolder = await SavedPropertyFolder.findOne({
-      oxyUserId,
-      name: { $regex: new RegExp(`^${name.trim()}$`, 'i') }
-    });
 
-    if (existingFolder) {
-      return res.status(409).json(
-        errorResponse("Folder with this name already exists", "FOLDER_NAME_EXISTS")
-      );
+    let folder;
+    try {
+      folder = await createSavedFolder(getDb(), {
+        oxyUserId,
+        // Trimmed HERE: mongoose's `trim` has no Postgres counterpart, and the
+        // unique index is on `lower(name)` over the stored bytes — an untrimmed
+        // name would make `'Madrid '` a second folder and quietly retire the
+        // duplicate-name rule.
+        name: name.trim(),
+        description,
+        color: color === undefined ? undefined : String(color),
+        icon: icon === undefined ? undefined : String(icon),
+      });
+    } catch (error) {
+      if (error instanceof SavedFolderNameTakenError) {
+        return res.status(409).json(
+          errorResponse("Folder with this name already exists", "FOLDER_NAME_EXISTS")
+        );
+      }
+      throw error;
     }
 
-    // Create new folder
-    const folder = new SavedPropertyFolder({
-      oxyUserId,
-      name: name.trim(),
-      description: description?.trim() || '',
-      color: color || '#3B82F6',
-      icon: icon || 'folder-outline',
-      isDefault: false
-    });
-
-    await folder.save();
-
-    res.status(201).json(
-      successResponse(folder, "Folder created successfully")
-    );
+    res.status(201).json(successResponse(toSavedFolderDTO(folder, 0), "Folder created successfully"));
   } catch (error) {
     next(error);
   }
@@ -103,9 +126,9 @@ export async function createSavedPropertyFolder(req: any, res: any, next: any) {
 /**
  * Update a saved property folder
  */
-export async function updateSavedPropertyFolder(req: any, res: any, next: any) {
+export async function updateSavedPropertyFolder(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
     const { folderId } = req.params;
     const { name, description, color, icon } = req.body;
 
@@ -120,11 +143,38 @@ export async function updateSavedPropertyFolder(req: any, res: any, next: any) {
         errorResponse("Folder ID is required", "FOLDER_ID_REQUIRED")
       );
     }
-// Find the folder
-    const folder = await SavedPropertyFolder.findOne({
-      _id: folderId,
-      oxyUserId
-    });
+
+    // Read first, because the default folder is refused BEFORE anything is
+    // written and the two answers differ: a folder that is not the caller's is a
+    // 404, the caller's own default folder is a 400.
+    const existing = await findSavedFolder(getDb(), folderId, oxyUserId);
+    if (!existing) {
+      return res.status(404).json(
+        errorResponse("Folder not found", "FOLDER_NOT_FOUND")
+      );
+    }
+    if (existing.isDefault) {
+      return res.status(400).json(
+        errorResponse("Cannot update default folder", "CANNOT_UPDATE_DEFAULT_FOLDER")
+      );
+    }
+
+    let folder;
+    try {
+      folder = await updateSavedFolderRow(getDb(), folderId, oxyUserId, {
+        name: name === undefined ? undefined : String(name).trim(),
+        description,
+        color: color === undefined ? undefined : String(color),
+        icon: icon === undefined ? undefined : String(icon),
+      });
+    } catch (error) {
+      if (error instanceof SavedFolderNameTakenError) {
+        return res.status(409).json(
+          errorResponse("Folder with this name already exists", "FOLDER_NAME_EXISTS")
+        );
+      }
+      throw error;
+    }
 
     if (!folder) {
       return res.status(404).json(
@@ -132,44 +182,12 @@ export async function updateSavedPropertyFolder(req: any, res: any, next: any) {
       );
     }
 
-    // Don't allow updating default folder
-    if (folder.isDefault) {
-      return res.status(400).json(
-        errorResponse("Cannot update default folder", "CANNOT_UPDATE_DEFAULT_FOLDER")
-      );
-    }
+    const counts = await countSavedPropertiesByFolder(getDb(), oxyUserId, [folder.id]);
 
-    // Check if new name conflicts with existing folder
-    if (name && name.trim() !== folder.name) {
-      const existingFolder = await SavedPropertyFolder.findOne({
-        oxyUserId,
-        name: { $regex: new RegExp(`^${name.trim()}$`, 'i') },
-        _id: { $ne: folderId }
-      });
-
-      if (existingFolder) {
-        return res.status(409).json(
-          errorResponse("Folder with this name already exists", "FOLDER_NAME_EXISTS")
-        );
-      }
-    }
-
-    // Update folder
-    const updateData: any = {};
-    if (name) updateData.name = name.trim();
-    if (description !== undefined) updateData.description = description?.trim() || '';
-    if (color) updateData.color = color;
-    if (icon) updateData.icon = icon;
-
-    const updatedFolder = await SavedPropertyFolder.findByIdAndUpdate(
-      folderId,
-      updateData,
-      { new: true }
-    );
-
-    res.json(
-      successResponse(updatedFolder, "Folder updated successfully")
-    );
+    res.json(successResponse(
+      toSavedFolderDTO(folder, counts.get(folder.id) ?? 0),
+      "Folder updated successfully",
+    ));
   } catch (error) {
     next(error);
   }
@@ -178,9 +196,9 @@ export async function updateSavedPropertyFolder(req: any, res: any, next: any) {
 /**
  * Delete a saved property folder
  */
-export async function deleteSavedPropertyFolder(req: any, res: any, next: any) {
+export async function deleteSavedPropertyFolder(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
     const { folderId } = req.params;
 
     if (!oxyUserId) {
@@ -194,37 +212,29 @@ export async function deleteSavedPropertyFolder(req: any, res: any, next: any) {
         errorResponse("Folder ID is required", "FOLDER_ID_REQUIRED")
       );
     }
-// Find the folder
-    const folder = await SavedPropertyFolder.findOne({
-      _id: folderId,
-      oxyUserId
-    });
 
-    if (!folder) {
+    const existing = await findSavedFolder(getDb(), folderId, oxyUserId);
+    if (!existing) {
       return res.status(404).json(
         errorResponse("Folder not found", "FOLDER_NOT_FOUND")
       );
     }
-
-    // Don't allow deleting default folder
-    if (folder.isDefault) {
+    if (existing.isDefault) {
       return res.status(400).json(
         errorResponse("Cannot delete default folder", "CANNOT_DELETE_DEFAULT_FOLDER")
       );
     }
 
-    // Move all properties in this folder to no folder (null) in unified Saved collection
-    await Saved.updateMany(
-      { oxyUserId, targetType: 'property', folderId: folderId },
-      { $set: { folderId: null } }
-    );
+    // The saves filed in it survive: `saved_items.folder_id` is
+    // `ON DELETE SET NULL`, so they return to "not in a folder" here.
+    const deleted = await deleteSavedFolderRow(getDb(), folderId, oxyUserId);
+    if (!deleted) {
+      return res.status(404).json(
+        errorResponse("Folder not found", "FOLDER_NOT_FOUND")
+      );
+    }
 
-    // Delete the folder
-    await SavedPropertyFolder.findByIdAndDelete(folderId);
-
-    res.json(
-      successResponse(null, "Folder deleted successfully")
-    );
+    res.json(successResponse(null, "Folder deleted successfully"));
   } catch (error) {
     next(error);
   }

--- a/packages/backend/controllers/profile/savedProperties.ts
+++ b/packages/backend/controllers/profile/savedProperties.ts
@@ -1,51 +1,95 @@
+/**
+ * Saved properties, on Postgres.
+ *
+ * Ported from the Mongo `Saved` collection to `db/saved/savedPropertyRepository.ts`.
+ * The collection held 0 documents in production, so no user-visible behaviour
+ * depends on a row this port had to preserve.
+ *
+ * ## The listings themselves come from the catalogue repository
+ *
+ * `Property.find({ _id: { $in: ids } }).populate('addressId')` becomes
+ * `findProperties` + `serializeProperty` — the same path every catalogue read
+ * already takes, so a saved listing is serialized by the ONE module that knows
+ * how to re-nest the flattened columns. Two orderings are in play and only one
+ * of them is the catalogue's: the response is ordered by when each listing was
+ * SAVED, so the ids are re-ordered here rather than in SQL.
+ *
+ * ## The dead-pointer filter is gone, because a dead pointer is unrepresentable
+ *
+ * The Mongo handler dropped any save whose property could not be found
+ * (`if (!prop) return null`), which was necessary: `targetId` was a bare string
+ * with nothing behind it. `saved_items.target_id` is a real foreign key with
+ * `ON DELETE CASCADE`, so a save outlives its listing for exactly no time at
+ * all. Keeping the filter would mean writing a branch no test could ever reach.
+ *
+ * ## `getProfileProperties` is DELETED
+ *
+ * It listed the caller's OWN listings, had no route and no caller, and
+ * duplicated `getMyProperties` in `controllers/property/retrieve.ts`, which is
+ * routed and already reads Postgres. It was reachable only through this
+ * package's barrel export.
+ */
+
+import type { NextFunction, Request, Response } from 'express';
+import { inArray } from 'drizzle-orm';
+
+import { getDb } from '../../db/postgres';
+import { properties } from '../../db/schema';
+import { findProperties } from '../../db/properties/propertyReads';
+import { serializeProperty } from '../../db/properties/propertySerializer';
 import {
-  Saved,
-  SavedPropertyFolder,
-  Property,
-  successResponse,
-  errorResponse,
-} from './shared';
+  listSavedProperties,
+  saveProperty as savePropertyRow,
+  SavedPropertyNotFoundError,
+  toSavedPropertyFields,
+  unsaveProperty as unsavePropertyRow,
+  updateSavedPropertyNotes as updateSavedPropertyNotesRow,
+} from '../../db/saved/savedPropertyRepository';
+import {
+  ensureDefaultFolder,
+  findSavedFolder,
+} from '../../db/saved/savedFolderRepository';
+import { errorResponse, successResponse } from './shared';
+
+/** Resolve the owner from the session, in the shape the auth layer sets. */
+function ownerOf(req: Request): string | undefined {
+  return req.user?.id || req.user?._id || undefined;
+}
 
 /**
  * Get saved properties for the current user's profile
  */
-export async function getSavedProperties(req: any, res: any, next: any) {
+export async function getSavedProperties(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
 
     if (!oxyUserId) {
       return res.status(401).json(
         errorResponse("Authentication required", "AUTHENTICATION_REQUIRED")
       );
     }
-// Use unified Saved collection
-    const savedRows = await Saved.find({ oxyUserId, targetType: 'property' })
-      .sort({ createdAt: -1 })
-      .lean();
 
-    const propertyIds = savedRows.map((row: any) => row.targetId);
-    const properties = await Property.find({ _id: { $in: propertyIds } }).populate('addressId').lean();
+    const saved = await listSavedProperties(getDb(), oxyUserId);
+    if (saved.length === 0) {
+      return res.json(successResponse([], "Saved properties retrieved successfully"));
+    }
 
-    // Map propertyId to doc for quick lookup
-    const propById: Record<string, any> = {};
-    properties.forEach((p: any) => { propById[String(p._id)] = p; });
+    const hydrated = await findProperties({
+      where: inArray(properties.id, saved.map((row) => row.targetId)),
+    });
+    const byId = new Map(hydrated.map((entry) => [entry.property.id, entry]));
 
-    const merged = savedRows
-      .map((row: any) => {
-        const prop = propById[String(row.targetId)];
-        if (!prop) return null;
-        return {
-          ...prop,
-          savedAt: row.createdAt || row.updatedAt,
-          notes: row.notes || '',
-          folderId: row.folderId || null,
-        };
-      })
-      .filter(Boolean);
+    // Ordered by `saved`, not by the catalogue read: the saved screen lists what
+    // was saved most recently first, and `findProperties` knows nothing of that.
+    const merged = saved.flatMap((row) => {
+      const listing = byId.get(row.targetId);
+      // Only reachable if a listing is deleted BETWEEN the two statements above;
+      // the foreign key rules out every other case. See the header.
+      if (!listing) return [];
+      return [{ ...serializeProperty(listing), ...toSavedPropertyFields(row) }];
+    });
 
-    const response = successResponse(merged, "Saved properties retrieved successfully");
-
-    res.json(response);
+    res.json(successResponse(merged, "Saved properties retrieved successfully"));
   } catch (error) {
     next(error);
   }
@@ -54,9 +98,9 @@ export async function getSavedProperties(req: any, res: any, next: any) {
 /**
  * Save a property for the current user's profile
  */
-export async function saveProperty(req: any, res: any, next: any) {
+export async function saveProperty(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
     const { propertyId, notes, folderId } = req.body;
 
     if (!oxyUserId) {
@@ -65,56 +109,45 @@ export async function saveProperty(req: any, res: any, next: any) {
       );
     }
 
-    if (!propertyId) {
+    if (typeof propertyId !== 'string' || !propertyId) {
       return res.status(400).json(
         errorResponse("Property ID is required", "PROPERTY_ID_REQUIRED")
       );
     }
-// Find or create default folder if no folderId provided
-    let targetFolder;
-    if (folderId) {
-      // Verify the folder exists
-      targetFolder = await SavedPropertyFolder.findOne({
-        _id: folderId,
-        oxyUserId
-      });
 
-      if (!targetFolder) {
+    // A named folder must be one of the CALLER's own. Scoped by owner in the
+    // lookup itself, so somebody else's folder id is indistinguishable from one
+    // that does not exist — it neither files a save into a stranger's folder nor
+    // tells the caller their folder exists.
+    let folder;
+    if (folderId) {
+      folder = await findSavedFolder(getDb(), String(folderId), oxyUserId);
+      if (!folder) {
         return res.status(404).json(
           errorResponse("Folder not found", "FOLDER_NOT_FOUND")
         );
       }
     } else {
-      // Find or create default folder
-      targetFolder = await SavedPropertyFolder.findOne({
-        oxyUserId,
-        isDefault: true
-      });
-
-      if (!targetFolder) {
-        // Create default folder
-        targetFolder = new SavedPropertyFolder({
-          oxyUserId,
-          name: "Favorites",
-          description: "Default folder for saved properties",
-          icon: "❤️",
-          isDefault: true,
-          properties: []
-        });
-        await targetFolder.save();
-      }
+      folder = await ensureDefaultFolder(getDb(), oxyUserId);
     }
 
-    // Upsert in unified Saved collection
-    await Saved.updateOne(
-      { oxyUserId, targetType: 'property', targetId: propertyId },
-      { $set: { oxyUserId, targetType: 'property', targetId: propertyId, notes: notes || null, folderId: targetFolder?._id, createdAt: new Date() } },
-      { upsert: true }
-    );
+    try {
+      await savePropertyRow(getDb(), {
+        oxyUserId,
+        propertyId,
+        notes,
+        folderId: folder.id,
+      });
+    } catch (error) {
+      if (error instanceof SavedPropertyNotFoundError) {
+        return res.status(404).json(
+          errorResponse("Property not found", "PROPERTY_NOT_FOUND")
+        );
+      }
+      throw error;
+    }
 
-    res.json(
-      successResponse({ folderId: targetFolder?._id }, "Property saved successfully")
-    );
+    res.json(successResponse({ folderId: folder.id }, "Property saved successfully"));
   } catch (error) {
     next(error);
   }
@@ -123,9 +156,9 @@ export async function saveProperty(req: any, res: any, next: any) {
 /**
  * Unsave a property for the current user's profile
  */
-export async function unsaveProperty(req: any, res: any, next: any) {
+export async function unsaveProperty(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
     const { propertyId } = req.params;
 
     if (!oxyUserId) {
@@ -139,14 +172,16 @@ export async function unsaveProperty(req: any, res: any, next: any) {
         errorResponse("Property ID is required", "PROPERTY_ID_REQUIRED")
       );
     }
-const result = await Saved.deleteOne({ oxyUserId, targetType: 'property', targetId: propertyId });
-    if (result.deletedCount === 0) {
-      return res.status(404).json(errorResponse("Saved property not found", "SAVED_PROPERTY_NOT_FOUND"));
+
+    const deleted = await unsavePropertyRow(getDb(), oxyUserId, propertyId);
+
+    if (!deleted) {
+      return res.status(404).json(
+        errorResponse("Saved property not found", "SAVED_PROPERTY_NOT_FOUND")
+      );
     }
 
-    res.json(
-      successResponse(null, "Property unsaved successfully")
-    );
+    res.json(successResponse(null, "Property unsaved successfully"));
   } catch (error) {
     next(error);
   }
@@ -154,10 +189,16 @@ const result = await Saved.deleteOne({ oxyUserId, targetType: 'property', target
 
 /**
  * Update saved property notes for the current user's profile
+ *
+ * The Mongo handler followed this with a best-effort mirror of the note into
+ * `SavedPropertyFolder.properties[].notes`, inside a `try {} catch {}` that
+ * swallowed its own failures. That second copy is not written any more — see the
+ * header of `db/saved/savedFolderRepository.ts` for why folder membership has
+ * exactly one representation.
  */
-export async function updateSavedPropertyNotes(req: any, res: any, next: any) {
+export async function updateSavedPropertyNotes(req: Request, res: Response, next: NextFunction) {
   try {
-    const oxyUserId = req.user?.id || req.user?._id;
+    const oxyUserId = ownerOf(req);
     const { propertyId } = req.params;
     const { notes } = req.body;
 
@@ -172,73 +213,19 @@ export async function updateSavedPropertyNotes(req: any, res: any, next: any) {
         errorResponse("Property ID is required", "PROPERTY_ID_REQUIRED")
       );
     }
-// Update notes on the saved record
-    const updated = await Saved.findOneAndUpdate(
-      { oxyUserId, targetType: 'property', targetId: propertyId },
-      { $set: { notes: notes || '' } },
-      { new: true }
-    );
+
+    const updated = await updateSavedPropertyNotesRow(getDb(), oxyUserId, propertyId, notes);
+
     if (!updated) {
-      return res.status(404).json(errorResponse("Saved property not found", "SAVED_PROPERTY_NOT_FOUND"));
-    }
-
-    // Best-effort: if property exists inside a folder's properties array, mirror notes there too
-    try {
-      const folder = await SavedPropertyFolder.findOne({
-        oxyUserId,
-        'properties.propertyId': propertyId
-      });
-      if (folder) {
-        const prop = folder.properties.find((p: any) => String(p.propertyId) === String(propertyId));
-        if (prop) {
-          prop.notes = notes || '';
-          await folder.save();
-        }
-      }
-    } catch {
-      // Non-fatal: failed to mirror notes to SavedPropertyFolder
-    }
-    res.json(successResponse(updated, "Property notes updated successfully"));
-  } catch (error) {
-    next(error);
-  }
-}
-
-/**
- * Get properties for the current user's profile
- */
-export async function getProfileProperties(req: any, res: any, next: any) {
-  try {
-    const oxyUserId = req.user?.id || req.user?._id;
-    const { page = 1, limit = 10 } = req.query;
-
-    if (!oxyUserId) {
-      return res.status(401).json(
-        errorResponse("Authentication required", "AUTHENTICATION_REQUIRED")
+      return res.status(404).json(
+        errorResponse("Saved property not found", "SAVED_PROPERTY_NOT_FOUND")
       );
     }
 
-    const skip = (parseInt(page) - 1) * parseInt(limit);
-    const [properties, total] = await Promise.all([
-      Property.find({ oxyUserId, status: { $ne: 'archived' } })
-        .populate('addressId')
-        .skip(skip)
-        .limit(parseInt(limit))
-        .sort({ createdAt: -1 })
-        .lean(),
-      Property.countDocuments({ oxyUserId, status: { $ne: 'archived' } })
-    ]);
-
-    const totalPages = Math.ceil(total / parseInt(limit));
-
-    res.json(
-      successResponse({
-        properties,
-        total,
-        page: parseInt(page),
-        totalPages
-      }, "Properties retrieved successfully")
-    );
+    res.json(successResponse(
+      { propertyId: updated.targetId, ...toSavedPropertyFields(updated) },
+      "Property notes updated successfully",
+    ));
   } catch (error) {
     next(error);
   }

--- a/packages/backend/controllers/profile/shared.ts
+++ b/packages/backend/controllers/profile/shared.ts
@@ -1,4 +1,8 @@
-import { Profile, Saved, SavedPropertyFolder, RecentlyViewed, Property } from '../../models';
+// `Saved`, `SavedPropertyFolder`, `RecentlyViewed` and `Property` were re-exported
+// here for the saved / folder / recently-viewed controllers. All four now read
+// Postgres through `db/saved/*` and `db/properties/*`, so the Mongoose models are
+// no longer reachable from this package.
+import { Profile } from '../../models';
 import { successResponse } from '../../middlewares/errorHandler';
 
 const errorResponse = (message = 'Error occurred', code = 'ERROR') => ({
@@ -81,10 +85,6 @@ function clearCachedProfile(oxyUserId: string) {
 
 export {
   Profile,
-  Saved,
-  SavedPropertyFolder,
-  RecentlyViewed,
-  Property,
   successResponse,
   errorResponse,
   profileCache,

--- a/packages/backend/db/saved/recentlyViewedRepository.ts
+++ b/packages/backend/db/saved/recentlyViewedRepository.ts
@@ -1,0 +1,169 @@
+/**
+ * `recently_viewed` — the listings a person has looked at, on Postgres.
+ *
+ * Ported from `models/schemas/RecentlyViewedSchema.ts`. The collection held **0
+ * documents in production** (measured), and the reason is not that nobody uses
+ * the feature — see "The write path was dead" below.
+ *
+ * ## This table is APPEND-HEAVY, and its bound is 90 days
+ *
+ * It is the only table in this domain that grows on READS rather than on
+ * deliberate user action, so it is the one that leaks if nothing prunes it.
+ * Mongo bounded it in exactly one way, and this port keeps that way and invents
+ * no other:
+ *
+ *  - **A 90-day retention sweep**, `services/cleanupService.cleanupOldData()`,
+ *    run from `services/cron.ts`. {@link pruneRecentlyViewedBefore} is its
+ *    Postgres half; `RECENTLY_VIEWED_RETENTION_DAYS` stays in `cleanupService`,
+ *    where the ViewingRequest window it sits beside also lives.
+ *  - **There is NO per-user row cap**, and none is invented here. Mongo had
+ *    none: the cap a reader might remember is the `?limit=` on the READ
+ *    (default 10), which bounds the response and not the table. Adding one
+ *    would be a new product rule wearing a migration's clothes.
+ *
+ * The unique key does most of the work regardless: one row per person per
+ * listing, so a user's row count is bounded by the number of DISTINCT listings
+ * they have opened in 90 days, not by how many times they opened them.
+ * `ON DELETE CASCADE` on `property_id` removes the rest — a reaped external ad
+ * takes its view rows with it.
+ *
+ * ## The write path was dead, which is why the table measured 0
+ *
+ * Two independent breaks, and each alone was enough:
+ *
+ *  - `trackPropertyView` was routed ONLY at
+ *    `POST /api/properties/:propertyId/track-view`, which no client calls, while
+ *    `packages/frontend/services/recentlyViewedService.ts` posted to
+ *    `POST /api/profiles/me/recent-properties/:propertyId`, which no router
+ *    served. The service caught the 404 and returned `{ success: false }`, so
+ *    nothing surfaced. The FIX IS SERVER-SIDE — the second spelling is now
+ *    mounted on the same handler — because a shipped mobile build cannot be
+ *    recalled, and correcting only the client would leave every installed app
+ *    still writing nothing.
+ *  - `controllers/property/retrieve.ts` also upserts a view, keyed
+ *    `{ profileId, propertyId }` — and `profileId` is not a field of
+ *    `RecentlyViewedSchema`, so mongoose strict mode drops it while the required
+ *    `oxyUserId` is never supplied. That write is left ALONE here: it is one of
+ *    the two Mongo writes that file's header reserves for the write batch.
+ *
+ * The consequence is deliberate and worth stating plainly: this table starts
+ * receiving rows for the first time, which is precisely what the 90-day sweep
+ * above exists to bound.
+ */
+
+import { desc, eq, lt } from 'drizzle-orm';
+
+import type { DatabaseOrTransaction } from '../postgres';
+import { recentlyViewed } from '../schema';
+import { isForeignKeyViolation } from '../uniqueViolation';
+
+export type RecentlyViewedRow = typeof recentlyViewed.$inferSelect;
+
+/**
+ * The listing whose view is being recorded does not exist.
+ *
+ * `recently_viewed_property_id_properties_id_fk` refuses the row rather than
+ * letting a view point at nothing, and the controller turns this into a 404.
+ */
+export class ViewedPropertyNotFoundError extends Error {
+  constructor(readonly propertyId: string) {
+    super(`Property ${propertyId} does not exist, so a view of it cannot be recorded.`);
+    this.name = 'ViewedPropertyNotFoundError';
+  }
+}
+
+/**
+ * Record that this person opened this listing.
+ *
+ * The Mongo handler read for an existing row and then either `save()`d it or
+ * constructed a new one — a read-then-write two concurrent opens of the same
+ * listing both pass, which then fails on the unique index anyway.
+ * `recently_viewed_owner_property_key` makes it one statement.
+ *
+ * `viewed_at` and `updated_at` both move, and `created_at` deliberately does
+ * not: it is when the listing was FIRST opened, which is a different fact from
+ * when it was last opened, and the read orders by the latter.
+ */
+export async function trackPropertyView(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+  propertyId: string,
+): Promise<RecentlyViewedRow> {
+  const viewedAt = new Date();
+  try {
+    const [row] = await db
+      .insert(recentlyViewed)
+      .values({ oxyUserId, propertyId, viewedAt })
+      .onConflictDoUpdate({
+        target: [recentlyViewed.oxyUserId, recentlyViewed.propertyId],
+        set: { viewedAt },
+      })
+      .returning();
+    return row;
+  } catch (error) {
+    if (isForeignKeyViolation(error, 'recently_viewed_property_id_properties_id_fk')) {
+      throw new ViewedPropertyNotFoundError(propertyId);
+    }
+    throw error;
+  }
+}
+
+/**
+ * The listings this person opened most recently, newest first.
+ *
+ * The Mongo handler de-duplicated the result into a `Map` keyed by property id
+ * after reading. That is not ported: the unique key makes a second row for the
+ * same `(owner, listing)` pair unrepresentable, so the de-duplication could only
+ * ever have been a no-op — and re-implementing it would hide a broken index
+ * rather than reveal one.
+ *
+ * @param limit How many rows to return. Bounds the RESPONSE only; see the header
+ *   on why the table's own bound is the retention sweep.
+ */
+export async function listRecentlyViewed(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+  limit: number,
+): Promise<readonly RecentlyViewedRow[]> {
+  return db
+    .select()
+    .from(recentlyViewed)
+    .where(eq(recentlyViewed.oxyUserId, oxyUserId))
+    .orderBy(desc(recentlyViewed.viewedAt))
+    .limit(limit);
+}
+
+/** Forget one person's whole history. Returns how many rows went. */
+export async function clearRecentlyViewed(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+): Promise<number> {
+  const rows = await db
+    .delete(recentlyViewed)
+    .where(eq(recentlyViewed.oxyUserId, oxyUserId))
+    .returning({ id: recentlyViewed.id });
+  return rows.length;
+}
+
+/**
+ * The retention sweep: drop every view older than `cutoff`, for every person.
+ *
+ * Deliberately NOT scoped to an owner — this is the table's only bound, and it
+ * has to run across all of them. `recently_viewed_owner_viewed_at_idx` leads
+ * with `oxy_user_id`, so this is a sequential scan; that is the right trade for
+ * a job that runs from cron against a table whose live set is 90 days wide, and
+ * it is what the Mongo `deleteMany` did too.
+ *
+ * @param cutoff Rows with `viewed_at` strictly before this are removed.
+ * @returns How many rows went.
+ */
+export async function pruneRecentlyViewedBefore(
+  db: DatabaseOrTransaction,
+  cutoff: Date,
+): Promise<number> {
+  const rows = await db
+    .delete(recentlyViewed)
+    .where(lt(recentlyViewed.viewedAt, cutoff))
+    .returning({ id: recentlyViewed.id });
+  return rows.length;
+}

--- a/packages/backend/db/saved/savedFolderRepository.ts
+++ b/packages/backend/db/saved/savedFolderRepository.ts
@@ -1,0 +1,312 @@
+/**
+ * `saved_property_folders` — a person's collections of saved listings, on
+ * Postgres.
+ *
+ * Ported from `models/schemas/SavedPropertyFolderSchema.ts`. The collection held
+ * **0 documents in production** (measured, not assumed), so this port has no
+ * backfill and no consistency window.
+ *
+ * ## `saved_property_folder_items` is NOT written, and that is the point
+ *
+ * The schema carries that table because the Mongo document carried a
+ * `properties[]` array and a schema port may not silently drop a field. But
+ * folder MEMBERSHIP has one representation and it is `saved_items.folder_id`:
+ * that is what `saveProperty` wrote, what the folder counts aggregated, and what
+ * every read in this package consults. The `properties[]` array was a second
+ * copy of the same fact, and the four Mongoose methods that maintained it
+ * (`addProperty`, `removeProperty`, `hasProperty`, `updatePropertyNotes`) have
+ * **zero call sites** — the only code that ever touched the array was a
+ * best-effort `try {} catch {}` mirror in `updateSavedPropertyNotes`, which
+ * swallowed its own failures and could therefore drift from `Saved` unobserved.
+ *
+ * Writing both would mean two representations of one fact, which is the failure
+ * this codebase names repeatedly. So the mirror is dropped rather than ported,
+ * and `saved_property_folder_items` is left with no writer — a fact recorded
+ * here, and in the PR, because a table with no producer is a trap for the next
+ * reader. Removing it is a `post`-phase migration and a separate, deliberate
+ * change; it is not smuggled in here.
+ *
+ * ## The case-insensitive name rule is the INDEX now
+ *
+ * Both handlers checked for a duplicate name with
+ * `{ $regex: new RegExp('^' + name + '$', 'i') }` and then wrote — a
+ * read-then-write with a window, and an unescaped regex built from user input
+ * besides (a folder named `.*` matched every existing name and made the folder
+ * unnameable). `saved_property_folders_owner_name_key` is a functional unique on
+ * `lower(name)`, so the port INSERTs and handles `23505`, which
+ * `db/MIGRATION-CONTRACT.md` names as the required shape for exactly this class
+ * of change. {@link SavedFolderNameTakenError} is what the controller turns back
+ * into the 409 the Mongo handler returned.
+ */
+
+import { and, asc, eq } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
+
+import type { DatabaseOrTransaction } from '../postgres';
+import { savedPropertyFolders } from '../schema';
+import { isUniqueViolation } from '../uniqueViolation';
+
+export type SavedFolderRow = typeof savedPropertyFolders.$inferSelect;
+
+/**
+ * The name of the folder `saveProperty` creates when a person saves their first
+ * listing without naming a folder. Mongo's literals, kept verbatim.
+ */
+const DEFAULT_FOLDER = {
+  name: 'Favorites',
+  description: 'Default folder for saved properties',
+  icon: '❤️',
+} as const;
+
+/** This person already has a folder by that name, ignoring case. */
+export class SavedFolderNameTakenError extends Error {
+  constructor(readonly folderName: string) {
+    super(`A saved-property folder named '${folderName}' already exists for this owner.`);
+    this.name = 'SavedFolderNameTakenError';
+  }
+}
+
+export interface CreateSavedFolderInput {
+  readonly oxyUserId: string;
+  readonly name: string;
+  readonly description?: string | null;
+  readonly color?: string;
+  readonly icon?: string;
+  readonly isDefault?: boolean;
+}
+
+/**
+ * Store an absent description as NULL rather than as `''`.
+ *
+ * `db/schema/CONVENTIONS.md` refuses a `default: ''` on the ground that an empty
+ * string is a VALUE and NULL is the absence; the column is nullable with no
+ * default, and this is the one place that decision is applied.
+ */
+function normalizeDescription(description: string | null | undefined): string | null {
+  if (typeof description !== 'string') return null;
+  const trimmed = description.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Create a folder.
+ *
+ * `color` and `icon` are passed through as `undefined` when absent so the COLUMN
+ * defaults apply. Passing an explicit `null` would fail `NOT NULL`, which is the
+ * same trap `notificationRepository` documents: mongoose applies a default at
+ * document construction, drizzle omits an `undefined` key and lets the server
+ * decide.
+ *
+ * @throws {SavedFolderNameTakenError} Raised from the index's own `23505` rather
+ *   than from a preceding read, so two concurrent requests cannot both succeed.
+ */
+export async function createSavedFolder(
+  db: DatabaseOrTransaction,
+  input: CreateSavedFolderInput,
+): Promise<SavedFolderRow> {
+  try {
+    const [row] = await db
+      .insert(savedPropertyFolders)
+      .values({
+        oxyUserId: input.oxyUserId,
+        name: input.name,
+        description: normalizeDescription(input.description),
+        color: input.color,
+        icon: input.icon,
+        isDefault: input.isDefault ?? false,
+      })
+      .returning();
+    return row;
+  } catch (error) {
+    if (isUniqueViolation(error, 'saved_property_folders_owner_name_key')) {
+      throw new SavedFolderNameTakenError(input.name);
+    }
+    throw error;
+  }
+}
+
+/** Every folder this person owns: the default one first, then oldest first. */
+export async function listSavedFolders(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+): Promise<readonly SavedFolderRow[]> {
+  return db
+    .select()
+    .from(savedPropertyFolders)
+    .where(eq(savedPropertyFolders.oxyUserId, oxyUserId))
+    // `{ isDefault: -1, createdAt: 1 }`, unchanged. `desc` on a boolean puts
+    // `true` first in Postgres, which is the same order Mongo produced.
+    .orderBy(sql`${savedPropertyFolders.isDefault} desc`, asc(savedPropertyFolders.createdAt));
+}
+
+/** One folder, scoped to its owner. */
+export async function findSavedFolder(
+  db: DatabaseOrTransaction,
+  id: string,
+  oxyUserId: string,
+): Promise<SavedFolderRow | undefined> {
+  const [row] = await db
+    .select()
+    .from(savedPropertyFolders)
+    .where(and(eq(savedPropertyFolders.id, id), eq(savedPropertyFolders.oxyUserId, oxyUserId)))
+    .limit(1);
+  return row;
+}
+
+export interface UpdateSavedFolderInput {
+  readonly name?: string;
+  readonly description?: string | null;
+  readonly color?: string;
+  readonly icon?: string;
+}
+
+/**
+ * Apply a partial update, scoped to the owner. `undefined` when the folder does
+ * not exist or belongs to somebody else.
+ *
+ * @throws {SavedFolderNameTakenError} When a rename collides with another of the
+ *   owner's folders, ignoring case.
+ */
+export async function updateSavedFolder(
+  db: DatabaseOrTransaction,
+  id: string,
+  oxyUserId: string,
+  input: UpdateSavedFolderInput,
+): Promise<SavedFolderRow | undefined> {
+  const values: Partial<typeof savedPropertyFolders.$inferInsert> = {};
+  if (input.name !== undefined) values.name = input.name;
+  if (input.description !== undefined) values.description = normalizeDescription(input.description);
+  if (input.color !== undefined) values.color = input.color;
+  if (input.icon !== undefined) values.icon = input.icon;
+
+  // An empty `set` would still restamp `updated_at` through drizzle's
+  // `$onUpdate` — the row is read back instead, as `notificationRepository` does.
+  if (Object.keys(values).length === 0) return findSavedFolder(db, id, oxyUserId);
+
+  try {
+    const [row] = await db
+      .update(savedPropertyFolders)
+      .set(values)
+      .where(and(eq(savedPropertyFolders.id, id), eq(savedPropertyFolders.oxyUserId, oxyUserId)))
+      .returning();
+    return row;
+  } catch (error) {
+    if (isUniqueViolation(error, 'saved_property_folders_owner_name_key')) {
+      throw new SavedFolderNameTakenError(input.name ?? '');
+    }
+    throw error;
+  }
+}
+
+/**
+ * Delete one folder, scoped to its owner. `false` when it was not theirs.
+ *
+ * The saves filed in it are NOT deleted: `saved_items.folder_id` is
+ * `ON DELETE SET NULL`, so they return to "not in a folder" in the same
+ * statement. See the header of `savedPropertyRepository.ts`.
+ */
+export async function deleteSavedFolder(
+  db: DatabaseOrTransaction,
+  id: string,
+  oxyUserId: string,
+): Promise<boolean> {
+  const rows = await db
+    .delete(savedPropertyFolders)
+    .where(and(eq(savedPropertyFolders.id, id), eq(savedPropertyFolders.oxyUserId, oxyUserId)))
+    .returning({ id: savedPropertyFolders.id });
+  return rows.length > 0;
+}
+
+/**
+ * The folder a save goes into when the caller named none — found, or created.
+ *
+ * Two races, both real, both closed by the index rather than by a lock:
+ *
+ *  - two concurrent first-saves each find no default folder and each insert one.
+ *    The second gets `23505` from `saved_property_folders_owner_name_key`, and
+ *    the re-read below returns the row the first one committed.
+ *  - a person already has a non-default folder literally named "Favorites". The
+ *    insert collides on the same index, and the re-read finds THAT folder, which
+ *    is the only sane answer — the alternative is a 500 on a save.
+ *
+ * `is_default` carries no unique index (Mongo had none either), so two default
+ * folders remain representable. The lookup is therefore ORDERED, so which one is
+ * chosen is stable rather than whatever the heap returns first.
+ */
+export async function ensureDefaultFolder(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+): Promise<SavedFolderRow> {
+  const [existing] = await db
+    .select()
+    .from(savedPropertyFolders)
+    .where(
+      and(
+        eq(savedPropertyFolders.oxyUserId, oxyUserId),
+        eq(savedPropertyFolders.isDefault, true),
+      ),
+    )
+    .orderBy(asc(savedPropertyFolders.createdAt))
+    .limit(1);
+  if (existing) return existing;
+
+  const [created] = await db
+    .insert(savedPropertyFolders)
+    .values({
+      oxyUserId,
+      name: DEFAULT_FOLDER.name,
+      description: DEFAULT_FOLDER.description,
+      icon: DEFAULT_FOLDER.icon,
+      isDefault: true,
+    })
+    // No `catch` on `23505` here: `DO NOTHING` returns an empty set for both
+    // races above, and the re-read that follows distinguishes neither — it just
+    // returns the row that won.
+    .onConflictDoNothing()
+    .returning();
+  if (created) return created;
+
+  const [raced] = await db
+    .select()
+    .from(savedPropertyFolders)
+    .where(
+      and(
+        eq(savedPropertyFolders.oxyUserId, oxyUserId),
+        sql`lower(${savedPropertyFolders.name}) = lower(${DEFAULT_FOLDER.name})`,
+      ),
+    )
+    .limit(1);
+  if (raced) return raced;
+
+  // Unreachable unless the conflicting row was deleted between the insert and
+  // the re-read. Thrown rather than returned as `undefined`, so a caller cannot
+  // file a save against a folder that does not exist.
+  throw new Error(
+    `Could not find or create the default saved-property folder for owner ${oxyUserId}.`,
+  );
+}
+
+/**
+ * The wire shape the saved screen reads.
+ *
+ * `id`, never `_id`. `propertyCount` is the Mongoose virtual, now computed from
+ * `saved_items` by {@link countSavedPropertiesByFolder} and passed in — the
+ * folder row itself stores no count, so there is nothing that can go stale.
+ */
+export function toSavedFolderDTO(
+  row: SavedFolderRow,
+  propertyCount: number,
+): Record<string, unknown> {
+  return {
+    id: row.id,
+    oxyUserId: row.oxyUserId,
+    name: row.name,
+    description: row.description,
+    color: row.color,
+    icon: row.icon,
+    isDefault: row.isDefault,
+    propertyCount,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/packages/backend/db/saved/savedPropertyRepository.ts
+++ b/packages/backend/db/saved/savedPropertyRepository.ts
@@ -1,0 +1,242 @@
+/**
+ * `saved_items` — a person's saved listings, on Postgres.
+ *
+ * Ported from `models/schemas/SavedSchema.ts`. The collection held **0 documents
+ * in production** (measured against `homiio-production`, not assumed), so this
+ * port has no backfill and no consistency window.
+ *
+ * ## Three read-then-write races became one `ON CONFLICT`
+ *
+ * `saveProperty` was an `updateOne(..., { upsert: true })`, which Mongo makes
+ * atomic only because the compound index existed. `saved_items_owner_target_key`
+ * is the same rule as a real UNIQUE, so the port is a single
+ * `INSERT ... ON CONFLICT DO UPDATE` and the "already saved?" question is never
+ * asked in a separate statement.
+ *
+ * ## `notes` is NULL when absent — both writers now agree
+ *
+ * The Mongo handlers disagreed with each other: `saveProperty` stored
+ * `notes || null` and `updateSavedPropertyNotes` stored `notes || ''`, so "no
+ * note" was `null` or `''` depending on which endpoint last touched the row.
+ * `db/schema/CONVENTIONS.md` refuses a `''` default precisely because an empty
+ * string is a VALUE and NULL is the absence, and `saved_items.notes` is nullable
+ * with no default. {@link normalizeNotes} is the ONE place that decision is
+ * applied, so both writers store the same thing.
+ *
+ * The WIRE is unchanged: {@link toSavedPropertyFields} emits `''` for a null
+ * note, exactly as the Mongo handler's `row.notes || ''` did.
+ *
+ * ## Deleting a folder is the FOREIGN KEY's job now
+ *
+ * `deleteSavedPropertyFolder` used to run
+ * `Saved.updateMany({ folderId }, { $set: { folderId: null } })` before removing
+ * the folder. `saved_items.folder_id` is declared `ON DELETE SET NULL`, so the
+ * server does exactly that in the same statement that drops the folder — and it
+ * cannot be forgotten by a second call site. There is deliberately no
+ * `clearFolderAssignment` here: adding one would re-create, in application code,
+ * a rule the schema already carries.
+ */
+
+import { and, count, desc, eq, inArray } from 'drizzle-orm';
+
+import type { DatabaseOrTransaction } from '../postgres';
+import { savedItems } from '../schema';
+import { isForeignKeyViolation } from '../uniqueViolation';
+
+export type SavedItemRow = typeof savedItems.$inferSelect;
+
+/**
+ * The listing being saved does not exist.
+ *
+ * Mongo stored `target_id` as a bare string with nothing behind it, so saving a
+ * listing that had just been reaped succeeded and left a pointer to nothing.
+ * `saved_items_target_id_properties_id_fk` refuses that row, and this is the
+ * 404 the caller earned rather than the 500 the raw `23503` would be.
+ */
+export class SavedPropertyNotFoundError extends Error {
+  constructor(readonly propertyId: string) {
+    super(`Property ${propertyId} does not exist, so it cannot be saved.`);
+    this.name = 'SavedPropertyNotFoundError';
+  }
+}
+
+/**
+ * Store "no note" as NULL rather than as an empty string.
+ *
+ * Trimmed as well as emptied: mongoose's `trim` has no Postgres counterpart and
+ * `CONVENTIONS.md` says it is re-applied where the value enters. A note of
+ * `'   '` is not a note.
+ */
+function normalizeNotes(notes: string | null | undefined): string | null {
+  if (typeof notes !== 'string') return null;
+  const trimmed = notes.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export interface SavePropertyInput {
+  readonly oxyUserId: string;
+  readonly propertyId: string;
+  readonly notes?: string | null;
+  /** `null` files the save outside any folder. */
+  readonly folderId?: string | null;
+}
+
+/**
+ * Save a listing, or update the save that is already there.
+ *
+ * `created_at` is rewritten on a repeat, which is what the Mongo upsert did
+ * (`$set: { ..., createdAt: new Date() }`). It is the "saved at" the list is
+ * ordered by, so re-saving — including moving a listing to another folder —
+ * moves it back to the top, and that is the behaviour the saved screen has
+ * always had.
+ */
+export async function saveProperty(
+  db: DatabaseOrTransaction,
+  input: SavePropertyInput,
+): Promise<SavedItemRow> {
+  const notes = normalizeNotes(input.notes);
+  const folderId = input.folderId ?? null;
+  const savedAt = new Date();
+
+  try {
+    const [row] = await db
+      .insert(savedItems)
+      .values({
+        oxyUserId: input.oxyUserId,
+        targetType: 'property',
+        targetId: input.propertyId,
+        notes,
+        folderId,
+        createdAt: savedAt,
+      })
+      .onConflictDoUpdate({
+        target: [savedItems.oxyUserId, savedItems.targetType, savedItems.targetId],
+        set: { notes, folderId, createdAt: savedAt },
+      })
+      .returning();
+    return row;
+  } catch (error) {
+    if (isForeignKeyViolation(error, 'saved_items_target_id_properties_id_fk')) {
+      throw new SavedPropertyNotFoundError(input.propertyId);
+    }
+    throw error;
+  }
+}
+
+/** Every listing this person has saved, most recently saved first. */
+export async function listSavedProperties(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+): Promise<readonly SavedItemRow[]> {
+  return db
+    .select()
+    .from(savedItems)
+    .where(and(eq(savedItems.oxyUserId, oxyUserId), eq(savedItems.targetType, 'property')))
+    .orderBy(desc(savedItems.createdAt));
+}
+
+/**
+ * Remove one save. `false` when this person had not saved that listing.
+ *
+ * Scoped by owner inside the `DELETE` rather than checked before it — an
+ * authorisation performed in a second statement is an IDOR the first time
+ * somebody forgets it.
+ */
+export async function unsaveProperty(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+  propertyId: string,
+): Promise<boolean> {
+  const rows = await db
+    .delete(savedItems)
+    .where(
+      and(
+        eq(savedItems.oxyUserId, oxyUserId),
+        eq(savedItems.targetType, 'property'),
+        eq(savedItems.targetId, propertyId),
+      ),
+    )
+    .returning({ id: savedItems.id });
+  return rows.length > 0;
+}
+
+/**
+ * Replace the note on a save. `undefined` when this person had not saved that
+ * listing.
+ */
+export async function updateSavedPropertyNotes(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+  propertyId: string,
+  notes: string | null | undefined,
+): Promise<SavedItemRow | undefined> {
+  const [row] = await db
+    .update(savedItems)
+    .set({ notes: normalizeNotes(notes) })
+    .where(
+      and(
+        eq(savedItems.oxyUserId, oxyUserId),
+        eq(savedItems.targetType, 'property'),
+        eq(savedItems.targetId, propertyId),
+      ),
+    )
+    .returning();
+  return row;
+}
+
+/**
+ * How many saves sit in each of `folderIds`, for this owner.
+ *
+ * This is `SavedPropertyFolder.propertyCount` — the Mongoose virtual
+ * `db/MIGRATION-CONTRACT.md` lists as one a DTO now has to compute. It counts
+ * `saved_items`, which is where folder MEMBERSHIP actually lives; the folder's
+ * own `properties[]` array was a second copy of the same fact and is not read.
+ * See the header on `saved_property_folder_items` in
+ * {@link file://./savedFolderRepository.ts}.
+ *
+ * @returns A count per folder id. A folder with no saves is ABSENT from the map
+ *   rather than present as `0`, so the caller's `?? 0` is what supplies the
+ *   empty case.
+ */
+export async function countSavedPropertiesByFolder(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+  folderIds: readonly string[],
+): Promise<Map<string, number>> {
+  if (folderIds.length === 0) return new Map();
+
+  const rows = await db
+    .select({ folderId: savedItems.folderId, total: count() })
+    .from(savedItems)
+    .where(
+      and(
+        eq(savedItems.oxyUserId, oxyUserId),
+        eq(savedItems.targetType, 'property'),
+        inArray(savedItems.folderId, [...folderIds]),
+      ),
+    )
+    .groupBy(savedItems.folderId);
+
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    // `folder_id` is nullable, but `inArray` over a list of real ids can never
+    // match a NULL — the guard states that rather than asserting it away.
+    if (row.folderId !== null) counts.set(row.folderId, row.total);
+  }
+  return counts;
+}
+
+/**
+ * The three fields a saved listing carries ON TOP of the property itself.
+ *
+ * The saved screen receives a property object with these merged in, which is the
+ * shape the Mongo handler built by spreading the lean property document. `notes`
+ * is emitted as `''` rather than `null` for the reason in the header.
+ */
+export function toSavedPropertyFields(row: SavedItemRow): Record<string, unknown> {
+  return {
+    savedAt: row.createdAt,
+    notes: row.notes ?? '',
+    folderId: row.folderId,
+  };
+}

--- a/packages/backend/db/uniqueViolation.ts
+++ b/packages/backend/db/uniqueViolation.ts
@@ -66,6 +66,9 @@
 /** The SQLSTATE for `unique_violation`. */
 const UNIQUE_VIOLATION = '23505';
 
+/** The SQLSTATE for `foreign_key_violation`. */
+const FOREIGN_KEY_VIOLATION = '23503';
+
 /**
  * How far down a `cause` chain to look.
  *
@@ -90,14 +93,45 @@ interface PostgresErrorLike {
  *   keeps propagating.
  */
 export function isUniqueViolation(error: unknown, constraintName: string): boolean {
+  return hasConstraintViolation(error, UNIQUE_VIOLATION, constraintName);
+}
+
+/**
+ * Whether `error`, or anything in its `cause` chain, is a `23503` raised by the
+ * NAMED foreign key.
+ *
+ * The same reasoning as {@link isUniqueViolation}, one SQLSTATE over. It exists
+ * because Mongo let a reference point at nothing and Postgres does not: writes
+ * that accept an id from the CLIENT — saving a listing, recording that one was
+ * viewed — used to store a dangling pointer silently and now raise `23503`. That
+ * is a 404 the caller earned, not the 500 an unhandled driver error would be.
+ *
+ * Naming the constraint matters as much here as it does above: a statement can
+ * touch several foreign keys, and treating any `23503` as "that listing is gone"
+ * would report an unrelated integrity failure as a missing property.
+ */
+export function isForeignKeyViolation(error: unknown, constraintName: string): boolean {
+  return hasConstraintViolation(error, FOREIGN_KEY_VIOLATION, constraintName);
+}
+
+/**
+ * Walk the `cause` chain for a violation of `constraintName` carrying
+ * `sqlState`.
+ *
+ * The walk is the part worth having once: drizzle WRAPS the driver's error (see
+ * the header), so the check has to look past the outermost object, and it is
+ * depth-bounded so a cyclic `cause` cannot spin.
+ */
+function hasConstraintViolation(
+  error: unknown,
+  sqlState: string,
+  constraintName: string,
+): boolean {
   let current = error;
   for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
     if (!current || typeof current !== 'object') return false;
     const candidate = current as PostgresErrorLike;
-    if (
-      candidate.code === UNIQUE_VIOLATION &&
-      candidate.constraint_name === constraintName
-    ) {
+    if (candidate.code === sqlState && candidate.constraint_name === constraintName) {
       return true;
     }
     current = candidate.cause;

--- a/packages/backend/routes/profiles.ts
+++ b/packages/backend/routes/profiles.ts
@@ -22,7 +22,12 @@ export default function () {
   router.get('/me', asyncHandler(profileController.getOrCreateProfile));
   router.put('/me', asyncHandler(profileController.updateMyProfile));
   router.get('/me/recent-properties', asyncHandler(profileController.getRecentProperties));
-  router.get('/me/recent-properties/debug', asyncHandler(profileController.debugRecentProperties));
+  // The recently-viewed WRITE. It used to live only at
+  // `POST /api/properties/:propertyId/track-view`, which no client called, while
+  // `services/recentlyViewedService` posted here — to a route no router served.
+  // Both spellings are now mounted on the same handler; the upsert is idempotent
+  // per (owner, listing), so which one a client uses cannot matter.
+  router.post('/me/recent-properties/:propertyId', asyncHandler(profileController.trackPropertyView));
   router.delete('/me/recent-properties', asyncHandler(profileController.clearRecentProperties));
   router.get('/me/saved-properties', asyncHandler(profileController.getSavedProperties));
   router.post('/me/save-property', asyncHandler(profileController.saveProperty));

--- a/packages/backend/services/cleanupService.ts
+++ b/packages/backend/services/cleanupService.ts
@@ -1,7 +1,19 @@
 import { Logger } from '../utils/logger';
 import { cleanupExpiredProperties } from './scraperService';
-import { RecentlyViewed, ViewingRequest } from '../models';
+import { ViewingRequest } from '../models';
+import { getDb } from '../db/postgres';
+import { pruneRecentlyViewedBefore } from '../db/saved/recentlyViewedRepository';
 
+/**
+ * The ONLY bound on `recently_viewed`, which is the one table in the saved-items
+ * domain that grows on reads rather than on deliberate user action.
+ *
+ * Ported unchanged from the Mongo sweep. There is deliberately no per-user row
+ * cap beside it — Mongo had none, and the `?limit=` on the read bounds the
+ * RESPONSE, not the table. The unique key does the rest: one row per person per
+ * listing, so a user's footprint is the number of DISTINCT listings they opened
+ * in the window, however often they opened them.
+ */
 const RECENTLY_VIEWED_RETENTION_DAYS = 90;
 const VIEWING_REQUEST_RETENTION_DAYS = 180;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -64,9 +76,9 @@ export class CleanupService {
     let errors = 0;
 
     try {
-      const result = await RecentlyViewed.deleteMany({ viewedAt: { $lt: recentlyViewedCutoff } });
-      deleted += result.deletedCount || 0;
-      this.logger.info(`Deleted ${result.deletedCount || 0} recently-viewed entries older than ${RECENTLY_VIEWED_RETENTION_DAYS} days`);
+      const removed = await pruneRecentlyViewedBefore(getDb(), recentlyViewedCutoff);
+      deleted += removed;
+      this.logger.info(`Deleted ${removed} recently-viewed entries older than ${RECENTLY_VIEWED_RETENTION_DAYS} days`);
     } catch (error) {
       errors += 1;
       this.logger.error('RecentlyViewed cleanup failed', error);


### PR DESCRIPTION
Ports the last three collections of the saved-items domain onto the tables migration `0006_engagement_saved_cache` already created. No new tables, no new migration.

## Production row counts, measured

Counted directly against `homiio-production` (a one-off ECS task on the live task definition, so the credential stayed in SSM and never reached a log):

| Collection | Documents |
|---|---|
| `saveds` | **0** |
| `savedpropertyfolders` | **0** |
| `recentlyvieweds` | **0** |
| `savedsearches` | 0 (already ported) |

All empty, so there is no backfill and no consistency window — the first row each table holds is the first one these repositories write. For scale, the same census read `properties = 17,644` and `images = 171,976`, so the zeroes are a real measurement rather than a failed connection.

**`recentlyvieweds` is empty because the feature was BROKEN, not unused** — see below. That is the one count here that should not be read as "nobody wants this".

## Shape

Repositories under `packages/backend/db/saved/`, each taking the drizzle connection as a parameter so they compose inside a transaction; controllers call the repository and never drizzle. Every `oxy_user_id` stays a foreign service's primary key carrying no foreign key, per `db/schema/CONVENTIONS.md`.

## Rules that moved out of application code and into the schema

- **Idempotency is the index.** The save upsert, the folder duplicate-name check and the recently-viewed read-then-write are `ON CONFLICT` against real composite uniques. The folder check was additionally an unescaped `RegExp` built from user input — a folder named `.*` matched every existing name, so the 409 fired against a folder the caller had never seen.
- **Deleting a folder no longer re-files its saves in application code.** `saved_items.folder_id` is `ON DELETE SET NULL`, so `Saved.updateMany({folderId}, {folderId: null})` is deleted. If that constraint were wrong, a person would lose every saved listing by tidying up a folder — pinned by a test.
- **A dead pointer is unrepresentable.** `target_id` is a real foreign key, so the `if (!prop) return null` filter is gone, and saving a listing that does not exist is a 404 rather than a silently stored dangling row. `isForeignKeyViolation` joins `isUniqueViolation` in `db/uniqueViolation.ts`, sharing the cause-chain walk drizzle's error wrapping requires.
- **`notes` has one spelling for absence.** The two Mongo writers disagreed (`null` vs `''`). The column is nullable with no default; the wire still emits `''`.

## Recently-viewed is the append-heavy table, and its bound is ported deliberately

The **90-day retention sweep** in `CleanupService.cleanupOldData` (run from cron) is ported to Postgres and tested **through the service**, not the repository — a repository-only test would pass just as happily with the service still wired to a Mongoose model that no longer receives rows.

**There is no per-user row cap, and none was invented.** Mongo had none; the cap a reader might remember is the read's `?limit=`, which bounds the response and not the table. That limit is now capped at 100 — it was unbounded, and hydration is a catalogue read with four joins plus three batched child queries per page. The unique key does the rest: a user's footprint is the number of *distinct* listings they opened in 90 days, however often they opened them.

### Its write path was dead in both directions

1. The client posts to `POST /api/profiles/me/recent-properties/:propertyId`, which **no router served**; `recentlyViewedService` caught the 404 and returned `{success:false}`, so nothing surfaced. The handler was only mounted at `POST /api/properties/:propertyId/track-view`, which no client calls.
2. `controllers/property/retrieve.ts` also upserts a view keyed `{profileId, propertyId}` — and `profileId` is not a field of `RecentlyViewedSchema`, so strict mode drops it while the required `oxyUserId` is never supplied.

(1) is fixed **server-side**, by mounting the spelling the client already uses: a shipped mobile build cannot be recalled, so correcting only the client would leave every installed app still writing nothing. (2) is **left alone** — it is one of the two Mongo writes `retrieve.ts`'s own header reserves for the property-write batch, which a sibling PR owns.

Consequence, stated plainly: this table starts receiving rows for the first time. That is exactly what the 90-day sweep exists to bound.

## Deleted rather than ported

- **`debugRecentProperties`** and its route — every fact it reported was a `populate()` artefact with no Postgres counterpart (`hasPopulatedProperty`, `populatedKeys`) or already answered by `GET /me/recent-properties`; its "does this property still exist?" check is a question `ON DELETE CASCADE` now answers *yes* by construction. Zero consumers in the repo.
- **`getProfileProperties`** — no route, no caller, duplicated `getMyProperties` in `retrieve.ts`, which is routed and already reads Postgres.
- **The `Profile.findByOxyUserId` guard on `clearRecentProperties`** — same reasoning as the saved-searches port: it authorised nothing (the delete is scoped by the session `oxyUserId` either way) and only 404'd people who had no profile document yet.
- **The best-effort note mirror** into `SavedPropertyFolder.properties[]`, a `try {} catch {}` that swallowed its own failures.

## One thing left behind on purpose: `saved_property_folder_items` has NO writer

Folder membership has one representation and it is `saved_items.folder_id` — that is what the Mongo save wrote, what the folder counts aggregated, and what every read consults. The folder's `properties[]` array was a second copy of the same fact, and its four Mongoose methods (`addProperty`, `removeProperty`, `hasProperty`, `updatePropertyNotes`) have **zero call sites**; the only code that touched the array was the swallowed mirror above.

Writing both would mean two representations of one fact. So the mirror is dropped and the table is left with no producer — **recorded here and in the repository header, because a table with no writer is a trap for the next reader.** Removing it is a `post`-phase migration and a separate, deliberate change; it is not smuggled into this PR.

## Tests: the real-Postgres harness, 45 cases

Every load-bearing case is one a mocked drizzle would accept and a real server refuses, or a behaviour the *server* performs and no application code does. Both directions of each unique are asserted — the permit half (two people may both save one listing / both own a "Favorites") is what a plain `UNIQUE(target_id)` would break while still passing every "rejects a duplicate" assertion.

**Mutation-tested**, each reverted and re-verified afterwards:

| Mutation | Result |
|---|---|
| `saved_items.folder_id` `SET NULL` → `CASCADE` | 1 failure, exactly "KEEPS the saves when their folder is deleted" |
| drop `oxy_user_id` from both composite uniques | 26 failures across both suites |
| retention sweep no longer reaches Postgres | 1 failure, exactly the 90-day case |

Because the suite builds its schema from `drizzle/*.sql`, the first two required mutating the migration SQL — mutating `db/schema/saved.ts` would have changed nothing and reported a false pass.

### A test-isolation bug this surfaced, fixed in my own files

Adding two suites turned `__tests__/db/geoBackfill.test.ts` red (10 FK failures). Root cause, reproduced deterministically with `jest --runInBand --runTestsByPath <mine> <geoBackfill>`: `countries_code_key` is UNIQUE on `code`, `db/backfill/geo.ts` copies with `ON CONFLICT DO NOTHING`, and my fixtures left an `ES` country behind — so the backfill silently skipped inserting its *own* country and then failed the `regions` foreign key.

Fixed by having my two suites clean up in `afterAll`. Worth flagging to whoever owns the backfill suite: **`geoBackfill.test.ts` never truncates and depends on no earlier file leaving an `ES` country behind**, unlike the ~15 other suites that truncate in `beforeEach`. It is latent, not mine to fix here.

## Gates

- Backend tests **114 suites / 1443 passed**. Baseline on `origin/main` measured first: 112 / 1398 — this PR adds exactly 2 suites and 45 tests.
- Backend typecheck, backend build, frontend typecheck: clean.
- Backend lint: **0 errors**, warnings **217 → 168** (the ported controllers dropped their `req: any, res: any, next: any` signatures).
- Lockfile in sync; migration deploy phases and version pins pass.
- The one frontend lint error is byte-identical on `origin/main` and the lint job is deliberately disarmed behind `HOMIIO_LINT_GATE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
