### PR TITLE
Move reservations to Postgres — the last tenancy table (#281)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,9 @@ jobs:
       # glob that stops matching all produce an empty green run, and that reads as
       # coverage forever because nothing contradicts it.
       #
-      # RAISED FROM 1345 TO 1380 by the exchanges port, which added
+      # RAISED FROM 1380 TO 1415 by the reservations port — the last tenancy
+      # table — which added `reservations.test.ts`. Before that it went
+      # 1345 -> 1380 for the exchanges port, which added
       # `exchangeRequests.test.ts` — measured 1398 -> 1424. Before that it went
       # 1310 -> 1345 for the viewings + applications port, which
       # added two real-database suites — measured 1352 -> 1389. Before that it
@@ -210,7 +212,7 @@ jobs:
         if: always()
         run: >-
           bun .github/scripts/assert-test-floor.mjs
-          "$RUNNER_TEMP/backend-tests.json" packages/backend 1380
+          "$RUNNER_TEMP/backend-tests.json" packages/backend 1415
 
   frontend:
     runs-on: ubuntu-24.04

--- a/packages/backend/__tests__/integration/reservations.test.ts
+++ b/packages/backend/__tests__/integration/reservations.test.ts
@@ -1,0 +1,477 @@
+/**
+ * Reservations — pricing, the two calendar conflicts, the cancellation policy
+ * and the three range CHECKs. Against the REAL Postgres.
+ *
+ * ## What makes these tests non-vacuous
+ *
+ * `reservations` was empty in production. Each case targets a rule with a way
+ * to be wrong:
+ *
+ *  - both overlap checks are asserted at the EXACT boundary, from ONE base
+ *    instant, because `[)` and `[]` agree everywhere else — the vacuity that
+ *    bit the exchanges suite in #309, where `Date.now()` per call put the two
+ *    "adjacent" windows milliseconds apart and three closed-bound mutations all
+ *    survived,
+ *  - the priced fields are asserted on their VALUES, not on being present: a
+ *    `nights` off by one, or taxes on the wrong base, is money,
+ *  - the three range CHECKs are asserted on what they refuse,
+ *  - every refusal re-reads the row.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { eq } from 'drizzle-orm';
+
+import reservationController from '../../controllers/reservationController';
+import { getDb } from '../../db/postgres';
+import { propertyAvailabilityWindows, reservations } from '../../db/schema';
+import { errorHandler } from '../../middlewares/errorHandler';
+import { resetGeoTables, seedListingWithGeo } from '../helpers/postgresGeoFixtures';
+
+function buildApp(oxyUserId?: string): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (oxyUserId) {
+      const authed = req as unknown as { user: { id: string }; userId: string };
+      authed.user = { id: oxyUserId };
+      authed.userId = oxyUserId;
+    }
+    next();
+  });
+  app.post('/reservations', (req, res, next) => reservationController.createReservation(req, res, next));
+  app.get('/reservations', (req, res, next) => reservationController.listMyReservations(req, res, next));
+  app.get('/reservations/:id', (req, res, next) => reservationController.getReservationById(req, res, next));
+  app.patch('/reservations/:id', (req, res, next) => reservationController.updateReservationStatus(req, res, next));
+  app.get('/properties/:id/availability', (req, res, next) => reservationController.getPropertyAvailability(req, res, next));
+  app.use(errorHandler);
+  return app;
+}
+
+/** A distinct ISO-3166 alpha-2 per geo chain — `countries_code_key` is UNIQUE. */
+let geoChainCounter = 0;
+function nextCountryCode(): string {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const index = geoChainCounter++;
+  return `${alphabet[Math.floor(index / 26) % 26]}${alphabet[index % 26]}`;
+}
+
+/** A vacation-bookable listing. Pricing is explicit so the maths is checkable. */
+async function seedBookableProperty(
+  overrides: Record<string, unknown> = {},
+): Promise<string> {
+  const { propertyId } = await seedListingWithGeo({
+    countryCode: nextCountryCode(),
+    overrides: {
+      oxyUserId: 'oxy-host',
+      status: 'published',
+      isExternal: false,
+      // `properties_offerings_short_term_rent_check` makes the offering exactly
+      // the presence of `nightly_rate`, so the two move together.
+      offerings: ['short_term_rent'],
+      shortTermRentNightlyRate: 100,
+      shortTermRentCurrency: 'EUR',
+      shortTermRentCleaningFee: 50,
+      shortTermRentServiceFee: 30,
+      shortTermRentTaxesPercent: 10,
+      maxGuests: 4,
+      cancellationPolicy: 'moderate',
+      ...overrides,
+    },
+  });
+  return propertyId;
+}
+
+const DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * A stay `fromDays`..`toDays` out, from an OPTIONAL fixed base.
+ *
+ * The base is what makes the boundary cases below real: without it each call
+ * re-reads `Date.now()` and two "adjacent" stays land milliseconds apart,
+ * disjoint under every bound convention. That exact vacuity shipped in the
+ * exchanges suite and was caught only by mutation testing.
+ */
+function stay(fromDays: number, toDays: number, base = Date.now()) {
+  return {
+    checkIn: new Date(base + fromDays * DAY).toISOString(),
+    checkOut: new Date(base + toDays * DAY).toISOString(),
+  };
+}
+
+async function reservationRow(id: string) {
+  const [row] = await getDb()
+    .select()
+    .from(reservations)
+    .where(eq(reservations.id, id))
+    .limit(1);
+  return row;
+}
+
+async function book(
+  propertyId: string,
+  guest = 'oxy-guest',
+  window = stay(10, 15),
+  guestCount = 2,
+): Promise<string> {
+  const res = await request(buildApp(guest))
+    .post('/reservations')
+    .send({ propertyId, ...window, guestCount });
+  expect(res.status).toBe(201);
+  return res.body.data.id;
+}
+
+beforeEach(async () => {
+  await getDb().delete(reservations);
+  await resetGeoTables();
+});
+
+afterAll(async () => {
+  // Leave the shared tables as this file found them — see the reproduced
+  // geoBackfill collision documented in `leaseOwnership.test.ts`.
+  await getDb().delete(reservations);
+  await resetGeoTables();
+});
+
+describe('createReservation — pricing', () => {
+  it('computes nights, subtotal, taxes and total from the short-term block', async () => {
+    const propertyId = await seedBookableProperty();
+    const id = await book(propertyId, 'oxy-guest', stay(10, 15));
+
+    const row = await reservationRow(id);
+    // 5 nights x 100 = 500; + 50 cleaning + 30 service = 580; 10% tax = 58;
+    // total 638. Asserted on VALUES — a `nights` off by one silently re-prices
+    // the whole booking.
+    expect(row.nights).toBe(5);
+    expect(row.nightlyRate).toBe(100);
+    expect(row.subtotal).toBe(500);
+    expect(row.cleaningFee).toBe(50);
+    expect(row.serviceFee).toBe(30);
+    expect(row.taxes).toBe(58);
+    expect(row.total).toBe(638);
+    expect(row.currency).toBe('EUR');
+    expect(row.hostOxyUserId).toBe('oxy-host');
+    expect(row.status).toBe('pending');
+    expect(row.instantBooked).toBe(false);
+  });
+
+  it('auto-confirms when the listing has instantBook', async () => {
+    const propertyId = await seedBookableProperty({ shortTermRentInstantBook: true });
+    const id = await book(propertyId);
+    const row = await reservationRow(id);
+    expect(row.instantBooked).toBe(true);
+    expect(row.status).toBe('confirmed');
+  });
+
+  it('falls back to the moderate policy when the listing names none', async () => {
+    const propertyId = await seedBookableProperty({ cancellationPolicy: null });
+    const id = await book(propertyId);
+    expect((await reservationRow(id)).cancellationPolicy).toBe('moderate');
+  });
+
+  it('refuses an unpublished, external, non-bookable or own listing', async () => {
+    const draft = await seedBookableProperty({ status: 'draft' });
+    expect((await request(buildApp('oxy-guest')).post('/reservations').send({ propertyId: draft, ...stay(10, 15), guestCount: 1 })).status).toBe(400);
+
+    const notBookable = (await seedListingWithGeo({
+      countryCode: nextCountryCode(),
+      overrides: { oxyUserId: 'oxy-host', status: 'published' },
+    })).propertyId;
+    expect((await request(buildApp('oxy-guest')).post('/reservations').send({ propertyId: notBookable, ...stay(10, 15), guestCount: 1 })).status).toBe(400);
+
+    const own = await seedBookableProperty();
+    expect((await request(buildApp('oxy-host')).post('/reservations').send({ propertyId: own, ...stay(10, 15), guestCount: 1 })).status).toBe(403);
+
+    expect(await getDb().select().from(reservations)).toHaveLength(0);
+  });
+
+  it('enforces min stay, max stay and guest capacity', async () => {
+    const propertyId = await seedBookableProperty({
+      shortTermRentMinNights: 3,
+      shortTermRentMaxNights: 7,
+    });
+    const app = buildApp('oxy-guest');
+
+    const tooShort = await request(app).post('/reservations').send({ propertyId, ...stay(10, 12), guestCount: 1 });
+    expect(tooShort.status).toBe(400);
+    const tooLong = await request(app).post('/reservations').send({ propertyId, ...stay(10, 30), guestCount: 1 });
+    expect(tooLong.status).toBe(400);
+    const tooMany = await request(app).post('/reservations').send({ propertyId, ...stay(10, 15), guestCount: 9 });
+    expect(tooMany.status).toBe(400);
+
+    expect(await getDb().select().from(reservations)).toHaveLength(0);
+  });
+
+  it('refuses a check-in in the past', async () => {
+    const propertyId = await seedBookableProperty();
+    const res = await request(buildApp('oxy-guest'))
+      .post('/reservations')
+      .send({ propertyId, ...stay(-5, 5), guestCount: 1 });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('the two calendar conflicts — half-open, at the boundary', () => {
+  it('blocks an overlapping reservation, pending or confirmed', async () => {
+    const propertyId = await seedBookableProperty();
+    await book(propertyId, 'oxy-guest-a', stay(10, 15));
+
+    // A PENDING reservation already occupies the calendar here — unlike
+    // exchanges, where only a confirmed one blocks.
+    const clash = await request(buildApp('oxy-guest-b'))
+      .post('/reservations')
+      .send({ propertyId, ...stay(12, 18), guestCount: 1 });
+    expect(clash.status).toBe(409);
+  });
+
+  it('PERMITS a back-to-back stay — asserted at the EXACT boundary, both directions', async () => {
+    // The one instant where `[)` and `[]` disagree, so both stays come from ONE
+    // base. Mutation-tested: closing either range turns this red.
+    const base = Date.now();
+    const propertyId = await seedBookableProperty();
+    await book(propertyId, 'oxy-guest-a', stay(10, 15, base));
+
+    const after = await request(buildApp('oxy-guest-b'))
+      .post('/reservations')
+      .send({ propertyId, ...stay(15, 20, base), guestCount: 1 });
+    expect(after.status).toBe(201);
+
+    // The reverse direction — the only one that catches a closed bound on the
+    // STORED range.
+    const other = await seedBookableProperty();
+    await book(other, 'oxy-guest-a', stay(15, 20, base));
+    const before = await request(buildApp('oxy-guest-b'))
+      .post('/reservations')
+      .send({ propertyId: other, ...stay(10, 15, base), guestCount: 1 });
+    expect(before.status).toBe(201);
+  });
+
+  it('blocks a stay a host calendar window closes, and ignores an `available` one', async () => {
+    const base = Date.now();
+    const propertyId = await seedBookableProperty();
+    await getDb().insert(propertyAvailabilityWindows).values({
+      propertyId,
+      scope: 'listing',
+      startsAt: new Date(base + 12 * DAY),
+      endsAt: new Date(base + 18 * DAY),
+      status: 'blocked',
+    });
+
+    const blocked = await request(buildApp('oxy-guest'))
+      .post('/reservations')
+      .send({ propertyId, ...stay(10, 15, base), guestCount: 1 });
+    expect(blocked.status).toBe(409);
+    expect(blocked.body.error.code).toBe('BLOCKED_BY_HOST');
+
+    // An `available` window must never block — it is the state that says the
+    // opposite, and dropping that exclusion refuses every booking on a listing
+    // whose host published a calendar.
+    const other = await seedBookableProperty();
+    await getDb().insert(propertyAvailabilityWindows).values({
+      propertyId: other,
+      scope: 'listing',
+      startsAt: new Date(base + 5 * DAY),
+      endsAt: new Date(base + 30 * DAY),
+      status: 'available',
+    });
+    const allowed = await request(buildApp('oxy-guest'))
+      .post('/reservations')
+      .send({ propertyId: other, ...stay(10, 15, base), guestCount: 1 });
+    expect(allowed.status).toBe(201);
+  });
+
+  it('ignores an EXCHANGE-scope window — the two calendars share a table', async () => {
+    // `property_availability_windows` holds both calendars under a `scope`
+    // discriminator. A query that forgot the scope would let an exchange
+    // window block a paid booking.
+    const base = Date.now();
+    const propertyId = await seedBookableProperty();
+    await getDb().insert(propertyAvailabilityWindows).values({
+      propertyId,
+      scope: 'exchange',
+      startsAt: new Date(base + 5 * DAY),
+      endsAt: new Date(base + 30 * DAY),
+      status: 'blocked',
+    });
+
+    const res = await request(buildApp('oxy-guest'))
+      .post('/reservations')
+      .send({ propertyId, ...stay(10, 15, base), guestCount: 1 });
+    expect(res.status).toBe(201);
+  });
+});
+
+describe('the range CHECKs', () => {
+  it('REFUSES an inverted stay, zero nights and zero guests', async () => {
+    const propertyId = await seedBookableProperty();
+    const base = {
+      propertyId,
+      guestOxyUserId: 'oxy-guest',
+      hostOxyUserId: 'oxy-host',
+      nightlyRate: 100,
+      subtotal: 100,
+      total: 100,
+      cancellationPolicy: 'moderate' as const,
+    };
+    const checkIn = new Date(Date.now() + 10 * DAY);
+    const checkOut = new Date(Date.now() + 15 * DAY);
+
+    // `reservations_stay_order_check` — Mongo declared this as a `validate` on
+    // `checkOut`, which does not run on an update.
+    await expect(
+      getDb().insert(reservations).values({ ...base, checkIn: checkOut, checkOut: checkIn, guestCount: 1, nights: 5 }),
+    ).rejects.toThrow();
+
+    // `reservations_nights_check` — a zero-night booking is a charge with
+    // nothing behind it.
+    await expect(
+      getDb().insert(reservations).values({ ...base, checkIn, checkOut, guestCount: 1, nights: 0 }),
+    ).rejects.toThrow();
+
+    // `reservations_guest_count_check`.
+    await expect(
+      getDb().insert(reservations).values({ ...base, checkIn, checkOut, guestCount: 0, nights: 5 }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('the transition machine', () => {
+  it('lets only the host confirm or decline, and only from pending', async () => {
+    const propertyId = await seedBookableProperty();
+    const id = await book(propertyId);
+
+    expect((await request(buildApp('oxy-guest')).patch(`/reservations/${id}`).send({ status: 'confirmed' })).status).toBe(403);
+    expect((await reservationRow(id)).status).toBe('pending');
+
+    expect((await request(buildApp('oxy-host')).patch(`/reservations/${id}`).send({ status: 'confirmed' })).status).toBe(200);
+    // The precondition is in the UPDATE, so a second decision matches no row.
+    expect((await request(buildApp('oxy-host')).patch(`/reservations/${id}`).send({ status: 'declined' })).status).toBe(400);
+  });
+
+  it('refuses confirming a stay another CONFIRMED booking now overlaps', async () => {
+    const base = Date.now();
+    const propertyId = await seedBookableProperty();
+    const first = await book(propertyId, 'oxy-guest-a', stay(10, 15, base));
+    await request(buildApp('oxy-host')).patch(`/reservations/${first}`).send({ status: 'confirmed' });
+
+    // A second overlapping request can only exist if it predates the confirm —
+    // seeded directly, since the create path refuses it.
+    const [second] = await getDb()
+      .insert(reservations)
+      .values({
+        propertyId,
+        guestOxyUserId: 'oxy-guest-b',
+        hostOxyUserId: 'oxy-host',
+        checkIn: new Date(base + 12 * DAY),
+        checkOut: new Date(base + 18 * DAY),
+        guestCount: 1,
+        nights: 6,
+        nightlyRate: 100,
+        subtotal: 600,
+        total: 600,
+        cancellationPolicy: 'moderate',
+        status: 'pending',
+      })
+      .returning();
+
+    const res = await request(buildApp('oxy-host')).patch(`/reservations/${second.id}`).send({ status: 'confirmed' });
+    expect(res.status).toBe(409);
+    expect((await reservationRow(second.id)).status).toBe('pending');
+  });
+
+  it('lets a guest cancel a PENDING booking whatever the policy says', async () => {
+    const propertyId = await seedBookableProperty({ cancellationPolicy: 'super_strict' });
+    const id = await book(propertyId);
+    const res = await request(buildApp('oxy-guest')).patch(`/reservations/${id}`).send({ status: 'cancelled' });
+    expect(res.status).toBe(200);
+    expect((await reservationRow(id)).status).toBe('cancelled');
+  });
+
+  it('applies the cancellation policy to a CONFIRMED booking', async () => {
+    // `super_strict` needs 30 days' notice; the stay is 10 days out, so the
+    // guest may not cancel — but the HOST always may.
+    const propertyId = await seedBookableProperty({ cancellationPolicy: 'super_strict' });
+    const id = await book(propertyId, 'oxy-guest', stay(10, 15));
+    await request(buildApp('oxy-host')).patch(`/reservations/${id}`).send({ status: 'confirmed' });
+
+    const byGuest = await request(buildApp('oxy-guest')).patch(`/reservations/${id}`).send({ status: 'cancelled' });
+    expect(byGuest.status).toBe(403);
+    expect(byGuest.body.error.code).toBe('POLICY_FORBIDS_CANCEL');
+    expect((await reservationRow(id)).status).toBe('confirmed');
+
+    const byHost = await request(buildApp('oxy-host')).patch(`/reservations/${id}`).send({ status: 'cancelled' });
+    expect(byHost.status).toBe(200);
+  });
+
+  it('lets a guest cancel a confirmed FLEXIBLE booking', async () => {
+    // The permit half of the policy — a rule that refused every confirmed
+    // cancellation would pass the case above and eat this one.
+    const propertyId = await seedBookableProperty({ cancellationPolicy: 'flexible' });
+    const id = await book(propertyId, 'oxy-guest', stay(10, 15));
+    await request(buildApp('oxy-host')).patch(`/reservations/${id}`).send({ status: 'confirmed' });
+
+    const res = await request(buildApp('oxy-guest')).patch(`/reservations/${id}`).send({ status: 'cancelled' });
+    expect(res.status).toBe(200);
+  });
+
+  it('converges on an already-cancelled booking and refuses an unsupported status', async () => {
+    const propertyId = await seedBookableProperty();
+    const id = await book(propertyId);
+    await request(buildApp('oxy-guest')).patch(`/reservations/${id}`).send({ status: 'cancelled' });
+
+    expect((await request(buildApp('oxy-guest')).patch(`/reservations/${id}`).send({ status: 'cancelled' })).status).toBe(200);
+    expect((await request(buildApp('oxy-host')).patch(`/reservations/${id}`).send({ status: 'completed' })).status).toBe(400);
+  });
+});
+
+describe('reads', () => {
+  it('shows a booking only to its two parties', async () => {
+    const propertyId = await seedBookableProperty();
+    const id = await book(propertyId);
+    expect((await request(buildApp('oxy-guest')).get(`/reservations/${id}`)).status).toBe(200);
+    expect((await request(buildApp('oxy-host')).get(`/reservations/${id}`)).status).toBe(200);
+    expect((await request(buildApp('oxy-stranger')).get(`/reservations/${id}`)).status).toBe(403);
+  });
+
+  it('splits the guest and host views', async () => {
+    const propertyId = await seedBookableProperty();
+    await book(propertyId);
+
+    expect((await request(buildApp('oxy-guest')).get('/reservations')).body.data).toHaveLength(1);
+    expect((await request(buildApp('oxy-host')).get('/reservations?asHost=true')).body.data).toHaveLength(1);
+    expect((await request(buildApp('oxy-host')).get('/reservations')).body.data).toHaveLength(0);
+  });
+
+  it('reports the calendar and the CONFIRMED stays on the availability endpoint', async () => {
+    const base = Date.now();
+    const propertyId = await seedBookableProperty({ shortTermRentMinNights: 2 });
+    await getDb().insert(propertyAvailabilityWindows).values({
+      propertyId,
+      scope: 'listing',
+      startsAt: new Date(base + 40 * DAY),
+      endsAt: new Date(base + 45 * DAY),
+      status: 'blocked',
+    });
+    const pending = await book(propertyId, 'oxy-guest-a', stay(10, 15, base));
+    const confirmed = await book(propertyId, 'oxy-guest-b', stay(20, 25, base));
+    await request(buildApp('oxy-host')).patch(`/reservations/${confirmed}`).send({ status: 'confirmed' });
+
+    const res = await request(buildApp('oxy-anyone')).get(`/properties/${propertyId}/availability`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.minNights).toBe(2);
+    expect(res.body.data.maxGuests).toBe(4);
+    expect(res.body.data.windows).toHaveLength(1);
+    expect(res.body.data.windows[0].start).toBeTruthy();
+    // Only the CONFIRMED stay is "booked" — a pending request is not a
+    // commitment, and listing it would show the calendar as fuller than it is.
+    expect(res.body.data.booked).toHaveLength(1);
+    expect(new Date(res.body.data.booked[0].start).getTime()).toBe(
+      new Date(base + 20 * DAY).getTime(),
+    );
+    expect(pending).toBeTruthy();
+  });
+
+  it('answers 404 for a malformed id rather than 400', async () => {
+    expect((await request(buildApp('oxy-guest')).get('/reservations/not-an-id')).status).toBe(404);
+  });
+});

--- a/packages/backend/controllers/reservationController.ts
+++ b/packages/backend/controllers/reservationController.ts
@@ -12,10 +12,29 @@
  * and confirmed -> cancelled | completed.
  */
 
-import { Property, Reservation } from '../models';
+import { getDb } from '../db/postgres';
+import {
+  computeNights,
+  createReservation,
+  findBlockingWindow,
+  findOverlappingReservation,
+  findReservationById,
+  isReservationStatus,
+  listAvailabilityWindows,
+  listConfirmedStays,
+  listReservations,
+  serializeReservation,
+  transitionReservation,
+  type ReservationRow,
+} from '../db/bookings/reservationReads';
+import {
+  findPropertyBookingBasis,
+  type PropertyBookingBasis,
+} from '../db/properties/propertyBookingBasis';
 import { logger } from '../middlewares/logging';
 import { AppError, successResponse, paginationResponse } from '../middlewares/errorHandler';
 import { ReservationStatus, PropertyStatus, CancellationPolicy, OfferingType, AvailabilityWindowStatus } from '@homiio/shared-types';
+import { RESERVATION_CANCELLATION_POLICIES } from '../db/schema/bookings';
 
 /** Default currency used when a short-term block somehow lacks one. */
 const DEFAULT_CURRENCY = 'EUR';
@@ -25,55 +44,8 @@ const PERCENT = 100;
 const CURRENCY_ROUNDING = 100;
 
 /** A property carries the short-term-rent offering (vacation-bookable). */
-function isVacationBookable(property: { offerings?: unknown }): boolean {
-  return Array.isArray(property.offerings) && property.offerings.includes(OfferingType.SHORT_TERM_RENT);
-}
-import { hasConflict } from '../utils/availabilityUtils';
-import type { DateWindow } from '../utils/availabilityUtils';
-
-const ACTIVE_RESERVATION_STATUSES = [ReservationStatus.PENDING, ReservationStatus.CONFIRMED];
-
-/** Number of milliseconds in one day, used to derive nights from a date range. */
-const MS_PER_DAY = 1000 * 60 * 60 * 24;
-
-/**
- * Raw shape of a stored availability window. At rest the dates are ISO strings,
- * but a hydrated Mongoose document exposes them as `Date`, so both are accepted.
- */
-interface RawAvailabilityWindow {
-  start?: Date | string;
-  end?: Date | string;
-  status?: string;
-}
-
-/**
- * Compute nights between two dates (half-open: checkOut exclusive).
- */
-function computeNights(checkIn: Date, checkOut: Date): number {
-  const ms = checkOut.getTime() - checkIn.getTime();
-  return Math.round(ms / MS_PER_DAY);
-}
-
-/**
- * Determine whether a property's availability windows BLOCK the requested
- * range. A request is blocked if any window with status `blocked` or `booked`
- * overlaps it.
- *
- * Available windows and windows with malformed dates are dropped before the
- * shared half-open overlap check (`hasConflict`) is applied, so they can never
- * block a valid request.
- */
-function isBlockedByWindows(windows: RawAvailabilityWindow[], checkIn: Date, checkOut: Date): boolean {
-  if (!Array.isArray(windows) || windows.length === 0) return false;
-  const blocking: DateWindow[] = [];
-  for (const window of windows) {
-    if (window?.status === AvailabilityWindowStatus.AVAILABLE) continue;
-    const wStart = window?.start instanceof Date ? window.start : new Date(String(window?.start));
-    const wEnd = window?.end instanceof Date ? window.end : new Date(String(window?.end));
-    if (Number.isNaN(wStart.getTime()) || Number.isNaN(wEnd.getTime())) continue;
-    blocking.push({ start: wStart, end: wEnd });
-  }
-  return hasConflict({ start: checkIn, end: checkOut }, blocking);
+function isVacationBookable(property: PropertyBookingBasis): boolean {
+  return property.offerings.includes(OfferingType.SHORT_TERM_RENT);
 }
 
 /**
@@ -88,11 +60,10 @@ function isBlockedByWindows(windows: RawAvailabilityWindow[], checkIn: Date, che
  * For already-pending reservations (not yet confirmed by host) the guest
  * can always cancel.
  */
-function canGuestCancel(reservation: any, now: Date): boolean {
+function canGuestCancel(reservation: ReservationRow, now: Date): boolean {
   if (reservation.status === ReservationStatus.PENDING) return true;
   if (reservation.status !== ReservationStatus.CONFIRMED) return false;
-  const checkIn: Date = reservation.checkIn instanceof Date ? reservation.checkIn : new Date(reservation.checkIn);
-  const hoursUntil = (checkIn.getTime() - now.getTime()) / (1000 * 60 * 60);
+  const hoursUntil = (reservation.checkIn.getTime() - now.getTime()) / (1000 * 60 * 60);
   switch (reservation.cancellationPolicy) {
     case CancellationPolicy.FLEXIBLE:
       return hoursUntil > 0;
@@ -119,7 +90,8 @@ class ReservationController {
       const oxyUserId = req.user?.id || req.user?._id || req.userId;
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      const property = await Property.findById(propertyId).lean();
+      const db = getDb();
+      const property = await findPropertyBookingBasis(db, String(propertyId));
       if (!property) return next(new AppError('Property not found', 404, 'NOT_FOUND'));
       if (property.status !== PropertyStatus.PUBLISHED) {
         return next(new AppError('Property is not available for booking', 400, 'PROPERTY_NOT_BOOKABLE'));
@@ -130,8 +102,12 @@ class ReservationController {
       if (!isVacationBookable(property)) {
         return next(new AppError('This property is not offered for short-term booking', 400, 'NOT_VACATION_BOOKABLE'));
       }
-      const shortTerm = property.shortTermRent;
-      if (!shortTerm) {
+      // `properties_offerings_short_term_rent_check` makes the offering exactly
+      // the presence of `nightly_rate`, so this narrowing is unreachable through
+      // a valid listing — it stays because it is also what turns
+      // `number | null` into `number` for the pricing below.
+      const nightlyRate = property.shortTermRentNightlyRate;
+      if (nightlyRate === null) {
         return next(new AppError('This property has no short-term pricing', 400, 'NOT_VACATION_BOOKABLE'));
       }
 
@@ -156,11 +132,11 @@ class ReservationController {
       if (nights < 1) return next(new AppError('Reservation must be at least 1 night', 400, 'INVALID_RANGE'));
 
       // Enforce min/max stay (from the short-term block)
-      if (shortTerm.minNights && nights < shortTerm.minNights) {
-        return next(new AppError(`Minimum stay is ${shortTerm.minNights} night(s)`, 400, 'BELOW_MIN_STAY'));
+      if (property.shortTermRentMinNights && nights < property.shortTermRentMinNights) {
+        return next(new AppError(`Minimum stay is ${property.shortTermRentMinNights} night(s)`, 400, 'BELOW_MIN_STAY'));
       }
-      if (shortTerm.maxNights && nights > shortTerm.maxNights) {
-        return next(new AppError(`Maximum stay is ${shortTerm.maxNights} night(s)`, 400, 'ABOVE_MAX_STAY'));
+      if (property.shortTermRentMaxNights && nights > property.shortTermRentMaxNights) {
+        return next(new AppError(`Maximum stay is ${property.shortTermRentMaxNights} night(s)`, 400, 'ABOVE_MAX_STAY'));
       }
 
       // Guest capacity
@@ -169,44 +145,42 @@ class ReservationController {
         return next(new AppError(`Property accepts at most ${cappedMaxGuests} guest(s)`, 400, 'TOO_MANY_GUESTS'));
       }
 
-      // Conflict: existing active reservations on overlapping range
-      const overlappingReservation = await Reservation.findOne({
-        propertyId,
-        status: { $in: ACTIVE_RESERVATION_STATUSES },
-        checkIn: { $lt: checkOutDate },
-        checkOut: { $gt: checkInDate }
-      }).lean();
+      const stay = { checkIn: checkInDate, checkOut: checkOutDate };
+
+      // Conflict: an existing active reservation overlaps. A range overlap now,
+      // half-open — see `db/bookings/reservationReads.ts`.
+      const overlappingReservation = await findOverlappingReservation(db, String(propertyId), stay);
       if (overlappingReservation) {
         return next(new AppError('Selected dates conflict with an existing reservation', 409, 'DATE_CONFLICT'));
       }
 
-      // Conflict: property availability windows
-      if (isBlockedByWindows(property.availabilityWindows ?? [], checkInDate, checkOutDate)) {
+      // Conflict: a host calendar window blocks it. Also a range overlap, where
+      // it used to load every window and overlap in JavaScript.
+      if (await findBlockingWindow(db, String(propertyId), stay)) {
         return next(new AppError('Selected dates are blocked by the host calendar', 409, 'BLOCKED_BY_HOST'));
       }
 
       // Pricing — all from the short-term block (NOT a monthly figure).
-      const nightlyRate = Number(shortTerm.nightlyRate) || 0;
       if (nightlyRate <= 0) return next(new AppError('Property has no valid nightly rate', 400, 'NO_RATE'));
       const subtotal = nightlyRate * nights;
-      const cleaningFee = Number(shortTerm.cleaningFee) || 0;
-      const serviceFee = Number(shortTerm.serviceFee) || 0;
-      const taxesPercent = Number(shortTerm.taxesPercent) || 0;
+      const cleaningFee = property.shortTermRentCleaningFee ?? 0;
+      const serviceFee = property.shortTermRentServiceFee ?? 0;
+      const taxesPercent = property.shortTermRentTaxesPercent ?? 0;
       const taxes = Math.round((subtotal + cleaningFee + serviceFee) * (taxesPercent / PERCENT) * CURRENCY_ROUNDING) / CURRENCY_ROUNDING;
       const total = Math.round((subtotal + cleaningFee + serviceFee + taxes) * CURRENCY_ROUNDING) / CURRENCY_ROUNDING;
-      const currency = (shortTerm.currency || DEFAULT_CURRENCY).toUpperCase();
+      const currency = (property.shortTermRentCurrency || DEFAULT_CURRENCY).toUpperCase();
 
       const cancellationPolicy = property.cancellationPolicy || CancellationPolicy.MODERATE;
-      const instantBooked = shortTerm.instantBook === true;
+      const instantBooked = property.shortTermRentInstantBook === true;
       const status = instantBooked ? ReservationStatus.CONFIRMED : ReservationStatus.PENDING;
 
-      const reservation = await Reservation.create({
-        propertyId,
+      const reservation = await createReservation(db, {
+        propertyId: String(propertyId),
         guestOxyUserId: oxyUserId,
         hostOxyUserId,
         checkIn: checkInDate,
         checkOut: checkOutDate,
-        guestCount,
+        guestCount: Number(guestCount),
         nights,
         nightlyRate,
         subtotal,
@@ -217,18 +191,18 @@ class ReservationController {
         currency,
         status,
         instantBooked,
-        cancellationPolicy,
-        specialRequests
+        cancellationPolicy: cancellationPolicy as (typeof RESERVATION_CANCELLATION_POLICIES)[number],
+        specialRequests: typeof specialRequests === 'string' ? specialRequests : undefined,
       });
 
       logger.info('Reservation created', {
-        reservationId: String(reservation._id),
+        reservationId: reservation.id,
         propertyId: String(propertyId),
         status,
         instantBooked
       });
 
-      res.status(201).json(successResponse(reservation.toJSON(), 'Reservation created'));
+      res.status(201).json(successResponse(serializeReservation(reservation), 'Reservation created'));
     } catch (error) {
       next(error);
     }
@@ -244,28 +218,22 @@ class ReservationController {
       const oxyUserId = req.user?.id || req.user?._id || req.userId;
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      const query: Record<string, unknown> = {};
-      if (String(asHost) === 'true') {
-        query.hostOxyUserId = oxyUserId;
-      } else {
-        query.guestOxyUserId = oxyUserId;
-      }
-      if (status) query.status = status;
-
       const pageNumber = Math.max(1, parseInt(String(page)) || 1);
       const limitNumber = Math.min(100, Math.max(1, parseInt(String(limit)) || 10));
       const skip = (pageNumber - 1) * limitNumber;
 
-      const [items, total] = await Promise.all([
-        Reservation.find(query)
-          .sort({ createdAt: -1 })
-          .skip(skip)
-          .limit(limitNumber)
-          .lean(),
-        Reservation.countDocuments(query)
-      ]);
+      const asHostView = String(asHost) === 'true';
+      const result = await listReservations(
+        getDb(),
+        {
+          guestOxyUserId: asHostView ? undefined : oxyUserId,
+          hostOxyUserId: asHostView ? oxyUserId : undefined,
+          status: isReservationStatus(status) ? status : undefined,
+        },
+        { limit: limitNumber, offset: skip },
+      );
 
-      res.json(paginationResponse(items, pageNumber, limitNumber, total, 'Reservations retrieved'));
+      res.json(paginationResponse(result.rows.map(serializeReservation), pageNumber, limitNumber, result.total, 'Reservations retrieved'));
     } catch (error) {
       next(error);
     }
@@ -280,14 +248,14 @@ class ReservationController {
       const oxyUserId = req.user?.id || req.user?._id || req.userId;
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      const reservation = await Reservation.findById(id).lean();
+      const reservation = await findReservationById(getDb(), id);
       if (!reservation) return next(new AppError('Reservation not found', 404, 'NOT_FOUND'));
 
-      const isGuest = String(reservation.guestOxyUserId) === String(oxyUserId);
-      const isHost = String(reservation.hostOxyUserId) === String(oxyUserId);
+      const isGuest = reservation.guestOxyUserId === oxyUserId;
+      const isHost = reservation.hostOxyUserId === oxyUserId;
       if (!isGuest && !isHost) return next(new AppError('Not authorized to view this reservation', 403, 'FORBIDDEN'));
 
-      res.json(successResponse(reservation, 'Reservation retrieved'));
+      res.json(successResponse(serializeReservation(reservation), 'Reservation retrieved'));
     } catch (error) {
       next(error);
     }
@@ -306,14 +274,18 @@ class ReservationController {
       const oxyUserId = req.user?.id || req.user?._id || req.userId;
       if (!oxyUserId) return next(new AppError('Authentication required', 401, 'AUTHENTICATION_REQUIRED'));
 
-      const reservation = await Reservation.findById(id);
+      const db = getDb();
+      const reservation = await findReservationById(db, id);
       if (!reservation) return next(new AppError('Reservation not found', 404, 'NOT_FOUND'));
 
-      const isGuest = String(reservation.guestOxyUserId) === String(oxyUserId);
-      const isHost = String(reservation.hostOxyUserId) === String(oxyUserId);
+      const isGuest = reservation.guestOxyUserId === oxyUserId;
+      const isHost = reservation.hostOxyUserId === oxyUserId;
       if (!isGuest && !isHost) return next(new AppError('Not authorized to update this reservation', 403, 'FORBIDDEN'));
 
       const now = new Date();
+      // Every transition carries its permitted FROM set into the `UPDATE`'s own
+      // predicate, so two hosts confirming at once cannot both succeed.
+      let updated: ReservationRow | undefined;
 
       if (nextStatus === ReservationStatus.CONFIRMED || nextStatus === ReservationStatus.DECLINED) {
         if (!isHost) return next(new AppError('Only the host can approve or decline', 403, 'FORBIDDEN'));
@@ -321,23 +293,25 @@ class ReservationController {
           return next(new AppError('Only pending reservations can be approved or declined', 400, 'INVALID_STATE'));
         }
         if (nextStatus === ReservationStatus.CONFIRMED) {
-          // Re-check conflicts before confirming.
-          const overlapping = await Reservation.findOne({
-            _id: { $ne: reservation._id },
-            propertyId: reservation.propertyId,
-            status: ReservationStatus.CONFIRMED,
-            checkIn: { $lt: reservation.checkOut },
-            checkOut: { $gt: reservation.checkIn }
-          }).lean();
+          // Re-check conflicts before committing, against CONFIRMED stays only
+          // and excluding this one so it never collides with itself.
+          const overlapping = await findOverlappingReservation(
+            db,
+            reservation.propertyId,
+            { checkIn: reservation.checkIn, checkOut: reservation.checkOut },
+            { statuses: [ReservationStatus.CONFIRMED], excludeId: reservation.id },
+          );
           if (overlapping) {
             return next(new AppError('Another confirmed reservation now conflicts with this one', 409, 'DATE_CONFLICT'));
           }
         }
-        reservation.status = nextStatus;
+        updated = await transitionReservation(db, id, nextStatus, [ReservationStatus.PENDING]);
+        if (!updated) {
+          return next(new AppError('Only pending reservations can be approved or declined', 400, 'INVALID_STATE'));
+        }
       } else if (nextStatus === ReservationStatus.CANCELLED) {
-        if (!isGuest && !isHost) return next(new AppError('Not authorized to cancel', 403, 'FORBIDDEN'));
         if (reservation.status === ReservationStatus.CANCELLED) {
-          return res.json(successResponse(reservation.toJSON(), 'Reservation already cancelled'));
+          return res.json(successResponse(serializeReservation(reservation), 'Reservation already cancelled'));
         }
         if (reservation.status === ReservationStatus.COMPLETED) {
           return next(new AppError('Completed reservations cannot be cancelled', 400, 'INVALID_STATE'));
@@ -346,20 +320,26 @@ class ReservationController {
         if (isGuest && !isHost && !canGuestCancel(reservation, now)) {
           return next(new AppError('Cancellation policy does not permit cancellation at this time', 403, 'POLICY_FORBIDS_CANCEL'));
         }
-        reservation.status = ReservationStatus.CANCELLED;
+        updated = await transitionReservation(db, id, ReservationStatus.CANCELLED, [
+          ReservationStatus.PENDING,
+          ReservationStatus.CONFIRMED,
+          ReservationStatus.DECLINED,
+        ]);
+        if (!updated) {
+          return next(new AppError('Completed reservations cannot be cancelled', 400, 'INVALID_STATE'));
+        }
       } else {
         return next(new AppError('Unsupported status transition', 400, 'INVALID_STATE'));
       }
 
-      await reservation.save();
       logger.info('Reservation status updated', {
-        reservationId: String(reservation._id),
-        nextStatus: reservation.status,
+        reservationId: updated.id,
+        nextStatus: updated.status,
         byHost: isHost,
         byGuest: isGuest
       });
 
-      res.json(successResponse(reservation.toJSON(), 'Reservation updated'));
+      res.json(successResponse(serializeReservation(updated), 'Reservation updated'));
     } catch (error) {
       next(error);
     }
@@ -373,35 +353,36 @@ class ReservationController {
   async getPropertyAvailability(req: any, res: any, next: any) {
     try {
       const { id } = req.params;
-      const property = await Property.findById(id)
-        .select('availabilityWindows maxGuests offerings shortTermRent cancellationPolicy')
-        .lean();
+      const db = getDb();
+      const property = await findPropertyBookingBasis(db, id);
       if (!property) return next(new AppError('Property not found', 404, 'NOT_FOUND'));
 
-      const bookedReservations = await Reservation.find({
-        propertyId: id,
-        status: ReservationStatus.CONFIRMED
-      })
-        .select('checkIn checkOut')
-        .sort({ checkIn: 1 })
-        .lean();
-
-      const bookedRanges = bookedReservations.map((reservation: any) => ({
-        start: reservation.checkIn,
-        end: reservation.checkOut,
-        status: AvailabilityWindowStatus.BOOKED
-      }));
+      const [windows, bookedStays] = await Promise.all([
+        listAvailabilityWindows(db, id),
+        listConfirmedStays(db, id),
+      ]);
 
       const data = {
         propertyId: id,
         offerings: property.offerings,
-        instantBook: property.shortTermRent?.instantBook ?? false,
+        instantBook: property.shortTermRentInstantBook ?? false,
         cancellationPolicy: property.cancellationPolicy,
-        minNights: property.shortTermRent?.minNights,
-        maxNights: property.shortTermRent?.maxNights,
+        minNights: property.shortTermRentMinNights,
+        maxNights: property.shortTermRentMaxNights,
         maxGuests: property.maxGuests,
-        windows: property.availabilityWindows || [],
-        booked: bookedRanges
+        // Re-nested to the wire shape: `start`/`end` where the columns are
+        // `starts_at`/`ends_at` (renamed because `end` is a reserved word).
+        windows: windows.map((row) => ({
+          id: row.id,
+          start: row.startsAt,
+          end: row.endsAt,
+          status: row.status,
+        })),
+        booked: bookedStays.map((stay) => ({
+          start: stay.checkIn,
+          end: stay.checkOut,
+          status: AvailabilityWindowStatus.BOOKED,
+        })),
       };
 
       res.json(successResponse(data, 'Availability retrieved'));

--- a/packages/backend/db/bookings/reservationReads.ts
+++ b/packages/backend/db/bookings/reservationReads.ts
@@ -1,0 +1,288 @@
+/**
+ * `reservations` — the paid short-term booking, on Postgres.
+ *
+ * Empty in production, so this port has no backfill and no consistency window.
+ * The LAST table of the tenancy domain.
+ *
+ * ## `nights` stays a STORED column, and that is the deliberate half
+ *
+ * `pre('save')` computed it as `round((checkOut - checkIn) / 86_400_000)` — a
+ * ROUNDING, so a stay crossing a DST boundary is 7 nights by that rule and
+ * 6.958 days by subtraction. It is also the PRICED quantity:
+ * `subtotal = nights × nightly_rate` is what the guest agreed to. A generated
+ * column would have to reproduce the rounding exactly to avoid silently
+ * re-pricing a booking, and a derivation that disagrees with a signed number is
+ * worse than a stored one that cannot. `db/schema/bookings.ts` records the same
+ * decision from the schema's side; {@link computeNights} is the one writer.
+ *
+ * ## Both conflict checks are range overlaps now
+ *
+ * The reservation clash was `checkIn < $checkOut AND checkOut > $checkIn` — a
+ * hand-written half-open overlap that works and states the rule twice. The
+ * calendar clash loaded EVERY window and overlapped in JavaScript.
+ *
+ * Both are `tstzrange(...) && tstzrange(...)`, **HALF-OPEN `[)`** — the default,
+ * matching `reservations_stay_range_gist` and `property_availability_windows_
+ * range_gist`, and meaning a stay that ends the morning another begins is not a
+ * conflict. `leases_term_range_gist` uses CLOSED `[]` and copying that spelling
+ * here would refuse legitimate back-to-back bookings.
+ *
+ * The bounds are bound as ISO STRINGS with an explicit `::timestamptz`, not as
+ * `Date`s: postgres.js infers a parameter's wire type from its position and
+ * cannot inside `tstzrange(...)`, where a bare `Date` fails at SERIALISATION
+ * (`The "string" argument must be of type string ... Received an instance of
+ * Date`) before the server ever sees the statement.
+ */
+
+import { and, asc, desc, eq, inArray, ne, sql } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+import type { DatabaseOrTransaction } from '../postgres';
+import { propertyAvailabilityWindows, reservations } from '../schema';
+import { RESERVATION_STATUSES } from '../schema/bookings';
+
+/** A reservation status the CHECK accepts. */
+export type ReservationStatusValue = (typeof RESERVATION_STATUSES)[number];
+
+export type ReservationRow = typeof reservations.$inferSelect;
+
+/** The statuses that occupy the calendar for a NEW booking. */
+export const ACTIVE_RESERVATION_STATUSES: readonly ReservationStatusValue[] = [
+  'pending',
+  'confirmed',
+];
+
+/** Whether `value` is one of the five declared statuses. */
+export function isReservationStatus(value: unknown): value is ReservationStatusValue {
+  return (
+    typeof value === 'string' && (RESERVATION_STATUSES as readonly string[]).includes(value)
+  );
+}
+
+/** Milliseconds in one day, used to derive nights from a date range. */
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+/**
+ * Nights between two dates, half-open (`checkOut` exclusive).
+ *
+ * `Math.round`, exactly as `pre('save')` had it — see the header. This is the
+ * ONE writer of the value `subtotal` is computed from.
+ */
+export function computeNights(checkIn: Date, checkOut: Date): number {
+  return Math.round((checkOut.getTime() - checkIn.getTime()) / MS_PER_DAY);
+}
+
+/** A half-open stay `[checkIn, checkOut)`. */
+export interface StayWindow {
+  readonly checkIn: Date;
+  readonly checkOut: Date;
+}
+
+/**
+ * Does an existing reservation in `statuses` overlap this stay?
+ *
+ * @param excludeId The reservation being confirmed, so it never conflicts with
+ *   itself.
+ */
+export async function findOverlappingReservation(
+  db: DatabaseOrTransaction,
+  propertyId: string,
+  stay: StayWindow,
+  options: {
+    readonly statuses?: readonly ReservationStatusValue[];
+    readonly excludeId?: string;
+  } = {},
+): Promise<ReservationRow | undefined> {
+  const start = stay.checkIn.toISOString();
+  const end = stay.checkOut.toISOString();
+
+  const clauses: SQL[] = [
+    eq(reservations.propertyId, propertyId),
+    inArray(reservations.status, [...(options.statuses ?? ACTIVE_RESERVATION_STATUSES)]),
+    sql`tstzrange(${reservations.checkIn}, ${reservations.checkOut})
+        && tstzrange(${start}::timestamptz, ${end}::timestamptz)`,
+  ];
+  if (options.excludeId !== undefined) clauses.push(ne(reservations.id, options.excludeId));
+
+  const [row] = await db
+    .select()
+    .from(reservations)
+    .where(and(...clauses) as SQL)
+    .limit(1);
+  return row;
+}
+
+/**
+ * Does a host-defined calendar window BLOCK this stay?
+ *
+ * Only `blocked` and `booked` windows block; `available` ones never do, which
+ * is the same exclusion the JavaScript version made before calling
+ * `hasConflict`. Scoped to the `listing` calendar — the table also holds the
+ * `exchange` one under the same `scope` discriminator.
+ */
+export async function findBlockingWindow(
+  db: DatabaseOrTransaction,
+  propertyId: string,
+  stay: StayWindow,
+): Promise<{ id: string } | undefined> {
+  const start = stay.checkIn.toISOString();
+  const end = stay.checkOut.toISOString();
+
+  const [row] = await db
+    .select({ id: propertyAvailabilityWindows.id })
+    .from(propertyAvailabilityWindows)
+    .where(
+      and(
+        eq(propertyAvailabilityWindows.propertyId, propertyId),
+        eq(propertyAvailabilityWindows.scope, 'listing'),
+        ne(propertyAvailabilityWindows.status, 'available'),
+        sql`tstzrange(${propertyAvailabilityWindows.startsAt}, ${propertyAvailabilityWindows.endsAt})
+            && tstzrange(${start}::timestamptz, ${end}::timestamptz)`,
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+/** The `listing` calendar for a property, in order. */
+export async function listAvailabilityWindows(
+  db: DatabaseOrTransaction,
+  propertyId: string,
+): Promise<readonly (typeof propertyAvailabilityWindows.$inferSelect)[]> {
+  return db
+    .select()
+    .from(propertyAvailabilityWindows)
+    .where(
+      and(
+        eq(propertyAvailabilityWindows.propertyId, propertyId),
+        eq(propertyAvailabilityWindows.scope, 'listing'),
+      ),
+    )
+    .orderBy(asc(propertyAvailabilityWindows.startsAt));
+}
+
+/** The confirmed stays on a property, soonest first — the "booked" ranges. */
+export async function listConfirmedStays(
+  db: DatabaseOrTransaction,
+  propertyId: string,
+): Promise<readonly { checkIn: Date; checkOut: Date }[]> {
+  return db
+    .select({ checkIn: reservations.checkIn, checkOut: reservations.checkOut })
+    .from(reservations)
+    .where(and(eq(reservations.propertyId, propertyId), eq(reservations.status, 'confirmed')))
+    .orderBy(asc(reservations.checkIn));
+}
+
+/** Insert a reservation. Every priced field is computed by the caller. */
+export async function createReservation(
+  db: DatabaseOrTransaction,
+  input: typeof reservations.$inferInsert,
+): Promise<ReservationRow> {
+  const [row] = await db.insert(reservations).values(input).returning();
+  return row;
+}
+
+/** One reservation by id. */
+export async function findReservationById(
+  db: DatabaseOrTransaction,
+  id: string,
+): Promise<ReservationRow | undefined> {
+  const [row] = await db.select().from(reservations).where(eq(reservations.id, id)).limit(1);
+  return row;
+}
+
+export interface ListReservationsFilter {
+  readonly guestOxyUserId?: string;
+  readonly hostOxyUserId?: string;
+  readonly status?: ReservationStatusValue;
+}
+
+/** The predicate shared by the page and its `count(*)`, so the two agree. */
+function listFilter(filter: ListReservationsFilter): SQL {
+  const clauses: SQL[] = [];
+  if (filter.guestOxyUserId !== undefined) {
+    clauses.push(eq(reservations.guestOxyUserId, filter.guestOxyUserId));
+  }
+  if (filter.hostOxyUserId !== undefined) {
+    clauses.push(eq(reservations.hostOxyUserId, filter.hostOxyUserId));
+  }
+  if (filter.status !== undefined) clauses.push(eq(reservations.status, filter.status));
+  return clauses.length > 0 ? (and(...clauses) as SQL) : sql`true`;
+}
+
+export interface ListReservationsResult {
+  readonly rows: readonly ReservationRow[];
+  readonly total: number;
+}
+
+/** One page of reservations, newest first. */
+export async function listReservations(
+  db: DatabaseOrTransaction,
+  filter: ListReservationsFilter,
+  page: { readonly limit: number; readonly offset: number },
+): Promise<ListReservationsResult> {
+  const where = listFilter(filter);
+  const [rows, [totalRow]] = await Promise.all([
+    db
+      .select()
+      .from(reservations)
+      .where(where)
+      .orderBy(desc(reservations.createdAt))
+      .limit(page.limit)
+      .offset(page.offset),
+    db.select({ value: sql<number>`count(*)::int` }).from(reservations).where(where),
+  ]);
+  return { rows, total: totalRow.value };
+}
+
+/**
+ * Move a reservation to `nextStatus`, but only from one of `fromStatuses`.
+ *
+ * The permitted FROM set is in the `UPDATE`'s own predicate, so two hosts
+ * confirming at once cannot both succeed — the read that precedes this in the
+ * controller chooses the ERROR, this chooses whether the write happens.
+ */
+export async function transitionReservation(
+  db: DatabaseOrTransaction,
+  id: string,
+  nextStatus: ReservationStatusValue,
+  fromStatuses: readonly ReservationStatusValue[],
+): Promise<ReservationRow | undefined> {
+  const [row] = await db
+    .update(reservations)
+    .set({ status: nextStatus })
+    .where(and(eq(reservations.id, id), inArray(reservations.status, [...fromStatuses])))
+    .returning();
+  return row;
+}
+
+/**
+ * The wire shape the booking screens read.
+ *
+ * The Mongoose handlers returned `reservation.toJSON()` — every field — so this
+ * carries every column. `id`, never `_id`.
+ */
+export function serializeReservation(row: ReservationRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    propertyId: row.propertyId,
+    guestOxyUserId: row.guestOxyUserId,
+    hostOxyUserId: row.hostOxyUserId,
+    checkIn: row.checkIn,
+    checkOut: row.checkOut,
+    guestCount: row.guestCount,
+    nights: row.nights,
+    nightlyRate: row.nightlyRate,
+    subtotal: row.subtotal,
+    cleaningFee: row.cleaningFee,
+    serviceFee: row.serviceFee,
+    taxes: row.taxes,
+    total: row.total,
+    currency: row.currency,
+    status: row.status,
+    instantBooked: row.instantBooked,
+    cancellationPolicy: row.cancellationPolicy,
+    specialRequests: row.specialRequests,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/packages/backend/db/properties/propertyBookingBasis.ts
+++ b/packages/backend/db/properties/propertyBookingBasis.ts
@@ -64,6 +64,24 @@ export interface PropertyBookingBasis {
    * default.
    */
   readonly exchangeMode: string | null;
+
+  // ── the short-term block, for `reservationController` ──
+  //
+  // Every column is nullable because `short_term_rent` is an OPTIONAL priced
+  // block: `properties_offerings_short_term_rent_check` makes the offering
+  // exactly the presence of `nightly_rate`, so a listing not offered for short
+  // stays has the whole block NULL rather than zeroed. A caller must treat the
+  // null as "not bookable", never as a free stay.
+  readonly maxGuests: number;
+  readonly cancellationPolicy: string | null;
+  readonly shortTermRentNightlyRate: number | null;
+  readonly shortTermRentCurrency: string | null;
+  readonly shortTermRentCleaningFee: number | null;
+  readonly shortTermRentServiceFee: number | null;
+  readonly shortTermRentTaxesPercent: number | null;
+  readonly shortTermRentMinNights: number | null;
+  readonly shortTermRentMaxNights: number | null;
+  readonly shortTermRentInstantBook: boolean | null;
 }
 
 /** The booking-relevant columns of one listing, or `undefined`. */
@@ -79,6 +97,16 @@ export async function findPropertyBookingBasis(
       oxyUserId: properties.oxyUserId,
       offerings: properties.offerings,
       exchangeMode: properties.exchangeMode,
+      maxGuests: properties.maxGuests,
+      cancellationPolicy: properties.cancellationPolicy,
+      shortTermRentNightlyRate: properties.shortTermRentNightlyRate,
+      shortTermRentCurrency: properties.shortTermRentCurrency,
+      shortTermRentCleaningFee: properties.shortTermRentCleaningFee,
+      shortTermRentServiceFee: properties.shortTermRentServiceFee,
+      shortTermRentTaxesPercent: properties.shortTermRentTaxesPercent,
+      shortTermRentMinNights: properties.shortTermRentMinNights,
+      shortTermRentMaxNights: properties.shortTermRentMaxNights,
+      shortTermRentInstantBook: properties.shortTermRentInstantBook,
     })
     .from(properties)
     .where(eq(properties.id, propertyId))


### PR DESCRIPTION
`reservations`, empty in production. With this, **every tenancy table is on Postgres** — leases (#303), viewings + applications (#305), exchanges (#309), reservations here — and `controllers/reservationController.ts` was the last one importing a tenancy model from the Mongo barrel.

## `nights` stays a STORED column, deliberately

`pre('save')` computed it as `round((checkOut − checkIn) / 86_400_000)` — a **rounding**, so a stay crossing DST is 7 nights by that rule and 6.958 days by subtraction. It is also the **priced quantity**: `subtotal = nights × nightly_rate` is what the guest agreed to. A generated column would have to reproduce the rounding exactly to avoid silently re-pricing a booking, and a derivation that disagrees with a signed number is worse than a stored one that cannot. `computeNights` is the one writer.

## Both conflict checks are range overlaps now

The reservation clash was a hand-written `checkIn < $checkOut AND checkOut > $checkIn`; the calendar clash loaded **every** window and overlapped in JavaScript. Both are `tstzrange(...) && tstzrange(...)` — **half-open `[)`**, matching `reservations_stay_range_gist` and `property_availability_windows_range_gist`. `leases_term_range_gist` uses CLOSED `[]`, and copying that spelling here would refuse legitimate back-to-back bookings.

The window query keeps **both** exclusions the JavaScript had, and they are separate rules:

- `scope = 'listing'` — the table holds the *exchange* calendar too, under the same discriminator, so forgetting it lets an exchange window block a paid booking;
- `status <> 'available'` — an available window is the state that says the *opposite* of blocking, so forgetting it refuses every booking on a listing whose host published a calendar.

## The shared booking projection, not a third property reader

`db/properties/propertyBookingBasis.ts` gains the short-term block, `max_guests` and `cancellation_policy` — **one** projection four controllers share, rather than a fourth reader with its own idea of what "bookable" means. It stays deliberately **not** a serializer: nothing in it reshapes a property for the wire, so `db/properties/propertySerializer.ts` remains the single authority on that.

## Tests

**117 suites / 1497 tests**, green — the new suite contributes 21. CI floor 1380 → 1415. Lint **217 → 166** warnings, 0 errors (the controller lost most of its `any`).

Mutation-tested, restored in place, `git diff` verified byte-clean afterwards:

| mutation | result |
|---|---|
| closed bounds on the STORED range | 1 red |
| closed bounds on the QUERY range | 1 red |
| drop `scope = 'listing'` | 1 red |
| drop `status <> 'available'` | 1 red |
| `nights` floor+1 instead of round | 2 red |

Both boundary cases are built from **one base instant** and asserted in **both directions**. That is the correction #309 earned the hard way: there, `window()` re-read `Date.now()` per call, so the two "adjacent" stays landed milliseconds apart and three separate closed-bound mutations all survived a test whose comment claimed to pin the boundary.

## Known follow-up, not fixed here

Four files in other batches still read now-Postgres tenancy tables through Mongo and will silently answer zero — `controllers/property/stats.ts` (`Lease`), `controllers/property/list.ts` (`Reservation`), `controllers/analyticsController.ts` and `services/cleanupService.ts` (`ViewingRequest`). All latent while the tables are empty. Two are `controllers/property/*`, which belongs to the property-writes batch, so they are tracked separately rather than edited in parallel. `cleanupService.ts` ranks highest: a sweep that silently reaps nothing has no symptom until disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/homiio/pull/311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->