### PR TITLE
Wire the expiry sweep — the call `db/expiry.ts` says nothing makes

### DIFF
--- a/packages/backend/__tests__/db/dataBackfill.test.ts
+++ b/packages/backend/__tests__/db/dataBackfill.test.ts
@@ -699,6 +699,25 @@ describe('data backfill — --reconcile', () => {
     expect(stored).toBeUndefined();
   }, 120_000);
 
+  it('a DRY RUN reports pending drift instead of failing on it', async () => {
+    // Left as a failure, the exit code depended on whether the 200-row fidelity
+    // sample happened to land on a drifted row — the production dry run exited 0
+    // with three updates pending, purely because it missed them. An exit code
+    // that means different things on two runs of the same command means nothing.
+    const report = await copyThenDrift(
+      async (database, ids) => {
+        for (const id of ids.properties) {
+          await database.collection('properties').updateOne({ _id: id }, { $set: { description: 'pending' } });
+        }
+      },
+      { dryRun: true },
+    );
+
+    expect(forTable(report, 'properties')?.updated).toBe(10);
+    // Reported, and the run stands.
+    expect(report.verified.some((entry) => entry.mismatches.length > 0)).toBe(true);
+  }, 120_000);
+
   it('NEVER deletes a row created in Postgres, whatever the source says', async () => {
     // The bug that would destroy live data. After the write path lands, "absent
     // from Mongo" means either "deleted before the cutover" (a ghost) or

--- a/packages/backend/__tests__/db/expiry.test.ts
+++ b/packages/backend/__tests__/db/expiry.test.ts
@@ -25,6 +25,7 @@ import { getTableName, sql } from 'drizzle-orm';
 import { findUnsupportedExpiryColumns } from '@oxyhq/db/assert';
 import { sqlColumnName } from '../../db/casing';
 import { EXPIRY_COLUMNS_THAT_MUST_NOT_DELETE, EXPIRY_SWEEP_TARGETS } from '../../db/expiry';
+import { getCronStatus, initCronJobs, runExpirySweepNow, stopCronJobs } from '../../services/cron';
 import { closePostgres, connectPostgres, type Database } from '../../db/postgres';
 
 let db: Database;
@@ -36,6 +37,51 @@ beforeAll(async () => {
 afterAll(async () => {
   await closePostgres();
 });
+
+/**
+ * A listing with a deadline, and the geo chain a listing cannot exist without.
+ *
+ * Written out rather than pulled from a factory because the point of the sweep
+ * test is the FK cascade: deleting the property must take its `property_images`
+ * with it, and a fixture that skips the parents would test a table in isolation
+ * that never exists in isolation.
+ */
+async function seedProperty(db: Database, expiresAt: Date): Promise<string> {
+  // The deadline goes in as an ISO string with an explicit cast: `db.execute`
+  // is raw SQL, so none of drizzle's column mappers run and postgres.js has no
+  // type to bind a JS `Date` to.
+  const suffix = Math.random().toString(36).slice(2, 10);
+  const countryId = `c-${suffix}`;
+  const regionId = `r-${suffix}`;
+  const cityId = `y-${suffix}`;
+  const addressId = `a-${suffix}`;
+  const propertyId = `p-${suffix}`;
+
+  // One statement per `execute`: a parameterised query cannot carry multiple
+  // commands, and batching them reads as a schema fault rather than as the
+  // protocol limit it is.
+  await db.execute(sql`insert into countries (id, code, name)
+    values (${countryId}, ${suffix.slice(0, 2).toUpperCase()}, ${`Country ${suffix}`})`);
+  await db.execute(sql`insert into regions (id, country_id, name)
+    values (${regionId}, ${countryId}, ${`Region ${suffix}`})`);
+  await db.execute(sql`insert into cities (id, name, country_id, region_id)
+    values (${cityId}, ${`City ${suffix}`}, ${countryId}, ${regionId})`);
+  await db.execute(sql`insert into addresses
+      (id, country_id, region_id, city_id, country_code, street, postal_code, longitude, latitude)
+    values (${addressId}, ${countryId}, ${regionId}, ${cityId}, 'ES', 'Carrer Test', '08001', 2.1686, 41.3985)`);
+  await db.execute(sql`insert into properties
+      (id, address_id, source_url, expires_at, offerings, long_term_rent_monthly_amount)
+    values (${propertyId}, ${addressId}, 'https://example.test/ad',
+            ${expiresAt.toISOString()}::timestamptz, '{long_term_rent}', 1000)`);
+  return propertyId;
+}
+
+async function propertyExists(db: Database, id: string): Promise<boolean> {
+  const rows = await db.execute<{ found: number }>(
+    sql`select count(*)::int as found from properties where id = ${id}`,
+  );
+  return (rows[0]?.found ?? 0) > 0;
+}
 
 describe('expiry sweep registry', () => {
   it('backs every registered column with a leading btree index', async () => {
@@ -109,6 +155,39 @@ describe('expiry sweep registry', () => {
 
     const negative = EXPIRY_SWEEP_TARGETS.filter((target) => target.retentionSeconds < 0);
     expect(negative).toEqual([]);
+  });
+
+  it('is SCHEDULED — the call this registry says nothing makes', () => {
+    // The gap this closes, stated as a test rather than as a comment. The
+    // registry was complete and correct for weeks and nothing ran it, so every
+    // registered table grew forever — no error, no failing test, no symptom of
+    // any kind until disk. Measured in production hours after the property
+    // cutover: 124 listings past their deadline, 121 already reaped from Mongo,
+    // all still being served.
+    //
+    // A registry entry cannot detect its own absence from the scheduler. This
+    // can.
+    initCronJobs();
+    try {
+      expect(Object.keys(getCronStatus())).toContain('expirySweep');
+    } finally {
+      stopCronJobs();
+    }
+  });
+
+  it('reaps a row through the REGISTRY the cron job actually passes', async () => {
+    // Through the CRON's own sweep, not `sweepAllExpiredRows` directly. "The
+    // mechanism works" and "the mechanism is pointed at the right tables" are
+    // different claims, and only the second was ever in doubt — a job wired to
+    // an empty target list satisfies the first perfectly. Calling the registry
+    // here instead let exactly that mutation survive.
+    const expired = await seedProperty(db, new Date(Date.now() - 86_400_000));
+    const live = await seedProperty(db, new Date(Date.now() + 86_400_000));
+
+    await runExpirySweepNow();
+
+    expect(await propertyExists(db, expired)).toBe(false);
+    expect(await propertyExists(db, live)).toBe(true);
   });
 
   it('sweeps a deadline that has passed and spares one that has not', async () => {

--- a/packages/backend/db/backfill/data.ts
+++ b/packages/backend/db/backfill/data.ts
@@ -1479,8 +1479,26 @@ export async function runDataBackfill(options: {
   }
 
   if (failures.length > 0) {
-    for (const failure of failures) logger.error(failure);
-    throw new Error(`Verification failed:\n  ${failures.join('\n  ')}`);
+    // A DRY RUN reports; it does not assert. Its whole contract is "tell me what
+    // would change", so a field-by-field difference is the ANSWER rather than a
+    // defect — the run deliberately did not apply the update that would have
+    // closed it.
+    //
+    // This is not a softening. Left as a failure, the exit code depended on
+    // whether the 200-row sample happened to land on one of the drifted rows:
+    // the production dry run exited 0 with three updates pending, purely
+    // because it missed them. An exit code that means different things on two
+    // runs of the same command means nothing.
+    if (dryRun) {
+      logger.warn(
+        'Dry run: the checks below describe what a real run would change, not ' +
+        'defects in the target',
+        { pending: failures },
+      );
+    } else {
+      for (const failure of failures) logger.error(failure);
+      throw new Error(`Verification failed:\n  ${failures.join('\n  ')}`);
+    }
   }
 
   return {

--- a/packages/backend/services/cron.ts
+++ b/packages/backend/services/cron.ts
@@ -11,6 +11,7 @@ import { expireShareLinks } from '../db/conversations/conversationRepository';
 import { getDb } from '../db/postgres';
 import config from '../config';
 import { syncAllHasImages } from '../db/hasImages';
+import { EXPIRY_SWEEP_TARGETS, sweepAllExpiredRows } from '../db/expiry';
 
 // Initialize services
 const logger = new Logger('CronService');
@@ -46,6 +47,7 @@ class CronJobManager {
     this.setupShareLinkExpiryJob();
     this.setupEvictionOutcomeReminderJob();
     this.setupModerationReconciliationJob();
+    this.setupExpirySweepJob();
     // Boot sweeps: repair mangled coords + start Wikimedia cover backfill
     // without waiting for the top of the hour.
     void this.runBootHousekeeping();
@@ -204,6 +206,103 @@ class CronJobManager {
     this.jobs.set('evictionOutcomeReminders', job);
     this.jobStatus.set('evictionOutcomeReminders', { isRunning: true, lastRun: undefined, nextRun: undefined });
     job.start();
+  }
+
+  /**
+   * Setup the expiry sweep — every five minutes.
+   *
+   * **This is the call `db/expiry.ts` says the registry does not make.** The
+   * registry is data; nothing ran it, and a table registered there still grew
+   * forever until this landed. Mongo reaped those rows with a TTL index — a
+   * behaviour of the SOURCE that no code search can find, because it was never
+   * in Homiio's code to be missed — and Postgres does not.
+   *
+   * The gap was not theoretical. Measured 2026-08-09, hours after the property
+   * cutover: 124 listings in Postgres were past their deadline, 121 of them had
+   * already been reaped from Mongo, and every one was still being served. The
+   * intersection was exact — nothing was absent for any other reason — which is
+   * what identifies the TTL index as the whole cause rather than one of several.
+   *
+   * ## Five minutes, not daily
+   *
+   * Mongo's TTL monitor runs every 60 seconds, so that is the cadence the read
+   * paths were written against. `db/expiry.ts` warns that a read depending on a
+   * swept row already being GONE turns the sweep interval into a correctness
+   * window; five minutes keeps that window close to what the application has
+   * always had, and the sweep is cheap — a range scan on an index that exists
+   * precisely to support it.
+   *
+   * Every task runs this, and that is safe rather than tolerated: the delete is
+   * idempotent, so two tasks sweeping concurrently costs a duplicate scan and
+   * nothing else. It is the same argument the moderation reconciliation makes.
+   */
+  private setupExpirySweepJob(): void {
+    const job = cron.schedule('*/5 * * * *', async () => {
+      await this.runExpirySweep();
+    }, {
+      timezone: 'UTC',
+      scheduled: false,
+    });
+
+    this.jobs.set('expirySweep', job);
+    this.jobStatus.set('expirySweep', { isRunning: true, lastRun: undefined, nextRun: undefined });
+    job.start();
+  }
+
+  /**
+   * One sweep across every registered target.
+   *
+   * ## A sweep that reaped nothing is DISTINGUISHABLE from one that never ran
+   *
+   * That is the whole logging decision here, and it is the failure mode
+   * `MIGRATION-CONTRACT.md` names for this class: an unwired sweep has no
+   * symptom until disk. If the job only logged when it deleted something, a
+   * silent log would mean either "nothing was due" or "the job is not
+   * scheduled", and the second is invisible for months.
+   *
+   * So EVERY run logs, at `debug` when it reaped nothing and at `info` when it
+   * did. `tablesSwept` is on both lines: a run that examined zero TABLES is a
+   * broken registry, and it must not read like a quiet, healthy one.
+   *
+   * `truncated` is surfaced because the sweep stops at a ceiling per call. A run
+   * that keeps reporting it is one that cannot keep up, which is a capacity
+   * signal rather than an error — and it is the only way to tell "nothing left
+   * to do" from "still working through a backlog".
+   */
+  /** The scheduled sweep, reachable on demand. See `runExpirySweepNow`. */
+  async runExpirySweepNow(): Promise<void> {
+    await this.runExpirySweep();
+  }
+
+  private async runExpirySweep(): Promise<void> {
+    this.jobStatus.set('expirySweep', { isRunning: true, lastRun: new Date() });
+    try {
+      const results = await sweepAllExpiredRows(getDb(), EXPIRY_SWEEP_TARGETS);
+      const deleted = results.reduce((total, result) => total + result.deleted, 0);
+      const truncated = results.filter((result) => result.truncated).map((result) => result.table);
+      const detail = {
+        tablesSwept: results.length,
+        deleted,
+        perTable: Object.fromEntries(results.map((result) => [result.table, result.deleted])),
+        truncated,
+      };
+
+      if (deleted > 0) this.logger.info('Expiry sweep reaped expired rows', detail);
+      // Logged even at zero — see the doc comment. Silence would make an
+      // unscheduled job look like a healthy one.
+      else this.logger.debug('Expiry sweep found nothing due', detail);
+
+      if (truncated.length > 0) {
+        this.logger.warn(
+          'Expiry sweep hit its batch ceiling; rows remain for the next run',
+          { truncated },
+        );
+      }
+    } catch (error) {
+      this.logger.error('Expiry sweep failed', error);
+    } finally {
+      this.jobStatus.set('expirySweep', { isRunning: false, lastRun: new Date() });
+    }
   }
 
   /**
@@ -411,6 +510,22 @@ export function initCronJobs(): void {
 export function stopCronJobs(): void {
   cronManager.stop();
   logger.info('Cron jobs stopped');
+}
+
+/**
+ * Run the expiry sweep once, now.
+ *
+ * Exists so the scheduled path is REACHABLE without waiting five minutes — by a
+ * test that needs to assert the cron passes the real registry, and by an
+ * operator clearing a backlog after an incident.
+ *
+ * Without it the only testable claims are "a job named `expirySweep` is
+ * scheduled" and "the registry works when called directly", and neither
+ * connects the two: a job wired to an empty target list satisfies both. This is
+ * the seam that makes the connection assertable.
+ */
+export async function runExpirySweepNow(): Promise<void> {
+  await cronManager.runExpirySweepNow();
 }
 
 /**


### PR DESCRIPTION
`db/expiry.ts` has stated its own gap since it was written:

> Registering a target is only half of the port. This list is data; **nothing
> runs it**. `services/cron.ts` must call `sweepAllExpiredRows` with it, and
> until that lands the table still grows forever — the registry makes the
> omission VISIBLE, it does not close it.

There were zero calls to `sweepAllExpiredRows` outside that file. This closes it.

## Measured in production, hours after the property cutover

```
Postgres properties        17,644     expired (expires_at < now)   124
Mongo    properties        17,523     absent from Mongo            121
intersection                          121
absent from Mongo but NOT expired       0
expired but still in Mongo               3   (Mongo's TTL monitor lags ~60s)
rows with no expires_at                  0
```

**Every absent row is an expired row, exactly** — so the TTL index is the whole
cause and there is no second defect hiding behind it. The 121 were being served
as ghost listings a user could click.

## These were never backfill drift, and the distinction picks the tool

Mongo carries a TTL index on `properties.expiresAt`. It reaps with no code path
and no `updatedAt` change, which is why the count kept falling while the
last-write timestamp stayed frozen. A reconciliation would clear the backlog and
let it rebuild; the sweep removes them **and keeps removing them**.

Every five minutes, not daily: Mongo's TTL monitor runs every 60 seconds, so that
is the cadence the read paths were written against, and `db/expiry.ts` warns that
a read depending on a swept row being GONE turns the sweep interval into a
correctness window.

## A sweep that reaped nothing is distinguishable from one that never ran

The failure mode `MIGRATION-CONTRACT.md` names for this class — an unwired sweep
has no symptom until disk. Every run logs: `debug` at zero, `info` when it
reaped, both carrying `tablesSwept`, because a run that examined zero **tables**
is a broken registry and must not read like a quiet healthy one. `truncated` is
surfaced separately — the only way to tell "nothing left to do" from "still
working through a backlog".

## `runExpirySweepNow`, and the mutation that forced it

It exists so the scheduled path is **reachable** — by a test that must assert the
cron passes the real registry, and by an operator clearing a backlog.

Without it the only assertable claims were *"a job named `expirySweep` is
scheduled"* and *"the registry works when called directly"* — and a job wired to
an empty target list satisfies both. That mutation **survived** until this seam
existed, which is why it is here.

## Also fixed: a dry run failed verification whenever it found drift

Its contract is "tell me what would change", so a field-by-field difference is
the **answer**, not a defect. Left as a failure, the exit code depended on
whether the 200-row fidelity sample happened to land on a drifted row — the
production dry run exited 0 with three updates pending purely because it missed
them. An exit code that means different things on two runs of the same command
means nothing.

## Four mutations, all caught

| mutation | case that fails |
|---|---|
| un-wire the setup call | `is SCHEDULED` |
| point the cron at an empty registry | `reaps a row through the REGISTRY` |
| a retention that spares nothing | same case, from the other side |
| a dry run that throws again | `a DRY RUN reports pending drift` |

Local: 123 suites, 1610 tests, green. Typecheck and eslint clean. No dependency
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)