### PR TITLE
A minted id must be deterministic, or `ON CONFLICT DO NOTHING` is a false claim

### DIFF
--- a/packages/backend/__tests__/db/dataBackfill.test.ts
+++ b/packages/backend/__tests__/db/dataBackfill.test.ts
@@ -39,6 +39,7 @@ import {
   DATA_COPY_ORDER,
   DATA_PLANS,
   DATA_RESOLUTIONS,
+  deterministicUuidV7,
   toAddressRow,
   toAgencyRow,
   toProfileChatMessageRows,
@@ -48,6 +49,7 @@ import {
   toPropertyWindowRows,
 } from '../../db/backfill/dataPlan';
 import { RowAuditor, UniqueKeyAuditor, type CandidateRow } from '../../db/backfill/rowAudit';
+import { isLiveEntityId } from '@oxyhq/db';
 import { ResolutionLog } from '../../db/backfill/geoPlan';
 
 /** The property rules, reached through the PLAN so the test cannot drift from it. */
@@ -70,7 +72,8 @@ function mongoDatabase() {
 
 const BARCELONA = { lng: 2.1686, lat: 41.3985 };
 const MADRID = { lng: -3.7038, lat: 40.4168 };
-const PARIS = { lng: 2.3522, lat: 48.8566 };
+const BERLIN = { lng: 13.4050, lat: 52.5200 };
+const WARSZAWA = { lng: 21.0122, lat: 52.2297 };
 
 interface GeoFixture {
   readonly countryId: mongoose.Types.ObjectId;
@@ -86,7 +89,8 @@ async function seedGeo(): Promise<GeoFixture> {
   const cityIds: Record<string, mongoose.Types.ObjectId> = {
     Barcelona: oid(),
     Madrid: oid(),
-    Paris: oid(),
+    Berlin: oid(),
+    Warszawa: oid(),
   };
 
   await database.collection('countries').insertOne({
@@ -107,7 +111,11 @@ async function seedGeo(): Promise<GeoFixture> {
     updatedAt: new Date('2026-01-01T00:00:00.000Z'),
   });
   for (const [name, id] of Object.entries(cityIds)) {
-    const point = name === 'Barcelona' ? BARCELONA : name === 'Madrid' ? MADRID : PARIS;
+    const point =
+      name === 'Barcelona' ? BARCELONA
+      : name === 'Madrid' ? MADRID
+      : name === 'Berlin' ? BERLIN
+      : WARSZAWA;
     await database.collection('cities').insertOne({
       _id: id,
       name,
@@ -204,6 +212,22 @@ function propertyDocument(
     updatedAt: new Date('2026-03-11T00:00:00.000Z'),
     ...overrides,
   };
+}
+
+/**
+ * Addresses in the cities the named distance pairs use.
+ *
+ * Verification requires at least two measurable real-world distances, so a
+ * fixture with addresses in one city anchors nothing — and a pair that cannot be
+ * measured is reported as such rather than counted as a pass. Madrid, Berlin and
+ * Warszawa give Madrid→Berlin and Berlin→Warszawa.
+ */
+async function seedMeasurableAddresses(geo: GeoFixture): Promise<void> {
+  await mongoDatabase().collection('addresses').insertMany([
+    addressDocument(geo, 'Madrid', MADRID, { street: 'Gran Vía', postal_code: '28013' }),
+    addressDocument(geo, 'Berlin', BERLIN, { street: 'Unter den Linden', postal_code: '10117', countryCode: 'DE' }),
+    addressDocument(geo, 'Warszawa', WARSZAWA, { street: 'Nowy Świat', postal_code: '00-001', countryCode: 'PL' }),
+  ]);
 }
 
 /** Seed a coherent source and copy the geo half, as production did. */
@@ -436,6 +460,88 @@ describe('data backfill — the mappers', () => {
   });
 });
 
+describe('data backfill — minted subdocument ids are deterministic', () => {
+  const log = () => new ResolutionLog();
+
+  // `availabilityWindowSchema` declares `{ _id: false }`, so a calendar window
+  // has no id to preserve. A RANDOM mint and `ON CONFLICT DO NOTHING` cannot
+  // both hold: a fresh random key never conflicts, so a re-run would DUPLICATE
+  // every window rather than skip it — in exactly the resumed-partial-run case
+  // the idempotence rule exists for.
+  const withWindows = (propertyId: mongoose.Types.ObjectId) =>
+    propertyDocument(propertyId, {
+      createdAt: new Date('2026-07-25T10:11:12.345Z'),
+      availabilityWindows: [
+        { start: new Date('2026-05-01'), end: new Date('2026-05-08'), status: 'available' },
+        { start: new Date('2026-06-01'), end: new Date('2026-06-08'), status: 'blocked' },
+      ],
+    });
+
+  it('produces the SAME id from the same document on every run', () => {
+    const document = withWindows(oid());
+    const first = toPropertyWindowRows(document, log()).map((row) => row.id);
+    const second = toPropertyWindowRows(document, log()).map((row) => row.id);
+    expect(first).toEqual(second);
+    expect(new Set(first).size).toBe(2);
+  });
+
+  it('separates the two calendars, which share a table and an index', () => {
+    // `availabilityWindows[0]` and `exchange.availabilityWindows[0]` are
+    // different rows; the PATH is in the natural key so they cannot collide.
+    const document = propertyDocument(oid(), {
+      offerings: ['long_term_rent', 'exchange'],
+      availabilityWindows: [{ start: new Date('2026-05-01'), end: new Date('2026-05-08') }],
+      exchange: {
+        mode: 'swap',
+        availabilityWindows: [{ start: new Date('2026-05-01'), end: new Date('2026-05-08') }],
+      },
+    });
+    const ids = toPropertyWindowRows(document, log()).map((row) => row.id);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it('mints an id the application would accept, checked against the REAL guard', () => {
+    const ids = toPropertyWindowRows(withWindows(oid()), log()).map((row) => String(row.id));
+    for (const id of ids) expect(isLiveEntityId(id)).toBe(true);
+  });
+
+  it("carries the parent's created_at in the timestamp prefix, so ids stay k-sortable", () => {
+    const created = new Date('2026-07-25T10:11:12.345Z');
+    const id = deterministicUuidV7(created, 'anything');
+    const prefix = Number.parseInt(id.replace(/-/g, '').slice(0, 12), 16);
+    expect(prefix).toBe(created.getTime());
+  });
+
+  it('falls back to the Unix epoch, NEVER to now, when the timestamp is unusable', () => {
+    // `Date.now()` here would reintroduce the whole defect for exactly the rows
+    // whose timestamps are broken — their ids would differ between two runs.
+    const first = deterministicUuidV7(undefined, 'k');
+    const second = deterministicUuidV7(new Date('nonsense'), 'k');
+    expect(first).toBe(second);
+    expect(Number.parseInt(first.replace(/-/g, '').slice(0, 12), 16)).toBe(0);
+  });
+
+  it('converges on a re-run rather than duplicating every window', async () => {
+    const geo = await seedAndCopyGeo();
+    const database = mongoDatabase();
+    const address = addressDocument(geo, 'Barcelona', BARCELONA);
+    await database.collection('addresses').insertOne(address);
+    await seedMeasurableAddresses(geo);
+    await database.collection('properties').insertOne(
+      withWindows(address._id as mongoose.Types.ObjectId),
+    );
+
+    await runDataBackfill({ mongo: database, database: getDb(), mode: 'copy', sampleSize: 5 });
+    await runDataBackfill({ mongo: database, database: getDb(), mode: 'copy', sampleSize: 5 });
+
+    const [row] = await getDb()
+      .select({ total: sql<number>`count(*)::int` })
+      .from(propertyAvailabilityWindows);
+    // Two windows, copied twice. A random mint gives four.
+    expect(row.total).toBe(2);
+  }, 120_000);
+});
+
 // ── the audit ──────────────────────────────────────────────────────
 
 describe('data backfill — the audit', () => {
@@ -559,8 +665,9 @@ describe('data backfill — end to end', () => {
 
     const barcelona = addressDocument(geo, 'Barcelona', BARCELONA);
     const madrid = addressDocument(geo, 'Madrid', MADRID, { street: 'Gran Vía', postal_code: '28013' });
-    const paris = addressDocument(geo, 'Paris', PARIS, { street: 'Rue de Rivoli', postal_code: '75001', countryCode: 'FR' });
-    await database.collection('addresses').insertMany([barcelona, madrid, paris]);
+    await database.collection('addresses').insertMany([barcelona, madrid]);
+    await seedMeasurableAddresses(geo);
+    const berlin = madrid;
 
     const agency = { _id: oid(), name: 'Finques Verdi', normalizedName: 'finques verdi', slug: 'finques-verdi', createdAt: new Date(), updatedAt: new Date() };
     await database.collection('agencies').insertOne(agency);
@@ -577,8 +684,8 @@ describe('data backfill — end to end', () => {
       hasImages: false,
     });
     const withoutPhoto = propertyDocument(madrid._id as mongoose.Types.ObjectId, { hasImages: true });
-    const parisian = propertyDocument(paris._id as mongoose.Types.ObjectId);
-    await database.collection('properties').insertMany([withPhoto, withoutPhoto, parisian]);
+    const berliner = propertyDocument(berlin._id as mongoose.Types.ObjectId);
+    await database.collection('properties').insertMany([withPhoto, withoutPhoto, berliner]);
 
     await database.collection('profiles').insertOne({
       _id: oid(),
@@ -648,11 +755,8 @@ describe('data backfill — end to end', () => {
   it('measures a REAL distance, so a transposed coordinate pair cannot pass', async () => {
     const geo = await seedAndCopyGeo();
     const database = mongoDatabase();
-    await database.collection('addresses').insertMany([
-      addressDocument(geo, 'Barcelona', BARCELONA),
-      addressDocument(geo, 'Madrid', MADRID, { street: 'Gran Vía' }),
-      addressDocument(geo, 'Paris', PARIS, { street: 'Rue de Rivoli', countryCode: 'FR' }),
-    ]);
+    await database.collection('addresses').insertOne(addressDocument(geo, 'Barcelona', BARCELONA));
+    await seedMeasurableAddresses(geo);
 
     await runDataBackfill({
       mongo: database,
@@ -663,15 +767,42 @@ describe('data backfill — end to end', () => {
     });
 
     const geometry = await checkGeometry(getDb());
-    expect(geometry.centroidSamples).toBe(3);
+    expect(geometry.centroidSamples).toBe(4);
     expect(geometry.centroidOverLimit).toBe(0);
 
-    const [toMadrid, toParis] = geometry.pairs;
-    expect(toMadrid.withinTolerance).toBe(true);
-    expect(toMadrid.measuredMetres).toBeGreaterThan(400_000);
-    expect(toMadrid.measuredMetres).toBeLessThan(600_000);
-    expect(toParis.withinTolerance).toBe(true);
-    expect(toParis.measuredMetres).toBeGreaterThan(700_000);
+    // Pairs chosen from cities that actually carry addresses. A pair that cannot
+    // be measured names its reason rather than answering a bare `null`.
+    const measured = geometry.pairs.filter((pair) => pair.measuredMetres !== null);
+    expect(measured.length).toBeGreaterThanOrEqual(2);
+    expect(measured.every((pair) => pair.withinTolerance === true)).toBe(true);
+    for (const pair of geometry.pairs) {
+      if (pair.measuredMetres === null) expect(pair.notMeasured).toMatch(/no address in/);
+      else expect(pair.notMeasured).toBeNull();
+    }
+  }, 60_000);
+
+  it('refuses when too FEW named pairs could be measured to anchor anything', async () => {
+    // The vacuity floor on the anchor itself. The first version of this check
+    // named Barcelona→Paris, which returned a bare `null` on every run because
+    // production holds no Paris address — a probe that answers `null` cannot
+    // tell "correct" from "nothing to measure against", and one surviving
+    // measurement is a coincidence away from meaning nothing.
+    const geo = await seedAndCopyGeo();
+    const database = mongoDatabase();
+    // Madrid only: no pair has both endpoints.
+    await database.collection('addresses').insertOne(
+      addressDocument(geo, 'Madrid', MADRID, { street: 'Gran Vía' }),
+    );
+
+    await expect(
+      runDataBackfill({
+        mongo: database,
+        database: getDb(),
+        mode: 'copy',
+        sampleSize: 5,
+        only: ['images', 'addresses'],
+      }),
+    ).rejects.toThrow(/named city\s+pairs could be measured/);
   }, 60_000);
 
   it('a TRANSPOSED pair lands thousands of kilometres from its own city', async () => {
@@ -712,11 +843,8 @@ describe('data backfill — end to end', () => {
     const geo = await seedAndCopyGeo();
     const database = mongoDatabase();
     const address = addressDocument(geo, 'Barcelona', BARCELONA);
-    await database.collection('addresses').insertMany([
-      address,
-      addressDocument(geo, 'Madrid', MADRID, { street: 'Gran Vía' }),
-      addressDocument(geo, 'Paris', PARIS, { street: 'Rue de Rivoli', countryCode: 'FR' }),
-    ]);
+    await database.collection('addresses').insertOne(address);
+    await seedMeasurableAddresses(geo);
     await database.collection('properties').insertMany([
       propertyDocument(address._id as mongoose.Types.ObjectId),
       propertyDocument(address._id as mongoose.Types.ObjectId),
@@ -745,10 +873,9 @@ describe('data backfill — end to end', () => {
     const good = Array.from({ length: 300 }, () =>
       addressDocument(geo, 'Barcelona', BARCELONA),
     );
+    await seedMeasurableAddresses(geo);
     await database.collection('addresses').insertMany([
       ...good,
-      addressDocument(geo, 'Madrid', MADRID, { street: 'Gran Vía' }),
-      addressDocument(geo, 'Paris', PARIS, { street: 'Rue de Rivoli', countryCode: 'FR' }),
       // One bad geocode: Caracas, filed under a Spanish city. 1 in 303 is well
       // under the 1% threshold.
       addressDocument(geo, 'Barcelona', { lng: -66.9858849, lat: 10.5251816 }),
@@ -764,7 +891,12 @@ describe('data backfill — end to end', () => {
 
     // Reported, not swallowed — and the run stands.
     expect(report.geometry?.centroidOverLimit).toBe(1);
-    expect(report.geometry?.centroidSamples).toBe(303);
+    expect(report.geometry?.centroidSamples).toBe(304);
+    // Classified and named, not folded into a count somebody has to go and look
+    // up. `(0,0)` is told apart from "wrong country" because the remedies differ.
+    expect(report.geometry?.outliers).toEqual([
+      expect.objectContaining({ resolution: 'SOURCE_COORDINATES_FAR_FROM_CITY' }),
+    ]);
   }, 120_000);
 
   it('refuses to write anything when the audit finds a violation', async () => {
@@ -806,11 +938,8 @@ describe('data backfill — end to end', () => {
     const address = addressDocument(geo, 'Barcelona', BARCELONA);
     // Madrid and Paris too: full verification demands at least one measurable
     // real-world distance, and one city cannot supply one.
-    await database.collection('addresses').insertMany([
-      address,
-      addressDocument(geo, 'Madrid', MADRID, { street: 'Gran Vía' }),
-      addressDocument(geo, 'Paris', PARIS, { street: 'Rue de Rivoli', countryCode: 'FR' }),
-    ]);
+    await database.collection('addresses').insertOne(address);
+    await seedMeasurableAddresses(geo);
     await database.collection('properties').insertOne(
       propertyDocument(address._id as mongoose.Types.ObjectId),
     );
@@ -820,13 +949,13 @@ describe('data backfill — end to end', () => {
 
     const inserted = (report: typeof first, collection: string) =>
       report.copied.find((entry) => entry.collection === collection)?.inserted ?? {};
-    expect(inserted(first, 'addresses').addresses).toBe(3);
+    expect(inserted(first, 'addresses').addresses).toBe(4);
     // `ON CONFLICT DO NOTHING` still reports the batch it SENT; what proves
     // convergence is that verification passes and the table did not grow.
     expect(second.verified.every((entry) => entry.missing === 0)).toBe(true);
 
     const [row] = await getDb().select({ total: sql<number>`count(*)::int` }).from(addresses);
-    expect(row.total).toBe(3);
+    expect(row.total).toBe(4);
   }, 90_000);
 
   it('links a geo cover image once images exist, and never restamps updated_at', async () => {
@@ -916,11 +1045,8 @@ describe('data backfill — end to end', () => {
     const geo = await seedAndCopyGeo();
     const database = mongoDatabase();
     const address = addressDocument(geo, 'Barcelona', BARCELONA);
-    await database.collection('addresses').insertMany([
-      address,
-      addressDocument(geo, 'Madrid', MADRID, { street: 'Gran Vía' }),
-      addressDocument(geo, 'Paris', PARIS, { street: 'Rue de Rivoli', countryCode: 'FR' }),
-    ]);
+    await database.collection('addresses').insertOne(address);
+    await seedMeasurableAddresses(geo);
 
     const photos = Array.from({ length: 55 * 11 }, () => imageDocument());
     await database.collection('images').insertMany(photos);
@@ -959,11 +1085,8 @@ describe('data backfill — end to end', () => {
     const geo = await seedAndCopyGeo();
     const database = mongoDatabase();
     const address = addressDocument(geo, 'Barcelona', BARCELONA);
-    await database.collection('addresses').insertMany([
-      address,
-      addressDocument(geo, 'Madrid', MADRID, { street: 'Gran Vía' }),
-      addressDocument(geo, 'Paris', PARIS, { street: 'Rue de Rivoli', countryCode: 'FR' }),
-    ]);
+    await database.collection('addresses').insertOne(address);
+    await seedMeasurableAddresses(geo);
     await database.collection('properties').insertOne(
       propertyDocument(address._id as mongoose.Types.ObjectId, {
         offerings: ['long_term_rent', 'exchange'],

--- a/packages/backend/db/MIGRATION-CONTRACT.md
+++ b/packages/backend/db/MIGRATION-CONTRACT.md
@@ -46,11 +46,39 @@ other tables and not find one. The complete set:
 | `TenantApplication.documents[]` | `tenant_application_documents` |
 | `EvictionCase.attendees[]` | `eviction_case_attendees` |
 | `PlacePoi.categories[]` | `place_poi_categories` |
+| `Property.availabilityWindows[]` and `Property.exchange.availabilityWindows[]` | `property_availability_windows` |
 
 Every OTHER embedded array in this migration is an implicit or explicit
 `{ _id: true }` subdocument and keeps its id verbatim — including
 `Lease.paymentSchedule[]`, whose ids `recordPayment` already looks rows up by,
 and `Conversation.messages[]`.
+
+**The last row was missing until the data backfill was written, and its absence
+was not harmless.** `availabilityWindowSchema` (`models/schemas/PropertySchema.ts`)
+declares `{ _id: false }` and backs BOTH property calendars, so this table has no
+id to preserve — while the sentence above asserted that it does. A reader
+trusting the table would look for a stored id and not find one.
+
+## A minted id must be DETERMINISTIC, or idempotence is a false claim
+
+The rule above and "every insert is `ON CONFLICT DO NOTHING`, so a re-run
+converges" cannot both hold if the mint is random: a freshly-random primary key
+never conflicts, so a second run does not skip those rows, it DUPLICATES every
+one of them — in precisely the resumed-partial-run case the idempotence rule
+exists for.
+
+So a minted id is a pure function of the position the row occupies:
+`sha256(parentId|path|index)` supplies the 74 random bits and the PARENT's own
+`created_at` supplies the 48-bit timestamp prefix, with the version and variant
+nibbles pinned exactly as `@oxyhq/db`'s `uuidv7` pins them so `isLiveEntityId`
+still accepts it. `db/backfill/dataPlan.ts`'s `deterministicUuidV7` is the
+implementation. Same reasoning that already makes `moderation_outbox.id`
+deterministic: where the id IS the deduplication mechanism, minting a fresh one
+deletes it.
+
+The fallback for an unusable `created_at` is the Unix epoch and NEVER
+`Date.now()`. `Date.now()` reintroduces the whole defect for exactly the rows
+whose timestamps are broken, which is the version hardest to notice.
 
 **Two tables take an id that is neither an ObjectId nor a minted uuid.**
 `moderation_outbox.id` is DETERMINISTIC (`moderation:report.submit:<reportId>`)

--- a/packages/backend/db/backfill/data.ts
+++ b/packages/backend/db/backfill/data.ts
@@ -144,6 +144,29 @@ const PROGRESS_INTERVAL = 25_000;
 /** Ids listed in a report when something is missing. Enough to grep for. */
 const MAX_REPORTED_IDS = 5;
 
+/** Coordinate outliers listed individually, with their ids and classification. */
+const MAX_REPORTED_OUTLIERS = 20;
+
+/**
+ * A stored coordinate pair that is `(0, 0)` — the classic "no geocode" sentinel.
+ *
+ * Reported, never rewritten. It will place that listing in the Gulf of Guinea
+ * for every radius search, which is a real product problem and Homiio's to
+ * decide; a copy that silently repaired it would be a synchroniser rather than a
+ * copy.
+ */
+export const SOURCE_COORDINATES_NULL_ISLAND = 'SOURCE_COORDINATES_NULL_ISLAND';
+
+/**
+ * A stored coordinate pair that sits far from the city the address names.
+ *
+ * Measured in production on two rows, both faithful copies of what Mongo holds:
+ * `6a51a9e63b4cc38a9d6053f1` on `León Capital` is at (-66.99, 10.53), which is
+ * Caracas. A defect that predates the port, and one the copy must report rather
+ * than fail on.
+ */
+export const SOURCE_COORDINATES_FAR_FROM_CITY = 'SOURCE_COORDINATES_FAR_FROM_CITY';
+
 /**
  * How far an address may sit from its own city's centroid before it is
  * reported.
@@ -189,9 +212,28 @@ const CITY_PAIR_TOLERANCE = 0.25;
  * transposition check has to answer.
  */
 const CITY_PAIRS = [
-  { from: 'Barcelona', to: 'Madrid', metres: 505_000 },
-  { from: 'Barcelona', to: 'Paris', metres: 830_000 },
+  { from: 'Madrid', to: 'Berlin', metres: 1_868_000 },
+  { from: 'Berlin', to: 'Warszawa', metres: 517_000 },
+  { from: 'Hamburg', to: 'Köln', metres: 356_000 },
 ] as const;
+
+/**
+ * How many named pairs must actually MEASURE for the anchor to mean anything.
+ *
+ * The first version named Barcelona→Madrid and Barcelona→Paris. Paris returned
+ * `null` on every run and always would: production is a Spanish/German/Polish
+ * portal and holds no Paris address at all. A probe that silently answers `null`
+ * is the vacuous shape — it cannot tell "correct" from "nothing to measure
+ * against" — so the pairs are now chosen from cities that DO carry addresses
+ * (Madrid 973, Warszawa 754, Hamburg 646, Köln 400, Berlin 301, measured
+ * 2026-08-09) and a pair that cannot be measured is reported as
+ * `notMeasured` with its reason rather than as a quiet `null`.
+ *
+ * Two of three, not all three: a city can legitimately empty out as listings
+ * expire, and a check that fails on that is a check somebody switches off. Two
+ * independent real-world distances is enough to anchor a coordinate system.
+ */
+const MINIMUM_MEASURED_PAIRS = 2;
 
 /** Per-collection outcome of the copy. */
 export interface CopyReport {
@@ -222,6 +264,15 @@ export interface GeometryReport {
     readonly expectedMetres: number;
     readonly measuredMetres: number | null;
     readonly withinTolerance: boolean | null;
+    /** Why a pair produced no distance. `null` when it did. */
+    readonly notMeasured: string | null;
+  }[];
+  /** The outliers themselves, classified — never a bare count. */
+  readonly outliers: readonly {
+    readonly addressId: string;
+    readonly city: string;
+    readonly metres: number;
+    readonly resolution: string;
   }[];
 }
 
@@ -866,31 +917,80 @@ export async function checkGeometry(database: Database): Promise<GeometryReport>
     ) measured
   `);
 
+  // The outliers THEMSELVES, classified — never a bare count. A number that
+  // somebody has to go and look up is a number nobody looks up, and these two
+  // rows are source defects an operator may want to act on independently of
+  // whether the run passes.
+  const outlierRows = await database.execute<{
+    id: string;
+    city: string;
+    metres: number;
+    longitude: number;
+    latitude: number;
+  }>(sql`
+    select a.id, c.name as city, a.longitude, a.latitude,
+           ST_Distance(a.geo, ST_MakePoint(c.longitude, c.latitude)::geography) as metres
+    from addresses a
+    join cities c on c.id = a.city_id
+    where c.longitude is not null and c.latitude is not null
+      and ST_Distance(a.geo, ST_MakePoint(c.longitude, c.latitude)::geography)
+          > ${CITY_CENTROID_LIMIT_METRES}
+    order by metres desc
+    limit ${MAX_REPORTED_OUTLIERS}
+  `);
+
+  const outliers = outlierRows.map((row) => ({
+    addressId: row.id,
+    city: row.city,
+    metres: row.metres,
+    // `(0, 0)` is the classic "no geocode" sentinel, not a position in the Gulf
+    // of Guinea, and it is worth telling apart from a listing that simply sits
+    // in the wrong country: the remedies differ. NEITHER is rewritten here — a
+    // backfill that silently repaired source data would be a synchroniser, and
+    // whether to null it is Homiio's call, not the copy's.
+    resolution:
+      row.longitude === 0 && row.latitude === 0
+        ? SOURCE_COORDINATES_NULL_ISLAND
+        : SOURCE_COORDINATES_FAR_FROM_CITY,
+  }));
+
   const pairs: GeometryReport['pairs'][number][] = [];
   for (const pair of CITY_PAIRS) {
-    const [row] = await database.execute<{ metres: number | null }>(sql`
-      select ST_Distance(
-        (select a.geo from addresses a join cities c on c.id = a.city_id
-          where lower(c.name) = lower(${pair.from}) limit 1),
-        (select a.geo from addresses a join cities c on c.id = a.city_id
-          where lower(c.name) = lower(${pair.to}) limit 1)
-      ) as metres
+    const [row] = await database.execute<{
+      metres: number | null;
+      from_addresses: string;
+      to_addresses: string;
+    }>(sql`
+      select
+        ST_Distance(
+          (select a.geo from addresses a join cities c on c.id = a.city_id
+            where lower(c.name) = lower(${pair.from}) limit 1),
+          (select a.geo from addresses a join cities c on c.id = a.city_id
+            where lower(c.name) = lower(${pair.to}) limit 1)
+        ) as metres,
+        (select count(*)::text from addresses a join cities c on c.id = a.city_id
+          where lower(c.name) = lower(${pair.from})) as from_addresses,
+        (select count(*)::text from addresses a join cities c on c.id = a.city_id
+          where lower(c.name) = lower(${pair.to})) as to_addresses
     `);
     const measuredMetres = row?.metres ?? null;
+    // A `null` distance is NAMED rather than left to be interpreted. The old
+    // shape returned a bare `null` for "no address in Paris", which reads
+    // identically to a failed measurement and to a passed one.
+    const notMeasured =
+      measuredMetres !== null
+        ? null
+        : `no address in ${Number(row?.from_addresses ?? 0) === 0 ? pair.from : pair.to}`;
     pairs.push({
       from: pair.from,
       to: pair.to,
       expectedMetres: pair.metres,
       measuredMetres,
-      // `null` rather than `false` when a city has no address: "nothing in
-      // Paris" is not a failed distance check, and reporting it as one would
-      // make an honest gap indistinguishable from a transposition. The CALLER
-      // decides what to do with it — and treats it as not-passed, so an absent
-      // city can never be read as a pass either.
       withinTolerance:
         measuredMetres === null
           ? null
           : Math.abs(measuredMetres - pair.metres) <= pair.metres * CITY_PAIR_TOLERANCE,
+      notMeasured,
     });
   }
 
@@ -899,6 +999,7 @@ export async function checkGeometry(database: Database): Promise<GeometryReport>
     centroidMaxMetres: centroid?.max_metres ?? null,
     centroidOverLimit: Number(centroid?.over_limit ?? 0),
     pairs,
+    outliers,
   };
 }
 
@@ -1085,6 +1186,14 @@ export async function runDataBackfill(options: {
       // Reported either way; the RATE decides whether the run is refused. See
       // CITY_CENTROID_OUTLIER_LIMIT — a transposition moves every address, a bad
       // geocode in the source moves one.
+      for (const outlier of geometry.outliers) {
+        logger.warn(
+          `geometry: ${outlier.resolution} ${outlier.addressId} in ${outlier.city}, ` +
+          `${Math.round(outlier.metres / 1000)} km from its city centroid. Reported, ` +
+          'not rewritten — the copy is faithful and repairing source data is a ' +
+          'separate decision.',
+        );
+      }
       if (share > CITY_CENTROID_OUTLIER_LIMIT) {
         failures.push(`geometry: ${line} — the shape a transposed pair makes`);
       } else {
@@ -1096,16 +1205,25 @@ export async function runDataBackfill(options: {
         );
       }
     }
-    // A pair with no address in one of its cities was NOT MEASURED, which is not
-    // the same as measured-and-wrong: reporting it as a failure would make an
-    // honest gap indistinguishable from a transposition. What must not happen is
-    // every pair going unmeasured and the check reporting a pass — so the
-    // vacuity floor is that at least one real-world distance was obtained.
+    // A pair with no address in one of its cities was NOT MEASURED, which is
+    // not the same as measured-and-wrong: reporting it as a failure would make
+    // an honest gap indistinguishable from a transposition. What must not happen
+    // is too FEW pairs measuring and the check reporting a pass anyway — a
+    // single anchor is one coincidence away from meaning nothing.
     const measured = geometry.pairs.filter((pair) => pair.measuredMetres !== null);
-    if (measured.length === 0) {
+    for (const pair of geometry.pairs) {
+      if (pair.notMeasured === null) continue;
+      logger.warn(
+        `geometry: ${pair.from}→${pair.to} was NOT measured — ${pair.notMeasured}. ` +
+        'Not a failure and not a pass; it contributes nothing either way.',
+      );
+    }
+    if (measured.length < MINIMUM_MEASURED_PAIRS) {
       failures.push(
-        'geometry: not one named city pair could be measured, so nothing anchored ' +
-        `the coordinates to a real-world distance (tried ${geometry.pairs.map((pair) => `${pair.from}→${pair.to}`).join(', ')})`,
+        `geometry: only ${measured.length} of ${geometry.pairs.length} named city ` +
+        `pairs could be measured, below the ${MINIMUM_MEASURED_PAIRS} needed to ` +
+        'anchor the coordinates to real-world distances at all ' +
+        `(${geometry.pairs.map((pair) => `${pair.from}→${pair.to}: ${pair.notMeasured ?? 'measured'}`).join('; ')})`,
       );
     }
     for (const pair of measured) {

--- a/packages/backend/db/backfill/dataPlan.ts
+++ b/packages/backend/db/backfill/dataPlan.ts
@@ -39,7 +39,7 @@
  * | `Region.imageIds[]` / `City.imageIds[]` | Dropped with the column: the relation already exists as `images.(entity_type, entity_id)`. |
  */
 
-import { uuidv7 } from '@oxyhq/db';
+import { createHash } from 'node:crypto';
 import type { PgTable } from 'drizzle-orm/pg-core';
 import {
   addresses,
@@ -848,8 +848,9 @@ export function toPropertyImageRows(
   log: ResolutionLog,
 ): readonly CandidateRow[] {
   const propertyId = idValue(document._id);
-  return subdocuments(document, 'images').map((child) => ({
-    id: mintedSubdocumentId(child, log),
+  const createdAt = createdAtValue(document, log);
+  return subdocuments(document, 'images').map((child, index) => ({
+    id: mintedSubdocumentId(child, propertyId, 'images', index, createdAt, log),
     propertyId,
     imageId: idValue(readPath(child, 'imageId')),
     url: optional(child, 'url'),
@@ -871,8 +872,9 @@ export function toPropertyDocumentRows(
   log: ResolutionLog,
 ): readonly CandidateRow[] {
   const propertyId = idValue(document._id);
-  return subdocuments(document, 'documents').map((child) => ({
-    id: mintedSubdocumentId(child, log),
+  const createdAt = createdAtValue(document, log);
+  return subdocuments(document, 'documents').map((child, index) => ({
+    id: mintedSubdocumentId(child, propertyId, 'documents', index, createdAt, log),
     propertyId,
     name: optional(child, 'name'),
     url: optional(child, 'url'),
@@ -897,9 +899,13 @@ export function toPropertyWindowRows(
   log: ResolutionLog,
 ): readonly CandidateRow[] {
   const propertyId = idValue(document._id);
+  const createdAt = createdAtValue(document, log);
+  // The path is part of the natural key, so the two calendars cannot collide
+  // even at the same index — `availabilityWindows[0]` and
+  // `exchange.availabilityWindows[0]` are different rows of the same table.
   const windows = (path: string, scope: 'listing' | 'exchange') =>
-    subdocuments(document, path).map((child) => ({
-      id: mintedSubdocumentId(child, log),
+    subdocuments(document, path).map((child, index) => ({
+      id: mintedSubdocumentId(child, propertyId, path, index, createdAt, log),
       propertyId,
       scope,
       // Mongo's `start` / `end`. Renamed because `end` is a reserved word and
@@ -1061,8 +1067,9 @@ export function toProfileReferenceRows(
   log: ResolutionLog,
 ): readonly CandidateRow[] {
   const profileId = idValue(document._id);
-  return subdocuments(document, 'personalProfile.references').map((child) => ({
-    id: mintedSubdocumentId(child, log),
+  const createdAt = createdAtValue(document, log);
+  return subdocuments(document, 'personalProfile.references').map((child, index) => ({
+    id: mintedSubdocumentId(child, profileId, 'personalProfile.references', index, createdAt, log),
     profileId,
     name: optional(child, 'name'),
     relationship: optional(child, 'relationship'),
@@ -1078,8 +1085,9 @@ export function toProfileRentalHistoryRows(
   log: ResolutionLog,
 ): readonly CandidateRow[] {
   const profileId = idValue(document._id);
-  return subdocuments(document, 'personalProfile.rentalHistory').map((child) => ({
-    id: mintedSubdocumentId(child, log),
+  const createdAt = createdAtValue(document, log);
+  return subdocuments(document, 'personalProfile.rentalHistory').map((child, index) => ({
+    id: mintedSubdocumentId(child, profileId, 'personalProfile.rentalHistory', index, createdAt, log),
     profileId,
     address: optional(child, 'address'),
     startDate: optional(child, 'startDate'),
@@ -1105,8 +1113,9 @@ export function toProfilePreferredLocationRows(
   log: ResolutionLog,
 ): readonly CandidateRow[] {
   const profileId = idValue(document._id);
-  return subdocuments(document, 'personalProfile.preferences.preferredLocations').map((child) => ({
-    id: mintedSubdocumentId(child, log),
+  const createdAt = createdAtValue(document, log);
+  return subdocuments(document, 'personalProfile.preferences.preferredLocations').map((child, index) => ({
+    id: mintedSubdocumentId(child, profileId, 'personalProfile.preferences.preferredLocations', index, createdAt, log),
     profileId,
     city: optional(child, 'city'),
     state: optional(child, 'state'),
@@ -1120,8 +1129,9 @@ export function toProfileRoommateHistoryRows(
   log: ResolutionLog,
 ): readonly CandidateRow[] {
   const profileId = idValue(document._id);
-  return subdocuments(document, 'personalProfile.settings.roommate.history').map((child) => ({
-    id: mintedSubdocumentId(child, log),
+  const createdAt = createdAtValue(document, log);
+  return subdocuments(document, 'personalProfile.settings.roommate.history').map((child, index) => ({
+    id: mintedSubdocumentId(child, profileId, 'personalProfile.settings.roommate.history', index, createdAt, log),
     profileId,
     startDate: optional(child, 'startDate'),
     endDate: optional(child, 'endDate'),
@@ -1143,12 +1153,13 @@ export function toProfileChatMessageRows(
   log: ResolutionLog,
 ): readonly CandidateRow[] {
   const profileId = idValue(document._id);
+  const createdAt = createdAtValue(document, log);
   return subdocuments(document, 'personalProfile.chatHistory').map((child, position) => ({
-    id: mintedSubdocumentId(child, log),
+    id: mintedSubdocumentId(child, profileId, 'personalProfile.chatHistory', position, createdAt, log),
     profileId,
     role: optional(child, 'role'),
     content: optional(child, 'content'),
-    timestamp: withSchemaDefault(child, 'timestamp', createdAtValue(document, log), log),
+    timestamp: withSchemaDefault(child, 'timestamp', createdAt, log),
     position,
   }));
 }
@@ -1264,20 +1275,86 @@ function subdocuments(document: SourceDocument, path: string): readonly SourceDo
 }
 
 /**
- * A subdocument's id, counting the mint.
+ * A subdocument's id: its own `_id` when it has one, else a DETERMINISTIC uuid
+ * v7 derived from where it sits.
  *
- * `uuidv7` comes from `@oxyhq/db`, which is where `generatedId()`'s own default
- * comes from — so a minted row id and an application-created one are the same
- * shape by construction rather than by two implementations agreeing.
+ * The DOCUMENT is asked rather than a hand-written list of which arrays declare
+ * `{ _id: false }` — that is one word in a schema file, and
+ * `availabilityWindowSchema` carries it while `MIGRATION-CONTRACT.md`'s table
+ * (now corrected) did not list it.
+ *
+ * ## Why the minted id may not be random
+ *
+ * A random primary key and `ON CONFLICT DO NOTHING` cannot both hold. Every
+ * insert here is `ON CONFLICT DO NOTHING` precisely so a run that died half way
+ * is a POSITION rather than a mess — and a freshly-random key never conflicts,
+ * so a second run would not skip those rows, it would DUPLICATE every one of
+ * them. That is the resumed-partial-run case the idempotence rule exists for,
+ * so the two rules met head-on and the random mint lost.
+ *
+ * Deterministic from the position the row occupies — parent, path, index — so
+ * the same source document produces the same id on every run. Same reasoning
+ * that already makes `moderation_outbox.id` deterministic: where the id IS the
+ * deduplication mechanism, minting a fresh one deletes it.
+ *
+ * Latent rather than active when written: production holds ZERO availability
+ * windows, so no row has ever taken this path. It would have fired the first
+ * time a listing grew a calendar and the copy was re-run — which is the shape of
+ * bug that ships because nothing exercises it.
  */
-function mintedSubdocumentId(child: SourceDocument, log: ResolutionLog): unknown {
+function mintedSubdocumentId(
+  child: SourceDocument,
+  parentId: unknown,
+  path: string,
+  index: number,
+  parentCreatedAt: unknown,
+  log: ResolutionLog,
+): unknown {
   const stored = child._id;
   if (stored !== undefined && stored !== null) return idValue(stored);
-  // Not a remap: there was no id to preserve, and nothing references these rows.
-  // The DOCUMENT is asked rather than a hand-written list of which arrays
-  // declare `{ _id: false }` — that is one word in a schema file, and
-  // `availabilityWindowSchema` carries it while `MIGRATION-CONTRACT.md`'s table
-  // does not list it.
   log.applied(DATA_RESOLUTIONS.SUBDOCUMENT_ID_MINTED);
-  return uuidv7();
+  return deterministicUuidV7(parentCreatedAt, `${String(parentId)}|${path}|${index}`);
 }
+
+/**
+ * A uuid v7 that is a pure function of its inputs.
+ *
+ * The 74 random bits become the leading bytes of `sha256(naturalKey)`; the
+ * 48-bit timestamp prefix is the PARENT's own `created_at`, so the ids stay
+ * k-sortable and the primary-key btree stays append-mostly instead of scattering
+ * inserts across the keyspace. The version and variant nibbles are pinned
+ * exactly as `@oxyhq/db`'s `uuidv7` pins them, which is what keeps
+ * `isLiveEntityId` accepting the result.
+ *
+ * **The fallback for an unusable timestamp is the Unix epoch, never
+ * `Date.now()`.** `Date.now()` there would silently reintroduce the entire bug
+ * for exactly the rows whose timestamps are broken — their ids would differ
+ * between two runs and duplicate on a re-run — and it is the hardest version to
+ * notice, because it only affects rows already known to be odd.
+ *
+ * Derived from the implementation `homiio-backfill-2` wrote and verified
+ * against the real `isLiveEntityId`.
+ */
+export function deterministicUuidV7(timestamp: unknown, naturalKey: string): string {
+  const digest = createHash('sha256').update(naturalKey).digest();
+  const bytes = new Uint8Array(UUID_BYTES);
+  bytes.set(digest.subarray(0, UUID_BYTES));
+
+  const instant =
+    timestamp instanceof Date && !Number.isNaN(timestamp.getTime()) ? timestamp.getTime() : 0;
+  let milliseconds = Math.max(0, Math.floor(instant));
+  for (let index = UUID_V7_TIMESTAMP_BYTES - 1; index >= 0; index -= 1) {
+    bytes[index] = milliseconds & 0xff;
+    milliseconds = Math.floor(milliseconds / 256);
+  }
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Buffer.from(bytes).toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+/** Bytes in a UUID, and how many of them the v7 timestamp occupies. */
+const UUID_BYTES = 16;
+const UUID_V7_TIMESTAMP_BYTES = 6;


### PR DESCRIPTION
Three corrections, all from `homiio-backfill-2`'s read of the same ground.

## 1. The contract's `_id: false` table was incomplete

`availabilityWindowSchema` declares `{ _id: false }` and backs **both** property
calendars, so `property_availability_windows` has no id to preserve — while the
table's own next sentence asserted that every other embedded array does. A reader
trusting it would look for a stored id and not find one. Corrected.

## 2. The mint was RANDOM, which makes idempotence a false claim for that table

*"Mint a uuid v7"* and *"every insert is `ON CONFLICT DO NOTHING`, so a re-run
converges"* cannot both hold. A freshly-random primary key never conflicts, so a
second run does not skip those rows — it **duplicates every one of them**, in
precisely the resumed-partial-run case the idempotence rule exists for.

The id is now a pure function of the position the row occupies:

- `sha256(parentId|path|index)` for the 74 random bits
- the **parent's** `created_at` for the 48-bit timestamp prefix, so ids stay
  k-sortable and the primary-key btree stays append-mostly
- version and variant nibbles pinned exactly as `@oxyhq/db`'s `uuidv7` pins them

Verified against the **real** `isLiveEntityId`, not a reimplementation. Same
reasoning that already makes `moderation_outbox.id` deterministic: where the id
IS the deduplication mechanism, minting a fresh one deletes it.

The fallback for an unusable `created_at` is the **Unix epoch, never
`Date.now()`** — which would reintroduce the whole defect for exactly the rows
whose timestamps are broken, the version hardest to notice because it only
affects rows already known to be odd.

**Latent, not active:** production holds zero availability windows, so no row has
ever taken this path. It would have fired the first time a listing grew a
calendar and the copy was re-run.

## 3. The geometry anchor could not tell "correct" from "nothing to measure"

It named Barcelona→Paris, which returned a bare `null` on every run and always
would — production is a Spanish/German/Polish portal with **no Paris address at
all**. That is the vacuous shape.

- Pairs are chosen from cities that carry addresses: Madrid 973, Warszawa 754,
  Hamburg 646, Köln 400, Berlin 301 (measured 2026-08-09).
- A pair that cannot be measured reports its **reason**, not a `null`.
- Fewer than two measured → refused. One anchor is a coincidence away from
  meaning nothing.

The two production outliers are reported individually and **classified**:
`SOURCE_COORDINATES_NULL_ISLAND` for `(0,0)`, the classic no-geocode sentinel,
and `SOURCE_COORDINATES_FAR_FROM_CITY` for a listing geocoded to Caracas while
naming León, Spain. **Neither is rewritten** — the copy is faithful, both defects
predate the port, and repairing source data is a separate decision with its own
count in front of it.

## Four mutations, all caught

| mutation | case that fails |
|---|---|
| random mint | determinism AND re-run convergence |
| `Date.now()` fallback | the epoch case |
| drop `path` from the natural key | the two calendars collide |
| lower the pair floor | the too-few-pairs case |

The last one is worth noting: the first version of that mutation **survived** —
the floor was untested until the mutation showed it, which is what the mutation
pass is for.

Local: dataBackfill, geoBackfill and the NUL-byte gate — 87 tests, green.
Typecheck and eslint clean. No dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)