### PR TITLE
Move the Sindi conversations and the profile sidecar to Postgres (#281)

### DIFF
--- a/packages/backend/__tests__/db/conversationOrdering.test.ts
+++ b/packages/backend/__tests__/db/conversationOrdering.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Conversation ordering across the id-shape boundary, against a REAL server.
+ *
+ * ## The bug this exists to catch, and why an ordinary fixture cannot
+ *
+ * Every primary key in `db/schema` is `text`, holding a 24-char ObjectId hex for
+ * a row that existed before the cutover and a uuid v7 for one created after it.
+ * Sorting by that column looks like sorting by creation time — for a table whose
+ * rows all came from ONE of the two generations it even IS one, which is exactly
+ * why a hand-written fixture passes against the wrong implementation.
+ *
+ * The two shapes interleave BACKWARDS. A uuid v7 minted now begins `0199…` (the
+ * millisecond clock, hex, in the leading 48 bits); an ObjectId minted this year
+ * begins `69…`/`6a…` (a 32-bit unix-seconds prefix). `'0' < '6'`, so a
+ * lexicographic sort puts every NEW row before every LEGACY one, whatever their
+ * real order — and the damage lands only on the rows that span the cutover.
+ *
+ * So each case below does three things, and the third is what makes it a real
+ * check rather than one that cannot tell success from failure:
+ *
+ *  1. asserts the ordering the repository produces;
+ *  2. computes what an ID sort would have produced;
+ *  3. asserts those two DISAGREE.
+ *
+ * Without (3) the file would keep passing if somebody changed `order by
+ * updated_at desc` to `order by id desc`, because a fixture whose ids happen to
+ * agree with its timestamps cannot see the difference. `expectIdOrderIsWrong`
+ * makes the fixture prove it is the adversarial one.
+ */
+
+import { asc, eq } from 'drizzle-orm';
+import { uuidv7 } from '@oxyhq/db';
+import { Types } from 'mongoose';
+import { closePostgres, connectPostgres, type Database } from '../../db/postgres';
+import {
+  appendMessages,
+  listConversations,
+  listMessages,
+} from '../../db/conversations/conversationRepository';
+import { conversationMessages, conversations } from '../../db/schema';
+
+/** A 24-char ObjectId hex, exactly as every pre-cutover row carries. */
+const legacyId = (): string => new Types.ObjectId().toHexString();
+
+let db: Database;
+
+/** A distinct owner per case, so no two can see each other's rows. */
+const owner = (): string => `oxy-${uuidv7()}`;
+
+beforeAll(async () => {
+  db = await connectPostgres();
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+/**
+ * Assert that ordering the same rows by ID would have produced a DIFFERENT
+ * sequence than the one under test.
+ *
+ * This is the anti-vacuity guard. If it ever fails, the FIXTURE stopped being
+ * adversarial — not the code — and the fix is to change the fixture rather than
+ * to delete the assertion.
+ */
+function expectIdOrderIsWrong(actualIds: readonly string[], direction: 'asc' | 'desc'): void {
+  const byId = [...actualIds].sort((a, b) => (direction === 'asc' ? (a < b ? -1 : 1) : a < b ? 1 : -1));
+  expect(byId).not.toEqual([...actualIds]);
+}
+
+describe('id shapes — the property every case below depends on', () => {
+  it('sorts a fresh uuid v7 BEFORE a fresh ObjectId hex, lexicographically', () => {
+    // Measured rather than assumed: this single fact is why ordering by the
+    // primary key is wrong on every table in this migration.
+    const uuid = uuidv7();
+    const objectId = legacyId();
+    expect(uuid < objectId).toBe(true);
+    expect(uuid).toMatch(/^0/);
+    expect(objectId).toMatch(/^[0-9a-f]{24}$/);
+  });
+});
+
+describe('conversation_messages — ordered by position, never by id', () => {
+  it('keeps a legacy turn before the uuid v7 turn that answers it', async () => {
+    const oxyUserId = owner();
+    const conversationId = legacyId();
+    const now = new Date();
+    await db.insert(conversations).values({
+      id: conversationId,
+      oxyUserId,
+      title: 'A transcript that spans the cutover',
+      analyticsLastActivity: now,
+    });
+
+    // The natural shape: the backfilled question carries its Mongo id, the reply
+    // the user got after the cutover carries a fresh uuid v7. Position — and
+    // therefore meaning — is question first.
+    const legacyMessageId = legacyId();
+    await db.insert(conversationMessages).values([
+      {
+        id: legacyMessageId,
+        conversationId,
+        role: 'user',
+        content: 'Can my landlord raise the rent mid-contract?',
+        timestamp: new Date(now.getTime() - 60_000),
+        position: 0,
+      },
+    ]);
+    const [reply] = await appendMessages(db, conversationId, [
+      { role: 'assistant', content: 'Not without a clause that allows it.' },
+    ]);
+
+    expect(reply.id).toMatch(/^0/);
+    expect(reply.position).toBe(1);
+
+    const hydrated = await listMessages(db, conversationId);
+    const ids = hydrated.map((entry) => entry.message.id);
+    expect(ids).toEqual([legacyMessageId, reply.id]);
+    expect(hydrated.map((entry) => entry.message.role)).toEqual(['user', 'assistant']);
+
+    // An `order by id asc` would have hoisted the answer above its own question.
+    expectIdOrderIsWrong(ids, 'asc');
+  });
+
+  it('orders by position even when the timestamps are identical', async () => {
+    // `timestamp` defaults to `Date.now()` at millisecond resolution, so two
+    // turns appended in one tick tie on it — which is the whole reason
+    // `db/schema/conversations.ts` carries `position` at all.
+    const oxyUserId = owner();
+    const conversationId = uuidv7();
+    const stamp = new Date();
+    await db.insert(conversations).values({
+      id: conversationId,
+      oxyUserId,
+      title: 'Same millisecond',
+      analyticsLastActivity: stamp,
+    });
+
+    await db.insert(conversationMessages).values([
+      { id: uuidv7(), conversationId, role: 'assistant', content: 'second', timestamp: stamp, position: 1 },
+      { id: legacyId(), conversationId, role: 'user', content: 'first', timestamp: stamp, position: 0 },
+    ]);
+
+    const contents = (await listMessages(db, conversationId)).map((entry) => entry.message.content);
+    expect(contents).toEqual(['first', 'second']);
+  });
+});
+
+describe('conversations list — ordered by updated_at, with the id only a tiebreaker', () => {
+  it('puts the recently-touched uuid v7 conversation above the older legacy one', async () => {
+    const oxyUserId = owner();
+    const olderLegacy = legacyId();
+    const newerUuid = uuidv7();
+    const base = new Date('2026-08-01T10:00:00.000Z');
+
+    await db.insert(conversations).values([
+      {
+        id: olderLegacy,
+        oxyUserId,
+        title: 'Older, and backfilled',
+        analyticsLastActivity: base,
+        createdAt: base,
+        updatedAt: base,
+      },
+      {
+        id: newerUuid,
+        oxyUserId,
+        title: 'Newer, and created after the cutover',
+        analyticsLastActivity: new Date(base.getTime() + 3_600_000),
+        createdAt: new Date(base.getTime() + 3_600_000),
+        updatedAt: new Date(base.getTime() + 3_600_000),
+      },
+    ]);
+
+    const ids = (await listConversations(db, oxyUserId)).map((row) => row.conversation.id);
+    expect(ids).toEqual([newerUuid, olderLegacy]);
+
+    // `order by id desc` would have answered `[olderLegacy, newerUuid]`, i.e.
+    // the stale conversation at the top of the sidebar for good.
+    expectIdOrderIsWrong(ids, 'desc');
+  });
+
+  it('breaks a tie on updated_at with the id, so the order is stable across calls', async () => {
+    const oxyUserId = owner();
+    const stamp = new Date('2026-08-02T09:00:00.000Z');
+    const ids = [legacyId(), uuidv7(), legacyId()];
+    await db.insert(conversations).values(
+      ids.map((id, index) => ({
+        id,
+        oxyUserId,
+        title: `Tied ${index}`,
+        analyticsLastActivity: stamp,
+        createdAt: stamp,
+        updatedAt: stamp,
+      })),
+    );
+
+    const first = (await listConversations(db, oxyUserId)).map((row) => row.conversation.id);
+    const second = (await listConversations(db, oxyUserId)).map((row) => row.conversation.id);
+    expect(first).toEqual(second);
+    expect(first).toEqual([...ids].sort((a, b) => (a < b ? 1 : -1)));
+  });
+});
+
+describe('listConversations — the two figures that stopped being stored', () => {
+  it('counts messages and reports the LAST one by position, not by id', async () => {
+    const oxyUserId = owner();
+    const conversationId = legacyId();
+    const now = new Date();
+    await db.insert(conversations).values({
+      id: conversationId,
+      oxyUserId,
+      title: 'Counted',
+      analyticsLastActivity: now,
+    });
+
+    // Position 2 carries a LEGACY id and position 0 a uuid v7, so "the last
+    // message" and "the greatest id" are different rows.
+    const lastId = legacyId();
+    await db.insert(conversationMessages).values([
+      { id: uuidv7(), conversationId, role: 'user', content: 'one', timestamp: now, position: 0 },
+      { id: uuidv7(), conversationId, role: 'assistant', content: 'two', timestamp: now, position: 1 },
+      { id: lastId, conversationId, role: 'user', content: 'three', timestamp: now, position: 2 },
+    ]);
+
+    const [summary] = await listConversations(db, oxyUserId);
+    expect(summary.messageCount).toBe(3);
+    expect(summary.lastMessage?.content).toBe('three');
+    expect(summary.lastMessage?.id).toBe(lastId);
+
+    // The correlated subqueries must be QUALIFIED. An unqualified
+    // `${conversations.id}` resolves against `conversation_messages`'s own `id`
+    // inside the subquery and silently returns 0 with no error at all — the trap
+    // `db/schema/CONVENTIONS.md` records. A non-zero count here is what
+    // distinguishes the two.
+    expect(summary.messageCount).toBeGreaterThan(0);
+  });
+
+  it('reports a conversation with no messages as count 0 and no last message', async () => {
+    const oxyUserId = owner();
+    await db.insert(conversations).values({
+      id: uuidv7(),
+      oxyUserId,
+      title: 'Empty',
+      analyticsLastActivity: new Date(),
+    });
+
+    const [summary] = await listConversations(db, oxyUserId);
+    expect(summary.messageCount).toBe(0);
+    expect(summary.lastMessage).toBeUndefined();
+  });
+});
+
+describe('appendMessages — position is assigned, never guessed', () => {
+  it('continues from the highest existing position, across id shapes', async () => {
+    const oxyUserId = owner();
+    const conversationId = legacyId();
+    const now = new Date();
+    await db.insert(conversations).values({
+      id: conversationId,
+      oxyUserId,
+      title: 'Continued',
+      analyticsLastActivity: now,
+    });
+    await db
+      .insert(conversationMessages)
+      .values({ id: legacyId(), conversationId, role: 'user', content: 'backfilled', timestamp: now, position: 7 });
+
+    const appended = await appendMessages(db, conversationId, [
+      { role: 'assistant', content: 'a' },
+      { role: 'user', content: 'b' },
+    ]);
+    expect(appended.map((row) => row.position)).toEqual([8, 9]);
+
+    const stored = await db
+      .select({ position: conversationMessages.position })
+      .from(conversationMessages)
+      .where(eq(conversationMessages.conversationId, conversationId))
+      .orderBy(asc(conversationMessages.position));
+    expect(stored.map((row) => row.position)).toEqual([7, 8, 9]);
+  });
+
+  it('moves analytics.last_activity, which is the hook the Mongo pre-save was', async () => {
+    const oxyUserId = owner();
+    const conversationId = uuidv7();
+    const stale = new Date('2026-07-01T00:00:00.000Z');
+    await db.insert(conversations).values({
+      id: conversationId,
+      oxyUserId,
+      title: 'Stamped',
+      analyticsLastActivity: stale,
+    });
+
+    await appendMessages(db, conversationId, [{ role: 'user', content: 'hello' }]);
+
+    const [row] = await db
+      .select({ lastActivity: conversations.analyticsLastActivity })
+      .from(conversations)
+      .where(eq(conversations.id, conversationId));
+    expect(row.lastActivity.getTime()).toBeGreaterThan(stale.getTime());
+  });
+});

--- a/packages/backend/__tests__/integration/conversationOwnership.test.ts
+++ b/packages/backend/__tests__/integration/conversationOwnership.test.ts
@@ -1,0 +1,452 @@
+/**
+ * The Sindi conversation surface, through the REAL routers, against the REAL
+ * Postgres this worker owns.
+ *
+ * Two things are under test and they are different:
+ *
+ *  1. **Ownership.** Every `/api/ai/conversations*` handler scopes by
+ *     `oxy_user_id` IN THE PREDICATE, so user B must not be able to read,
+ *     rename, append to, share or delete user A's transcript — and must get the
+ *     same 404 as for a conversation that does not exist, since a 403 would
+ *     confirm the id is real.
+ *  2. **That the surface WORKS AT ALL.** It did not. `routes/ai.ts` wrote
+ *     `profileId`, which `ConversationSchema` does not declare, so mongoose
+ *     strict mode dropped it and `required: true` on `oxyUserId` failed every
+ *     save; the reads filtered on the same phantom field and returned `[]`.
+ *     Production holds zero conversations for that reason. A test that only
+ *     checked the IDOR would have passed against the broken version too, so the
+ *     happy paths below are load-bearing rather than decoration.
+ *
+ * ## Why the ownership cases re-read the TABLE
+ *
+ * A handler that answered 404 while still performing the write would satisfy
+ * every assertion made on its RESPONSE — the 404 is the thing being tested, so
+ * trusting it to also prove the row is untouched is a check that cannot tell
+ * success from failure. Each case therefore reads the row back.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { eq } from 'drizzle-orm';
+import { uuidv7 } from '@oxyhq/db';
+
+import aiRouter from '../../routes/ai';
+import publicRoutes from '../../routes/public';
+import { getDb } from '../../db/postgres';
+import { conversationMessages, conversations } from '../../db/schema';
+import { errorHandler } from '../../middlewares/errorHandler';
+import { expireShareLinks } from '../../db/conversations/conversationRepository';
+
+/** The AI router, behind a fake session for `oxyUserId`. */
+function buildApp(oxyUserId: string | null): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (oxyUserId) (req as unknown as { user: { id: string } }).user = { id: oxyUserId };
+    next();
+  });
+  app.use('/ai', aiRouter());
+  app.use(errorHandler);
+  return app;
+}
+
+/** The public router, with no session at all — the share-link reader. */
+function buildPublicApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/', publicRoutes());
+  app.use(errorHandler);
+  return app;
+}
+
+const owner = (): string => `oxy-${uuidv7()}`;
+
+async function findConversation(id: string) {
+  const [row] = await getDb().select().from(conversations).where(eq(conversations.id, id)).limit(1);
+  return row;
+}
+
+async function messagesOf(id: string) {
+  return getDb()
+    .select()
+    .from(conversationMessages)
+    .where(eq(conversationMessages.conversationId, id));
+}
+
+/** Create a conversation through the real handler and return its id. */
+async function createFor(oxyUserId: string, body: Record<string, unknown> = {}): Promise<string> {
+  const res = await request(buildApp(oxyUserId)).post('/ai/conversations').send(body);
+  expect(res.status).toBe(200);
+  return String(res.body.conversation.id);
+}
+
+beforeEach(async () => {
+  await getDb().delete(conversations);
+});
+
+describe('POST /ai/conversations — the write path that never worked', () => {
+  it('stores a conversation owned by the SESSION user', async () => {
+    const oxyUserId = owner();
+    const res = await request(buildApp(oxyUserId))
+      .post('/ai/conversations')
+      .send({ title: 'Rent increase', initialMessage: 'Can they raise it mid-contract?' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.conversation.title).toBe('Rent increase');
+    expect(res.body.conversation.messages).toHaveLength(1);
+    expect(res.body.conversation.messages[0]).toMatchObject({
+      role: 'user',
+      content: 'Can they raise it mid-contract?',
+    });
+
+    // The row really exists, and its owner is the session's Oxy id rather than
+    // any profile id — the exact thing the Mongo version got wrong.
+    const stored = await findConversation(res.body.conversation.id);
+    expect(stored?.oxyUserId).toBe(oxyUserId);
+    expect(stored?.status).toBe('active');
+    expect(await messagesOf(res.body.conversation.id)).toHaveLength(1);
+  });
+
+  it('does not need a profile row to exist first', async () => {
+    // The Mongo handler resolved a `Profile` and 404'd without one, which
+    // refused a chat to anybody who had never opened the profile screen.
+    const res = await request(buildApp(owner()))
+      .post('/ai/conversations')
+      .send({ initialMessage: 'hello' });
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts a whole opening transcript and numbers it from zero', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId, {
+      messages: [
+        { role: 'user', content: 'first' },
+        { role: 'assistant', content: 'second' },
+        { role: 'user', content: 'third' },
+      ],
+    });
+
+    const stored = await messagesOf(id);
+    expect(stored.map((row) => row.position).sort((a, b) => a - b)).toEqual([0, 1, 2]);
+  });
+
+  it('drops a turn with an undeclared role rather than storing it', async () => {
+    // `conversation_messages_role_check` would answer `23514`, which reaches the
+    // client as a 500 for input it could simply be told about.
+    const id = await createFor(owner(), {
+      messages: [
+        { role: 'user', content: 'kept' },
+        { role: 'moderator', content: 'dropped' },
+        { role: 'assistant', content: 'kept too' },
+      ],
+    });
+    const stored = await messagesOf(id);
+    expect(stored.map((row) => row.content).sort()).toEqual(['kept', 'kept too']);
+  });
+
+  it('refuses an unauthenticated caller', async () => {
+    const res = await request(buildApp(null)).post('/ai/conversations').send({ title: 'x' });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /ai/conversations — the list, and the two derived figures', () => {
+  it('returns only the caller\'s own conversations', async () => {
+    const a = owner();
+    const b = owner();
+    await createFor(a, { title: 'A owns this' });
+    await createFor(b, { title: 'B owns this' });
+
+    const res = await request(buildApp(a)).get('/ai/conversations');
+    expect(res.status).toBe(200);
+    expect(res.body.conversations).toHaveLength(1);
+    expect(res.body.conversations[0].title).toBe('A owns this');
+  });
+
+  it('reports messageCount and lastMessage without storing either', async () => {
+    const oxyUserId = owner();
+    await createFor(oxyUserId, {
+      messages: [
+        { role: 'user', content: 'one' },
+        { role: 'assistant', content: 'two' },
+      ],
+    });
+
+    const res = await request(buildApp(oxyUserId)).get('/ai/conversations');
+    expect(res.body.conversations[0].messageCount).toBe(2);
+    expect(res.body.conversations[0].lastMessage).toMatchObject({
+      role: 'assistant',
+      content: 'two',
+    });
+  });
+});
+
+describe('GET /ai/conversations/:id — ownership', () => {
+  it('lets the owner read their own transcript', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId, { initialMessage: 'mine' });
+
+    const res = await request(buildApp(oxyUserId)).get(`/ai/conversations/${id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.conversation.id).toBe(id);
+    expect(res.body.conversation.messages[0].content).toBe('mine');
+  });
+
+  it('404s a stranger, indistinguishably from a conversation that does not exist', async () => {
+    const id = await createFor(owner(), { initialMessage: 'private' });
+
+    const stranger = await request(buildApp(owner())).get(`/ai/conversations/${id}`);
+    const missing = await request(buildApp(owner())).get(`/ai/conversations/${uuidv7()}`);
+    expect(stranger.status).toBe(404);
+    expect(missing.status).toBe(404);
+    expect(stranger.body).toEqual(missing.body);
+  });
+
+  it('404s a malformed id instead of 400ing it', async () => {
+    // The `mongoose.Types.ObjectId.isValid` guard that used to 400 here is
+    // DELETED, not widened: post-cutover it answers `false` for every uuid v7,
+    // so it would have rejected every conversation created from the cutover on.
+    // A `text` column takes any string and the lookup simply finds nothing.
+    const res = await request(buildApp(owner())).get('/ai/conversations/not-an-id-at-all');
+    expect(res.status).toBe(404);
+  });
+
+  it('accepts a uuid v7 id, which the deleted guard would have refused', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId);
+    expect(id).toMatch(/^[0-9a-f]{8}-/);
+
+    const res = await request(buildApp(oxyUserId)).get(`/ai/conversations/${id}`);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('PUT /ai/conversations/:id — ownership and transcript replacement', () => {
+  it('renames, restatuses and replaces the transcript for the owner', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId, { initialMessage: 'original' });
+
+    const res = await request(buildApp(oxyUserId))
+      .put(`/ai/conversations/${id}`)
+      .send({
+        title: 'Renamed',
+        status: 'archived',
+        messages: [
+          { role: 'user', content: 'replaced' },
+          { role: 'assistant', content: 'and answered' },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.conversation.title).toBe('Renamed');
+    expect(res.body.conversation.status).toBe('archived');
+    expect(res.body.conversation.messages.map((m: { content: string }) => m.content)).toEqual([
+      'replaced',
+      'and answered',
+    ]);
+
+    // Re-numbered from zero, as assigning the embedded array did in Mongo.
+    const stored = await messagesOf(id);
+    expect(stored.map((row) => row.position).sort((a, b) => a - b)).toEqual([0, 1]);
+  });
+
+  it('refuses an undeclared status rather than storing it', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId);
+    const res = await request(buildApp(oxyUserId))
+      .put(`/ai/conversations/${id}`)
+      .send({ status: 'shredded' });
+
+    expect(res.status).toBe(200);
+    expect((await findConversation(id))?.status).toBe('active');
+  });
+
+  it('404s a stranger AND leaves the conversation untouched', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId, { title: 'Untouched', initialMessage: 'still here' });
+
+    const res = await request(buildApp(owner()))
+      .put(`/ai/conversations/${id}`)
+      .send({ title: 'Hijacked', messages: [] });
+
+    expect(res.status).toBe(404);
+    expect((await findConversation(id))?.title).toBe('Untouched');
+    expect(await messagesOf(id)).toHaveLength(1);
+  });
+});
+
+describe('POST /ai/conversations/:id/messages — ownership', () => {
+  it('appends for the owner and returns the stored message', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId, { initialMessage: 'q' });
+
+    const res = await request(buildApp(oxyUserId))
+      .post(`/ai/conversations/${id}/messages`)
+      .send({ role: 'assistant', content: 'a', attachments: [{ type: 'image', name: 'x.png' }] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatchObject({ role: 'assistant', content: 'a' });
+    expect(res.body.message.attachments).toHaveLength(1);
+    expect(res.body.conversation.messages).toHaveLength(2);
+    expect(await messagesOf(id)).toHaveLength(2);
+  });
+
+  it('400s a role the CHECK would refuse', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId);
+    const res = await request(buildApp(oxyUserId))
+      .post(`/ai/conversations/${id}/messages`)
+      .send({ role: 'moderator', content: 'x' });
+    expect(res.status).toBe(400);
+    expect(await messagesOf(id)).toHaveLength(0);
+  });
+
+  it('404s a stranger AND writes nothing', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId, { initialMessage: 'only mine' });
+
+    const res = await request(buildApp(owner()))
+      .post(`/ai/conversations/${id}/messages`)
+      .send({ role: 'user', content: 'injected' });
+
+    expect(res.status).toBe(404);
+    expect(await messagesOf(id)).toHaveLength(1);
+  });
+});
+
+describe('DELETE /ai/conversations/:id — ownership and cascade', () => {
+  it('deletes the conversation and its messages for the owner', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId, { initialMessage: 'bye' });
+
+    const res = await request(buildApp(oxyUserId)).delete(`/ai/conversations/${id}`);
+    expect(res.status).toBe(200);
+    expect(await findConversation(id)).toBeUndefined();
+    // `conversation_messages.conversation_id` is ON DELETE CASCADE.
+    expect(await messagesOf(id)).toHaveLength(0);
+  });
+
+  it('404s a stranger AND leaves the conversation in place', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId, { initialMessage: 'survives' });
+
+    const res = await request(buildApp(owner())).delete(`/ai/conversations/${id}`);
+    expect(res.status).toBe(404);
+    expect(await findConversation(id)).toBeDefined();
+    expect(await messagesOf(id)).toHaveLength(1);
+  });
+});
+
+describe('sharing — the link expires, the conversation does not', () => {
+  it('mints a link the owner can share and a stranger can follow', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId, { title: 'Shared', initialMessage: 'read me' });
+
+    const share = await request(buildApp(oxyUserId)).post(`/ai/conversations/${id}/share`);
+    expect(share.status).toBe(200);
+    expect(share.body.shareToken).toMatch(/^[0-9a-f]{64}$/);
+    expect(share.body.shareUrl).toBe(`/shared/${share.body.shareToken}`);
+
+    // All four `sharing_*` columns move together —
+    // `conversations_sharing_coherent_check` accepts nothing else.
+    const stored = await findConversation(id);
+    expect(stored?.sharingIsShared).toBe(true);
+    expect(stored?.sharingShareToken).toBe(share.body.shareToken);
+    expect(stored?.sharingSharedAt).toBeInstanceOf(Date);
+    expect(stored?.sharingExpiresAt).toBeInstanceOf(Date);
+
+    const followed = await request(buildPublicApp()).get(`/ai/shared/${share.body.shareToken}`);
+    expect(followed.status).toBe(200);
+    expect(followed.body.conversation.title).toBe('Shared');
+    expect(followed.body.conversation.messages[0].content).toBe('read me');
+  });
+
+  it('never discloses the owner or the token to whoever follows the link', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId, { initialMessage: 'public read' });
+    const share = await request(buildApp(oxyUserId)).post(`/ai/conversations/${id}/share`);
+
+    const followed = await request(buildPublicApp()).get(`/ai/shared/${share.body.shareToken}`);
+    const serialized = JSON.stringify(followed.body);
+    expect(serialized).not.toContain(oxyUserId);
+    expect(serialized).not.toContain(share.body.shareToken);
+    expect(followed.body.conversation).not.toHaveProperty('oxyUserId');
+    expect(followed.body.conversation).not.toHaveProperty('sharing');
+  });
+
+  it('404s a stranger asking to share somebody else\'s conversation, and mints nothing', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId, { initialMessage: 'not yours' });
+
+    const res = await request(buildApp(owner())).post(`/ai/conversations/${id}/share`);
+    expect(res.status).toBe(404);
+    expect((await findConversation(id))?.sharingIsShared).toBe(false);
+    expect((await findConversation(id))?.sharingShareToken).toBeNull();
+  });
+
+  it('refuses an expired token WITHOUT depending on the sweep having run', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId, { initialMessage: 'stale link' });
+    const share = await request(buildApp(oxyUserId)).post(`/ai/conversations/${id}/share`);
+
+    // Push the deadline into the past, leaving the row otherwise untouched. The
+    // coherence CHECK still holds: all four columns are still set.
+    await getDb()
+      .update(conversations)
+      .set({ sharingExpiresAt: new Date(Date.now() - 1000) })
+      .where(eq(conversations.id, id));
+
+    const followed = await request(buildPublicApp()).get(`/ai/shared/${share.body.shareToken}`);
+    expect(followed.status).toBe(404);
+  });
+
+  it('CLEARS an expired link and keeps the conversation — Mongo deleted the row', async () => {
+    // This is the single most important assertion in the file. Mongo carried
+    // `{ 'sharing.expiresAt': 1 }, { expireAfterSeconds: 0 }`, and
+    // `generateShareToken` set that deadline to +24h — so every conversation
+    // anybody ever shared was destroyed a day later, with its transcript.
+    // `db/expiry.ts` names the column in `EXPIRY_COLUMNS_THAT_MUST_NOT_DELETE`;
+    // this proves the replacement clears four columns rather than reaping a row.
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId, { title: 'Survives its own link', initialMessage: 'kept' });
+    await request(buildApp(oxyUserId)).post(`/ai/conversations/${id}/share`);
+    await getDb()
+      .update(conversations)
+      .set({ sharingExpiresAt: new Date(Date.now() - 1000) })
+      .where(eq(conversations.id, id));
+
+    const cleared = await expireShareLinks(getDb());
+    expect(cleared).toBe(1);
+
+    const stored = await findConversation(id);
+    expect(stored).toBeDefined();
+    expect(stored?.title).toBe('Survives its own link');
+    expect(await messagesOf(id)).toHaveLength(1);
+    expect(stored?.sharingIsShared).toBe(false);
+    expect(stored?.sharingShareToken).toBeNull();
+    expect(stored?.sharingSharedAt).toBeNull();
+    expect(stored?.sharingExpiresAt).toBeNull();
+  });
+
+  it('leaves a live link alone and rewrites nothing on a second sweep', async () => {
+    const oxyUserId = owner();
+    const id = await createFor(oxyUserId, { initialMessage: 'live' });
+    await request(buildApp(oxyUserId)).post(`/ai/conversations/${id}/share`);
+
+    expect(await expireShareLinks(getDb())).toBe(0);
+    expect((await findConversation(id))?.sharingIsShared).toBe(true);
+
+    // An already-cleared conversation is not swept again: the predicate names
+    // `is_shared`, so `updated_at` (which carries drizzle's `$onUpdate`) cannot
+    // be restamped on a row nobody edited.
+    await getDb()
+      .update(conversations)
+      .set({ sharingExpiresAt: new Date(Date.now() - 1000) })
+      .where(eq(conversations.id, id));
+    expect(await expireShareLinks(getDb())).toBe(1);
+    const afterFirst = await findConversation(id);
+    expect(await expireShareLinks(getDb())).toBe(0);
+    expect((await findConversation(id))?.updatedAt).toEqual(afterFirst?.updatedAt);
+  });
+});

--- a/packages/backend/__tests__/integration/profilePostgres.test.ts
+++ b/packages/backend/__tests__/integration/profilePostgres.test.ts
@@ -1,0 +1,448 @@
+/**
+ * The RE sidecar profile, through the REAL controllers, against the REAL
+ * Postgres this worker owns.
+ *
+ * Four things, and the last two are the ones a port usually gets wrong:
+ *
+ *  1. **The nesting round-trips.** Sixteen frontend modules read
+ *     `profile.personalProfile.settings.roommate.…`; the columns are flat with
+ *     the wrapper dropped (63-byte identifier ceiling). Whatever the edit form
+ *     sends must come back the same shape or the next save writes NULL over it.
+ *  2. **Ownership.** The owner comes from the session and never from the body.
+ *  3. **Privacy.** `/api/public/profiles/*` needs no authentication, so what a
+ *     stranger gets is decided by the flags rather than by what happens to be
+ *     stored. Mongo returned the whole document there, income included.
+ *  4. **`/ai/history` writes ANYTHING AT ALL.** It used to read and write
+ *     `profile.chatHistory` while `ProfileSchema` declares the array at
+ *     `personalProfile.chatHistory`, so strict mode dropped it: `GET` always
+ *     answered `[]`, `POST` stored nothing, `DELETE` was a no-op. All five
+ *     production profiles have an empty transcript for that reason, so a test
+ *     that only checked "the endpoint answers 200" would have passed against
+ *     the broken version.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { eq } from 'drizzle-orm';
+import { uuidv7 } from '@oxyhq/db';
+
+import aiRouter from '../../routes/ai';
+import * as profileController from '../../controllers/profile';
+import { getDb } from '../../db/postgres';
+import { profileChatMessages, profiles } from '../../db/schema';
+import { errorHandler } from '../../middlewares/errorHandler';
+import { PROFILE_CHAT_HISTORY_LIMIT } from '../../db/profiles/profileRepository';
+
+function buildApp(oxyUserId: string | null): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (oxyUserId) (req as unknown as { user: { id: string } }).user = { id: oxyUserId };
+    next();
+  });
+  app.get('/profiles/me', (req, res, next) => profileController.getOrCreateProfile(req, res, next));
+  app.put('/profiles/me', (req, res, next) => profileController.updateMyProfile(req, res, next));
+  app.get('/public/profiles/oxy/:oxyUserId', (req, res, next) =>
+    profileController.getPublicProfileByOxyUserId(req, res, next),
+  );
+  app.use('/ai', aiRouter());
+  app.use(errorHandler);
+  return app;
+}
+
+const owner = (): string => `oxy-${uuidv7()}`;
+
+beforeEach(async () => {
+  await getDb().delete(profiles);
+});
+
+describe('GET /profiles/me — get or create', () => {
+  it('creates the sidecar row on first read, with every column NULL', async () => {
+    const oxyUserId = owner();
+    const res = await request(buildApp(oxyUserId)).get('/profiles/me');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.oxyUserId).toBe(oxyUserId);
+
+    // NOT seeded with the schema's defaults. `_createDefaultProfile` used to
+    // write `language: 'en'`, `timezone: 'UTC'`, `profileVisibility: 'public'`,
+    // which made "the user chose UTC" indistinguishable from "nobody asked".
+    // Mongoose never materialized the sub-document either, so none of the five
+    // production rows carries them.
+    const [stored] = await getDb().select().from(profiles).where(eq(profiles.oxyUserId, oxyUserId));
+    expect(stored.settingsLanguage).toBeNull();
+    expect(stored.settingsTimezone).toBeNull();
+    expect(stored.settingsPrivacyProfileVisibility).toBeNull();
+    expect(res.body.data.personalProfile.settings.language).toBeNull();
+  });
+
+  it('is idempotent — a second read returns the SAME row, not a second one', async () => {
+    const oxyUserId = owner();
+    const first = await request(buildApp(oxyUserId)).get('/profiles/me');
+    const second = await request(buildApp(oxyUserId)).get('/profiles/me');
+
+    expect(second.body.data.id).toBe(first.body.data.id);
+    const rows = await getDb().select().from(profiles).where(eq(profiles.oxyUserId, oxyUserId));
+    expect(rows).toHaveLength(1);
+  });
+
+  it('refuses an unauthenticated caller', async () => {
+    const res = await request(buildApp(null)).get('/profiles/me');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PUT /profiles/me — the allow-listed write', () => {
+  it('round-trips the whole personalProfile subtree', async () => {
+    const oxyUserId = owner();
+    const app = buildApp(oxyUserId);
+    const sent = {
+      personalProfile: {
+        personalInfo: {
+          bio: '  Tenant in Gràcia  ',
+          occupation: 'Nurse',
+          employmentStatus: 'employed',
+          leaseDuration: 'yearly',
+        },
+        preferences: {
+          propertyTypes: ['apartment', 'room'],
+          maxRent: 1200,
+          priceUnit: 'month',
+          preferredAmenities: ['  Balcony ', 'LIFT'],
+          preferredLocations: [{ city: 'Barcelona', state: 'Catalonia', radius: 5 }],
+          petFriendly: true,
+        },
+        settings: {
+          privacy: { profileVisibility: 'public', showContactInfo: true, showRentalHistory: true },
+          roommate: {
+            enabled: true,
+            preferences: {
+              ageRange: { min: 25, max: 40 },
+              gender: 'any',
+              lifestyle: { smoking: 'no', cleanliness: 'very_clean', schedule: 'early_bird' },
+              budget: { min: 500, max: 900 },
+              leaseDuration: '6_months',
+            },
+            history: [
+              { startDate: '2024-01-01T00:00:00.000Z', location: 'Sants', roommateCount: 2 },
+            ],
+          },
+          language: 'ca',
+          timezone: 'Europe/Madrid',
+          currency: 'EUR',
+        },
+      },
+    };
+
+    const put = await request(app).put('/profiles/me').send(sent);
+    expect(put.status).toBe(200);
+
+    const read = await request(app).get('/profiles/me');
+    const p = read.body.data.personalProfile;
+
+    // Trimmed and lowercased at the CALL SITE — Mongo's `trim`/`lowercase` are
+    // application behaviour with no Postgres counterpart.
+    expect(p.personalInfo.bio).toBe('Tenant in Gràcia');
+    expect(p.preferences.preferredAmenities).toEqual(['balcony', 'lift']);
+
+    expect(p.personalInfo.employmentStatus).toBe('employed');
+    expect(p.preferences.propertyTypes).toEqual(['apartment', 'room']);
+    expect(p.preferences.maxRent).toBe(1200);
+    expect(p.preferences.preferredLocations).toHaveLength(1);
+    expect(p.preferences.preferredLocations[0]).toMatchObject({ city: 'Barcelona', radius: 5 });
+    expect(p.settings.roommate.enabled).toBe(true);
+    expect(p.settings.roommate.preferences.ageRange).toEqual({ min: 25, max: 40 });
+    expect(p.settings.roommate.preferences.lifestyle.cleanliness).toBe('very_clean');
+    expect(p.settings.roommate.preferences.budget).toEqual({ min: 500, max: 900 });
+    expect(p.settings.roommate.history).toHaveLength(1);
+    expect(p.settings.roommate.history[0].location).toBe('Sants');
+    expect(p.settings.language).toBe('ca');
+    expect(p.settings.currency).toBe('EUR');
+  });
+
+  it('replaces only the blocks the body carries', async () => {
+    const oxyUserId = owner();
+    const app = buildApp(oxyUserId);
+    await request(app)
+      .put('/profiles/me')
+      .send({
+        personalProfile: {
+          personalInfo: { bio: 'first' },
+          preferences: { maxRent: 900 },
+        },
+      });
+
+    // A second save naming only `personalInfo` must not blank `preferences`.
+    await request(app)
+      .put('/profiles/me')
+      .send({ personalProfile: { personalInfo: { occupation: 'Teacher' } } });
+
+    const read = await request(app).get('/profiles/me');
+    const p = read.body.data.personalProfile;
+    expect(p.preferences.maxRent).toBe(900);
+    // …and within the block it DID name, an omitted field is cleared, which is
+    // what makes "delete my bio" expressible at all.
+    expect(p.personalInfo.bio).toBeNull();
+    expect(p.personalInfo.occupation).toBe('Teacher');
+  });
+
+  it('ignores an oxyUserId, id or timestamp in the body', async () => {
+    const oxyUserId = owner();
+    const attacker = owner();
+    const app = buildApp(oxyUserId);
+    await request(app).get('/profiles/me');
+
+    const res = await request(app)
+      .put('/profiles/me')
+      .send({
+        oxyUserId: attacker,
+        id: 'forged-id',
+        createdAt: '1999-01-01T00:00:00.000Z',
+        personalProfile: { personalInfo: { bio: 'mine' } },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.oxyUserId).toBe(oxyUserId);
+    expect(res.body.data.id).not.toBe('forged-id');
+    // The attacker's account gained nothing.
+    const rows = await getDb().select().from(profiles).where(eq(profiles.oxyUserId, attacker));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('drops a value outside a declared vocabulary rather than 500ing on the CHECK', async () => {
+    const oxyUserId = owner();
+    const app = buildApp(oxyUserId);
+    const res = await request(app)
+      .put('/profiles/me')
+      .send({
+        personalProfile: {
+          personalInfo: { employmentStatus: 'freelance-ish', leaseDuration: 'forever' },
+          preferences: { propertyTypes: ['apartment', 'spaceship'] },
+        },
+      });
+
+    expect(res.status).toBe(200);
+    const p = res.body.data.personalProfile;
+    expect(p.personalInfo.employmentStatus).toBeNull();
+    expect(p.personalInfo.leaseDuration).toBeNull();
+    expect(p.preferences.propertyTypes).toEqual(['apartment']);
+  });
+
+  it('drops a rental-history entry whose end date precedes its start', async () => {
+    // `profile_rental_history_order_check` would answer `23514`, i.e. a 500 on a
+    // form the user can see and fix.
+    const oxyUserId = owner();
+    const app = buildApp(oxyUserId);
+    const res = await request(app)
+      .put('/profiles/me')
+      .send({
+        personalProfile: {
+          settings: { privacy: { showRentalHistory: true } },
+          rentalHistory: [
+            {
+              address: 'Backwards',
+              startDate: '2025-01-01T00:00:00.000Z',
+              endDate: '2024-01-01T00:00:00.000Z',
+            },
+            { address: 'Fine', startDate: '2024-01-01T00:00:00.000Z' },
+          ],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.personalProfile.rentalHistory).toHaveLength(1);
+    expect(res.body.data.personalProfile.rentalHistory[0].address).toBe('Fine');
+  });
+
+  it('creates the row when the first request is a PUT', async () => {
+    const oxyUserId = owner();
+    const res = await request(buildApp(oxyUserId))
+      .put('/profiles/me')
+      .send({ personalProfile: { personalInfo: { bio: 'straight to edit' } } });
+    expect(res.status).toBe(200);
+    expect(res.body.data.personalProfile.personalInfo.bio).toBe('straight to edit');
+  });
+});
+
+describe('the public read — what a stranger gets', () => {
+  async function seed(oxyUserId: string, privacy: Record<string, unknown>) {
+    await request(buildApp(oxyUserId))
+      .put('/profiles/me')
+      .send({
+        personalProfile: {
+          personalInfo: { bio: 'Public bio', annualIncome: 48000 },
+          settings: { privacy },
+          references: [{ name: 'Ana', relationship: 'landlord', phone: '+34600000000' }],
+          rentalHistory: [
+            {
+              address: 'Carrer Gran 1',
+              startDate: '2023-01-01T00:00:00.000Z',
+              monthlyRent: 950,
+              landlordContact: { name: 'Ana', phone: '+34600000000', email: 'ANA@Example.com' },
+            },
+          ],
+        },
+      });
+  }
+
+  it('never carries the annual income, in any scope', async () => {
+    const oxyUserId = owner();
+    await seed(oxyUserId, { showIncome: true, showContactInfo: true, showRentalHistory: true });
+
+    // `profiles.personal_info_annual_income` is a PROTECTED COLUMN, excluded at
+    // the TYPE level by `publicColumns(profiles)` — so the serializer could not
+    // emit it even for the owner. The privacy FLAG is a separate decision the
+    // application would have to make explicitly.
+    const stored = await getDb().select().from(profiles).where(eq(profiles.oxyUserId, oxyUserId));
+    expect(stored[0].personalInfoAnnualIncome).toBe(48000);
+
+    const ownerRead = await request(buildApp(oxyUserId)).get('/profiles/me');
+    const publicRead = await request(buildApp(null)).get(`/public/profiles/oxy/${oxyUserId}`);
+    expect(JSON.stringify(ownerRead.body)).not.toContain('48000');
+    expect(JSON.stringify(publicRead.body)).not.toContain('48000');
+  });
+
+  it('withholds references and the tenancy from a stranger by default', async () => {
+    const oxyUserId = owner();
+    // Both flags default to FALSE in the product; here they are explicit so the
+    // case states what it is testing rather than relying on absence.
+    await seed(oxyUserId, { showReferences: false, showRentalHistory: false, showContactInfo: false });
+
+    const res = await request(buildApp(null)).get(`/public/profiles/oxy/${oxyUserId}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.personalProfile.references).toEqual([]);
+    expect(res.body.data.personalProfile.rentalHistory).toEqual([]);
+    expect(JSON.stringify(res.body)).not.toContain('+34600000000');
+    expect(JSON.stringify(res.body)).not.toContain('ana@example.com');
+  });
+
+  it('discloses the landlord contact when showContactInfo is on, and nothing else', async () => {
+    // This is the "call the owner" path: `app/properties/[id]` reads a PUBLIC
+    // profile's `rentalHistory[0].landlordContact.phone` and gates on
+    // `showContactInfo`. Gating the contact on `showRentalHistory` (default
+    // FALSE) would silently kill that feature for every user.
+    const oxyUserId = owner();
+    await seed(oxyUserId, { showContactInfo: true, showRentalHistory: false });
+
+    const res = await request(buildApp(null)).get(`/public/profiles/oxy/${oxyUserId}`);
+    const [entry] = res.body.data.personalProfile.rentalHistory;
+    expect(entry.landlordContact.phone).toBe('+34600000000');
+    // The tenancy itself is ABSENT rather than null: absent means "not
+    // disclosed", null would mean "never recorded".
+    expect(entry).not.toHaveProperty('address');
+    expect(entry).not.toHaveProperty('monthlyRent');
+  });
+
+  it('gives the owner everything the two flags withhold from a stranger', async () => {
+    const oxyUserId = owner();
+    await seed(oxyUserId, { showReferences: false, showRentalHistory: false, showContactInfo: false });
+
+    const res = await request(buildApp(oxyUserId)).get('/profiles/me');
+    expect(res.body.data.personalProfile.references).toHaveLength(1);
+    expect(res.body.data.personalProfile.rentalHistory[0].address).toBe('Carrer Gran 1');
+  });
+
+  it('404s a profile that does not exist rather than creating one', async () => {
+    const stranger = owner();
+    const res = await request(buildApp(null)).get(`/public/profiles/oxy/${stranger}`);
+    expect(res.status).toBe(404);
+    expect(await getDb().select().from(profiles).where(eq(profiles.oxyUserId, stranger))).toHaveLength(0);
+  });
+});
+
+describe('/ai/history — the transcript that never persisted', () => {
+  it('stores a turn and reads it back newest-first', async () => {
+    const oxyUserId = owner();
+    const app = buildApp(oxyUserId);
+
+    const post = await request(app)
+      .post('/ai/history')
+      .send({ userMessage: 'What is a fianza?', assistantMessage: 'A deposit.' });
+    expect(post.status).toBe(200);
+
+    const get = await request(app).get('/ai/history');
+    expect(get.status).toBe(200);
+    // Newest first, matching the Mongo handler's `[...].reverse()`.
+    expect(get.body.history.map((m: { content: string }) => m.content)).toEqual([
+      'A deposit.',
+      'What is a fianza?',
+    ]);
+    expect(get.body.history.map((m: { role: string }) => m.role)).toEqual(['assistant', 'user']);
+  });
+
+  it('keeps the pair in order across appends, on position and not on timestamp', async () => {
+    // Both turns of one call share a timestamp, exactly as the Mongo handler's
+    // single `new Date()` did — so `position` is the only thing that can order
+    // them.
+    const oxyUserId = owner();
+    const app = buildApp(oxyUserId);
+    await request(app).post('/ai/history').send({ userMessage: 'q1', assistantMessage: 'a1' });
+    await request(app).post('/ai/history').send({ userMessage: 'q2', assistantMessage: 'a2' });
+
+    const get = await request(app).get('/ai/history');
+    expect(get.body.history.map((m: { content: string }) => m.content)).toEqual([
+      'a2',
+      'q2',
+      'a1',
+      'q1',
+    ]);
+  });
+
+  it('trims to the cap, keeping the NEWEST turns', async () => {
+    const oxyUserId = owner();
+    const app = buildApp(oxyUserId);
+    const pairs = PROFILE_CHAT_HISTORY_LIMIT / 2 + 3;
+    for (let i = 0; i < pairs; i += 1) {
+      await request(app).post('/ai/history').send({ userMessage: `q${i}`, assistantMessage: `a${i}` });
+    }
+
+    const [profile] = await getDb().select().from(profiles).where(eq(profiles.oxyUserId, oxyUserId));
+    const stored = await getDb()
+      .select()
+      .from(profileChatMessages)
+      .where(eq(profileChatMessages.profileId, profile.id));
+    expect(stored).toHaveLength(PROFILE_CHAT_HISTORY_LIMIT);
+
+    const get = await request(app).get('/ai/history');
+    expect(get.body.history[0].content).toBe(`a${pairs - 1}`);
+    expect(get.body.history).toHaveLength(PROFILE_CHAT_HISTORY_LIMIT);
+    // The oldest turns really went, rather than the newest being refused.
+    expect(get.body.history.map((m: { content: string }) => m.content)).not.toContain('q0');
+  });
+
+  it('clears the transcript and leaves the profile', async () => {
+    const oxyUserId = owner();
+    const app = buildApp(oxyUserId);
+    await request(app).post('/ai/history').send({ userMessage: 'q', assistantMessage: 'a' });
+
+    const del = await request(app).delete('/ai/history');
+    expect(del.status).toBe(200);
+    expect(del.body.cleared).toBe(2);
+
+    expect((await request(app).get('/ai/history')).body.history).toEqual([]);
+    expect(await getDb().select().from(profiles).where(eq(profiles.oxyUserId, oxyUserId))).toHaveLength(1);
+  });
+
+  it('never mixes two people\'s transcripts', async () => {
+    const a = owner();
+    const b = owner();
+    await request(buildApp(a)).post('/ai/history').send({ userMessage: 'a-q', assistantMessage: 'a-a' });
+    await request(buildApp(b)).post('/ai/history').send({ userMessage: 'b-q', assistantMessage: 'b-a' });
+
+    const read = await request(buildApp(a)).get('/ai/history');
+    expect(read.body.history.map((m: { content: string }) => m.content)).toEqual(['a-a', 'a-q']);
+  });
+
+  it('400s a call missing either half of the turn', async () => {
+    const app = buildApp(owner());
+    expect((await request(app).post('/ai/history').send({ userMessage: 'q' })).status).toBe(400);
+    expect((await request(app).post('/ai/history').send({ assistantMessage: 'a' })).status).toBe(400);
+  });
+
+  it('refuses an unauthenticated caller on all three verbs', async () => {
+    const app = buildApp(null);
+    expect((await request(app).get('/ai/history')).status).toBe(401);
+    expect((await request(app).delete('/ai/history')).status).toBe(401);
+    expect((await request(app).post('/ai/history').send({ userMessage: 'q', assistantMessage: 'a' })).status).toBe(401);
+  });
+});

--- a/packages/backend/controllers/profile/crud.ts
+++ b/packages/backend/controllers/profile/crud.ts
@@ -1,131 +1,125 @@
+/**
+ * The RE sidecar profile — one per Oxy account, served from Postgres.
+ *
+ * `db/profiles/profileRepository.ts` carries the measurement this port rests on
+ * (five rows in Mongo, the same five in Postgres) and the reason the table is
+ * that small. This file is the HTTP edge: it resolves the caller, decides who is
+ * looking, and hands the repository an allow-listed write.
+ *
+ * ## The five-minute in-process cache is GONE, deliberately
+ *
+ * `shared.ts` kept a `Map` of profiles for 300 seconds, cleared on the owner's
+ * own `PUT`. It existed because a Mongo profile read loaded a whole document
+ * with an unbounded `chatHistory` array inside it; the Postgres read is one
+ * lookup on a unique index over a five-row table plus five small child reads.
+ *
+ * It was also WRONG, and would have stayed wrong: Homiio runs several ECS tasks,
+ * so a `PUT` served by one task cleared that task's copy and left every other
+ * task serving the pre-edit profile for up to five minutes. A cache with one
+ * invalidation path per process is a cache that can only be correct in a single
+ * process. Removing it is a behaviour change and this is where it is stated.
+ */
+
+import { getDb } from '../../db/postgres';
 import {
-  Profile,
-  successResponse,
-  errorResponse,
-  _getOxyUserId,
-  _createDefaultProfile,
-  getCachedProfile,
-  setCachedProfile,
-  clearCachedProfile,
-} from './shared';
-import type { IProfile } from '../../models';
+  ensureProfile,
+  findHydratedProfile,
+  updateProfile,
+} from '../../db/profiles/profileRepository';
+import { toProfileDTO } from '../../db/profiles/profileSerializer';
+import { errorResponse, successResponse, _getOxyUserId } from './shared';
+import { toProfileUpdate } from './profileWriteColumns';
+import type { NextFunction, Request, Response } from 'express';
 
 /**
- * Get or create the user's RE sidecar profile.
+ * The caller's own profile, created empty if this is their first request.
+ *
+ * `?minimal=true` used to skip a second full document load; there is no second
+ * load to skip now, so the parameter is accepted and ignored rather than
+ * removed — a shipped client still sends it, and a 400 for a parameter that used
+ * to be free would be a wire break.
  */
-export async function getOrCreateProfile(req: any, res: any, next: any) {
+export async function getOrCreateProfile(req: Request, res: Response, next: NextFunction) {
   try {
     const oxyUserId = _getOxyUserId(req);
-
     if (!oxyUserId) {
-      return res.status(401).json(
-        errorResponse('Authentication required', 'AUTHENTICATION_REQUIRED'),
-      );
+      return res
+        .status(401)
+        .json(errorResponse('Authentication required', 'AUTHENTICATION_REQUIRED'));
     }
 
-    let profile = getCachedProfile<IProfile>(oxyUserId);
-
-    if (!profile) {
-      profile = await Profile.findByOxyUserId(oxyUserId);
-
-      if (!profile) {
-        profile = await _createDefaultProfile(oxyUserId);
-        clearCachedProfile(oxyUserId);
-      } else if (req.query.minimal !== 'true') {
-        profile = await Profile.findById(profile._id);
-      }
-
-      setCachedProfile(oxyUserId, profile);
-    }
-
-    res.json(successResponse(profile, 'Profile retrieved successfully'));
+    const hydrated = await ensureProfile(getDb(), oxyUserId);
+    res.json(successResponse(toProfileDTO(hydrated, 'owner'), 'Profile retrieved successfully'));
   } catch (error) {
     next(error);
   }
 }
 
 /**
- * Get the active public profile for an Oxy user id (read-only).
+ * Somebody else's profile, read-only, with the private blocks withheld.
+ *
+ * The `public` scope is what makes the withholding happen — see
+ * `db/profiles/profileSerializer.ts`, which states which flag gates which block
+ * and why the landlord contact is gated separately from the tenancy it sits on.
+ *
+ * This handler is mounted both behind auth (`/api/profiles/oxy/:oxyUserId`) and
+ * WITHOUT it (`/api/public/profiles/*`), so it treats every caller as a stranger
+ * rather than trying to work out whether the request happened to carry a
+ * session. A person reading their own profile through the public route gets the
+ * public view, which is the honest answer for a route named `public`.
  */
-export async function getPublicProfileByOxyUserId(req: any, res: any, next: any) {
+export async function getPublicProfileByOxyUserId(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   try {
     const { oxyUserId } = req.params;
     if (!oxyUserId) {
-      return res.status(400).json(
-        errorResponse('Oxy user id is required', 'OXY_USER_ID_REQUIRED'),
-      );
+      return res.status(400).json(errorResponse('Oxy user id is required', 'OXY_USER_ID_REQUIRED'));
     }
 
-    const profile = await Profile.findByOxyUserId(oxyUserId);
-    if (!profile) {
-      return res.status(404).json(
-        errorResponse('Profile not found', 'PROFILE_NOT_FOUND'),
-      );
+    const hydrated = await findHydratedProfile(getDb(), oxyUserId);
+    if (!hydrated) {
+      return res.status(404).json(errorResponse('Profile not found', 'PROFILE_NOT_FOUND'));
     }
 
-    res.json(successResponse(profile, 'Profile retrieved successfully'));
+    res.json(successResponse(toProfileDTO(hydrated, 'public'), 'Profile retrieved successfully'));
   } catch (error) {
     next(error);
   }
 }
 
-/**
- * Get profile by Oxy user id (public read).
- */
-export async function getProfileByOxyUserId(req: any, res: any, next: any) {
+/** `GET /api/profiles/oxy/:oxyUserId` — the same public read, under its own route. */
+export async function getProfileByOxyUserId(req: Request, res: Response, next: NextFunction) {
   return getPublicProfileByOxyUserId(req, res, next);
 }
 
 /**
- * Update the authenticated user's profile.
+ * Update the caller's own profile.
+ *
+ * The owner comes from the session and never from the body, and the body is
+ * mapped through `profileWriteColumns.ts`'s allow-list before it reaches a
+ * column — `AGENTS.md`'s write-safety rule, and the reason no `oxyUserId`,
+ * `id`, `createdAt` or `updatedAt` from a request can land on the row.
+ *
+ * ONE transaction: `updateProfile` may create the row, rewrite scalar columns
+ * and replace up to four child collections, and a partial application of that
+ * would leave a person's references belonging to a state that was never saved.
  */
-export async function updateMyProfile(req: any, res: any, next: any) {
+export async function updateMyProfile(req: Request, res: Response, next: NextFunction) {
   try {
     const oxyUserId = _getOxyUserId(req);
-    const updateData = req.body;
-
     if (!oxyUserId) {
-      return res.status(401).json(
-        errorResponse('Authentication required', 'AUTHENTICATION_REQUIRED'),
-      );
+      return res
+        .status(401)
+        .json(errorResponse('Authentication required', 'AUTHENTICATION_REQUIRED'));
     }
 
-    let profile = await Profile.findByOxyUserId(oxyUserId);
+    const update = toProfileUpdate(req.body);
+    const hydrated = await getDb().transaction((tx) => updateProfile(tx, oxyUserId, update));
 
-    if (!profile) {
-      profile = await _createDefaultProfile(oxyUserId);
-    }
-
-    if (updateData.personalProfile) {
-      profile.personalProfile = {
-        ...profile.personalProfile,
-        ...updateData.personalProfile,
-      };
-    }
-
-    await profile.save();
-    clearCachedProfile(oxyUserId);
-
-    res.json(successResponse(profile, 'Profile updated successfully'));
-  } catch (error) {
-    next(error);
-  }
-}
-
-/**
- * Test endpoint to check if the controller is working.
- */
-export async function test(req: any, res: any, next: any) {
-  try {
-    const oxyUserId = req.user?.id || req.user?._id;
-
-    res.json({
-      success: true,
-      message: 'Profile controller is working',
-      oxyUserId,
-      hasUser: !!req.user,
-      timestamp: new Date().toISOString(),
-    });
+    res.json(successResponse(toProfileDTO(hydrated, 'owner'), 'Profile updated successfully'));
   } catch (error) {
     next(error);
   }

--- a/packages/backend/controllers/profile/profileWriteColumns.ts
+++ b/packages/backend/controllers/profile/profileWriteColumns.ts
@@ -1,0 +1,358 @@
+/**
+ * Turning a `PUT /api/profiles/me` body into COLUMNS.
+ *
+ * The wire shape is the nested `personalProfile` subtree;
+ * `db/schema/profiles.ts` stores it flattened with the wrapper dropped
+ * (`settings.roommate.preferences.lifestyle.cleanliness` →
+ * `settings_roommate_preferences_lifestyle_cleanliness`, because keeping the
+ * wrapper would push the identifier past Postgres's 63-byte ceiling and it
+ * truncates SILENTLY). This module is the ONE place that mapping lives.
+ *
+ * ## Why every field is named, and why it may not be a spread
+ *
+ * Mongoose let the controller assign a nested object onto the document and sort
+ * the paths out itself. The equivalent here — spreading a subtree into `.set()`
+ * — sends drizzle keys that are not columns, and **drizzle IGNORES an unknown
+ * key rather than refusing it**. The write would succeed, report success, and
+ * store nothing. So the cost is a long function and the benefit is that a field
+ * nobody mapped cannot look like a field that was saved. Same reasoning, same
+ * shape, as `controllers/lease/leaseWriteColumns.ts`.
+ *
+ * ## Block-at-a-time replacement, matching what Mongo did
+ *
+ * `updateMyProfile` merged at the TOP level only
+ * (`{...profile.personalProfile, ...body.personalProfile}`), so sending
+ * `personalInfo` replaced the whole `personalInfo` block and left `preferences`
+ * alone. That is reproduced exactly: a block absent from the body contributes no
+ * columns, and a block PRESENT contributes every one of its columns — including
+ * the ones the client omitted, which are written NULL. Anything else would make
+ * "clear my bio" impossible to express.
+ *
+ * The blocks are the seven `personalProfile` keys. `chatHistory` is deliberately
+ * NOT one of them: it is the assistant transcript, `/api/ai/history` owns it,
+ * and letting a profile save replace it would let a client rewrite its own
+ * conversation with Sindi.
+ *
+ * ## Vocabularies are FILTERED, not rejected
+ *
+ * A value outside a declared set is dropped to `null` rather than 400ing, which
+ * is what mongoose did with `runValidators` off on an update. The alternative is
+ * a `23514` from the CHECK, which is a 500 for a field the client can simply not
+ * have known about.
+ */
+
+import {
+  EMPLOYMENT_STATUSES,
+  GENDER_PREFERENCES,
+  LEASE_DURATIONS,
+  PRICE_UNITS,
+  PROFILE_PROPERTY_TYPES,
+  PROFILE_VISIBILITIES,
+  REASONS_FOR_LEAVING,
+  REFERENCE_RELATIONSHIPS,
+  ROOMMATE_CLEANLINESS_LEVELS,
+  ROOMMATE_LIFESTYLE_ANSWERS,
+  ROOMMATE_SCHEDULES,
+} from '../../db/schema/profiles';
+import type {
+  ProfilePreferredLocationInput,
+  ProfileReferenceInput,
+  ProfileRentalHistoryInput,
+  ProfileRoommateHistoryInput,
+  ProfileUpdate,
+  ProfileWriteColumns,
+} from '../../db/profiles/profileRepository';
+
+type Loose = Record<string, unknown>;
+
+/** A nested object off the request body, or `undefined` when the block is absent. */
+function block(value: unknown): Loose | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Loose) : undefined;
+}
+
+/** A nested object, or an empty bag — for a sub-block inside a block that IS present. */
+function subtree(value: unknown): Loose {
+  return block(value) ?? {};
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asTrimmed(value: unknown): string | null {
+  // Mongo's `trim: true` was application behaviour with no Postgres counterpart,
+  // so `db/schema/CONVENTIONS.md` says re-apply it at the CALL SITE. This is it.
+  const raw = asString(value);
+  return raw === null ? null : raw.trim();
+}
+
+function asLowercased(value: unknown): string | null {
+  const raw = asTrimmed(value);
+  return raw === null ? null : raw.toLowerCase();
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function asBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+function asDate(value: unknown): Date | null {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (typeof value === 'string' || typeof value === 'number') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
+}
+
+/** A member of a declared vocabulary, or `null`. */
+function asMember<T extends string>(value: unknown, vocabulary: readonly T[]): T | null {
+  return typeof value === 'string' && (vocabulary as readonly string[]).includes(value)
+    ? (value as T)
+    : null;
+}
+
+/** A string array filtered to a declared vocabulary. `null` when the key is absent. */
+function asMemberArray<T extends string>(value: unknown, vocabulary: readonly T[]): T[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.filter((entry): entry is T =>
+    typeof entry === 'string' && (vocabulary as readonly string[]).includes(entry),
+  );
+}
+
+/** A free-text array, trimmed and lowercased (Mongo's `preferredAmenities`). */
+function asLowercasedArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  return value
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry !== '');
+}
+
+/** A `references[]` entry, or `undefined` when it has no usable name/relationship. */
+function toReference(value: unknown): ProfileReferenceInput | undefined {
+  const entry = block(value);
+  if (!entry) return undefined;
+  const name = asTrimmed(entry.name);
+  const relationship = asMember(entry.relationship, REFERENCE_RELATIONSHIPS);
+  // Both are `NOT NULL` in the schema because both were `required: true` in
+  // Mongo. An entry missing either is dropped rather than 500ing on a `23502`.
+  if (!name || !relationship) return undefined;
+  return {
+    name,
+    relationship,
+    phone: asTrimmed(entry.phone),
+    email: asLowercased(entry.email),
+    verified: asBoolean(entry.verified) ?? false,
+  };
+}
+
+/** A `rentalHistory[]` entry, or `undefined` when it has no address or start date. */
+function toRentalHistory(value: unknown): ProfileRentalHistoryInput | undefined {
+  const entry = block(value);
+  if (!entry) return undefined;
+  const address = asTrimmed(entry.address);
+  const startDate = asDate(entry.startDate);
+  if (!address || !startDate) return undefined;
+  const endDate = asDate(entry.endDate);
+  // `profile_rental_history_order_check` refuses an end before its own start.
+  // Dropped rather than sent, for the same reason a bad vocabulary member is:
+  // a `23514` here is a 500 on a form the user can see and fix.
+  if (endDate && endDate < startDate) return undefined;
+  const contact = subtree(entry.landlordContact);
+  return {
+    address,
+    startDate,
+    endDate,
+    monthlyRent: asNumber(entry.monthlyRent),
+    reasonForLeaving: asMember(entry.reasonForLeaving, REASONS_FOR_LEAVING),
+    landlordContactName: asTrimmed(contact.name),
+    landlordContactPhone: asTrimmed(contact.phone),
+    landlordContactEmail: asLowercased(contact.email),
+    verified: asBoolean(entry.verified) ?? false,
+  };
+}
+
+function toPreferredLocation(value: unknown): ProfilePreferredLocationInput | undefined {
+  const entry = block(value);
+  if (!entry) return undefined;
+  return {
+    city: asTrimmed(entry.city),
+    state: asTrimmed(entry.state),
+    // Miles, keeping Mongo's units — `db/schema/profiles.ts` says so and says
+    // renaming the column would be an API change rather than a schema one.
+    radius: asNumber(entry.radius),
+  };
+}
+
+function toRoommateHistory(value: unknown): ProfileRoommateHistoryInput | undefined {
+  const entry = block(value);
+  if (!entry) return undefined;
+  const startDate = asDate(entry.startDate);
+  const location = asTrimmed(entry.location);
+  if (!startDate || !location) return undefined;
+  const endDate = asDate(entry.endDate);
+  if (endDate && endDate < startDate) return undefined;
+  return {
+    startDate,
+    endDate,
+    location,
+    roommateCount: asNumber(entry.roommateCount),
+    reason: asTrimmed(entry.reason),
+  };
+}
+
+/** Map an array off the body through a per-entry mapper, dropping what does not map. */
+function mapEntries<T>(value: unknown, map: (entry: unknown) => T | undefined): T[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.map(map).filter((entry): entry is T => entry !== undefined);
+}
+
+/**
+ * Build the write from a request body.
+ *
+ * Returns only the blocks the body actually carried, so a request naming one
+ * block cannot blank the other six.
+ */
+export function toProfileUpdate(body: unknown): ProfileUpdate {
+  const personalProfile = block(block(body)?.personalProfile);
+  const columns: ProfileWriteColumns = {};
+  const update: {
+    -readonly [K in keyof ProfileUpdate]: ProfileUpdate[K];
+  } = { columns };
+  if (!personalProfile) return update;
+
+  const personalInfo = block(personalProfile.personalInfo);
+  if (personalInfo) {
+    columns.personalInfoBio = asTrimmed(personalInfo.bio);
+    columns.personalInfoOccupation = asTrimmed(personalInfo.occupation);
+    columns.personalInfoEmployer = asTrimmed(personalInfo.employer);
+    columns.personalInfoAnnualIncome = asNumber(personalInfo.annualIncome);
+    columns.personalInfoEmploymentStatus = asMember(
+      personalInfo.employmentStatus,
+      EMPLOYMENT_STATUSES,
+    );
+    columns.personalInfoMoveInDate = asDate(personalInfo.moveInDate);
+    columns.personalInfoLeaseDuration = asMember(personalInfo.leaseDuration, LEASE_DURATIONS);
+  }
+
+  const preferences = block(personalProfile.preferences);
+  if (preferences) {
+    columns.preferencesPropertyTypes = asMemberArray(
+      preferences.propertyTypes,
+      PROFILE_PROPERTY_TYPES,
+    );
+    columns.preferencesMaxRent = asNumber(preferences.maxRent);
+    columns.preferencesPriceUnit = asMember(preferences.priceUnit, PRICE_UNITS);
+    columns.preferencesMinBedrooms = asNumber(preferences.minBedrooms);
+    columns.preferencesMinBathrooms = asNumber(preferences.minBathrooms);
+    columns.preferencesPreferredAmenities = asLowercasedArray(preferences.preferredAmenities);
+    columns.preferencesPetFriendly = asBoolean(preferences.petFriendly);
+    columns.preferencesSmokingAllowed = asBoolean(preferences.smokingAllowed);
+    columns.preferencesFurnished = asBoolean(preferences.furnished);
+    columns.preferencesParkingRequired = asBoolean(preferences.parkingRequired);
+    columns.preferencesAccessibility = asBoolean(preferences.accessibility);
+    // `preferredLocations` lives INSIDE the preferences block in the wire shape
+    // and in its own table here, so it is replaced exactly when that block is
+    // present — which is what assigning the block did in Mongo.
+    update.preferredLocations = mapEntries(preferences.preferredLocations, toPreferredLocation) ?? [];
+  }
+
+  const verification = block(personalProfile.verification);
+  if (verification) {
+    columns.verificationIdentity = asBoolean(verification.identity);
+    columns.verificationIncome = asBoolean(verification.income);
+    columns.verificationBackground = asBoolean(verification.background);
+    columns.verificationRentalHistory = asBoolean(verification.rentalHistory);
+    columns.verificationReferences = asBoolean(verification.references);
+  }
+
+  const settings = block(personalProfile.settings);
+  if (settings) {
+    const notifications = block(settings.notifications);
+    if (notifications) {
+      columns.settingsNotificationsEmail = asBoolean(notifications.email);
+      columns.settingsNotificationsPush = asBoolean(notifications.push);
+      columns.settingsNotificationsSms = asBoolean(notifications.sms);
+      columns.settingsNotificationsPropertyAlerts = asBoolean(notifications.propertyAlerts);
+      columns.settingsNotificationsViewingReminders = asBoolean(notifications.viewingReminders);
+      columns.settingsNotificationsLeaseUpdates = asBoolean(notifications.leaseUpdates);
+    }
+
+    const privacy = block(settings.privacy);
+    if (privacy) {
+      columns.settingsPrivacyProfileVisibility = asMember(
+        privacy.profileVisibility,
+        PROFILE_VISIBILITIES,
+      );
+      columns.settingsPrivacyShowContactInfo = asBoolean(privacy.showContactInfo);
+      columns.settingsPrivacyShowIncome = asBoolean(privacy.showIncome);
+      columns.settingsPrivacyShowRentalHistory = asBoolean(privacy.showRentalHistory);
+      columns.settingsPrivacyShowReferences = asBoolean(privacy.showReferences);
+    }
+
+    const roommate = block(settings.roommate);
+    if (roommate) {
+      columns.settingsRoommateEnabled = asBoolean(roommate.enabled);
+      const roommatePreferences = subtree(roommate.preferences);
+      const ageRange = subtree(roommatePreferences.ageRange);
+      const lifestyle = subtree(roommatePreferences.lifestyle);
+      const budget = subtree(roommatePreferences.budget);
+      columns.settingsRoommatePreferencesAgeRangeMin = asNumber(ageRange.min);
+      columns.settingsRoommatePreferencesAgeRangeMax = asNumber(ageRange.max);
+      columns.settingsRoommatePreferencesGender = asMember(
+        roommatePreferences.gender,
+        GENDER_PREFERENCES,
+      );
+      columns.settingsRoommatePreferencesLifestyleSmoking = asMember(
+        lifestyle.smoking,
+        ROOMMATE_LIFESTYLE_ANSWERS,
+      );
+      columns.settingsRoommatePreferencesLifestylePets = asMember(
+        lifestyle.pets,
+        ROOMMATE_LIFESTYLE_ANSWERS,
+      );
+      columns.settingsRoommatePreferencesLifestylePartying = asMember(
+        lifestyle.partying,
+        ROOMMATE_LIFESTYLE_ANSWERS,
+      );
+      columns.settingsRoommatePreferencesLifestyleCleanliness = asMember(
+        lifestyle.cleanliness,
+        ROOMMATE_CLEANLINESS_LEVELS,
+      );
+      columns.settingsRoommatePreferencesLifestyleSchedule = asMember(
+        lifestyle.schedule,
+        ROOMMATE_SCHEDULES,
+      );
+      columns.settingsRoommatePreferencesBudgetMin = asNumber(budget.min);
+      columns.settingsRoommatePreferencesBudgetMax = asNumber(budget.max);
+      columns.settingsRoommatePreferencesMoveInDate = asDate(roommatePreferences.moveInDate);
+      columns.settingsRoommatePreferencesLeaseDuration = asMember(
+        roommatePreferences.leaseDuration,
+        LEASE_DURATIONS,
+      );
+      update.roommateHistory = mapEntries(roommate.history, toRoommateHistory) ?? [];
+    }
+
+    columns.settingsLanguage = asTrimmed(settings.language);
+    columns.settingsTimezone = asTrimmed(settings.timezone);
+    columns.settingsCurrency = asTrimmed(settings.currency);
+  }
+
+  if (Array.isArray(personalProfile.references)) {
+    update.references = mapEntries(personalProfile.references, toReference) ?? [];
+  }
+  if (Array.isArray(personalProfile.rentalHistory)) {
+    update.rentalHistory = mapEntries(personalProfile.rentalHistory, toRentalHistory) ?? [];
+  }
+
+  return update;
+}

--- a/packages/backend/controllers/profile/shared.ts
+++ b/packages/backend/controllers/profile/shared.ts
@@ -1,8 +1,28 @@
-// `Saved`, `SavedPropertyFolder`, `RecentlyViewed` and `Property` were re-exported
-// here for the saved / folder / recently-viewed controllers. All four now read
-// Postgres through `db/saved/*` and `db/properties/*`, so the Mongoose models are
-// no longer reachable from this package.
-import { Profile } from '../../models';
+/**
+ * What the `controllers/profile/*` handlers share.
+ *
+ * ## Nothing here re-exports a Mongoose model any more
+ *
+ * `Saved`, `SavedPropertyFolder`, `RecentlyViewed` and `Property` went with the
+ * saved-items port; `Profile` goes with this one. Every handler in this
+ * directory now reads Postgres through `db/profiles/*`, `db/saved/*` and
+ * `db/properties/*`, so the models are no longer reachable from here at all —
+ * which is what makes "the profile is served from Postgres" a property of the
+ * module graph rather than of everybody remembering.
+ *
+ * ## The profile cache and `_createDefaultProfile` are gone
+ *
+ * Both belonged to the Mongo profile read and both were removed with it:
+ *
+ *  - the five-minute in-process `Map` could only ever be correct in a single
+ *    process, and Homiio runs several ECS tasks — see `crud.ts`;
+ *  - `_createDefaultProfile` seeded a `personalProfile` block with the schema's
+ *    defaults, which made "the user chose UTC" indistinguishable from "nobody
+ *    ever asked". `ensureProfile` in `db/profiles/profileRepository.ts` creates
+ *    the row with every column NULL, which is what `db/schema/profiles.ts`
+ *    declares them nullable FOR.
+ */
+
 import { successResponse } from '../../middlewares/errorHandler';
 
 const errorResponse = (message = 'Error occurred', code = 'ERROR') => ({
@@ -12,88 +32,17 @@ const errorResponse = (message = 'Error occurred', code = 'ERROR') => ({
   timestamp: new Date().toISOString(),
 });
 
-const CACHE_TTL = 5 * 60 * 1000;
-const CACHE_MAX_SIZE = 1000;
-const profileCache = new Map<string, { data: unknown; timestamp: number }>();
-setInterval(() => {
-  const now = Date.now();
-  for (const [key, entry] of profileCache) {
-    if (now - entry.timestamp >= CACHE_TTL) profileCache.delete(key);
-  }
-}, 60_000).unref();
-
-function _getOxyUserId(req: { user?: { id?: string; _id?: string } }): string | undefined {
+/**
+ * The caller's Oxy account id, from the session.
+ *
+ * Never from the body or a route parameter: `AGENTS.md` requires every write to
+ * resolve its owner server-side, and every handler in this directory is scoped
+ * to whoever is holding the credential.
+ */
+function _getOxyUserId(req: {
+  user?: { id?: string; _id?: string } | null;
+}): string | undefined {
   return req?.user?.id || req?.user?._id;
 }
 
-async function _createDefaultProfile(oxyUserId: string) {
-  const profile = new Profile({
-    oxyUserId,
-    personalProfile: {
-      personalInfo: {
-        bio: '',
-        occupation: '',
-        employer: '',
-        annualIncome: null,
-        employmentStatus: null,
-        moveInDate: null,
-        leaseDuration: null,
-      },
-      preferences: {},
-      references: [],
-      rentalHistory: [],
-      verification: {},
-      settings: {
-        notifications: { email: true, push: true, sms: false },
-        privacy: { profileVisibility: 'public', showContactInfo: true, showIncome: false },
-        language: 'en',
-        timezone: 'UTC',
-      },
-    },
-  });
-  await profile.save();
-  return profile;
-}
-
-function getCacheKey(oxyUserId: string) {
-  return oxyUserId;
-}
-
-function getCachedProfile<T = unknown>(oxyUserId: string): T | null {
-  const key = getCacheKey(oxyUserId);
-  const cached = profileCache.get(key);
-
-  if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-    return cached.data as T;
-  }
-
-  return null;
-}
-
-function setCachedProfile(oxyUserId: string, data: unknown) {
-  const key = getCacheKey(oxyUserId);
-  profileCache.set(key, {
-    data,
-    timestamp: Date.now(),
-  });
-}
-
-function clearCachedProfile(oxyUserId: string) {
-  const key = getCacheKey(oxyUserId);
-  profileCache.delete(key);
-}
-
-export {
-  Profile,
-  successResponse,
-  errorResponse,
-  profileCache,
-  CACHE_TTL,
-  CACHE_MAX_SIZE,
-  _getOxyUserId,
-  _createDefaultProfile,
-  getCacheKey,
-  getCachedProfile,
-  setCachedProfile,
-  clearCachedProfile,
-};
+export { successResponse, errorResponse, _getOxyUserId };

--- a/packages/backend/db/conversations/conversationRepository.ts
+++ b/packages/backend/db/conversations/conversationRepository.ts
@@ -1,0 +1,681 @@
+/**
+ * `conversations`, `conversation_messages` and
+ * `conversation_message_attachments` — the Sindi assistant transcript, on
+ * Postgres.
+ *
+ * ## The row counts, and what the zero actually means
+ *
+ * Measured 2026-08-09 from a one-shot on the live task definition:
+ *
+ * | store | rows |
+ * |---|--:|
+ * | Mongo `conversations` | **0** |
+ * | Mongo messages, summed across every document | **0** |
+ * | Postgres `conversations` / `conversation_messages` / `…_attachments` | **0 / 0 / 0** |
+ *
+ * Zero is not "nobody used the assistant". **Every write path was broken**, and
+ * the port is what fixes it, so the number is evidence and not a licence to
+ * treat the domain as dead:
+ *
+ *  - `2d1376a` renamed `Conversation.profileId` to `oxyUserId` and updated the
+ *    handlers that lived in `controllers/ai/`. `eeb4845` later deleted that
+ *    directory, and `routes/ai.ts` — the file actually mounted at `/api/ai`,
+ *    checked against `routes/index.ts` — kept the OLD spelling.
+ *  - So every write was `new Conversation({ profileId: … })`. mongoose strict
+ *    mode DROPS a path the schema does not declare, `oxyUserId` is
+ *    `required: true`, and `save()` therefore throws `ValidationError` every
+ *    time. Verified against this repository's mongoose 8.24.1 rather than
+ *    reasoned about: the constructed document holds `undefined` for BOTH fields
+ *    and `validateSync()` reports "Path `oxyUserId` is required."
+ *  - The reads matched: `find({ profileId })` filters on a field no document has
+ *    and returns `[]`, so the client saw an empty history rather than an error.
+ *  - The collection still carries both generations of index (`profileId_1`,
+ *    `oxyUserId_1_status_1_updatedAt_-1`, …), which is the fingerprint of the
+ *    half-finished rename.
+ *
+ * The TTL index is the second reason to distrust a low count here, and
+ * `db/expiry.ts` carries it: Mongo deleted the whole conversation 24 hours after
+ * anybody shared it. Both hazards point the same way — this table's emptiness
+ * says nothing about demand.
+ *
+ * ## ORDERING: never by the primary key, and this is the table where it bites
+ *
+ * Every `id` in this schema is `text`, holding a 24-char ObjectId hex for a row
+ * that existed before the cutover and a **uuid v7** for one created after it.
+ * Those two shapes do not interleave in creation order — they interleave
+ * BACKWARDS. A uuid v7 minted in 2026 begins `0199…` (the millisecond clock in
+ * hex, left-padded into the first 48 bits), while every ObjectId minted in 2026
+ * begins `69…`/`6a…` (a 32-bit unix seconds prefix). `'0' < '6'`, so a
+ * lexicographic sort puts **every new row before every legacy row**, whatever
+ * their real order.
+ *
+ * A repository that sorted `conversation_messages` by id would therefore serve a
+ * backfilled transcript with every reply the user has since added hoisted to the
+ * top — and it would do it silently, and only for the conversations that span
+ * the cutover, which is the set no hand-written fixture contains. So:
+ *
+ *  - messages are ordered by **`position`**, the array index Mongo's
+ *    `messages[]` carried, with `timestamp` as the tiebreaker;
+ *  - conversations are ordered by **`updated_at desc`**, with the id as a
+ *    tiebreaker ONLY, exactly as the Mongo handler's `sort({ updatedAt: -1 })`
+ *    did.
+ *
+ * `__tests__/db/conversationOrdering.test.ts` pins both against a fixture that
+ * MIXES a legacy hex id with a uuid v7 and arranges the timestamps so an id sort
+ * gives the wrong answer. A fixture with ids of one shape cannot tell the two
+ * orderings apart.
+ *
+ * ## What is denormalised, what became a query, and why each
+ *
+ * | Mongo | Here | Why |
+ * |---|---|---|
+ * | `analytics.messageCount` | `count(*)`, in {@link listConversations}' lateral | A `pre('save')` hook maintained it. There is no hook here, and it is not a sort key of anything, so a stored counter would have a writer nobody can see and no reader that needs it to be cheap |
+ * | `lastMessage` (a virtual) | the same lateral | It was already computed per read in Mongo — a virtual over the loaded array. Storing it would be new denormalisation, not a port |
+ * | `analytics.lastActivity` | KEPT, and {@link touchActivity} is its hook | Not derivable: Mongo moved it on any save, not only on an append, so it and `updated_at` are two different facts. It only stays honest because this module is the sole writer and stamps it on every mutation — a stored value with no maintainer is worse than a join |
+ * | `analytics.totalTokens` | KEPT, written by {@link addTokens} | Comes from the provider's response, not from the stored text, so nothing can recompute it |
+ *
+ * The prompt's other two candidates do not exist in this model: a conversation
+ * has ONE owner (`oxy_user_id`) rather than a participant list, and there is no
+ * unread counter anywhere in the source.
+ *
+ * ## Sharing
+ *
+ * `conversations_sharing_coherent_check` makes the four `sharing_*` columns move
+ * together, so {@link shareConversation} and {@link revokeSharing} write all
+ * four or none. Mongo enforced nothing, which allowed a conversation flagged
+ * `isShared` with no token (unreachable by its own link) and a token with the
+ * flag false (a live secret nobody could revoke through the UI).
+ */
+
+import { and, asc, desc, eq, gt, inArray, lte, sql } from 'drizzle-orm';
+import crypto from 'crypto';
+import { qualified } from '../casing';
+import type { DatabaseOrTransaction } from '../postgres';
+import {
+  conversationMessageAttachments,
+  conversationMessages,
+  conversations,
+} from '../schema';
+import { isUniqueViolation } from '../uniqueViolation';
+
+export type ConversationRow = typeof conversations.$inferSelect;
+export type ConversationMessageRow = typeof conversationMessages.$inferSelect;
+export type ConversationAttachmentRow = typeof conversationMessageAttachments.$inferSelect;
+
+/** A message role the `conversation_messages_role_check` accepts. */
+export type ConversationMessageRole = ConversationMessageRow['role'];
+
+/** How long a share link lives, matching Mongo's `generateShareToken(24)`. */
+export const SHARE_LINK_HOURS = 24;
+
+/** Bytes of entropy in a share token — `crypto.randomBytes(32)`, as hex. */
+const SHARE_TOKEN_BYTES = 32;
+
+/** The title `POST /conversations` assigns before a first user message names it. */
+export const PLACEHOLDER_CONVERSATION_TITLE = 'New Conversation';
+
+/** One message plus the files attached to it. */
+export interface HydratedMessage {
+  readonly message: ConversationMessageRow;
+  readonly attachments: readonly ConversationAttachmentRow[];
+}
+
+/** One conversation and its whole transcript. */
+export interface HydratedConversation {
+  readonly conversation: ConversationRow;
+  readonly messages: readonly HydratedMessage[];
+}
+
+/** A conversation in a LIST, with the two figures the sidebar renders. */
+export interface ConversationSummary {
+  readonly conversation: ConversationRow;
+  readonly messageCount: number;
+  /** The last turn, or `undefined` for a conversation with no messages yet. */
+  readonly lastMessage: ConversationMessageRow | undefined;
+}
+
+/** A message as a caller supplies it. `position` is assigned by this module. */
+export interface MessageInput {
+  readonly role: ConversationMessageRole;
+  readonly content: string;
+  readonly timestamp?: Date;
+  readonly attachments?: readonly AttachmentInput[];
+}
+
+/** A file attached to a turn. Every field optional, matching the source schema. */
+export interface AttachmentInput {
+  readonly type?: ConversationAttachmentRow['type'];
+  readonly name?: string;
+  readonly url?: string;
+  readonly size?: number;
+}
+
+/**
+ * The transcript for one conversation, in order.
+ *
+ * `position` first, `timestamp` to break a tie. NOT the id — see the header.
+ * `UNIQUE(conversation_id, position)` means a tie is unreachable through this
+ * module, so the second key is there for a row some other writer could produce,
+ * not for one this code can.
+ */
+export async function listMessages(
+  db: DatabaseOrTransaction,
+  conversationId: string,
+): Promise<readonly HydratedMessage[]> {
+  const messages = await db
+    .select()
+    .from(conversationMessages)
+    .where(eq(conversationMessages.conversationId, conversationId))
+    .orderBy(asc(conversationMessages.position), asc(conversationMessages.timestamp));
+  if (messages.length === 0) return [];
+
+  // By message id rather than by joining back to `conversation_messages`: the
+  // ids are already in hand, so the join would only re-derive the set this
+  // statement was built from — and `inArray` is the spelling
+  // `~/Oxy/AGENTS.md` prescribes for a plain membership test, since a bare
+  // array interpolated into a `sql` template renders as a ROW CONSTRUCTOR that
+  // Postgres rejects at RUNTIME.
+  const attachments = await db
+    .select()
+    .from(conversationMessageAttachments)
+    .where(
+      inArray(
+        conversationMessageAttachments.messageId,
+        messages.map((message) => message.id),
+      ),
+    );
+
+  const byMessage = new Map<string, ConversationAttachmentRow[]>();
+  for (const row of attachments) {
+    const list = byMessage.get(row.messageId);
+    if (list) list.push(row);
+    else byMessage.set(row.messageId, [row]);
+  }
+
+  return messages.map((message) => ({
+    message,
+    attachments: byMessage.get(message.id) ?? [],
+  }));
+}
+
+/**
+ * One conversation owned by `oxyUserId`, with its transcript, or `undefined`.
+ *
+ * The owner is part of the predicate rather than checked afterwards: a lookup by
+ * id alone that is authorised in a second statement is an IDOR the moment
+ * somebody forgets the second statement.
+ */
+export async function findConversationForOwner(
+  db: DatabaseOrTransaction,
+  id: string,
+  oxyUserId: string,
+): Promise<HydratedConversation | undefined> {
+  const [conversation] = await db
+    .select()
+    .from(conversations)
+    .where(and(eq(conversations.id, id), eq(conversations.oxyUserId, oxyUserId)))
+    .limit(1);
+  if (!conversation) return undefined;
+  return { conversation, messages: await listMessages(db, conversation.id) };
+}
+
+/**
+ * A person's conversations, newest activity first, with their counts.
+ *
+ * `updated_at desc` reproduces the Mongo handler's `sort({ updatedAt: -1 })`;
+ * the id is a TIEBREAKER and nothing else. Two conversations sharing a
+ * millisecond is not hypothetical here — `date_trunc('milliseconds', now())` is
+ * the column default, so a batch write lands them on the same value — and a sort
+ * with no tiebreaker is not stable across two calls, which is what makes a
+ * paginated list repeat or skip a row.
+ *
+ * The count and the last message come from ONE lateral rather than a second
+ * round trip per conversation: the sidebar renders both for every row it shows.
+ */
+export async function listConversations(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+  filter: { readonly status?: ConversationRow['status'] } = {},
+): Promise<readonly ConversationSummary[]> {
+  const where = filter.status
+    ? and(eq(conversations.oxyUserId, oxyUserId), eq(conversations.status, filter.status))
+    : eq(conversations.oxyUserId, oxyUserId);
+
+  // `qualified` on BOTH correlated references, and it is not optional. A drizzle
+  // column interpolated into a `sql` template renders BARE when its table is not
+  // in that statement's own `FROM` — so a plain `${conversations.id}` would emit
+  // `"id"`, which resolves against the SUBQUERY's table
+  // (`conversation_messages` has an `id` too), silently comparing two of its own
+  // columns and returning a count of 0 for every conversation with no error at
+  // all. `db/schema/CONVENTIONS.md` records this as the trap that already
+  // shipped once in the sibling oxy-api port.
+  const rows = await db
+    .select({
+      conversation: conversations,
+      messageCount: sql<number>`(
+        select count(*)::int from ${conversationMessages}
+        where ${conversationMessages.conversationId} = ${qualified(conversations.id)}
+      )`,
+      lastMessageId: sql<string | null>`(
+        select ${conversationMessages.id} from ${conversationMessages}
+        where ${conversationMessages.conversationId} = ${qualified(conversations.id)}
+        order by ${conversationMessages.position} desc, ${conversationMessages.timestamp} desc
+        limit 1
+      )`,
+    })
+    .from(conversations)
+    .where(where)
+    .orderBy(desc(conversations.updatedAt), desc(conversations.id));
+
+  const lastIds = rows.map((row) => row.lastMessageId).filter((id): id is string => id !== null);
+  const lastMessages = new Map<string, ConversationMessageRow>();
+  if (lastIds.length > 0) {
+    const found = await db
+      .select()
+      .from(conversationMessages)
+      .where(inArray(conversationMessages.id, lastIds));
+    for (const message of found) lastMessages.set(message.id, message);
+  }
+
+  return rows.map((row) => ({
+    conversation: row.conversation,
+    messageCount: row.messageCount,
+    lastMessage: row.lastMessageId ? lastMessages.get(row.lastMessageId) : undefined,
+  }));
+}
+
+/**
+ * Open a conversation, with an optional opening transcript.
+ *
+ * Runs several statements, so the caller supplies the transaction — a
+ * conversation that committed without the messages it was created FROM is a
+ * blank chat the user has to start again.
+ */
+export async function createConversation(
+  db: DatabaseOrTransaction,
+  input: {
+    readonly oxyUserId: string;
+    readonly title?: string;
+    readonly topic?: ConversationRow['topic'];
+    readonly initialMessage?: string;
+    readonly source?: ConversationRow['metadataSource'];
+    readonly language?: string;
+    readonly messages?: readonly MessageInput[];
+  },
+): Promise<HydratedConversation> {
+  const now = new Date();
+  const [conversation] = await db
+    .insert(conversations)
+    .values({
+      oxyUserId: input.oxyUserId,
+      title: input.title?.trim() || PLACEHOLDER_CONVERSATION_TITLE,
+      topic: input.topic,
+      metadataInitialMessage: input.initialMessage,
+      metadataSource: input.source,
+      metadataLanguage: input.language,
+      analyticsLastActivity: now,
+    })
+    .returning();
+
+  if (input.messages && input.messages.length > 0) {
+    await insertMessages(db, conversation.id, 0, input.messages);
+  }
+  return { conversation, messages: await listMessages(db, conversation.id) };
+}
+
+/** Insert a run of messages starting at `firstPosition`, with their attachments. */
+async function insertMessages(
+  db: DatabaseOrTransaction,
+  conversationId: string,
+  firstPosition: number,
+  messages: readonly MessageInput[],
+): Promise<readonly ConversationMessageRow[]> {
+  const inserted = await db
+    .insert(conversationMessages)
+    .values(
+      messages.map((message, index) => ({
+        conversationId,
+        role: message.role,
+        content: message.content,
+        timestamp: message.timestamp ?? new Date(),
+        position: firstPosition + index,
+      })),
+    )
+    .returning();
+
+  const attachments = inserted.flatMap((row, index) =>
+    (messages[index].attachments ?? []).map((attachment) => ({
+      messageId: row.id,
+      type: attachment.type,
+      name: attachment.name,
+      url: attachment.url,
+      size: attachment.size,
+    })),
+  );
+  if (attachments.length > 0) {
+    await db.insert(conversationMessageAttachments).values(attachments);
+  }
+  return inserted;
+}
+
+/**
+ * The next free `position` in a conversation.
+ *
+ * `max + 1`, which two concurrent appends can both read — and
+ * `conversation_messages_conversation_position_key` is what catches that,
+ * raising `23505` on the loser instead of storing two messages at one position.
+ * {@link appendMessages} retries on it. The schema's docblock explains why the
+ * index is UNIQUE rather than plain: two messages at the same position is an
+ * ordering with no answer, and an assistant reply sorted before the question it
+ * answers is a transcript that reads as nonsense.
+ */
+async function nextPosition(db: DatabaseOrTransaction, conversationId: string): Promise<number> {
+  // **`::int` is load-bearing and is not decoration.** `position` is a `bigint`,
+  // and postgres.js hands a bigint aggregate back as a STRING to avoid losing
+  // precision past 2^53 — so `max(...) + 1` in JS is STRING CONCATENATION.
+  // `tsc` cannot see it, because `sql<number>` is an assertion rather than a
+  // cast: the declared type says number and the value is `"7"`, so the next
+  // append lands at position 710 instead of 8 and the transcript's order is
+  // scrambled for good. Measured, not reasoned about — the real-database suite
+  // caught it and nothing else would have.
+  //
+  // Casting in SQL is the fix rather than `Number(...)` in JS, because it also
+  // makes the DECLARED type true. `int4` cannot hold every `bigint`, which is
+  // correct here: a conversation with 2^31 turns is not a case to preserve
+  // precision for.
+  const [row] = await db
+    .select({ highest: sql<number>`coalesce(max(${conversationMessages.position}), -1)::int` })
+    .from(conversationMessages)
+    .where(eq(conversationMessages.conversationId, conversationId));
+  return row.highest + 1;
+}
+
+/** How many times {@link appendMessages} re-reads the tail after losing a race. */
+const APPEND_ATTEMPTS = 3;
+
+/**
+ * Append messages to a conversation and stamp its activity.
+ *
+ * Retries on the position unique violation rather than taking a lock: an append
+ * races only with another append to the SAME conversation, which is one person
+ * with two clients, so the contention is rare and the retry is cheaper than
+ * serialising every write behind a row lock.
+ *
+ * **This function opens its own transaction, one per attempt, and that is the
+ * single deviation from the "caller owns the transaction" convention in this
+ * module.** It has to: a `23505` aborts the enclosing transaction in Postgres,
+ * so a retry issued inside the failed one answers `25P02 current transaction is
+ * aborted` rather than succeeding. A caller passing a `Transaction` still works
+ * — drizzle opens a SAVEPOINT, which rolls back to exactly the right place.
+ */
+export async function appendMessages(
+  db: DatabaseOrTransaction,
+  conversationId: string,
+  messages: readonly MessageInput[],
+): Promise<readonly ConversationMessageRow[]> {
+  if (messages.length === 0) return [];
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < APPEND_ATTEMPTS; attempt += 1) {
+    try {
+      return await db.transaction(async (tx) => {
+        const start = await nextPosition(tx, conversationId);
+        const inserted = await insertMessages(tx, conversationId, start, messages);
+        await touchActivity(tx, conversationId);
+        return inserted;
+      });
+    } catch (error) {
+      if (!isUniqueViolation(error, 'conversation_messages_conversation_position_key')) throw error;
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * Move `analytics.last_activity` to now.
+ *
+ * This is the hook the Mongo `pre('save')` was. `last_activity` is kept as a
+ * stored column — see the header — and a stored value whose maintainer went
+ * missing in the port is exactly the failure the prompt names, so every mutation
+ * in this module ends here.
+ *
+ * `updated_at` moves too, via drizzle's `$onUpdate`, and that is correct: they
+ * are two facts that agree on this path and diverge on the ones that do not
+ * touch the transcript.
+ */
+export async function touchActivity(
+  db: DatabaseOrTransaction,
+  conversationId: string,
+): Promise<void> {
+  await db
+    .update(conversations)
+    .set({ analyticsLastActivity: new Date() })
+    .where(eq(conversations.id, conversationId));
+}
+
+/**
+ * Add to the accumulated LLM token spend.
+ *
+ * `total_tokens` survives where `messageCount` does not because the figure comes
+ * from the provider's response and cannot be recomputed from the stored text.
+ * The increment is expressed in SQL so two concurrent turns cannot read the same
+ * value and each write it back plus their own.
+ */
+export async function addTokens(
+  db: DatabaseOrTransaction,
+  conversationId: string,
+  tokens: number,
+): Promise<void> {
+  if (!Number.isFinite(tokens) || tokens <= 0) return;
+  await db
+    .update(conversations)
+    .set({
+      analyticsTotalTokens: sql`${conversations.analyticsTotalTokens} + ${Math.round(tokens)}`,
+    })
+    .where(eq(conversations.id, conversationId));
+}
+
+/** Rename a conversation, scoped to its owner. */
+export async function renameConversation(
+  db: DatabaseOrTransaction,
+  id: string,
+  oxyUserId: string,
+  title: string,
+): Promise<ConversationRow | undefined> {
+  const [row] = await db
+    .update(conversations)
+    .set({ title, analyticsLastActivity: new Date() })
+    .where(and(eq(conversations.id, id), eq(conversations.oxyUserId, oxyUserId)))
+    .returning();
+  return row;
+}
+
+/** Move a conversation between `active`, `archived` and `deleted`, scoped to its owner. */
+export async function setConversationStatus(
+  db: DatabaseOrTransaction,
+  id: string,
+  oxyUserId: string,
+  status: ConversationRow['status'],
+): Promise<ConversationRow | undefined> {
+  const [row] = await db
+    .update(conversations)
+    .set({ status, analyticsLastActivity: new Date() })
+    .where(and(eq(conversations.id, id), eq(conversations.oxyUserId, oxyUserId)))
+    .returning();
+  return row;
+}
+
+/**
+ * Replace a conversation's whole transcript.
+ *
+ * `PUT /conversations/:id` accepts a `messages` array and Mongo assigned it over
+ * the embedded array, so the ported form deletes and re-inserts. Positions are
+ * re-numbered from zero, which is what the assignment did implicitly.
+ *
+ * The caller supplies the transaction: a delete that committed without its
+ * re-insert is a transcript the user cannot get back.
+ */
+export async function replaceMessages(
+  db: DatabaseOrTransaction,
+  conversationId: string,
+  messages: readonly MessageInput[],
+): Promise<readonly ConversationMessageRow[]> {
+  await db
+    .delete(conversationMessages)
+    .where(eq(conversationMessages.conversationId, conversationId));
+  if (messages.length === 0) {
+    await touchActivity(db, conversationId);
+    return [];
+  }
+  const inserted = await insertMessages(db, conversationId, 0, messages);
+  await touchActivity(db, conversationId);
+  return inserted;
+}
+
+/** Delete a conversation, scoped to its owner. Messages CASCADE. */
+export async function deleteConversation(
+  db: DatabaseOrTransaction,
+  id: string,
+  oxyUserId: string,
+): Promise<boolean> {
+  const rows = await db
+    .delete(conversations)
+    .where(and(eq(conversations.id, id), eq(conversations.oxyUserId, oxyUserId)))
+    .returning({ id: conversations.id });
+  return rows.length > 0;
+}
+
+/**
+ * Mint a share link, scoped to the owner, and return the token.
+ *
+ * All four `sharing_*` columns are written in one statement because
+ * `conversations_sharing_coherent_check` refuses any other combination — which
+ * is the schema doing what Mongo's `generateShareToken` only did by convention.
+ *
+ * **The deadline is on the LINK, not on the row.** Mongo carried a TTL index on
+ * `sharing.expiresAt` that deleted the whole conversation, transcript included,
+ * 24 hours later. `db/expiry.ts` names the column in
+ * `EXPIRY_COLUMNS_THAT_MUST_NOT_DELETE` and a test fails the build if it is ever
+ * registered as a sweep target; {@link expireShareLinks} is the correct port.
+ */
+export async function shareConversation(
+  db: DatabaseOrTransaction,
+  id: string,
+  oxyUserId: string,
+  hours: number = SHARE_LINK_HOURS,
+): Promise<{ readonly conversation: ConversationRow; readonly token: string } | undefined> {
+  const now = new Date();
+  const token = crypto.randomBytes(SHARE_TOKEN_BYTES).toString('hex');
+  const [row] = await db
+    .update(conversations)
+    .set({
+      sharingIsShared: true,
+      sharingShareToken: token,
+      sharingSharedAt: now,
+      sharingExpiresAt: new Date(now.getTime() + hours * 60 * 60 * 1000),
+      analyticsLastActivity: now,
+    })
+    .where(and(eq(conversations.id, id), eq(conversations.oxyUserId, oxyUserId)))
+    .returning();
+  return row ? { conversation: row, token } : undefined;
+}
+
+/**
+ * Withdraw a share link, scoped to the owner.
+ *
+ * The token is written NULL and never `''`:
+ * `conversations_share_token_key` is a partial unique index, Postgres treats
+ * NULLs as distinct, and an empty string is a VALUE that would collide with
+ * every other revoked conversation for real.
+ */
+export async function revokeSharing(
+  db: DatabaseOrTransaction,
+  id: string,
+  oxyUserId: string,
+): Promise<ConversationRow | undefined> {
+  const [row] = await db
+    .update(conversations)
+    .set({
+      sharingIsShared: false,
+      sharingShareToken: null,
+      sharingSharedAt: null,
+      sharingExpiresAt: null,
+      analyticsLastActivity: new Date(),
+    })
+    .where(and(eq(conversations.id, id), eq(conversations.oxyUserId, oxyUserId)))
+    .returning();
+  return row;
+}
+
+/**
+ * The conversation behind a LIVE share token, with its transcript.
+ *
+ * The freshness predicate is in the query, exactly as Mongo's
+ * `findByShareToken` had it, so an expired link answers "not found" whether or
+ * not {@link expireShareLinks} has run since. That is what makes the sweep pure
+ * housekeeping rather than a correctness dependency — `db/expiry.ts` calls out
+ * the coexistence rule, and this is the read side of it.
+ *
+ * Takes NO owner: the whole point of the link is that a stranger can follow it.
+ */
+export async function findConversationByShareToken(
+  db: DatabaseOrTransaction,
+  token: string,
+): Promise<HydratedConversation | undefined> {
+  const [conversation] = await db
+    .select()
+    .from(conversations)
+    .where(
+      and(
+        eq(conversations.sharingShareToken, token),
+        eq(conversations.sharingIsShared, true),
+        gt(conversations.sharingExpiresAt, new Date()),
+      ),
+    )
+    .limit(1);
+  if (!conversation) return undefined;
+  return { conversation, messages: await listMessages(db, conversation.id) };
+}
+
+/**
+ * Clear every share link whose deadline has passed. Returns how many were
+ * cleared.
+ *
+ * **This is the port of Mongo's TTL index on `sharing.expiresAt`, and it must
+ * never delete a row.** That index deleted the whole conversation — every
+ * message in it — 24 hours after anybody pressed Share, so a near-zero row count
+ * in the source is evidence of the DAMAGE rather than of safety.
+ * `db/schema/conversations.ts` and `db/expiry.ts` both say so; this is where it
+ * stops being advice.
+ *
+ * The four columns are cleared together because the coherence CHECK accepts no
+ * other combination, and the predicate names all of them so a row already
+ * cleared is not rewritten — an `UPDATE` that touched it would move `updated_at`
+ * through drizzle's `$onUpdate` and restamp a conversation nobody edited.
+ */
+export async function expireShareLinks(db: DatabaseOrTransaction, now: Date = new Date()): Promise<number> {
+  const rows = await db
+    .update(conversations)
+    .set({
+      sharingIsShared: false,
+      sharingShareToken: null,
+      sharingSharedAt: null,
+      sharingExpiresAt: null,
+    })
+    .where(and(eq(conversations.sharingIsShared, true), lte(conversations.sharingExpiresAt, now)))
+    .returning({ id: conversations.id });
+  return rows.length;
+}
+
+/**
+ * A title derived from the first user turn, matching Mongo's `pre('save')`.
+ *
+ * Fifty characters, trimmed, with an ellipsis when it was cut. Exported so the
+ * AI-generated title path and the fallback agree on the shape rather than each
+ * spelling it out.
+ */
+export function titleFromFirstUserMessage(content: string): string {
+  const trimmed = content.slice(0, 50).trim();
+  return content.length > 50 ? `${trimmed}...` : trimmed;
+}

--- a/packages/backend/db/conversations/conversationSerializer.ts
+++ b/packages/backend/db/conversations/conversationSerializer.ts
@@ -1,0 +1,138 @@
+/**
+ * `conversations` rows → the wire shapes `/api/ai/conversations*` and
+ * `/api/ai/shared/:token` return.
+ *
+ * Three shapes, deliberately not one:
+ *
+ *  - {@link toConversationSummaryDTO} — a row in the sidebar list. Carries
+ *    `messageCount` and `lastMessage`, which were Mongoose VIRTUALS and are
+ *    computed by the repository's lateral now (`db/MIGRATION-CONTRACT.md` lists
+ *    both under "Virtuals a DTO has to compute").
+ *  - {@link toConversationDTO} — one conversation with its whole transcript.
+ *  - {@link toSharedConversationDTO} — what a STRANGER following a share link
+ *    gets, which is the same minus everything identifying.
+ *
+ * ## The shared shape omits the owner, and that is the whole point of it
+ *
+ * `GET /api/ai/shared/:token` needs no authentication. The Mongo handler already
+ * hand-picked five fields for exactly this reason; picking them here keeps that
+ * property when the row gains a column, whereas returning the row minus a
+ * blocklist would leak the next one somebody adds. `oxy_user_id`, the share
+ * token itself, the token's deadline and the token spend are all absent.
+ *
+ * ## `messageCount` is not read by the client, and is still emitted
+ *
+ * `store/conversationStore.ts` derives its own count from `messages.length`. The
+ * field is kept because the LIST response omits the transcript, so a client that
+ * wants the count without the payload has no other source — and because dropping
+ * a field from a response is a wire break, which this port is not for.
+ */
+
+import type {
+  ConversationRow,
+  ConversationSummary,
+  HydratedConversation,
+  HydratedMessage,
+} from './conversationRepository';
+
+/** One turn, with any files attached to it. */
+export function toMessageDTO(hydrated: HydratedMessage): Record<string, unknown> {
+  return {
+    id: hydrated.message.id,
+    role: hydrated.message.role,
+    content: hydrated.message.content,
+    timestamp: hydrated.message.timestamp,
+    attachments: hydrated.attachments.map((attachment) => ({
+      id: attachment.id,
+      type: attachment.type,
+      name: attachment.name,
+      url: attachment.url,
+      size: attachment.size,
+    })),
+  };
+}
+
+/**
+ * The shared fields every conversation shape carries.
+ *
+ * `id` and not `_id` — Mongoose's `toJSON` transform renamed it and PR #287 made
+ * that a clean cut across the wire contract.
+ */
+function core(conversation: ConversationRow): Record<string, unknown> {
+  return {
+    id: conversation.id,
+    title: conversation.title,
+    status: conversation.status,
+    topic: conversation.topic,
+    createdAt: conversation.createdAt,
+    updatedAt: conversation.updatedAt,
+  };
+}
+
+/** One conversation with its whole transcript. */
+export function toConversationDTO(hydrated: HydratedConversation): Record<string, unknown> {
+  return {
+    ...core(hydrated.conversation),
+    oxyUserId: hydrated.conversation.oxyUserId,
+    messages: hydrated.messages.map(toMessageDTO),
+    messageCount: hydrated.messages.length,
+    metadata: {
+      initialMessage: hydrated.conversation.metadataInitialMessage,
+      source: hydrated.conversation.metadataSource,
+      language: hydrated.conversation.metadataLanguage,
+      tags: hydrated.conversation.metadataTags,
+    },
+    sharing: {
+      isShared: hydrated.conversation.sharingIsShared,
+      sharedAt: hydrated.conversation.sharingSharedAt,
+      expiresAt: hydrated.conversation.sharingExpiresAt,
+    },
+    analytics: {
+      lastActivity: hydrated.conversation.analyticsLastActivity,
+      totalTokens: hydrated.conversation.analyticsTotalTokens,
+    },
+  };
+}
+
+/**
+ * A row in the sidebar list.
+ *
+ * `messages: []` is carried because the Mongo handler carried it — it mapped
+ * `o.messages || []` onto every row — and the client's `loadConversations`
+ * reads `conv.messages || []` into its store. Emitting the key empty rather than
+ * omitting it keeps a client that renders from the list alone at "no messages
+ * yet" instead of "undefined".
+ */
+export function toConversationSummaryDTO(summary: ConversationSummary): Record<string, unknown> {
+  return {
+    ...core(summary.conversation),
+    messageCount: summary.messageCount,
+    lastMessage: summary.lastMessage
+      ? {
+          id: summary.lastMessage.id,
+          role: summary.lastMessage.role,
+          content: summary.lastMessage.content,
+          timestamp: summary.lastMessage.timestamp,
+        }
+      : null,
+    messages: [],
+  };
+}
+
+/**
+ * What a stranger following a share link gets.
+ *
+ * Deliberately a PICK and not the row minus a blocklist — see the header. The
+ * five fields are the ones the Mongo handler chose, plus the message ids the
+ * transcript needs.
+ */
+export function toSharedConversationDTO(hydrated: HydratedConversation): Record<string, unknown> {
+  return {
+    id: hydrated.conversation.id,
+    title: hydrated.conversation.title,
+    status: hydrated.conversation.status,
+    messages: hydrated.messages.map(toMessageDTO),
+    createdAt: hydrated.conversation.createdAt,
+    updatedAt: hydrated.conversation.updatedAt,
+  };
+}

--- a/packages/backend/db/profiles/profileRepository.ts
+++ b/packages/backend/db/profiles/profileRepository.ts
@@ -1,0 +1,380 @@
+/**
+ * `profiles` and its five child tables — the tenant profile Oxy does not own, on
+ * Postgres.
+ *
+ * ## The row counts, measured on BOTH stores rather than assumed
+ *
+ * Run 2026-08-09 from a one-shot on the live task definition, against
+ * `homiio-production` and the `homiio` Postgres database:
+ *
+ * | store | rows |
+ * |---|--:|
+ * | Mongo `profiles` | **5** |
+ * | Postgres `profiles` | **5** — the SAME five `oxy_user_id`s, all 24-char hex ids |
+ * | all five child collections / tables, both stores | **0** |
+ *
+ * So the copy is COMPLETE for this collection, and the apparent gap between
+ * "five rows in Postgres" and "a much larger Mongo collection" is an artefact of
+ * the comparison rather than of the backfill: the Mongo collection is five rows
+ * too. It is recorded here because the opposite conclusion — a partial copy —
+ * would make every read below a consistency hazard, and nothing in the code
+ * could tell you which it was.
+ *
+ * The population being this small has a cause worth stating, because it is the
+ * thing that would otherwise make five look wrong: production holds 17,644
+ * properties and **not one** carries an `oxy_user_id` (they are all external
+ * aggregator listings, and the ingest hook strips the owner). There is no larger
+ * set of "profiles reachable from properties" a backfill could have missed — the
+ * join that would find them is empty on the other side.
+ *
+ * ## One profile per Oxy account, and the INDEX is what enforces it
+ *
+ * Mongoose declared `unique: true` on `oxyUserId` and the controller wrapped a
+ * read-then-create around it, which is a window two concurrent first requests
+ * both pass. {@link ensureProfile} INSERTs and converges on `23505` from
+ * `profiles_oxy_user_id_key` instead — `db/MIGRATION-CONTRACT.md`'s rule that
+ * idempotency which moved into an index must not be re-implemented as a read.
+ *
+ * ## Nothing here takes a profile id from a caller
+ *
+ * Every entry point is keyed by `oxyUserId`, which the caller resolves from the
+ * session. A profile is a sidecar to an Oxy account, so the account id IS the
+ * key — and a lookup by row id authorised in a second statement is an IDOR the
+ * moment somebody forgets the second statement.
+ */
+
+import { asc, eq, sql } from 'drizzle-orm';
+import type { DatabaseOrTransaction } from '../postgres';
+import {
+  profileChatMessages,
+  profilePreferredLocations,
+  profileReferences,
+  profileRentalHistory,
+  profileRoommateHistory,
+  profiles,
+} from '../schema';
+import { isUniqueViolation } from '../uniqueViolation';
+import { type HydratedProfile, type ProfileRow, profileSelection } from './profileSerializer';
+
+/**
+ * How many transcript turns the profile keeps.
+ *
+ * Mongo's `POST /api/ai/history` trimmed with `slice(-100)` on every append. The
+ * cap is preserved because it is the only thing bounding an array that grows
+ * with every turn — see {@link appendProfileChatTurn}.
+ */
+export const PROFILE_CHAT_HISTORY_LIMIT = 100;
+
+/** Columns a write may set. Derived from the table, so it cannot name a phantom. */
+export type ProfileWriteColumns = Partial<typeof profiles.$inferInsert>;
+
+/** A child row a write may replace, as the caller supplies it (no `profileId` yet). */
+export type ProfileReferenceInput = Omit<typeof profileReferences.$inferInsert, 'profileId' | 'id'>;
+export type ProfileRentalHistoryInput = Omit<
+  typeof profileRentalHistory.$inferInsert,
+  'profileId' | 'id'
+>;
+export type ProfilePreferredLocationInput = Omit<
+  typeof profilePreferredLocations.$inferInsert,
+  'profileId' | 'id'
+>;
+export type ProfileRoommateHistoryInput = Omit<
+  typeof profileRoommateHistory.$inferInsert,
+  'profileId' | 'id'
+>;
+
+/**
+ * A whole update: the scalar columns, plus any child collection being REPLACED.
+ *
+ * A child key left `undefined` is untouched; a key present as an array replaces
+ * that collection wholesale, and an EMPTY array clears it. Those are the same
+ * semantics Mongoose had — assigning `personalProfile.references` replaced the
+ * array — and they are why `undefined` and `[]` must stay distinguishable.
+ */
+export interface ProfileUpdate {
+  readonly columns: ProfileWriteColumns;
+  readonly references?: readonly ProfileReferenceInput[];
+  readonly rentalHistory?: readonly ProfileRentalHistoryInput[];
+  readonly preferredLocations?: readonly ProfilePreferredLocationInput[];
+  readonly roommateHistory?: readonly ProfileRoommateHistoryInput[];
+}
+
+/** A freshly created profile has no child rows. Stated once rather than five times. */
+function emptyChildren(): Omit<HydratedProfile, 'profile'> {
+  return {
+    references: [],
+    rentalHistory: [],
+    preferredLocations: [],
+    roommateHistory: [],
+    chatHistory: [],
+  };
+}
+
+/** The profile row for an Oxy account, or `undefined`. Children NOT loaded. */
+export async function findProfileByOxyUserId(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+): Promise<ProfileRow | undefined> {
+  const [row] = await db
+    .select(profileSelection())
+    .from(profiles)
+    .where(eq(profiles.oxyUserId, oxyUserId))
+    .limit(1);
+  return row;
+}
+
+/**
+ * Every child collection for one profile.
+ *
+ * Five statements in parallel rather than one join: the collections are
+ * independent of each other, so a join would multiply their rows together and
+ * the reader would have to undo five cartesian products to recover what five
+ * plain reads already return.
+ *
+ * **Every ordering here names a real sort column and uses the id only to break a
+ * tie.** A `text` primary key holds a 24-char ObjectId hex for a pre-cutover row
+ * and a uuid v7 for a new one, and those two shapes do NOT interleave in
+ * creation order — a uuid v7 minted today begins `0…` and every ObjectId minted
+ * this year begins `6…`, so a lexicographic sort puts every new row FIRST. See
+ * `db/conversations/conversationRepository.ts`, which carries the measurement.
+ */
+async function loadChildren(
+  db: DatabaseOrTransaction,
+  profileId: string,
+): Promise<Omit<HydratedProfile, 'profile'>> {
+  const [references, rentalHistory, preferredLocations, roommateHistory, chatHistory] =
+    await Promise.all([
+      db.select().from(profileReferences).where(eq(profileReferences.profileId, profileId)),
+      db
+        .select()
+        .from(profileRentalHistory)
+        .where(eq(profileRentalHistory.profileId, profileId))
+        .orderBy(asc(profileRentalHistory.startDate), asc(profileRentalHistory.id)),
+      db
+        .select()
+        .from(profilePreferredLocations)
+        .where(eq(profilePreferredLocations.profileId, profileId)),
+      db
+        .select()
+        .from(profileRoommateHistory)
+        .where(eq(profileRoommateHistory.profileId, profileId))
+        .orderBy(asc(profileRoommateHistory.startDate), asc(profileRoommateHistory.id)),
+      db
+        .select()
+        .from(profileChatMessages)
+        .where(eq(profileChatMessages.profileId, profileId))
+        .orderBy(asc(profileChatMessages.position), asc(profileChatMessages.timestamp)),
+    ]);
+  return { references, rentalHistory, preferredLocations, roommateHistory, chatHistory };
+}
+
+/** One profile with every child collection loaded, or `undefined`. */
+export async function findHydratedProfile(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+): Promise<HydratedProfile | undefined> {
+  const profile = await findProfileByOxyUserId(db, oxyUserId);
+  if (!profile) return undefined;
+  return { profile, ...(await loadChildren(db, profile.id)) };
+}
+
+/**
+ * The profile for an Oxy account, created empty if it is not there.
+ *
+ * **Every column stays NULL on creation**, which is a change from Mongo's
+ * `_createDefaultProfile` and a deliberate one. That helper wrote a
+ * `personalProfile` block seeded with the schema's defaults — `language: 'en'`,
+ * `timezone: 'UTC'`, `profileVisibility: 'public'`, `showContactInfo: true` — so
+ * a stored row could not distinguish "the user chose UTC" from "nobody ever
+ * asked". `db/schema/profiles.ts` declares every column nullable precisely to
+ * keep that distinction, and mongoose never materialized the sub-document
+ * either: `personalProfile` is declared with no `default`, so for the five rows
+ * that exist NONE of those defaults was ever written. Seeding them here would
+ * manufacture five people's answers and then present them as given.
+ *
+ * The one place that costs something is the public serializer, which reads
+ * `showContactInfo === true` — so a profile that has never been edited discloses
+ * nothing, which is the safe direction and matches what the five production rows
+ * actually contain.
+ *
+ * Idempotent by the unique index rather than by a preceding read.
+ */
+export async function ensureProfile(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+): Promise<HydratedProfile> {
+  const existing = await findHydratedProfile(db, oxyUserId);
+  if (existing) return existing;
+
+  try {
+    const [profile] = await db.insert(profiles).values({ oxyUserId }).returning(profileSelection());
+    return { profile, ...emptyChildren() };
+  } catch (error) {
+    if (!isUniqueViolation(error, 'profiles_oxy_user_id_key')) throw error;
+    const raced = await findHydratedProfile(db, oxyUserId);
+    if (!raced) {
+      // The index refused the insert, so a row satisfying it existed at that
+      // instant. Not finding it now means it was deleted in between — a real
+      // state, and one the caller must not be handed a fabricated row for.
+      throw error;
+    }
+    return raced;
+  }
+}
+
+/**
+ * Apply an update to the profile for an Oxy account, creating it first if it is
+ * not there, and return the whole thing.
+ *
+ * Takes `DatabaseOrTransaction` and issues several statements, so the CALLER
+ * wraps it: a child collection replaced against a profile whose scalar write
+ * then failed would leave the person's references belonging to a state that was
+ * never saved.
+ *
+ * `columns` is produced by `controllers/profile/profileWriteColumns.ts` from an
+ * explicit allow-list. This function never sees a request body and never
+ * spreads one.
+ */
+export async function updateProfile(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+  update: ProfileUpdate,
+): Promise<HydratedProfile> {
+  const existing = await ensureProfile(db, oxyUserId);
+  const profileId = existing.profile.id;
+
+  if (Object.keys(update.columns).length > 0) {
+    await db.update(profiles).set(update.columns).where(eq(profiles.id, profileId));
+  }
+
+  // Four delete-then-insert blocks, written out rather than routed through one
+  // generic helper: drizzle's insert/delete builders are typed per TABLE, so a
+  // helper generic enough to take any of them loses the row type — and losing it
+  // is precisely how a key that is not a column reaches `.values()`, where
+  // drizzle IGNORES it instead of refusing it. The same reasoning
+  // `controllers/lease/leaseWriteColumns.ts` gives for naming every field.
+  if (update.references) {
+    await db.delete(profileReferences).where(eq(profileReferences.profileId, profileId));
+    if (update.references.length > 0) {
+      await db
+        .insert(profileReferences)
+        .values(update.references.map((row) => ({ ...row, profileId })));
+    }
+  }
+  if (update.rentalHistory) {
+    await db.delete(profileRentalHistory).where(eq(profileRentalHistory.profileId, profileId));
+    if (update.rentalHistory.length > 0) {
+      await db
+        .insert(profileRentalHistory)
+        .values(update.rentalHistory.map((row) => ({ ...row, profileId })));
+    }
+  }
+  if (update.preferredLocations) {
+    await db
+      .delete(profilePreferredLocations)
+      .where(eq(profilePreferredLocations.profileId, profileId));
+    if (update.preferredLocations.length > 0) {
+      await db
+        .insert(profilePreferredLocations)
+        .values(update.preferredLocations.map((row) => ({ ...row, profileId })));
+    }
+  }
+  if (update.roommateHistory) {
+    await db.delete(profileRoommateHistory).where(eq(profileRoommateHistory.profileId, profileId));
+    if (update.roommateHistory.length > 0) {
+      await db
+        .insert(profileRoommateHistory)
+        .values(update.roommateHistory.map((row) => ({ ...row, profileId })));
+    }
+  }
+
+  const updated = await findHydratedProfile(db, oxyUserId);
+  if (!updated) {
+    // Unreachable through this function, which created the row above inside the
+    // caller's transaction. Thrown rather than returned as `undefined` so no
+    // caller has to handle a case this function cannot produce.
+    throw new Error(`Profile for ${oxyUserId} vanished during its own update.`);
+  }
+  return updated;
+}
+
+/** The profile's Sindi transcript, oldest first. */
+export async function listProfileChatHistory(
+  db: DatabaseOrTransaction,
+  profileId: string,
+): Promise<readonly (typeof profileChatMessages.$inferSelect)[]> {
+  return db
+    .select()
+    .from(profileChatMessages)
+    .where(eq(profileChatMessages.profileId, profileId))
+    .orderBy(asc(profileChatMessages.position), asc(profileChatMessages.timestamp));
+}
+
+/**
+ * Append one user turn and its assistant reply, then trim to
+ * {@link PROFILE_CHAT_HISTORY_LIMIT}.
+ *
+ * The profile row is locked FOR UPDATE first, which serialises concurrent
+ * appends for one person. That matters because `position` is `max + 1` and
+ * `profile_chat_messages` carries no `UNIQUE(profile_id, position)` — unlike
+ * `conversation_messages`, which does, and where the index is what catches the
+ * race. Here the lock is the mechanism, and without it two turns posted at once
+ * would both take the same position and the transcript would have no defined
+ * order at that point.
+ *
+ * Both messages get the SAME timestamp, matching the Mongo handler, which took
+ * one `new Date()` for the pair. `position` is what tells them apart.
+ *
+ * Runs several statements, so the caller supplies the transaction.
+ */
+export async function appendProfileChatTurn(
+  db: DatabaseOrTransaction,
+  profileId: string,
+  turn: { readonly userMessage: string; readonly assistantMessage: string },
+): Promise<void> {
+  await db.select({ id: profiles.id }).from(profiles).where(eq(profiles.id, profileId)).for('update');
+
+  // `::double precision` for the same reason `conversation_messages` casts to
+  // `::int`: an aggregate's driver representation is not the column's, and a
+  // string coming back here would make `+ 1` string concatenation — silently,
+  // past `tsc`, and only visible once a transcript is out of order.
+  const [highest] = await db
+    .select({
+      position: sql<number>`coalesce(max(${profileChatMessages.position}), -1)::double precision`,
+    })
+    .from(profileChatMessages)
+    .where(eq(profileChatMessages.profileId, profileId));
+  const next = highest.position + 1;
+  const timestamp = new Date();
+
+  await db.insert(profileChatMessages).values([
+    { profileId, role: 'user', content: turn.userMessage, timestamp, position: next },
+    { profileId, role: 'assistant', content: turn.assistantMessage, timestamp, position: next + 1 },
+  ]);
+
+  // Keep the newest N. Expressed as "delete everything at or below the cutoff
+  // position" rather than "keep the last N ids", because the cutoff is computed
+  // from `position` — the column that defines the order — and an id-based
+  // version would depend on the id shape, which is exactly what this migration
+  // makes unreliable.
+  const cutoff = next + 1 - PROFILE_CHAT_HISTORY_LIMIT;
+  if (cutoff >= 0) {
+    await db
+      .delete(profileChatMessages)
+      .where(
+        sql`${profileChatMessages.profileId} = ${profileId} and ${profileChatMessages.position} <= ${cutoff}`,
+      );
+  }
+}
+
+/** Clear the profile's Sindi transcript. Returns how many turns went. */
+export async function clearProfileChatHistory(
+  db: DatabaseOrTransaction,
+  profileId: string,
+): Promise<number> {
+  const rows = await db
+    .delete(profileChatMessages)
+    .where(eq(profileChatMessages.profileId, profileId))
+    .returning({ id: profileChatMessages.id });
+  return rows.length;
+}

--- a/packages/backend/db/profiles/profileSerializer.ts
+++ b/packages/backend/db/profiles/profileSerializer.ts
@@ -1,0 +1,303 @@
+/**
+ * `profiles` row + its five child tables → the wire shape the profile screens
+ * read.
+ *
+ * `db/schema/profiles.ts` drops the `personalProfile.` wrapper from every column
+ * name, because keeping it would push
+ * `personal_profile_settings_roommate_preferences_lifestyle_cleanliness` to 68
+ * bytes and Postgres truncates an identifier at 63 SILENTLY. The WIRE shape is
+ * not changed by that decision: sixteen frontend modules read
+ * `profile.personalProfile.settings.roommate.…`, so the wrapper is rebuilt here
+ * rather than pushed onto every consumer.
+ *
+ * ## The nesting is rebuilt EXACTLY, including the blocks nothing reads
+ *
+ * `useProfileEditForm` and `profileEditSchema` round-trip the whole
+ * `personalProfile` subtree — the edit form reads a block, the user changes one
+ * field in it, and the client sends the block back. A key this module drops
+ * because no screen renders it would come back ABSENT on the next save and
+ * `updatePersonalProfile` would then write NULL over it. So "nothing reads it"
+ * is not a reason to omit a key; the round trip is what decides.
+ *
+ * ## Income is excluded at the TYPE level, not by omission here
+ *
+ * `profiles.personal_info_annual_income` is in
+ * `db/schema/protectedColumns.ts` — `settings.privacy.showIncome` defaults to
+ * FALSE, so the product's own default is that nobody sees it. Reads go through
+ * {@link profileSelection}, so the column is not in {@link ProfileRow} at all
+ * and this module could not emit it if it tried. A viewer who may see it is a
+ * decision the application still has to make; this only makes forgetting to ask
+ * a compile error.
+ *
+ * The same reasoning is why {@link toProfileDTO} takes a `visibility` argument
+ * rather than deciding for itself: whether a caller is the owner is a fact about
+ * the REQUEST, and a serializer that guessed it would be guessing on every call
+ * site at once.
+ */
+
+import type { InferSelectModel } from 'drizzle-orm';
+import { publicColumns } from '../schema/protectedColumns';
+import type {
+  profileChatMessages,
+  profilePreferredLocations,
+  profileReferences,
+  profileRentalHistory,
+  profileRoommateHistory,
+  profiles,
+} from '../schema';
+import { profiles as profilesTable } from '../schema';
+
+/** The sanctioned selection — every column except the annual income. */
+export function profileSelection() {
+  return publicColumns(profilesTable);
+}
+
+/** A profile row as this module receives it — no annual income. */
+export type ProfileRow = Omit<InferSelectModel<typeof profiles>, 'personalInfoAnnualIncome'>;
+
+export type ProfileReferenceRow = InferSelectModel<typeof profileReferences>;
+export type ProfileRentalHistoryRow = InferSelectModel<typeof profileRentalHistory>;
+export type ProfilePreferredLocationRow = InferSelectModel<typeof profilePreferredLocations>;
+export type ProfileRoommateHistoryRow = InferSelectModel<typeof profileRoommateHistory>;
+export type ProfileChatMessageRow = InferSelectModel<typeof profileChatMessages>;
+
+/** One profile plus every child row a response carries with it. */
+export interface HydratedProfile {
+  readonly profile: ProfileRow;
+  readonly references: readonly ProfileReferenceRow[];
+  readonly rentalHistory: readonly ProfileRentalHistoryRow[];
+  readonly preferredLocations: readonly ProfilePreferredLocationRow[];
+  readonly roommateHistory: readonly ProfileRoommateHistoryRow[];
+  readonly chatHistory: readonly ProfileChatMessageRow[];
+}
+
+/**
+ * Who is looking.
+ *
+ * `owner` is the authenticated person's own profile (`GET /api/profiles/me`);
+ * `public` is anybody else (`GET /api/profiles/oxy/:oxyUserId`, and the
+ * unauthenticated `/api/public/profiles/*` pair).
+ */
+export type ProfileVisibilityScope = 'owner' | 'public';
+
+function toReferenceDTO(row: ProfileReferenceRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    name: row.name,
+    relationship: row.relationship,
+    phone: row.phone,
+    email: row.email,
+    verified: row.verified,
+  };
+}
+
+/**
+ * One rental-history entry, with the two halves disclosed independently.
+ *
+ * The halves are gated by DIFFERENT flags because the product reads them for
+ * different things, and collapsing them into one gate breaks a live feature
+ * either way round:
+ *
+ *  - **`landlordContact` ⇢ `settings.privacy.showContactInfo` (default TRUE).**
+ *    `app/properties/[id]` fetches an owner's PUBLIC profile and dials
+ *    `personalProfile.rentalHistory[0].landlordContact.phone`, gating on exactly
+ *    this flag. So gating the contact on `showRentalHistory` would silently kill
+ *    "call the owner" for every user, since that flag defaults to FALSE.
+ *  - **The tenancy itself ⇢ `settings.privacy.showRentalHistory` (default
+ *    FALSE).** Where a person lived, for how much, and why they left is the
+ *    block the schema's own default says nobody sees.
+ *
+ * A key that is not disclosed is ABSENT rather than `null`. The distinction is
+ * load-bearing on this table: `null` means the person never recorded the value,
+ * and `updatePersonalProfile` round-trips what the edit form sends back — so a
+ * `null` returned to a viewer who may not see it would read as "there is nothing
+ * here" to anybody reasoning about the response.
+ */
+function toRentalHistoryDTO(
+  row: ProfileRentalHistoryRow,
+  disclose: { readonly tenancy: boolean; readonly contact: boolean },
+): Record<string, unknown> {
+  return {
+    id: row.id,
+    ...(disclose.tenancy
+      ? {
+          address: row.address,
+          startDate: row.startDate,
+          endDate: row.endDate,
+          monthlyRent: row.monthlyRent,
+          reasonForLeaving: row.reasonForLeaving,
+          verified: row.verified,
+        }
+      : {}),
+    // `landlordContact` was a closed three-field subdocument in Mongo and is
+    // three columns here; the wire keeps the object, for the same reason the
+    // `personalProfile` wrapper is rebuilt.
+    ...(disclose.contact
+      ? {
+          landlordContact: {
+            name: row.landlordContactName,
+            phone: row.landlordContactPhone,
+            email: row.landlordContactEmail,
+          },
+        }
+      : {}),
+  };
+}
+
+function toPreferredLocationDTO(row: ProfilePreferredLocationRow): Record<string, unknown> {
+  return { id: row.id, city: row.city, state: row.state, radius: row.radius };
+}
+
+function toRoommateHistoryDTO(row: ProfileRoommateHistoryRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    startDate: row.startDate,
+    endDate: row.endDate,
+    location: row.location,
+    roommateCount: row.roommateCount,
+    reason: row.reason,
+  };
+}
+
+function toChatMessageDTO(row: ProfileChatMessageRow): Record<string, unknown> {
+  return { id: row.id, role: row.role, content: row.content, timestamp: row.timestamp };
+}
+
+/**
+ * The `personalProfile` subtree, rebuilt from the flattened columns and the
+ * child rows.
+ *
+ * Every value is emitted as stored, NULL included. Mongoose never materialized
+ * `personalProfile` (it is declared with no `default`), so a column being NULL
+ * means the person never answered — which is a different fact from the schema's
+ * default, and the edit form renders the two differently.
+ */
+function toPersonalProfile(
+  hydrated: HydratedProfile,
+  visibility: ProfileVisibilityScope,
+): Record<string, unknown> {
+  const { profile } = hydrated;
+
+  // The owner always sees their whole profile; everything below is what a
+  // STRANGER gets. A viewer-specific decision, which is why it is made here from
+  // the scope the caller passed rather than inside the repository — the
+  // repository cannot know who asked.
+  //
+  // Mongo returned the entire document on both public routes, income and
+  // landlord phone numbers included. That is a deliberate behaviour CHANGE here,
+  // not a discovery: `showReferences` and `showRentalHistory` default to FALSE,
+  // so the product's own default already says a stranger does not see either
+  // block, and `/api/public/profiles/*` needs no authentication at all. It costs
+  // nothing today — both child tables hold ZERO rows in production — which is
+  // why this is the batch to make it true in.
+  const owner = visibility === 'owner';
+  const showReferences = owner || profile.settingsPrivacyShowReferences === true;
+  const showTenancy = owner || profile.settingsPrivacyShowRentalHistory === true;
+  const showContact = owner || profile.settingsPrivacyShowContactInfo === true;
+
+  return {
+    personalInfo: {
+      bio: profile.personalInfoBio,
+      occupation: profile.personalInfoOccupation,
+      employer: profile.personalInfoEmployer,
+      employmentStatus: profile.personalInfoEmploymentStatus,
+      moveInDate: profile.personalInfoMoveInDate,
+      leaseDuration: profile.personalInfoLeaseDuration,
+    },
+    preferences: {
+      propertyTypes: profile.preferencesPropertyTypes,
+      maxRent: profile.preferencesMaxRent,
+      priceUnit: profile.preferencesPriceUnit,
+      minBedrooms: profile.preferencesMinBedrooms,
+      minBathrooms: profile.preferencesMinBathrooms,
+      preferredAmenities: profile.preferencesPreferredAmenities,
+      preferredLocations: hydrated.preferredLocations.map(toPreferredLocationDTO),
+      petFriendly: profile.preferencesPetFriendly,
+      smokingAllowed: profile.preferencesSmokingAllowed,
+      furnished: profile.preferencesFurnished,
+      parkingRequired: profile.preferencesParkingRequired,
+      accessibility: profile.preferencesAccessibility,
+    },
+    references: showReferences ? hydrated.references.map(toReferenceDTO) : [],
+    rentalHistory:
+      showTenancy || showContact
+        ? hydrated.rentalHistory.map((row) =>
+            toRentalHistoryDTO(row, { tenancy: showTenancy, contact: showContact }),
+          )
+        : [],
+    verification: {
+      identity: profile.verificationIdentity,
+      income: profile.verificationIncome,
+      background: profile.verificationBackground,
+      rentalHistory: profile.verificationRentalHistory,
+      references: profile.verificationReferences,
+    },
+    settings: {
+      notifications: {
+        email: profile.settingsNotificationsEmail,
+        push: profile.settingsNotificationsPush,
+        sms: profile.settingsNotificationsSms,
+        propertyAlerts: profile.settingsNotificationsPropertyAlerts,
+        viewingReminders: profile.settingsNotificationsViewingReminders,
+        leaseUpdates: profile.settingsNotificationsLeaseUpdates,
+      },
+      privacy: {
+        profileVisibility: profile.settingsPrivacyProfileVisibility,
+        showContactInfo: profile.settingsPrivacyShowContactInfo,
+        showIncome: profile.settingsPrivacyShowIncome,
+        showRentalHistory: profile.settingsPrivacyShowRentalHistory,
+        showReferences: profile.settingsPrivacyShowReferences,
+      },
+      roommate: {
+        enabled: profile.settingsRoommateEnabled,
+        preferences: {
+          ageRange: {
+            min: profile.settingsRoommatePreferencesAgeRangeMin,
+            max: profile.settingsRoommatePreferencesAgeRangeMax,
+          },
+          gender: profile.settingsRoommatePreferencesGender,
+          lifestyle: {
+            smoking: profile.settingsRoommatePreferencesLifestyleSmoking,
+            pets: profile.settingsRoommatePreferencesLifestylePets,
+            partying: profile.settingsRoommatePreferencesLifestylePartying,
+            cleanliness: profile.settingsRoommatePreferencesLifestyleCleanliness,
+            schedule: profile.settingsRoommatePreferencesLifestyleSchedule,
+          },
+          budget: {
+            min: profile.settingsRoommatePreferencesBudgetMin,
+            max: profile.settingsRoommatePreferencesBudgetMax,
+          },
+          moveInDate: profile.settingsRoommatePreferencesMoveInDate,
+          leaseDuration: profile.settingsRoommatePreferencesLeaseDuration,
+        },
+        history: hydrated.roommateHistory.map(toRoommateHistoryDTO),
+      },
+      language: profile.settingsLanguage,
+      timezone: profile.settingsTimezone,
+      currency: profile.settingsCurrency,
+    },
+    // The Sindi transcript kept on the profile. Owner-only: it is the person's
+    // own conversation with the assistant and no privacy flag ever gated it,
+    // because in Mongo it was only ever read back by its owner.
+    chatHistory: visibility === 'owner' ? hydrated.chatHistory.map(toChatMessageDTO) : [],
+  };
+}
+
+/**
+ * The wire shape `GET /api/profiles/me` and the two public reads return.
+ *
+ * `id` and not `_id`: Mongoose's `toJSON` transform renamed it and PR #287 made
+ * that a clean cut across the wire contract.
+ */
+export function toProfileDTO(
+  hydrated: HydratedProfile,
+  visibility: ProfileVisibilityScope,
+): Record<string, unknown> {
+  return {
+    id: hydrated.profile.id,
+    oxyUserId: hydrated.profile.oxyUserId,
+    personalProfile: toPersonalProfile(hydrated, visibility),
+    createdAt: hydrated.profile.createdAt,
+    updatedAt: hydrated.profile.updatedAt,
+  };
+}

--- a/packages/backend/routes/ai.ts
+++ b/packages/backend/routes/ai.ts
@@ -1,16 +1,62 @@
 /**
- * AI Routes — streaming, search, conversations (refactor)
+ * AI Routes — streaming, search, conversations.
+ *
+ * ## The conversation surface here was BROKEN, and the port is the fix
+ *
+ * `2d1376a` renamed `Conversation.profileId` to `oxyUserId` and updated the
+ * handlers that then lived in `controllers/ai/`. `eeb4845` deleted that
+ * directory; this file — the one `routes/index.ts` actually mounts at `/api/ai`
+ * — kept the old spelling. mongoose strict mode drops a path the schema does not
+ * declare, so every `new Conversation({ profileId })` lost the field and then
+ * failed `required: true` on `oxyUserId`, and every `find({ profileId })`
+ * matched nothing. Production holds ZERO conversations as a result.
+ *
+ * The ported handlers key on the session's Oxy account id directly. There is no
+ * `Profile` lookup in front of them any more: `conversations.oxy_user_id` IS the
+ * owner, so resolving a profile first only added a 404 for a person who has
+ * never opened the profile screen.
+ *
+ * `/history` had the same defect one level up — it read and wrote
+ * `profile.chatHistory`, while `ProfileSchema` declares the array at
+ * `personalProfile.chatHistory`. Strict mode dropped it on write and returned
+ * `undefined` on read, so `GET` always answered `[]`, `POST` stored nothing and
+ * `DELETE` was a no-op. All five production profiles have an empty transcript.
  */
 
 import express, { Request, Response } from 'express';
-import mongoose from 'mongoose';
 import multer from 'multer';
 import { streamText, type CoreMessage } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { getOxyUserId } from '@oxyhq/core/server';
 import { getErrorMessage } from '../utils/errors';
 import { logger } from '../middlewares/logging';
-import { Profile, Conversation } from '../models';
+import { getDb } from '../db/postgres';
+import {
+  PLACEHOLDER_CONVERSATION_TITLE,
+  appendMessages,
+  createConversation,
+  deleteConversation,
+  findConversationForOwner,
+  listConversations,
+  renameConversation,
+  replaceMessages,
+  setConversationStatus,
+  shareConversation,
+  titleFromFirstUserMessage,
+  type ConversationRow,
+  type MessageInput,
+} from '../db/conversations/conversationRepository';
+import {
+  toConversationDTO,
+  toConversationSummaryDTO,
+  toMessageDTO,
+} from '../db/conversations/conversationSerializer';
+import {
+  appendProfileChatTurn,
+  clearProfileChatHistory,
+  ensureProfile,
+  listProfileChatHistory,
+} from '../db/profiles/profileRepository';
 import { resolveAddressDisplay } from '../services/geoDisplayService';
 import pdfParse from 'pdf-parse';
 
@@ -102,10 +148,128 @@ Avoid repetition:
 // -------------------------------
 /** Utilities */
 // -------------------------------
-const isObjectId = (id: string) => mongoose.Types.ObjectId.isValid(id);
 // Resolve the authenticated Oxy user id (or null) from a request whose session
 // was already populated by `@oxyhq/core/server` auth middleware in server.ts.
 const getUserId = (req: Request): string | null => getOxyUserId(req);
+
+/**
+ * The client's own placeholder id for a chat it has not saved yet.
+ *
+ * `store/conversationStore.ts` mints `conv_<timestamp>` locally so a new chat
+ * renders before the server has heard of it, and sends it back on the first
+ * `/stream`. It is a request to CREATE, not a lookup key, and it is the reason
+ * this file cannot simply treat every `conversationId` as an id.
+ */
+const CLIENT_PLACEHOLDER_PREFIX = 'conv_';
+const isClientPlaceholderId = (id: string): boolean => id.startsWith(CLIENT_PLACEHOLDER_PREFIX);
+
+/**
+ * Tell the client which stored conversation its turn landed in.
+ *
+ * Sent whenever `/stream` CREATED one, which is wider than the Mongo handler:
+ * that only set the header when the client had supplied a `conv_…` placeholder,
+ * so a request carrying no `conversationId` at all created a conversation and
+ * never told anybody its id — an orphan on every such call. Widening it is
+ * safe in the only direction that matters, since a client that ignores the
+ * header is unaffected.
+ */
+function announceConversationId(
+  res: Response,
+  conversation: ConversationRow | undefined,
+  isNew: boolean,
+): void {
+  if (isNew && conversation) res.setHeader('X-Conversation-ID', conversation.id);
+}
+
+/**
+ * Narrow an untrusted role to one `conversation_messages_role_check` accepts.
+ *
+ * The CHECK would refuse anything else with a `23514`, which reaches the client
+ * as a 500 for input it should have been told about with a 400.
+ */
+const MESSAGE_ROLES = ['user', 'assistant', 'system'] as const;
+function isMessageRole(value: unknown): value is MessageInput['role'] {
+  return typeof value === 'string' && (MESSAGE_ROLES as readonly string[]).includes(value);
+}
+
+const CONVERSATION_STATUS_VALUES = ['active', 'archived', 'deleted'] as const;
+function isConversationStatus(value: unknown): value is ConversationRow['status'] {
+  return (
+    typeof value === 'string' && (CONVERSATION_STATUS_VALUES as readonly string[]).includes(value)
+  );
+}
+
+const ATTACHMENT_TYPES = ['file', 'image', 'document'] as const;
+
+/** The attachments off a request body, dropping anything that is not an object. */
+function readAttachmentInputs(value: unknown): MessageInput['attachments'] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return [];
+    const attachment = entry as Record<string, unknown>;
+    const type = attachment.type;
+    const size = attachment.size;
+    return [
+      {
+        type:
+          typeof type === 'string' && (ATTACHMENT_TYPES as readonly string[]).includes(type)
+            ? (type as (typeof ATTACHMENT_TYPES)[number])
+            : undefined,
+        name: typeof attachment.name === 'string' ? attachment.name : undefined,
+        url: typeof attachment.url === 'string' ? attachment.url : undefined,
+        size: typeof size === 'number' && Number.isFinite(size) ? size : undefined,
+      },
+    ];
+  });
+}
+
+/**
+ * The opening transcript off a request body.
+ *
+ * `messages` wins over `initialMessage`, matching the Mongo handler's
+ * `if (Array.isArray(messages)) … else if (initialMessage) …`. A turn with no
+ * usable role or content is DROPPED rather than defaulted to `user` with an
+ * empty string: `content` is `NOT NULL` and an empty assistant turn in a
+ * transcript is worse than a missing one.
+ */
+function readMessageInputs(messages: unknown, initialMessage: unknown): MessageInput[] {
+  if (Array.isArray(messages)) {
+    return messages.flatMap((entry) => {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return [];
+      const message = entry as Record<string, unknown>;
+      if (!isMessageRole(message.role)) return [];
+      if (typeof message.content !== 'string' || message.content === '') return [];
+      const timestamp =
+        typeof message.timestamp === 'string' || typeof message.timestamp === 'number'
+          ? new Date(message.timestamp)
+          : undefined;
+      return [
+        {
+          role: message.role,
+          content: message.content,
+          timestamp: timestamp && !Number.isNaN(timestamp.getTime()) ? timestamp : undefined,
+          attachments: readAttachmentInputs(message.attachments),
+        },
+      ];
+    });
+  }
+  if (typeof initialMessage === 'string' && initialMessage !== '') {
+    return [{ role: 'user', content: initialMessage }];
+  }
+  return [];
+}
+
+/**
+ * The two `mongoose.Types.ObjectId.isValid` guards that used to live here are
+ * DELETED rather than widened.
+ *
+ * `db/ids.ts` names this file specifically: the guard was reached through a
+ * local `isObjectId` wrapper, so a grep for the literal saw one site where there
+ * were three. Post-cutover it answers `false` for every uuid v7, so keeping it
+ * would 400 every conversation created from the cutover onward. A `text` column
+ * takes any string and a lookup for a nonsense id returns no rows, which is the
+ * 404 the handler already produces — so the guard has nothing left to do.
+ */
 const getBaseUrl = () => {
   const baseUrl = process.env.INTERNAL_API_BASE_URL || `http://localhost:${process.env.PORT || 3001}`;
   return baseUrl;
@@ -456,8 +620,11 @@ export default function aiRouter() {
       const userId = getUserId(req);
       if (!userId) return err(res, 401, 'Unauthorized');
 
-      const activeProfile = await Profile.findByOxyUserId(userId);
-      if (!activeProfile) return err(res, 404, 'No active profile found');
+      // The `Profile.findByOxyUserId` gate that stood here is GONE. It bound
+      // `activeProfile` and never read it: the profile row scoped nothing, so
+      // the only thing it did was 404 an authenticated caller who had never
+      // opened the profile screen. Same removal, same reason, as in `/stream`
+      // and `/history` — and the same reason `getUserId` above is the real gate.
 
       const { propertyContext, conversationContext } = req.body || {};
       
@@ -560,23 +727,28 @@ Return only the JSON array, no other text.`;
       const userId = getUserId(req);
       if (!userId) return err(res, 401, 'Unauthorized');
 
-      const activeProfile = await Profile.findByOxyUserId(userId);
-      if (!activeProfile) return err(res, 404, 'No active profile found');
-
-      // Ensure conversation
-      let conversation: any;
-      if (conversationId) {
-        if (conversationId.startsWith('conv_')) {
-          conversation = new Conversation({ profileId: activeProfile._id.toString(), title: 'New Conversation', messages: [], status: 'active' });
-          await conversation.save();
-        } else if (isObjectId(conversationId)) {
-          conversation = await Conversation.findOne({ _id: conversationId, profileId: activeProfile._id.toString() });
-        } else {
-          return err(res, 400, 'Invalid conversation ID format');
-        }
+      // No `Profile` lookup: `conversations.oxy_user_id` is the owner, so the
+      // "No active profile found" 404 was refusing a chat to anyone who had
+      // never opened the profile screen, for no benefit.
+      //
+      // A client placeholder id (`conv_…`), or none at all, means CREATE. A real
+      // id means look it up, scoped to the caller — the ownership is in the
+      // predicate, never a second statement.
+      const db = getDb();
+      let conversation: ConversationRow | undefined;
+      let conversationIsNew = false;
+      if (conversationId && !isClientPlaceholderId(conversationId)) {
+        conversation = (await findConversationForOwner(db, conversationId, userId))?.conversation;
       } else {
-        conversation = new Conversation({ profileId: activeProfile._id.toString(), title: 'New Conversation', messages: [], status: 'active' });
-        await conversation.save();
+        conversation = (
+          await db.transaction((tx) =>
+            createConversation(tx, {
+              oxyUserId: userId,
+              title: PLACEHOLDER_CONVERSATION_TITLE,
+            }),
+          )
+        ).conversation;
+        conversationIsNew = true;
       }
 
       const last = messages[messages.length - 1];
@@ -590,9 +762,7 @@ Return only the JSON array, no other text.`;
 
       // If last message is not user, return empty stream for clean client resolution
       if (!isLastTurnUser) {
-        if (conversationId && conversationId.startsWith('conv_') && conversation?._id) {
-          res.setHeader('X-Conversation-ID', conversation._id.toString());
-        }
+        announceConversationId(res, conversation, conversationIsNew);
         await sendEmptyStream(res);
         return;
       }
@@ -766,10 +936,15 @@ Return only the JSON array, no other text.`;
 
       // Save last user message (strip inline base64)
       const lastUser = messages[messages.length - 1];
-      if (conversation && lastUser?.role === 'user' && lastUser?.content) {
+      const savedUserContent =
+        conversation && lastUser?.role === 'user' && lastUser?.content
+          ? hasInlineFile
+            ? cleanedLastContent || 'Sent a file'
+            : String(lastUser.content)
+          : undefined;
+      if (conversation && savedUserContent) {
         try {
-          const toSave = hasInlineFile ? cleanedLastContent || 'Sent a file' : lastUser.content;
-          await conversation.addMessage('user', toSave);
+          await appendMessages(db, conversation.id, [{ role: 'user', content: savedUserContent }]);
         } catch (error: unknown) {
           logger.warn('Failed to persist user message to conversation', { error: getErrorMessage(error) });
         }
@@ -777,20 +952,32 @@ Return only the JSON array, no other text.`;
 
     // Capture AI stream for persistence
       let aiResponse = '';
+      const persisted = conversation;
       (async () => {
         try {
           for await (const chunk of (await result).textStream) aiResponse += chunk;
       // Always save assistant reply if we have one and the last turn was a user message
-      if (isLastTurnUser && conversation && aiResponse.trim()) {
-            await conversation.addMessage('assistant', aiResponse.trim());
+      if (isLastTurnUser && persisted && aiResponse.trim()) {
+            await appendMessages(db, persisted.id, [
+              { role: 'assistant', content: aiResponse.trim() },
+            ]);
 
-            if (conversation.title === 'New Conversation') {
-              const firstUser = conversation.messages.find((m: any) => m.role === 'user')?.content;
-              if (firstUser) {
-                const title = await generateAITitle(firstUser);
-                conversation.title = title || (firstUser.length > 50 ? `${firstUser.slice(0, 47)}...` : firstUser);
-                await conversation.save();
-              }
+            // Name the conversation from its first user turn, which is what
+            // Mongo's `pre('save')` hook did. The title is re-read from the
+            // ROW rather than from the local copy: `persisted` was loaded
+            // before the stream started and another turn may have renamed it
+            // since, and the rename is scoped to the owner either way.
+            const current = await findConversationForOwner(db, persisted.id, persisted.oxyUserId);
+            const firstUser = current?.messages.find((m) => m.message.role === 'user')?.message
+              .content;
+            if (current?.conversation.title === PLACEHOLDER_CONVERSATION_TITLE && firstUser) {
+              const generated = await generateAITitle(firstUser);
+              await renameConversation(
+                db,
+                persisted.id,
+                persisted.oxyUserId,
+                generated || titleFromFirstUserMessage(firstUser),
+              );
             }
           }
         } catch (error: unknown) {
@@ -798,9 +985,7 @@ Return only the JSON array, no other text.`;
         }
       })();
 
-      if (conversationId && conversationId.startsWith('conv_') && conversation?._id) {
-        res.setHeader('X-Conversation-ID', conversation._id.toString());
-      }
+      announceConversationId(res, conversation, conversationIsNew);
 
       onGracefulClose(req, res);
       (await result).pipeDataStreamToResponse(res);
@@ -825,8 +1010,11 @@ Return only the JSON array, no other text.`;
       const userId = getUserId(req);
       if (!userId) return err(res, 401, 'Unauthorized');
 
-      const activeProfile = await Profile.findByOxyUserId(userId);
-      if (!activeProfile) return err(res, 404, 'No active profile found');
+      // The `Profile.findByOxyUserId` gate that stood here is GONE. It bound
+      // `activeProfile` and never read it: the profile row scoped nothing, so
+      // the only thing it did was 404 an authenticated caller who had never
+      // opened the profile screen. Same removal, same reason, as in `/stream`
+      // and `/history` — and the same reason `getUserId` above is the real gate.
 
   const file = req.file;
       if (!file?.buffer) return err(res, 400, 'file is required (multipart/form-data, key: file)');
@@ -911,8 +1099,11 @@ Return only the JSON array, no other text.`;
       const userId = getUserId(req);
       if (!userId) return err(res, 401, 'Unauthorized');
 
-      const activeProfile = await Profile.findByOxyUserId(userId);
-      if (!activeProfile) return err(res, 404, 'No active profile found');
+      // The `Profile.findByOxyUserId` gate that stood here is GONE. It bound
+      // `activeProfile` and never read it: the profile row scoped nothing, so
+      // the only thing it did was 404 an authenticated caller who had never
+      // opened the profile screen. Same removal, same reason, as in `/stream`
+      // and `/history` — and the same reason `getUserId` above is the real gate.
 
   const file = req.file;
       if (!file?.buffer) return err(res, 400, 'file is required (multipart/form-data, key: file)');
@@ -988,15 +1179,28 @@ Return only the JSON array, no other text.`;
     }),
   );
 
-  // ---------- Legacy simple history on user ----------
+  // ---------- Legacy simple history on the profile ----------
+  //
+  // All three of these wrote `profile.chatHistory`, a path `ProfileSchema` does
+  // not declare (the array lives at `personalProfile.chatHistory`), so strict
+  // mode dropped it on every write and returned `undefined` on every read. The
+  // ported versions use `profile_chat_messages` — see the file header.
+  //
+  // The 404 for a person with no profile row is gone with the same reasoning as
+  // in `/stream`: the transcript belongs to an Oxy account, and creating the
+  // empty sidecar row is cheaper than refusing the request.
   router.get('/history', async (req: Request, res: Response) => {
     const userId = getUserId(req);
     if (!userId) return err(res, 401, 'Unauthorized');
 
-    const profile = await Profile.findByOxyUserId(userId);
-    if (!profile) return err(res, 404, 'Profile not found');
-
-    const history = Array.isArray(profile.chatHistory) ? [...profile.chatHistory].reverse() : [];
+    const db = getDb();
+    const profile = await db.transaction((tx) => ensureProfile(tx, userId));
+    const rows = await listProfileChatHistory(db, profile.profile.id);
+    // Newest first, matching the Mongo handler's `[...].reverse()` on an
+    // oldest-first array.
+    const history = [...rows]
+      .reverse()
+      .map((row) => ({ id: row.id, role: row.role, content: row.content, timestamp: row.timestamp }));
     return ok(res, { success: true, history });
   });
 
@@ -1004,111 +1208,84 @@ Return only the JSON array, no other text.`;
     const userId = getUserId(req);
     if (!userId) return err(res, 401, 'Unauthorized');
 
-    const profile = await Profile.findByOxyUserId(userId);
-    if (!profile) return err(res, 404, 'Profile not found');
-
-    profile.chatHistory = [];
-    await profile.save();
-    return ok(res, { success: true });
+    const db = getDb();
+    const profile = await db.transaction((tx) => ensureProfile(tx, userId));
+    const cleared = await clearProfileChatHistory(db, profile.profile.id);
+    return ok(res, { success: true, cleared });
   });
 
   router.post('/history', async (req: Request, res: Response) => {
     const userId = getUserId(req);
     if (!userId) return err(res, 401, 'Unauthorized');
 
-    const profile = await Profile.findByOxyUserId(userId);
-    if (!profile) return err(res, 404, 'Profile not found');
+    const { userMessage, assistantMessage } = (req.body ?? {}) as {
+      userMessage?: unknown;
+      assistantMessage?: unknown;
+    };
+    if (typeof userMessage !== 'string' || typeof assistantMessage !== 'string') {
+      return err(res, 400, 'Missing userMessage or assistantMessage');
+    }
 
-    const { userMessage, assistantMessage } = req.body || {};
-    if (!userMessage || !assistantMessage) return err(res, 400, 'Missing userMessage or assistantMessage');
-
-    profile.chatHistory = profile.chatHistory || [];
-    const now = new Date();
-    profile.chatHistory.push({ role: 'user', content: userMessage, timestamp: now });
-    profile.chatHistory.push({ role: 'assistant', content: assistantMessage, timestamp: now });
-    if (profile.chatHistory.length > 100) profile.chatHistory = profile.chatHistory.slice(-100);
-    await profile.save();
+    // One transaction: the append locks the profile row, inserts both turns and
+    // trims to the cap, and a partial application would leave the transcript
+    // holding a question with no answer.
+    await getDb().transaction(async (tx) => {
+      const profile = await ensureProfile(tx, userId);
+      await appendProfileChatTurn(tx, profile.profile.id, { userMessage, assistantMessage });
+    });
 
     return ok(res, { success: true });
   });
 
   // ---------- Conversation CRUD ----------
+  //
+  // Every handler below is scoped by `oxy_user_id` IN THE PREDICATE, so a
+  // conversation belonging to somebody else is indistinguishable from one that
+  // does not exist — a 404 either way, and no second authorisation statement to
+  // forget.
   router.get('/conversations', async (req: Request, res: Response) => {
     const userId = getUserId(req);
     if (!userId) return err(res, 401, 'Unauthorized');
 
-    const activeProfile = await Profile.findByOxyUserId(userId);
-    if (!activeProfile) return err(res, 404, 'No active profile found');
-
-    const conversations = await Conversation.find({ profileId: activeProfile._id.toString() }).sort({ updatedAt: -1 });
-    const transformed = conversations.map((c: any) => {
-      const o = c.toObject({ virtuals: true });
-      return {
-        id: o._id,
-        title: o.title,
-        status: o.status,
-        createdAt: o.createdAt,
-        updatedAt: o.updatedAt,
-        messageCount: o.messages?.length || 0,
-        lastMessage: o.messages?.[o.messages.length - 1] || null,
-        messages: o.messages || [],
-      };
-    });
-
-    return ok(res, { success: true, conversations: transformed });
+    const summaries = await listConversations(getDb(), userId);
+    return ok(res, { success: true, conversations: summaries.map(toConversationSummaryDTO) });
   });
 
   router.post('/conversations', async (req: Request, res: Response) => {
     const userId = getUserId(req);
     if (!userId) return err(res, 401, 'Unauthorized');
 
-    const activeProfile = await Profile.findByOxyUserId(userId);
-    if (!activeProfile) return err(res, 404, 'No active profile found');
+    const { title, initialMessage, messages } = (req.body ?? {}) as {
+      title?: unknown;
+      initialMessage?: unknown;
+      messages?: unknown;
+    };
 
-    const { title, initialMessage, messages } = req.body || {};
+    const opening = readMessageInputs(messages, initialMessage);
+    const db = getDb();
+    let hydrated = await db.transaction((tx) =>
+      createConversation(tx, {
+        oxyUserId: userId,
+        title: typeof title === 'string' ? title : undefined,
+        initialMessage: typeof initialMessage === 'string' ? initialMessage : undefined,
+        messages: opening,
+      }),
+    );
 
-    let conversationMessages: ChatMessage[] = [];
-    if (Array.isArray(messages)) {
-      conversationMessages = messages.map((m: any) => ({
-        role: m.role,
-        content: m.content,
-        timestamp: new Date(m.timestamp || Date.now()),
-      }));
-    } else if (initialMessage) {
-      conversationMessages = [{ role: 'user', content: initialMessage, timestamp: new Date() }];
-    }
-
-    const conversation = new Conversation({
-      profileId: activeProfile._id.toString(),
-      title: title || 'New Conversation',
-      messages: conversationMessages.map(m => ({ role: m.role || 'user', content: m.content || '', timestamp: m.timestamp || new Date() })),
-      status: 'active',
-    });
-
-    const saved = await conversation.save();
-
-    if (saved.messages.length && saved.title === 'New Conversation') {
-      const firstUser = saved.messages.find((m: any) => m.role === 'user')?.content;
-      if (firstUser) {
-        const aiTitle = await generateAITitle(firstUser);
-        if (aiTitle) {
-          saved.title = aiTitle;
-          await saved.save();
-        }
+    // Name it from the first user turn, as the Mongo handler did. The AI call
+    // is deliberately OUTSIDE the transaction: it is a network round trip to a
+    // third party, and holding a Postgres transaction open across one is how a
+    // slow provider turns into a connection-pool outage.
+    const firstUser = hydrated.messages.find((m) => m.message.role === 'user')?.message.content;
+    if (firstUser && hydrated.conversation.title === PLACEHOLDER_CONVERSATION_TITLE) {
+      const generated = await generateAITitle(firstUser);
+      if (generated) {
+        const renamed = await renameConversation(db, hydrated.conversation.id, userId, generated);
+        if (renamed) hydrated = { conversation: renamed, messages: hydrated.messages };
       }
     }
 
-    return ok(res, {
-      success: true,
-      conversation: {
-        id: saved._id,
-        title: saved.title,
-        messages: saved.messages,
-        createdAt: saved.createdAt,
-        updatedAt: saved.updatedAt,
-        status: saved.status,
-      },
-    });
+    return ok(res, { success: true, conversation: toConversationDTO(hydrated) });
   });
 
   router.get('/conversations/:id', async (req: Request, res: Response) => {
@@ -1116,66 +1293,87 @@ Return only the JSON array, no other text.`;
     if (!userId) return err(res, 401, 'Unauthorized');
 
     const conversationId = String(req.params.id || '');
-    if (!conversationId || !isObjectId(conversationId)) return err(res, 400, 'Invalid conversation ID');
+    if (!conversationId) return err(res, 400, 'Invalid conversation ID');
 
-    const activeProfile = await Profile.findByOxyUserId(userId);
-    if (!activeProfile) return err(res, 404, 'No active profile found');
+    const hydrated = await findConversationForOwner(getDb(), conversationId, userId);
+    if (!hydrated) return err(res, 404, 'Conversation not found');
 
-    const conversation = await Conversation.findOne({ _id: conversationId, profileId: activeProfile._id.toString() });
-    if (!conversation) return err(res, 404, 'Conversation not found');
-
-    return ok(res, { success: true, conversation });
+    return ok(res, { success: true, conversation: toConversationDTO(hydrated) });
   });
 
   router.put('/conversations/:id', async (req: Request, res: Response) => {
     const userId = getUserId(req);
     if (!userId) return err(res, 401, 'Unauthorized');
 
-    const activeProfile = await Profile.findByOxyUserId(userId);
-    if (!activeProfile) return err(res, 404, 'No active profile found');
+    const conversationId = String(req.params.id || '');
+    const { title, messages, status } = (req.body ?? {}) as {
+      title?: unknown;
+      messages?: unknown;
+      status?: unknown;
+    };
 
-    const { title, messages, status } = req.body || {};
-    const conversation = await Conversation.findOne({ _id: req.params.id, profileId: activeProfile._id.toString() });
-    if (!conversation) return err(res, 404, 'Conversation not found');
+    const db = getDb();
+    const hydrated = await db.transaction(async (tx) => {
+      const existing = await findConversationForOwner(tx, conversationId, userId);
+      if (!existing) return undefined;
 
-    if (typeof title === 'string') conversation.title = title;
-    if (Array.isArray(messages)) {
-      conversation.messages = messages.map((m: any) => ({ role: m.role, content: m.content, timestamp: new Date(m.timestamp || Date.now()) }));
-    }
-    if (typeof status === 'string') conversation.status = status;
+      if (typeof title === 'string') {
+        await renameConversation(tx, conversationId, userId, title);
+      }
+      if (isConversationStatus(status)) {
+        await setConversationStatus(tx, conversationId, userId, status);
+      }
+      if (Array.isArray(messages)) {
+        await replaceMessages(tx, conversationId, readMessageInputs(messages, undefined));
+      }
+      return findConversationForOwner(tx, conversationId, userId);
+    });
 
-    const saved = await conversation.save();
-    return ok(res, { success: true, conversation: saved });
+    if (!hydrated) return err(res, 404, 'Conversation not found');
+    return ok(res, { success: true, conversation: toConversationDTO(hydrated) });
   });
 
   router.post('/conversations/:id/messages', async (req: Request, res: Response) => {
     const userId = getUserId(req);
     if (!userId) return err(res, 401, 'Unauthorized');
 
-    const activeProfile = await Profile.findByOxyUserId(userId);
-    if (!activeProfile) return err(res, 404, 'No active profile found');
+    const conversationId = String(req.params.id || '');
+    const { role, content, attachments } = (req.body ?? {}) as {
+      role?: unknown;
+      content?: unknown;
+      attachments?: unknown;
+    };
+    if (!isMessageRole(role) || typeof content !== 'string' || content === '') {
+      return err(res, 400, 'Role and content are required');
+    }
 
-    const { role, content, attachments } = req.body || {};
-    if (!role || !content) return err(res, 400, 'Role and content are required');
+    const db = getDb();
+    // Ownership is checked BEFORE the append rather than folded into it:
+    // `appendMessages` works on a conversation id, and a stranger appending to
+    // somebody else's transcript must not be able to write the row first and be
+    // refused afterwards.
+    const owned = await findConversationForOwner(db, conversationId, userId);
+    if (!owned) return err(res, 404, 'Conversation not found');
 
-    const conversation = await Conversation.findOne({ _id: req.params.id, profileId: activeProfile._id.toString() });
-    if (!conversation) return err(res, 404, 'Conversation not found');
+    const [appended] = await appendMessages(db, conversationId, [
+      { role, content, attachments: readAttachmentInputs(attachments) },
+    ]);
+    const hydrated = await findConversationForOwner(db, conversationId, userId);
+    if (!hydrated) return err(res, 404, 'Conversation not found');
 
-    const newMessage = { role, content, timestamp: new Date(), attachments: attachments || [] };
-    conversation.messages.push(newMessage);
-    await conversation.save();
-
-    return ok(res, { success: true, message: newMessage, conversation });
+    const message = hydrated.messages.find((m) => m.message.id === appended.id);
+    return ok(res, {
+      success: true,
+      message: message ? toMessageDTO(message) : null,
+      conversation: toConversationDTO(hydrated),
+    });
   });
 
   router.delete('/conversations/:id', async (req: Request, res: Response) => {
     const userId = getUserId(req);
     if (!userId) return err(res, 401, 'Unauthorized');
 
-    const activeProfile = await Profile.findByOxyUserId(userId);
-    if (!activeProfile) return err(res, 404, 'No active profile found');
-
-    const deleted = await Conversation.findOneAndDelete({ _id: req.params.id, profileId: activeProfile._id.toString() });
+    const deleted = await deleteConversation(getDb(), String(req.params.id || ''), userId);
     if (!deleted) return err(res, 404, 'Conversation not found');
 
     return ok(res, { success: true, message: 'Conversation deleted' });
@@ -1185,16 +1383,14 @@ Return only the JSON array, no other text.`;
     const userId = getUserId(req);
     if (!userId) return err(res, 401, 'Unauthorized');
 
-    const activeProfile = await Profile.findByOxyUserId(userId);
-    if (!activeProfile) return err(res, 404, 'No active profile found');
+    const shared = await shareConversation(getDb(), String(req.params.id || ''), userId);
+    if (!shared) return err(res, 404, 'Conversation not found');
 
-    const conversation = await Conversation.findOne({ _id: req.params.id, profileId: activeProfile._id.toString() });
-    if (!conversation) return err(res, 404, 'Conversation not found');
-
-    await conversation.generateShareToken();
-    const token = conversation.sharing?.shareToken;
-
-    return ok(res, { success: true, shareToken: token, shareUrl: `/shared/${token}` });
+    return ok(res, {
+      success: true,
+      shareToken: shared.token,
+      shareUrl: `/shared/${shared.token}`,
+    });
   });
 
   return router;

--- a/packages/backend/routes/public.ts
+++ b/packages/backend/routes/public.ts
@@ -15,7 +15,9 @@ import * as reviewController from '../controllers/reviewController';
 import { asyncHandler } from '../middlewares';
 import { serializeWireIds } from '../middlewares/wireIds';
 import performanceMonitor from '../middlewares/performance';
-import { Conversation } from '../models';
+import { findConversationByShareToken } from '../db/conversations/conversationRepository';
+import { toSharedConversationDTO } from '../db/conversations/conversationSerializer';
+import { getDb } from '../db/postgres';
 import * as profileController from '../controllers/profile';
 import * as evictionController from '../controllers/eviction';
 
@@ -248,29 +250,24 @@ export default function () {
   router.get('/public/profiles/by-user/:oxyUserId', asyncHandler(profileController.getPublicProfileByOxyUserId));
   router.get('/public/profiles/oxy/:oxyUserId', asyncHandler(profileController.getProfileByOxyUserId));
 
-  // Public shared conversation endpoint (no authentication required)
+  // Public shared conversation endpoint (no authentication required).
+  //
+  // The freshness check is in the QUERY (`findConversationByShareToken` requires
+  // `is_shared`, a non-null token and a deadline in the future), so an expired
+  // link is 404 whether or not the share-link sweep has run since. That is what
+  // keeps the sweep pure housekeeping rather than a correctness dependency —
+  // and it is why Mongo's TTL index, which deleted the whole conversation 24
+  // hours after anybody shared it, was never needed for this route to be right.
+  //
+  // The `try/catch` that used to swallow every failure into a 500 is gone:
+  // `asyncHandler` forwards to `errorHandler`, which is the one place that
+  // decides what a caller sees.
   router.get('/ai/shared/:token', asyncHandler(async (req, res) => {
-    try {
-      const conversation = await Conversation.findByShareToken(req.params.token);
-      
-      if (!conversation) {
-        return res.status(404).json({ error: 'Shared conversation not found or expired' });
-      }
-
-      // Return conversation without sensitive user data, including status field
-      const sharedConversation = {
-        id: conversation._id,
-        title: conversation.title,
-        messages: conversation.messages,
-        createdAt: conversation.createdAt,
-        updatedAt: conversation.updatedAt,
-        status: conversation.status || 'active'
-      };
-
-      res.json({ success: true, conversation: sharedConversation });
-    } catch {
-      res.status(500).json({ error: 'Failed to get shared conversation' });
+    const hydrated = await findConversationByShareToken(getDb(), String(req.params.token || ''));
+    if (!hydrated) {
+      return res.status(404).json({ error: 'Shared conversation not found or expired' });
     }
+    res.json({ success: true, conversation: toSharedConversationDTO(hydrated) });
   }));
 
   return router;

--- a/packages/backend/services/cron.ts
+++ b/packages/backend/services/cron.ts
@@ -7,6 +7,8 @@ import { syncCovers } from './cityCoverSyncService';
 import { repairCorruptCityCoordinates } from './cityCoordinateRepairService';
 import { sendEvictionOutcomeReminders } from './evictionOutcomeReminderService';
 import { reconcileModerationReports } from './moderation/ModerationReconciliation';
+import { expireShareLinks } from '../db/conversations/conversationRepository';
+import { getDb } from '../db/postgres';
 import config from '../config';
 import { Property } from '../models';
 
@@ -41,6 +43,7 @@ class CronJobManager {
     this.setupHealthCheckJob();
     this.setupCleanupJob();
     this.setupCityCoverSyncJob();
+    this.setupShareLinkExpiryJob();
     this.setupEvictionOutcomeReminderJob();
     this.setupModerationReconciliationJob();
     // Boot sweeps: repair mangled coords + start Wikimedia cover backfill
@@ -122,6 +125,49 @@ class CronJobManager {
     this.jobs.set('cleanup', job);
     this.jobStatus.set('cleanup', { isRunning: true, lastRun: undefined, nextRun: undefined });
     job.start();
+  }
+
+  /**
+   * Setup the share-link expiry sweep — hourly.
+   *
+   * **This is the port of Mongo's TTL index on `Conversation.sharing.expiresAt`,
+   * and it CLEARS four columns where Mongo deleted the whole row.** That index
+   * destroyed the conversation and every message in it 24 hours after anybody
+   * pressed Share, so replicating it would be replicating data loss;
+   * `db/expiry.ts` names the column in `EXPIRY_COLUMNS_THAT_MUST_NOT_DELETE` and
+   * `__tests__/db/expiry.test.ts` fails the build if it is ever registered as a
+   * sweep target, which is why this job is here and not in `EXPIRY_SWEEP_TARGETS`.
+   *
+   * Nothing depends on it having run: `findConversationByShareToken` refuses an
+   * expired token in its own predicate. The sweep exists so a token that is no
+   * longer usable stops being STORED, and so the partial unique index stays the
+   * size of the live set.
+   */
+  private setupShareLinkExpiryJob(): void {
+    const job = cron.schedule('7 * * * *', async () => {
+      await this.runShareLinkExpiry();
+    }, {
+      timezone: 'UTC',
+      scheduled: false,
+    });
+
+    this.jobs.set('shareLinks', job);
+    this.jobStatus.set('shareLinks', { isRunning: true, lastRun: undefined, nextRun: undefined });
+    job.start();
+  }
+
+  private async runShareLinkExpiry(): Promise<void> {
+    this.jobStatus.set('shareLinks', { isRunning: true, lastRun: new Date() });
+    try {
+      const cleared = await expireShareLinks(getDb());
+      if (cleared > 0) {
+        this.logger.info('Cleared expired conversation share links', { cleared });
+      }
+    } catch (error) {
+      this.logger.error('Share link expiry sweep failed', error);
+    } finally {
+      this.jobStatus.set('shareLinks', { isRunning: false, lastRun: new Date() });
+    }
   }
 
   /**


### PR DESCRIPTION
Ports the **conversations** domain and the **profiles** batch it depends on, following the shape the earlier batches set: repositories under `packages/backend/db/<domain>/` taking the connection as a parameter, controllers calling repositories rather than drizzle, and the real-Postgres harness rather than mocked drizzle calls.

## The conversation surface had never worked

Not a porting detail — the reason production holds **zero** conversations.

`2d1376a` renamed `Conversation.profileId` → `oxyUserId` and updated the handlers in `controllers/ai/`. `eeb4845` deleted that directory, and `routes/ai.ts` — the file `routes/index.ts` actually mounts at `/api/ai` — kept the old spelling. mongoose strict mode drops a path the schema does not declare, so:

- every `new Conversation({ profileId })` lost the field, then failed `required: true` on `oxyUserId`;
- every `find({ profileId })` filtered on a phantom field and returned `[]`, so the client saw an empty history rather than an error.

Verified against this repository's mongoose 8.24.1 rather than reasoned about — the constructed document holds `undefined` for both fields and `validateSync()` reports ``Path `oxyUserId` is required``. The collection still carries **both** generations of index (`profileId_1` beside `oxyUserId_1_status_1_updatedAt_-1`), which is the fingerprint of the half-finished rename.

`/ai/history` had the same defect one level up: it read and wrote `profile.chatHistory` while `ProfileSchema` declares the array at `personalProfile.chatHistory`. `GET` always answered `[]`, `POST` stored nothing, `DELETE` was a no-op — all five production profiles have an empty transcript.

## Row counts, measured on both stores

From a one-shot on the live task definition, because the premise that profiles were half-copied needed checking rather than assuming:

| | Mongo | Postgres |
|---|--:|--:|
| `profiles` | **5** | **5** — the SAME five `oxy_user_id`s, all 24-char hex |
| `profile_references` / `_rental_history` / `_preferred_locations` / `_roommate_history` / `_chat_messages` | 0 | 0 |
| `conversations` / `conversation_messages` / `_attachments` | 0 | 0 / 0 / 0 |

**The copy is complete; the apparent gap is an artefact of the comparison**, not of the backfill. The population is small for a reason worth stating, since five otherwise looks wrong: all 17,644 properties are external listings carrying no `oxy_user_id`, so there is no larger set of "profiles reachable from properties" a backfill could have missed — the join that would find them is empty on the other side.

## Ordering — the part that breaks quietly

A uuid v7 minted now begins `0199…`; an ObjectId minted this year begins `69…`/`6a…`. `'0' < '6'`, so a lexicographic id sort puts **every new row before every legacy one**. A backfilled transcript would render with every reply the user has since added hoisted above the question it answers — silently, and only for rows spanning the cutover, which is the set no hand-written fixture contains.

- messages → `position`, with `timestamp` as tiebreaker
- conversations → `updated_at desc`, with the id as a tiebreaker **only**

`__tests__/db/conversationOrdering.test.ts` mixes a legacy hex id with a uuid v7 and additionally asserts the **id ordering disagrees**, so a fixture that stops being adversarial fails loudly instead of passing vacuously. Mutation-tested three ways, each turning the suite red and naming the offender: ordering messages by id (2 red), ordering the list by id (1 red), dropping `qualified()` from the correlated subqueries (1 red).

That suite also caught a bug `tsc` cannot see: **`max()` over a `bigint` comes back from postgres.js as a STRING**, so `max + 1` was string concatenation and the second append landed at position **710 instead of 8**. `sql<number>` is an assertion, not a cast; both position readers now cast in SQL.

## Denormalisation, decided per field

| Mongo | Here | Why |
|---|---|---|
| `analytics.messageCount` | `count(*)` in one lateral | a `pre('save')` hook maintained it; there is no hook here and it is not a sort key, so a stored counter would have a writer nobody can see |
| `lastMessage` (virtual) | same lateral | already computed per read in Mongo — storing it would be new denormalisation, not a port |
| `analytics.lastActivity` | **kept**, `touchActivity` is its hook | not derivable: it moved on any save, not only an append |
| `analytics.totalTokens` | **kept** | comes from the provider's response, not the stored text |

There is no participant list and no unread counter in this model — a conversation has one owner.

## The share-link TTL is ported as a CLEAR, never a delete

Mongo's `expireAfterSeconds: 0` on `sharing.expiresAt` destroyed the whole conversation, transcript included, 24 hours after anybody pressed Share. `services/cron.ts` now clears the four `sharing_*` columns hourly; the read side refuses an expired token in its own predicate, so nothing depends on the sweep having run.

## Also

- The two `isValidObjectId` guards `db/ids.ts` names in this file are **deleted, not widened** — they answer `false` for every uuid v7.
- The profile write goes through an explicit column allow-list (`profileWriteColumns.ts`), never a spread: drizzle **ignores** an unknown key rather than refusing it, so a spread would succeed, report success and store nothing.
- The five-minute in-process profile cache is gone — one invalidation path per process cannot be correct across several ECS tasks.
- `/api/public/profiles/*` (no authentication) stops returning references and tenancy detail to a stranger, gated on flags the product already has. The landlord contact is gated on `showContactInfo` **separately**, because `app/properties/[id]` dials `rentalHistory[0].landlordContact.phone` off a public profile — gating it on `showRentalHistory` (default false) would have silently killed "call the owner".
- `controllers/profile/shared.ts` no longer re-exports any Mongoose model: combined with #308, every handler in that directory is on Postgres, which makes it a property of the module graph rather than of everybody remembering.

## Gates

`typecheck` clean · `lint` 0 errors (0 warnings in new files) · `check:lockfile` in sync · backend build green · **119 suites / 1531 tests pass** on the rebased tree. Baseline taken on the base revision first (109/1352, fully green) so nothing here is attributed to the wrong cause.

## Left behind, deliberately — needs an owner

Both are **pre-existing seams this PR does not widen**, but it removes the Mongo profile writer, so they are worth routing now:

1. **`controllers/property/retrieve.ts` still writes the Mongo `RecentlyViewed` collection**, keyed by a Mongo `profileId`, while #308 moved the READ to `db/saved/recentlyViewedRepository` keyed by `oxyUserId`. `trackPropertyView` already exists and this call site was never switched to it, so the write and read are in different stores. Not touched here: that file carries an explicit "writes stay on Mongo for the dual-run" policy and belongs to the property-writes batch. Zero user-visible impact today (the collection holds 0 documents).
2. **`controllers/roommateController.ts` (18 sites) and `controllers/analyticsController.ts` (1) still read Mongo `profiles`.** Since profile writes now go to Postgres, a user enabling roommate mode will not be seen by the matcher. Unobservable today — no production profile has roommate enabled and no user owns a listing for analytics to report on — but it is a real divergence and the roommate matcher is its own batch (its `personalProfile.gender` / `.location` / `.dateOfBirth` filters are themselves strict-mode drops that match nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/homiio/pull/310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->