### PR TITLE
Reconciliation may carry a stale target forward, never roll a live write back

### DIFF
--- a/packages/backend/__tests__/db/dataBackfill.test.ts
+++ b/packages/backend/__tests__/db/dataBackfill.test.ts
@@ -764,6 +764,64 @@ describe('data backfill — --reconcile', () => {
     expect(kept?.id).toBe(nativeId);
   }, 120_000);
 
+  it('NEVER rolls back a row the target wrote more recently', async () => {
+    // The window this mode was written in has closed. It assumed Mongo was the
+    // only writer, so "the source differs" meant "the target is stale" — and
+    // once the write path moved, the target can be AHEAD. Measured the hour that
+    // landed: of three differing properties, TWO were newer in Postgres (the
+    // ingest worker refreshing `expires_at` against the new authority), and a
+    // blind apply would have moved both deadlines backwards by about an hour,
+    // into the path of the expiry sweep.
+    const geo = await seedAndCopyGeo();
+    const database = mongoDatabase();
+    const address = addressDocument(geo, 'Barcelona', BARCELONA);
+    await database.collection('addresses').insertOne(address);
+    await seedMeasurableAddresses(geo);
+    const listing = propertyDocument(address._id as mongoose.Types.ObjectId, {
+      description: 'from mongo',
+      updatedAt: new Date('2026-08-09T10:00:00.000Z'),
+    });
+    await database.collection('properties').insertOne(listing);
+    await runDataBackfill({ mongo: database, database: getDb(), mode: 'copy', sampleSize: 5 });
+
+    // Postgres moves ahead — a live write by the authoritative store.
+    await getDb()
+      .update(properties)
+      .set({ description: 'written in postgres', updatedAt: new Date('2026-08-09T12:00:00.000Z') })
+      .where(eq(properties.id, String(listing._id)));
+
+    const report = await runDataBackfill({
+      mongo: database,
+      database: getDb(),
+      mode: 'reconcile',
+      sampleSize: 5,
+    });
+
+    const properties_ = forTable(report, 'properties');
+    expect(properties_?.updated).toBe(0);
+    expect(properties_?.skippedTargetNewer).toBe(1);
+
+    const [kept] = await getDb()
+      .select({ description: properties.description })
+      .from(properties)
+      .where(eq(properties.id, String(listing._id)));
+    expect(kept.description).toBe('written in postgres');
+  }, 120_000);
+
+  it('still carries a STALE target forward — the guard is directional, not symmetric', async () => {
+    // The other half. "Never roll back" must not become "never update".
+    const report = await copyThenDrift(async (database, ids) => {
+      await database.collection('properties').updateOne(
+        { _id: ids.properties[0] },
+        { $set: { description: 'newer in mongo', updatedAt: new Date(Date.now() + 3_600_000) } },
+      );
+    });
+
+    const properties_ = forTable(report, 'properties');
+    expect(properties_?.updated).toBe(1);
+    expect(properties_?.skippedTargetNewer).toBe(0);
+  }, 120_000);
+
   it('converges: a second reconcile changes nothing and reports it as unchanged', async () => {
     // A reconciliation that only reports what it CHANGED cannot tell a converged
     // run from one that examined nothing.

--- a/packages/backend/db/backfill/data.ts
+++ b/packages/backend/db/backfill/data.ts
@@ -84,6 +84,7 @@ import {
   ABSOLUTE_SURPLUS_FLOOR,
   couldHaveComeFromMongo,
   countTable,
+  isTargetNewer,
   deletionAllowance,
   findSurplusIds,
   mayDelete,
@@ -791,6 +792,7 @@ async function compareSample(
   const log = new ResolutionLog();
   const mismatches: string[] = [];
   let compared = 0;
+  let aheadOfSource = 0;
 
   for (const document of documents) {
     const mapped = plan.map(document, log);
@@ -822,6 +824,17 @@ async function compareSample(
           mismatches.push(`${table}/${String(expected.id)}: absent from the target`);
           continue;
         }
+        // A row the TARGET has written since the copy is not the copy's to be
+        // faithful about. The verifier's claim is "what was copied is what is
+        // stored", and once Postgres became the authority it can legitimately be
+        // AHEAD — reporting that as a fidelity failure would make the check fail
+        // permanently on live data, which is how a check stops being believed.
+        // The same directional rule the reconcile applies: stale is a finding,
+        // ahead is not.
+        if (isTargetNewer(expected, actual)) {
+          aheadOfSource += 1;
+          continue;
+        }
         for (const column of columnNames(target)) {
           // GENERATED ALWAYS columns are not the copy's to produce — `geo`,
           // `address_level` and `search_vector` are derived by the DATABASE from
@@ -851,6 +864,13 @@ async function compareSample(
     }
   }
 
+  if (aheadOfSource > 0) {
+    logger.info(
+      `${plan.name}: ${aheadOfSource} sampled row(s) are AHEAD of the source and were ` +
+      'not compared — the target has written them since the copy, which is ' +
+      'expected once Postgres is the authority',
+    );
+  }
   return { compared, mismatches };
 }
 
@@ -1136,6 +1156,7 @@ async function deleteSurplusParents(
     deletionRefused: null,
     retainedPostCutover,
     deletions: [],
+    skippedTargetNewer: 0,
   };
   if (retainedPostCutover > 0) {
     logger.info(
@@ -1197,6 +1218,7 @@ function mergeReports(reports: readonly ReconcileTableReport[]): ReconcileTableR
       deletionRefused: current.deletionRefused ?? report.deletionRefused,
       retainedPostCutover: current.retainedPostCutover + report.retainedPostCutover,
       deletions: [...current.deletions, ...report.deletions],
+      skippedTargetNewer: current.skippedTargetNewer + report.skippedTargetNewer,
     });
   }
   return [...merged.values()];

--- a/packages/backend/db/backfill/reconcile.ts
+++ b/packages/backend/db/backfill/reconcile.ts
@@ -96,6 +96,24 @@ export function deletionAllowance(stored: number): number {
   return Math.max(Math.floor(stored * MAX_SOURCE_SHRINK), ABSOLUTE_SURPLUS_FLOOR);
 }
 
+/**
+ * Whether the stored row is newer than the one the mappers produced.
+ *
+ * Compared on `updatedAt`, which both sides carry and which the copy preserves
+ * verbatim — so the question is "which store wrote this row last", answered by
+ * the value each store recorded rather than by a clock this process reads.
+ *
+ * A row with no usable timestamp on either side is NOT treated as newer: the
+ * comparison cannot be made, and refusing to update on an unanswerable question
+ * would silently stop reconciling those rows forever.
+ */
+export function isTargetNewer(source: CandidateRow, target: CandidateRow): boolean {
+  const sourceAt = source.updatedAt;
+  const targetAt = target.updatedAt;
+  if (!(sourceAt instanceof Date) || !(targetAt instanceof Date)) return false;
+  return targetAt.getTime() > sourceAt.getTime();
+}
+
 /** Whether removing `surplus` of `stored` rows is permitted. */
 export function mayDelete(surplus: number, stored: number): boolean {
   if (stored > 0 && surplus >= stored) return false;
@@ -165,6 +183,11 @@ export interface ReconcileTableReport {
   readonly retainedPostCutover: number;
   /** Ids this run removed, or WOULD remove under `--dry-run`. */
   readonly deletions: readonly string[];
+  /**
+   * Rows left alone because the TARGET's `updated_at` is NEWER than the
+   * source's — a live write this must not roll back.
+   */
+  readonly skippedTargetNewer: number;
 }
 
 /**
@@ -228,6 +251,7 @@ export async function reconcileTable(options: {
   let inserted = 0;
   let updated = 0;
   let unchanged = 0;
+  let skippedTargetNewer = 0;
   const differing: Record<string, number> = {};
 
   for (const row of rows) {
@@ -270,6 +294,26 @@ export async function reconcileTable(options: {
     );
     if (changed.length === 0) {
       unchanged += 1;
+      continue;
+    }
+
+    // NEVER roll a live write back.
+    //
+    // This mode was written while Mongo was the only writer, so "the source
+    // differs" meant "the target is stale". Once the write path moved, that
+    // stopped being true in one direction: the target can now be AHEAD, and
+    // applying the source over it undoes work the authoritative store just did.
+    //
+    // Measured the hour the write path landed: of three differing properties,
+    // TWO were newer in Postgres — the ingest worker refreshing `expires_at`
+    // against the new authority — and a blind apply would have moved both
+    // deadlines backwards by about an hour, into the path of the expiry sweep.
+    //
+    // So the rule is directional rather than symmetric: reconciliation may only
+    // ever carry a STALE target forward. A target that is ahead is not drift, it
+    // is the future, and it is skipped and counted.
+    if (isTargetNewer(row, current)) {
+      skippedTargetNewer += 1;
       continue;
     }
     for (const column of changed) differing[column] = (differing[column] ?? 0) + 1;
@@ -347,6 +391,7 @@ export async function reconcileTable(options: {
     deletionRefused,
     retainedPostCutover,
     deletions: deletionRefused === null ? surplus : [],
+    skippedTargetNewer,
   };
   logger.info(`Reconciled ${tableName}`, report);
   return report;


### PR DESCRIPTION
`--reconcile` was written while Mongo was the only writer, so *"the source
differs"* meant *"the target is stale"*. The property write path has landed and
that stopped being true in one direction: **the target can now be ahead**, and
applying the source over it undoes work the authoritative store just did.

## Measured the hour it landed

Three properties differed between the stores. **Two were newer in Postgres** —
the ingest worker refreshing `expires_at` against the new authority:

| id | Mongo `updatedAt` | Postgres `updated_at` | newer |
|---|---|---|---|
| `6a5077660094d2d7e631cb40` | 11:16:56Z | 12:13:19Z | **Postgres** |
| `6a507e5aef9011fdd32068d2` | 10:43:31Z | 12:13:19Z | **Postgres** |
| `6a649037b5ffe7efdb4dada9` | 07:05:42Z | 2026-07-25 | Mongo |

A blind apply would have moved both `expires_at` deadlines **backwards by about
an hour** — into the path of the expiry sweep that now runs every five minutes.
The tool would have deleted live listings by way of reconciling them.

## The rule is directional, not symmetric

Reconciliation may only ever carry a **stale** target forward. A target that is
ahead is not drift, it is the future — skipped and counted as
`skippedTargetNewer`.

`updatedAt` is the comparison because both stores carry it and the copy preserves
it verbatim, so the question is *"which store wrote this row last"*, answered by
what each store recorded rather than by a clock this process reads. A row with no
usable timestamp on either side is **not** treated as newer: refusing to update
on an unanswerable question would silently stop reconciling those rows forever.

## The same rule belongs in the verifier

Its claim is *"what was copied is what is stored"*, and a row the target has
written since is not the copy's to be faithful about. Reporting it as a fidelity
failure would make the check fail permanently on live data — which is how a check
stops being believed. Those rows are skipped, counted and logged.

This is the mode's own documentation coming true: it said it becomes the
**verification** path once the write path lands. This is what that has to mean
mechanically.

## Two mutations, one per direction

| mutation | case that fails |
|---|---|
| drop the guard | `NEVER rolls back a row the target wrote more recently` |
| make it symmetric (`!==` not `>`) | `still carries a STALE target forward` |

The second matters as much as the first: without it, "never roll back" quietly
becomes "never update".

Local: 124 suites, 1618 tests, green. Typecheck and eslint clean. No dependency
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)