### PR TITLE
Point the property-directory stragglers at Postgres, and fix an availability check that approved everything (#281)

### DIFF
--- a/packages/backend/__tests__/helpers/postgresGeoFixtures.ts
+++ b/packages/backend/__tests__/helpers/postgresGeoFixtures.ts
@@ -39,6 +39,7 @@ import {
   neighborhoods,
   properties,
   propertyAvailabilityWindows,
+  reservations,
   propertyDocuments,
   propertyImages,
   regions,
@@ -64,6 +65,12 @@ export async function resetGeoTables(): Promise<void> {
   // from `leases`, so this single statement takes the co-tenants, the payment
   // schedule, the documents, the inspections and their findings with it.
   await db.delete(leases);
+  // Reservations are the same shape as leases above and RESTRICT for the same
+  // reason: a booking is a commitment against a listing, not a copy of it, so
+  // deleting the listing under one RAISES. Any suite that seeds a reservation
+  // would otherwise fail here rather than in its own fixture, which reads as a
+  // mysterious teardown error two files away from the cause.
+  await db.delete(reservations);
   // Listings next: `properties.address_id` is ON DELETE RESTRICT, so an
   // address delete with a listing still on it RAISES rather than cascading —
   // which is the constraint working, and would read here as a mysterious

--- a/packages/backend/__tests__/integration/availabilityConflicts.test.ts
+++ b/packages/backend/__tests__/integration/availabilityConflicts.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Date-range availability on the browse feed, against a REAL Postgres.
+ *
+ * ## Why this suite exists
+ *
+ * The reservation half of the availability check read Mongo into an id list and
+ * applied it only `if (ids.length > 0)`. Once `reservations` moved to Postgres
+ * that read returned nothing, the guard skipped the exclusion, and every booked
+ * listing was reported free.
+ *
+ * Nothing errored. An availability check with no bookings in front of it
+ * APPROVES — so the wrong answer was the successful-looking one, and the
+ * symptom would have been a double booking rather than a failure anyone could
+ * see. That is exactly the shape a presence assertion cannot catch, so every
+ * case below asserts on WHICH listings come back, and each seeds a listing that
+ * must be EXCLUDED alongside one that must not. A test that only checked "some
+ * results came back" would have passed against the bug.
+ *
+ * The boundary cases are the point of the `[)` range bounds: a stay that starts
+ * exactly when another ends does not conflict, and one that overlaps by a single
+ * day does.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { OfferingType, PropertyStatus, PropertyType } from '@homiio/shared-types';
+
+import { getProperties } from '../../controllers/property/list';
+import { errorHandler } from '../../middlewares/errorHandler';
+import { serializeWireIds } from '../../middlewares/wireIds';
+import { getDb } from '../../db/postgres';
+import { reservations } from '../../db/schema';
+import {
+  objectIdHex,
+  resetGeoTables,
+  seedAddress,
+  seedGeoChain,
+  seedProperty,
+  type GeoChain,
+} from '../helpers/postgresGeoFixtures';
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(serializeWireIds);
+  app.get('/properties', getProperties);
+  app.use(errorHandler);
+  return app;
+}
+
+const STAY_START = '2026-09-10';
+const STAY_END = '2026-09-14';
+
+/** A published, short-term-bookable listing. */
+async function seedBookable(chain: GeoChain, street: string): Promise<string> {
+  const addressId = await seedAddress({ chain, street });
+  return seedProperty({
+    addressId,
+    idShape: 'generated',
+    overrides: {
+      type: PropertyType.APARTMENT,
+      bedrooms: 1,
+      offerings: [OfferingType.SHORT_TERM_RENT],
+      shortTermRentNightlyRate: 120,
+      shortTermRentCurrency: 'EUR',
+      status: PropertyStatus.PUBLISHED,
+      availabilityIsAvailable: true,
+    },
+  });
+}
+
+async function seedReservation(options: {
+  propertyId: string;
+  checkIn: string;
+  checkOut: string;
+  status?: 'confirmed' | 'pending' | 'cancelled';
+}): Promise<void> {
+  await getDb()
+    .insert(reservations)
+    .values({
+      id: objectIdHex(),
+      propertyId: options.propertyId,
+      guestOxyUserId: 'oxy-guest',
+      hostOxyUserId: 'oxy-host',
+      checkIn: new Date(options.checkIn),
+      checkOut: new Date(options.checkOut),
+      guestCount: 2,
+      nights: 4,
+      nightlyRate: 120,
+      subtotal: 480,
+      total: 480,
+      currency: 'EUR',
+      cancellationPolicy: 'flexible',
+      status: options.status ?? 'confirmed',
+    });
+}
+
+/** The listing ids the feed returns for the stay under test. */
+async function idsAvailableForStay(): Promise<string[]> {
+  const res = await request(buildApp())
+    .get(`/properties?checkIn=${STAY_START}&checkOut=${STAY_END}&limit=50`)
+    .expect(200);
+  return (res.body.data as { id: string }[]).map((listing) => listing.id);
+}
+
+beforeEach(async () => {
+  await resetGeoTables();
+});
+
+describe('date-range availability', () => {
+  it('excludes a listing whose confirmed reservation overlaps the stay', async () => {
+    const chain = await seedGeoChain({ cityName: 'Barcelona', countryCode: 'ES-av' });
+    const booked = await seedBookable(chain, 'Carrer Booked');
+    const free = await seedBookable(chain, 'Carrer Free');
+    await seedReservation({ propertyId: booked, checkIn: '2026-09-12', checkOut: '2026-09-16' });
+
+    const available = await idsAvailableForStay();
+
+    // Both halves asserted: without the FREE listing this would also pass if the
+    // endpoint simply returned nothing.
+    expect(available).toContain(free);
+    expect(available).not.toContain(booked);
+  });
+
+  it('excludes a listing booked for exactly the requested range', async () => {
+    const chain = await seedGeoChain({ cityName: 'Barcelona', countryCode: 'ES-aw' });
+    const booked = await seedBookable(chain, 'Carrer Exact');
+    const free = await seedBookable(chain, 'Carrer Open');
+    await seedReservation({ propertyId: booked, checkIn: STAY_START, checkOut: STAY_END });
+
+    const available = await idsAvailableForStay();
+
+    expect(available).toContain(free);
+    expect(available).not.toContain(booked);
+  });
+
+  it('keeps a listing whose reservation ENDS the day the stay begins', async () => {
+    // `[)` bounds: a checkout and the next check-in on the same day do not
+    // collide. This is the case an inclusive range would get wrong, and it is
+    // why the predicate uses `tstzrange` rather than two `<=` comparisons.
+    const chain = await seedGeoChain({ cityName: 'Barcelona', countryCode: 'ES-ax' });
+    const backToBack = await seedBookable(chain, 'Carrer Adjacent');
+    await seedReservation({ propertyId: backToBack, checkIn: '2026-09-06', checkOut: STAY_START });
+
+    expect(await idsAvailableForStay()).toContain(backToBack);
+  });
+
+  it('keeps a listing whose reservation BEGINS the day the stay ends', async () => {
+    const chain = await seedGeoChain({ cityName: 'Barcelona', countryCode: 'ES-ay' });
+    const backToBack = await seedBookable(chain, 'Carrer Following');
+    await seedReservation({ propertyId: backToBack, checkIn: STAY_END, checkOut: '2026-09-20' });
+
+    expect(await idsAvailableForStay()).toContain(backToBack);
+  });
+
+  it('ignores reservations that are not confirmed', async () => {
+    // A pending or cancelled booking holds no dates. Seeded as an overlapping
+    // range on purpose, so the status is the ONLY thing keeping the listing in
+    // the results — a predicate that ignored `status` would fail here.
+    const chain = await seedGeoChain({ cityName: 'Barcelona', countryCode: 'ES-az' });
+    const pending = await seedBookable(chain, 'Carrer Pending');
+    const cancelled = await seedBookable(chain, 'Carrer Cancelled');
+    await seedReservation({
+      propertyId: pending,
+      checkIn: '2026-09-12',
+      checkOut: '2026-09-16',
+      status: 'pending',
+    });
+    await seedReservation({
+      propertyId: cancelled,
+      checkIn: '2026-09-12',
+      checkOut: '2026-09-16',
+      status: 'cancelled',
+    });
+
+    const available = await idsAvailableForStay();
+
+    expect(available).toContain(pending);
+    expect(available).toContain(cancelled);
+  });
+
+  it('excludes only the booked listing, not every listing at the same address', async () => {
+    // The correlated subquery has to bind to the OUTER listing. If the
+    // correlation bound to the reservations table instead — the failure mode the
+    // `qualified()` helper exists to prevent — the predicate would match every
+    // row and exclude the whole catalogue, which this case detects.
+    const chain = await seedGeoChain({ cityName: 'Barcelona', countryCode: 'ES-ba' });
+    const addressId = await seedAddress({ chain, street: 'Carrer Shared' });
+    const booked = await seedProperty({
+      addressId,
+      idShape: 'generated',
+      overrides: {
+        type: PropertyType.APARTMENT,
+        offerings: [OfferingType.SHORT_TERM_RENT],
+        shortTermRentNightlyRate: 120,
+        status: PropertyStatus.PUBLISHED,
+        availabilityIsAvailable: true,
+      },
+    });
+    const sibling = await seedProperty({
+      addressId,
+      idShape: 'generated',
+      overrides: {
+        type: PropertyType.APARTMENT,
+        offerings: [OfferingType.SHORT_TERM_RENT],
+        shortTermRentNightlyRate: 130,
+        status: PropertyStatus.PUBLISHED,
+        availabilityIsAvailable: true,
+      },
+    });
+    await seedReservation({ propertyId: booked, checkIn: '2026-09-11', checkOut: '2026-09-13' });
+
+    const available = await idsAvailableForStay();
+
+    expect(available).toContain(sibling);
+    expect(available).not.toContain(booked);
+  });
+});

--- a/packages/backend/__tests__/integration/neighborhoodMetrics.test.ts
+++ b/packages/backend/__tests__/integration/neighborhoodMetrics.test.ts
@@ -30,10 +30,11 @@ import {
   seedAddress,
   seedGeoChain,
   seedNeighborhood,
+  seedProperty,
   type GeoChain,
 } from '../helpers/postgresGeoFixtures';
 
-const { Property, Profile } = models;
+const { Profile } = models;
 
 function buildApp(): Express {
   const app = express();
@@ -64,20 +65,32 @@ async function seedProfile(): Promise<{ oxyUserId: string }> {
   return Profile.create({ oxyUserId, personalProfile: {} });
 }
 
+/**
+ * A published listing at a given address.
+ *
+ * POSTGRES, because that is the store the metrics now read: this endpoint used
+ * to hop through Mongo for the listing half, and a fixture seeded there would
+ * make the test assert against rows the handler cannot see.
+ */
 async function seedListing(
   oxyUserId: string,
   addressId: string,
   monthlyAmount: number,
-): Promise<{ _id: unknown }> {
-  return Property.create({
-    oxyUserId,
+): Promise<string> {
+  return seedProperty({
     addressId,
-    type: PropertyType.APARTMENT,
-    bedrooms: 2,
-    bathrooms: 1,
-    offerings: [OfferingType.LONG_TERM_RENT],
-    longTermRent: { monthlyAmount, currency: 'EUR' },
-    status: PropertyStatus.PUBLISHED,
+    idShape: 'generated',
+    overrides: {
+      oxyUserId,
+      type: PropertyType.APARTMENT,
+      bedrooms: 2,
+      bathrooms: 1,
+      offerings: [OfferingType.LONG_TERM_RENT],
+      longTermRentMonthlyAmount: monthlyAmount,
+      longTermRentCurrency: 'EUR',
+      status: PropertyStatus.PUBLISHED,
+      availabilityIsAvailable: true,
+    },
   });
 }
 
@@ -92,9 +105,9 @@ describe('GET /api/neighborhoods/by-property/:propertyId', () => {
     const gracia = await seedNeighborhood({ cityId: chain.cityId, name: 'Gracia' });
     const profile = await seedProfile();
     const addressId = await seedStreet(chain, gracia);
-    const listing = await seedListing(profile.oxyUserId, addressId, 1000);
+    const listingId = await seedListing(profile.oxyUserId, addressId, 1000);
 
-    const res = await request(buildApp()).get(`/api/neighborhoods/by-property/${listing._id}`);
+    const res = await request(buildApp()).get(`/api/neighborhoods/by-property/${listingId}`);
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
@@ -116,9 +129,9 @@ describe('GET /api/neighborhoods/by-property/:propertyId', () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
     const profile = await seedProfile();
     const addressId = await seedStreet(chain, undefined);
-    const listing = await seedListing(profile.oxyUserId, addressId, 1000);
+    const listingId = await seedListing(profile.oxyUserId, addressId, 1000);
 
-    const res = await request(buildApp()).get(`/api/neighborhoods/by-property/${listing._id}`);
+    const res = await request(buildApp()).get(`/api/neighborhoods/by-property/${listingId}`);
 
     expect(res.status).toBe(404);
   });

--- a/packages/backend/controllers/analyticsController.ts
+++ b/packages/backend/controllers/analyticsController.ts
@@ -8,10 +8,14 @@ import type { Request, Response, NextFunction } from 'express';
 
 import { AppError, successResponse } from '../middlewares/errorHandler';
 import { logger } from '../middlewares/logging';
-import { City, Profile, Property } from '../models';
+import { Profile } from '../models';
 import { getDb } from '../db/postgres';
 import {
+  countAppWideCatalogue,
   countAppWideSaves,
+  countListingsByPriceBucket,
+  findTopCitiesByListings,
+  summarizeCatalogueRent,
   countSavesOfProperties,
   countViewsOfProperties,
   listOwnedPropertyIds,
@@ -23,21 +27,42 @@ function errorMessage(error: unknown): string {
   return String(error);
 }
 
-interface TopCityRow {
-  _id: unknown;
-  city?: { name?: string };
-  region?: { name?: string };
-  properties: number;
-  averageRent: number;
-}
-
-interface PriceBucketRow {
-  _id: string | number;
-  count: number;
-}
 
 const PERIOD_DAYS: Record<string, number> = { '7d': 7, '30d': 30, '90d': 90 };
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** How many cities the "most listed" table shows. */
+const TOP_CITIES_LIMIT = 6;
+
+/**
+ * The monthly-rent bands the public stats endpoint reports, verbatim from the
+ * Mongo `$bucket` boundaries this replaces.
+ */
+const PRICE_BUCKET_BOUNDARIES = [0, 500, 1000, 1500, 2000, 3000, 5000, 10000] as const;
+
+/**
+ * Label each band and drop the empty ones.
+ *
+ * `width_bucket` numbers bands from 1, and returns `boundaries.length` for
+ * anything at or above the last boundary — which is the `default: '10000+'`
+ * overflow the Mongo version declared. A band nobody's listing falls in is
+ * ABSENT from the map, and stays absent from the response, exactly as `$bucket`
+ * omitted it.
+ */
+function priceBucketLabels(
+  counts: ReadonlyMap<number, number>,
+): { bucket: string; count: number }[] {
+  const labels: { bucket: string; count: number }[] = [];
+  for (const [bucket, count] of [...counts.entries()].sort((a, b) => a[0] - b[0])) {
+    if (bucket >= PRICE_BUCKET_BOUNDARIES.length) {
+      labels.push({ bucket: `${PRICE_BUCKET_BOUNDARIES[PRICE_BUCKET_BOUNDARIES.length - 1]}+`, count });
+      continue;
+    }
+    const low = PRICE_BUCKET_BOUNDARIES[bucket - 1];
+    labels.push({ bucket: `${low}-${low + 499}`, count });
+  }
+  return labels;
+}
 
 class AnalyticsController {
   /**
@@ -164,91 +189,36 @@ class AnalyticsController {
       // The saved pair moves, because `saved_items` is on Postgres — and
       // `uniqueSavers` was another `distinct('profileId')` against a schema
       // whose column is `oxyUserId`, so it has always been 0.
-      const [totalProperties, totalCities, appSaves] = await Promise.all([
-        Property.countDocuments({}),
-        City.countDocuments({}),
+      const [catalogue, appSaves, pricing, topCities, priceBuckets] = await Promise.all([
+        countAppWideCatalogue(getDb()),
         countAppWideSaves(getDb()),
-      ]);
-      const totalSaves = appSaves.total;
-      const uniqueSavers = appSaves.uniqueSavers;
-
-      // Pricing aggregates
-      const pricingAgg = await Property.aggregate([
-        { $match: { 'longTermRent.monthlyAmount': { $gt: 0 } } },
-        {
-          $group: {
-            _id: null,
-            averageRent: { $avg: '$longTermRent.monthlyAmount' },
-            minRent: { $min: '$longTermRent.monthlyAmount' },
-            maxRent: { $max: '$longTermRent.monthlyAmount' },
-          },
-        },
-      ]);
-
-      const pricing = pricingAgg[0] || { averageRent: 0, minRent: 0, maxRent: 0 };
-
-      // Top cities by property count with avg rent. Geo is relational, so this
-      // joins Property → Address → City (and Region for the label) and groups by
-      // the canonical cityId rather than a free-text city string.
-      const topCities = await Property.aggregate([
-        { $match: { addressId: { $exists: true, $ne: null } } },
-        { $lookup: { from: 'addresses', localField: 'addressId', foreignField: '_id', as: 'address' } },
-        { $unwind: '$address' },
-        { $match: { 'address.cityId': { $exists: true, $ne: null } } },
-        {
-          $group: {
-            _id: '$address.cityId',
-            regionId: { $first: '$address.regionId' },
-            properties: { $sum: 1 },
-            averageRent: { $avg: '$longTermRent.monthlyAmount' },
-          },
-        },
-        { $sort: { properties: -1 } },
-        { $limit: 6 },
-        { $lookup: { from: 'cities', localField: '_id', foreignField: '_id', as: 'city' } },
-        { $unwind: { path: '$city', preserveNullAndEmptyArrays: true } },
-        { $lookup: { from: 'regions', localField: 'regionId', foreignField: '_id', as: 'region' } },
-        { $unwind: { path: '$region', preserveNullAndEmptyArrays: true } },
-      ]);
-
-      // Price buckets (preset boundaries)
-      const priceBuckets = await Property.aggregate([
-        { $match: { 'longTermRent.monthlyAmount': { $gte: 0 } } },
-        {
-          $bucket: {
-            groupBy: '$longTermRent.monthlyAmount',
-            boundaries: [0, 500, 1000, 1500, 2000, 3000, 5000, 10000],
-            default: '10000+',
-            output: { count: { $sum: 1 } },
-          },
-        },
+        summarizeCatalogueRent(getDb()),
+        findTopCitiesByListings(getDb(), TOP_CITIES_LIMIT),
+        countListingsByPriceBucket(getDb(), PRICE_BUCKET_BOUNDARIES),
       ]);
 
       return res.json(
         successResponse(
           {
             totals: {
-              properties: totalProperties,
-              cities: totalCities,
-              saves: totalSaves,
-              uniqueSavers: uniqueSavers,
+              properties: catalogue.properties,
+              cities: catalogue.cities,
+              saves: appSaves.total,
+              uniqueSavers: appSaves.uniqueSavers,
             },
             pricing: {
-              averageRent: Math.round(pricing.averageRent || 0),
-              minRent: pricing.minRent || 0,
-              maxRent: pricing.maxRent || 0,
+              averageRent: Math.round(pricing.averageRent),
+              minRent: pricing.minRent,
+              maxRent: pricing.maxRent,
             },
-            topCities: (topCities as TopCityRow[]).map((c) => ({
-              cityId: c._id,
-              city: c.city?.name ?? null,
-              state: c.region?.name ?? null,
-              properties: c.properties,
-              averageRent: Math.round(c.averageRent || 0),
+            topCities: topCities.map((city) => ({
+              cityId: city.cityId,
+              city: city.city,
+              state: city.state,
+              properties: city.properties,
+              averageRent: Math.round(city.averageRent),
             })),
-            priceBuckets: (priceBuckets as PriceBucketRow[]).map((b) => ({
-              bucket: typeof b._id === 'string' ? b._id : `${b._id}-${Number(b._id) + 499}`,
-              count: b.count,
-            })),
+            priceBuckets: priceBucketLabels(priceBuckets),
           },
           'App stats retrieved successfully',
         ),

--- a/packages/backend/controllers/neighborhoodController.ts
+++ b/packages/backend/controllers/neighborhoodController.ts
@@ -20,24 +20,22 @@
  * Public (no auth), mirroring `area-insights` / `cities` reads: the handlers
  * read only `req.params`/`req.query` and never touch `req.user`.
  *
- * ## This file straddles both stores on purpose, and the seam is explicit
+ * ## The two-store seam is gone, and so is what it cost
  *
- * Neighborhoods, cities and addresses are Postgres. The RENT STATISTICS are
- * counts and averages over PROPERTIES, and `properties` lands in batch 3 — so
- * every aggregation here is still a Mongoose pipeline, keyed by the address ids
- * Postgres supplies. Ids are preserved verbatim across the migration, which is
- * what makes that join work at all.
+ * This file used to straddle both stores: neighbourhoods, cities and addresses
+ * in Postgres, the rent STATISTICS as Mongoose pipelines keyed by address ids
+ * Postgres supplied. Every scope therefore materialised an uncapped array of
+ * address ids just to hand it to an `$in`, and each id had to be converted to an
+ * `ObjectId` by hand because an aggregation `$match` does not apply Mongoose's
+ * casting — a string list matched nothing and returned an empty result with no
+ * error, the silent-zero shape the migration contract warns about.
  *
- * The seam has ONE sharp edge, {@link toMongoAddressIds}: an aggregation `$match`
- * does NOT apply Mongoose's schema casting, so handing it id STRINGS matches
- * nothing and returns an empty result with no error — the exact silent-zero
- * shape the migration contract warns about. The conversion is therefore
- * explicit, and it THROWS on an id Mongo cannot represent rather than dropping
- * it.
+ * Listings are in the same database as addresses now, so every one of those is
+ * an ordinary join: no id arrays, no conversion, and no way for the two halves
+ * to disagree about what an id is.
  */
 
 import type { Request, Response, NextFunction } from 'express';
-import { Types } from 'mongoose';
 import { and, asc, eq, ilike, sql, inArray, type SQL } from 'drizzle-orm';
 import type {
   NeighborhoodMetrics,
@@ -45,10 +43,9 @@ import type {
   ListingCurrency,
 } from '@homiio/shared-types';
 
-import { Property } from '../models';
 import { getDb } from '../db/postgres';
 import { escapeLikePattern } from '../db/likePattern';
-import { addresses, cities, neighborhoods } from '../db/schema';
+import { addresses, cities, neighborhoods, properties } from '../db/schema';
 import { nearestAddressesQuery } from '../services/addressService';
 import { AppError, successResponse } from '../middlewares/errorHandler';
 import { resolveCityId } from '../services/geoQueryService';
@@ -90,11 +87,6 @@ interface RentStats {
   rentAvg: number | null;
 }
 
-/** Aggregation row shape for the rent-stats `$group`. */
-interface RentStatsRow {
-  listingCount: number;
-  rentAvg: number | null;
-}
 
 /** The neighborhood columns every response reads. */
 const NEIGHBORHOOD_COLUMNS = {
@@ -106,71 +98,38 @@ const NEIGHBORHOOD_COLUMNS = {
 } as const;
 
 /**
- * Convert Postgres address ids into the `ObjectId`s a Mongo AGGREGATION needs.
+ * Listing count + average long-term monthly rent over a set of addresses,
+ * restricted to published + available listings.
  *
- * `Model.find({ addressId: { $in: [...] } })` casts strings through the schema;
- * `Model.aggregate([{ $match: … }])` does NOT, so a raw string list silently
- * matches zero documents. Converting explicitly makes the boundary visible, and
- * makes an id Mongo cannot represent (a post-cutover uuid v7) throw here rather
- * than read as "this neighborhood has no listings".
+ * Takes a PREDICATE on `addresses`, not a list of address ids. The Mongo
+ * version could only take ids — it read every address in the neighbourhood (or
+ * the whole city) into an uncapped array, converted each to an `ObjectId`
+ * because `aggregate` does not cast, and `$in`-ed the result. Listings live in
+ * the same database as addresses now, so it is one join, and `toMongoAddressIds`
+ * plus the two id-list helpers are gone rather than ported.
  *
- * Deleted in batch 4, when the properties these ids point at are in Postgres too
- * and the whole indirection becomes a join.
+ * `rentAvg` averages only listings with a positive monthly amount — `avg()`
+ * ignores NULLs, so `nullif(..., 0)` does what the `$$REMOVE` branch did — and
+ * is `null` when none qualify.
  */
-function toMongoAddressIds(addressIds: readonly string[]): Types.ObjectId[] {
-  return addressIds.map((id) => new Types.ObjectId(id));
-}
-
-/**
- * Compute listing count + average long-term monthly rent over a set of address
- * ids, restricted to published + available listings. `rentAvg` averages only
- * listings with a positive `longTermRent.monthlyAmount` (others are mapped to
- * `$$REMOVE`, so `$avg` ignores them) and is `null` when none qualify.
- */
-async function rentStatsForAddressIds(addressIds: readonly string[]): Promise<RentStats> {
-  if (addressIds.length === 0) return { listingCount: 0, rentAvg: null };
-  const rows = await Property.aggregate<RentStatsRow>([
-    {
-      $match: {
-        addressId: { $in: toMongoAddressIds(addressIds) },
-        status: 'published',
-        'availability.isAvailable': true,
-      },
-    },
-    {
-      $group: {
-        _id: null,
-        listingCount: { $sum: 1 },
-        rentAvg: {
-          $avg: {
-            $cond: [
-              { $gt: ['$longTermRent.monthlyAmount', 0] },
-              '$longTermRent.monthlyAmount',
-              '$$REMOVE',
-            ],
-          },
-        },
-      },
-    },
-  ]);
-  const row = rows[0];
+async function rentStatsForAddresses(addressScope: SQL): Promise<RentStats> {
+  const [row] = await getDb()
+    .select({
+      listingCount: sql<number>`count(*)::int`,
+      rentAvg: sql<number | null>`avg(nullif(${properties.longTermRentMonthlyAmount}, 0))`,
+    })
+    .from(properties)
+    .innerJoin(addresses, eq(properties.addressId, addresses.id))
+    .where(
+      and(
+        addressScope,
+        eq(properties.status, 'published'),
+        eq(properties.availabilityIsAvailable, true),
+      ),
+    );
   if (!row) return { listingCount: 0, rentAvg: null };
-  return { listingCount: row.listingCount, rentAvg: row.rentAvg ?? null };
-}
-
-/** Address ids whose `neighborhood_id` matches. */
-async function addressIdsForNeighborhood(neighborhoodId: string): Promise<string[]> {
-  const rows = await getDb()
-    .select({ id: addresses.id })
-    .from(addresses)
-    .where(eq(addresses.neighborhoodId, neighborhoodId));
-  return rows.map((row) => row.id);
-}
-
-/** Address ids whose `city_id` matches. */
-async function addressIdsForCity(cityId: string): Promise<string[]> {
-  const rows = await getDb().select({ id: addresses.id }).from(addresses).where(eq(addresses.cityId, cityId));
-  return rows.map((row) => row.id);
+  // postgres.js returns `numeric` aggregates as strings.
+  return { listingCount: row.listingCount, rentAvg: row.rentAvg === null ? null : Number(row.rentAvg) };
 }
 
 /** Resolve a city's display name + currency (once per city, via the caches). */
@@ -213,13 +172,13 @@ async function buildMetrics(
     cityInfoCache.set(cityKey, cityInfo);
   }
 
-  const stats = presetStats ?? (await rentStatsForAddressIds(await addressIdsForNeighborhood(n.id)));
+  const stats = presetStats ?? (await rentStatsForAddresses(eq(addresses.neighborhoodId, n.id)));
 
   let vsCity: NeighborhoodVsCity | null = null;
   if (stats.rentAvg !== null) {
     let cityStats = cityStatsCache.get(cityKey);
     if (!cityStats) {
-      cityStats = await rentStatsForAddressIds(await addressIdsForCity(n.cityId));
+      cityStats = await rentStatsForAddresses(eq(addresses.cityId, n.cityId));
       cityStatsCache.set(cityKey, cityStats);
     }
     vsCity = buildVsCity(stats.rentAvg, cityStats.rentAvg);
@@ -339,27 +298,25 @@ export async function getNeighborhoodByName(req: Request, res: Response, next: N
 export async function getNeighborhoodByProperty(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
     const { propertyId } = req.params;
-    if (!Types.ObjectId.isValid(propertyId)) {
-      return next(new AppError('Invalid property ID', 400, 'INVALID_ID'));
-    }
+    // No id-SHAPE guard — `Types.ObjectId.isValid` rejects every uuid v7 id
+    // minted after the cutover. See `db/ids.ts`.
 
-    const property = await Property.findById(propertyId)
-      .select('addressId')
-      .lean<{ addressId?: Types.ObjectId } | null>();
-    if (!property) {
-      return next(new AppError('Property not found', 404, 'NOT_FOUND'));
-    }
-    if (!property.addressId) {
-      return next(new AppError('Property has no resolved neighborhood', 404, 'NOT_FOUND'));
-    }
-
+    // ONE statement, listings → addresses → neighbourhoods. The Mongo hop this
+    // replaces read `properties.addressId` from a different store first, which
+    // is what made `addressId` nullable-looking here; the column is `NOT NULL`
+    // with a RESTRICT reference, so a listing always has an address and the
+    // only real absence is a neighbourhood the address never resolved.
     const rows = await getDb()
       .select(NEIGHBORHOOD_COLUMNS)
-      .from(addresses)
+      .from(properties)
+      .innerJoin(addresses, eq(properties.addressId, addresses.id))
       .innerJoin(neighborhoods, eq(addresses.neighborhoodId, neighborhoods.id))
-      .where(eq(addresses.id, String(property.addressId)))
+      .where(eq(properties.id, propertyId))
       .limit(1);
     if (!rows[0]) {
+      // Deliberately one message for both "no such listing" and "no
+      // neighbourhood resolved": the endpoint answers a neighbourhood or it does
+      // not, and distinguishing them would confirm a listing exists.
       return next(new AppError('Property has no resolved neighborhood', 404, 'NOT_FOUND'));
     }
 
@@ -421,20 +378,6 @@ export async function searchNeighborhoods(req: Request, res: Response, next: Nex
   }
 }
 
-/**
- * One `$group` row of the popular-neighborhoods ranking: the listings at a
- * single address.
- *
- * The rent total and its count are carried SEPARATELY rather than pre-averaged,
- * because the groups are folded up to their neighborhood afterwards and an
- * average of per-address averages is not the average over listings.
- */
-interface PopularAddressGroup {
-  _id: Types.ObjectId;
-  listingCount: number;
-  rentSum: number;
-  rentCount: number;
-}
 
 /**
  * GET /api/neighborhoods/popular?city=&limit=
@@ -458,62 +401,35 @@ export async function getPopularNeighborhoods(req: Request, res: Response, next:
 
     const limit = parseLimit(req.query.limit, DEFAULT_POPULAR_LIMIT);
 
-    // The `$lookup` into `addresses` is gone: addresses live in Postgres now, so
-    // the city's neighborhood-bearing addresses are read here and the Mongo
-    // aggregation groups by the neighborhood id carried alongside them. Batch 4
-    // collapses the whole two-store shape into one join.
-    const cityAddresses = await getDb()
-      .select({ id: addresses.id, neighborhoodId: addresses.neighborhoodId })
-      .from(addresses)
-      .where(and(eq(addresses.cityId, cityId), sql`${addresses.neighborhoodId} is not null`));
-    if (cityAddresses.length === 0) {
-      res.json(successResponse([], 'Popular neighborhoods retrieved successfully'));
-      return;
-    }
+    // ONE grouped join, where this used to be: read every neighbourhood-bearing
+    // address in the city into an array, `$in` it against a Mongo aggregation,
+    // then fold the per-address groups up to their neighbourhood in JS. The
+    // grouping is the query's now, and nothing intermediate is materialised.
+    const grouped = await getDb()
+      .select({
+        neighborhoodId: addresses.neighborhoodId,
+        listingCount: sql<number>`count(*)::int`,
+        rentAvg: sql<number | null>`avg(nullif(${properties.longTermRentMonthlyAmount}, 0))`,
+      })
+      .from(properties)
+      .innerJoin(addresses, eq(properties.addressId, addresses.id))
+      .where(
+        and(
+          eq(addresses.cityId, cityId),
+          sql`${addresses.neighborhoodId} is not null`,
+          eq(properties.status, 'published'),
+          eq(properties.availabilityIsAvailable, true),
+        ),
+      )
+      .groupBy(addresses.neighborhoodId);
 
-    const neighborhoodByAddressId = new Map(cityAddresses.map((a) => [a.id, a.neighborhoodId as string]));
-    const rows = await Property.aggregate<PopularAddressGroup>([
-      {
-        $match: {
-          addressId: { $in: toMongoAddressIds(cityAddresses.map((a) => a.id)) },
-          status: 'published',
-          'availability.isAvailable': true,
-        },
-      },
-      {
-        $group: {
-          _id: '$addressId',
-          listingCount: { $sum: 1 },
-          rentSum: {
-            $sum: {
-              $cond: [{ $gt: ['$longTermRent.monthlyAmount', 0] }, '$longTermRent.monthlyAmount', 0],
-            },
-          },
-          rentCount: {
-            $sum: { $cond: [{ $gt: ['$longTermRent.monthlyAmount', 0] }, 1, 0] },
-          },
-        },
-      },
-    ]);
-
-    // Fold the per-address groups up to their neighborhood.
-    const totals = new Map<string, { listingCount: number; rentSum: number; rentCount: number }>();
-    for (const row of rows) {
-      const neighborhoodId = neighborhoodByAddressId.get(String(row._id));
-      if (!neighborhoodId) continue;
-      const acc = totals.get(neighborhoodId) ?? { listingCount: 0, rentSum: 0, rentCount: 0 };
-      acc.listingCount += row.listingCount;
-      acc.rentSum += row.rentSum;
-      acc.rentCount += row.rentCount;
-      totals.set(neighborhoodId, acc);
-    }
-
-    const ranked = [...totals.entries()]
-      .map(([neighborhoodId, acc]) => ({
-        neighborhoodId,
+    const ranked = grouped
+      .map((row) => ({
+        neighborhoodId: String(row.neighborhoodId),
         stats: {
-          listingCount: acc.listingCount,
-          rentAvg: acc.rentCount > 0 ? acc.rentSum / acc.rentCount : null,
+          listingCount: row.listingCount,
+          // postgres.js returns `numeric` aggregates as strings.
+          rentAvg: row.rentAvg === null ? null : Number(row.rentAvg),
         } satisfies RentStats,
       }))
       .sort((a, b) => b.stats.listingCount - a.stats.listingCount)

--- a/packages/backend/controllers/property/areaInsights.ts
+++ b/packages/backend/controllers/property/areaInsights.ts
@@ -2,601 +2,85 @@
  * Area price-insights controller.
  *
  * Powers the property-detail "price range in this area" section. Given a target
- * property it computes how that listing's price compares to SIMILAR homes
- * nearby, returning min/max/avg/median, a verdict, a price distribution and a
- * set of comparable listings.
+ * listing it reports how that listing's price compares to SIMILAR homes nearby:
+ * min/max/avg/median, a verdict, a price distribution and a set of comparables.
  *
  * Public (no auth) — mirrors the auth posture of the nearby/radius/stats routes
  * in `routes/public.ts`.
  *
- * Geo model: coordinates live on the referenced Address (GeoJSON Point with a
- * `2dsphere` index). Geo filtering therefore resolves the matching Address ids
- * first (via `$geoWithin`/`$near`, the same pattern as
- * `PropertySchema.statics.findWithinRadius` / `findNearby`) and then constrains
- * properties by `addressId`. This keeps every query index-backed.
+ * Like-for-like is preserved: a target is compared only against listings
+ * carrying the SAME offering (monthly vs monthly, nightly vs nightly, sale vs
+ * sale), so a €/month listing is never mixed with a €/night one. That rule lives
+ * in `buildBaseComparableFilter`.
  *
- * Like-for-like guarantee: a target is compared only against listings carrying
- * the SAME offering (long-term monthly vs long-term monthly, short-term nightly
- * vs short-term nightly, sale price vs sale price), so a €/month listing is
- * never mixed with a €/night one.
+ * ## This file was a 770-line COPY of `services/areaPriceComparison`
+ *
+ * The two carried ~493 near-identical lines — the same thresholds, scope
+ * resolution, aggregates and distribution builder, maintained twice. The
+ * service is the single authority (`priceEthicsService` already computes its
+ * market verdict through it), so this is now the HTTP wrapper it should always
+ * have been, and the comparison logic has one place left to be wrong in.
+ *
+ * ## The scopes are SQL predicates, not id lists
+ *
+ * The copy resolved each scope by loading every matching ADDRESS id into an
+ * uncapped array and `$in`-ing it against the listings, because Mongo could not
+ * join. `radiusScope` / `cityScope` / `neighborhoodScope` are predicates over
+ * the address join `propertyReads` already makes, so those intermediate arrays —
+ * and the over-fetch-then-re-sort that reproduced their distance ordering — are
+ * gone rather than ported.
  */
 
 import type { Request, Response, NextFunction } from 'express';
-import { Types, type Model } from 'mongoose';
-import { OfferingType } from '@homiio/shared-types';
-import type {
-  PropertyAreaInsights,
-  AreaPriceVerdict,
-  AreaInsightsBasis,
-  AreaPriceComparison,
-  AreaPriceDistribution,
-  AreaPriceDistributionBucket,
-  AreaPricePerSqm,
-  AreaNeighborhoodVsCity,
-} from '@homiio/shared-types';
-import type { IProperty } from '../../models/documentTypes';
-import type { IAddress } from '../../models/Address';
+import type { AreaInsightsBasis, PropertyAreaInsights } from '@homiio/shared-types';
 
-import * as models from '../../models';
-const Property: Model<IProperty> = models.Property;
-const Address: Model<IAddress> = models.Address;
 import { AppError, successResponse } from '../../middlewares/errorHandler';
-
-// ---- Tunable constants (no magic numbers inline) ----
-/** Radius, in kilometres, used for the primary (neighborhood-scale) comparison. */
-const RADIUS_KM = 2;
-/** Metres per kilometre. */
-const METERS_PER_KM = 1000;
-/** Minimum comparables required before we trust the radius scope; below this we fall back to city. */
-const MIN_RADIUS_SAMPLE = 5;
-/** Bedroom tolerance: comparables must be within ±this many bedrooms of the target. */
-const BEDROOM_TOLERANCE = 1;
-/** Number of even buckets in the price distribution histogram. */
-const BUCKET_COUNT = 8;
-/** Maximum number of full comparable property documents returned (nearest first). */
-const COMPARABLES_LIMIT = 12;
-/**
- * Over-fetch factor for the comparables-list query. `scopeAddressIds` is
- * distance-ordered, so we slice it to `COMPARABLES_LIMIT * this` before the
- * `find` (rather than fetching the entire scope and slicing in memory). The
- * cushion absorbs addresses that have 0/multiple matching comparables so we
- * still surface ~COMPARABLES_LIMIT nearest docs without scanning hundreds.
- */
-const COMPARABLES_OVERFETCH_FACTOR = 3;
-/** Percent thresholds (target-vs-average) that map a price difference to a verdict. */
-const VERDICT_GOOD_DEAL_MAX = -7;
-const VERDICT_BELOW_AVG_MAX = -2;
-const VERDICT_AVERAGE_MAX = 2;
-
-/**
- * Mongo field paths the comparison can be denominated in, one per offering. A
- * target is compared only against listings carrying the same offering, in the
- * matching price field, so a monthly figure is never mixed with a nightly one
- * or a sale total.
- */
-const PRICE_FIELD_LONG_TERM = 'longTermRent.monthlyAmount';
-const PRICE_FIELD_SHORT_TERM = 'shortTermRent.nightlyRate';
-const PRICE_FIELD_SALE = 'sale.price';
-type PriceField =
-  | typeof PRICE_FIELD_LONG_TERM
-  | typeof PRICE_FIELD_SHORT_TERM
-  | typeof PRICE_FIELD_SALE;
-
-/** The offering each price field belongs to, for the comparable membership filter. */
-const OFFERING_FOR_PRICE_FIELD: Record<PriceField, OfferingType> = {
-  [PRICE_FIELD_LONG_TERM]: OfferingType.LONG_TERM_RENT,
-  [PRICE_FIELD_SHORT_TERM]: OfferingType.SHORT_TERM_RENT,
-  [PRICE_FIELD_SALE]: OfferingType.SALE,
-};
-
-/** A short-term-mode price unit label, for the response `priceUnit` field. */
-const PRICE_UNIT_MONTH = 'month';
-const PRICE_UNIT_NIGHT = 'night';
-const PRICE_UNIT_SALE = 'sale';
+import { findPropertyById } from '../../db/properties/propertyReads';
+import { serializeProperty } from '../../db/properties/propertySerializer';
+import {
+  aggregatePriceStats,
+  buildBaseComparableFilter,
+  buildComparison,
+  buildDistribution,
+  buildNeighborhoodContrast,
+  buildPricePerSqm,
+  buildTargetContext,
+  cityScope,
+  fetchComparables,
+  MIN_RADIUS_SAMPLE,
+  PRICE_UNIT_MONTH,
+  RADIUS_KM,
+  radiusScope,
+  type ComparableProperty,
+} from '../../services/areaPriceComparison';
 
 /**
  * Outgoing response shape. Field-for-field the shared `PropertyAreaInsights`
  * contract, except `comparables`: the shared type exposes full `Property[]`,
- * while this controller returns lean projections (`Record<string, unknown>[]`)
- * to avoid eagerly materialising Mongoose documents. The boundary is narrowed
- * here rather than loosening the shared type.
+ * while this endpoint returns serialized listings
+ * (`Record<string, unknown>[]`). The boundary is narrowed here rather than
+ * loosening the shared type.
  */
 type AreaInsightsResponse = Omit<PropertyAreaInsights, 'comparables'> & {
   comparables: Record<string, unknown>[];
 };
 
-/** Aggregation row produced by the comparable price-stats pipeline. */
-interface PriceStatsRow {
-  count: number;
-  min: number;
-  max: number;
-  avg: number;
-  median: number | null;
-  prices: number[];
-  /**
-   * Average of `<priceField> / squareFootage` over the SAME scope, restricted to
-   * comparables with `squareFootage > 0` (others are mapped to `$$REMOVE` so the
-   * `$avg` ignores them). `null` when no comparable in scope exposes a usable
-   * square footage — folded into this pipeline to save a Mongo round-trip.
-   */
-  avgPricePerSqm: number | null;
-}
-
-/** Aggregation row produced by an average-only pipeline. */
-interface AvgRow {
-  avg: number;
-  count: number;
-}
-
-/** Lean Address projection used for geo id-resolution. */
-type AddressGeoLean = { _id: Types.ObjectId };
-
-/** A geo ref field as read off a lean Address: a bare id or a populated doc. */
-type GeoRefField = Types.ObjectId | { _id: Types.ObjectId; name?: string } | null | undefined;
-
-/** The geo-bearing subset of a populated Address used by area insights. */
-interface PopulatedGeoAddress {
-  coordinates?: { coordinates?: [number, number] };
-  cityId?: GeoRefField;
-  neighborhoodId?: GeoRefField;
-}
-
-/** Extract `{ id, name? }` from a geo ref that may be an id or a populated doc. */
-function extractGeoRef(ref: GeoRefField): { id: Types.ObjectId; name?: string } | null {
-  if (!ref) return null;
-  if (ref instanceof Types.ObjectId) return { id: ref };
-  if (typeof ref === 'object' && '_id' in ref && ref._id) {
-    return { id: ref._id, name: typeof ref.name === 'string' ? ref.name : undefined };
-  }
-  return null;
-}
-
-/** Target fields needed to build the comparable query and the response. */
-interface TargetContext {
-  id: Types.ObjectId;
-  bedrooms: number;
-  /** Human price-unit label for the response (`month` / `night` / `sale`). */
-  priceUnit: string;
-  currency: string;
-  /** The target's own price in the comparison basis (the offering's price field). */
-  price: number;
-  /**
-   * Which price the comparison is denominated in — the price field of the
-   * target's primary offering. Comparables are matched on the SAME offering and
-   * the SAME field, so a monthly figure is never mixed with a nightly one.
-   */
-  priceField: PriceField;
-  squareFootage: number;
-  longitude: number;
-  latitude: number;
-  /** Canonical city id (Address.cityId) used to scope city-wide comparables. */
-  cityId: Types.ObjectId;
-  /** Canonical neighborhood id (Address.neighborhoodId), null when unknown. */
-  neighborhoodId: Types.ObjectId | null;
-  /** Display name of the city, resolved from the populated City doc. */
-  city: string;
-  /** Display name of the neighborhood, resolved from the populated Neighborhood doc. */
-  neighborhood: string | null;
-}
-
 /**
- * Base comparable filter (everything except the geo / city scope).
+ * The "not enough data" response.
  *
- * Comparable = a published, available listing that is NOT the target, within
- * ±BEDROOM_TOLERANCE bedrooms, carrying the SAME offering as the target's
- * primary basis, with a positive price in the matching field. Matching on the
- * offering (rather than a price-unit string) is what keeps prices like-for-like.
+ * Returned when the listing carries no positive price at all: there is no basis
+ * to compare against, so a graceful `sampleSize: 0` beats a comparison against
+ * zero. The frontend hides the section on that.
  */
-function buildBaseComparableFilter(target: TargetContext): Record<string, unknown> {
-  return {
-    _id: { $ne: target.id },
-    status: 'published',
-    'availability.isAvailable': true,
-    bedrooms: {
-      $gte: target.bedrooms - BEDROOM_TOLERANCE,
-      $lte: target.bedrooms + BEDROOM_TOLERANCE,
-    },
-    offerings: OFFERING_FOR_PRICE_FIELD[target.priceField],
-    [target.priceField]: { $gt: 0 },
-  };
-}
-
-/**
- * Resolve the ordered (nearest-first) list of Address ids within `radiusKm` of
- * the target. Mirrors `PropertySchema.statics.findWithinRadius`'s geo approach
- * (`$geoWithin` on the 2dsphere index) but uses `$near` so the result is
- * distance-ordered, which lets us return comparables nearest-first.
- */
-async function resolveRadiusAddressIds(
-  target: TargetContext,
-  radiusKm: number
-): Promise<Types.ObjectId[]> {
-  const maxDistanceMeters = radiusKm * METERS_PER_KM;
-  const matches = await Address.find({
-    coordinates: {
-      $near: {
-        $geometry: { type: 'Point', coordinates: [target.longitude, target.latitude] },
-        $maxDistance: maxDistanceMeters,
-      },
-    },
-  })
-    .select('_id')
-    .lean<AddressGeoLean[]>();
-  return matches.map((a) => a._id);
-}
-
-/**
- * Resolve the ordered (nearest-first) list of Address ids in the target's city.
- * Ordered by distance from the target so the city-fallback comparables are
- * still returned nearest-first.
- */
-async function resolveCityAddressIds(target: TargetContext): Promise<Types.ObjectId[]> {
-  const matches = await Address.find({
-    cityId: target.cityId,
-    coordinates: {
-      $near: {
-        $geometry: { type: 'Point', coordinates: [target.longitude, target.latitude] },
-      },
-    },
-  })
-    .select('_id')
-    .lean<AddressGeoLean[]>();
-  return matches.map((a) => a._id);
-}
-
-/** Resolve Address ids in the target's neighborhood (relational, by id). */
-async function resolveNeighborhoodAddressIds(
-  target: TargetContext
-): Promise<Types.ObjectId[]> {
-  if (!target.neighborhoodId) return [];
-  const matches = await Address.find({ neighborhoodId: target.neighborhoodId })
-    .select('_id')
-    .lean<AddressGeoLean[]>();
-  return matches.map((a) => a._id);
-}
-
-/** Round to the nearest integer, treating non-finite input as 0. */
-function roundInt(value: number): number {
-  return Number.isFinite(value) ? Math.round(value) : 0;
-}
-
-/**
- * Run the comparable price-stats aggregation over the given address-id scope,
- * denominated in `priceField` (the target offering's price field). Returns null
- * when the scope yields no comparables. Uses the `$median` accumulator (MongoDB 7.0+)
- * and also keeps the sorted price array so the histogram can be built without a
- * second pass.
- *
- * `avgPricePerSqm` is folded into this same `$group` (same `$match` scope) to
- * avoid a separate Mongo round-trip: it averages `<priceField> / squareFootage`
- * over comparables with `squareFootage > 0`, mapping the rest to `$$REMOVE` so
- * the `$avg` ignores them — yielding the identical value a `squareFootage > 0`
- * `$match` would. `$avg` returns `null` when every comparable is removed.
- */
-async function aggregatePriceStats(
-  baseFilter: Record<string, unknown>,
-  addressIds: Types.ObjectId[],
-  priceField: PriceField
-): Promise<PriceStatsRow | null> {
-  if (addressIds.length === 0) return null;
-  const priceRef = `$${priceField}`;
-  const rows = await Property.aggregate<PriceStatsRow>([
-    { $match: { ...baseFilter, addressId: { $in: addressIds } } },
-    { $sort: { [priceField]: 1 } },
-    {
-      $group: {
-        _id: null,
-        count: { $sum: 1 },
-        min: { $min: priceRef },
-        max: { $max: priceRef },
-        avg: { $avg: priceRef },
-        median: { $median: { input: priceRef, method: 'approximate' } },
-        prices: { $push: priceRef },
-        avgPricePerSqm: {
-          $avg: {
-            $cond: [
-              { $gt: ['$squareFootage', 0] },
-              { $divide: [priceRef, '$squareFootage'] },
-              '$$REMOVE',
-            ],
-          },
-        },
-      },
-    },
-  ]);
-  const row = rows[0];
-  if (!row || row.count === 0) return null;
-  return row;
-}
-
-/** Average price (in `priceField`) over a scope; returns null when empty. */
-async function aggregateAvg(
-  baseFilter: Record<string, unknown>,
-  addressIds: Types.ObjectId[],
-  priceField: PriceField
-): Promise<number | null> {
-  if (addressIds.length === 0) return null;
-  const rows = await Property.aggregate<AvgRow>([
-    { $match: { ...baseFilter, addressId: { $in: addressIds } } },
-    { $group: { _id: null, avg: { $avg: `$${priceField}` }, count: { $sum: 1 } } },
-  ]);
-  const row = rows[0];
-  if (!row || row.count === 0) return null;
-  return row.avg;
-}
-
-/** Map a percent difference from the average to a verdict. */
-function classifyVerdict(percentDiffFromAvg: number): AreaPriceVerdict {
-  if (percentDiffFromAvg <= VERDICT_GOOD_DEAL_MAX) return 'good_deal';
-  if (percentDiffFromAvg <= VERDICT_BELOW_AVG_MAX) return 'below_average';
-  if (percentDiffFromAvg <= VERDICT_AVERAGE_MAX) return 'average';
-  return 'above_average';
-}
-
-/** Build the comparison block from the stats row (or the target alone when sparse). */
-function buildComparison(stats: PriceStatsRow | null, thisPrice: number): AreaPriceComparison {
-  if (!stats) {
-    // No comparables at all — describe the target against itself so the
-    // frontend can render a graceful "not enough data" state without special-casing.
-    return {
-      min: roundInt(thisPrice),
-      max: roundInt(thisPrice),
-      avg: roundInt(thisPrice),
-      median: roundInt(thisPrice),
-      thisPrice: roundInt(thisPrice),
-      percentDiffFromAvg: 0,
-      verdict: 'average',
-    };
-  }
-  const avg = stats.avg;
-  const median = stats.median ?? medianFromSorted(stats.prices);
-  const percentDiffFromAvg = avg > 0 ? roundInt(((thisPrice - avg) / avg) * 100) : 0;
-  return {
-    min: roundInt(stats.min),
-    max: roundInt(stats.max),
-    avg: roundInt(avg),
-    median: roundInt(median),
-    thisPrice: roundInt(thisPrice),
-    percentDiffFromAvg,
-    verdict: classifyVerdict(percentDiffFromAvg),
-  };
-}
-
-/** Median from an ascending-sorted array — fallback when `$median` is unavailable. */
-function medianFromSorted(sorted: number[]): number {
-  if (sorted.length === 0) return 0;
-  const mid = Math.floor(sorted.length / 2);
-  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
-}
-
-/**
- * Build the price-distribution histogram: BUCKET_COUNT even buckets across
- * [min, max], the count of comparable prices in each, and the index of the
- * bucket the target's price falls in (-1 if outside the range).
- *
- * Prices are the comparable prices PLUS the target price, so the histogram
- * reflects where the target sits among its peers. When min == max (all equal,
- * or a single data point) a single bucket is used.
- */
-function buildDistribution(stats: PriceStatsRow | null, thisPrice: number): AreaPriceDistribution {
-  const prices = stats ? [...stats.prices, thisPrice] : [thisPrice];
-  const min = stats ? Math.min(stats.min, thisPrice) : thisPrice;
-  const max = stats ? Math.max(stats.max, thisPrice) : thisPrice;
-
-  if (min === max) {
-    const single: AreaPriceDistributionBucket = {
-      min: roundInt(min),
-      max: roundInt(max),
-      count: prices.length,
-    };
-    return { buckets: [single], thisBucketIndex: 0 };
-  }
-
-  const span = max - min;
-  const step = span / BUCKET_COUNT;
-  const buckets: AreaPriceDistributionBucket[] = [];
-  for (let i = 0; i < BUCKET_COUNT; i += 1) {
-    const bucketMin = min + step * i;
-    const bucketMax = i === BUCKET_COUNT - 1 ? max : min + step * (i + 1);
-    buckets.push({ min: roundInt(bucketMin), max: roundInt(bucketMax), count: 0 });
-  }
-
-  const bucketIndexFor = (price: number): number => {
-    if (price < min || price > max) return -1;
-    // Clamp so the inclusive upper bound (max) lands in the last bucket.
-    return Math.min(BUCKET_COUNT - 1, Math.floor((price - min) / step));
-  };
-
-  for (const price of prices) {
-    const idx = bucketIndexFor(price);
-    if (idx >= 0) buckets[idx].count += 1;
-  }
-
-  return { buckets, thisBucketIndex: bucketIndexFor(thisPrice) };
-}
-
-/** Build pricePerSqm, or null when target or area lacks usable square footage. */
-function buildPricePerSqm(
-  targetSqm: number,
-  targetPrice: number,
-  areaAvgPricePerSqm: number | null
-): AreaPricePerSqm | null {
-  if (targetSqm <= 0 || areaAvgPricePerSqm === null) return null;
-  return {
-    this: roundInt(targetPrice / targetSqm),
-    areaAvg: roundInt(areaAvgPricePerSqm),
-  };
-}
-
-/**
- * Build the neighborhood-vs-city block, or null when:
- *  - the target has no neighborhood,
- *  - the neighborhood scope is effectively the whole city (no distinct contrast), or
- *  - either the neighborhood or the city sample is empty.
- */
-function buildNeighborhoodVsCity(
-  target: TargetContext,
-  neighborhoodAvg: number | null,
-  cityAvg: number | null
-): AreaNeighborhoodVsCity | null {
-  if (!target.neighborhood || neighborhoodAvg === null || cityAvg === null) return null;
-  const percentDiff = cityAvg > 0 ? roundInt(((neighborhoodAvg - cityAvg) / cityAvg) * 100) : 0;
-  return {
-    neighborhood: target.neighborhood,
-    city: target.city,
-    neighborhoodAvg: roundInt(neighborhoodAvg),
-    cityAvg: roundInt(cityAvg),
-    percentDiff,
-  };
-}
-
-/**
- * Resolve the comparison BASIS for a target listing — the single offering its
- * price comparison is denominated in.
- *
- * Precedence (a multi-offering listing has ONE comparison basis): long-term
- * monthly rent → short-term nightly rate → sale price. EXCHANGE carries no
- * monetary price, so an exchange-only listing has no basis (the caller then
- * returns `sampleSize: 0` rather than comparing against a 0 basis).
- */
-function resolvePriceBasis(
-  property: IProperty
-): { priceField: PriceField; price: number; currency: string; priceUnit: string } | null {
-  const monthly = property.longTermRent?.monthlyAmount;
-  if (typeof monthly === 'number' && monthly > 0) {
-    return {
-      priceField: PRICE_FIELD_LONG_TERM,
-      price: monthly,
-      currency: property.longTermRent?.currency ?? 'EUR',
-      priceUnit: PRICE_UNIT_MONTH,
-    };
-  }
-  const nightly = property.shortTermRent?.nightlyRate;
-  if (typeof nightly === 'number' && nightly > 0) {
-    return {
-      priceField: PRICE_FIELD_SHORT_TERM,
-      price: nightly,
-      currency: property.shortTermRent?.currency ?? 'EUR',
-      priceUnit: PRICE_UNIT_NIGHT,
-    };
-  }
-  const salePrice = property.sale?.price;
-  if (typeof salePrice === 'number' && salePrice > 0) {
-    return {
-      priceField: PRICE_FIELD_SALE,
-      price: salePrice,
-      currency: property.sale?.currency ?? 'EUR',
-      priceUnit: PRICE_UNIT_SALE,
-    };
-  }
-  return null;
-}
-
-/**
- * Build the target context from the populated property document.
- *
- * Returns null when the property lacks usable address coordinates (the caller
- * maps this to a 422) OR when it has no positive price in either basis (the
- * caller maps this to a graceful `sampleSize: 0` response). The two cases are
- * distinguished by `reason`.
- */
-function buildTargetContext(
-  property: IProperty
-): { context: TargetContext } | { reason: 'no_coordinates' | 'no_price' } {
-  // After `.populate('addressId').lean()`, the schema's post-find hook runs
-  // `transformAddressFields`, which renames the populated `addressId` to
-  // `address` (and deletes `addressId`). Read `address` first, then fall back
-  // to the raw `addressId` in case the transform did not run.
-  const populated = property as unknown as { address?: PopulatedGeoAddress; addressId?: PopulatedGeoAddress };
-  const address = populated.address ?? populated.addressId ?? null;
-  const coords = address?.coordinates?.coordinates;
-  if (!address || !Array.isArray(coords) || coords.length !== 2) return { reason: 'no_coordinates' };
-  const [longitude, latitude] = coords;
-  if (typeof longitude !== 'number' || typeof latitude !== 'number') return { reason: 'no_coordinates' };
-
-  // Geo is relational: scope by the resolved cityId/neighborhoodId, and read the
-  // display names from the (deep-)populated City/Neighborhood docs. Without a
-  // cityId there is no comparable scope to build.
-  const cityRef = extractGeoRef(address.cityId);
-  if (!cityRef) return { reason: 'no_coordinates' };
-  const neighborhoodRef = extractGeoRef(address.neighborhoodId);
-
-  const basis = resolvePriceBasis(property);
-  if (!basis) return { reason: 'no_price' };
-
-  return {
-    context: {
-      id: property._id,
-      bedrooms: typeof property.bedrooms === 'number' ? property.bedrooms : 0,
-      priceUnit: basis.priceUnit,
-      currency: basis.currency,
-      price: basis.price,
-      priceField: basis.priceField,
-      squareFootage: typeof property.squareFootage === 'number' ? property.squareFootage : 0,
-      longitude,
-      latitude,
-      cityId: cityRef.id,
-      neighborhoodId: neighborhoodRef?.id ?? null,
-      city: cityRef.name ?? '',
-      neighborhood: neighborhoodRef?.name ?? null,
-    },
-  };
-}
-
-/**
- * Compute the neighborhood-vs-city contrast block (or null).
- *
- * Returns null without issuing ANY query when the target has no neighborhood —
- * so neighborhood-less listings never pay for an unbounded city `$near` scan
- * whose result would only be discarded. Otherwise resolves the neighborhood
- * scope and the city-wide contrast scope (reusing `cityScopeAddressIds` when
- * the chosen scope already IS the city), and returns null when the neighborhood
- * is effectively the whole city (no distinct contrast) or either sample is
- * empty.
- *
- * `cityScopeAddressIds` is the already-resolved city scope when `basis==='city'`
- * (so the contrast reuses it instead of re-querying); null on the radius path,
- * where the contrast city scope is resolved here on demand.
- */
-async function buildNeighborhoodContrast(
-  target: TargetContext,
-  baseFilter: Record<string, unknown>,
-  cityScopeAddressIds: Types.ObjectId[] | null
-): Promise<AreaNeighborhoodVsCity | null> {
-  if (!target.neighborhood) return null;
-
-  const [neighborhoodAddressIds, cityAddressIdsForContrast] = await Promise.all([
-    resolveNeighborhoodAddressIds(target),
-    cityScopeAddressIds ? Promise.resolve(cityScopeAddressIds) : resolveCityAddressIds(target),
-  ]);
-
-  const neighborhoodIsWholeCity =
-    neighborhoodAddressIds.length > 0 &&
-    neighborhoodAddressIds.length === cityAddressIdsForContrast.length;
-  if (neighborhoodAddressIds.length === 0 || neighborhoodIsWholeCity) return null;
-
-  const [neighborhoodAvg, cityAvg] = await Promise.all([
-    aggregateAvg(baseFilter, neighborhoodAddressIds, target.priceField),
-    aggregateAvg(baseFilter, cityAddressIdsForContrast, target.priceField),
-  ]);
-  return buildNeighborhoodVsCity(target, neighborhoodAvg, cityAvg);
-}
-
-/**
- * Build the graceful empty (`sampleSize: 0`) payload for a listing that has no
- * positive price in any basis. Reuses the same null-stats comparison/distribution
- * shape as the "no comparables found" path so the frontend's "not enough data"
- * state renders identically. No queries are issued.
- */
-function buildEmptyInsights(property: IProperty): AreaInsightsResponse {
+function buildEmptyInsights(property: ComparableProperty): AreaInsightsResponse {
   return {
     basis: 'city',
     radiusKm: RADIUS_KM,
     areaLabel: '',
     currency:
-      property.longTermRent?.currency ??
-      property.shortTermRent?.currency ??
-      property.sale?.currency ??
+      (property.longTermRent?.currency as string | undefined) ??
+      (property.shortTermRent?.currency as string | undefined) ??
+      (property.sale?.currency as string | undefined) ??
       'EUR',
     priceUnit: PRICE_UNIT_MONTH,
     sampleSize: 0,
@@ -611,86 +95,62 @@ function buildEmptyInsights(property: IProperty): AreaInsightsResponse {
 /**
  * GET /api/properties/:propertyId/area-insights
  *
- * Returns price context (range, average, median, verdict, distribution and
- * comparable listings) for similar homes in the same area as the target
- * property. Never 500s on sparse data — falls back from a 2 km radius to the
- * whole city, and finally to a target-only "not enough data" response.
+ * Never 500s on sparse data — it falls back from a 2 km radius to the whole
+ * city, and finally to a target-only "not enough data" response.
  */
-export async function getAreaInsights(req: Request, res: Response, next: NextFunction): Promise<void> {
+export async function getAreaInsights(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
   try {
     const { propertyId } = req.params;
-    if (!Types.ObjectId.isValid(propertyId)) {
-      return next(new AppError('Invalid property ID', 400, 'INVALID_ID'));
-    }
-
-    const property = await Property.findById(propertyId)
-      .populate({
-        path: 'addressId',
-        populate: [
-          { path: 'cityId', select: 'name' },
-          { path: 'neighborhoodId', select: 'name' },
-        ],
-      })
-      .lean<IProperty | null>();
-    if (!property) {
+    // No id-SHAPE guard. `Types.ObjectId.isValid` answers `false` for every
+    // listing minted after the cutover, so this endpoint 400'd on exactly the
+    // listings most likely to be looked at. A `text` primary key takes any
+    // string and a nonsense id matches no row — see `db/ids.ts`.
+    const hydrated = await findPropertyById(propertyId);
+    if (!hydrated) {
       return next(new AppError('Property not found', 404, 'NOT_FOUND'));
     }
+    const property = serializeProperty(hydrated) as ComparableProperty;
 
     const targetResult = buildTargetContext(property);
     if ('reason' in targetResult) {
       if (targetResult.reason === 'no_coordinates') {
-        return next(new AppError('Property is missing address coordinates', 422, 'MISSING_COORDINATES'));
+        return next(
+          new AppError('Property is missing address coordinates', 422, 'MISSING_COORDINATES'),
+        );
       }
-      // `no_price`: no positive rent and no positive sale price — there is no
-      // meaningful basis to compare against, so return a graceful empty result
-      // (sampleSize 0) rather than a comparison against a 0 basis. The frontend
-      // hides the section when sampleSize === 0.
-      res.json(successResponse(buildEmptyInsights(property), 'Area insights retrieved successfully'));
+      res.json(
+        successResponse(buildEmptyInsights(property), 'Area insights retrieved successfully'),
+      );
       return;
     }
     const target = targetResult.context;
-
     const baseFilter = buildBaseComparableFilter(target);
 
-    // --- Primary scope: comparables within RADIUS_KM (neighborhood scale) ---
-    // Inherently sequential: the radius price-stats decide whether the radius
-    // scope is dense enough, which in turn decides the scope everything below
-    // operates on. Price-per-sqm is folded into `aggregatePriceStats`, so this
-    // is the only stats round-trip per scope.
-    const radiusAddressIds = await resolveRadiusAddressIds(target, RADIUS_KM);
-    const radiusStats = await aggregatePriceStats(baseFilter, radiusAddressIds, target.priceField);
-    const radiusCount = radiusStats?.count ?? 0;
+    // Inherently sequential: the radius stats decide whether the radius scope is
+    // dense enough, which decides the scope everything below operates on.
+    const radius = radiusScope(target, RADIUS_KM);
+    const radiusStats = await aggregatePriceStats(baseFilter, radius, target.priceField);
+    const useRadius = (radiusStats?.count ?? 0) >= MIN_RADIUS_SAMPLE;
 
-    // --- Fallback to the whole city when the radius scope is too sparse ---
-    const useRadius = radiusCount >= MIN_RADIUS_SAMPLE;
-    let basis: AreaInsightsBasis;
-    let scopeAddressIds: Types.ObjectId[];
-    let stats: PriceStatsRow | null;
+    const basis: AreaInsightsBasis = useRadius ? 'radius' : 'city';
+    const scope = useRadius ? radius : cityScope(target);
+    const stats = useRadius
+      ? radiusStats
+      : await aggregatePriceStats(baseFilter, scope, target.priceField);
 
-    if (useRadius) {
-      basis = 'radius';
-      scopeAddressIds = radiusAddressIds;
-      stats = radiusStats;
-    } else {
-      basis = 'city';
-      scopeAddressIds = await resolveCityAddressIds(target);
-      stats = await aggregatePriceStats(baseFilter, scopeAddressIds, target.priceField);
-    }
+    const areaLabel = basis === 'radius' ? (target.neighborhood ?? target.city) : target.city;
 
-    const areaLabel =
-      basis === 'radius' ? target.neighborhood ?? target.city : target.city;
-    const sampleSize = stats?.count ?? 0;
-
-    // --- Independent work, run concurrently once the scope is fixed ---
-    //  - comparable documents over the chosen scope (nearest-first ordering is
-    //    preserved by `fetchComparables`, since `$in` does not honour the
-    //    distance-ordered `scopeAddressIds`); and
-    //  - the neighborhood-vs-city contrast, which resolves its own scopes
-    //    (reusing `scopeAddressIds` on the city path).
-    // Neither depends on the other, so they overlap on the wire.
+    // Independent once the scope is fixed, so they overlap on the wire.
     const [comparables, neighborhoodVsCity] = await Promise.all([
-      fetchComparables(baseFilter, scopeAddressIds),
-      buildNeighborhoodContrast(target, baseFilter, basis === 'city' ? scopeAddressIds : null),
+      fetchComparables(baseFilter, scope, {
+        longitude: target.longitude,
+        latitude: target.latitude,
+      }),
+      buildNeighborhoodContrast(target, baseFilter),
     ]);
 
     const response: AreaInsightsResponse = {
@@ -699,11 +159,13 @@ export async function getAreaInsights(req: Request, res: Response, next: NextFun
       areaLabel,
       currency: target.currency,
       priceUnit: target.priceUnit,
-      sampleSize,
+      sampleSize: stats?.count ?? 0,
       comparison: buildComparison(stats, target.price),
-      // Price-per-sqm comes from the folded `avgPricePerSqm` accumulator on the
-      // chosen scope's stats row (null when the scope is empty or sqm-less).
-      pricePerSqm: buildPricePerSqm(target.squareFootage, target.price, stats?.avgPricePerSqm ?? null),
+      pricePerSqm: buildPricePerSqm(
+        target.squareFootage,
+        target.price,
+        stats?.avgPricePerSqm ?? null,
+      ),
       distribution: buildDistribution(stats, target.price),
       neighborhoodVsCity,
       comparables,
@@ -713,58 +175,4 @@ export async function getAreaInsights(req: Request, res: Response, next: NextFun
   } catch (error) {
     next(error);
   }
-}
-
-/**
- * Fetch up to COMPARABLES_LIMIT full comparable property documents, ordered
- * nearest-first.
- *
- * `scopeAddressIds` is distance-ordered, so we cap the query to the nearest
- * `COMPARABLES_LIMIT * COMPARABLES_OVERFETCH_FACTOR` addresses (the cushion
- * absorbs addresses with 0/multiple comparables) instead of fetching+populating
- * the ENTIRE scope and slicing to 12 in memory. We then re-sort the returned
- * docs to honour the distance ordering (a `$in` query does not preserve array
- * order on its own) and slice to COMPARABLES_LIMIT. The full-scope STATS
- * aggregation is unaffected — only this comparables-list fetch is capped.
- */
-async function fetchComparables(
-  baseFilter: Record<string, unknown>,
-  scopeAddressIds: Types.ObjectId[]
-): Promise<Record<string, unknown>[]> {
-  if (scopeAddressIds.length === 0) return [];
-  // Over-fetch only the nearest slice of the distance-ordered scope.
-  const nearestAddressIds = scopeAddressIds.slice(0, COMPARABLES_LIMIT * COMPARABLES_OVERFETCH_FACTOR);
-  const orderById = new Map<string, number>();
-  nearestAddressIds.forEach((id, index) => orderById.set(id.toString(), index));
-
-  const docs = await Property.find({ ...baseFilter, addressId: { $in: nearestAddressIds } })
-    .limit(COMPARABLES_LIMIT * COMPARABLES_OVERFETCH_FACTOR)
-    .populate('addressId')
-    .lean<Record<string, unknown>[]>();
-
-  docs.sort((a, b) => {
-    const aId = extractAddressId(a);
-    const bId = extractAddressId(b);
-    const aRank = aId ? orderById.get(aId) ?? Number.MAX_SAFE_INTEGER : Number.MAX_SAFE_INTEGER;
-    const bRank = bId ? orderById.get(bId) ?? Number.MAX_SAFE_INTEGER : Number.MAX_SAFE_INTEGER;
-    return aRank - bRank;
-  });
-
-  return docs.slice(0, COMPARABLES_LIMIT);
-}
-
-/**
- * Extract the address ObjectId (as a string) from a lean property document.
- * After population the address may live under `address` (post-transform) or
- * `addressId` (raw), as a nested object or a bare id.
- */
-function extractAddressId(doc: Record<string, unknown>): string | null {
-  const candidate = doc.address ?? doc.addressId;
-  if (!candidate) return null;
-  if (typeof candidate === 'object') {
-    const nested = candidate as { _id?: unknown; id?: unknown };
-    const id = nested._id ?? nested.id;
-    return id ? String(id) : null;
-  }
-  return String(candidate);
 }

--- a/packages/backend/controllers/property/list.ts
+++ b/packages/backend/controllers/property/list.ts
@@ -1,40 +1,38 @@
 /**
  * The home/browse feed.
  *
- * Reads Postgres for the listings, their addresses and their photos. Three
- * collections it decorates the page with — `Saved`, `RecentlyViewed` and
- * `Reservation` — are still Mongo and stay that way: they are not part of the
- * catalogue, and ids are preserved verbatim across the copy, so a listing id
- * from Postgres matches the same id in Mongo with nothing to translate.
+ * Everything it reads is Postgres now — the listings, their addresses and
+ * photos, and the three things it decorates the page with (`saved_items`,
+ * `recently_viewed`, `reservations`). This file used to carry a note saying
+ * those three "stay Mongo"; they were ported in #308 and #311, and the readers
+ * here were the stragglers left behind.
  *
- * ## Two things carried across VERBATIM that a reader will want to query
+ * ## The straggler that mattered: an availability check that APPROVED
  *
- *  - **The saves count now matches on STRINGS, and that is a fix this port could
- *    not defer.** `Saved.targetId` is declared `String`; the pipeline compared it
- *    against `ObjectId`s and `aggregate` does not cast, so it has always matched
- *    nothing and `savesCount` has always been `0` —
- *    `db/MIGRATION-CONTRACT.md` names the identical defect in `stats.ts` and
- *    says a count that starts being non-zero after the cutover is correct
- *    behaviour arriving.
+ * The reservation conflict half read Mongo into an id list and applied it only
+ * `if (ids.length > 0)`. Once `reservations` moved, that read returned nothing,
+ * the guard skipped the exclusion, and every booked listing was reported free.
+ * Nothing errored — an availability check with no bookings in front of it
+ * approves, so the wrong answer was the successful-looking one and the symptom
+ * would have been a double booking. It is now a `NOT EXISTS` beside the
+ * calendar half, in the same statement, with no id list to be empty.
  *
- *    Leaving it alone was the plan until the integration suite showed what the
- *    cast actually does: `new ObjectId('019fd591-…')` THROWS, synchronously,
- *    outside the `.catch()` — so the first listing carrying a uuid v7 id turns
- *    this whole feed into a 500. Every listing created after the cutover carries
- *    one. Preserving a comparison that can never match, at the price of a
- *    guaranteed outage, is not preservation. The consequence is stated plainly:
- *    `savesCount` starts reporting real numbers, and the geo-ranked branch
- *    orders by it.
- *  - **An unknown `sortBy` now falls back to recency** instead of being passed
+ * ## Two behaviours that changed with the port, both deliberate
+ *
+ *  - **`savesCount` reports real numbers.** The Mongo pipeline compared
+ *    `Saved.targetId` (declared `String`) against `ObjectId`s, and `aggregate`
+ *    does not cast, so it matched nothing and the count was always `0`. The
+ *    same defect is recorded for `stats.ts` in `db/MIGRATION-CONTRACT.md`: a
+ *    count that starts being non-zero after the cutover is correct behaviour
+ *    arriving, not a regression. The geo-ranked branch orders by it.
+ *  - **An unknown `sortBy` falls back to recency** instead of being passed
  *    through as a field name. Mongo accepted any string and sorted by a path
- *    that did not exist, which is a silent no-op; the SQL equivalent would be
- *    building a column name out of user input, which is not a thing to do. The
- *    five real sort fields are unchanged.
+ *    that did not exist — a silent no-op; the SQL equivalent would be building
+ *    a column name out of user input. The five real sort fields are unchanged.
  */
 
 import { Request, Response, NextFunction } from 'express';
 import type { SQL } from 'drizzle-orm';
-import { RecentlyViewed, Reservation, Saved } from '../../models';
 import { paginationResponse } from '../../middlewares/errorHandler';
 import { logger } from '../../middlewares/logging';
 import {
@@ -46,7 +44,6 @@ import {
 } from './searchQueryBuilder';
 import { buildCommonPropertyFilters } from './commonFilters';
 import { OfferingType } from '@homiio/shared-types';
-import { ReservationStatus } from '@homiio/shared-types';
 import { properties } from '../../db/schema';
 import {
   allOf,
@@ -58,8 +55,8 @@ import {
   addressIs,
   booleanIs,
   calendarIsFree,
+  noConfirmedReservationOverlaps,
   hasOffering,
-  idNotIn,
   inCity,
   inRange,
   inRegion,
@@ -69,6 +66,12 @@ import {
   statusIsNot,
 } from '../../db/properties/propertyFilters';
 import { serializeProperty } from '../../db/properties/propertySerializer';
+import { getDb } from '../../db/postgres';
+import { listRecentlyViewed } from '../../db/saved/recentlyViewedRepository';
+import {
+  countSavesByPropertyIds,
+  listSavedProperties,
+} from '../../db/saved/savedPropertyRepository';
 import { resolveCityId, resolveRegionId } from '../../services/geoQueryService';
 
 const OFFERING_VALUES: ReadonlySet<string> = new Set(Object.values(OfferingType));
@@ -88,6 +91,15 @@ const PRICE_BUCKET_MEDIUM_MAX = 2000;
 
 /** Default radius (metres) for the "inside my area" half of the geo ranking. */
 const DEFAULT_PREFERRED_RADIUS_METERS = 45000;
+
+/**
+ * How far back the personalisation signal looks.
+ *
+ * Ten, carried over from the Mongo `.limit(10)` it replaces. It bounds the
+ * INPUT to the preference weighting, not the table — `recently_viewed` has its
+ * own retention sweep.
+ */
+const RECENT_VIEWS_FOR_PERSONALISATION = 10;
 
 /**
  * A representative monthly-scale price for recommendation bucketing: the
@@ -264,29 +276,22 @@ export const getProperties = async (req: Request, res: Response, next: NextFunct
 
     // ---- Date-range availability ----
     // Excludes listings whose host calendar blocks the range, AND listings with
-    // a confirmed Reservation overlapping it. The calendar half is a single
-    // `NOT EXISTS` over the GiST-indexed range; the reservation half is still a
-    // Mongo read, because `Reservation` is not part of this port.
+    // a confirmed reservation overlapping it. BOTH halves are now `NOT EXISTS`
+    // predicates in the same statement.
+    //
+    // The reservation half used to read Mongo into an id list and apply it only
+    // `if (ids.length > 0)`. Once `reservations` moved to Postgres that read
+    // returned nothing, the guard skipped the exclusion, and every booked
+    // listing was reported free — an availability check that sees no bookings
+    // APPROVES rather than fails, so the symptom was a double booking and not
+    // an error anywhere.
     const checkInDate = parseDateParam(checkIn);
     const checkOutDate = parseDateParam(checkOut);
     const hasStay = checkInDate !== null && checkOutDate !== null && checkOutDate.getTime() > checkInDate.getTime();
 
     if (hasStay && checkInDate && checkOutDate) {
       conditions.push(calendarIsFree(checkInDate, checkOutDate));
-
-      const conflictingReservations = await Reservation.find({
-        status: ReservationStatus.CONFIRMED,
-        checkIn: { $lt: checkOutDate },
-        checkOut: { $gt: checkInDate },
-      })
-        .select('propertyId')
-        .lean();
-      const conflictingPropertyIds = conflictingReservations
-        .map((reservation: { propertyId?: unknown }) => String(reservation.propertyId ?? ''))
-        .filter(Boolean);
-      if (conflictingPropertyIds.length > 0) {
-        conditions.push(idNotIn(conflictingPropertyIds));
-      }
+      conditions.push(noConfirmedReservationOverlaps(checkInDate, checkOutDate));
     }
 
     const where = allOf(conditions);
@@ -329,19 +334,13 @@ export const getProperties = async (req: Request, res: Response, next: NextFunct
     const ids = serialized
       .map((property) => property.id)
       .filter((id): id is string => typeof id === 'string');
-    let savesMap: Record<string, number> = {};
-    if (ids.length > 0) {
-      // STRING ids, matching what `Saved.targetId` is declared as — see the
-      // module doc for why this stopped being deferrable.
-      const savesAgg = await Saved.aggregate([
-        { $match: { targetType: 'property', targetId: { $in: ids } } },
-        { $group: { _id: '$targetId', count: { $sum: 1 } } }
-      ]).catch(() => []);
-      savesMap = Array.isArray(savesAgg) ? savesAgg.reduce((acc: Record<string, number>, doc: { _id?: unknown; count?: number }) => {
-        acc[String(doc._id)] = doc.count || 0;
-        return acc;
-      }, {}) : {};
-    }
+    // Popularity, for the geo ranking below. A listing nobody saved is absent
+    // from the map, so the `?? 0` at each read supplies the empty case.
+    //
+    // The `.catch(() => [])` this replaces is gone with it: it turned a failed
+    // aggregate into "nobody has saved anything", which ranks every listing as
+    // unpopular and looks exactly like a quiet feed.
+    const savesMap = await countSavesByPropertyIds(getDb(), ids);
 
     const preferredRadiusMeters = radius ? parseFloat(String(radius)) : DEFAULT_PREFERRED_RADIUS_METERS;
     let ordered: ListingForScoring[];
@@ -349,7 +348,7 @@ export const getProperties = async (req: Request, res: Response, next: NextFunct
     if (wantsDistance) {
       const decorated = serialized.map((property, index) => {
         const distance = typeof property.distance === 'number' ? property.distance : Number.POSITIVE_INFINITY;
-        const savesCount = savesMap[String(property.id)] || 0;
+        const savesCount = savesMap.get(String(property.id)) ?? 0;
         return {
           index,
           distance,
@@ -369,24 +368,21 @@ export const getProperties = async (req: Request, res: Response, next: NextFunct
       });
       ordered = decorated.map((entry) => ({ ...entry.prop, savesCount: entry.savesCount, distance: entry.distance }));
     } else {
-      ordered = serialized.map((property) => ({ ...property, savesCount: savesMap[String(property.id)] || 0, isSaved: false }));
+      ordered = serialized.map((property) => ({ ...property, savesCount: savesMap.get(String(property.id)) ?? 0, isSaved: false }));
     }
 
-    if (req.user?.id || req.user?._id) {
+    // Narrowed to a `string` in ONE place rather than re-derived: the Mongo
+    // reads took `unknown` filters and never had to, and the repositories are
+    // typed, so the union has to collapse before it reaches them.
+    const oxyUserId = req.user?.id ?? req.user?._id;
+    if (typeof oxyUserId === 'string' && oxyUserId.length > 0) {
       try {
-        const oxyUserId = req.user.id || req.user._id;
         const [recentlyViewed, savedProperties] = await Promise.all([
-          RecentlyViewed.find({ oxyUserId })
-            .sort({ viewedAt: -1 })
-            .limit(10)
-            .select('propertyId')
-            .lean(),
-          Saved.find({ oxyUserId, targetType: 'property' })
-            .select('targetId')
-            .lean()
+          listRecentlyViewed(getDb(), oxyUserId, RECENT_VIEWS_FOR_PERSONALISATION),
+          listSavedProperties(getDb(), oxyUserId),
         ]);
 
-        const savedIds = new Set(savedProperties.map((saved) => String((saved as { targetId?: unknown }).targetId)));
+        const savedIds = new Set(savedProperties.map((saved) => saved.targetId));
 
         // Build O(1) lookup map instead of O(n) .find() per view item
         const orderedMap = new Map<string, ListingForScoring>();
@@ -400,7 +396,7 @@ export const getProperties = async (req: Request, res: Response, next: NextFunct
         } = { propertyTypes: {}, priceRanges: {}, locations: {}, amenities: {} };
         const recentlyViewedIds = new Set<string>();
         for (const view of recentlyViewed) {
-          const viewPropId = String((view as { propertyId?: unknown }).propertyId);
+          const viewPropId = view.propertyId;
           recentlyViewedIds.add(viewPropId);
           const property = orderedMap.get(viewPropId);
           if (property) {

--- a/packages/backend/controllers/property/nearbyServices.ts
+++ b/packages/backend/controllers/property/nearbyServices.ts
@@ -22,30 +22,27 @@
  */
 
 import type { Request, Response, NextFunction } from 'express';
-import { Types, type Model } from 'mongoose';
-import type { IProperty } from '../../models/documentTypes';
-import type { IAddress } from '../../models/Address';
 import {
   getNearbyServices,
   emptyNearbyServices,
   RADIUS_M,
 } from '../../services/nearbyServicesService';
 
-import * as models from '../../models';
-const Property: Model<IProperty> = models.Property;
 import { AppError, successResponse } from '../../middlewares/errorHandler';
+import { findPropertyById } from '../../db/properties/propertyReads';
+import { serializeProperty } from '../../db/properties/propertySerializer';
 
 /**
  * Resolve a property's `[longitude, latitude]` from its populated address.
  *
- * After `.populate('addressId').lean()` the schema's post-find hook renames the
- * populated `addressId` to `address` (see `transformAddressFields`); read
- * `address` first, then fall back to the raw `addressId`. Returns null when no
- * usable numeric coordinate pair is present.
+ * The address is nested under `address` on the wire and carries the historical
+ * GeoJSON `[lng, lat]` pair, so that is what this reads. The
+ * populate-or-raw-`addressId` fallback it replaces existed because Mongoose's
+ * post-find hook renamed the populated reference; a join has no such ambiguity.
+ * Returns null when no usable numeric coordinate pair is present.
  */
-function resolveCoordinates(property: IProperty): [number, number] | null {
-  const populated = property as unknown as { address?: IAddress; addressId?: IAddress };
-  const address = populated.address ?? populated.addressId ?? null;
+function resolveCoordinates(property: Record<string, unknown>): [number, number] | null {
+  const address = property.address as { coordinates?: { coordinates?: unknown } } | undefined;
   const coords = address?.coordinates?.coordinates;
   if (!Array.isArray(coords) || coords.length !== 2) return null;
   const [longitude, latitude] = coords;
@@ -70,18 +67,14 @@ export async function getPropertyNearbyServices(
 ): Promise<void> {
   try {
     const { propertyId } = req.params;
-    if (!Types.ObjectId.isValid(propertyId)) {
-      return next(new AppError('Invalid property ID', 400, 'INVALID_ID'));
-    }
-
-    const property = await Property.findById(propertyId)
-      .populate('addressId')
-      .lean<IProperty | null>();
-    if (!property) {
+    // No id-SHAPE guard — `Types.ObjectId.isValid` rejects every uuid v7 id
+    // minted after the cutover. See `db/ids.ts`.
+    const hydrated = await findPropertyById(propertyId);
+    if (!hydrated) {
       return next(new AppError('Property not found', 404, 'NOT_FOUND'));
     }
 
-    const coordinates = resolveCoordinates(property);
+    const coordinates = resolveCoordinates(serializeProperty(hydrated));
     if (!coordinates) {
       // No usable coordinates — return a graceful degraded snapshot so the
       // frontend can simply hide the section rather than handle an error.

--- a/packages/backend/controllers/property/retrieve.ts
+++ b/packages/backend/controllers/property/retrieve.ts
@@ -12,12 +12,21 @@
  * cutover will see them reset, and the honest explanation is that they were
  * never being counted, not that the port lost them.
  *
- * The recently-viewed upsert is still Mongo, and deliberately so: it belongs to
- * the saved-items batch (`Saved`, `SavedPropertyFolder`, `RecentlyViewed`),
- * which moves as one piece.
+ * ## The recently-viewed upsert moved too, and it had drifted further than a
+ * ## store
+ *
+ * It wrote Mongo keyed by a `profileId` while #308 moved the READ of that table
+ * to Postgres keyed by `oxy_user_id` — so the write and the read were in
+ * different stores AND on different keys, and neither would ever have found the
+ * other's rows. It is `trackPropertyView` now, which takes the Oxy user id
+ * directly.
+ *
+ * That removes the `Profile.findByOxyUserId` lookup entirely rather than
+ * porting it: it existed only to turn an Oxy user id into the profile id this
+ * table used to be keyed by, and the table is not keyed that way any more. A
+ * listing view no longer depends on the viewer having a profile row at all.
  */
 
-import { Profile, RecentlyViewed } from '../../models';
 import { AppError, successResponse, paginationResponse } from '../../middlewares/errorHandler';
 import { logger } from '../../middlewares/logging';
 import {
@@ -28,6 +37,8 @@ import {
   NEWEST_FIRST,
 } from '../../db/properties/propertyReads';
 import { ownedBy, statusIsNot } from '../../db/properties/propertyFilters';
+import { getDb } from '../../db/postgres';
+import { trackPropertyView } from '../../db/saved/recentlyViewedRepository';
 import { incrementPropertyViews } from '../../db/properties/propertyWrites';
 import { serializeProperty } from '../../db/properties/propertySerializer';
 import { getErrorName } from '../../utils/errors';
@@ -60,23 +71,13 @@ export async function getPropertyById(req: ControllerRequest, res: ControllerRes
       logger.warn('Failed to increment property view count', { propertyId, error });
     });
 
-    const oxyUserId = req.user?.id || req.user?._id;
-    if (req.userId && oxyUserId) {
-      try {
-        const activeProfile = await Profile.findByOxyUserId(oxyUserId);
-        if (activeProfile) {
-          const profileId = activeProfile._id;
-          RecentlyViewed.findOneAndUpdate(
-            { profileId, propertyId },
-            { profileId, propertyId, viewedAt: new Date() },
-            { upsert: true, new: true }
-          ).catch((error: unknown) => {
-            logger.warn('Failed to update recently viewed property', { propertyId, error });
-          });
-        }
-      } catch (error) {
-        logger.warn('Failed to resolve profile for recently viewed property', { propertyId, error });
-      }
+    const oxyUserId = req.user?.id ?? req.user?._id;
+    if (typeof oxyUserId === 'string' && oxyUserId.length > 0) {
+      // Best-effort, like the counter above: a reading history is not worth
+      // failing the read it records.
+      void trackPropertyView(getDb(), oxyUserId, propertyId).catch((error: unknown) => {
+        logger.warn('Failed to update recently viewed property', { propertyId, error });
+      });
     }
     res.json(successResponse(serializeProperty(hydrated), 'Property retrieved successfully'));
   } catch (error) {

--- a/packages/backend/controllers/telegramController.ts
+++ b/packages/backend/controllers/telegramController.ts
@@ -7,11 +7,28 @@ import type { Request, Response, NextFunction } from 'express';
 
 import { telegramService } from '../services';
 import { AppError, successResponse } from '../middlewares/errorHandler';
-import { Property } from '../models';
-import type { IProperty } from '../models/documentTypes';
+import type { SQL } from 'drizzle-orm';
+
 import config from '../config';
-import { resolveAddressDisplay } from '../services/geoDisplayService';
-import { resolveGeoFilterAddressIds } from '../services/geoQueryService';
+import { properties } from '../db/schema';
+import {
+  allOf,
+  findProperties,
+  findPropertyById,
+  NEWEST_FIRST,
+} from '../db/properties/propertyReads';
+import { idIn, inCity, inDateRange, statusIs, typeIn } from '../db/properties/propertyFilters';
+import { serializeProperty } from '../db/properties/propertySerializer';
+import { resolveAddressDisplay, type AddressGeoLike } from '../services/geoDisplayService';
+import { resolveCityId } from '../services/geoQueryService';
+
+/**
+ * How many listings one bulk-notification request may fan out to.
+ *
+ * Carried over from the Mongo `.limit(50)`, whose comment read "prevent abuse" —
+ * this endpoint sends real messages, so the bound is the point.
+ */
+const BULK_NOTIFICATION_LIMIT = 50;
 
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -123,13 +140,16 @@ class TelegramController {
     try {
       const { propertyId } = req.params;
 
-      // Populate the address so the notifier can resolve the relational geo.
-      const property = await Property.findById(propertyId).populate('addressId');
-      if (!property) {
+      const hydrated = await findPropertyById(propertyId);
+      if (!hydrated) {
         return next(new AppError('Property not found', 404, 'PROPERTY_NOT_FOUND'));
       }
+      // The serialized listing nests its address and carries the resolved geo
+      // NAMES on it, which is what the notifier reads — the `.populate()` this
+      // replaces existed only to produce that shape.
+      const property = serializeProperty(hydrated);
 
-      const geo = await resolveAddressDisplay(property.address);
+      const geo = await resolveAddressDisplay(property.address as AddressGeoLike);
       const success = await telegramService.sendPropertyNotification(property);
 
       res.status(success ? 200 : 500).json(successResponse(
@@ -151,44 +171,51 @@ class TelegramController {
     try {
       const { propertyIds, filters } = req.body;
 
-      let properties: IProperty[] = [];
+      let notifiable: Record<string, unknown>[] = [];
 
       if (propertyIds && propertyIds.length > 0) {
         // Send notifications for specific properties
-        properties = await Property.find({ _id: { $in: propertyIds } }).populate('addressId');
+        const ids = (propertyIds as unknown[]).map(String);
+        notifiable = (await findProperties({ where: idIn(ids) })).map(serializeProperty);
       } else if (filters) {
-        // Send notifications based on filters
-        const query: Record<string, unknown> = {};
-        
-        // Handle city filter via RELATIONAL geo resolution (name/id → cityId).
+        const conditions: (SQL | undefined)[] = [];
+
+        // City filter via RELATIONAL geo: the city NAME (or id) resolves to a
+        // canonical `cities.id` and the address join compares against it. The
+        // `resolveGeoFilterAddressIds` call this replaces loaded every address
+        // id in the city into an uncapped `$in`.
         if (filters.city) {
-          const addressIds = await resolveGeoFilterAddressIds({ city: String(filters.city) });
-          if (addressIds === null || addressIds.length === 0) {
+          const cityId = await resolveCityId(String(filters.city));
+          if (!cityId) {
             return res.json(successResponse(
               { total: 0, successful: 0, failed: 0 },
               'No properties found in specified city'
             ));
           }
-          query.addressId = { $in: addressIds };
+          conditions.push(inCity(cityId));
         }
-        
-        if (filters.type) query.type = filters.type;
-        if (filters.createdAfter) query.createdAt = { $gte: new Date(filters.createdAfter) };
-        if (filters.status) query.status = filters.status;
 
-        properties = await Property.find(query).populate('addressId').limit(50); // Limit to prevent abuse
+        if (filters.type) conditions.push(typeIn([String(filters.type)]));
+        if (filters.createdAfter) {
+          conditions.push(inDateRange(properties.createdAt, new Date(String(filters.createdAfter)), undefined));
+        }
+        if (filters.status) conditions.push(statusIs(String(filters.status)));
+
+        notifiable = (
+          await findProperties({ where: allOf(conditions), limit: BULK_NOTIFICATION_LIMIT })
+        ).map(serializeProperty);
       } else {
         return next(new AppError('Either propertyIds or filters must be provided', 400, 'MISSING_PARAMETERS'));
       }
 
-      if (properties.length === 0) {
+      if (notifiable.length === 0) {
         return res.json(successResponse(
           { total: 0, successful: 0, failed: 0 },
           'No properties found matching criteria'
         ));
       }
 
-      const results = await telegramService.sendBulkNotifications(properties);
+      const results = await telegramService.sendBulkNotifications(notifiable);
 
       res.json(successResponse(results, 'Bulk notifications processed'));
     } catch (error) {
@@ -269,13 +296,13 @@ class TelegramController {
 
       // Get recent properties
       const sinceDate = new Date(Date.now() - hoursNum * 60 * 60 * 1000);
-      const recentProperties = await Property.find({
-        createdAt: { $gte: sinceDate },
-        status: 'active'
-      })
-      .populate('addressId')
-      .limit(limitNum)
-      .sort({ createdAt: -1 });
+      const recentProperties = (
+        await findProperties({
+          where: allOf([inDateRange(properties.createdAt, sinceDate, undefined), statusIs('active')]),
+          orderBy: [NEWEST_FIRST],
+          limit: limitNum,
+        })
+      ).map(serializeProperty);
 
       if (recentProperties.length === 0) {
         return res.json(successResponse(
@@ -290,17 +317,17 @@ class TelegramController {
 
       const results = await telegramService.sendBulkNotifications(recentProperties);
 
-      const properties = await Promise.all(recentProperties.map(async (p: IProperty) => ({
-        id: p._id,
-        city: (await resolveAddressDisplay(p.address)).city,
-        type: p.type,
-        createdAt: p.createdAt
+      const summaries = await Promise.all(recentProperties.map(async (listing) => ({
+        id: listing.id,
+        city: (await resolveAddressDisplay(listing.address as AddressGeoLike)).city,
+        type: listing.type,
+        createdAt: listing.createdAt,
       })));
 
       res.json(successResponse({
         ...results,
         timeframe: `${hoursNum} hours`,
-        properties
+        properties: summaries,
       }, 'Test notifications sent for recent properties'));
     } catch (error) {
       next(error);

--- a/packages/backend/db/analytics/ownerAnalytics.ts
+++ b/packages/backend/db/analytics/ownerAnalytics.ts
@@ -30,9 +30,9 @@
  * correct behaviour arriving, not a defect to diagnose.
  */
 
-import { and, count, countDistinct, eq, gte, inArray, ne } from 'drizzle-orm';
+import { and, count, countDistinct, desc, eq, gte, inArray, isNotNull, ne, sql } from 'drizzle-orm';
 import type { DatabaseOrTransaction } from '../postgres';
-import { properties, recentlyViewed, savedItems } from '../schema';
+import { addresses, cities, properties, recentlyViewed, regions, savedItems } from '../schema';
 
 /**
  * The ids of the listings this person owns, excluding archived ones.
@@ -122,4 +122,124 @@ export async function countSavesOfProperties(
       ),
     );
   return row.total;
+}
+
+/** The app-wide totals the public stats endpoint leads with. */
+export async function countAppWideCatalogue(
+  db: DatabaseOrTransaction,
+): Promise<{ properties: number; cities: number }> {
+  // Two independent counts, so two statements — there is no join between them
+  // and a single query would need a cross product to produce both.
+  const [propertyRow] = await db.select({ total: count() }).from(properties);
+  const [cityRow] = await db.select({ total: count() }).from(cities);
+  return { properties: propertyRow.total, cities: cityRow.total };
+}
+
+/**
+ * Long-term rent min / max / average across the whole catalogue.
+ *
+ * `> 0` rather than "field exists": a listing with no long-term price has NULL
+ * in that column, and including it would drag the average toward zero. This is
+ * the same predicate the Mongo `$match` used, said against a column.
+ */
+export async function summarizeCatalogueRent(
+  db: DatabaseOrTransaction,
+): Promise<{ averageRent: number; minRent: number; maxRent: number }> {
+  const [row] = await db
+    .select({
+      averageRent: sql<number | null>`avg(${properties.longTermRentMonthlyAmount})`,
+      minRent: sql<number | null>`min(${properties.longTermRentMonthlyAmount})`,
+      maxRent: sql<number | null>`max(${properties.longTermRentMonthlyAmount})`,
+    })
+    .from(properties)
+    .where(sql`${properties.longTermRentMonthlyAmount} > 0`);
+  // postgres.js returns `numeric` aggregates as STRINGS — `min`/`max` over a
+  // `double precision` come back numeric, and an un-coerced value would reach
+  // `Math.round` as a string and read as `NaN`.
+  return {
+    averageRent: Number(row?.averageRent ?? 0),
+    minRent: Number(row?.minRent ?? 0),
+    maxRent: Number(row?.maxRent ?? 0),
+  };
+}
+
+/** One row of the "most listed cities" table. */
+export interface TopCity {
+  cityId: string;
+  city: string | null;
+  state: string | null;
+  properties: number;
+  averageRent: number;
+}
+
+/**
+ * The cities with the most listings, with each city's average long-term rent.
+ *
+ * ONE statement. The Mongo pipeline needed three `$lookup` + `$unwind` pairs —
+ * into `addresses`, then `cities`, then `regions` — because it could not join;
+ * grouping by the canonical `city_id` rather than a free-text city name was
+ * already the intent and is now simply what the query does.
+ */
+export async function findTopCitiesByListings(
+  db: DatabaseOrTransaction,
+  limit: number,
+): Promise<TopCity[]> {
+  const rows = await db
+    .select({
+      cityId: addresses.cityId,
+      city: cities.name,
+      state: regions.name,
+      properties: count(),
+      averageRent: sql<number | null>`avg(${properties.longTermRentMonthlyAmount})`,
+    })
+    .from(properties)
+    .innerJoin(addresses, eq(properties.addressId, addresses.id))
+    .leftJoin(cities, eq(addresses.cityId, cities.id))
+    .leftJoin(regions, eq(addresses.regionId, regions.id))
+    .where(isNotNull(addresses.cityId))
+    .groupBy(addresses.cityId, cities.name, regions.name)
+    .orderBy(desc(count()))
+    .limit(limit);
+
+  return rows.map((row) => ({
+    cityId: String(row.cityId),
+    city: row.city,
+    state: row.state,
+    properties: row.properties,
+    averageRent: Number(row.averageRent ?? 0),
+  }));
+}
+
+/**
+ * How many listings fall in each preset monthly-rent band.
+ *
+ * `width_bucket` over the same boundaries the Mongo `$bucket` used. Bucket 0
+ * (below the first boundary) cannot occur because the predicate excludes
+ * negative rents, and `boundaries.length` is the overflow band — the
+ * `default: '10000+'` the pipeline declared.
+ *
+ * Written as ONE raw statement rather than a `.select()` projection, and that is
+ * load-bearing: inside a projection drizzle renders an interpolated column
+ * UNQUALIFIED, so the same expression appeared as `"long_term_rent_monthly_amount"`
+ * in the SELECT and `"properties"."long_term_rent_monthly_amount"` in the
+ * GROUP BY, and Postgres rejected it as not grouped. A standalone `sql` renders
+ * both sides qualified and identical.
+ */
+export async function countListingsByPriceBucket(
+  db: DatabaseOrTransaction,
+  boundaries: readonly number[],
+): Promise<Map<number, number>> {
+  const bounds = sql.join(
+    boundaries.map((boundary) => sql`${boundary}`),
+    sql`, `,
+  );
+  const rows = await db.execute<{ bucket: number; total: number }>(sql`
+    select
+      width_bucket(${properties.longTermRentMonthlyAmount}, array[${bounds}]::double precision[]) as bucket,
+      count(*)::int as total
+    from ${properties}
+    where ${properties.longTermRentMonthlyAmount} >= 0
+    group by bucket
+  `);
+  return new Map([...rows].map((row) => [Number(row.bucket), Number(row.total)]));
 }

--- a/packages/backend/db/properties/propertyFilters.ts
+++ b/packages/backend/db/properties/propertyFilters.ts
@@ -35,7 +35,7 @@ import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 import { qualified } from '../casing';
 import { escapeLikePattern } from '../likePattern';
 import { TEXT_SEARCH_CONFIGURATION } from '../extensions';
-import { addresses, properties, propertyAvailabilityWindows } from '../schema';
+import { addresses, properties, propertyAvailabilityWindows, reservations } from '../schema';
 
 /** Never surface a soft-deleted (archived) listing. */
 export function notDeleted(): SQL {
@@ -286,7 +286,55 @@ export function textRank(term: string): SQL<number> {
  * subquery's own `FROM`, so `${properties.id}` would emit `"id"` and resolve
  * against `property_availability_windows` — comparing two of its own columns,
  * matching nothing, and raising no error at all.
+ *
+ * **`.toISOString()` on the bounds is load-bearing, and the cast alone is not
+ * enough.** A `Date` interpolated into a `sql` template inside `tstzrange()`
+ * never reaches Postgres: postgres.js has no column to infer the type from,
+ * falls back to serializing the value as text, and throws
+ * `The "string" argument must be of type string ... Received an instance of
+ * Date` in Node. That made EVERY dated availability request a 500 — measured
+ * against a real server, and adding `::timestamptz` did NOT fix it, because the
+ * failure happens in the driver before any cast is parsed. No test covered the
+ * dated path, so nothing reported it. An explicit ISO string plus the cast is
+ * what makes the bound unambiguous on both sides.
  */
+/**
+ * Listings with no CONFIRMED reservation overlapping the stay.
+ *
+ * The other half of availability, and the half that fails DANGEROUSLY. The
+ * Mongo version this replaces read `Reservation.find({...}).select('propertyId')`
+ * into an id list and pushed `idNotIn(...)` — but only `if (ids.length > 0)`.
+ * Once `reservations` moved to Postgres that read returned nothing, the guard
+ * skipped the exclusion entirely, and every booked listing was reported free.
+ * An availability check that sees no bookings does not error, it APPROVES: the
+ * wrong answer is the successful-looking one, and a double booking is the
+ * result.
+ *
+ * A `NOT EXISTS` rather than an id list, matching {@link calendarIsFree}. The
+ * id-list form also loaded EVERY confirmed reservation in the system into an
+ * uncapped `$in` to answer a question about one page of listings.
+ *
+ * `[)` bounds via `tstzrange`, so a checkout and the next checkin on the same
+ * day do not collide — the same `checkIn < checkOut AND checkOut > checkIn`
+ * test Mongo spelled out, and the same convention the calendar half uses.
+ *
+ * `qualified` on the correlated reference is not optional, for the reason
+ * {@link calendarIsFree} records: a drizzle column interpolated into a subquery
+ * renders BARE when its table is not in the subquery's own `FROM`, so
+ * `${properties.id}` would emit `"id"`, resolve against `reservations`, compare
+ * that table's own id to itself, match every row, and exclude every listing —
+ * silently and with no error.
+ */
+export function noConfirmedReservationOverlaps(checkIn: Date, checkOut: Date): SQL {
+  return sql`not exists (
+    select 1 from ${reservations}
+    where ${reservations.propertyId} = ${qualified(properties.id)}
+      and ${reservations.status} = 'confirmed'
+      and tstzrange(${reservations.checkIn}, ${reservations.checkOut})
+          && tstzrange(${checkIn.toISOString()}::timestamptz, ${checkOut.toISOString()}::timestamptz)
+  )`;
+}
+
 export function calendarIsFree(checkIn: Date, checkOut: Date): SQL {
   return sql`not exists (
     select 1 from ${propertyAvailabilityWindows}
@@ -294,6 +342,6 @@ export function calendarIsFree(checkIn: Date, checkOut: Date): SQL {
       and ${propertyAvailabilityWindows.scope} = 'listing'
       and ${propertyAvailabilityWindows.status} <> 'available'
       and tstzrange(${propertyAvailabilityWindows.startsAt}, ${propertyAvailabilityWindows.endsAt})
-          && tstzrange(${checkIn}, ${checkOut})
+          && tstzrange(${checkIn.toISOString()}::timestamptz, ${checkOut.toISOString()}::timestamptz)
   )`;
 }

--- a/packages/backend/db/saved/savedPropertyRepository.ts
+++ b/packages/backend/db/saved/savedPropertyRepository.ts
@@ -136,6 +136,37 @@ export async function listSavedProperties(
 }
 
 /**
+ * How many people have saved each of these listings.
+ *
+ * A POPULARITY signal across all users, so it is deliberately NOT scoped to one
+ * `oxy_user_id` the way every other read in this module is — the feed uses it to
+ * rank, not to show anybody their own saves.
+ *
+ * @returns A count per listing id. A listing nobody has saved is ABSENT from the
+ *   map rather than present as `0`, matching `countSavedPropertiesByFolder`; the
+ *   caller's `?? 0` supplies the empty case.
+ */
+export async function countSavesByPropertyIds(
+  db: DatabaseOrTransaction,
+  propertyIds: readonly string[],
+): Promise<Map<string, number>> {
+  if (propertyIds.length === 0) return new Map();
+
+  const rows = await db
+    .select({ propertyId: savedItems.targetId, total: count() })
+    .from(savedItems)
+    .where(
+      and(
+        eq(savedItems.targetType, 'property'),
+        inArray(savedItems.targetId, [...propertyIds]),
+      ),
+    )
+    .groupBy(savedItems.targetId);
+
+  return new Map(rows.map((row) => [row.propertyId, Number(row.total)]));
+}
+
+/**
  * Remove one save. `false` when this person had not saved that listing.
  *
  * Scoped by owner inside the `DELETE` rather than checked before it — an


### PR DESCRIPTION
The reader census after the write-path port (#316): which OTHER files read the tables already on Postgres. Run over **every** ported table rather than only the ones this batch moved, with a **directory pathspec** and a **positive control** (`list.ts` = 4 sites, `retrieve.ts` = 1 — both confirmed non-zero before trusting the result). That found **33 sites in 8 files**; this PR is the property slice.

## The one that mattered

`list.ts`'s availability conflict check read Mongo into an id list and applied it only `if (ids.length > 0)`. Once `reservations` moved to Postgres that read returned nothing, the guard skipped the exclusion, and **every booked listing was reported free**.

Nothing errored. An availability check with no bookings in front of it *approves* — the wrong answer is the successful-looking one, and the symptom would have been a double booking rather than a failure anyone could see. It is now a `NOT EXISTS` beside the calendar half, in the same statement, with no id list to be empty.

## Found while testing it, and NOT introduced here

**`calendarIsFree` — the other half, already merged and live — never worked either.** A `Date` interpolated into a `sql` template inside `tstzrange()` never reaches Postgres: postgres.js has no column to infer a type from, falls back to serializing it as text, and throws `The "string" argument must be of type string ... Received an instance of Date` in Node.

So **every dated availability request 500s on `main` today**. No test covered the dated path, so nothing reported it. Both bounds now pass an explicit ISO string — and `::timestamptz` alone does **not** fix it, because the failure happens in the driver before any cast is parsed. I measured that rather than assuming it.

## Also ported

| file | what |
|---|---|
| `retrieve.ts` | the recently-viewed **WRITE** — it wrote Mongo keyed by `profileId` while the read moved to Postgres keyed by `oxy_user_id`, so neither would ever have found the other's rows. `trackPropertyView` takes the Oxy id, which *removes* the profile lookup rather than porting it |
| `list.ts` | saves count + the personalisation reads |
| `areaInsights.ts` | **770 → 178 lines** — it was a copy of the ported `areaPriceComparison`, ~493 near-identical lines maintained twice |
| `neighborhoodController.ts` | rent stats, by-property, popular neighbourhoods |
| `analyticsController.ts` | the app-stats aggregates |
| `telegramController.ts`, `nearbyServices.ts` | listing reads |

Every uncapped "load all address ids, then `$in`" is gone — that was the shape Mongo forced, and each is an ordinary join here.

`db/analytics/ownerAnalytics.ts` gains the app-wide aggregates. The price-bucket query is a **raw statement on purpose**: in a `.select()` projection drizzle renders an interpolated column unqualified, so the same expression appeared unqualified in the SELECT and qualified in the GROUP BY, and Postgres rejected it as not grouped.

## Behaviour changes, both deliberate

- **`savesCount` reports real numbers.** The Mongo pipeline compared `Saved.targetId` (declared `String`) against `ObjectId`s, and `aggregate` does not cast — it matched nothing and the count was always `0`. Same class as `properties.views` in #316: a number that starts being non-zero is correct behaviour arriving.
- The `.catch(() => 0)` fallbacks are gone. They turned a failed aggregate into a confident zero, which is the failure mode this whole port is about.

## Verification

- `tsc --noEmit` clean; eslint **0 errors**; `bun run build` green; `bun.lock` unchanged.
- Full suite **124 suites / 1613 tests**.
- New `__tests__/integration/availabilityConflicts.test.ts` — 6 cases, each asserting **which** listings come back with a must-exclude and a must-include listing seeded together, so a test that only checked "some results came back" would have passed against the bug. Covers both `[)` boundary cases (a checkout and the next check-in on the same day do not collide) and a same-address pair that would fail if the correlated subquery bound to the wrong table.
- `__tests__/db/*` flake under `-w 2` remains **pre-existing**: reproduced again on those suites alone (1 of 3 runs), and this PR touches none of them.

## Still open, deliberately

`reviewController` — 13 sites (Address 8, Agency 4, Property 1). Reviews are still Mongo and their `addressId` is a Mongo ObjectId path, so that file is internally consistent today and moves with the reviews batch (#33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)