### PR TITLE
`--dry-run`, and never delete a row Postgres created

### DIFF
--- a/packages/backend/__tests__/db/dataBackfill.test.ts
+++ b/packages/backend/__tests__/db/dataBackfill.test.ts
@@ -49,7 +49,7 @@ import {
   toPropertyWindowRows,
 } from '../../db/backfill/dataPlan';
 import { RowAuditor, UniqueKeyAuditor, type CandidateRow } from '../../db/backfill/rowAudit';
-import { isLiveEntityId } from '@oxyhq/db';
+import { isLiveEntityId, uuidv7 } from '@oxyhq/db';
 import { ResolutionLog } from '../../db/backfill/geoPlan';
 
 /** The property rules, reached through the PLAN so the test cannot drift from it. */
@@ -549,6 +549,7 @@ describe('data backfill — --reconcile', () => {
       readonly address: mongoose.Types.ObjectId;
       readonly properties: readonly mongoose.Types.ObjectId[];
     }) => Promise<void>,
+    options: { readonly dryRun?: boolean } = {},
   ) {
     const geo = await seedAndCopyGeo();
     const database = mongoDatabase();
@@ -567,7 +568,13 @@ describe('data backfill — --reconcile', () => {
       properties: listings.map((listing) => listing._id as mongoose.Types.ObjectId),
     });
 
-    return runDataBackfill({ mongo: database, database: getDb(), mode: 'reconcile', sampleSize: 5 });
+    return runDataBackfill({
+      mongo: database,
+      database: getDb(),
+      mode: 'reconcile',
+      sampleSize: 5,
+      dryRun: options.dryRun,
+    });
   }
 
   const forTable = (report: Awaited<ReturnType<typeof copyThenDrift>>, table: string) =>
@@ -653,6 +660,89 @@ describe('data backfill — --reconcile', () => {
       .select({ total: sql<number>`count(*)::int` })
       .from(propertyImages);
     expect(row.total).toBe(2);
+  }, 120_000);
+
+  it('DRY RUN names every row it would remove, and removes none of them', async () => {
+    // The point of the mode: an operator eyeballs 86 ids rather than discovering
+    // 8,600 after the fact.
+    const report = await copyThenDrift(
+      async (database, ids) => {
+        await database.collection('properties').deleteOne({ _id: ids.properties[0] });
+      },
+      { dryRun: true },
+    );
+
+    const properties_ = forTable(report, 'properties');
+    expect(properties_?.deleted).toBe(1);
+    expect(properties_?.deletions).toHaveLength(1);
+
+    // Reported as removable, still present.
+    const [row] = await getDb().select({ total: sql<number>`count(*)::int` }).from(properties);
+    expect(row.total).toBe(10);
+  }, 120_000);
+
+  it('DRY RUN writes no UPDATE either, not just no delete', async () => {
+    const report = await copyThenDrift(
+      async (database, ids) => {
+        await database
+          .collection('properties')
+          .updateOne({ _id: ids.properties[0] }, { $set: { description: 'dry' } });
+      },
+      { dryRun: true },
+    );
+    expect(forTable(report, 'properties')?.updated).toBe(1);
+
+    const [stored] = await getDb()
+      .select({ description: properties.description })
+      .from(properties)
+      .where(eq(properties.description, 'dry'));
+    expect(stored).toBeUndefined();
+  }, 120_000);
+
+  it('NEVER deletes a row created in Postgres, whatever the source says', async () => {
+    // The bug that would destroy live data. After the write path lands, "absent
+    // from Mongo" means either "deleted before the cutover" (a ghost) or
+    // "created in Postgres" (real data that was never in Mongo). Absence alone
+    // cannot tell them apart; the id SHAPE can — a copied row carries a 24-char
+    // ObjectId hex, a created one a uuid v7.
+    const geo = await seedAndCopyGeo();
+    const database = mongoDatabase();
+    const address = addressDocument(geo, 'Barcelona', BARCELONA);
+    await database.collection('addresses').insertOne(address);
+    await seedMeasurableAddresses(geo);
+    const listing = propertyDocument(address._id as mongoose.Types.ObjectId);
+    await database.collection('properties').insertOne(listing);
+    await runDataBackfill({ mongo: database, database: getDb(), mode: 'copy', sampleSize: 5 });
+
+    // A listing created in Postgres AFTER the cutover — a uuid v7 id, no Mongo
+    // document, and never one.
+    const nativeId = uuidv7();
+    await getDb()
+      .insert(properties)
+      .values({
+        id: nativeId,
+        addressId: String(address._id),
+        sourceUrl: 'https://example.test/native',
+        offerings: ['long_term_rent'],
+        longTermRentMonthlyAmount: 900,
+      });
+
+    const report = await runDataBackfill({
+      mongo: database,
+      database: getDb(),
+      mode: 'reconcile',
+      sampleSize: 5,
+    });
+
+    const properties_ = forTable(report, 'properties');
+    expect(properties_?.deleted).toBe(0);
+    expect(properties_?.retainedPostCutover).toBe(1);
+
+    const [kept] = await getDb()
+      .select({ id: properties.id })
+      .from(properties)
+      .where(eq(properties.id, nativeId));
+    expect(kept?.id).toBe(nativeId);
   }, 120_000);
 
   it('converges: a second reconcile changes nothing and reports it as unchanged', async () => {

--- a/packages/backend/db/backfill/data.ts
+++ b/packages/backend/db/backfill/data.ts
@@ -82,6 +82,7 @@ import {
 import { columnNames, foreignKeyRule } from './geoPlan';
 import {
   ABSOLUTE_SURPLUS_FLOOR,
+  couldHaveComeFromMongo,
   countTable,
   deletionAllowance,
   findSurplusIds,
@@ -153,6 +154,15 @@ const PROGRESS_INTERVAL = 25_000;
 
 /** Ids listed in a report when something is missing. Enough to grep for. */
 const MAX_REPORTED_IDS = 5;
+
+/**
+ * Ids printed when a deletion is proposed.
+ *
+ * Far larger than {@link MAX_REPORTED_IDS}, because under `--dry-run` this list
+ * IS the deliverable — the point is that an operator eyeballs 86 rather than
+ * discovers 8,600.
+ */
+const MAX_DRY_RUN_IDS = 500;
 
 /** Coordinate outliers listed individually, with their ids and classification. */
 const MAX_REPORTED_OUTLIERS = 20;
@@ -1038,6 +1048,7 @@ async function reconcileCollection(
   mongo: MongoDatabase,
   plan: DataCollectionPlan,
   log: ResolutionLog,
+  dryRun: boolean,
 ): Promise<ReconcileTableReport[]> {
   const reports: ReconcileTableReport[] = [];
   const parentTable = plan.tables[0];
@@ -1070,6 +1081,7 @@ async function reconcileCollection(
           // separate, guarded phase below.
           scopedTo: isParent ? null : { column: parentColumn as string, parentIds },
           allowDeletes: !isParent,
+          dryRun,
         }),
       );
     }
@@ -1083,7 +1095,7 @@ async function reconcileCollection(
   }
   await flushChunk();
 
-  reports.push(await deleteSurplusParents(database, plan, parentTable, sourceIds));
+  reports.push(await deleteSurplusParents(database, plan, parentTable, sourceIds, dryRun));
   return mergeReports(reports);
 }
 
@@ -1104,9 +1116,15 @@ async function deleteSurplusParents(
   plan: DataCollectionPlan,
   parentTable: string,
   sourceIds: readonly string[],
+  dryRun: boolean,
 ): Promise<ReconcileTableReport> {
   const table = requireTable(parentTable);
-  const surplus = await findSurplusIds(database, table, sourceIds);
+  const absent = await findSurplusIds(database, table, sourceIds);
+  // A row created in Postgres was never in Mongo, so its absence says nothing
+  // about it. Removing one would destroy live data in the authoritative store,
+  // with no source left to re-copy it from. See `couldHaveComeFromMongo`.
+  const surplus = absent.filter((id) => couldHaveComeFromMongo(id));
+  const retainedPostCutover = absent.length - surplus.length;
   const stored = await countTable(database, table);
   const empty: ReconcileTableReport = {
     table: parentTable,
@@ -1116,7 +1134,15 @@ async function deleteSurplusParents(
     unchanged: 0,
     columns: {},
     deletionRefused: null,
+    retainedPostCutover,
+    deletions: [],
   };
+  if (retainedPostCutover > 0) {
+    logger.info(
+      `${parentTable}: ${retainedPostCutover} row(s) absent from ${plan.sourceCollection} ` +
+      'were RETAINED — their id shape says they were created in Postgres, not copied',
+    );
+  }
   if (surplus.length === 0) return empty;
 
   if (!mayDelete(surplus.length, stored)) {
@@ -1130,19 +1156,22 @@ async function deleteSurplusParents(
     return { ...empty, deletionRefused: refused };
   }
 
-  // Logged BEFORE the delete, so the record survives a run that then fails.
-  logger.warn(`${parentTable}: removing ${surplus.length} row(s) absent from the source`, {
-    ids: surplus.slice(0, MAX_REPORTED_IDS),
-    truncated: Math.max(0, surplus.length - MAX_REPORTED_IDS),
-  });
+  // Logged BEFORE the delete, so the record survives a run that then fails —
+  // and under `--dry-run` this IS the output, so the whole list is printed
+  // rather than a sample.
+  logger.warn(
+    `${parentTable}: ${dryRun ? 'WOULD remove' : 'removing'} ${surplus.length} row(s) ` +
+    `absent from ${plan.sourceCollection}`,
+    { ids: surplus.slice(0, MAX_DRY_RUN_IDS), truncated: Math.max(0, surplus.length - MAX_DRY_RUN_IDS) },
+  );
   const idColumn = getTableColumns(table).id;
   let deleted = 0;
   for (let start = 0; start < surplus.length; start += MONGO_LOOKUP_BATCH) {
     const batch = surplus.slice(start, start + MONGO_LOOKUP_BATCH);
-    await database.delete(table).where(inArray(idColumn, batch));
+    if (!dryRun) await database.delete(table).where(inArray(idColumn, batch));
     deleted += batch.length;
   }
-  return { ...empty, deleted };
+  return { ...empty, deleted, deletions: surplus };
 }
 
 /** One line per table, however many chunks contributed to it. */
@@ -1166,6 +1195,8 @@ function mergeReports(reports: readonly ReconcileTableReport[]): ReconcileTableR
       unchanged: current.unchanged + report.unchanged,
       columns,
       deletionRefused: current.deletionRefused ?? report.deletionRefused,
+      retainedPostCutover: current.retainedPostCutover + report.retainedPostCutover,
+      deletions: [...current.deletions, ...report.deletions],
     });
   }
   return [...merged.values()];
@@ -1194,9 +1225,19 @@ export async function runDataBackfill(options: {
   readonly mode: Mode;
   readonly sampleSize?: number;
   readonly only?: readonly DataCollectionName[];
+  /**
+   * Decide and report everything, write nothing.
+   *
+   * Only meaningful with `--reconcile`, and the reason it exists is that
+   * reconciliation is the one mode that DELETES. A dry run turns "trust the
+   * guard" into "read the 86 ids it proposes to remove", which is the difference
+   * between eyeballing 86 and discovering 8,600.
+   */
+  readonly dryRun?: boolean;
 }): Promise<DataBackfillReport> {
   const { mongo, database, mode } = options;
   const sampleSize = options.sampleSize ?? DEFAULT_SAMPLE_ROWS;
+  const dryRun = options.dryRun ?? false;
   const selected = options.only ?? DATA_COPY_ORDER;
   const plans = DATA_COPY_ORDER.filter((name) => selected.includes(name)).map(
     (name) => DATA_PLANS[name],
@@ -1291,7 +1332,7 @@ export async function runDataBackfill(options: {
   const reconciled: ReconcileTableReport[] = [];
   if (mode === 'reconcile') {
     for (const plan of [...plans].reverse()) {
-      reconciled.push(...(await reconcileCollection(database, mongo, plan, copyLog)));
+      reconciled.push(...(await reconcileCollection(database, mongo, plan, copyLog, dryRun)));
     }
     for (const report of reconciled) {
       if (report.deletionRefused !== null) {
@@ -1324,7 +1365,7 @@ export async function runDataBackfill(options: {
   // them as unresolvable.
   let hasImagesRederived: number | null = null;
   let covers: CoverReport[] = [];
-  const wrote = mode === 'copy' || mode === 'reconcile';
+  const wrote = (mode === 'copy' || mode === 'reconcile') && !dryRun;
   if (wrote && !partial) {
     hasImagesRederived = await syncAllHasImages(database);
     logger.info('properties.has_images re-derived from property_images', { hasImagesRederived });
@@ -1509,13 +1550,22 @@ async function main(): Promise<void> {
   const mode = readMode(argv);
   const sampleSize = readSampleSize(argv);
   const only = readOnly(argv);
+  const dryRun = argv.includes('--dry-run');
+  if (dryRun && mode !== 'reconcile') {
+    // Refused rather than ignored. `--dry-run` on a copy would read as "this
+    // showed me what the copy would do", and it would not have.
+    throw new Error(
+      '--dry-run is only meaningful with --reconcile. `--audit-only` is the ' +
+      'read-only form of a copy, and `--verify-only` of a verification.',
+    );
+  }
 
   const mongoUrl = process.env.MONGODB_URI;
   if (!mongoUrl) throw new Error('MONGODB_URI is not set; there is nothing to copy from.');
   const postgresUrl = process.env.DATABASE_URL;
   if (!postgresUrl) throw new Error('DATABASE_URL is not set; there is nowhere to copy to.');
 
-  logger.info('Data backfill starting', { source, target, mode, sampleSize, only });
+  logger.info('Data backfill starting', { source, target, mode, sampleSize, only, dryRun });
 
   await mongoose.connect(mongoUrl);
   const client = postgres(postgresUrl, { max: 1 });
@@ -1532,7 +1582,7 @@ async function main(): Promise<void> {
     await assertMigrationTarget(client, target);
 
     const database = drizzle(client, { schema, casing: DATABASE_CASING });
-    const report = await runDataBackfill({ mongo, database, mode, sampleSize, only });
+    const report = await runDataBackfill({ mongo, database, mode, sampleSize, only, dryRun });
     logger.info('Data backfill complete', {
       source,
       target,

--- a/packages/backend/db/backfill/reconcile.ts
+++ b/packages/backend/db/backfill/reconcile.ts
@@ -102,6 +102,48 @@ export function mayDelete(surplus: number, stored: number): boolean {
   return surplus <= deletionAllowance(stored);
 }
 
+/**
+ * A row that could have come from Mongo, decided by the SHAPE of its id.
+ *
+ * ## The bug this exists to make impossible
+ *
+ * "Absent from the source" means two completely different things after the write
+ * path lands, and only one of them is a ghost:
+ *
+ *  - a row copied from Mongo whose document has since been DELETED — a ghost,
+ *    and the thing this mode removes;
+ *  - a row CREATED in Postgres, which was never in Mongo and never will be.
+ *
+ * Deleting the second is destroying live data in the authoritative store, with
+ * no source left to re-copy it from. The two are indistinguishable by absence
+ * alone, so they have to be told apart some other way.
+ *
+ * ## Why the id SHAPE and not `created_at`
+ *
+ * `db/ids.ts` states the invariant this rests on: every primary key is `text`
+ * holding a 24-char ObjectId hex for rows that existed before the cutover, and a
+ * uuid v7 for every row created after it. `generatedId()` mints the uuid; no
+ * write path can produce an ObjectId hex for a new row, and no copied row can
+ * carry anything else, because the backfill copies `_id` verbatim.
+ *
+ * That makes the test STRUCTURAL — it depends on how the id was made, not on a
+ * clock. A `created_at` filter would depend on the copy's own timestamps being
+ * trustworthy and on picking a cutover instant, and both of those are exactly
+ * the kind of thing that is off by an hour at 3am. This one cannot be off by an
+ * hour.
+ *
+ * It is also permanent rather than a property of this week: it stays correct
+ * long after the current window (in which Postgres has created nothing at all,
+ * so the ambiguity is empty) has closed.
+ */
+const MONGO_ID_SHAPE = /^[0-9a-f]{24}$/i;
+
+/** Whether this id could have come from Mongo, and so may be considered for
+ *  deletion. See {@link MONGO_ID_SHAPE}. */
+export function couldHaveComeFromMongo(id: string): boolean {
+  return MONGO_ID_SHAPE.test(id);
+}
+
 /** What one table's reconciliation did. */
 export interface ReconcileTableReport {
   readonly table: string;
@@ -113,6 +155,16 @@ export interface ReconcileTableReport {
   readonly columns: Readonly<Record<string, number>>;
   /** Set when deletion was refused, saying why. */
   readonly deletionRefused: string | null;
+  /**
+   * Rows absent from the source that were NOT considered for deletion, because
+   * their id shape says they were created in Postgres.
+   *
+   * Reported rather than silently skipped: an exclusion nobody can see is
+   * indistinguishable from a filter that never ran.
+   */
+  readonly retainedPostCutover: number;
+  /** Ids this run removed, or WOULD remove under `--dry-run`. */
+  readonly deletions: readonly string[];
 }
 
 /**
@@ -137,8 +189,10 @@ export async function reconcileTable(options: {
   readonly scopedTo: { readonly column: string; readonly parentIds: readonly string[] } | null;
   /** Whether this run may delete at all. */
   readonly allowDeletes: boolean;
+  /** Decide and report everything, write nothing. */
+  readonly dryRun: boolean;
 }): Promise<ReconcileTableReport> {
-  const { database, table, tableName, produced, scopedTo, allowDeletes } = options;
+  const { database, table, tableName, produced, scopedTo, allowDeletes, dryRun } = options;
   const columns = getTableColumns(table);
   const idColumn = columns.id;
   const writable: string[] = columnNames(table).filter(
@@ -179,10 +233,16 @@ export async function reconcileTable(options: {
   for (const row of rows) {
     const current = stored.get(row.id);
     if (current === undefined) {
-      await database
-        .insert(table)
-        .values(row as PgTable['$inferInsert'])
-        .onConflictDoNothing();
+      // `onConflictDoNothing` is only meaningful because every id here is either
+      // copied verbatim from Mongo or DETERMINISTICALLY minted (#318) — a random
+      // mint would make the conflict clause unreachable, so a re-run would insert
+      // duplicates while reporting convergence.
+      if (!dryRun) {
+        await database
+          .insert(table)
+          .values(row as PgTable['$inferInsert'])
+          .onConflictDoNothing();
+      }
       inserted += 1;
       continue;
     }
@@ -219,15 +279,27 @@ export async function reconcileTable(options: {
     // with this process's clock and destroys the historical value the migration
     // exists to preserve — the trap `CONVENTIONS.md` was corrected to name, and
     // the reason `geo.ts`'s reconcile writes whole rows too.
-    await database
-      .update(table)
-      .set(Object.fromEntries(comparable.map((column: string) => [column, row[column]])))
-      .where(eq(idColumn, row.id));
+    if (!dryRun) {
+      await database
+        .update(table)
+        .set(Object.fromEntries(comparable.map((column: string) => [column, row[column]])))
+        .where(eq(idColumn, row.id));
+    }
     updated += 1;
   }
 
   // ── deletion ──
-  const surplus = [...stored.keys()].filter((id) => !byId.has(id));
+  const absent = [...stored.keys()].filter((id) => !byId.has(id));
+  // A row created in Postgres was never in Mongo, so its absence says nothing.
+  // Removing it would destroy live data in the authoritative store.
+  const surplus = absent.filter((id) => couldHaveComeFromMongo(id));
+  const retainedPostCutover = absent.length - surplus.length;
+  if (retainedPostCutover > 0) {
+    logger.info(
+      `${tableName}: ${retainedPostCutover} row(s) absent from the source were RETAINED — ` +
+      'their id shape says they were created in Postgres, not copied from Mongo',
+    );
+  }
   let deleted = 0;
   let deletionRefused: string | null = null;
 
@@ -248,13 +320,17 @@ export async function reconcileTable(options: {
         logger.error(`${tableName}: ${deletionRefused}`);
       } else {
         // Logged BEFORE the delete, so the record survives a run that then fails.
-        logger.warn(`${tableName}: removing ${surplus.length} row(s) absent from the source`, {
-          ids: surplus.slice(0, MAX_LOGGED_DELETIONS),
-          truncated: Math.max(0, surplus.length - MAX_LOGGED_DELETIONS),
-        });
+        logger.warn(
+          `${tableName}: ${dryRun ? 'WOULD remove' : 'removing'} ${surplus.length} row(s) ` +
+          'absent from the source',
+          {
+            ids: surplus.slice(0, MAX_LOGGED_DELETIONS),
+            truncated: Math.max(0, surplus.length - MAX_LOGGED_DELETIONS),
+          },
+        );
         for (let start = 0; start < surplus.length; start += BATCH_IDS) {
           const batch = surplus.slice(start, start + BATCH_IDS);
-          await database.delete(table).where(inArray(idColumn, batch));
+          if (!dryRun) await database.delete(table).where(inArray(idColumn, batch));
           deleted += batch.length;
         }
       }
@@ -269,6 +345,8 @@ export async function reconcileTable(options: {
     unchanged,
     columns: differing,
     deletionRefused,
+    retainedPostCutover,
+    deletions: deletionRefused === null ? surplus : [],
   };
   logger.info(`Reconciled ${tableName}`, report);
   return report;


### PR DESCRIPTION
Two things `--reconcile` needed before it is safe to point at the authoritative
store, now that the property write path has landed and Mongo has stopped moving.

## 1. A row created in Postgres must never be deleted for being absent from Mongo

After the cutover, *"absent from the source"* means two completely different
things and only one of them is a ghost:

- a row **copied from Mongo** whose document has since been deleted — the thing
  this mode removes;
- a row **created in Postgres**, which was never in Mongo and never will be.

Absence alone cannot tell them apart, and removing the second destroys live data
in the authoritative store, with no source left to re-copy it from.

**The discriminator is the id SHAPE, not `created_at`.** `db/ids.ts` states the
invariant this rests on: every primary key is a 24-char ObjectId hex for rows
that existed before the cutover and a uuid v7 for every row created after it.
`generatedId()` mints the uuid, no write path can produce an ObjectId hex for a
new row, and no copied row can carry anything else because the backfill copies
`_id` verbatim.

That makes the test **structural** — it depends on how the id was made, not on a
clock — so it cannot be off by an hour at 3am the way a chosen cutover instant
can. And it is **permanent** rather than a property of this week: right now
`max(created_at)` in Postgres is 2026-07-25, so nothing has been created there
and the ambiguity is empty, but a script that is correct only during a window
nobody documented is the next incident.

Retained rows are counted and reported (`retainedPostCutover`) — an exclusion
nobody can see is indistinguishable from a filter that never ran.

## 2. `--dry-run`

Reconciliation is the one mode that deletes, and the guard being sound is not the
same as an operator having seen what it proposes to remove.

- decides everything, writes nothing — no delete, **no update, no insert**;
- prints the **whole list**, not a sample, because the point is to eyeball 86 ids
  rather than discover 8,600;
- refuses on any mode but `--reconcile`: `--dry-run` on a copy would read as
  "this showed me what the copy would do", and it would not have.

```
node packages/backend/dist/db/backfill/data.js \
  --source-database=homiio-production --target-database=homiio \
  --reconcile --dry-run
```

## Three mutations, all caught

| mutation | case that fails |
|---|---|
| drop the id-shape filter | the Postgres-created row is deleted |
| dry run still deletes | the row count changes |
| dry run still updates | the new value is stored |

Local: 123 suites, 1607 tests, green. Typecheck and eslint clean. No dependency
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)