### PR TITLE
Point the ViewingRequest stragglers at Postgres, and fix an endpoint that always returned zeros (#281)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,9 @@ jobs:
       # glob that stops matching all produce an empty green run, and that reads as
       # coverage forever because nothing contradicts it.
       #
-      # RAISED FROM 1380 TO 1415 by the reservations port — the last tenancy
+      # RAISED FROM 1415 TO 1450 by the ViewingRequest stragglers (the
+      # retention sweep and the owner analytics). Before that it went
+      # 1380 -> 1415 for the reservations port — the last tenancy
       # table — which added `reservations.test.ts`. Before that it went
       # 1345 -> 1380 for the exchanges port, which added
       # `exchangeRequests.test.ts` — measured 1398 -> 1424. Before that it went
@@ -212,7 +214,7 @@ jobs:
         if: always()
         run: >-
           bun .github/scripts/assert-test-floor.mjs
-          "$RUNNER_TEMP/backend-tests.json" packages/backend 1415
+          "$RUNNER_TEMP/backend-tests.json" packages/backend 1450
 
   frontend:
     runs-on: ubuntu-24.04

--- a/packages/backend/__tests__/integration/viewingStragglers.test.ts
+++ b/packages/backend/__tests__/integration/viewingStragglers.test.ts
@@ -1,0 +1,252 @@
+/**
+ * The two readers that were left pointing at Mongo after `viewing_requests`
+ * moved — the retention sweep and the owner analytics — plus the owner selector
+ * they both depend on.
+ *
+ * ## Why these need tests at all, when the port itself was mechanical
+ *
+ * Both failed SILENTLY, and in the worse of the two ways:
+ *
+ *  - `cleanupService` kept issuing its `deleteMany` against Mongo, so it reaped
+ *    NOTHING. Unlike a read that returns an empty list, a sweep that deletes
+ *    nothing produces no output at all — its only symptom is disk, months
+ *    later. So the test asserts a POSITIVE deletion count and that the rows
+ *    really went, not merely that the call resolved.
+ *  - `analyticsController` selected the caller's listings by `profileId`, which
+ *    `PropertySchema` never declared, so every figure it reported had been 0
+ *    since it was written. The test asserts NON-ZERO numbers, because a port
+ *    that moved the queries and left the selector broken would still return
+ *    zeros and look done.
+ *
+ * The retention window and the status filter are asserted on what they SPARE as
+ * well as what they reap: a sweep scoped too widely deletes live rows, and
+ * nothing about a successful sweep says which it was.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { eq } from 'drizzle-orm';
+
+import analyticsController from '../../controllers/analyticsController';
+import { getDb } from '../../db/postgres';
+import { pruneClosedViewingsBefore } from '../../db/bookings/viewingReads';
+import { recentlyViewed, savedItems, viewingRequests } from '../../db/schema';
+import { errorHandler } from '../../middlewares/errorHandler';
+import { Profile } from '../../models';
+import { resetGeoTables, seedListingWithGeo } from '../helpers/postgresGeoFixtures';
+
+function buildApp(oxyUserId: string): Express {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    const authed = req as unknown as { user: { id: string }; userId: string };
+    authed.user = { id: oxyUserId };
+    authed.userId = oxyUserId;
+    next();
+  });
+  app.get('/analytics', (req, res, next) => analyticsController.getAnalytics(req, res, next));
+  app.use(errorHandler);
+  return app;
+}
+
+/** A distinct ISO-3166 alpha-2 per geo chain — `countries_code_key` is UNIQUE. */
+let geoChainCounter = 0;
+function nextCountryCode(): string {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const index = geoChainCounter++;
+  return `${alphabet[Math.floor(index / 26) % 26]}${alphabet[index % 26]}`;
+}
+
+const DAY = 24 * 60 * 60 * 1000;
+
+async function seedOwnedListing(oxyUserId: string): Promise<string> {
+  const { propertyId } = await seedListingWithGeo({
+    countryCode: nextCountryCode(),
+    overrides: { oxyUserId, status: 'published' },
+  });
+  return propertyId;
+}
+
+/** Insert a viewing request with an explicit status and `updated_at`. */
+async function seedViewing(options: {
+  propertyId: string;
+  ownerOxyUserId: string;
+  status: 'pending' | 'approved' | 'declined' | 'cancelled';
+  updatedAt?: Date;
+  createdAt?: Date;
+}) {
+  const [row] = await getDb()
+    .insert(viewingRequests)
+    .values({
+      propertyId: options.propertyId,
+      requesterOxyUserId: 'oxy-requester',
+      ownerOxyUserId: options.ownerOxyUserId,
+      scheduledAt: new Date(Date.now() + 30 * DAY),
+      status: options.status,
+      // `cancelled_by` is an equivalence with the status — the CHECK refuses a
+      // cancelled row that names nobody.
+      cancelledBy: options.status === 'cancelled' ? 'requester' : undefined,
+      ...(options.updatedAt ? { updatedAt: options.updatedAt } : {}),
+      ...(options.createdAt ? { createdAt: options.createdAt } : {}),
+    })
+    .returning();
+  return row;
+}
+
+beforeEach(async () => {
+  await getDb().delete(viewingRequests);
+  await getDb().delete(recentlyViewed);
+  await getDb().delete(savedItems);
+  await resetGeoTables();
+});
+
+afterAll(async () => {
+  // Leave the shared tables as this file found them — see the reproduced
+  // geoBackfill collision documented in `leaseOwnership.test.ts`.
+  await getDb().delete(viewingRequests);
+  await getDb().delete(recentlyViewed);
+  await getDb().delete(savedItems);
+  await resetGeoTables();
+});
+
+describe('pruneClosedViewingsBefore — the sweep that was reaping nothing', () => {
+  it('REAPS declined and cancelled requests past the cutoff', async () => {
+    const propertyId = await seedOwnedListing('oxy-owner');
+    const old = new Date(Date.now() - 200 * DAY);
+    const declined = await seedViewing({ propertyId, ownerOxyUserId: 'oxy-owner', status: 'declined', updatedAt: old });
+    const cancelled = await seedViewing({ propertyId, ownerOxyUserId: 'oxy-owner', status: 'cancelled', updatedAt: old });
+
+    const removed = await pruneClosedViewingsBefore(getDb(), new Date(Date.now() - 90 * DAY));
+
+    // A POSITIVE count, and the rows really gone. A sweep that resolved without
+    // deleting — which is exactly what the Mongo-backed version did after the
+    // table moved — passes any assertion that only checks it did not throw.
+    expect(removed).toBe(2);
+    expect(await getDb().select().from(viewingRequests).where(eq(viewingRequests.id, declined.id))).toHaveLength(0);
+    expect(await getDb().select().from(viewingRequests).where(eq(viewingRequests.id, cancelled.id))).toHaveLength(0);
+  });
+
+  it('SPARES a closed request inside the window, and open ones at any age', async () => {
+    // The half a sweep scoped too widely gets wrong — and nothing about a
+    // successful deletion says which rows it took.
+    const propertyId = await seedOwnedListing('oxy-owner');
+    const old = new Date(Date.now() - 200 * DAY);
+    const recent = new Date(Date.now() - 10 * DAY);
+
+    const recentlyDeclined = await seedViewing({ propertyId, ownerOxyUserId: 'oxy-owner', status: 'declined', updatedAt: recent });
+    const oldPending = await seedViewing({ propertyId, ownerOxyUserId: 'oxy-owner', status: 'pending', updatedAt: old });
+    const oldApproved = await seedViewing({ propertyId, ownerOxyUserId: 'oxy-owner', status: 'approved', updatedAt: old });
+
+    const removed = await pruneClosedViewingsBefore(getDb(), new Date(Date.now() - 90 * DAY));
+
+    expect(removed).toBe(0);
+    for (const row of [recentlyDeclined, oldPending, oldApproved]) {
+      expect(await getDb().select().from(viewingRequests).where(eq(viewingRequests.id, row.id))).toHaveLength(1);
+    }
+  });
+});
+
+describe('owner analytics — the endpoint that always returned zeros', () => {
+  /**
+   * The controller still resolves a Profile before it will answer, so the test
+   * seeds one. That guard is untouched by this change: unlike the saved-search
+   * and exchange cases, this endpoint's early return is a documented response
+   * shape rather than a vestigial ownership check.
+   */
+  async function seedProfile(oxyUserId: string) {
+    return Profile.create({ oxyUserId, personalProfile: {} });
+  }
+
+  it('reports REAL numbers for views, saves and viewing requests', async () => {
+    // The assertion that matters: non-zero. `Property.distinct('_id', {
+    // profileId })` matched nothing, so a port that moved these queries and
+    // left the selector alone would still answer 0 everywhere and look done.
+    await seedProfile('oxy-owner');
+    const propertyId = await seedOwnedListing('oxy-owner');
+    const second = await seedOwnedListing('oxy-owner');
+
+    // ONE viewer across TWO listings, plus a second viewer on one of them: 3
+    // views from 2 distinct people. The fixture has to make `count(*)` and
+    // `count(distinct viewer)` DISAGREE, or a mutation swapping one for the
+    // other survives — measured, it did. `recently_viewed_owner_property_key`
+    // is unique per (person, listing), so the repeat has to be a second
+    // listing rather than a second row on the same one.
+    await getDb().insert(recentlyViewed).values([
+      { oxyUserId: 'oxy-viewer-a', propertyId },
+      { oxyUserId: 'oxy-viewer-a', propertyId: second },
+      { oxyUserId: 'oxy-viewer-b', propertyId },
+    ]);
+    await getDb().insert(savedItems).values({
+      oxyUserId: 'oxy-viewer-a',
+      targetType: 'property',
+      targetId: propertyId,
+    });
+    await seedViewing({ propertyId, ownerOxyUserId: 'oxy-owner', status: 'pending' });
+    await seedViewing({ propertyId, ownerOxyUserId: 'oxy-owner', status: 'approved' });
+    await seedViewing({ propertyId, ownerOxyUserId: 'oxy-owner', status: 'declined' });
+
+    const res = await request(buildApp('oxy-owner')).get('/analytics');
+    expect(res.status).toBe(200);
+
+    expect(res.body.data.views.total).toBe(3);
+    // Two DISTINCT viewers out of three views — `count_distinct` on the owner
+    // column, where the source did `$addToSet: '$profileId'` on a path that
+    // does not exist. The two figures differ here on purpose.
+    expect(res.body.data.views.uniqueViewers).toBe(2);
+    expect(res.body.data.saves.total).toBe(1);
+    expect(res.body.data.viewingRequests.received).toBe(3);
+    expect(res.body.data.viewingRequests.pending).toBe(1);
+    expect(res.body.data.viewingRequests.approved).toBe(1);
+    expect(res.body.data.viewingRequests.declined).toBe(1);
+    expect(res.body.data.viewingRequests.cancelled).toBe(0);
+  });
+
+  it("counts only the CALLER's own listings and requests", async () => {
+    await seedProfile('oxy-owner');
+    await seedProfile('oxy-other');
+    const mine = await seedOwnedListing('oxy-owner');
+    const theirs = await seedOwnedListing('oxy-other');
+
+    await getDb().insert(recentlyViewed).values([
+      { oxyUserId: 'oxy-viewer-a', propertyId: mine },
+      { oxyUserId: 'oxy-viewer-b', propertyId: theirs },
+    ]);
+    await seedViewing({ propertyId: mine, ownerOxyUserId: 'oxy-owner', status: 'pending' });
+    await seedViewing({ propertyId: theirs, ownerOxyUserId: 'oxy-other', status: 'pending' });
+
+    const res = await request(buildApp('oxy-owner')).get('/analytics');
+    expect(res.body.data.views.total).toBe(1);
+    expect(res.body.data.viewingRequests.received).toBe(1);
+  });
+
+  it('excludes ARCHIVED listings from the owner selector', async () => {
+    await seedProfile('oxy-owner');
+    const live = await seedOwnedListing('oxy-owner');
+    const { propertyId: archived } = await seedListingWithGeo({
+      countryCode: nextCountryCode(),
+      overrides: { oxyUserId: 'oxy-owner', status: 'archived' },
+    });
+
+    await getDb().insert(recentlyViewed).values([
+      { oxyUserId: 'oxy-viewer-a', propertyId: live },
+      { oxyUserId: 'oxy-viewer-b', propertyId: archived },
+    ]);
+
+    const res = await request(buildApp('oxy-owner')).get('/analytics');
+    expect(res.body.data.views.total).toBe(1);
+  });
+
+  it('honours the reporting period', async () => {
+    await seedProfile('oxy-owner');
+    const propertyId = await seedOwnedListing('oxy-owner');
+
+    await getDb().insert(recentlyViewed).values([
+      { oxyUserId: 'oxy-recent', propertyId },
+      // `viewed_at` is `createdAt()`-defaulted, so an old row has to name it.
+      { oxyUserId: 'oxy-ancient', propertyId, viewedAt: new Date(Date.now() - 400 * DAY) },
+    ]);
+
+    const res = await request(buildApp('oxy-owner')).get('/analytics?period=30d');
+    expect(res.body.data.views.total).toBe(1);
+  });
+});

--- a/packages/backend/controllers/analyticsController.ts
+++ b/packages/backend/controllers/analyticsController.ts
@@ -8,7 +8,15 @@ import type { Request, Response, NextFunction } from 'express';
 
 import { AppError, successResponse } from '../middlewares/errorHandler';
 import { logger } from '../middlewares/logging';
-import { City, Profile, Property, RecentlyViewed, Saved, ViewingRequest } from '../models';
+import { City, Profile, Property } from '../models';
+import { getDb } from '../db/postgres';
+import {
+  countAppWideSaves,
+  countSavesOfProperties,
+  countViewsOfProperties,
+  listOwnedPropertyIds,
+} from '../db/analytics/ownerAnalytics';
+import { countViewingsByStatusForOwner } from '../db/bookings/viewingReads';
 
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -73,55 +81,29 @@ class AnalyticsController {
         );
       }
 
-      const propertyIds = await Property.distinct('_id', {
-        profileId: activeProfile._id,
-        status: { $ne: 'archived' },
-      });
+      // The owner key is `oxy_user_id`. The Mongo original filtered on
+      // `profileId`, which `PropertySchema` does not declare — so it matched no
+      // document, `propertyIds` was always empty, and the two guarded
+      // aggregates below never ran. Every number this endpoint reported has
+      // been 0 since it was written; see `db/analytics/ownerAnalytics.ts`.
+      const db = getDb();
+      const propertyIds = await listOwnedPropertyIds(db, oxyUserId);
 
-      const [viewsAgg, savesAgg, viewingAgg] = await Promise.all([
-        propertyIds.length
-          ? RecentlyViewed.aggregate([
-              { $match: { propertyId: { $in: propertyIds }, viewedAt: { $gte: since } } },
-              {
-                $group: {
-                  _id: null,
-                  total: { $sum: 1 },
-                  uniqueViewers: { $addToSet: '$profileId' },
-                },
-              },
-              { $project: { _id: 0, total: 1, uniqueViewers: { $size: '$uniqueViewers' } } },
-            ])
-          : Promise.resolve([]),
-        propertyIds.length
-          ? Saved.aggregate([
-              {
-                $match: {
-                  targetType: 'property',
-                  targetId: { $in: propertyIds },
-                  createdAt: { $gte: since },
-                },
-              },
-              { $group: { _id: null, total: { $sum: 1 } } },
-            ])
-          : Promise.resolve([]),
-        ViewingRequest.aggregate([
-          { $match: { ownerOxyUserId: activeProfile._id, createdAt: { $gte: since } } },
-          { $group: { _id: '$status', count: { $sum: 1 } } },
-        ]),
+      const [views, savesTotal, viewingBuckets] = await Promise.all([
+        countViewsOfProperties(db, propertyIds, since),
+        countSavesOfProperties(db, propertyIds, since),
+        countViewingsByStatusForOwner(db, oxyUserId, since),
       ]);
 
-      const views = {
-        total: viewsAgg[0]?.total || 0,
-        uniqueViewers: viewsAgg[0]?.uniqueViewers || 0,
-      };
-      const saves = { total: savesAgg[0]?.total || 0 };
+      const saves = { total: savesTotal };
 
       const viewingByStatus: Record<string, number> = {};
       let viewingReceived = 0;
-      for (const bucket of viewingAgg) {
-        viewingByStatus[bucket._id] = bucket.count;
+      for (const bucket of viewingBuckets) {
+        viewingByStatus[bucket.status] = bucket.count;
         viewingReceived += bucket.count;
       }
+
       const viewingRequests = {
         received: viewingReceived,
         pending: viewingByStatus.pending || 0,
@@ -174,12 +156,21 @@ class AnalyticsController {
   async getAppStats(req: Request, res: Response, next: NextFunction): Promise<void | Response> {
     try {
 
-      const [totalProperties, totalCities, totalSaves, uniqueSavers] = await Promise.all([
+      // `Property` and `City` stay on Mongo here: the catalogue aggregates
+      // below are the property batch's to move, and these two counts join
+      // nothing to the saved figures, so a mixed read produces two independent
+      // correct numbers rather than an inconsistency.
+      //
+      // The saved pair moves, because `saved_items` is on Postgres — and
+      // `uniqueSavers` was another `distinct('profileId')` against a schema
+      // whose column is `oxyUserId`, so it has always been 0.
+      const [totalProperties, totalCities, appSaves] = await Promise.all([
         Property.countDocuments({}),
         City.countDocuments({}),
-        Saved.countDocuments({ targetType: 'property' }),
-        Saved.distinct('profileId', { targetType: 'property' }).then((arr: unknown[]) => arr.length),
+        countAppWideSaves(getDb()),
       ]);
+      const totalSaves = appSaves.total;
+      const uniqueSavers = appSaves.uniqueSavers;
 
       // Pricing aggregates
       const pricingAgg = await Property.aggregate([

--- a/packages/backend/db/analytics/ownerAnalytics.ts
+++ b/packages/backend/db/analytics/ownerAnalytics.ts
@@ -1,0 +1,125 @@
+/**
+ * The owner analytics rollup — views, saves and viewing requests on a person's
+ * own listings.
+ *
+ * A module of its own rather than functions bolted onto
+ * `db/saved/*` or `db/properties/*`: these are CROSS-domain aggregates that
+ * belong to no single table's repository, and adding them to somebody else's
+ * would make three modules co-own one endpoint's shape.
+ *
+ * ## The endpoint has always returned zeros, and this is where that is fixed
+ *
+ * `analyticsController` selected the caller's listings with
+ * `Property.distinct('_id', { profileId: activeProfile._id, … })` — and
+ * **`PropertySchema` declares no `profileId`**. It has `oxyUserId` and nothing
+ * else that names an owner. Mongo matches no document against an undeclared
+ * field, so `propertyIds` was ALWAYS empty; the views and saves aggregates were
+ * guarded by `propertyIds.length ? … : Promise.resolve([])` and therefore never
+ * ran at all, and the viewing rollup matched `ownerOxyUserId` against a PROFILE
+ * id, which is a different id space again.
+ *
+ * So every number this endpoint reports has been 0 since it was written. Fixing
+ * the owner key is what makes the port meaningful — porting the reads while
+ * leaving the selector broken would move three queries to Postgres and still
+ * return zeros, which is worse than not porting them, because it looks done.
+ *
+ * **This is a user-visible behaviour change**, in the same class as the two
+ * `db/MIGRATION-CONTRACT.md` already names — `properties.views` starting to
+ * increment, and the saved-listing count starting to be non-zero once both
+ * sides of the comparison are `text`. Real numbers appearing where zeros were is
+ * correct behaviour arriving, not a defect to diagnose.
+ */
+
+import { and, count, countDistinct, eq, gte, inArray, ne } from 'drizzle-orm';
+import type { DatabaseOrTransaction } from '../postgres';
+import { properties, recentlyViewed, savedItems } from '../schema';
+
+/**
+ * The ids of the listings this person owns, excluding archived ones.
+ *
+ * `oxy_user_id` is the owner column — see the header for why the Mongo original
+ * matched nothing.
+ */
+export async function listOwnedPropertyIds(
+  db: DatabaseOrTransaction,
+  oxyUserId: string,
+): Promise<string[]> {
+  const rows = await db
+    .select({ id: properties.id })
+    .from(properties)
+    .where(and(eq(properties.oxyUserId, oxyUserId), ne(properties.status, 'archived')));
+  return rows.map((row) => row.id);
+}
+
+export interface ViewRollup {
+  readonly total: number;
+  readonly uniqueViewers: number;
+}
+
+/**
+ * Views of `propertyIds` since `since`.
+ *
+ * `countDistinct` on the viewer, where Mongo used `$addToSet` then `$size` —
+ * the same question, answered without materialising the set. Note the source
+ * grouped `$addToSet: '$profileId'` on a collection whose column is
+ * `oxy_user_id`; that path does not exist either, so the unique count was
+ * `[null]`, i.e. 1, on any row it had ever seen. It counts the owner column now.
+ */
+export async function countViewsOfProperties(
+  db: DatabaseOrTransaction,
+  propertyIds: readonly string[],
+  since: Date,
+): Promise<ViewRollup> {
+  if (propertyIds.length === 0) return { total: 0, uniqueViewers: 0 };
+  const [row] = await db
+    .select({
+      total: count(),
+      uniqueViewers: countDistinct(recentlyViewed.oxyUserId),
+    })
+    .from(recentlyViewed)
+    .where(
+      and(
+        inArray(recentlyViewed.propertyId, [...propertyIds]),
+        gte(recentlyViewed.viewedAt, since),
+      ),
+    );
+  return { total: row.total, uniqueViewers: row.uniqueViewers };
+}
+
+/**
+ * App-wide saved-listing totals: how many saves, and how many distinct people.
+ *
+ * `uniqueSavers` had the SAME defect as the owner selector above and for the
+ * same reason: `Saved.distinct('profileId', …)` on a schema whose column is
+ * `oxyUserId`, so it has always answered 0. `count_distinct` on the real owner
+ * column is what it was trying to say.
+ */
+export async function countAppWideSaves(
+  db: DatabaseOrTransaction,
+): Promise<{ total: number; uniqueSavers: number }> {
+  const [row] = await db
+    .select({ total: count(), uniqueSavers: countDistinct(savedItems.oxyUserId) })
+    .from(savedItems)
+    .where(eq(savedItems.targetType, 'property'));
+  return { total: row.total, uniqueSavers: row.uniqueSavers };
+}
+
+/** Saves of `propertyIds` since `since`. */
+export async function countSavesOfProperties(
+  db: DatabaseOrTransaction,
+  propertyIds: readonly string[],
+  since: Date,
+): Promise<number> {
+  if (propertyIds.length === 0) return 0;
+  const [row] = await db
+    .select({ total: count() })
+    .from(savedItems)
+    .where(
+      and(
+        eq(savedItems.targetType, 'property'),
+        inArray(savedItems.targetId, [...propertyIds]),
+        gte(savedItems.createdAt, since),
+      ),
+    );
+  return row.total;
+}

--- a/packages/backend/db/bookings/viewingReads.ts
+++ b/packages/backend/db/bookings/viewingReads.ts
@@ -27,7 +27,7 @@
  * cardinality of the predicate, not a preference.
  */
 
-import { and, asc, eq, inArray, ne, sql } from 'drizzle-orm';
+import { and, asc, eq, inArray, lt, ne, sql } from 'drizzle-orm';
 import type { SQL } from 'drizzle-orm';
 import type { DatabaseOrTransaction } from '../postgres';
 import { viewingRequests } from '../schema';
@@ -267,6 +267,69 @@ export async function rescheduleViewing(
     )
     .returning();
   return row;
+}
+
+/**
+ * Delete declined and cancelled requests last touched before `cutoff`.
+ *
+ * The Postgres half of `cleanupService`'s retention sweep. `VIEWING_REQUEST_
+ * RETENTION_DAYS` stays in `cleanupService`, beside the RecentlyViewed window it
+ * sits next to, so the two retention policies are read in one place.
+ *
+ * ## Why this one mattered more than the other stale readers
+ *
+ * When the table moved to Postgres this sweep kept issuing its `deleteMany`
+ * against Mongo, so it reaped NOTHING — and unlike a read that returns an empty
+ * list, a sweep that deletes nothing produces no output a caller can notice. Its
+ * only symptom is disk, months later, by which time nobody connects it to a
+ * migration. `db/expiry.ts` records the same hazard from the schema side: a
+ * table ported without its sweep grows forever, with no error and no failing
+ * test.
+ *
+ * `updated_at` is the retention key, exactly as in Mongo — it carries drizzle's
+ * `$onUpdate`, so it moves when the request is declined or cancelled, which is
+ * the instant the clock should start from.
+ *
+ * @param cutoff Rows with `updated_at` strictly before this are removed.
+ * @returns How many rows went.
+ */
+export async function pruneClosedViewingsBefore(
+  db: DatabaseOrTransaction,
+  cutoff: Date,
+): Promise<number> {
+  const rows = await db
+    .delete(viewingRequests)
+    .where(
+      and(
+        inArray(viewingRequests.status, ['declined', 'cancelled']),
+        lt(viewingRequests.updatedAt, cutoff),
+      ),
+    )
+    .returning({ id: viewingRequests.id });
+  return rows.length;
+}
+
+/**
+ * Viewing requests received by a listing owner since `since`, grouped by status.
+ *
+ * The analytics rollup. A `group by` in SQL where Mongo used a `$group`
+ * pipeline, so the five buckets come from one statement rather than five.
+ */
+export async function countViewingsByStatusForOwner(
+  db: DatabaseOrTransaction,
+  ownerOxyUserId: string,
+  since: Date,
+): Promise<readonly { status: string; count: number }[]> {
+  return db
+    .select({ status: viewingRequests.status, count: sql<number>`count(*)::int` })
+    .from(viewingRequests)
+    .where(
+      and(
+        eq(viewingRequests.ownerOxyUserId, ownerOxyUserId),
+        sql`${viewingRequests.createdAt} >= ${since.toISOString()}::timestamptz`,
+      ),
+    )
+    .groupBy(viewingRequests.status);
 }
 
 /**

--- a/packages/backend/services/cleanupService.ts
+++ b/packages/backend/services/cleanupService.ts
@@ -1,8 +1,8 @@
 import { Logger } from '../utils/logger';
 import { cleanupExpiredProperties } from './scraperService';
-import { ViewingRequest } from '../models';
 import { getDb } from '../db/postgres';
 import { pruneRecentlyViewedBefore } from '../db/saved/recentlyViewedRepository';
+import { pruneClosedViewingsBefore } from '../db/bookings/viewingReads';
 
 /**
  * The ONLY bound on `recently_viewed`, which is the one table in the saved-items
@@ -85,12 +85,9 @@ export class CleanupService {
     }
 
     try {
-      const result = await ViewingRequest.deleteMany({
-        status: { $in: ['declined', 'cancelled'] },
-        updatedAt: { $lt: viewingRequestCutoff },
-      });
-      deleted += result.deletedCount || 0;
-      this.logger.info(`Deleted ${result.deletedCount || 0} declined/cancelled viewing requests older than ${VIEWING_REQUEST_RETENTION_DAYS} days`);
+      const removed = await pruneClosedViewingsBefore(getDb(), viewingRequestCutoff);
+      deleted += removed;
+      this.logger.info(`Deleted ${removed} declined/cancelled viewing requests older than ${VIEWING_REQUEST_RETENTION_DAYS} days`);
     } catch (error) {
       errors += 1;
       this.logger.error('ViewingRequest cleanup failed', error);


### PR DESCRIPTION
The two files that kept reading `viewing_requests` from Mongo after the table moved in #305. Assigned by ownership of the **table** rather than of the directory — `controllers/property/stats.ts` and `list.ts` read `Lease`/`Reservation`/`Saved` and go to the property batch instead, untouched here.

## `cleanupService` was the worse of the two, and the reason is worth naming

Its `deleteMany` kept going to Mongo, so the retention sweep **reaped nothing**. The other stale readers return zero to a caller who can at least *see* an empty result; a sweep that deletes nothing produces no output at all. Its only symptom is disk, months later, by which time nobody connects it to a migration — the same shape as a check whose success and whose total failure look identical from outside. `db/expiry.ts` records the hazard from the schema side.

`pruneClosedViewingsBefore` is its Postgres half, sitting beside the `pruneRecentlyViewedBefore` the sibling added in #308; the two retention windows stay together in `cleanupService`.

## The analytics endpoint has ALWAYS returned zeros, and this is where that ends

Porting the reads alone would have moved three queries to Postgres and still answered 0 — worse than not porting them, because it looks done. **Three independent defects, all predating the migration:**

- `Property.distinct('_id', { profileId: … })` — `PropertySchema` declares no `profileId`, only `oxyUserId`. Mongo matches nothing against an undeclared field, so `propertyIds` was always empty and the two aggregates guarded by `propertyIds.length ? … : Promise.resolve([])` **never ran at all**.
- `ViewingRequest.aggregate` matched `ownerOxyUserId` against `activeProfile._id` — a *profile* id in an Oxy-user-id column.
- `$addToSet: '$profileId'` on a collection whose column is `oxyUserId`, so `uniqueViewers` counted a set of nulls.

`getAppStats` had a fourth of the same kind: `Saved.distinct('profileId', …)`. `Property` and `City` stay on Mongo there — those aggregates belong to the property batch, and they join nothing to the saved figures, so the mixed read produces two independent correct numbers rather than an inconsistency.

**This is a user-visible behaviour change**, in the class `db/MIGRATION-CONTRACT.md` already names alongside `properties.views` starting to increment: real numbers appearing where zeros were is correct behaviour arriving, not a defect to diagnose.

## Tests

**117 suites / 1497 tests → 121 / 1558**, green. CI floor 1415 → 1450. Lint 166 → **145** warnings, 0 errors.

Mutation-tested, restored in place, `git diff` verified byte-clean. **One survived the first round, and the fixture was at fault rather than the code:**

| mutation | result |
|---|---|
| sweep deletes nothing | 1 red |
| sweep drops the status filter | 1 red |
| owner selector drops the owner | 1 red |
| owner selector keeps archived listings | 1 red |
| `count_distinct` → `count` | **survived** → 1 red |

Two views by two people make `count(*)` and `count(distinct viewer)` agree, so the assertion could not tell them apart. The fixture now has **one viewer across two listings plus a second viewer** — 3 views, 2 people — so the two figures must disagree. Same class as the vacuous boundary test #309 turned up, and the second time a too-tidy fixture has hidden a real gap in my own work.

## Census note

Re-running the reader census across **all** ported tables (not just tenancy) found the true straggler set is 7 sites in 5 files, not the 4 I first reported — `Saved` and `RecentlyViewed` are also read from `controllers/property/{stats,list,retrieve}.ts`. Those three are the property batch's. After this PR, `ViewingRequest` has **zero** remaining barrel readers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)