### PR TITLE
Move home exchanges to Postgres, and turn a JS overlap scan into a range query (#281)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,9 @@ jobs:
       # glob that stops matching all produce an empty green run, and that reads as
       # coverage forever because nothing contradicts it.
       #
-      # RAISED FROM 1310 TO 1345 by the viewings + applications port, which
+      # RAISED FROM 1345 TO 1380 by the exchanges port, which added
+      # `exchangeRequests.test.ts` — measured 1398 -> 1424. Before that it went
+      # 1310 -> 1345 for the viewings + applications port, which
       # added two real-database suites — measured 1352 -> 1389. Before that it
       # went 1225 -> 1310 for the lease port, which added
       # `leasePaymentSchedule.test.ts` and rewrote `leaseOwnership.test.ts`
@@ -171,7 +173,7 @@ jobs:
         if: always()
         run: >-
           bun .github/scripts/assert-test-floor.mjs
-          "$RUNNER_TEMP/backend-tests.json" packages/backend 1345
+          "$RUNNER_TEMP/backend-tests.json" packages/backend 1380
 
   frontend:
     runs-on: ubuntu-24.04

--- a/packages/backend/__tests__/integration/exchangeRequests.test.ts
+++ b/packages/backend/__tests__/integration/exchangeRequests.test.ts
@@ -1,0 +1,587 @@
+/**
+ * Home exchanges — the mode matrix, the dual-role calendar conflict, the two
+ * coherence CHECKs, and the reviews that follow. Against the REAL Postgres.
+ *
+ * ## What makes these tests non-vacuous
+ *
+ * `exchange_requests` and `exchange_reviews` were empty in production. Each case
+ * targets a rule with a way to be wrong:
+ *
+ *  - the overlap is asserted at the BOUNDARY instant, because `[)` and `[]`
+ *    bounds agree everywhere except there — a port that copied `leases`'
+ *    closed-bound spelling would refuse a legitimate back-to-back stay and pass
+ *    every other test in this file,
+ *  - the conflict is asserted in BOTH roles (target and offered), because a
+ *    scan that forgot the offered role lets a swap double-book the home the
+ *    requester offers in return,
+ *  - `exchange_requests_offered_window_check` is asserted on the HALF-a-pair it
+ *    exists to refuse, which is the shape a NULL-tolerant CHECK admits,
+ *  - every refusal re-reads the row.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { eq } from 'drizzle-orm';
+
+import exchangeController from '../../controllers/exchangeController';
+import exchangeReviewController from '../../controllers/exchangeReviewController';
+import { getDb } from '../../db/postgres';
+import { exchangeRequests, exchangeReviews } from '../../db/schema';
+import { errorHandler } from '../../middlewares/errorHandler';
+import { resetGeoTables, seedListingWithGeo } from '../helpers/postgresGeoFixtures';
+
+function buildApp(oxyUserId?: string): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (oxyUserId) {
+      const authed = req as unknown as { user: { id: string }; userId: string };
+      authed.user = { id: oxyUserId };
+      authed.userId = oxyUserId;
+    }
+    next();
+  });
+  app.post('/exchanges', (req, res, next) => exchangeController.createExchangeRequest(req, res, next));
+  app.get('/exchanges', (req, res, next) => exchangeController.listMyExchangeRequests(req, res, next));
+  app.get('/exchanges/:id', (req, res, next) => exchangeController.getExchangeRequest(req, res, next));
+  app.patch('/exchanges/:id', (req, res, next) => exchangeController.updateExchangeRequestStatus(req, res, next));
+  app.post('/exchanges/:id/reviews', (req, res, next) => exchangeReviewController.createExchangeReview(req, res, next));
+  app.get('/exchanges/:id/reviews', (req, res, next) => exchangeReviewController.getExchangeReviews(req, res, next));
+  app.get('/profiles/:oxyUserId/exchange-reviews', (req, res, next) => exchangeReviewController.getProfileExchangeReviews(req, res, next));
+  app.use(errorHandler);
+  return app;
+}
+
+/** A distinct ISO-3166 alpha-2 per geo chain — `countries_code_key` is UNIQUE. */
+let geoChainCounter = 0;
+function nextCountryCode(): string {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const index = geoChainCounter++;
+  return `${alphabet[Math.floor(index / 26) % 26]}${alphabet[index % 26]}`;
+}
+
+/** A listing open to home exchange in `mode`. */
+async function seedExchangeProperty(
+  oxyUserId: string,
+  mode: 'swap' | 'host' | 'both' = 'both',
+): Promise<string> {
+  const { propertyId } = await seedListingWithGeo({
+    countryCode: nextCountryCode(),
+    overrides: {
+      oxyUserId,
+      status: 'published',
+      isExternal: false,
+      // `properties_offerings_exchange_check` makes the offering exactly the
+      // presence of the priced block, so the mode has to be set for the
+      // offering to be listed.
+      offerings: ['exchange'],
+      exchangeMode: mode,
+    },
+  });
+  return propertyId;
+}
+
+const DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * A window `fromDays`..`toDays` out, measured from an OPTIONAL fixed base.
+ *
+ * The base matters, and getting it wrong made an earlier version of the
+ * boundary test below VACUOUS. Without it every call re-reads `Date.now()`, so
+ * `window(10, 20).end` and `window(20, 30).start` land a few milliseconds
+ * apart rather than on the same instant — the two windows are then disjoint
+ * under EVERY bound convention, and the test passes whether the ranges are
+ * `[)` or `[]`. Measured: three separate closed-bound mutations all survived
+ * it. Pinning one base is what makes the boundary a real boundary.
+ */
+function window(fromDays: number, toDays: number, base = Date.now()) {
+  return {
+    start: new Date(base + fromDays * DAY).toISOString(),
+    end: new Date(base + toDays * DAY).toISOString(),
+  };
+}
+
+async function exchangeRow(id: string) {
+  const [row] = await getDb()
+    .select()
+    .from(exchangeRequests)
+    .where(eq(exchangeRequests.id, id))
+    .limit(1);
+  return row;
+}
+
+/** Open a HOST request and return its id. */
+async function createHostRequest(
+  propertyId: string,
+  requester = 'oxy-guest',
+  requestedWindow = window(10, 20),
+): Promise<string> {
+  const res = await request(buildApp(requester))
+    .post('/exchanges')
+    .send({ propertyId, mode: 'host', requestedWindow });
+  expect(res.status).toBe(201);
+  return res.body.data.id;
+}
+
+beforeEach(async () => {
+  await getDb().delete(exchangeReviews);
+  await getDb().delete(exchangeRequests);
+  await resetGeoTables();
+});
+
+afterAll(async () => {
+  // Leave the shared tables as this file found them — see the reproduced
+  // geoBackfill collision documented in `leaseOwnership.test.ts`.
+  await getDb().delete(exchangeReviews);
+  await getDb().delete(exchangeRequests);
+  await resetGeoTables();
+});
+
+describe('createExchangeRequest — the mode matrix', () => {
+  it('opens a HOST request with a server-resolved host and no offer', async () => {
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    const res = await request(buildApp('oxy-guest'))
+      .post('/exchanges')
+      // A forged host and status must be ignored.
+      .send({ propertyId, mode: 'host', requestedWindow: window(10, 20), hostOxyUserId: 'attacker', status: 'confirmed' });
+
+    expect(res.status).toBe(201);
+    const persisted = await exchangeRow(res.body.data.id);
+    expect(persisted.hostOxyUserId).toBe('oxy-host');
+    expect(persisted.status).toBe('pending');
+    // `exchange_requests_host_mode_offers_nothing_check` — a host request
+    // offers nothing, and the response omits the window entirely.
+    expect(persisted.offeredPropertyId).toBeNull();
+    expect(persisted.offeredWindowStart).toBeNull();
+    expect(res.body.data.offeredWindow).toBeUndefined();
+  });
+
+  it('refuses a mode the listing does not accept, and accepts either on `both`', async () => {
+    const hostOnly = await seedExchangeProperty('oxy-host', 'host');
+    const swapAttempt = await request(buildApp('oxy-guest'))
+      .post('/exchanges')
+      .send({ propertyId: hostOnly, mode: 'swap', requestedWindow: window(10, 20) });
+    expect(swapAttempt.status).toBe(400);
+
+    const both = await seedExchangeProperty('oxy-host-2', 'both');
+    const hostOnBoth = await request(buildApp('oxy-guest'))
+      .post('/exchanges')
+      .send({ propertyId: both, mode: 'host', requestedWindow: window(10, 20) });
+    expect(hostOnBoth.status).toBe(201);
+  });
+
+  it('refuses `both` as a REQUEST mode — it is a listing capability, not a request', async () => {
+    const propertyId = await seedExchangeProperty('oxy-host', 'both');
+    const res = await request(buildApp('oxy-guest'))
+      .post('/exchanges')
+      .send({ propertyId, mode: 'both', requestedWindow: window(10, 20) });
+    expect(res.status).toBe(400);
+  });
+
+  it('refuses a listing not open to exchange, an external one, and your own', async () => {
+    const notExchangeable = (await seedListingWithGeo({
+      countryCode: nextCountryCode(),
+      overrides: { oxyUserId: 'oxy-host', status: 'published' },
+    })).propertyId;
+    expect(
+      (await request(buildApp('oxy-guest')).post('/exchanges').send({ propertyId: notExchangeable, mode: 'host', requestedWindow: window(10, 20) })).status,
+    ).toBe(400);
+
+    const own = await seedExchangeProperty('oxy-guest', 'host');
+    expect(
+      (await request(buildApp('oxy-guest')).post('/exchanges').send({ propertyId: own, mode: 'host', requestedWindow: window(10, 20) })).status,
+    ).toBe(403);
+
+    expect(await getDb().select().from(exchangeRequests)).toHaveLength(0);
+  });
+
+  it('refuses a window in the past and an inverted one', async () => {
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    const app = buildApp('oxy-guest');
+
+    const inPast = await request(app).post('/exchanges').send({ propertyId, mode: 'host', requestedWindow: window(-5, 5) });
+    expect(inPast.status).toBe(400);
+    const inverted = await request(app).post('/exchanges').send({ propertyId, mode: 'host', requestedWindow: window(20, 10) });
+    expect(inverted.status).toBe(400);
+  });
+
+  it('requires an offered property AND window for a swap, and that you own it', async () => {
+    const target = await seedExchangeProperty('oxy-host', 'swap');
+    const app = buildApp('oxy-guest');
+
+    const noOffer = await request(app)
+      .post('/exchanges')
+      .send({ propertyId: target, mode: 'swap', requestedWindow: window(10, 20) });
+    expect(noOffer.status).toBe(400);
+
+    const notMine = await seedExchangeProperty('oxy-somebody-else', 'swap');
+    const notOwned = await request(app).post('/exchanges').send({
+      propertyId: target,
+      mode: 'swap',
+      offeredPropertyId: notMine,
+      requestedWindow: window(10, 20),
+      offeredWindow: window(30, 40),
+    });
+    expect(notOwned.status).toBe(403);
+
+    const mine = await seedExchangeProperty('oxy-guest', 'swap');
+    const noWindow = await request(app).post('/exchanges').send({
+      propertyId: target,
+      mode: 'swap',
+      offeredPropertyId: mine,
+      requestedWindow: window(10, 20),
+    });
+    expect(noWindow.status).toBe(400);
+
+    expect(await getDb().select().from(exchangeRequests)).toHaveLength(0);
+  });
+
+  it('stores a swap with both windows', async () => {
+    const target = await seedExchangeProperty('oxy-host', 'swap');
+    const mine = await seedExchangeProperty('oxy-guest', 'swap');
+
+    const res = await request(buildApp('oxy-guest')).post('/exchanges').send({
+      propertyId: target,
+      mode: 'swap',
+      offeredPropertyId: mine,
+      requestedWindow: window(10, 20),
+      offeredWindow: window(30, 40),
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.data.offeredWindow.start).toBeTruthy();
+
+    const persisted = await exchangeRow(res.body.data.id);
+    expect(persisted.offeredPropertyId).toBe(mine);
+    expect(persisted.offeredWindowStart).not.toBeNull();
+    expect(persisted.offeredWindowEnd).not.toBeNull();
+  });
+});
+
+describe('exchange_requests_offered_window_check', () => {
+  it('REFUSES half an offered window — the shape a NULL-tolerant CHECK admits', async () => {
+    // `CONVENTIONS.md` records that the first draft of this constraint let
+    // exactly this through: with one side set the coherent branch is `false`,
+    // the comparison is NULL, and `false or NULL` is NULL rather than false.
+    const propertyId = await seedExchangeProperty('oxy-host', 'swap');
+    const offered = await seedExchangeProperty('oxy-guest', 'swap');
+    const base = {
+      propertyId,
+      requesterOxyUserId: 'oxy-guest',
+      hostOxyUserId: 'oxy-host',
+      mode: 'swap' as const,
+      requestedWindowStart: new Date(Date.now() + 10 * DAY),
+      requestedWindowEnd: new Date(Date.now() + 20 * DAY),
+      offeredPropertyId: offered,
+    };
+
+    await expect(
+      getDb().insert(exchangeRequests).values({ ...base, offeredWindowStart: new Date(Date.now() + 30 * DAY) }),
+    ).rejects.toThrow();
+
+    await expect(
+      getDb().insert(exchangeRequests).values({ ...base, offeredWindowEnd: new Date(Date.now() + 40 * DAY) }),
+    ).rejects.toThrow();
+
+    // And it PERMITS both halves absent, which is the `host` shape.
+    const [ok] = await getDb().insert(exchangeRequests).values(base).returning();
+    expect(ok.offeredWindowStart).toBeNull();
+  });
+
+  it('REFUSES a host-mode request that carries an offer', async () => {
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    const offered = await seedExchangeProperty('oxy-guest', 'swap');
+    await expect(
+      getDb().insert(exchangeRequests).values({
+        propertyId,
+        requesterOxyUserId: 'oxy-guest',
+        hostOxyUserId: 'oxy-host',
+        mode: 'host',
+        requestedWindowStart: new Date(Date.now() + 10 * DAY),
+        requestedWindowEnd: new Date(Date.now() + 20 * DAY),
+        offeredPropertyId: offered,
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('the calendar conflict — half-open, and both roles', () => {
+  it('blocks an overlapping request once one is CONFIRMED, and not before', async () => {
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    const first = await createHostRequest(propertyId, 'oxy-guest-a', window(10, 20));
+
+    // A pending request does not occupy the calendar.
+    const whilePending = await request(buildApp('oxy-guest-b'))
+      .post('/exchanges')
+      .send({ propertyId, mode: 'host', requestedWindow: window(15, 25) });
+    expect(whilePending.status).toBe(201);
+
+    await request(buildApp('oxy-host')).patch(`/exchanges/${first}`).send({ status: 'confirmed' });
+
+    const afterConfirm = await request(buildApp('oxy-guest-c'))
+      .post('/exchanges')
+      .send({ propertyId, mode: 'host', requestedWindow: window(15, 25) });
+    expect(afterConfirm.status).toBe(409);
+  });
+
+  it('PERMITS a back-to-back stay — `[)` bounds, asserted at the EXACT boundary', async () => {
+    // The one instant where `[)` and `[]` disagree, so both windows are built
+    // from ONE base: the first ends at exactly the instant the second begins.
+    // Mutation-tested — closing either range, or both, turns this red.
+    const base = Date.now();
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    const first = await createHostRequest(propertyId, 'oxy-guest-a', window(10, 20, base));
+    await request(buildApp('oxy-host')).patch(`/exchanges/${first}`).send({ status: 'confirmed' });
+
+    const adjacent = await request(buildApp('oxy-guest-b'))
+      .post('/exchanges')
+      .send({ propertyId, mode: 'host', requestedWindow: window(20, 30, base) });
+    expect(adjacent.status).toBe(201);
+
+    // And the REVERSE order, which exercises the other side of the boundary: a
+    // confirmed LATER stay must not block the earlier one that ends where it
+    // starts. Only this direction catches a closed bound on the STORED range.
+    const other = await seedExchangeProperty('oxy-host-2', 'host');
+    const later = await createHostRequest(other, 'oxy-guest-a', window(20, 30, base));
+    await request(buildApp('oxy-host-2')).patch(`/exchanges/${later}`).send({ status: 'confirmed' });
+
+    const earlier = await request(buildApp('oxy-guest-b'))
+      .post('/exchanges')
+      .send({ propertyId: other, mode: 'host', requestedWindow: window(10, 20, base) });
+    expect(earlier.status).toBe(201);
+  });
+
+  it('blocks on the OFFERED role too — a swap cannot double-book the home offered in return', async () => {
+    // The half an overlap scan that only checked `property_id` would miss.
+    const targetA = await seedExchangeProperty('oxy-host-a', 'swap');
+    const targetB = await seedExchangeProperty('oxy-host-b', 'swap');
+    const mine = await seedExchangeProperty('oxy-guest', 'swap');
+
+    const first = await request(buildApp('oxy-guest')).post('/exchanges').send({
+      propertyId: targetA,
+      mode: 'swap',
+      offeredPropertyId: mine,
+      requestedWindow: window(10, 20),
+      offeredWindow: window(30, 40),
+    });
+    expect(first.status).toBe(201);
+    await request(buildApp('oxy-host-a')).patch(`/exchanges/${first.body.data.id}`).send({ status: 'confirmed' });
+
+    // My home is now committed for days 30-40. Offering it again over an
+    // overlapping window must be refused, even against a different host.
+    const second = await request(buildApp('oxy-guest')).post('/exchanges').send({
+      propertyId: targetB,
+      mode: 'swap',
+      offeredPropertyId: mine,
+      requestedWindow: window(50, 60),
+      offeredWindow: window(35, 45),
+    });
+    expect(second.status).toBe(409);
+    expect(second.body.error.code).toBe('OFFERED_DATE_CONFLICT');
+  });
+
+  it('does not let a request conflict with ITSELF at confirm time', async () => {
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    const id = await createHostRequest(propertyId);
+    const res = await request(buildApp('oxy-host')).patch(`/exchanges/${id}`).send({ status: 'confirmed' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe('confirmed');
+  });
+});
+
+describe('the transition machine', () => {
+  it('lets only the host confirm or decline, and only from pending', async () => {
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    const id = await createHostRequest(propertyId);
+
+    expect((await request(buildApp('oxy-guest')).patch(`/exchanges/${id}`).send({ status: 'confirmed' })).status).toBe(403);
+    expect((await exchangeRow(id)).status).toBe('pending');
+
+    expect((await request(buildApp('oxy-host')).patch(`/exchanges/${id}`).send({ status: 'confirmed' })).status).toBe(200);
+    // The precondition is in the UPDATE, so a second confirm matches no row.
+    expect((await request(buildApp('oxy-host')).patch(`/exchanges/${id}`).send({ status: 'declined' })).status).toBe(400);
+  });
+
+  it('lets only the requester cancel, from pending or confirmed, and converges', async () => {
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    const id = await createHostRequest(propertyId);
+
+    expect((await request(buildApp('oxy-host')).patch(`/exchanges/${id}`).send({ status: 'cancelled' })).status).toBe(403);
+
+    expect((await request(buildApp('oxy-guest')).patch(`/exchanges/${id}`).send({ status: 'cancelled' })).status).toBe(200);
+    // Already cancelled: 200 with the current state, and the message still applies.
+    const again = await request(buildApp('oxy-guest')).patch(`/exchanges/${id}`).send({ status: 'cancelled', message: 'sorry' });
+    expect(again.status).toBe(200);
+    expect((await exchangeRow(id)).message).toBe('sorry');
+  });
+
+  it('completes only a CONFIRMED exchange whose window has passed', async () => {
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    // A window entirely in the past — seeded directly, since the create path
+    // refuses one.
+    const [row] = await getDb()
+      .insert(exchangeRequests)
+      .values({
+        propertyId,
+        requesterOxyUserId: 'oxy-guest',
+        hostOxyUserId: 'oxy-host',
+        mode: 'host',
+        requestedWindowStart: new Date(Date.now() - 20 * DAY),
+        requestedWindowEnd: new Date(Date.now() - 10 * DAY),
+        status: 'pending',
+      })
+      .returning();
+
+    // Not confirmed yet.
+    expect((await request(buildApp('oxy-guest')).patch(`/exchanges/${row.id}`).send({ status: 'completed' })).status).toBe(400);
+
+    await request(buildApp('oxy-host')).patch(`/exchanges/${row.id}`).send({ status: 'confirmed' });
+    const completed = await request(buildApp('oxy-guest')).patch(`/exchanges/${row.id}`).send({ status: 'completed' });
+    expect(completed.status).toBe(200);
+  });
+
+  it('refuses to complete a confirmed exchange whose window has NOT passed', async () => {
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    const id = await createHostRequest(propertyId);
+    await request(buildApp('oxy-host')).patch(`/exchanges/${id}`).send({ status: 'confirmed' });
+
+    const res = await request(buildApp('oxy-guest')).patch(`/exchanges/${id}`).send({ status: 'completed' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('STAY_NOT_ENDED');
+  });
+
+  it('refuses an unsupported transition and a non-party', async () => {
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    const id = await createHostRequest(propertyId);
+
+    expect((await request(buildApp('oxy-host')).patch(`/exchanges/${id}`).send({ status: 'pending' })).status).toBe(400);
+    expect((await request(buildApp('oxy-stranger')).patch(`/exchanges/${id}`).send({ status: 'confirmed' })).status).toBe(403);
+  });
+});
+
+describe('reads', () => {
+  it('shows a request only to its two parties', async () => {
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    const id = await createHostRequest(propertyId);
+
+    expect((await request(buildApp('oxy-guest')).get(`/exchanges/${id}`)).status).toBe(200);
+    expect((await request(buildApp('oxy-host')).get(`/exchanges/${id}`)).status).toBe(200);
+    expect((await request(buildApp('oxy-stranger')).get(`/exchanges/${id}`)).status).toBe(403);
+  });
+
+  it('splits the guest and host views, with no profile needed', async () => {
+    // The `Profile.findByOxyUserId` guard is dropped: `oxy-guest` has no profile
+    // document anywhere in this suite and must still see their own request.
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    await createHostRequest(propertyId);
+
+    const asGuest = await request(buildApp('oxy-guest')).get('/exchanges');
+    expect(asGuest.status).toBe(200);
+    expect(asGuest.body.data).toHaveLength(1);
+
+    const asHost = await request(buildApp('oxy-host')).get('/exchanges?asHost=true');
+    expect(asHost.body.data).toHaveLength(1);
+
+    const hostOwnView = await request(buildApp('oxy-host')).get('/exchanges');
+    expect(hostOwnView.body.data).toHaveLength(0);
+  });
+
+  it('answers 404 for a malformed id rather than 400', async () => {
+    const res = await request(buildApp('oxy-guest')).get('/exchanges/not-an-id');
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('exchange reviews', () => {
+  /** A completed exchange between `oxy-guest` and `oxy-host`. */
+  async function completedExchange(): Promise<string> {
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    const [row] = await getDb()
+      .insert(exchangeRequests)
+      .values({
+        propertyId,
+        requesterOxyUserId: 'oxy-guest',
+        hostOxyUserId: 'oxy-host',
+        mode: 'host',
+        requestedWindowStart: new Date(Date.now() - 20 * DAY),
+        requestedWindowEnd: new Date(Date.now() - 10 * DAY),
+        status: 'completed',
+      })
+      .returning();
+    return row.id;
+  }
+
+  it('lets each party review the OTHER, once', async () => {
+    const id = await completedExchange();
+
+    const byGuest = await request(buildApp('oxy-guest'))
+      .post(`/exchanges/${id}/reviews`)
+      .send({ rating: 5, comment: 'lovely', categories: { communication: 5, cleanliness: 4 } });
+    expect(byGuest.status).toBe(201);
+    // The subject is resolved server-side — the reviewer never names it.
+    expect(byGuest.body.data.subjectOxyUserId).toBe('oxy-host');
+    expect(byGuest.body.data.categories.communication).toBe(5);
+
+    // Second review by the same reviewer: 409 from the UNIQUE index, no
+    // pre-read.
+    const twice = await request(buildApp('oxy-guest'))
+      .post(`/exchanges/${id}/reviews`)
+      .send({ rating: 3 });
+    expect(twice.status).toBe(409);
+    expect(twice.body.error.code).toBe('ALREADY_REVIEWED');
+
+    // The other party may still review.
+    const byHost = await request(buildApp('oxy-host')).post(`/exchanges/${id}/reviews`).send({ rating: 4 });
+    expect(byHost.status).toBe(201);
+    expect(byHost.body.data.subjectOxyUserId).toBe('oxy-guest');
+
+    expect(await getDb().select().from(exchangeReviews)).toHaveLength(2);
+  });
+
+  it('refuses a review before the exchange is completed, and from a non-party', async () => {
+    const propertyId = await seedExchangeProperty('oxy-host', 'host');
+    const pending = await createHostRequest(propertyId);
+    expect((await request(buildApp('oxy-guest')).post(`/exchanges/${pending}/reviews`).send({ rating: 5 })).status).toBe(400);
+
+    const done = await completedExchange();
+    expect((await request(buildApp('oxy-stranger')).post(`/exchanges/${done}/reviews`).send({ rating: 5 })).status).toBe(403);
+
+    expect(await getDb().select().from(exchangeReviews)).toHaveLength(0);
+  });
+
+  it('REFUSES a rating outside 1-5 and a self-review', async () => {
+    const id = await completedExchange();
+    const res = await request(buildApp('oxy-guest')).post(`/exchanges/${id}/reviews`).send({ rating: 9 });
+    // The CHECK, surfaced as a 500 rather than a 400 — the rating is not
+    // narrowed in the controller, so this pins where the refusal comes from
+    // rather than claiming a validation that is not there.
+    expect(res.status).toBe(500);
+
+    await expect(
+      getDb().insert(exchangeReviews).values({
+        exchangeRequestId: id,
+        reviewerOxyUserId: 'oxy-same',
+        subjectOxyUserId: 'oxy-same',
+        rating: 5,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('aggregates a subject average from ONE statement', async () => {
+    const first = await completedExchange();
+    const second = await completedExchange();
+    await request(buildApp('oxy-guest')).post(`/exchanges/${first}/reviews`).send({ rating: 5 });
+    await request(buildApp('oxy-guest')).post(`/exchanges/${second}/reviews`).send({ rating: 4 });
+
+    const res = await request(buildApp('oxy-anyone')).get('/profiles/oxy-host/exchange-reviews');
+    expect(res.status).toBe(200);
+    expect(res.body.pagination.total).toBe(2);
+    expect(res.body.meta.averageRating).toBe(4.5);
+    expect(res.body.meta.reviewCount).toBe(2);
+  });
+
+  it('reports 0 rather than null for a subject with no reviews', async () => {
+    const res = await request(buildApp('oxy-anyone')).get('/profiles/oxy-nobody/exchange-reviews');
+    expect(res.status).toBe(200);
+    expect(res.body.meta.averageRating).toBe(0);
+  });
+});

--- a/packages/backend/controllers/exchangeController.ts
+++ b/packages/backend/controllers/exchangeController.ts
@@ -19,23 +19,35 @@ import type { Request, Response, NextFunction } from 'express';
 import type {
   CreateExchangeRequestData,
   UpdateExchangeRequestData,
-  ExchangeWindow,
 } from '@homiio/shared-types';
 
-import { Property, ExchangeRequest, Profile } from '../models';
+import { getDb } from '../db/postgres';
+import {
+  createExchangeRequest,
+  findExchangeRequestById,
+  hasPropertyConflict,
+  isExchangeStatus,
+  listExchangeRequests,
+  serializeExchangeRequest,
+  setExchangeRequestMessage,
+  transitionExchangeRequest,
+  type ExchangeModeValue,
+  type ExchangeStatusValue,
+  type ExchangeWindowInput,
+} from '../db/exchanges/exchangeReads';
+import {
+  findPropertyBookingBasis,
+  type PropertyBookingBasis,
+} from '../db/properties/propertyBookingBasis';
 import { logger } from '../middlewares/logging';
 import { AppError, successResponse, paginationResponse } from '../middlewares/errorHandler';
 import { ExchangeMode, ExchangeRequestStatus, OfferingType } from '@homiio/shared-types';
-import { Types } from 'mongoose';
-import { windowsOverlap } from '../utils/availabilityUtils';
 
 // ---- Tunable constants (no magic numbers / strings inline) ----
 /** Default page size for list endpoints. */
 const DEFAULT_PAGE_SIZE = 10;
 /** Hard cap on page size to protect the database. */
 const MAX_PAGE_SIZE = 100;
-/** Statuses that occupy the calendar and therefore block an overlapping request. */
-const BLOCKING_EXCHANGE_STATUSES = [ExchangeRequestStatus.CONFIRMED];
 
 /**
  * Whether a listing's configured exchange `mode` accepts a request of the given
@@ -54,8 +66,8 @@ function modeAccepts(listingMode: string, requestedMode: string): boolean {
 }
 
 /** A property carries the EXCHANGE offering. */
-function hasExchangeOffering(property: { offerings?: unknown }): boolean {
-  return Array.isArray(property.offerings) && property.offerings.includes(OfferingType.EXCHANGE);
+function hasExchangeOffering(property: PropertyBookingBasis): boolean {
+  return property.offerings.includes(OfferingType.EXCHANGE);
 }
 
 /**
@@ -85,61 +97,6 @@ function resolveOxyUserId(req: Request): string | undefined {
   return user.user?.id || user.user?._id || user.userId;
 }
 
-/** A confirmed-exchange row projected for conflict detection (both roles). */
-interface ConflictRow {
-  _id: unknown;
-  propertyId?: unknown;
-  offeredPropertyId?: unknown;
-  requestedWindow?: ExchangeWindow;
-  offeredWindow?: ExchangeWindow;
-}
-
-/**
- * Detect whether a committed (CONFIRMED) exchange already occupies `propertyId`
- * for any time overlapping `window`. A property can be committed in BOTH roles:
- *  - as the TARGET of a confirmed exchange (`propertyId` + `requestedWindow`), or
- *  - as the OFFERED home of a confirmed SWAP (`offeredPropertyId` + `offeredWindow`).
- *
- * Both roles are checked so a swap can never double-book the home a requester
- * offers in return. `excludeRequestId` omits a specific request from the scan
- * (used at confirm time so a request never conflicts with itself).
- */
-async function hasPropertyConflict(
-  propertyId: unknown,
-  window: { start: Date; end: Date },
-  excludeRequestId?: unknown
-): Promise<boolean> {
-  const baseQuery: Record<string, unknown> = {
-    status: { $in: BLOCKING_EXCHANGE_STATUSES },
-    $or: [{ propertyId }, { offeredPropertyId: propertyId }],
-  };
-  if (excludeRequestId !== undefined) {
-    baseQuery._id = { $ne: excludeRequestId };
-  }
-
-  const committed = await ExchangeRequest.find(baseQuery)
-    .select('propertyId offeredPropertyId requestedWindow offeredWindow')
-    .lean<ConflictRow[]>();
-
-  const target = String(propertyId);
-  return committed.some((row) => {
-    // Compare against whichever window pins THIS property in the existing row.
-    if (String(row.propertyId) === target) {
-      const other = parseWindow(row.requestedWindow);
-      if (other && windowsOverlap(window.start, window.end, other.start, other.end)) {
-        return true;
-      }
-    }
-    if (String(row.offeredPropertyId) === target) {
-      const other = parseWindow(row.offeredWindow);
-      if (other && windowsOverlap(window.start, window.end, other.start, other.end)) {
-        return true;
-      }
-    }
-    return false;
-  });
-}
-
 class ExchangeController {
   /**
    * POST /api/exchanges
@@ -153,14 +110,16 @@ class ExchangeController {
       const oxyUserId = resolveOxyUserId(req);
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      if (!Types.ObjectId.isValid(propertyId)) {
-        return next(new AppError('Invalid property ID', 400, 'INVALID_ID'));
-      }
+      // The `ObjectId.isValid` guards are DELETED rather than widened
+      // (`db/ids.ts`): post-cutover every listing id is a uuid v7, which they
+      // reject — and the lookups below already answer 404 for an id that names
+      // nothing, whatever its shape.
       if (mode !== ExchangeMode.SWAP && mode !== ExchangeMode.HOST) {
         return next(new AppError('Exchange mode must be "swap" or "host"', 400, 'INVALID_MODE'));
       }
 
-      const property = await Property.findById(propertyId).lean();
+      const db = getDb();
+      const property = await findPropertyBookingBasis(db, String(propertyId));
       if (!property) return next(new AppError('Property not found', 404, 'NOT_FOUND'));
       if (property.isExternal) {
         return next(new AppError('Cannot request an exchange on external listings', 400, 'EXTERNAL_PROPERTY'));
@@ -168,7 +127,7 @@ class ExchangeController {
       if (!hasExchangeOffering(property)) {
         return next(new AppError('This property is not open to home exchange', 400, 'NOT_EXCHANGEABLE'));
       }
-      const listingMode = property.exchange?.mode;
+      const listingMode = property.exchangeMode;
       if (!listingMode || !modeAccepts(listingMode, mode)) {
         return next(new AppError(`This listing does not accept "${mode}" exchanges`, 400, 'MODE_NOT_ACCEPTED'));
       }
@@ -190,17 +149,17 @@ class ExchangeController {
         return next(new AppError('Requested window must start in the future', 400, 'DATE_IN_PAST'));
       }
 
-      // SWAP requires a verified offered property + offered window; HOST clears them.
-      let resolvedOfferedPropertyId: unknown;
-      let resolvedOfferedWindow: { start: Date; end: Date } | undefined;
+      // SWAP requires a verified offered property + offered window; HOST offers
+      // nothing at all, which `exchange_requests_host_mode_offers_nothing_check`
+      // now enforces — the port of a `pre('save')` hook `findOneAndUpdate`
+      // walked straight past.
+      let resolvedOfferedPropertyId: string | undefined;
+      let resolvedOfferedWindow: ExchangeWindowInput | undefined;
       if (mode === ExchangeMode.SWAP) {
         if (!offeredPropertyId) {
           return next(new AppError('A swap requires an offered property', 400, 'OFFERED_PROPERTY_REQUIRED'));
         }
-        if (!Types.ObjectId.isValid(offeredPropertyId)) {
-          return next(new AppError('Invalid offered property ID', 400, 'INVALID_ID'));
-        }
-        const offeredProperty = await Property.findById(offeredPropertyId).lean();
+        const offeredProperty = await findPropertyBookingBasis(db, String(offeredPropertyId));
         if (!offeredProperty) return next(new AppError('Offered property not found', 404, 'NOT_FOUND'));
         if (offeredProperty.oxyUserId !== oxyUserId) {
           return next(new AppError('Offered property does not belong to you', 403, 'FORBIDDEN'));
@@ -217,45 +176,43 @@ class ExchangeController {
         if (offered.start.getTime() < now.getTime()) {
           return next(new AppError('Offered window must start in the future', 400, 'DATE_IN_PAST'));
         }
-        resolvedOfferedPropertyId = offeredProperty._id;
+        resolvedOfferedPropertyId = offeredProperty.id;
         resolvedOfferedWindow = offered;
       }
 
       // Conflict: a committed (CONFIRMED) exchange already occupies the TARGET
-      // property over the requested window. `hasPropertyConflict` checks both
-      // roles the property may be committed in (target + offered). Pending
-      // requests never block — only committed ones.
-      if (await hasPropertyConflict(propertyId, requested)) {
+      // property over the requested window. One range-overlap query, both roles
+      // — see `db/exchanges/exchangeReads.ts`. Pending requests never block.
+      if (await hasPropertyConflict(db, String(propertyId), requested)) {
         return next(new AppError('Requested dates conflict with a confirmed exchange', 409, 'DATE_CONFLICT'));
       }
 
       // For a SWAP, the OFFERED home must also be free over its offered window —
       // otherwise a requester could double-book the home they offer in return.
-      if (mode === ExchangeMode.SWAP && resolvedOfferedPropertyId && resolvedOfferedWindow) {
-        if (await hasPropertyConflict(resolvedOfferedPropertyId, resolvedOfferedWindow)) {
+      if (resolvedOfferedPropertyId && resolvedOfferedWindow) {
+        if (await hasPropertyConflict(db, resolvedOfferedPropertyId, resolvedOfferedWindow)) {
           return next(new AppError('Offered dates conflict with a confirmed exchange', 409, 'OFFERED_DATE_CONFLICT'));
         }
       }
 
-      const exchangeRequest = await ExchangeRequest.create({
-        propertyId,
+      const exchangeRequest = await createExchangeRequest(db, {
+        propertyId: String(propertyId),
         requesterOxyUserId: oxyUserId,
         hostOxyUserId,
-        mode,
-        offeredPropertyId: mode === ExchangeMode.SWAP ? resolvedOfferedPropertyId : undefined,
+        mode: mode as ExchangeModeValue,
         requestedWindow: requested,
-        offeredWindow: mode === ExchangeMode.SWAP ? resolvedOfferedWindow : undefined,
-        message,
-        status: ExchangeRequestStatus.PENDING,
+        offeredPropertyId: resolvedOfferedPropertyId,
+        offeredWindow: resolvedOfferedWindow,
+        message: typeof message === 'string' ? message : undefined,
       });
 
       logger.info('Exchange request created', {
-        exchangeRequestId: String(exchangeRequest._id),
+        exchangeRequestId: exchangeRequest.id,
         propertyId: String(propertyId),
         mode,
       });
 
-      res.status(201).json(successResponse(exchangeRequest.toJSON(), 'Exchange request created'));
+      res.status(201).json(successResponse(serializeExchangeRequest(exchangeRequest), 'Exchange request created'));
     } catch (error) {
       next(error);
     }
@@ -272,34 +229,29 @@ class ExchangeController {
       const oxyUserId = resolveOxyUserId(req);
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      const activeProfile = await Profile.findByOxyUserId(oxyUserId);
-      if (!activeProfile) {
-        res.json(paginationResponse([], 1, DEFAULT_PAGE_SIZE, 0, 'No profile found for user'));
-        return;
-      }
-
-      const query: Record<string, unknown> = {};
-      if (String(asHost) === 'true') {
-        query.hostOxyUserId = oxyUserId;
-      } else {
-        query.requesterOxyUserId = oxyUserId;
-      }
-      if (status) query.status = status;
-
+      // The `Profile.findByOxyUserId` guard is DROPPED, not ported. It was not an
+      // authorisation check — both branches below are already scoped by the
+      // session `oxyUserId` — so its only effect was to answer an empty list to
+      // somebody who owned rows and happened to have no profile document yet.
+      // Keeping it would make this controller depend on `profiles`, a table
+      // another batch owns, to reproduce a check that protected nothing. Same
+      // call, same reasoning, as `savedSearches` in #301.
       const pageNumber = Math.max(1, parseInt(String(page), 10) || 1);
       const limitNumber = Math.min(MAX_PAGE_SIZE, Math.max(1, parseInt(String(limit), 10) || DEFAULT_PAGE_SIZE));
       const skip = (pageNumber - 1) * limitNumber;
 
-      const [items, total] = await Promise.all([
-        ExchangeRequest.find(query)
-          .sort({ createdAt: -1 })
-          .skip(skip)
-          .limit(limitNumber)
-          .lean(),
-        ExchangeRequest.countDocuments(query),
-      ]);
+      const asHostView = String(asHost) === 'true';
+      const result = await listExchangeRequests(
+        getDb(),
+        {
+          requesterOxyUserId: asHostView ? undefined : oxyUserId,
+          hostOxyUserId: asHostView ? oxyUserId : undefined,
+          status: isExchangeStatus(status) ? status : undefined,
+        },
+        { limit: limitNumber, offset: skip },
+      );
 
-      res.json(paginationResponse(items, pageNumber, limitNumber, total, 'Exchange requests retrieved'));
+      res.json(paginationResponse(result.rows.map(serializeExchangeRequest), pageNumber, limitNumber, result.total, 'Exchange requests retrieved'));
     } catch (error) {
       next(error);
     }
@@ -315,20 +267,16 @@ class ExchangeController {
       const oxyUserId = resolveOxyUserId(req);
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      if (!Types.ObjectId.isValid(id)) {
-        return next(new AppError('Invalid exchange request ID', 400, 'INVALID_ID'));
-      }
-
-      const exchangeRequest = await ExchangeRequest.findById(id).lean();
+      const exchangeRequest = await findExchangeRequestById(getDb(), id);
       if (!exchangeRequest) return next(new AppError('Exchange request not found', 404, 'NOT_FOUND'));
 
-      const isRequester = String(exchangeRequest.requesterOxyUserId) === String(oxyUserId);
-      const isHost = String(exchangeRequest.hostOxyUserId) === String(oxyUserId);
+      const isRequester = exchangeRequest.requesterOxyUserId === oxyUserId;
+      const isHost = exchangeRequest.hostOxyUserId === oxyUserId;
       if (!isRequester && !isHost) {
         return next(new AppError('Not authorized to view this exchange request', 403, 'FORBIDDEN'));
       }
 
-      res.json(successResponse(exchangeRequest, 'Exchange request retrieved'));
+      res.json(successResponse(serializeExchangeRequest(exchangeRequest), 'Exchange request retrieved'));
     } catch (error) {
       next(error);
     }
@@ -351,20 +299,23 @@ class ExchangeController {
       const oxyUserId = resolveOxyUserId(req);
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      if (!Types.ObjectId.isValid(id)) {
-        return next(new AppError('Invalid exchange request ID', 400, 'INVALID_ID'));
-      }
-
-      const exchangeRequest = await ExchangeRequest.findById(id);
+      const db = getDb();
+      const exchangeRequest = await findExchangeRequestById(db, id);
       if (!exchangeRequest) return next(new AppError('Exchange request not found', 404, 'NOT_FOUND'));
 
-      const isRequester = String(exchangeRequest.requesterOxyUserId) === String(oxyUserId);
-      const isHost = String(exchangeRequest.hostOxyUserId) === String(oxyUserId);
+      const isRequester = exchangeRequest.requesterOxyUserId === oxyUserId;
+      const isHost = exchangeRequest.hostOxyUserId === oxyUserId;
       if (!isRequester && !isHost) {
         return next(new AppError('Not authorized to update this exchange request', 403, 'FORBIDDEN'));
       }
 
       const now = new Date();
+      const nextMessage = typeof message === 'string' ? message : undefined;
+      // Every transition below carries its permitted FROM set into the
+      // `UPDATE`'s own predicate, so two hosts confirming at once cannot both
+      // succeed. The reads choose the ERROR; the predicate chooses the write.
+      let updated: Awaited<ReturnType<typeof transitionExchangeRequest>>;
+      let fromStatuses: readonly ExchangeStatusValue[];
 
       if (nextStatus === ExchangeRequestStatus.CONFIRMED || nextStatus === ExchangeRequestStatus.DECLINED) {
         if (!isHost) return next(new AppError('Only the host can confirm or decline', 403, 'FORBIDDEN'));
@@ -374,91 +325,101 @@ class ExchangeController {
         if (nextStatus === ExchangeRequestStatus.CONFIRMED) {
           // Re-validate the listing at confirm time: it may have dropped the
           // exchange intent or changed/cleared its mode since the request was
-          // made. Confirming against a listing that no longer offers this
-          // exchange/mode is rejected.
-          const targetProperty = await Property.findById(exchangeRequest.propertyId).lean();
+          // made.
+          const targetProperty = await findPropertyBookingBasis(db, exchangeRequest.propertyId);
           if (!targetProperty) {
             return next(new AppError('Property no longer exists', 404, 'NOT_FOUND'));
           }
           if (!hasExchangeOffering(targetProperty)) {
             return next(new AppError('This property is no longer open to home exchange', 409, 'NOT_EXCHANGEABLE'));
           }
-          const listingMode = targetProperty.exchange?.mode;
+          const listingMode = targetProperty.exchangeMode;
           if (!listingMode || !modeAccepts(listingMode, exchangeRequest.mode)) {
             return next(new AppError(`This listing no longer accepts "${exchangeRequest.mode}" exchanges`, 409, 'MODE_NOT_ACCEPTED'));
           }
 
           // Re-check conflicts before committing, excluding this request so it
-          // never collides with itself. Check the TARGET (requested window)…
-          const requested = parseWindow(exchangeRequest.requestedWindow);
-          if (!requested) {
-            return next(new AppError('Invalid requested window', 400, 'INVALID_WINDOW'));
-          }
-          if (await hasPropertyConflict(exchangeRequest.propertyId, requested, exchangeRequest._id)) {
+          // never collides with itself. The TARGET first…
+          const requested = {
+            start: exchangeRequest.requestedWindowStart,
+            end: exchangeRequest.requestedWindowEnd,
+          };
+          if (await hasPropertyConflict(db, exchangeRequest.propertyId, requested, { excludeId: exchangeRequest.id })) {
             return next(new AppError('Another confirmed exchange now conflicts with this one', 409, 'DATE_CONFLICT'));
           }
-          // …and, for a SWAP, the OFFERED home (offered window).
+          // …and, for a SWAP, the OFFERED home.
           if (exchangeRequest.mode === ExchangeMode.SWAP) {
-            const offered = parseWindow(exchangeRequest.offeredWindow);
-            if (!offered) {
+            // `exchange_requests_offered_window_check` is all-or-none, so these
+            // three are present together or not at all — but a swap whose offer
+            // was never recorded cannot be confirmed against a calendar.
+            if (
+              !exchangeRequest.offeredPropertyId ||
+              !exchangeRequest.offeredWindowStart ||
+              !exchangeRequest.offeredWindowEnd
+            ) {
               return next(new AppError('Invalid offered window', 400, 'INVALID_WINDOW'));
             }
-            if (await hasPropertyConflict(exchangeRequest.offeredPropertyId, offered, exchangeRequest._id)) {
+            const offered = {
+              start: exchangeRequest.offeredWindowStart,
+              end: exchangeRequest.offeredWindowEnd,
+            };
+            if (await hasPropertyConflict(db, exchangeRequest.offeredPropertyId, offered, { excludeId: exchangeRequest.id })) {
               return next(new AppError('The offered home now conflicts with a confirmed exchange', 409, 'OFFERED_DATE_CONFLICT'));
             }
           }
         }
-        exchangeRequest.status = nextStatus;
+        fromStatuses = [ExchangeRequestStatus.PENDING];
+        updated = await transitionExchangeRequest(db, id, nextStatus, fromStatuses, { message: nextMessage });
+        if (!updated) {
+          return next(new AppError('Only pending requests can be confirmed or declined', 400, 'INVALID_STATE'));
+        }
       } else if (nextStatus === ExchangeRequestStatus.CANCELLED) {
         if (!isRequester) return next(new AppError('Only the requester can cancel', 403, 'FORBIDDEN'));
         if (exchangeRequest.status === ExchangeRequestStatus.CANCELLED) {
-          if (typeof message === 'string') exchangeRequest.message = message;
-          await exchangeRequest.save();
-          res.json(successResponse(exchangeRequest.toJSON(), 'Exchange request already cancelled'));
+          // Already in the state the caller asked for. The message is still
+          // applied, matching the Mongoose handler's convergence path.
+          const converged = nextMessage === undefined
+            ? exchangeRequest
+            : (await setExchangeRequestMessage(db, id, nextMessage)) ?? exchangeRequest;
+          res.json(successResponse(serializeExchangeRequest(converged), 'Exchange request already cancelled'));
           return;
         }
-        if (
-          exchangeRequest.status !== ExchangeRequestStatus.PENDING &&
-          exchangeRequest.status !== ExchangeRequestStatus.CONFIRMED
-        ) {
+        fromStatuses = [ExchangeRequestStatus.PENDING, ExchangeRequestStatus.CONFIRMED];
+        updated = await transitionExchangeRequest(db, id, nextStatus, fromStatuses, { message: nextMessage });
+        if (!updated) {
           return next(new AppError('Only pending or confirmed requests can be cancelled', 400, 'INVALID_STATE'));
         }
-        exchangeRequest.status = ExchangeRequestStatus.CANCELLED;
       } else if (nextStatus === ExchangeRequestStatus.COMPLETED) {
         if (exchangeRequest.status !== ExchangeRequestStatus.CONFIRMED) {
           return next(new AppError('Only confirmed exchanges can be completed', 400, 'INVALID_STATE'));
         }
-        const requested = parseWindow(exchangeRequest.requestedWindow);
-        if (!requested || requested.end.getTime() > now.getTime()) {
+        if (exchangeRequest.requestedWindowEnd.getTime() > now.getTime()) {
           return next(new AppError('An exchange can only be completed after the stay window has passed', 400, 'STAY_NOT_ENDED'));
         }
-        // A SWAP only completes once BOTH legs have ended: the offered stay must
-        // also be in the past. Host-mode requests have no offered window and so
-        // keep the requested-only check above.
+        // A SWAP only completes once BOTH legs have ended. Host-mode requests
+        // have no offered window and keep the requested-only check above.
         if (exchangeRequest.mode === ExchangeMode.SWAP) {
-          const offered = parseWindow(exchangeRequest.offeredWindow);
-          if (!offered || offered.end.getTime() > now.getTime()) {
+          if (!exchangeRequest.offeredWindowEnd || exchangeRequest.offeredWindowEnd.getTime() > now.getTime()) {
             return next(new AppError('A swap can only be completed after both stay windows have passed', 400, 'STAY_NOT_ENDED'));
           }
         }
-        exchangeRequest.status = ExchangeRequestStatus.COMPLETED;
+        fromStatuses = [ExchangeRequestStatus.CONFIRMED];
+        updated = await transitionExchangeRequest(db, id, nextStatus, fromStatuses, { message: nextMessage });
+        if (!updated) {
+          return next(new AppError('Only confirmed exchanges can be completed', 400, 'INVALID_STATE'));
+        }
       } else {
         return next(new AppError('Unsupported status transition', 400, 'INVALID_STATE'));
       }
 
-      if (typeof message === 'string') {
-        exchangeRequest.message = message;
-      }
-
-      await exchangeRequest.save();
       logger.info('Exchange request status updated', {
-        exchangeRequestId: String(exchangeRequest._id),
-        nextStatus: exchangeRequest.status,
+        exchangeRequestId: updated.id,
+        nextStatus: updated.status,
         byHost: isHost,
         byRequester: isRequester,
       });
 
-      res.json(successResponse(exchangeRequest.toJSON(), 'Exchange request updated'));
+      res.json(successResponse(serializeExchangeRequest(updated), 'Exchange request updated'));
     } catch (error) {
       next(error);
     }

--- a/packages/backend/controllers/exchangeReviewController.ts
+++ b/packages/backend/controllers/exchangeReviewController.ts
@@ -13,31 +13,28 @@
 import type { Request, Response, NextFunction } from 'express';
 import type { ExchangeReviewCategories } from '@homiio/shared-types';
 
-import { ExchangeRequest, ExchangeReview } from '../models';
+import { getDb } from '../db/postgres';
+import { findExchangeRequestById } from '../db/exchanges/exchangeReads';
+import {
+  createExchangeReview,
+  ExchangeAlreadyReviewedError,
+  listReviewsForExchange,
+  listReviewsForSubject,
+  serializeExchangeReview,
+} from '../db/exchanges/exchangeReviewReads';
 import { logger } from '../middlewares/logging';
 import { AppError, successResponse, paginationResponse } from '../middlewares/errorHandler';
 import { ExchangeRequestStatus } from '@homiio/shared-types';
-import { Types } from 'mongoose';
 
 // ---- Tunable constants (no magic numbers inline) ----
 /** Default page size for the profile-reviews list. */
 const DEFAULT_PAGE_SIZE = 10;
 /** Hard cap on page size to protect the database. */
 const MAX_PAGE_SIZE = 100;
-/** MongoDB duplicate-key error code. */
-const DUPLICATE_KEY_CODE = 11000;
-/** Decimal places kept on the aggregate average rating. */
-const RATING_DECIMALS = 2;
 
 function resolveOxyUserId(req: Request): string | undefined {
   const user = (req as Request & { user?: { id?: string; _id?: string }; userId?: string });
   return user.user?.id || user.user?._id || user.userId;
-}
-
-/** Round to `RATING_DECIMALS` decimal places. */
-function roundRating(value: number): number {
-  const factor = 10 ** RATING_DECIMALS;
-  return Math.round(value * factor) / factor;
 }
 
 class ExchangeReviewController {
@@ -58,15 +55,14 @@ class ExchangeReviewController {
       const oxyUserId = resolveOxyUserId(req);
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      if (!Types.ObjectId.isValid(id)) {
-        return next(new AppError('Invalid exchange request ID', 400, 'INVALID_ID'));
-      }
-
-      const exchangeRequest = await ExchangeRequest.findById(id).lean();
+      // The `ObjectId.isValid` guard is deleted rather than widened
+      // (`db/ids.ts`) — the lookup already 404s for an id naming nothing.
+      const db = getDb();
+      const exchangeRequest = await findExchangeRequestById(db, id);
       if (!exchangeRequest) return next(new AppError('Exchange request not found', 404, 'NOT_FOUND'));
 
-      const isRequester = String(exchangeRequest.requesterOxyUserId) === String(oxyUserId);
-      const isHost = String(exchangeRequest.hostOxyUserId) === String(oxyUserId);
+      const isRequester = exchangeRequest.requesterOxyUserId === oxyUserId;
+      const isHost = exchangeRequest.hostOxyUserId === oxyUserId;
       if (!isRequester && !isHost) {
         return next(new AppError('Not authorized to review this exchange', 403, 'FORBIDDEN'));
       }
@@ -75,47 +71,44 @@ class ExchangeReviewController {
         return next(new AppError('You can only review a completed exchange', 400, 'EXCHANGE_NOT_COMPLETED'));
       }
 
-      // The reviewer reviews the other party.
+      if (typeof rating !== 'number' || !Number.isFinite(rating)) {
+        return next(new AppError('A rating is required', 400, 'INVALID_RATING'));
+      }
+
+      // The reviewer reviews the other party. Resolved server-side, which is
+      // also what makes `exchange_reviews_distinct_parties_check` unreachable
+      // through this path — it rejects only a bug.
       const subjectOxyUserId = isRequester
         ? exchangeRequest.hostOxyUserId
         : exchangeRequest.requesterOxyUserId;
 
-      // Defensive pre-check: one review per reviewer per exchange. The unique
-      // compound index is the race-safe backstop (handled below); this gives a
-      // clean 409 immediately and stays correct even before the index finishes
-      // building on a freshly-created collection.
-      const existingReview = await ExchangeReview.findOne({
-        exchangeRequestId: exchangeRequest._id,
-        reviewerOxyUserId: oxyUserId,
-      })
-        .select('_id')
-        .lean();
-      if (existingReview) {
-        return next(new AppError('You have already reviewed this exchange', 409, 'ALREADY_REVIEWED'));
-      }
-
+      // No "already reviewed?" pre-read: `exchange_reviews_request_reviewer_key`
+      // is a real UNIQUE, so the INSERT is the check and the 409 comes from its
+      // own violation. The Mongoose version did both, which left a redundant
+      // round trip in front of a constraint that already decides it.
+      let review;
       try {
-        const review = await ExchangeReview.create({
-          exchangeRequestId: exchangeRequest._id,
+        review = await createExchangeReview(db, {
+          exchangeRequestId: exchangeRequest.id,
           reviewerOxyUserId: oxyUserId,
           subjectOxyUserId,
           rating,
           comment,
           categories,
         });
-
-        logger.info('Exchange review created', {
-          exchangeReviewId: String(review._id),
-          exchangeRequestId: String(exchangeRequest._id),
-        });
-
-        res.status(201).json(successResponse(review.toJSON(), 'Exchange review created'));
       } catch (error) {
-        if ((error as { code?: number }).code === DUPLICATE_KEY_CODE) {
+        if (error instanceof ExchangeAlreadyReviewedError) {
           return next(new AppError('You have already reviewed this exchange', 409, 'ALREADY_REVIEWED'));
         }
         throw error;
       }
+
+      logger.info('Exchange review created', {
+        exchangeReviewId: review.id,
+        exchangeRequestId: exchangeRequest.id,
+      });
+
+      res.status(201).json(successResponse(serializeExchangeReview(review), 'Exchange review created'));
     } catch (error) {
       next(error);
     }
@@ -131,24 +124,19 @@ class ExchangeReviewController {
       const oxyUserId = resolveOxyUserId(req);
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      if (!Types.ObjectId.isValid(id)) {
-        return next(new AppError('Invalid exchange request ID', 400, 'INVALID_ID'));
-      }
-
-      const exchangeRequest = await ExchangeRequest.findById(id).lean();
+      const db = getDb();
+      const exchangeRequest = await findExchangeRequestById(db, id);
       if (!exchangeRequest) return next(new AppError('Exchange request not found', 404, 'NOT_FOUND'));
 
-      const isRequester = String(exchangeRequest.requesterOxyUserId) === String(oxyUserId);
-      const isHost = String(exchangeRequest.hostOxyUserId) === String(oxyUserId);
+      const isRequester = exchangeRequest.requesterOxyUserId === oxyUserId;
+      const isHost = exchangeRequest.hostOxyUserId === oxyUserId;
       if (!isRequester && !isHost) {
         return next(new AppError('Not authorized to view these reviews', 403, 'FORBIDDEN'));
       }
 
-      const reviews = await ExchangeReview.find({ exchangeRequestId: exchangeRequest._id })
-        .sort({ createdAt: -1 })
-        .lean();
+      const reviews = await listReviewsForExchange(db, exchangeRequest.id);
 
-      res.json(successResponse(reviews, 'Exchange reviews retrieved'));
+      res.json(successResponse(reviews.map(serializeExchangeReview), 'Exchange reviews retrieved'));
     } catch (error) {
       next(error);
     }
@@ -172,26 +160,20 @@ class ExchangeReviewController {
       const limitNumber = Math.min(MAX_PAGE_SIZE, Math.max(1, parseInt(String(limit), 10) || DEFAULT_PAGE_SIZE));
       const skip = (pageNumber - 1) * limitNumber;
 
-      const [items, total, aggregate] = await Promise.all([
-        ExchangeReview.find({ subjectOxyUserId: oxyUserId })
-          .sort({ createdAt: -1 })
-          .skip(skip)
-          .limit(limitNumber)
-          .lean(),
-        ExchangeReview.countDocuments({ subjectOxyUserId: oxyUserId }),
-        ExchangeReview.aggregate([
-          { $match: { subjectOxyUserId: oxyUserId } },
-          { $group: { _id: null, averageRating: { $avg: '$rating' }, count: { $sum: 1 } } },
-        ]),
-      ]);
-
-      const averageRating = aggregate.length > 0 ? roundRating(aggregate[0].averageRating) : 0;
+      const result = await listReviewsForSubject(getDb(), oxyUserId, {
+        limit: limitNumber,
+        offset: skip,
+      });
 
       res.json(
-        paginationResponse(items, pageNumber, limitNumber, total, 'Profile exchange reviews retrieved', {
-          averageRating,
-          reviewCount: total,
-        }),
+        paginationResponse(
+          result.rows.map(serializeExchangeReview),
+          pageNumber,
+          limitNumber,
+          result.total,
+          'Profile exchange reviews retrieved',
+          { averageRating: result.averageRating, reviewCount: result.total },
+        ),
       );
     } catch (error) {
       next(error);

--- a/packages/backend/db/exchanges/exchangeReads.ts
+++ b/packages/backend/db/exchanges/exchangeReads.ts
@@ -1,0 +1,305 @@
+/**
+ * `exchange_requests` — the home-swap and free-hosting flow, on Postgres.
+ *
+ * Empty in production, so this port has no backfill and no consistency window.
+ *
+ * ## The conflict scan becomes ONE overlap query
+ *
+ * `hasPropertyConflict` loaded EVERY confirmed exchange touching a property,
+ * hydrated both windows and overlapped them in JavaScript — a full scan of the
+ * committed set per request, growing with the table. Postgres answers it with a
+ * range overlap, and `exchange_requests_requested_window_gist` exists precisely
+ * for the target half.
+ *
+ * **`tstzrange(a, b)` is HALF-OPEN `[)` by default**, which is what the schema's
+ * GiST index uses and what `utils/availabilityUtils.windowsOverlap` means: a
+ * stay ending exactly when the next begins is NOT a conflict. Writing `'[]'`
+ * here — the spelling `leases_term_range_gist` correctly uses — would make
+ * adjacent stays collide and silently refuse legitimate bookings.
+ *
+ * A property can be committed in TWO roles and both are checked, because a swap
+ * must not double-book the home the requester offers in return:
+ *
+ *  - as the TARGET of a confirmed exchange (`property_id` + requested window),
+ *  - as the OFFERED home of a confirmed swap (`offered_property_id` + offered
+ *    window).
+ *
+ * Only the first is index-backed today. The second is a filtered scan, which is
+ * correct and — on a table with no rows — costs nothing measurable; an index for
+ * it would be speculative under `CONVENTIONS.md`'s rule, and it needs a
+ * migration rather than a line in a code port. Recorded so whoever measures a
+ * real workload knows where to look.
+ *
+ * ## Two CHECKs the writer has to respect
+ *
+ * `exchange_requests_offered_window_check` is ALL-OR-NONE plus ordered, and
+ * `exchange_requests_host_mode_offers_nothing_check` says a `host` request
+ * offers nothing — the port of a `pre('save')` hook that `findOneAndUpdate`
+ * walked straight past. {@link createExchangeRequest} writes the offered trio
+ * together or not at all, which satisfies both by construction.
+ */
+
+import { and, desc, eq, inArray, ne, or, sql } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+import type { DatabaseOrTransaction } from '../postgres';
+import { exchangeRequests } from '../schema';
+import {
+  EXCHANGE_REQUEST_MODES,
+  EXCHANGE_REQUEST_STATUSES,
+} from '../schema/exchanges';
+
+/** An exchange mode the CHECK accepts. */
+export type ExchangeModeValue = (typeof EXCHANGE_REQUEST_MODES)[number];
+
+/** An exchange status the CHECK accepts. */
+export type ExchangeStatusValue = (typeof EXCHANGE_REQUEST_STATUSES)[number];
+
+export type ExchangeRequestRow = typeof exchangeRequests.$inferSelect;
+
+/**
+ * The statuses that occupy the calendar.
+ *
+ * Only a CONFIRMED exchange blocks — a pending request is a proposal, and two
+ * people may propose the same dates. Declared once because the create-time and
+ * confirm-time checks share it.
+ */
+export const BLOCKING_EXCHANGE_STATUSES: readonly ExchangeStatusValue[] = ['confirmed'];
+
+/** Whether `value` is one of the five declared statuses. */
+export function isExchangeStatus(value: unknown): value is ExchangeStatusValue {
+  return (
+    typeof value === 'string' && (EXCHANGE_REQUEST_STATUSES as readonly string[]).includes(value)
+  );
+}
+
+/** A half-open window `[start, end)`. */
+export interface ExchangeWindowInput {
+  readonly start: Date;
+  readonly end: Date;
+}
+
+/**
+ * Is `propertyId` already committed over `window`, in EITHER role?
+ *
+ * @param excludeId The request being confirmed, so it never conflicts with
+ *   itself.
+ */
+export async function hasPropertyConflict(
+  db: DatabaseOrTransaction,
+  propertyId: string,
+  window: ExchangeWindowInput,
+  options: { readonly excludeId?: string } = {},
+): Promise<boolean> {
+  // `tstzrange(a, b)` — default `[)` bounds. See the header: `'[]'` here would
+  // make two adjacent stays collide.
+  //
+  // The two bounds are bound as ISO STRINGS with an explicit `::timestamptz`,
+  // not as `Date`s. postgres.js infers a parameter's wire type from its position
+  // and cannot do so inside `tstzrange(...)` — a bare `Date` there fails at
+  // SERIALISATION with `The "string" argument must be of type string ... Received
+  // an instance of Date`, before the server ever sees the statement. The cast is
+  // what tells it, and it also states the type the range is built from.
+  const start = window.start.toISOString();
+  const end = window.end.toISOString();
+
+  const overlapsRequested = sql`
+    ${exchangeRequests.propertyId} = ${propertyId}
+    and tstzrange(${exchangeRequests.requestedWindowStart}, ${exchangeRequests.requestedWindowEnd})
+        && tstzrange(${start}::timestamptz, ${end}::timestamptz)`;
+
+  // The offered window is nullable, and `tstzrange(null, null)` is NULL rather
+  // than an error — so a row with no offered window simply never overlaps, which
+  // is the answer we want and needs no extra predicate.
+  const overlapsOffered = sql`
+    ${exchangeRequests.offeredPropertyId} = ${propertyId}
+    and tstzrange(${exchangeRequests.offeredWindowStart}, ${exchangeRequests.offeredWindowEnd})
+        && tstzrange(${start}::timestamptz, ${end}::timestamptz)`;
+
+  const clauses: SQL[] = [
+    inArray(exchangeRequests.status, [...BLOCKING_EXCHANGE_STATUSES]),
+    or(overlapsRequested, overlapsOffered) as SQL,
+  ];
+  if (options.excludeId !== undefined) clauses.push(ne(exchangeRequests.id, options.excludeId));
+
+  const [row] = await db
+    .select({ id: exchangeRequests.id })
+    .from(exchangeRequests)
+    .where(and(...clauses) as SQL)
+    .limit(1);
+  return row !== undefined;
+}
+
+export interface CreateExchangeRequestInput {
+  readonly propertyId: string;
+  readonly requesterOxyUserId: string;
+  readonly hostOxyUserId: string;
+  readonly mode: ExchangeModeValue;
+  readonly requestedWindow: ExchangeWindowInput;
+  /** SWAP only. Written as a trio with the offered window, or not at all. */
+  readonly offeredPropertyId?: string;
+  readonly offeredWindow?: ExchangeWindowInput;
+  readonly message?: string;
+}
+
+/**
+ * Open an exchange request. Always `pending`, never from the body.
+ *
+ * The offered property and window are written TOGETHER or omitted together,
+ * which is what `exchange_requests_offered_window_check` (all-or-none) and
+ * `exchange_requests_host_mode_offers_nothing_check` both require.
+ */
+export async function createExchangeRequest(
+  db: DatabaseOrTransaction,
+  input: CreateExchangeRequestInput,
+): Promise<ExchangeRequestRow> {
+  const [row] = await db
+    .insert(exchangeRequests)
+    .values({
+      propertyId: input.propertyId,
+      requesterOxyUserId: input.requesterOxyUserId,
+      hostOxyUserId: input.hostOxyUserId,
+      mode: input.mode,
+      requestedWindowStart: input.requestedWindow.start,
+      requestedWindowEnd: input.requestedWindow.end,
+      offeredPropertyId: input.offeredPropertyId,
+      offeredWindowStart: input.offeredWindow?.start,
+      offeredWindowEnd: input.offeredWindow?.end,
+      message: input.message,
+      status: 'pending',
+    })
+    .returning();
+  return row;
+}
+
+/** One exchange request by id. */
+export async function findExchangeRequestById(
+  db: DatabaseOrTransaction,
+  id: string,
+): Promise<ExchangeRequestRow | undefined> {
+  const [row] = await db
+    .select()
+    .from(exchangeRequests)
+    .where(eq(exchangeRequests.id, id))
+    .limit(1);
+  return row;
+}
+
+export interface ListExchangeRequestsFilter {
+  readonly requesterOxyUserId?: string;
+  readonly hostOxyUserId?: string;
+  readonly status?: ExchangeStatusValue;
+}
+
+/** The predicate shared by the page and its `count(*)`, so the two agree. */
+function listFilter(filter: ListExchangeRequestsFilter): SQL {
+  const clauses: SQL[] = [];
+  if (filter.requesterOxyUserId !== undefined) {
+    clauses.push(eq(exchangeRequests.requesterOxyUserId, filter.requesterOxyUserId));
+  }
+  if (filter.hostOxyUserId !== undefined) {
+    clauses.push(eq(exchangeRequests.hostOxyUserId, filter.hostOxyUserId));
+  }
+  if (filter.status !== undefined) clauses.push(eq(exchangeRequests.status, filter.status));
+  return clauses.length > 0 ? (and(...clauses) as SQL) : sql`true`;
+}
+
+export interface ListExchangeRequestsResult {
+  readonly rows: readonly ExchangeRequestRow[];
+  readonly total: number;
+}
+
+/** One page of exchange requests, newest first. */
+export async function listExchangeRequests(
+  db: DatabaseOrTransaction,
+  filter: ListExchangeRequestsFilter,
+  page: { readonly limit: number; readonly offset: number },
+): Promise<ListExchangeRequestsResult> {
+  const where = listFilter(filter);
+  const [rows, [totalRow]] = await Promise.all([
+    db
+      .select()
+      .from(exchangeRequests)
+      .where(where)
+      .orderBy(desc(exchangeRequests.createdAt))
+      .limit(page.limit)
+      .offset(page.offset),
+    db
+      .select({ value: sql<number>`count(*)::int` })
+      .from(exchangeRequests)
+      .where(where),
+  ]);
+  return { rows, total: totalRow.value };
+}
+
+/**
+ * Move a request to `nextStatus`, but only from one of `fromStatuses`.
+ *
+ * The permitted FROM set is in the `UPDATE`'s own predicate, so two hosts
+ * confirming at once cannot both succeed — the read that precedes this in the
+ * controller chooses the ERROR, this chooses whether the write happens.
+ */
+export async function transitionExchangeRequest(
+  db: DatabaseOrTransaction,
+  id: string,
+  nextStatus: ExchangeStatusValue,
+  fromStatuses: readonly ExchangeStatusValue[],
+  options: { readonly message?: string } = {},
+): Promise<ExchangeRequestRow | undefined> {
+  const values: Partial<typeof exchangeRequests.$inferInsert> = { status: nextStatus };
+  if (options.message !== undefined) values.message = options.message;
+
+  const [row] = await db
+    .update(exchangeRequests)
+    .set(values)
+    .where(
+      and(
+        eq(exchangeRequests.id, id),
+        inArray(exchangeRequests.status, [...fromStatuses]),
+      ),
+    )
+    .returning();
+  return row;
+}
+
+/** Update only the message, for the already-in-that-state convergence path. */
+export async function setExchangeRequestMessage(
+  db: DatabaseOrTransaction,
+  id: string,
+  message: string,
+): Promise<ExchangeRequestRow | undefined> {
+  const [row] = await db
+    .update(exchangeRequests)
+    .set({ message })
+    .where(eq(exchangeRequests.id, id))
+    .returning();
+  return row;
+}
+
+/**
+ * The wire shape the exchange screens read.
+ *
+ * The two windows are RE-NESTED: `db/schema/CONVENTIONS.md` flattens them into
+ * four columns because they are the filter of the overlap query, and the wire
+ * contract (`ExchangeWindow` in shared-types) is still `{ start, end }`. The
+ * offered window is emitted only when it is present — all-or-none, matching the
+ * CHECK, so a `host` request carries no empty shell.
+ */
+export function serializeExchangeRequest(row: ExchangeRequestRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    propertyId: row.propertyId,
+    requesterOxyUserId: row.requesterOxyUserId,
+    hostOxyUserId: row.hostOxyUserId,
+    mode: row.mode,
+    offeredPropertyId: row.offeredPropertyId,
+    requestedWindow: { start: row.requestedWindowStart, end: row.requestedWindowEnd },
+    offeredWindow:
+      row.offeredWindowStart === null || row.offeredWindowEnd === null
+        ? undefined
+        : { start: row.offeredWindowStart, end: row.offeredWindowEnd },
+    message: row.message,
+    status: row.status,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/packages/backend/db/exchanges/exchangeReviewReads.ts
+++ b/packages/backend/db/exchanges/exchangeReviewReads.ts
@@ -1,0 +1,174 @@
+/**
+ * `exchange_reviews` — what each side said after a completed exchange.
+ *
+ * Empty in production. Distinct from `reviews`, which rates an ADDRESS; this one
+ * rates a PERSON and is scoped to one exchange.
+ *
+ * ## The "already reviewed" pre-check is GONE, and the index is the answer
+ *
+ * The Mongoose controller read for an existing review, then inserted, then ALSO
+ * caught the duplicate-key error — a read-then-write with a window plus a
+ * backstop. `exchange_reviews_request_reviewer_key` is a real UNIQUE, so the
+ * insert IS the check: `db/MIGRATION-CONTRACT.md` says the ported code should
+ * INSERT and handle `23505` rather than re-implement the read, and keeping the
+ * read would leave a redundant round trip in front of a constraint that already
+ * decides it.
+ *
+ * The 409 is unchanged; it is raised from the index's own violation now.
+ *
+ * ## The average is `avg()`, and it is rounded in ONE place
+ *
+ * Mongo used a `$group` pipeline and rounded in JS. Postgres does the same work
+ * in the same query as the count, so the page, the total and the average cannot
+ * come from three different snapshots of the table.
+ */
+
+import { desc, eq, sql } from 'drizzle-orm';
+import type { DatabaseOrTransaction } from '../postgres';
+import { exchangeReviews } from '../schema';
+import { isUniqueViolation } from '../uniqueViolation';
+
+export type ExchangeReviewRow = typeof exchangeReviews.$inferSelect;
+
+/** This reviewer has already reviewed this exchange. */
+export class ExchangeAlreadyReviewedError extends Error {
+  constructor() {
+    super('This reviewer has already reviewed this exchange.');
+    this.name = 'ExchangeAlreadyReviewedError';
+  }
+}
+
+export interface CreateExchangeReviewInput {
+  readonly exchangeRequestId: string;
+  readonly reviewerOxyUserId: string;
+  readonly subjectOxyUserId: string;
+  readonly rating: number;
+  readonly comment?: string;
+  readonly categories?: {
+    readonly communication?: number;
+    readonly cleanliness?: number;
+    readonly accuracy?: number;
+    readonly hospitality?: number;
+  };
+}
+
+/**
+ * Insert one review.
+ *
+ * @throws {ExchangeAlreadyReviewedError} From
+ *   `exchange_reviews_request_reviewer_key`'s own `23505`, so two concurrent
+ *   submissions cannot both land.
+ */
+export async function createExchangeReview(
+  db: DatabaseOrTransaction,
+  input: CreateExchangeReviewInput,
+): Promise<ExchangeReviewRow> {
+  try {
+    const [row] = await db
+      .insert(exchangeReviews)
+      .values({
+        exchangeRequestId: input.exchangeRequestId,
+        reviewerOxyUserId: input.reviewerOxyUserId,
+        subjectOxyUserId: input.subjectOxyUserId,
+        rating: input.rating,
+        comment: input.comment,
+        // The four `categories` are a closed subdocument flattened into named
+        // columns; each is optional and CHECK-bounded to 1-5 when present.
+        categoriesCommunication: input.categories?.communication,
+        categoriesCleanliness: input.categories?.cleanliness,
+        categoriesAccuracy: input.categories?.accuracy,
+        categoriesHospitality: input.categories?.hospitality,
+      })
+      .returning();
+    return row;
+  } catch (error) {
+    if (isUniqueViolation(error, 'exchange_reviews_request_reviewer_key')) {
+      throw new ExchangeAlreadyReviewedError();
+    }
+    throw error;
+  }
+}
+
+/** Both reviews tied to one exchange, newest first. */
+export async function listReviewsForExchange(
+  db: DatabaseOrTransaction,
+  exchangeRequestId: string,
+): Promise<readonly ExchangeReviewRow[]> {
+  return db
+    .select()
+    .from(exchangeReviews)
+    .where(eq(exchangeReviews.exchangeRequestId, exchangeRequestId))
+    .orderBy(desc(exchangeReviews.createdAt));
+}
+
+export interface SubjectReviewsResult {
+  readonly rows: readonly ExchangeReviewRow[];
+  readonly total: number;
+  /** `avg(rating)` over EVERY review of this subject, rounded to 2 places. */
+  readonly averageRating: number;
+}
+
+/**
+ * One page of the reviews written ABOUT a person, plus the aggregate.
+ *
+ * The count and the average come from ONE statement, so the header figures and
+ * the page cannot disagree about which rows exist.
+ */
+export async function listReviewsForSubject(
+  db: DatabaseOrTransaction,
+  subjectOxyUserId: string,
+  page: { readonly limit: number; readonly offset: number },
+): Promise<SubjectReviewsResult> {
+  const where = eq(exchangeReviews.subjectOxyUserId, subjectOxyUserId);
+  const [rows, [aggregate]] = await Promise.all([
+    db
+      .select()
+      .from(exchangeReviews)
+      .where(where)
+      .orderBy(desc(exchangeReviews.createdAt))
+      .limit(page.limit)
+      .offset(page.offset),
+    db
+      .select({
+        total: sql<number>`count(*)::int`,
+        // `round(...)` needs a numeric; `rating` is double precision, hence the
+        // cast. `coalesce` makes an empty set 0 rather than NULL, matching the
+        // Mongo handler's `aggregate.length > 0 ? … : 0`.
+        averageRating: sql<number>`coalesce(round(avg(${exchangeReviews.rating})::numeric, 2), 0)::float8`,
+      })
+      .from(exchangeReviews)
+      .where(where),
+  ]);
+  return { rows, total: aggregate.total, averageRating: aggregate.averageRating };
+}
+
+/**
+ * The wire shape the exchange-review screens read.
+ *
+ * `categories` is RE-NESTED from its four columns, and emitted only when at
+ * least one is present — the sub-document never materialized in Mongo when the
+ * client sent nothing, so an empty shell would be a new field rather than a
+ * preserved one.
+ */
+export function serializeExchangeReview(row: ExchangeReviewRow): Record<string, unknown> {
+  const categories = {
+    communication: row.categoriesCommunication,
+    cleanliness: row.categoriesCleanliness,
+    accuracy: row.categoriesAccuracy,
+    hospitality: row.categoriesHospitality,
+  };
+  const hasCategory = Object.values(categories).some((value) => value !== null);
+
+  return {
+    id: row.id,
+    exchangeRequestId: row.exchangeRequestId,
+    reviewerOxyUserId: row.reviewerOxyUserId,
+    subjectOxyUserId: row.subjectOxyUserId,
+    rating: row.rating,
+    comment: row.comment,
+    categories: hasCategory ? categories : undefined,
+    isVerified: row.isVerified,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/packages/backend/db/properties/propertyBookingBasis.ts
+++ b/packages/backend/db/properties/propertyBookingBasis.ts
@@ -55,6 +55,15 @@ export interface PropertyBookingBasis {
    * than a hint.
    */
   readonly offerings: readonly string[];
+  /**
+   * Which exchange the listing accepts (`swap` | `host` | `both`), or NULL.
+   *
+   * Nullable because `exchange` is an OPTIONAL priced block — a listing not
+   * open to home exchange simply has none, which is why
+   * `exchangeController` treats a missing mode as a refusal rather than a
+   * default.
+   */
+  readonly exchangeMode: string | null;
 }
 
 /** The booking-relevant columns of one listing, or `undefined`. */
@@ -69,6 +78,7 @@ export async function findPropertyBookingBasis(
       isExternal: properties.isExternal,
       oxyUserId: properties.oxyUserId,
       offerings: properties.offerings,
+      exchangeMode: properties.exchangeMode,
     })
     .from(properties)
     .where(eq(properties.id, propertyId))


### PR DESCRIPTION
`exchange_requests` and `exchange_reviews`, both empty in production. `db/exchanges/{exchangeReads,exchangeReviewReads}.ts`.

## The conflict scan becomes ONE overlap query

`hasPropertyConflict` loaded **every** confirmed exchange touching a property, hydrated both windows and overlapped them in JavaScript — a full scan of the committed set per request, growing with the table. Postgres answers it with a range overlap, and `exchange_requests_requested_window_gist` exists for exactly the target half.

The offered half is a filtered scan; an index for it would be speculative under `CONVENTIONS.md` and needs a migration rather than a line in a code port, so it is recorded in the module header instead. Both **roles** are still checked — target and offered — because a swap must not double-book the home the requester offers in return.

## Two driver-level facts, both measured

**`tstzrange(a, b)` is HALF-OPEN `[)` by default**, which is what the schema's GiST index and `windowsOverlap` both mean. Writing `'[]'` — the spelling `leases_term_range_gist` correctly uses — would make adjacent stays collide and silently refuse legitimate bookings.

**A bare `Date` inside `tstzrange(...)` fails at SERIALISATION**, before the server sees the statement: postgres.js infers a parameter's wire type from its position and cannot do it there, so it throws `The "string" argument must be of type string ... Received an instance of Date`. The bounds are bound as ISO strings with an explicit `::timestamptz`.

## Guards deleted, a Profile guard dropped

Four `Types.ObjectId.isValid` guards across the two controllers are **deleted** per `db/ids.ts` — post-cutover every listing and request id is a uuid v7, which they reject, and the lookups already 404 for an id naming nothing.

`listMyExchangeRequests`'s `Profile.findByOxyUserId` is dropped for the reason `savedSearches` was in #301: it was not an authorisation check — both branches are already scoped by the session `oxyUserId` — so its only effect was to answer an empty list to somebody who owned rows and had no profile document yet.

## The exchange-review pre-read is gone

The controller read for an existing review, inserted, **and** caught the duplicate key. `exchange_reviews_request_reviewer_key` is a real UNIQUE, so the INSERT is the check and the 409 comes from its own violation. The subject average is now `avg()` in the same statement as the count, so the header figures and the page cannot come from two snapshots of the table.

## Tests

**112 suites / 1398 tests → 113 / 1424**, green. CI floor 1345 → 1380.

Mutation-tested — and the first round **found a vacuous test of my own.** The back-to-back boundary case survived closed bounds on the query range, on the stored range, *and* on both: `window()` re-read `Date.now()` per call, so the two "adjacent" windows were milliseconds apart and disjoint under every bound convention. The claim in its comment was simply not what it tested.

Pinning one base instant, and adding the **reverse order** (a confirmed *later* stay must not block the earlier one ending where it starts — the only direction that catches a closed bound on the STORED range), makes all three red:

| mutation | before | after |
|---|---|---|
| closed bounds, query range only | **survived** | 1 red |
| closed bounds, stored range only | **survived** | 1 red |
| closed bounds, both | **survived** | 1 red |
| drop the OFFERED role from the scan | 1 red | 1 red |
| review subject taken from the request rather than the reviewer | 1 red | 1 red |

Other things the suite pins in both directions: `exchange_requests_offered_window_check` on the **half-a-pair** it exists to refuse (the shape a NULL-tolerant CHECK admits — `CONVENTIONS.md` records that the first draft let it through), `exchange_requests_host_mode_offers_nothing_check`, and the mode matrix including `both` being a listing capability rather than a request mode.

## Still deferred

`reservations` is the last tenancy table. It needs `nights` (a stored column deliberately — it is the priced quantity, `subtotal = nights × nightly_rate`, and a generated column would have to reproduce the `round()` exactly) and the short-term pricing block on the property projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)