### PR TITLE
Fix the three findings the automated review raised on #310 (#281)

### DIFF
--- a/packages/backend/__tests__/integration/conversationOwnership.test.ts
+++ b/packages/backend/__tests__/integration/conversationOwnership.test.ts
@@ -151,6 +151,42 @@ describe('POST /ai/conversations — the write path that never worked', () => {
   });
 });
 
+describe('/ai/stream — creation has exactly ONE owner', () => {
+  it('creates NOTHING when the caller supplies no conversationId', async () => {
+    // `useSindiConversation` sends `conversationId: undefined` for a chat it has
+    // not persisted yet, and `conversationStore.saveConversation` separately
+    // POSTs `/ai/conversations` with the whole transcript. If `/stream` also
+    // created one, every new Sindi chat would appear TWICE in the user's list,
+    // one copy of which they could not recognise or clean up.
+    //
+    // The stream itself needs a live model, so this asserts the SIDE EFFECT
+    // rather than the response: after the request, the user still owns nothing.
+    const oxyUserId = owner();
+    await request(buildApp(oxyUserId))
+      .post('/ai/stream')
+      .send({ messages: [{ role: 'user', content: 'hello' }] });
+
+    const rows = await getDb()
+      .select()
+      .from(conversations)
+      .where(eq(conversations.oxyUserId, oxyUserId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('does not adopt or write into somebody else\'s conversation', async () => {
+    const victim = owner();
+    const id = await createFor(victim, { initialMessage: 'private' });
+
+    await request(buildApp(owner()))
+      .post('/ai/stream')
+      .send({ conversationId: id, messages: [{ role: 'user', content: 'injected' }] });
+
+    // The lookup is scoped to the caller, so a stranger's id resolves to
+    // nothing and the turn is dropped rather than appended.
+    expect(await messagesOf(id)).toHaveLength(1);
+  });
+});
+
 describe('GET /ai/conversations — the list, and the two derived figures', () => {
   it('returns only the caller\'s own conversations', async () => {
     const a = owner();

--- a/packages/backend/__tests__/integration/profilePostgres.test.ts
+++ b/packages/backend/__tests__/integration/profilePostgres.test.ts
@@ -31,7 +31,7 @@ import * as profileController from '../../controllers/profile';
 import { getDb } from '../../db/postgres';
 import { profileChatMessages, profiles } from '../../db/schema';
 import { errorHandler } from '../../middlewares/errorHandler';
-import { PROFILE_CHAT_HISTORY_LIMIT } from '../../db/profiles/profileRepository';
+import { PROFILE_CHAT_HISTORY_LIMIT, ensureProfile } from '../../db/profiles/profileRepository';
 
 function buildApp(oxyUserId: string | null): Express {
   const app = express();
@@ -89,6 +89,50 @@ describe('GET /profiles/me — get or create', () => {
   it('refuses an unauthenticated caller', async () => {
     const res = await request(buildApp(null)).get('/profiles/me');
     expect(res.status).toBe(401);
+  });
+
+  it('converges when two first requests race, INSIDE a caller transaction', async () => {
+    // The hazard: `ensureProfile` runs inside a transaction its CALLER opened
+    // (`updateMyProfile`, and all three `/ai/history` handlers). A caught
+    // `23505` would abort that transaction, so the recovery SELECT would answer
+    // `25P02 current transaction is aborted` and the race the unique index
+    // exists to absorb would surface as a 500 — only under concurrency, which
+    // is exactly where nobody would see it. `ON CONFLICT DO NOTHING` never
+    // fails, so no statement can abort anything.
+    const oxyUserId = owner();
+    const db = getDb();
+
+    const results = await Promise.all([
+      db.transaction((tx) => ensureProfile(tx, oxyUserId, 'owner')),
+      db.transaction((tx) => ensureProfile(tx, oxyUserId, 'owner')),
+      db.transaction((tx) => ensureProfile(tx, oxyUserId, 'owner')),
+    ]);
+
+    const ids = new Set(results.map((r) => r.profile.id));
+    expect(ids.size).toBe(1);
+    expect(await getDb().select().from(profiles).where(eq(profiles.oxyUserId, oxyUserId))).toHaveLength(1);
+  });
+
+  it('converges when the row is created between the read and the insert', async () => {
+    // The narrow window the `ON CONFLICT` branch exists for, forced rather than
+    // waited for: the row appears after `ensureProfile` has already looked and
+    // found nothing, so the insert is the statement that meets the conflict.
+    const oxyUserId = owner();
+    const db = getDb();
+
+    await db.transaction(async (tx) => {
+      const before = await tx.select().from(profiles).where(eq(profiles.oxyUserId, oxyUserId));
+      expect(before).toHaveLength(0);
+      // A committed row from "another request", inserted on the ROOT handle so
+      // it is visible to the transaction's next statement.
+      await getDb().insert(profiles).values({ oxyUserId });
+
+      const converged = await ensureProfile(tx, oxyUserId, 'owner');
+      expect(converged.profile.oxyUserId).toBe(oxyUserId);
+      // The transaction is still usable afterwards, which is the whole point.
+      const after = await tx.select().from(profiles).where(eq(profiles.oxyUserId, oxyUserId));
+      expect(after).toHaveLength(1);
+    });
   });
 });
 
@@ -285,21 +329,66 @@ describe('the public read — what a stranger gets', () => {
       });
   }
 
-  it('never carries the annual income, in any scope', async () => {
+  it('never carries the annual income to a STRANGER', async () => {
     const oxyUserId = owner();
     await seed(oxyUserId, { showIncome: true, showContactInfo: true, showRentalHistory: true });
 
-    // `profiles.personal_info_annual_income` is a PROTECTED COLUMN, excluded at
-    // the TYPE level by `publicColumns(profiles)` — so the serializer could not
-    // emit it even for the owner. The privacy FLAG is a separate decision the
-    // application would have to make explicitly.
+    // `profiles.personal_info_annual_income` is a PROTECTED COLUMN: excluded at
+    // the TYPE level by `publicColumns(profiles)`, so the public path has no
+    // field to leak by accident — not even with `showIncome` deliberately on,
+    // which is a per-viewer decision the application has not been built to make.
     const stored = await getDb().select().from(profiles).where(eq(profiles.oxyUserId, oxyUserId));
     expect(stored[0].personalInfoAnnualIncome).toBe(48000);
 
-    const ownerRead = await request(buildApp(oxyUserId)).get('/profiles/me');
     const publicRead = await request(buildApp(null)).get(`/public/profiles/oxy/${oxyUserId}`);
-    expect(JSON.stringify(ownerRead.body)).not.toContain('48000');
     expect(JSON.stringify(publicRead.body)).not.toContain('48000');
+    expect(publicRead.body.data.personalProfile.personalInfo).not.toHaveProperty('annualIncome');
+  });
+
+  it('DOES return the income to its owner, or the next save would erase it', async () => {
+    // The owner read names the protected column explicitly — the escape hatch
+    // `protectedColumns.ts` sanctions. Withholding it from the owner is not a
+    // privacy win: the edit form round-trips the whole `personalInfo` block, and
+    // a block that comes back without a key it never received writes NULL over
+    // the stored value. Excluding it here would silently delete people's income.
+    const oxyUserId = owner();
+    await seed(oxyUserId, { showContactInfo: true });
+
+    const ownerRead = await request(buildApp(oxyUserId)).get('/profiles/me');
+    expect(ownerRead.body.data.personalProfile.personalInfo.annualIncome).toBe(48000);
+  });
+
+  it('survives the edit form round trip rather than being blanked', async () => {
+    // The regression this exists to catch, end to end: read the profile, send
+    // the `personalInfo` block straight back the way the edit form does, and
+    // assert the income is still there.
+    const oxyUserId = owner();
+    const app = buildApp(oxyUserId);
+    await seed(oxyUserId, { showContactInfo: true });
+
+    const read = await request(app).get('/profiles/me');
+    const personalInfo = read.body.data.personalProfile.personalInfo;
+    await request(app).put('/profiles/me').send({ personalProfile: { personalInfo } });
+
+    const after = await request(app).get('/profiles/me');
+    expect(after.body.data.personalProfile.personalInfo.annualIncome).toBe(48000);
+    const stored = await getDb().select().from(profiles).where(eq(profiles.oxyUserId, oxyUserId));
+    expect(stored[0].personalInfoAnnualIncome).toBe(48000);
+  });
+
+  it('still lets the owner clear their income deliberately', async () => {
+    // The other direction: an explicit null must not be ignored, or "remove my
+    // income" becomes impossible.
+    const oxyUserId = owner();
+    const app = buildApp(oxyUserId);
+    await seed(oxyUserId, { showContactInfo: true });
+
+    await request(app)
+      .put('/profiles/me')
+      .send({ personalProfile: { personalInfo: { bio: 'kept', annualIncome: null } } });
+
+    const stored = await getDb().select().from(profiles).where(eq(profiles.oxyUserId, oxyUserId));
+    expect(stored[0].personalInfoAnnualIncome).toBeNull();
   });
 
   it('withholds references and the tenancy from a stranger by default', async () => {

--- a/packages/backend/controllers/profile/crud.ts
+++ b/packages/backend/controllers/profile/crud.ts
@@ -48,7 +48,7 @@ export async function getOrCreateProfile(req: Request, res: Response, next: Next
         .json(errorResponse('Authentication required', 'AUTHENTICATION_REQUIRED'));
     }
 
-    const hydrated = await ensureProfile(getDb(), oxyUserId);
+    const hydrated = await ensureProfile(getDb(), oxyUserId, 'owner');
     res.json(successResponse(toProfileDTO(hydrated, 'owner'), 'Profile retrieved successfully'));
   } catch (error) {
     next(error);
@@ -117,7 +117,9 @@ export async function updateMyProfile(req: Request, res: Response, next: NextFun
     }
 
     const update = toProfileUpdate(req.body);
-    const hydrated = await getDb().transaction((tx) => updateProfile(tx, oxyUserId, update));
+    const hydrated = await getDb().transaction((tx) =>
+      updateProfile(tx, oxyUserId, update, 'owner'),
+    );
 
     res.json(successResponse(toProfileDTO(hydrated, 'owner'), 'Profile updated successfully'));
   } catch (error) {

--- a/packages/backend/db/profiles/profileRepository.ts
+++ b/packages/backend/db/profiles/profileRepository.ts
@@ -31,9 +31,11 @@
  *
  * Mongoose declared `unique: true` on `oxyUserId` and the controller wrapped a
  * read-then-create around it, which is a window two concurrent first requests
- * both pass. {@link ensureProfile} INSERTs and converges on `23505` from
+ * both pass. {@link ensureProfile} INSERTs `ON CONFLICT DO NOTHING` against
  * `profiles_oxy_user_id_key` instead — `db/MIGRATION-CONTRACT.md`'s rule that
  * idempotency which moved into an index must not be re-implemented as a read.
+ * Why `ON CONFLICT` rather than a caught `23505` is the load-bearing part, and
+ * it is explained on the function.
  *
  * ## Nothing here takes a profile id from a caller
  *
@@ -53,7 +55,6 @@ import {
   profileRoommateHistory,
   profiles,
 } from '../schema';
-import { isUniqueViolation } from '../uniqueViolation';
 import { type HydratedProfile, type ProfileRow, profileSelection } from './profileSerializer';
 
 /**
@@ -168,14 +169,33 @@ async function loadChildren(
   return { references, rentalHistory, preferredLocations, roommateHistory, chatHistory };
 }
 
-/** One profile with every child collection loaded, or `undefined`. */
+/**
+ * One profile with every child collection loaded, or `undefined`.
+ *
+ * `scope: 'owner'` additionally reads the PROTECTED `personal_info_annual_income`
+ * column, in a statement that names it explicitly — the escape hatch
+ * `db/schema/protectedColumns.ts` sanctions, and the only use of it in this
+ * package. Without it the owner's own edit form round-trips a block it cannot
+ * see and writes NULL over their income on the next save; see
+ * {@link OwnerOnlyProfileFields}. The default is `'public'`, so a caller who
+ * does not think about it gets the protected view.
+ */
 export async function findHydratedProfile(
   db: DatabaseOrTransaction,
   oxyUserId: string,
+  scope: 'owner' | 'public' = 'public',
 ): Promise<HydratedProfile | undefined> {
   const profile = await findProfileByOxyUserId(db, oxyUserId);
   if (!profile) return undefined;
-  return { profile, ...(await loadChildren(db, profile.id)) };
+  const children = await loadChildren(db, profile.id);
+  if (scope !== 'owner') return { profile, ...children };
+
+  const [income] = await db
+    .select({ annualIncome: profiles.personalInfoAnnualIncome })
+    .from(profiles)
+    .where(eq(profiles.id, profile.id))
+    .limit(1);
+  return { profile, ...children, ownerOnly: { annualIncome: income?.annualIncome ?? null } };
 }
 
 /**
@@ -198,28 +218,61 @@ export async function findHydratedProfile(
  * actually contain.
  *
  * Idempotent by the unique index rather than by a preceding read.
+ *
+ * ## Convergence is `ON CONFLICT DO NOTHING`, NOT a caught `23505`
+ *
+ * The obvious spelling — insert, catch the unique violation, re-read — is wrong
+ * HERE even though it is right in `db/roommates/roommateRepository.ts`, and the
+ * difference is the caller. Every call site of this function runs inside a
+ * transaction the CALLER opened (`updateMyProfile`, and the three `/ai/history`
+ * handlers). In Postgres a failed statement aborts the enclosing transaction, so
+ * the recovery `SELECT` would answer `25P02 current transaction is aborted`
+ * rather than the row — turning the race the unique index exists to absorb into
+ * a 500, and only under concurrency, which is where it would never be noticed.
+ *
+ * `ON CONFLICT DO NOTHING` never fails, so no statement can abort anything: an
+ * empty `RETURNING` set IS the "somebody else got there first" answer, and the
+ * read that follows runs in a healthy transaction. Same mechanism, and the same
+ * reasoning, as `enqueueModerationOutboxEvent`'s claim.
+ *
+ * `appendMessages` in the conversation repository solves the same hazard the
+ * other way — by opening its own transaction per attempt — because it genuinely
+ * needs to RETRY with a recomputed value. Nothing here needs recomputing.
  */
 export async function ensureProfile(
   db: DatabaseOrTransaction,
   oxyUserId: string,
+  scope: 'owner' | 'public' = 'public',
 ): Promise<HydratedProfile> {
-  const existing = await findHydratedProfile(db, oxyUserId);
+  const existing = await findHydratedProfile(db, oxyUserId, scope);
   if (existing) return existing;
 
-  try {
-    const [profile] = await db.insert(profiles).values({ oxyUserId }).returning(profileSelection());
-    return { profile, ...emptyChildren() };
-  } catch (error) {
-    if (!isUniqueViolation(error, 'profiles_oxy_user_id_key')) throw error;
-    const raced = await findHydratedProfile(db, oxyUserId);
-    if (!raced) {
-      // The index refused the insert, so a row satisfying it existed at that
-      // instant. Not finding it now means it was deleted in between — a real
-      // state, and one the caller must not be handed a fabricated row for.
-      throw error;
-    }
-    return raced;
+  const [created] = await db
+    .insert(profiles)
+    .values({ oxyUserId })
+    // Targeted rather than bare: this is the one conflict we are prepared to
+    // treat as an idempotent repeat. A future second unique index on this table
+    // must not be silently absorbed by the same clause.
+    .onConflictDoNothing({ target: profiles.oxyUserId })
+    .returning(profileSelection());
+  if (created) {
+    // A row this statement just created holds NULL in every column, income
+    // included, so the owner view needs no second read here.
+    return {
+      profile: created,
+      ...emptyChildren(),
+      ...(scope === 'owner' ? { ownerOnly: { annualIncome: null } } : {}),
+    };
   }
+
+  const raced = await findHydratedProfile(db, oxyUserId, scope);
+  if (!raced) {
+    // The index refused the insert, so a row satisfying it existed at that
+    // instant. Not finding it now means it was deleted in between — a real
+    // state, and one the caller must not be handed a fabricated row for.
+    throw new Error(`Profile for ${oxyUserId} was created and removed concurrently.`);
+  }
+  return raced;
 }
 
 /**
@@ -239,8 +292,9 @@ export async function updateProfile(
   db: DatabaseOrTransaction,
   oxyUserId: string,
   update: ProfileUpdate,
+  scope: 'owner' | 'public' = 'public',
 ): Promise<HydratedProfile> {
-  const existing = await ensureProfile(db, oxyUserId);
+  const existing = await ensureProfile(db, oxyUserId, scope);
   const profileId = existing.profile.id;
 
   if (Object.keys(update.columns).length > 0) {
@@ -288,7 +342,7 @@ export async function updateProfile(
     }
   }
 
-  const updated = await findHydratedProfile(db, oxyUserId);
+  const updated = await findHydratedProfile(db, oxyUserId, scope);
   if (!updated) {
     // Unreachable through this function, which created the row above inside the
     // caller's transaction. Thrown rather than returned as `undefined` so no

--- a/packages/backend/db/profiles/profileSerializer.ts
+++ b/packages/backend/db/profiles/profileSerializer.ts
@@ -55,6 +55,29 @@ export function profileSelection() {
 /** A profile row as this module receives it — no annual income. */
 export type ProfileRow = Omit<InferSelectModel<typeof profiles>, 'personalInfoAnnualIncome'>;
 
+/**
+ * The owner's own annual income, read EXPLICITLY.
+ *
+ * `protectedColumns.ts` states the escape hatch this uses: "A path that
+ * genuinely needs the column names it … There is deliberately no helper for
+ * that — the whole point is that it reads differently from an ordinary select."
+ * This is that path, and it is the only one in this package.
+ *
+ * It exists because the alternative is silent DATA LOSS rather than privacy. The
+ * edit form round-trips the whole `personalInfo` block, and
+ * `profileWriteColumns.ts` replaces a present block column-for-column — so a
+ * figure the owner cannot READ comes back absent on their next save and is
+ * written NULL. Excluding it from the owner's own view does not protect them
+ * from anybody; it deletes their answer.
+ *
+ * The PUBLIC scope still cannot reach it: `toProfileDTO` only consults this when
+ * the caller passed `'owner'`, and the value is carried beside the row rather
+ * than on it so the public path has no field to leak by accident.
+ */
+export interface OwnerOnlyProfileFields {
+  readonly annualIncome: number | null;
+}
+
 export type ProfileReferenceRow = InferSelectModel<typeof profileReferences>;
 export type ProfileRentalHistoryRow = InferSelectModel<typeof profileRentalHistory>;
 export type ProfilePreferredLocationRow = InferSelectModel<typeof profilePreferredLocations>;
@@ -69,6 +92,12 @@ export interface HydratedProfile {
   readonly preferredLocations: readonly ProfilePreferredLocationRow[];
   readonly roommateHistory: readonly ProfileRoommateHistoryRow[];
   readonly chatHistory: readonly ProfileChatMessageRow[];
+  /**
+   * Present ONLY when the repository was asked for the owner's own view.
+   * `undefined` on every public read, which is what keeps the protected column
+   * unreachable there — see {@link OwnerOnlyProfileFields}.
+   */
+  readonly ownerOnly?: OwnerOnlyProfileFields;
 }
 
 /**
@@ -200,6 +229,11 @@ function toPersonalProfile(
       bio: profile.personalInfoBio,
       occupation: profile.personalInfoOccupation,
       employer: profile.personalInfoEmployer,
+      // Owner only, and ABSENT rather than null for anybody else — a `null`
+      // here would be indistinguishable from "never recorded" and would come
+      // back as a deliberate clear on the next save. See
+      // `OwnerOnlyProfileFields`.
+      ...(owner ? { annualIncome: hydrated.ownerOnly?.annualIncome ?? null } : {}),
       employmentStatus: profile.personalInfoEmploymentStatus,
       moveInDate: profile.personalInfoMoveInDate,
       leaseDuration: profile.personalInfoLeaseDuration,

--- a/packages/backend/routes/ai.ts
+++ b/packages/backend/routes/ai.ts
@@ -734,12 +734,29 @@ Return only the JSON array, no other text.`;
       // A client placeholder id (`conv_…`), or none at all, means CREATE. A real
       // id means look it up, scoped to the caller — the ownership is in the
       // predicate, never a second statement.
+      // **The CLIENT owns creation, and this handler must not race it.**
+      //
+      // `useSindiConversation` sends `conversationId: undefined` for a chat it
+      // has not persisted yet, and `conversationStore.saveConversation`
+      // separately POSTs `/ai/conversations` with the whole transcript. So
+      // treating "no id" as CREATE — which the Mongo handler did — produces TWO
+      // rows for one chat, one of which the user cannot recognise. That never
+      // showed up before only because every Mongo write failed validation; the
+      // moment the write path works, the duplicate is real and visible in
+      // `GET /ai/conversations`.
+      //
+      // Nothing on the client reads `X-Conversation-ID` either (the AI SDK's
+      // `useChat` does not surface response headers), so announcing the id
+      // cannot reconcile the two. Hence: no id means PERSIST NOTHING and let the
+      // client's own POST be the single writer. An explicit `conv_…` placeholder
+      // still means create — a caller that sends one is asking for a row, and it
+      // gets the header back.
       const db = getDb();
       let conversation: ConversationRow | undefined;
       let conversationIsNew = false;
       if (conversationId && !isClientPlaceholderId(conversationId)) {
         conversation = (await findConversationForOwner(db, conversationId, userId))?.conversation;
-      } else {
+      } else if (conversationId) {
         conversation = (
           await db.transaction((tx) =>
             createConversation(tx, {


### PR DESCRIPTION
Follow-up to #310, which merged while these were being fixed. All three findings were **real**, and each is pinned by a test that was mutation-verified to fail without the fix.

## 1. 🔴 The owner could not read their own income, so the next save deleted it

`profiles.personal_info_annual_income` is a protected column, so `profileSelection()` removed it from every read — **including the owner's own**. But the edit form round-trips the whole `personalInfo` block, and `profileWriteColumns.ts` replaces a present block column-for-column, so a key the client never received came back absent and was written NULL.

Withholding a person's income from *that person* is not a privacy win — it is silent data loss, and it is exactly the hazard `profileSerializer.ts`'s own header warns about ("a key this module drops would come back ABSENT on the next save and write NULL over it").

The owner scope now names the column explicitly, which is the escape hatch `protectedColumns.ts` sanctions ("a path that genuinely needs the column names it … there is deliberately no helper for that") and the only use of it in this package. The value is carried *beside* the row rather than on it, so the public path has no field to leak by accident. A deliberate `null` still clears it.

## 2. 🔴 Every new Sindi chat would have been stored twice

`useSindiConversation.ts:158` sends `conversationId: undefined` for a chat it has not persisted yet, and `conversationStore.saveConversation` separately POSTs `/ai/conversations` with the whole transcript. So `/stream` treating "no id" as CREATE produced **two rows for one chat**, one of which the user could not recognise or clean up.

Nothing reads `X-Conversation-ID` either — the AI SDK's `useChat` does not surface response headers — so announcing the id could not reconcile them. This was invisible before only because every Mongo write failed validation; the moment the write path worked, the duplicate became real.

The client owns creation: **no id now means persist nothing**. An explicit `conv_…` placeholder still creates and still gets the header back, since a caller that sends one is asking for a row.

## 3. 🟡 `ensureProfile`'s convergence could not work

Every caller runs it inside a transaction *they* opened (`updateMyProfile`, and the three `/ai/history` handlers). In Postgres a failed statement aborts the enclosing transaction, so the caught-`23505` recovery `SELECT` answered `25P02 current transaction is aborted` — the race the unique index exists to absorb surfaced as a 500, and only under concurrency, which is where nobody would have seen it.

`ON CONFLICT DO NOTHING` never fails, so no statement can abort anything, and the empty `RETURNING` set **is** the "somebody else got there first" answer. Same mechanism as `enqueueModerationOutboxEvent`'s claim. Targeted on `profiles_oxy_user_id_key` rather than bare, so a future second unique index cannot be silently absorbed by the same clause.

(`appendMessages` solves the same hazard the other way — its own transaction per attempt — because it genuinely needs to RETRY with a recomputed position. Nothing here needs recomputing.)

## Mutation-verified

Each fix reverted, one at a time, restored in place and verified by md5:

| Mutation | Result |
|---|---|
| `/stream` creates on no-id again | 1 red — *creates NOTHING when the caller supplies no conversationId* |
| owner DTO drops `annualIncome` | 2 red — *DOES return the income to its owner* + *survives the edit form round trip* |
| `ON CONFLICT` → caught `23505` | 1 red, reproducing the exact `PostgresError: current transaction is aborted` |

## Gates

`typecheck` clean · `lint` 0 errors · backend build green · **119 suites / 1538 tests pass** (up from 1531; +7 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/homiio/pull/312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->