### PR TITLE
Serve the roommate + profile reads from Postgres, and repair three selectors that matched nothing (#281)

### DIFF
--- a/packages/backend/__tests__/db/dataBackfill.test.ts
+++ b/packages/backend/__tests__/db/dataBackfill.test.ts
@@ -1412,3 +1412,97 @@ describe('data backfill — end to end', () => {
     expect(windows.map((row) => row.scope).sort()).toEqual(['exchange', 'listing']);
   }, 60_000);
 });
+
+describe('a column with NO Mongo source that the application really writes', () => {
+  /**
+   * `schema/unmappedColumns.ts` was documentation until the roommate port, and
+   * the two escapes that covered its first two entries do not cover its second
+   * two.
+   *
+   * `properties.views` is skipped because it has a DEFAULT ("the schema decided
+   * this"); `properties.title` is skipped because nothing writes it, so an
+   * omitted key and a stored NULL agree. `settings_roommate_preferences_location`
+   * is nullable, has no default, AND is written by
+   * `PUT /api/roommates/preferences` — so during the dual-run window a perfectly
+   * correct row carries a value the mapper cannot produce.
+   *
+   * Without the registry the verifier reads that as `expected NULL, stored
+   * "Barcelona"` and FAILS the run (`data.ts` turns any mismatch into a
+   * failure), and `--reconcile` reports the row as differing on every pass.
+   * Both are asserted, because they are different code paths with different
+   * consequences.
+   */
+  async function copyProfileThenWriteTheUnmappedColumn(): Promise<string> {
+    const database = mongoDatabase();
+    const updatedAt = new Date('2026-08-01T10:00:00.000Z');
+    const document = {
+      _id: oid(),
+      oxyUserId: 'oxy-roommate-seeker',
+      personalProfile: { personalInfo: { bio: 'Looking to share' } },
+      createdAt: new Date('2026-07-01T10:00:00.000Z'),
+      updatedAt,
+    };
+    await database.collection('profiles').insertOne(document);
+    await runDataBackfill({
+      mongo: database,
+      database: getDb(),
+      mode: 'copy',
+      sampleSize: 5,
+      only: ['profiles'],
+    });
+
+    // `updated_at` is written EXPLICITLY, which is what isolates the question
+    // this file is asking. `$onUpdate` fires on any `db.update()` that does not
+    // name it (`CONVENTIONS.md`), so a write that let it drift would differ from
+    // Mongo on `updated_at` too — a real and separately documented consequence
+    // of Mongo staying authoritative during the window, and one that would make
+    // this case pass or fail for a reason that has nothing to do with the
+    // registry.
+    await getDb()
+      .update(profiles)
+      .set({
+        settingsRoommatePreferencesLocation: 'Barcelona',
+        settingsRoommatePreferencesInterests: ['climbing'],
+        updatedAt,
+      })
+      .where(eq(profiles.id, String(document._id)));
+    return String(document._id);
+  }
+
+  it('does not report a fidelity mismatch for it', async () => {
+    await copyProfileThenWriteTheUnmappedColumn();
+
+    const report = await runDataBackfill({
+      mongo: mongoDatabase(),
+      database: getDb(),
+      mode: 'copy',
+      sampleSize: 5,
+      only: ['profiles'],
+    });
+
+    const verified = report.verified.find((entry) => entry.table === 'profiles');
+    expect(verified?.compared).toBeGreaterThan(0);
+    expect(verified?.mismatches).toEqual([]);
+  }, 60_000);
+
+  it('does not let --reconcile report or rewrite it', async () => {
+    const profileId = await copyProfileThenWriteTheUnmappedColumn();
+
+    const report = await runDataBackfill({
+      mongo: mongoDatabase(),
+      database: getDb(),
+      mode: 'reconcile',
+      sampleSize: 5,
+      only: ['profiles'],
+    });
+
+    const reconciled = report.reconciled.find((entry) => entry.table === 'profiles');
+    expect(reconciled?.updated).toBe(0);
+    expect(reconciled?.unchanged).toBe(1);
+
+    // And the value survives, which is the fact a report line cannot express.
+    const [stored] = await getDb().select().from(profiles).where(eq(profiles.id, profileId));
+    expect(stored.settingsRoommatePreferencesLocation).toBe('Barcelona');
+    expect(stored.settingsRoommatePreferencesInterests).toEqual(['climbing']);
+  }, 60_000);
+});

--- a/packages/backend/__tests__/db/roommateDiscovery.test.ts
+++ b/packages/backend/__tests__/db/roommateDiscovery.test.ts
@@ -1,0 +1,410 @@
+/**
+ * The roommate candidate search, against a REAL Postgres server.
+ *
+ * This file exists because THREE of the filters it covers matched nothing at
+ * all in Mongo, and the failure was invisible from the code: the selectors named
+ * `personalProfile.gender`, `personalProfile.location` and
+ * `personalProfile.dateOfBirth`, `personalProfileSchema` declares none of them,
+ * and `database/connection.ts` sets `strictQuery: false` — so mongoose passed
+ * them through rather than stripping them, and MongoDB matched no document.
+ * Nothing errored. `?gender=`, `?location=` and `?ageRange=` simply returned an
+ * empty page, always.
+ *
+ * A port that carried those selectors verbatim would answer zero just as
+ * reliably in Postgres and LOOK finished, so each one is re-pointed at a fact
+ * this product really stores. That makes every case below a behaviour change,
+ * and a test is the only place a behaviour change can be pinned rather than
+ * described.
+ *
+ * ## Every fixture sits on the side of the distinction its case exists to make
+ *
+ * `db/MIGRATION-CONTRACT.md` names the failure mode: the tidiest fixture is
+ * usually the one that makes a check vacuous, and a green run cannot tell the
+ * two apart. So, concretely —
+ *
+ *  - the gender cases seed `male`, `female`, `any` AND `NULL`, because a filter
+ *    that did nothing would return all four;
+ *  - the age-range cases seed a DISJOINT range and two that touch the query at
+ *    exactly one endpoint, so `<=` versus `<` is visible;
+ *  - the location cases seed a value differing only in CASE (a case-sensitive
+ *    comparison passes every other case in the file) and one that a LIKE
+ *    metacharacter would match if the term were not escaped;
+ *  - the "unknown admits" cases seed a NULL beside every stated value, since
+ *    `is null or …` and a bare comparison agree on every row that has an answer.
+ *
+ * Bounds are literal numbers rather than anything derived at run time: the
+ * contract records a boundary test built from two independent `Date.now()`
+ * calls that tested nothing about the boundary.
+ */
+
+import { eq } from 'drizzle-orm';
+import { uuidv7 } from '@oxyhq/db';
+
+import { closePostgres, connectPostgres, getDb, type Database } from '../../db/postgres';
+import {
+  searchRoommateCandidates,
+  type RoommateCandidateQuery,
+} from '../../db/profiles/profileRepository';
+import { profilePreferredLocations, profileRoommateHistory, profiles } from '../../db/schema';
+
+let db: Database;
+
+/** The caller. Every query excludes them, so they never appear in a result. */
+const CALLER = 'oxy-caller';
+
+beforeAll(async () => {
+  db = await connectPostgres();
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+beforeEach(async () => {
+  await getDb().delete(profiles);
+  await getDb().insert(profiles).values({ oxyUserId: CALLER, settingsRoommateEnabled: true });
+});
+
+async function seedCandidate(
+  oxyUserId: string,
+  columns: Partial<typeof profiles.$inferInsert> = {},
+): Promise<string> {
+  const [row] = await getDb()
+    .insert(profiles)
+    .values({ oxyUserId, settingsRoommateEnabled: true, ...columns })
+    .returning({ id: profiles.id });
+  return row.id;
+}
+
+/** Run a search with the pagination defaults these cases do not care about. */
+async function search(
+  filters: Omit<RoommateCandidateQuery, 'excludeOxyUserId' | 'limit' | 'offset'> &
+    Partial<Pick<RoommateCandidateQuery, 'limit' | 'offset'>>,
+) {
+  return searchRoommateCandidates(db, {
+    excludeOxyUserId: CALLER,
+    limit: 50,
+    offset: 0,
+    ...filters,
+  });
+}
+
+/** The candidates a search returned, by Oxy account id, sorted for comparison. */
+function matched(page: { candidates: readonly { profile: { oxyUserId: string } }[] }): string[] {
+  return page.candidates.map((candidate) => candidate.profile.oxyUserId).sort();
+}
+
+describe('who is a candidate at all', () => {
+  it('takes only profiles with matching ENABLED, and never the caller', async () => {
+    await seedCandidate('oxy-on');
+    await seedCandidate('oxy-off', { settingsRoommateEnabled: false });
+    // NULL is a third state — the person never answered — and `= true` is what
+    // keeps it out. `is not false` would let them in.
+    await seedCandidate('oxy-never-asked', { settingsRoommateEnabled: null });
+
+    const page = await search({});
+    expect(matched(page)).toEqual(['oxy-on']);
+    expect(page.total).toBe(1);
+  });
+});
+
+describe('the GENDER filter — re-pointed at the stated roommate preference', () => {
+  beforeEach(async () => {
+    await seedCandidate('oxy-female', { settingsRoommatePreferencesGender: 'female' });
+    await seedCandidate('oxy-male', { settingsRoommatePreferencesGender: 'male' });
+    await seedCandidate('oxy-any', { settingsRoommatePreferencesGender: 'any' });
+    await seedCandidate('oxy-unstated', { settingsRoommatePreferencesGender: null });
+  });
+
+  it('matches exactly the candidates who stated that preference', async () => {
+    // Four fixtures, one match: a filter that was dropped would return four,
+    // and one that also admitted `any` or NULL would return two or three.
+    expect(matched(await search({ gender: 'female' }))).toEqual(['oxy-female']);
+    expect(matched(await search({ gender: 'male' }))).toEqual(['oxy-male']);
+  });
+
+  it('is EXACT rather than "compatible with"', async () => {
+    // `any` means "I do not mind", which is a different question from "who is
+    // looking for a woman" — answering it here would make the filter mean
+    // something nobody asked for and would be invisible without this case.
+    expect(matched(await search({ gender: 'any' }))).toEqual(['oxy-any']);
+  });
+
+  it('returns everybody when no gender is asked for', async () => {
+    expect(matched(await search({}))).toEqual([
+      'oxy-any',
+      'oxy-female',
+      'oxy-male',
+      'oxy-unstated',
+    ]);
+  });
+});
+
+describe('the AGE RANGE filter — an overlap, because no date of birth exists', () => {
+  /**
+   * Oxy owns identity and Homiio does not mirror it, so there is no date of
+   * birth in either store and there must not be one. The stored fact is the
+   * candidate's own preferred age range, and the question becomes "does their
+   * range overlap the one you asked for" — a different question with the same
+   * intent, and the only honest one available.
+   */
+  beforeEach(async () => {
+    const range = (min: number | null, max: number | null) => ({
+      settingsRoommatePreferencesAgeRangeMin: min,
+      settingsRoommatePreferencesAgeRangeMax: max,
+    });
+    await seedCandidate('oxy-below', range(18, 24));
+    await seedCandidate('oxy-touches-low', range(24, 30));
+    await seedCandidate('oxy-inside', range(32, 35));
+    await seedCandidate('oxy-touches-high', range(40, 50));
+    await seedCandidate('oxy-above', range(41, 60));
+    await seedCandidate('oxy-open', range(null, null));
+    await seedCandidate('oxy-min-only', range(35, null));
+    await seedCandidate('oxy-max-only', range(null, 20));
+  });
+
+  it('includes a range that touches the request at exactly one endpoint', async () => {
+    // The bounds are CLOSED. `oxy-touches-low` ends at 30 and the request starts
+    // at 30; `oxy-touches-high` starts at 40 and the request ends at 40. Turn
+    // either comparison strict and both disappear — which is what makes this
+    // the case that tells `>=` from `>`.
+    const page = await search({ ageRange: { min: 30, max: 40 } });
+    expect(matched(page)).toEqual([
+      'oxy-inside',
+      'oxy-min-only',
+      'oxy-open',
+      'oxy-touches-high',
+      'oxy-touches-low',
+    ]);
+  });
+
+  it('excludes a range that is strictly disjoint on either side', async () => {
+    const page = await search({ ageRange: { min: 30, max: 40 } });
+    expect(matched(page)).not.toContain('oxy-below');
+    expect(matched(page)).not.toContain('oxy-above');
+    expect(matched(page)).not.toContain('oxy-max-only');
+  });
+
+  it('admits an unstated bound, and answers a ONE-SIDED range on the side that was stated', async () => {
+    // "Did not say" is not "does not match". The Mongo controller's own budget
+    // filter established the rule — `if (typeof profileMax !== 'number') return
+    // true` — and every predicate here follows it.
+    //
+    // The two halves are answered independently rather than through a single
+    // "did they state a range" guard, which is what puts `oxy-min-only`
+    // (`[35, …]`, so 90-99 really is inside what they asked for) beside
+    // `oxy-open` here while `oxy-max-only` (`[…, 20]`) stays out of the 30-40
+    // case above.
+    expect(matched(await search({ ageRange: { min: 90, max: 99 } }))).toEqual([
+      'oxy-min-only',
+      'oxy-open',
+    ]);
+  });
+});
+
+describe('the LOCATION filter — a column that did not exist until migration 0008', () => {
+  it('matches case-insensitively', async () => {
+    // The stored value differs from the term only in CASE, so a case-sensitive
+    // comparison fails here and passes everywhere else in this file.
+    await seedCandidate('oxy-bcn', { settingsRoommatePreferencesLocation: 'Barcelona' });
+    await seedCandidate('oxy-mad', { settingsRoommatePreferencesLocation: 'Madrid' });
+
+    expect(matched(await search({ location: 'barcelona' }))).toEqual(['oxy-bcn']);
+    expect(matched(await search({ location: 'BARCELONA' }))).toEqual(['oxy-bcn']);
+  });
+
+  it('matches on a substring, the way the regex filter did', async () => {
+    await seedCandidate('oxy-gracia', {
+      settingsRoommatePreferencesLocation: 'Barcelona, Gràcia',
+    });
+    expect(matched(await search({ location: 'Gràcia' }))).toEqual(['oxy-gracia']);
+  });
+
+  it('treats a LIKE metacharacter in the term as a literal', async () => {
+    // `_` matches any single character in a LIKE pattern and means nothing in a
+    // regex, so porting `{ $regex }` to `ILIKE` without `escapeLikePattern`
+    // would silently widen the filter. `S_nts` must not find `Sants`.
+    await seedCandidate('oxy-sants', { settingsRoommatePreferencesLocation: 'Sants' });
+    await seedCandidate('oxy-literal', { settingsRoommatePreferencesLocation: 'S_nts' });
+
+    expect(matched(await search({ location: 'S_nts' }))).toEqual(['oxy-literal']);
+    expect(matched(await search({ location: 'Sants' }))).toEqual(['oxy-sants']);
+  });
+
+  it('does not admit a candidate who stated no location', async () => {
+    // The one place "unknown" does NOT admit, and deliberately: a text search
+    // that returned everybody with no answer would drown the answers.
+    await seedCandidate('oxy-silent', { settingsRoommatePreferencesLocation: null });
+    await seedCandidate('oxy-bcn', { settingsRoommatePreferencesLocation: 'Barcelona' });
+    expect(matched(await search({ location: 'Barcelona' }))).toEqual(['oxy-bcn']);
+  });
+});
+
+describe('the three filters that already worked, moved from JavaScript into SQL', () => {
+  /**
+   * `maxBudget`, `withPets` and `nonSmoking` were applied to the page AFTER
+   * `skip`/`limit` had cut it, so they returned short pages beside a `total`
+   * that counted rows the page had just dropped. Their per-candidate meaning is
+   * carried across unchanged, "unknown admits" included.
+   */
+  it('keeps a candidate whose stated ceiling reaches the asked-for budget', async () => {
+    await seedCandidate('oxy-rich', { settingsRoommatePreferencesBudgetMax: 1500 });
+    await seedCandidate('oxy-exact', { settingsRoommatePreferencesBudgetMax: 1200 });
+    await seedCandidate('oxy-lower', { settingsRoommatePreferencesBudgetMax: 1000 });
+    await seedCandidate('oxy-unstated', { settingsRoommatePreferencesBudgetMax: null });
+
+    expect(matched(await search({ maxBudget: 1200 }))).toEqual([
+      'oxy-exact',
+      'oxy-rich',
+      'oxy-unstated',
+    ]);
+  });
+
+  it('keeps pet-friendly and unstated candidates, and drops the refusals', async () => {
+    await seedCandidate('oxy-yes', { settingsRoommatePreferencesLifestylePets: 'yes' });
+    await seedCandidate('oxy-no', { settingsRoommatePreferencesLifestylePets: 'no' });
+    await seedCandidate('oxy-prefer-not', {
+      settingsRoommatePreferencesLifestylePets: 'prefer_not',
+    });
+    await seedCandidate('oxy-unstated', { settingsRoommatePreferencesLifestylePets: null });
+
+    // `prefer_not` is a real ANSWER — "I would rather not say" — and is not the
+    // same as never having been asked, which is what NULL means.
+    expect(matched(await search({ withPets: true }))).toEqual(['oxy-unstated', 'oxy-yes']);
+  });
+
+  it('keeps non-smokers and unstated candidates', async () => {
+    await seedCandidate('oxy-no', { settingsRoommatePreferencesLifestyleSmoking: 'no' });
+    await seedCandidate('oxy-yes', { settingsRoommatePreferencesLifestyleSmoking: 'yes' });
+    await seedCandidate('oxy-unstated', { settingsRoommatePreferencesLifestyleSmoking: null });
+
+    expect(matched(await search({ nonSmoking: true }))).toEqual(['oxy-no', 'oxy-unstated']);
+  });
+
+  it('counts the filtered set rather than the whole table', async () => {
+    await seedCandidate('oxy-yes', { settingsRoommatePreferencesLifestyleSmoking: 'yes' });
+    await seedCandidate('oxy-no-1', { settingsRoommatePreferencesLifestyleSmoking: 'no' });
+    await seedCandidate('oxy-no-2', { settingsRoommatePreferencesLifestyleSmoking: 'no' });
+
+    const page = await search({ nonSmoking: true, limit: 1 });
+    // ONE row on the page and TWO in the count: the page is cut, the count is
+    // not, and both see the same predicate.
+    expect(page.candidates).toHaveLength(1);
+    expect(page.total).toBe(2);
+  });
+});
+
+describe('paging and ordering', () => {
+  it('walks a stable order across pages, newest first', async () => {
+    // Written with explicit, distinct `updated_at` values rather than by
+    // inserting quickly and hoping: rows written in one statement can share a
+    // millisecond, and an ordering test that cannot distinguish two rows tests
+    // nothing.
+    const stamp = (iso: string) => ({ updatedAt: new Date(iso) });
+    await seedCandidate('oxy-oldest', stamp('2026-01-01T00:00:00.000Z'));
+    await seedCandidate('oxy-middle', stamp('2026-02-01T00:00:00.000Z'));
+    await seedCandidate('oxy-newest', stamp('2026-03-01T00:00:00.000Z'));
+
+    const first = await search({ limit: 2, offset: 0 });
+    const second = await search({ limit: 2, offset: 2 });
+
+    expect(first.candidates.map((candidate) => candidate.profile.oxyUserId)).toEqual([
+      'oxy-newest',
+      'oxy-middle',
+    ]);
+    expect(second.candidates.map((candidate) => candidate.profile.oxyUserId)).toEqual([
+      'oxy-oldest',
+    ]);
+    expect(first.total).toBe(3);
+  });
+});
+
+describe('hydration of a page', () => {
+  it('gives each candidate ONLY its own child rows', async () => {
+    // The page is hydrated with five statements for the whole set rather than
+    // five per profile, so the grouping is the thing that can be wrong — and a
+    // grouping that ignored `profile_id` would hand every candidate everybody
+    // else's history. Two profiles with one distinguishable row each is the
+    // smallest fixture that can see it.
+    const first = await seedCandidate('oxy-first');
+    const second = await seedCandidate('oxy-second');
+    await getDb().insert(profilePreferredLocations).values([
+      { profileId: first, city: 'Barcelona' },
+      { profileId: second, city: 'Madrid' },
+    ]);
+    await getDb().insert(profileRoommateHistory).values([
+      { profileId: first, startDate: new Date('2024-01-01T00:00:00.000Z'), location: 'Gràcia' },
+      { profileId: second, startDate: new Date('2024-01-01T00:00:00.000Z'), location: 'Lavapiés' },
+    ]);
+
+    const page = await search({});
+    const byOxyUserId = new Map(
+      page.candidates.map((candidate) => [candidate.profile.oxyUserId, candidate]),
+    );
+
+    expect(byOxyUserId.get('oxy-first')?.preferredLocations.map((row) => row.city)).toEqual([
+      'Barcelona',
+    ]);
+    expect(byOxyUserId.get('oxy-second')?.preferredLocations.map((row) => row.city)).toEqual([
+      'Madrid',
+    ]);
+    expect(byOxyUserId.get('oxy-first')?.roommateHistory.map((row) => row.location)).toEqual([
+      'Gràcia',
+    ]);
+    expect(byOxyUserId.get('oxy-second')?.roommateHistory.map((row) => row.location)).toEqual([
+      'Lavapiés',
+    ]);
+  });
+
+  it('gives a candidate with no child rows empty collections rather than nothing', async () => {
+    await seedCandidate('oxy-bare');
+    const [candidate] = (await search({})).candidates;
+    expect(candidate.references).toEqual([]);
+    expect(candidate.rentalHistory).toEqual([]);
+    expect(candidate.preferredLocations).toEqual([]);
+    expect(candidate.roommateHistory).toEqual([]);
+    expect(candidate.chatHistory).toEqual([]);
+  });
+
+  it('never selects the protected income column', async () => {
+    // `profileSelection()` excludes `personal_info_annual_income` at the TYPE
+    // level, so this is a runtime confirmation that the search really goes
+    // through it — a hand-written `select()` here would compile and leak.
+    const id = await seedCandidate('oxy-rich', { personalInfoAnnualIncome: 48000 });
+    const [stored] = await getDb().select().from(profiles).where(eq(profiles.id, id));
+    expect(stored.personalInfoAnnualIncome).toBe(48000);
+
+    const [candidate] = (await search({})).candidates;
+    expect(Object.keys(candidate.profile)).not.toContain('personalInfoAnnualIncome');
+    expect(JSON.stringify(candidate)).not.toContain('48000');
+  });
+});
+
+describe('the two columns migration 0008 added', () => {
+  it('stores and reads back an interests array', async () => {
+    // Mongoose strict mode discarded every write of this field, so the column
+    // holding a value at all is the fact under test.
+    const id = await seedCandidate(`oxy-${uuidv7()}`, {
+      settingsRoommatePreferencesInterests: ['climbing', 'cooking'],
+      settingsRoommatePreferencesLocation: 'Barcelona',
+    });
+
+    const [stored] = await getDb().select().from(profiles).where(eq(profiles.id, id));
+    expect(stored.settingsRoommatePreferencesInterests).toEqual(['climbing', 'cooking']);
+    expect(stored.settingsRoommatePreferencesLocation).toBe('Barcelona');
+  });
+
+  it('keeps an empty array distinguishable from never having answered', async () => {
+    const listed = await seedCandidate('oxy-none-listed', {
+      settingsRoommatePreferencesInterests: [],
+    });
+    const silent = await seedCandidate('oxy-never-asked', {
+      settingsRoommatePreferencesInterests: null,
+    });
+
+    const [listedRow] = await getDb().select().from(profiles).where(eq(profiles.id, listed));
+    const [silentRow] = await getDb().select().from(profiles).where(eq(profiles.id, silent));
+    expect(listedRow.settingsRoommatePreferencesInterests).toEqual([]);
+    expect(silentRow.settingsRoommatePreferencesInterests).toBeNull();
+  });
+});

--- a/packages/backend/__tests__/db/unmappedColumns.test.ts
+++ b/packages/backend/__tests__/db/unmappedColumns.test.ts
@@ -44,15 +44,24 @@ describe('unmapped column registry', () => {
     expect(unexplained).toEqual([]);
   });
 
-  it('holds the two columns the census proved have no source', () => {
+  it('holds the four columns the census proved have no source', () => {
     // A floor, not a target. Written as an exact set rather than a count so
     // that REMOVING an entry is as visible as adding one — a column quietly
     // dropped from this list is a column the coverage check will start
     // reporting as under-populated, and the reason will be gone.
+    //
+    // The two `profiles` entries are the same mongoose-strict-mode discard as
+    // the two `properties` ones, on a field the write allow-list ACCEPTS: see
+    // `db/schema/profiles.ts` for what each one broke.
     const named = UNMAPPED_COLUMNS
       .map((entry) => `${getTableName(entry.table)}.${entry.property}`)
       .sort();
-    expect(named).toEqual(['properties.title', 'properties.views']);
+    expect(named).toEqual([
+      'profiles.settingsRoommatePreferencesInterests',
+      'profiles.settingsRoommatePreferencesLocation',
+      'properties.title',
+      'properties.views',
+    ]);
   });
 });
 

--- a/packages/backend/__tests__/integration/profilePostgres.test.ts
+++ b/packages/backend/__tests__/integration/profilePostgres.test.ts
@@ -298,6 +298,56 @@ describe('PUT /profiles/me — the allow-listed write', () => {
     expect(res.body.data.personalProfile.rentalHistory[0].address).toBe('Fine');
   });
 
+  it('round-trips the roommate location and interests rather than blanking them', async () => {
+    // The two columns migration 0008 added are written by a DIFFERENT endpoint
+    // (`PUT /api/roommates/preferences`) and read back through this one, so the
+    // seam between them is where they would be lost: this handler replaces the
+    // whole `settings.roommate` block, and a key the serializer did not emit
+    // would come back absent from the edit form and be written NULL on the next
+    // save. Exactly the failure the annual-income round trip above exists for,
+    // one block over.
+    const oxyUserId = owner();
+    const app = buildApp(oxyUserId);
+    await getDb()
+      .insert(profiles)
+      .values({
+        oxyUserId,
+        settingsRoommateEnabled: true,
+        settingsRoommatePreferencesLocation: 'Barcelona',
+        settingsRoommatePreferencesInterests: ['climbing', 'cooking'],
+      });
+
+    const read = await request(app).get('/profiles/me');
+    const roommate = read.body.data.personalProfile.settings.roommate;
+    expect(roommate.preferences.location).toBe('Barcelona');
+    expect(roommate.preferences.interests).toEqual(['climbing', 'cooking']);
+
+    await request(app).put('/profiles/me').send({ personalProfile: { settings: { roommate } } });
+
+    const [stored] = await getDb().select().from(profiles).where(eq(profiles.oxyUserId, oxyUserId));
+    expect(stored.settingsRoommatePreferencesLocation).toBe('Barcelona');
+    expect(stored.settingsRoommatePreferencesInterests).toEqual(['climbing', 'cooking']);
+  });
+
+  it('still clears a roommate field the block deliberately omits', async () => {
+    // The other direction, and the reason the case above is not simply "never
+    // write NULL": block-at-a-time replacement is what makes "remove my
+    // location" expressible at all.
+    const oxyUserId = owner();
+    const app = buildApp(oxyUserId);
+    await getDb()
+      .insert(profiles)
+      .values({ oxyUserId, settingsRoommatePreferencesLocation: 'Barcelona' });
+
+    await request(app)
+      .put('/profiles/me')
+      .send({ personalProfile: { settings: { roommate: { preferences: { gender: 'any' } } } } });
+
+    const [stored] = await getDb().select().from(profiles).where(eq(profiles.oxyUserId, oxyUserId));
+    expect(stored.settingsRoommatePreferencesLocation).toBeNull();
+    expect(stored.settingsRoommatePreferencesGender).toBe('any');
+  });
+
   it('creates the row when the first request is a PUT', async () => {
     const oxyUserId = owner();
     const res = await request(buildApp(oxyUserId))

--- a/packages/backend/__tests__/integration/roommateOwnership.test.ts
+++ b/packages/backend/__tests__/integration/roommateOwnership.test.ts
@@ -1,15 +1,16 @@
 /**
  * Roommate controller — profile resolution, preferences mass-assignment (IDOR),
- * the request handshake, relationship lifecycle, and relationship ownership.
+ * the request handshake, relationship lifecycle, relationship ownership, and
+ * the wire shape all of it is served in.
  *
- * ## This suite spans BOTH stores on purpose
+ * ## Both stores are gone from this suite, and that is the point
  *
- * `roommate_requests` and `roommate_relationships` are on Postgres; `profiles`
- * is still the Mongo model, because it belongs to another batch. The two need no
- * transaction between them — a request row and a profile READ are independent,
- * and nothing here writes both — so the split is a real intermediate state of
- * the migration rather than a lost guarantee. When profiles move, only the
- * `Profile.` calls in the controller change.
+ * `roommate_requests` and `roommate_relationships` moved first; the PROFILE
+ * reads beside them moved with this change, so the file no longer touches
+ * mongoose at all. While the two were split, a profile written by
+ * `PUT /api/profiles/me` (Postgres) was invisible to every roommate endpoint
+ * (Mongo) — the fixtures below are Postgres rows for the same reason the
+ * controller now reads them.
  *
  * ## What makes these tests non-vacuous
  *
@@ -26,11 +27,10 @@ import { and, eq } from 'drizzle-orm';
 
 import roommateController from '../../controllers/roommateController';
 import { getDb } from '../../db/postgres';
-import { roommateRelationships, roommateRequests } from '../../db/schema';
+import { profiles, roommateRelationships, roommateRequests } from '../../db/schema';
 import { sortPair } from '../../db/roommates/roommateRepository';
 import { asyncHandler } from '../../middlewares';
 import { errorHandler } from '../../middlewares/errorHandler';
-import { Profile } from '../../models';
 
 beforeAll(() => {
   (global as unknown as { fetch: jest.Mock }).fetch = jest.fn(async () => ({
@@ -44,6 +44,7 @@ beforeEach(async () => {
   // Relationships first: `request_id` references `roommate_requests`.
   await getDb().delete(roommateRelationships);
   await getDb().delete(roommateRequests);
+  await getDb().delete(profiles);
 });
 
 function buildApp(oxyUserId: string): Express {
@@ -55,7 +56,10 @@ function buildApp(oxyUserId: string): Express {
     next();
   });
   app.get('/roommates', asyncHandler(roommateController.getRoommateProfiles));
+  app.get('/roommates/preferences', asyncHandler(roommateController.getMyRoommatePreferences));
   app.put('/roommates/preferences', asyncHandler(roommateController.updateRoommatePreferences));
+  app.patch('/roommates/toggle', asyncHandler(roommateController.toggleRoommateMatching));
+  app.get('/roommates/status', asyncHandler(roommateController.getCurrentUserRoommateStatus));
   app.get('/roommates/requests', asyncHandler(roommateController.getRoommateRequests));
   app.get('/roommates/relationships', asyncHandler(roommateController.getRoommateRelationships));
   app.delete('/roommates/relationships/:relationshipId', asyncHandler(roommateController.endRoommateRelationship));
@@ -66,25 +70,27 @@ function buildApp(oxyUserId: string): Express {
   return app;
 }
 
+/**
+ * A profile with roommate matching on, carrying the same preferences the
+ * Mongo-era fixture did (budget 500-1200, non-smoker, pets welcome).
+ */
 async function createRoommateProfile(
   oxyUserId: string,
-  overrides: Record<string, unknown> = {},
+  overrides: Partial<typeof profiles.$inferInsert> = {},
 ) {
-  return Profile.create({
-    oxyUserId,
-    personalProfile: {
-      settings: {
-        roommate: {
-          enabled: true,
-          preferences: {
-            budget: { min: 500, max: 1200 },
-            lifestyle: { smoking: 'no', pets: 'yes' },
-          },
-        },
-      },
-    },
-    ...overrides,
-  });
+  const [row] = await getDb()
+    .insert(profiles)
+    .values({
+      oxyUserId,
+      settingsRoommateEnabled: true,
+      settingsRoommatePreferencesBudgetMin: 500,
+      settingsRoommatePreferencesBudgetMax: 1200,
+      settingsRoommatePreferencesLifestyleSmoking: 'no',
+      settingsRoommatePreferencesLifestylePets: 'yes',
+      ...overrides,
+    })
+    .returning();
+  return row;
 }
 
 /** Insert a pending request directly, for cases that start from one. */
@@ -112,6 +118,11 @@ async function activeRelationshipBetween(a: string, b: string) {
   return row;
 }
 
+async function storedProfile(oxyUserId: string) {
+  const [row] = await getDb().select().from(profiles).where(eq(profiles.oxyUserId, oxyUserId));
+  return row;
+}
+
 describe('roommateController.getRoommateProfiles — profile resolution', () => {
   it('requires an authenticated user', async () => {
     const app = express();
@@ -134,6 +145,172 @@ describe('roommateController.getRoommateProfiles — profile resolution', () => 
     expect(ids).toContain('oxy-other');
     expect(ids).not.toContain('oxy-me');
   });
+
+  it('omits a candidate who has not enabled matching', async () => {
+    await createRoommateProfile('oxy-me');
+    await createRoommateProfile('oxy-hidden', { settingsRoommateEnabled: false });
+    await createRoommateProfile('oxy-never-asked', { settingsRoommateEnabled: null });
+
+    const res = await request(buildApp('oxy-me')).get('/roommates');
+    expect((res.body.profiles as Array<{ oxyUserId: string }>).map((p) => p.oxyUserId)).toEqual([]);
+    expect(res.body.total).toBe(0);
+  });
+});
+
+describe('the discover filters that used to match nothing', () => {
+  /**
+   * Each of these was written against a path `personalProfileSchema` never
+   * declared (`personalProfile.gender` / `.location` / `.dateOfBirth`). With
+   * `strictQuery: false` mongoose passed them through to MongoDB rather than
+   * stripping them, so they matched NO document and the endpoint answered an
+   * empty page for every value. The cases below are the wiring — that a query
+   * parameter reaches the column the filter now means; the predicates
+   * themselves, with the fixtures that can tell them apart, are pinned in
+   * `__tests__/db/roommateDiscovery.test.ts`.
+   */
+  beforeEach(async () => {
+    await createRoommateProfile('oxy-me');
+  });
+
+  it('filters on the stated roommate GENDER preference', async () => {
+    await createRoommateProfile('oxy-wants-female', {
+      settingsRoommatePreferencesGender: 'female',
+    });
+    await createRoommateProfile('oxy-wants-male', { settingsRoommatePreferencesGender: 'male' });
+
+    const res = await request(buildApp('oxy-me')).get('/roommates').query({ gender: 'female' });
+    expect(res.status).toBe(200);
+    expect((res.body.profiles as Array<{ oxyUserId: string }>).map((p) => p.oxyUserId)).toEqual([
+      'oxy-wants-female',
+    ]);
+    expect(res.body.total).toBe(1);
+  });
+
+  it('treats gender=any as no filter at all', async () => {
+    await createRoommateProfile('oxy-wants-female', {
+      settingsRoommatePreferencesGender: 'female',
+    });
+    await createRoommateProfile('oxy-wants-male', { settingsRoommatePreferencesGender: 'male' });
+
+    const res = await request(buildApp('oxy-me')).get('/roommates').query({ gender: 'any' });
+    expect(res.body.total).toBe(2);
+  });
+
+  it('refuses a gender outside the stored vocabulary rather than ignoring it', async () => {
+    // Ignoring it would answer an UNFILTERED page, which looks like a result.
+    const res = await request(buildApp('oxy-me')).get('/roommates').query({ gender: 'unicorn' });
+    expect(res.status).toBe(400);
+    expect(String(res.body.error)).toContain('gender');
+  });
+
+  it('filters on the stated LOCATION, case-insensitively', async () => {
+    await createRoommateProfile('oxy-bcn', {
+      settingsRoommatePreferencesLocation: 'Barcelona, Gràcia',
+    });
+    await createRoommateProfile('oxy-mad', { settingsRoommatePreferencesLocation: 'Madrid' });
+
+    const res = await request(buildApp('oxy-me')).get('/roommates').query({ location: 'barcelona' });
+    expect((res.body.profiles as Array<{ oxyUserId: string }>).map((p) => p.oxyUserId)).toEqual([
+      'oxy-bcn',
+    ]);
+  });
+
+  it('overlaps the requested AGE RANGE against the stated one', async () => {
+    await createRoommateProfile('oxy-young', {
+      settingsRoommatePreferencesAgeRangeMin: 18,
+      settingsRoommatePreferencesAgeRangeMax: 24,
+    });
+    await createRoommateProfile('oxy-overlapping', {
+      settingsRoommatePreferencesAgeRangeMin: 24,
+      settingsRoommatePreferencesAgeRangeMax: 35,
+    });
+
+    const res = await request(buildApp('oxy-me'))
+      .get('/roommates')
+      .query({ ageRange: JSON.stringify({ min: 30, max: 40 }) });
+    expect((res.body.profiles as Array<{ oxyUserId: string }>).map((p) => p.oxyUserId)).toEqual([
+      'oxy-overlapping',
+    ]);
+  });
+
+  it('answers 400 for a malformed ageRange rather than 500', async () => {
+    // `JSON.parse(String(ageRange))` threw straight into the catch-all.
+    const res = await request(buildApp('oxy-me')).get('/roommates').query({ ageRange: 'nonsense' });
+    expect(res.status).toBe(400);
+  });
+
+  it('answers 400 for a non-numeric maxBudget rather than an empty page', async () => {
+    // `parseInt('abc')` is NaN and `1200 >= NaN` is false, so a typo silently
+    // dropped every candidate.
+    const res = await request(buildApp('oxy-me')).get('/roommates').query({ maxBudget: 'abc' });
+    expect(res.status).toBe(400);
+  });
+
+  it('counts what the page contains — the SQL filters run before the cut', async () => {
+    // The three preference filters used to run in JavaScript AFTER `skip`/
+    // `limit`, so `total` counted rows the page had just dropped.
+    await createRoommateProfile('oxy-smoker', {
+      settingsRoommatePreferencesLifestyleSmoking: 'yes',
+    });
+    await createRoommateProfile('oxy-clean-air', {
+      settingsRoommatePreferencesLifestyleSmoking: 'no',
+    });
+
+    const res = await request(buildApp('oxy-me')).get('/roommates').query({ nonSmoking: 'true' });
+    expect(res.body.total).toBe(1);
+    expect(res.body.profiles).toHaveLength(1);
+    expect(res.body.totalPages).toBe(1);
+  });
+});
+
+describe('the wire shape the roommate endpoints serve', () => {
+  /**
+   * `ProfileSchema`'s `toJSON` transform renamed `_id` → `id` and stripped
+   * `__v`; these endpoints never went through it (they projected by hand), so
+   * the rename is applied by the serializer instead. A regression here is the
+   * class of bug that took Homiio's frontend down once already.
+   */
+  it('carries id, never _id or __v, on every roommate payload', async () => {
+    await createRoommateProfile('oxy-a');
+    await createRoommateProfile('oxy-b');
+    const pending = await seedPendingRequest('oxy-a', 'oxy-b');
+    await request(buildApp('oxy-b')).post(`/roommates/requests/${pending.id}/accept`);
+
+    const discover = await request(buildApp('oxy-a')).get('/roommates');
+    const requests = await request(buildApp('oxy-a')).get('/roommates/requests');
+    const relationships = await request(buildApp('oxy-a')).get('/roommates/relationships');
+    const status = await request(buildApp('oxy-a')).get('/roommates/status');
+
+    for (const res of [discover, requests, relationships, status]) {
+      expect(res.status).toBe(200);
+      expect(JSON.stringify(res.body)).not.toContain('"_id"');
+      expect(JSON.stringify(res.body)).not.toContain('"__v"');
+    }
+
+    expect(discover.body.profiles[0].id).toEqual(expect.any(String));
+    expect(requests.body.data.sent[0].sender.id).toEqual(expect.any(String));
+    expect(relationships.body.data[0].profile1.id).toEqual(expect.any(String));
+    expect(status.body.profile.id).toEqual(expect.any(String));
+  });
+
+  it('never carries another person\'s annual income or transcript', async () => {
+    // The Mongo version attached `personalProfile` verbatim to every candidate
+    // and every request participant. `personal_info_annual_income` is a
+    // PROTECTED COLUMN and the participant DTO is built at PUBLIC visibility.
+    await createRoommateProfile('oxy-me');
+    await createRoommateProfile('oxy-rich', { personalInfoAnnualIncome: 48000 });
+    await seedPendingRequest('oxy-rich', 'oxy-me');
+
+    const discover = await request(buildApp('oxy-me')).get('/roommates');
+    const requests = await request(buildApp('oxy-me')).get('/roommates/requests');
+
+    expect(JSON.stringify(discover.body)).not.toContain('48000');
+    expect(JSON.stringify(requests.body)).not.toContain('48000');
+    expect(discover.body.profiles[0].personalProfile.personalInfo).not.toHaveProperty(
+      'annualIncome',
+    );
+    expect(requests.body.data.received[0].sender.personalProfile.chatHistory).toEqual([]);
+  });
 });
 
 describe('roommateController.updateRoommatePreferences — mass-assignment guard', () => {
@@ -148,11 +325,146 @@ describe('roommateController.updateRoommatePreferences — mass-assignment guard
       });
 
     expect(res.status).toBe(200);
-    const reloaded = await Profile.findByOxyUserId('oxy-me');
-    expect(reloaded?.oxyUserId).toBe('oxy-me');
-    const prefs = reloaded?.personalProfile?.settings?.roommate?.preferences;
-    expect(prefs?.budget?.min).toBe(600);
-    expect(prefs?.budget?.max).toBe(1300);
+    const reloaded = await storedProfile('oxy-me');
+    expect(reloaded.oxyUserId).toBe('oxy-me');
+    expect(reloaded.settingsRoommatePreferencesBudgetMin).toBe(600);
+    expect(reloaded.settingsRoommatePreferencesBudgetMax).toBe(1300);
+    // The attacker's account gained nothing.
+    expect(await storedProfile('evil-inject')).toBeUndefined();
+  });
+
+  it('replaces only the fields the body names', async () => {
+    // The Mongo version `$set` one path per field, so a body naming `budget`
+    // alone left `lifestyle` alone. That is the difference from
+    // `PUT /api/profiles/me`, which sends the block and replaces it.
+    await createRoommateProfile('oxy-me');
+
+    await request(buildApp('oxy-me')).put('/roommates/preferences').send({ gender: 'female' });
+
+    const reloaded = await storedProfile('oxy-me');
+    expect(reloaded.settingsRoommatePreferencesGender).toBe('female');
+    expect(reloaded.settingsRoommatePreferencesBudgetMax).toBe(1200);
+    expect(reloaded.settingsRoommatePreferencesLifestylePets).toBe('yes');
+  });
+
+  it('round-trips location and interests, which strict mode used to discard', async () => {
+    // The whole reason migration 0008 exists. `EDITABLE_ROOMMATE_PREFERENCE_FIELDS`
+    // has always accepted both, and both were written to paths
+    // `personalProfileSchema` does not declare — so mongoose dropped them from
+    // every update and the endpoint answered 200 having stored nothing.
+    await createRoommateProfile('oxy-me');
+    const app = buildApp('oxy-me');
+
+    const put = await request(app)
+      .put('/roommates/preferences')
+      .send({ location: '  Barcelona, Gràcia  ', interests: ['Climbing', ' cooking ', ''] });
+
+    expect(put.status).toBe(200);
+    expect(put.body.data.location).toBe('Barcelona, Gràcia');
+    expect(put.body.data.interests).toEqual(['Climbing', 'cooking']);
+
+    const stored = await storedProfile('oxy-me');
+    expect(stored.settingsRoommatePreferencesLocation).toBe('Barcelona, Gràcia');
+    expect(stored.settingsRoommatePreferencesInterests).toEqual(['Climbing', 'cooking']);
+
+    const read = await request(app).get('/roommates/preferences');
+    expect(read.body.data.location).toBe('Barcelona, Gràcia');
+    expect(read.body.data.interests).toEqual(['Climbing', 'cooking']);
+  });
+
+  it('answers data: null for somebody who has stated nothing', async () => {
+    // A row full of NULLs is not the same fact as an object full of nulls:
+    // mongoose never materialised `personalProfile`, so "never answered" was
+    // `undefined` and has to stay expressible.
+    await getDb().insert(profiles).values({ oxyUserId: 'oxy-blank' });
+    const res = await request(buildApp('oxy-blank')).get('/roommates/preferences');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBeNull();
+  });
+});
+
+describe('toggleRoommateMatching', () => {
+  it('writes the flag and reports what was stored', async () => {
+    await createRoommateProfile('oxy-me', { settingsRoommateEnabled: false });
+
+    const res = await request(buildApp('oxy-me')).patch('/roommates/toggle').send({ enabled: true });
+    expect(res.status).toBe(200);
+    expect(res.body.enabled).toBe(true);
+    expect((await storedProfile('oxy-me')).settingsRoommateEnabled).toBe(true);
+  });
+
+  it('refuses a non-boolean rather than guessing', async () => {
+    await createRoommateProfile('oxy-me', { settingsRoommateEnabled: false });
+    const res = await request(buildApp('oxy-me')).patch('/roommates/toggle').send({ enabled: 'yes' });
+    expect(res.status).toBe(400);
+    expect((await storedProfile('oxy-me')).settingsRoommateEnabled).toBe(false);
+  });
+});
+
+describe('the compatibility score', () => {
+  /**
+   * The interests branch is worth 20 of the 100 points and has NEVER been able
+   * to fire: `prefs1.interests && prefs2.interests` guarded a field mongoose
+   * strict mode discarded on every write, so the scorer has been running on 80
+   * points for its whole life.
+   */
+  const lifestyle = {
+    settingsRoommatePreferencesLifestyleSmoking: 'no',
+    settingsRoommatePreferencesLifestylePets: 'yes',
+    settingsRoommatePreferencesLifestyleCleanliness: 'clean',
+    settingsRoommatePreferencesLifestyleSchedule: 'flexible',
+  } as const;
+
+  it('counts SHARED interests, and only the shared ones', async () => {
+    await createRoommateProfile('oxy-me', {
+      ...lifestyle,
+      settingsRoommatePreferencesInterests: ['climbing', 'cooking', 'music'],
+    });
+    // Two of three in common — a partial overlap, so a scorer that ignored the
+    // branch (100) and one that awarded it wholesale (100) are both visible as
+    // wrong.
+    await createRoommateProfile('oxy-partial', {
+      ...lifestyle,
+      settingsRoommatePreferencesInterests: ['climbing', 'chess', 'music'],
+    });
+    // No interests at all: the branch does not fire and the pair is scored out
+    // of the 80 points they did answer.
+    await createRoommateProfile('oxy-silent', lifestyle);
+
+    await seedPendingRequest('oxy-me', 'oxy-partial');
+    await seedPendingRequest('oxy-me', 'oxy-silent');
+
+    const res = await request(buildApp('oxy-me')).get('/roommates/requests');
+    const scoreFor = (oxyUserId: string) =>
+      (res.body.data.sent as Array<{ receiverOxyUserId: string; matchScore: number }>).find(
+        (entry) => entry.receiverOxyUserId === oxyUserId,
+      )?.matchScore;
+
+    // (20 budget + 60 lifestyle + 20 × 2/3 interests) / 100.
+    expect(scoreFor('oxy-partial')).toBe(93);
+    // (20 + 60) / 80.
+    expect(scoreFor('oxy-silent')).toBe(100);
+  });
+
+  it('scores a person who has stated nothing at 0 rather than perfectly', async () => {
+    // Two all-NULL rows agree on every `===` the scorer performs, so the naive
+    // flattening of `personalProfile` — where "did not answer" stops being
+    // representable — reads them as a 100% match. Mongo got the distinction for
+    // free (`personalProfile` was `undefined` until somebody filled the form
+    // in); here it is rebuilt by two guards in `toMatchInputs`.
+    //
+    // Mutation-tested, and the result is worth stating because it bounds what
+    // this assertion can see: the two guards are INDEPENDENTLY sufficient.
+    // Removing `hasStatedRoommatePreferences` alone leaves the suite green (the
+    // per-block presence checks still produce no factors), and making the
+    // lifestyle block unconditional alone leaves it green too (the early return
+    // fires first). Removing BOTH scores this pair 100 and turns this case red.
+    await getDb().insert(profiles).values({ oxyUserId: 'oxy-blank-a' });
+    await getDb().insert(profiles).values({ oxyUserId: 'oxy-blank-b' });
+    await seedPendingRequest('oxy-blank-a', 'oxy-blank-b');
+
+    const res = await request(buildApp('oxy-blank-a')).get('/roommates/requests');
+    expect(res.body.data.sent[0].matchScore).toBe(0);
   });
 });
 
@@ -170,6 +482,15 @@ describe('sendRoommateRequest — the pending-pair rule', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].fromOxyUserId).toBe('oxy-a');
     expect(rows[0].message).toBe('hola');
+  });
+
+  it('refuses a target who has not enabled matching', async () => {
+    await createRoommateProfile('oxy-a');
+    await createRoommateProfile('oxy-b', { settingsRoommateEnabled: false });
+
+    const res = await request(buildApp('oxy-a')).post('/roommates/oxy-b/request');
+    expect(res.status).toBe(400);
+    expect(await getDb().select().from(roommateRequests)).toHaveLength(0);
   });
 
   it('refuses a second pending request in the SAME direction with 409', async () => {
@@ -247,6 +568,8 @@ describe('respondToRoommateRequest — only the recipient, only once', () => {
     expect(relationship?.oxyUser1Id).toBe('oxy-a');
     expect(relationship?.oxyUser2Id).toBe('oxy-b');
     expect(relationship?.requestId).toBe(pending.id);
+    // Scored from the two profiles' preferences, which are identical here.
+    expect(relationship?.matchScore).toBe(100);
   });
 
   it('is idempotent — a second accept of the same request 404s and creates nothing', async () => {
@@ -317,6 +640,9 @@ describe('getRoommateRequests', () => {
     expect(res.body.data.received).toHaveLength(1);
     expect(res.body.data.sent[0].receiverOxyUserId).toBe('oxy-x');
     expect(res.body.data.received[0].senderOxyUserId).toBe('oxy-y');
+    // A participant with no profile row is a real state — the roommate tables
+    // carry Oxy account ids and no foreign key into `profiles`.
+    expect(res.body.data.sent[0].receiver).toBeNull();
   });
 });
 

--- a/packages/backend/__tests__/integration/viewingStragglers.test.ts
+++ b/packages/backend/__tests__/integration/viewingStragglers.test.ts
@@ -30,9 +30,8 @@ import { eq } from 'drizzle-orm';
 import analyticsController from '../../controllers/analyticsController';
 import { getDb } from '../../db/postgres';
 import { pruneClosedViewingsBefore } from '../../db/bookings/viewingReads';
-import { recentlyViewed, savedItems, viewingRequests } from '../../db/schema';
+import { profiles, recentlyViewed, savedItems, viewingRequests } from '../../db/schema';
 import { errorHandler } from '../../middlewares/errorHandler';
-import { Profile } from '../../models';
 import { resetGeoTables, seedListingWithGeo } from '../helpers/postgresGeoFixtures';
 
 function buildApp(oxyUserId: string): Express {
@@ -97,6 +96,7 @@ beforeEach(async () => {
   await getDb().delete(viewingRequests);
   await getDb().delete(recentlyViewed);
   await getDb().delete(savedItems);
+  await getDb().delete(profiles);
   await resetGeoTables();
 });
 
@@ -106,6 +106,7 @@ afterAll(async () => {
   await getDb().delete(viewingRequests);
   await getDb().delete(recentlyViewed);
   await getDb().delete(savedItems);
+  await getDb().delete(profiles);
   await resetGeoTables();
 });
 
@@ -148,13 +149,20 @@ describe('pruneClosedViewingsBefore — the sweep that was reaping nothing', () 
 
 describe('owner analytics — the endpoint that always returned zeros', () => {
   /**
-   * The controller still resolves a Profile before it will answer, so the test
+   * The controller still resolves a profile before it will answer, so the test
    * seeds one. That guard is untouched by this change: unlike the saved-search
    * and exchange cases, this endpoint's early return is a documented response
    * shape rather than a vestigial ownership check.
+   *
+   * It is a POSTGRES row now. The gate itself was always sound — a plain
+   * `findOne({ oxyUserId })` on a declared, indexed path — but profiles are
+   * WRITTEN to Postgres, so a Mongo read of them would answer zeros forever for
+   * anyone whose profile was created after that port landed. A fixture left on
+   * `Profile.create` would go on passing against the Mongo version and fail
+   * here, which is what it did.
    */
   async function seedProfile(oxyUserId: string) {
-    return Profile.create({ oxyUserId, personalProfile: {} });
+    return getDb().insert(profiles).values({ oxyUserId });
   }
 
   it('reports REAL numbers for views, saves and viewing requests', async () => {

--- a/packages/backend/controllers/analyticsController.ts
+++ b/packages/backend/controllers/analyticsController.ts
@@ -8,7 +8,6 @@ import type { Request, Response, NextFunction } from 'express';
 
 import { AppError, successResponse } from '../middlewares/errorHandler';
 import { logger } from '../middlewares/logging';
-import { Profile } from '../models';
 import { getDb } from '../db/postgres';
 import {
   countAppWideCatalogue,
@@ -20,6 +19,7 @@ import {
   countViewsOfProperties,
   listOwnedPropertyIds,
 } from '../db/analytics/ownerAnalytics';
+import { findProfileByOxyUserId } from '../db/profiles/profileRepository';
 import { countViewingsByStatusForOwner } from '../db/bookings/viewingReads';
 
 function errorMessage(error: unknown): string {
@@ -88,7 +88,17 @@ class AnalyticsController {
       const since = new Date(Date.now() - periodDays * DAY_MS);
 
 
-      const activeProfile = await Profile.findByOxyUserId(oxyUserId);
+      // A GATE, not a lookup: nothing below reads this row — every figure is
+      // keyed by `oxyUserId` — so its only job is "does this person have a
+      // Homiio profile at all". It is the last Mongo read in this file's own
+      // handler and it was SOUND, unlike the three defects the rest of this
+      // endpoint carried: `Profile.findByOxyUserId` is a plain
+      // `findOne({ oxyUserId })` on a declared, indexed path. It moves anyway,
+      // because profiles are WRITTEN to Postgres now — leaving it on Mongo
+      // would answer zeros forever for anyone whose profile was created after
+      // that port landed.
+      const db = getDb();
+      const activeProfile = await findProfileByOxyUserId(db, oxyUserId);
       if (!activeProfile) {
         return res.json(
           successResponse(
@@ -111,7 +121,6 @@ class AnalyticsController {
       // document, `propertyIds` was always empty, and the two guarded
       // aggregates below never ran. Every number this endpoint reported has
       // been 0 since it was written; see `db/analytics/ownerAnalytics.ts`.
-      const db = getDb();
       const propertyIds = await listOwnedPropertyIds(db, oxyUserId);
 
       const [views, savesTotal, viewingBuckets] = await Promise.all([

--- a/packages/backend/controllers/profile/profileWriteColumns.ts
+++ b/packages/backend/controllers/profile/profileWriteColumns.ts
@@ -62,6 +62,10 @@ import type {
   ProfileUpdate,
   ProfileWriteColumns,
 } from '../../db/profiles/profileRepository';
+import {
+  EDITABLE_ROOMMATE_PREFERENCE_FIELDS,
+  type EditableRoommatePreferenceField,
+} from '../roommate/editableFields';
 
 type Loose = Record<string, unknown>;
 
@@ -134,6 +138,24 @@ function asLowercasedArray(value: unknown): string[] | null {
   return value
     .filter((entry): entry is string => typeof entry === 'string')
     .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry !== '');
+}
+
+/**
+ * A free-text array, trimmed but NOT lowercased — the roommate `interests` tags.
+ *
+ * `preferredAmenities` is lowercased because Mongo declared `lowercase: true`
+ * on it and the amenity vocabulary is machine-matched. Interests are typed by
+ * people and shown back to them, and the only thing that compares them is
+ * `calculateMatchPercentage`'s exact-string intersection, which two users type
+ * consistently or not regardless of case. Folding them would be inventing a
+ * normalization the source never had.
+ */
+function asTrimmedArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  return value
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
     .filter((entry) => entry !== '');
 }
 
@@ -214,6 +236,103 @@ function toRoommateHistory(value: unknown): ProfileRoommateHistoryInput | undefi
 function mapEntries<T>(value: unknown, map: (entry: unknown) => T | undefined): T[] | undefined {
   if (!Array.isArray(value)) return undefined;
   return value.map(map).filter((entry): entry is T => entry !== undefined);
+}
+
+/**
+ * The columns for a set of roommate preference FIELDS, as the wire spells them.
+ *
+ * Two endpoints write these columns and they must coerce identically, or the
+ * same input would be stored differently depending on which one a client used:
+ * `PUT /api/profiles/me` sends the whole `settings.roommate` block (and so
+ * passes every field, replacing the lot), while
+ * `PUT /api/roommates/preferences` sends a flat, PARTIAL set and passes only
+ * the fields its allow-list picked. That difference is the `fields` argument
+ * and nothing else.
+ *
+ * The `switch` is exhaustive over {@link EditableRoommatePreferenceField}, so a
+ * field added to the allow-list without a column here fails to compile. The
+ * alternative — a lookup object, or a spread — is what let `interests` and
+ * `location` sit on the allow-list for their whole life while being written
+ * nowhere.
+ */
+export function roommatePreferenceColumns(
+  preferences: Record<string, unknown>,
+  fields: readonly EditableRoommatePreferenceField[],
+): ProfileWriteColumns {
+  const columns: ProfileWriteColumns = {};
+  for (const field of fields) {
+    switch (field) {
+      case 'ageRange': {
+        const ageRange = subtree(preferences.ageRange);
+        columns.settingsRoommatePreferencesAgeRangeMin = asNumber(ageRange.min);
+        columns.settingsRoommatePreferencesAgeRangeMax = asNumber(ageRange.max);
+        break;
+      }
+      case 'gender':
+        columns.settingsRoommatePreferencesGender = asMember(
+          preferences.gender,
+          GENDER_PREFERENCES,
+        );
+        break;
+      case 'lifestyle': {
+        const lifestyle = subtree(preferences.lifestyle);
+        columns.settingsRoommatePreferencesLifestyleSmoking = asMember(
+          lifestyle.smoking,
+          ROOMMATE_LIFESTYLE_ANSWERS,
+        );
+        columns.settingsRoommatePreferencesLifestylePets = asMember(
+          lifestyle.pets,
+          ROOMMATE_LIFESTYLE_ANSWERS,
+        );
+        columns.settingsRoommatePreferencesLifestylePartying = asMember(
+          lifestyle.partying,
+          ROOMMATE_LIFESTYLE_ANSWERS,
+        );
+        columns.settingsRoommatePreferencesLifestyleCleanliness = asMember(
+          lifestyle.cleanliness,
+          ROOMMATE_CLEANLINESS_LEVELS,
+        );
+        columns.settingsRoommatePreferencesLifestyleSchedule = asMember(
+          lifestyle.schedule,
+          ROOMMATE_SCHEDULES,
+        );
+        break;
+      }
+      case 'budget': {
+        const budget = subtree(preferences.budget);
+        columns.settingsRoommatePreferencesBudgetMin = asNumber(budget.min);
+        columns.settingsRoommatePreferencesBudgetMax = asNumber(budget.max);
+        break;
+      }
+      case 'moveInDate':
+        columns.settingsRoommatePreferencesMoveInDate = asDate(preferences.moveInDate);
+        break;
+      case 'leaseDuration':
+        columns.settingsRoommatePreferencesLeaseDuration = asMember(
+          preferences.leaseDuration,
+          LEASE_DURATIONS,
+        );
+        break;
+      // Added by migration 0008 — see `db/schema/profiles.ts` for what each one
+      // was silently discarding before the column existed.
+      case 'interests':
+        columns.settingsRoommatePreferencesInterests = asTrimmedArray(preferences.interests);
+        break;
+      case 'location':
+        columns.settingsRoommatePreferencesLocation = asTrimmed(preferences.location);
+        break;
+      default: {
+        // The exhaustiveness check that makes the paragraph above TRUE rather
+        // than aspirational: a `switch` missing a case is not an error to
+        // TypeScript on its own, so without this a field added to the allow-list
+        // would compile, be picked off the body, and be written nowhere — the
+        // exact shape of the bug `interests` and `location` were.
+        const unmapped: never = field;
+        throw new Error(`No column mapping for roommate preference field ${String(unmapped)}`);
+      }
+    }
+  }
+  return columns;
 }
 
 /**
@@ -302,42 +421,16 @@ export function toProfileUpdate(body: unknown): ProfileUpdate {
     const roommate = block(settings.roommate);
     if (roommate) {
       columns.settingsRoommateEnabled = asBoolean(roommate.enabled);
-      const roommatePreferences = subtree(roommate.preferences);
-      const ageRange = subtree(roommatePreferences.ageRange);
-      const lifestyle = subtree(roommatePreferences.lifestyle);
-      const budget = subtree(roommatePreferences.budget);
-      columns.settingsRoommatePreferencesAgeRangeMin = asNumber(ageRange.min);
-      columns.settingsRoommatePreferencesAgeRangeMax = asNumber(ageRange.max);
-      columns.settingsRoommatePreferencesGender = asMember(
-        roommatePreferences.gender,
-        GENDER_PREFERENCES,
-      );
-      columns.settingsRoommatePreferencesLifestyleSmoking = asMember(
-        lifestyle.smoking,
-        ROOMMATE_LIFESTYLE_ANSWERS,
-      );
-      columns.settingsRoommatePreferencesLifestylePets = asMember(
-        lifestyle.pets,
-        ROOMMATE_LIFESTYLE_ANSWERS,
-      );
-      columns.settingsRoommatePreferencesLifestylePartying = asMember(
-        lifestyle.partying,
-        ROOMMATE_LIFESTYLE_ANSWERS,
-      );
-      columns.settingsRoommatePreferencesLifestyleCleanliness = asMember(
-        lifestyle.cleanliness,
-        ROOMMATE_CLEANLINESS_LEVELS,
-      );
-      columns.settingsRoommatePreferencesLifestyleSchedule = asMember(
-        lifestyle.schedule,
-        ROOMMATE_SCHEDULES,
-      );
-      columns.settingsRoommatePreferencesBudgetMin = asNumber(budget.min);
-      columns.settingsRoommatePreferencesBudgetMax = asNumber(budget.max);
-      columns.settingsRoommatePreferencesMoveInDate = asDate(roommatePreferences.moveInDate);
-      columns.settingsRoommatePreferencesLeaseDuration = asMember(
-        roommatePreferences.leaseDuration,
-        LEASE_DURATIONS,
+      // EVERY field, because this is the block-replacement path: a block the
+      // body carries contributes all of its columns, including the ones the
+      // client omitted, which are written NULL. Passing a subset here would
+      // make "clear my roommate budget" inexpressible.
+      Object.assign(
+        columns,
+        roommatePreferenceColumns(
+          subtree(roommate.preferences),
+          EDITABLE_ROOMMATE_PREFERENCE_FIELDS,
+        ),
       );
       update.roommateHistory = mapEntries(roommate.history, toRoommateHistory) ?? [];
     }

--- a/packages/backend/controllers/roommate/editableFields.ts
+++ b/packages/backend/controllers/roommate/editableFields.ts
@@ -1,18 +1,31 @@
 /**
  * Mass-assignment protection for the roommate preferences write endpoint.
  *
- * `updateRoommatePreferences` must NEVER spread `req.body` into the Mongoose
- * update: the profile document also holds owner/system fields (`oxyUserId`,
- * verification, …) that a client
- * must not be able to reach through the roommate settings endpoint. The
- * controller instead picks ONLY the roommate-matching preference fields listed
- * here and writes them under `personalProfile.settings.roommate.preferences`.
+ * `updateRoommatePreferences` must NEVER spread `req.body` into the update: the
+ * profile row also holds owner/system fields (`oxyUserId`, verification, the
+ * privacy flags, the protected annual income) that a client must not be able to
+ * reach through the roommate settings endpoint. The controller picks ONLY the
+ * fields listed here and maps each one to a column through
+ * `controllers/profile/profileWriteColumns.ts`.
  *
- * Keep this in sync with `RoommatePreferences.preferences` in
- * `packages/shared-types/src/profile.ts` (plus the `interests`/`location`
- * matching inputs the controller's compatibility score reads).
+ * ## This tuple is now the ONE list, and that closes a real hole
+ *
+ * It used to be a `readonly string[]` read only by `pickFields`, with a comment
+ * asking the reader to keep it in sync with two other places by hand. It did
+ * not stay in sync: `interests` and `location` were on it, were sent by the
+ * client, and were written to `personalProfile.settings.roommate.preferences.*`
+ * — paths `personalProfileSchema` never declared, so mongoose strict mode
+ * discarded both on every save, silently, for as long as the endpoint has
+ * existed.
+ *
+ * As a `const` tuple it is also the domain of
+ * `roommatePreferenceColumns`, whose `switch` is exhaustive over
+ * {@link EditableRoommatePreferenceField}. A field added here with no column
+ * mapping is now a COMPILE error rather than a write that reports success and
+ * stores nothing — which is exactly the failure this file spent its life
+ * demonstrating.
  */
-export const EDITABLE_ROOMMATE_PREFERENCE_FIELDS: readonly string[] = [
+export const EDITABLE_ROOMMATE_PREFERENCE_FIELDS = [
   'ageRange',
   'gender',
   'lifestyle',
@@ -21,4 +34,7 @@ export const EDITABLE_ROOMMATE_PREFERENCE_FIELDS: readonly string[] = [
   'leaseDuration',
   'interests',
   'location',
-];
+] as const;
+
+export type EditableRoommatePreferenceField =
+  (typeof EDITABLE_ROOMMATE_PREFERENCE_FIELDS)[number];

--- a/packages/backend/controllers/roommate/matching.ts
+++ b/packages/backend/controllers/roommate/matching.ts
@@ -1,0 +1,156 @@
+/**
+ * Roommate compatibility scoring, over Postgres profile rows.
+ *
+ * Pure, and separate from the controller for that reason: the score is
+ * arithmetic on two people's stated preferences and needs neither a request nor
+ * a database to be exercised.
+ *
+ * ## "Has this person stated any preference at all?" is a real question here
+ *
+ * In Mongo it answered itself. `personalProfile` was declared with no `default`,
+ * so mongoose never materialised it and `prefsOf(profile)` was `undefined` for
+ * anybody who had not filled the form in — which is what
+ * `calculateMatchPercentage`'s `if (!prefs1 || !prefs2) return 0` reads. Flatten
+ * the block into columns and that distinction has nowhere to live unless it is
+ * rebuilt: an all-NULL row would otherwise present as a preferences object whose
+ * every field happens to be empty, and two such people would score against each
+ * other as though they had answered.
+ *
+ * So {@link toMatchInputs} returns `undefined` when NO roommate preference
+ * column is set, and each sub-block is present only when one of ITS columns is —
+ * reproducing exactly which branches of the scorer used to fire.
+ *
+ * ## The scorer's own quirks are carried VERBATIM, with one exception
+ *
+ * Two people who both left `smoking` unanswered score 15 points for agreeing,
+ * because the comparison is `===` on two absent values — `undefined ===
+ * undefined` in Mongo, `null === null` here. That is the same answer the same
+ * arithmetic has always given and it is not this port's to change.
+ *
+ * The exception is forced rather than chosen. `interests` has never been
+ * storable (see `db/schema/profiles.ts`), so the branch that divides by
+ * `Math.max(len1, len2)` has never run; with the column added it can, and two
+ * EMPTY lists would divide by zero and put `NaN` on the wire — `JSON.stringify`
+ * renders that as `null`, so a client would read "no score" rather than an
+ * error. An empty list is therefore treated as an unstated one.
+ */
+
+import {
+  hasStatedRoommatePreferences,
+  type ProfileRow,
+} from '../../db/profiles/profileSerializer';
+
+/**
+ * The four facts the score is computed from.
+ *
+ * Deliberately NOT the whole preferences DTO: this type exists so a reader can
+ * see at a glance what can move a score, and so a field added to the wire shape
+ * cannot start affecting compatibility without somebody deciding it should.
+ */
+export interface RoommateMatchInputs {
+  readonly budget?: { readonly min: number | null; readonly max: number | null };
+  readonly lifestyle?: {
+    readonly smoking: string | null;
+    readonly pets: string | null;
+    readonly cleanliness: string | null;
+    readonly schedule: string | null;
+  };
+  readonly interests?: readonly string[];
+}
+
+/**
+ * The scoring inputs for a profile row, or `undefined` when the person has
+ * stated no roommate preference at all.
+ *
+ * `enabled` is deliberately not consulted: it says whether they want to appear
+ * in the feed, not what they are looking for, and a candidate can be scored
+ * without it (the two request lists score people who may since have switched
+ * matching off).
+ */
+export function toMatchInputs(profile: ProfileRow): RoommateMatchInputs | undefined {
+  // The same question `GET /api/roommates/preferences` answers `null` to, and
+  // deliberately the same function: "this person stated nothing" must not be
+  // true for one endpoint and false for the other.
+  if (!hasStatedRoommatePreferences(profile)) return undefined;
+
+  const budgetStated =
+    profile.settingsRoommatePreferencesBudgetMin !== null ||
+    profile.settingsRoommatePreferencesBudgetMax !== null;
+  const lifestyleStated =
+    profile.settingsRoommatePreferencesLifestyleSmoking !== null ||
+    profile.settingsRoommatePreferencesLifestylePets !== null ||
+    profile.settingsRoommatePreferencesLifestylePartying !== null ||
+    profile.settingsRoommatePreferencesLifestyleCleanliness !== null ||
+    profile.settingsRoommatePreferencesLifestyleSchedule !== null;
+  const interests = profile.settingsRoommatePreferencesInterests ?? [];
+
+  return {
+    ...(budgetStated
+      ? {
+          budget: {
+            min: profile.settingsRoommatePreferencesBudgetMin,
+            max: profile.settingsRoommatePreferencesBudgetMax,
+          },
+        }
+      : {}),
+    ...(lifestyleStated
+      ? {
+          lifestyle: {
+            smoking: profile.settingsRoommatePreferencesLifestyleSmoking,
+            pets: profile.settingsRoommatePreferencesLifestylePets,
+            cleanliness: profile.settingsRoommatePreferencesLifestyleCleanliness,
+            schedule: profile.settingsRoommatePreferencesLifestyleSchedule,
+          },
+        }
+      : {}),
+    ...(interests.length > 0 ? { interests } : {}),
+  };
+}
+
+/**
+ * A 0-100 compatibility percentage between two people's stated preferences.
+ *
+ * Scored out of the factors BOTH sides stated, so a pair who only ever
+ * discussed budget is scored out of 20 rather than penalised for the 80 points
+ * neither of them answered.
+ */
+export function calculateMatchPercentage(
+  first: RoommateMatchInputs | undefined,
+  second: RoommateMatchInputs | undefined,
+): number {
+  if (!first || !second) return 0;
+
+  let matchScore = 0;
+  let totalFactors = 0;
+
+  if (first.budget && second.budget) {
+    const max1 = first.budget.max ?? 0;
+    const max2 = second.budget.max ?? 0;
+    const min1 = first.budget.min ?? 0;
+    const min2 = second.budget.min ?? 0;
+    if (Math.min(max1, max2) - Math.max(min1, min2) > 0) {
+      matchScore += 20;
+    }
+    totalFactors += 20;
+  }
+
+  if (first.lifestyle && second.lifestyle) {
+    if (first.lifestyle.smoking === second.lifestyle.smoking) matchScore += 15;
+    if (first.lifestyle.pets === second.lifestyle.pets) matchScore += 15;
+    if (first.lifestyle.cleanliness === second.lifestyle.cleanliness) matchScore += 15;
+    if (first.lifestyle.schedule === second.lifestyle.schedule) matchScore += 15;
+    totalFactors += 60;
+  }
+
+  // Reachable for the first time: the column this reads was added by migration
+  // 0008, and `toMatchInputs` guarantees both lists are non-empty so the
+  // denominator cannot be zero.
+  if (first.interests && second.interests) {
+    const theirs = new Set(second.interests);
+    const common = first.interests.filter((interest) => theirs.has(interest)).length;
+    matchScore += (common / Math.max(first.interests.length, second.interests.length)) * 20;
+    totalFactors += 20;
+  }
+
+  return totalFactors > 0 ? Math.round((matchScore / totalFactors) * 100) : 0;
+}

--- a/packages/backend/controllers/roommate/serialize.ts
+++ b/packages/backend/controllers/roommate/serialize.ts
@@ -3,6 +3,7 @@
  */
 
 import config from '../../config';
+import { type HydratedProfile, toProfileDTO } from '../../db/profiles/profileSerializer';
 import { logger } from '../../middlewares/logging';
 
 /**
@@ -11,9 +12,9 @@ import { logger } from '../../middlewares/logging';
  * The `_id` here is deliberate and must NOT be renamed by a sweep of Homiio's
  * own `_id` → `id` cut. This is a foreign service's response shape, not Homiio's
  * wire: Oxy decides what it sends, and editing this declaration would only make
- * Homiio stop reading a field Oxy still emits. It is also never re-served — the
- * payload is projected into {@link SerializedRoommateProfile} below and the raw
- * object never reaches `res.json`.
+ * Homiio stop reading a field Oxy still emits. It is also never re-served —
+ * {@link hydrateDisplayNames} keeps the display name and nothing else, so the
+ * raw object never reaches `res.json`.
  */
 interface OxyPublicUser {
   id?: string;
@@ -21,21 +22,6 @@ interface OxyPublicUser {
   username?: string;
   name?: { displayName?: string };
 }
-
-export interface SerializedRoommateProfile {
-  id: string;
-  oxyUserId?: string;
-  displayName?: string;
-  personalProfile?: unknown;
-}
-
-export interface PopulatedProfileLike {
-  _id: unknown;
-  oxyUserId?: string;
-  personalProfile?: unknown;
-}
-
-export const ROOMMATE_PROFILE_FIELDS = 'oxyUserId personalProfile';
 
 const USERS_BY_IDS_CAP = 100;
 
@@ -90,18 +76,39 @@ export async function hydrateDisplayNames(
   return result;
 }
 
+/**
+ * One participant of a request or a relationship, as the roommate screens read
+ * them.
+ *
+ * ## The whole DTO comes from `toProfileDTO`, at PUBLIC visibility
+ *
+ * Two things follow from that, and both are changes:
+ *
+ *  - **`id` is the profile row id and there is no `_id`.** The Mongoose
+ *    `toJSON` transform renamed `_id` → `id` and stripped `__v`; these
+ *    endpoints bypassed it (they `.lean()`-ed and re-projected by hand), so the
+ *    rename is applied here rather than lost with the transform. `__v` has no
+ *    Postgres counterpart to leak.
+ *  - **A stranger no longer receives the whole profile document.** The Mongo
+ *    version attached `personalProfile` verbatim — annual income, references,
+ *    landlord phone numbers and the Sindi transcript included — to everybody
+ *    who had ever sent or received a request. `toProfileDTO(…, 'public')`
+ *    applies the same privacy flags `/api/public/profiles/*` does, and the
+ *    income column is unreachable at the TYPE level.
+ *
+ * `displayName` is hydrated from Oxy and is not part of the stored profile,
+ * which is why it is spread on here rather than being a column.
+ */
 export function serializeRoommateProfile(
-  profile: PopulatedProfileLike | null | undefined,
+  hydrated: HydratedProfile | null | undefined,
   displayNames: Map<string, string>,
-): SerializedRoommateProfile | null {
-  if (!profile) {
+): Record<string, unknown> | null {
+  if (!hydrated) {
     return null;
   }
-  const oxyUserId = profile.oxyUserId ? String(profile.oxyUserId) : undefined;
+  const { oxyUserId } = hydrated.profile;
   return {
-    id: String(profile._id),
-    oxyUserId,
-    displayName: oxyUserId ? displayNames.get(oxyUserId) : undefined,
-    personalProfile: profile.personalProfile,
+    ...toProfileDTO(hydrated, 'public'),
+    displayName: displayNames.get(oxyUserId),
   };
 }

--- a/packages/backend/controllers/roommateController.ts
+++ b/packages/backend/controllers/roommateController.ts
@@ -1,14 +1,61 @@
 /**
- * Roommate Controller
- * Handles roommate matching operations with Oxy user data integration
+ * Roommate matching — discovery, preferences, the request handshake and the
+ * relationships it produces.
+ *
+ * `roommate_requests` and `roommate_relationships` moved to Postgres with the
+ * roommate batch; this file finishes the job by moving the PROFILE reads that
+ * sat beside them. Until now they read Mongo `profiles` while every profile
+ * WRITE already went to Postgres, so the two stores had begun to diverge: a
+ * preference saved through `PUT /api/profiles/me` was invisible to every
+ * roommate endpoint, and a preference saved through this controller was
+ * invisible to the profile screen.
+ *
+ * ## Three filters here matched NOTHING, and are repaired rather than ported
+ *
+ * `getRoommateProfiles` filtered on `personalProfile.gender`,
+ * `personalProfile.location` and `personalProfile.dateOfBirth`.
+ * `personalProfileSchema` declares none of them, and `database/connection.ts`
+ * sets `strictQuery: false`, so mongoose passed all three through to MongoDB
+ * rather than stripping them — where they matched no document, because strict
+ * mode (which is ON for writes) meant nothing had ever been stored at those
+ * paths. `?gender=`, `?location=` and `?ageRange=` have therefore returned an
+ * empty page for the whole life of the feature.
+ *
+ * `db/profiles/profileRepository.ts`'s `roommateCandidateFilter` carries what
+ * each one means now. The short version: gender and ageRange are re-pointed at
+ * the roommate PREFERENCE the product really stores, and `location` gets a
+ * column, because the write allow-list had been accepting a field mongoose was
+ * discarding.
+ *
+ * ## Two behaviour changes worth stating out loud
+ *
+ *  - **A malformed filter is a 400 rather than a 500 or an empty page.**
+ *    `JSON.parse(String(ageRange))` threw into the catch-all and answered 500;
+ *    `parseInt('abc')` for `maxBudget` produced `NaN`, and `x >= NaN` is false,
+ *    so a typo silently emptied the feed.
+ *  - **A participant profile is serialized at PUBLIC visibility.** The request
+ *    and relationship lists used to attach `personalProfile` verbatim — annual
+ *    income, references, landlord phone numbers, the Sindi transcript — to
+ *    anybody who had exchanged a request. See `roommate/serialize.ts`.
  */
 
 import type { Request, Response } from 'express';
-import type { PopulatedProfileLike } from './roommate/serialize';
-import type { IProfile } from '../models/documentTypes';
 
-import { Profile } from '../models';
 import { getDb } from '../db/postgres';
+import {
+  findHydratedProfilesByOxyUserIds,
+  findProfileByOxyUserId,
+  searchRoommateCandidates,
+  updateProfile,
+  type RoommateCandidateQuery,
+} from '../db/profiles/profileRepository';
+import {
+  hasStatedRoommatePreferences,
+  toProfileDTO,
+  toRoommatePreferencesDTO,
+  type HydratedProfile,
+} from '../db/profiles/profileSerializer';
+import { GENDER_PREFERENCES } from '../db/schema/profiles';
 import {
   createRoommateRequest,
   endRoommateRelationship as endRelationshipRow,
@@ -25,8 +72,13 @@ import {
 import { logger } from '../middlewares/logging';
 import { notificationDispatchService } from '../services/notificationDispatchService';
 import { pickFields } from '../utils/pickFields';
-import { EDITABLE_ROOMMATE_PREFERENCE_FIELDS } from './roommate/editableFields';
-import { ROOMMATE_PROFILE_FIELDS, hydrateDisplayNames, serializeRoommateProfile } from './roommate/serialize';
+import { roommatePreferenceColumns } from './profile/profileWriteColumns';
+import {
+  EDITABLE_ROOMMATE_PREFERENCE_FIELDS,
+  type EditableRoommatePreferenceField,
+} from './roommate/editableFields';
+import { calculateMatchPercentage, toMatchInputs } from './roommate/matching';
+import { hydrateDisplayNames, serializeRoommateProfile } from './roommate/serialize';
 
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -41,166 +93,163 @@ function resolveOxyUserId(req: Request): string | undefined {
 }
 
 /**
- * Domain shape of the roommate-matching slice stored under
- * `IProfile.personalProfile.settings.roommate`. The schema persists this as a
- * Mixed subdocument, so we re-declare the bits this controller actually
- * touches and narrow at the read boundary (see `getRoommatePrefs` below).
+ * A page of candidates is hydrated (five child reads per page), so an uncapped
+ * `?limit=` is a request a client can make arbitrarily expensive. Mongo's
+ * `.limit()` took whatever arrived, including a negative number that would make
+ * the Postgres `OFFSET` invalid.
  */
-interface RoommatePreferences {
-  budget?: { min?: number; max?: number };
-  lifestyle?: {
-    pets?: string;
-    smoking?: string;
-    [key: string]: unknown;
-  };
-  ageRange?: { min?: number; max?: number };
-  gender?: string;
-  moveInDate?: string;
-  leaseDuration?: string;
-  interests?: string[];
-  location?: string;
-  enabled?: boolean;
-  [key: string]: unknown;
+const MAX_DISCOVER_PAGE_SIZE = 100;
+const DEFAULT_DISCOVER_PAGE_SIZE = 20;
+
+/** A rejected filter value, carrying the message the client is answered with. */
+class InvalidFilterError extends Error {}
+
+function positiveInteger(value: unknown, fallback: number, cap?: number): number {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+  return cap === undefined ? parsed : Math.min(parsed, cap);
 }
 
-interface RoommateSlice {
-  enabled?: boolean;
-  preferences?: RoommatePreferences;
+/**
+ * The candidate filters, off the query string.
+ *
+ * Every malformed value is refused rather than ignored: a filter the API cannot
+ * mean is a client mistake, and answering it with an unfiltered page (or, as
+ * `maxBudget` did, with an empty one) hides the mistake behind a plausible
+ * result. `gender=any` is not a filter — it is the absence of one, which is
+ * what the value means in `RoommateFilters` and in the stored vocabulary.
+ *
+ * @throws {InvalidFilterError} With a message naming the offending parameter.
+ */
+function parseCandidateFilters(
+  query: Request['query'],
+  excludeOxyUserId: string,
+  limit: number,
+  offset: number,
+): RoommateCandidateQuery {
+  const filters: {
+    -readonly [K in keyof RoommateCandidateQuery]: RoommateCandidateQuery[K];
+  } = { excludeOxyUserId, limit, offset };
+
+  const gender = query.gender;
+  if (typeof gender === 'string' && gender !== '' && gender !== 'any') {
+    const member = GENDER_PREFERENCES.find((value) => value === gender);
+    if (!member) {
+      throw new InvalidFilterError(`gender must be one of ${GENDER_PREFERENCES.join(', ')}`);
+    }
+    filters.gender = member;
+  }
+
+  const location = query.location;
+  if (typeof location === 'string' && location.trim() !== '') {
+    filters.location = location.trim();
+  }
+
+  if (query.ageRange !== undefined && query.ageRange !== '') {
+    filters.ageRange = parseAgeRange(query.ageRange);
+  }
+
+  if (query.maxBudget !== undefined && query.maxBudget !== '') {
+    const maxBudget = Number(query.maxBudget);
+    if (!Number.isFinite(maxBudget)) {
+      throw new InvalidFilterError('maxBudget must be a number');
+    }
+    filters.maxBudget = maxBudget;
+  }
+
+  // Both arrive as the strings the client's query serializer produced.
+  filters.withPets = query.withPets === 'true';
+  filters.nonSmoking = query.nonSmoking === 'true';
+
+  return filters;
 }
 
-interface PersonalProfileShape {
-  settings?: { roommate?: RoommateSlice } & Record<string, unknown>;
-  [key: string]: unknown;
+/** `?ageRange={"min":25,"max":30}`, the shape the client's serializer sends. */
+function parseAgeRange(raw: unknown): { min: number; max: number } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(String(raw));
+  } catch {
+    throw new InvalidFilterError('ageRange must be JSON of the form {"min":25,"max":30}');
+  }
+  const range = parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+  const min = Number(range.min);
+  const max = Number(range.max);
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    throw new InvalidFilterError('ageRange must carry numeric min and max');
+  }
+  return { min, max };
 }
 
-/** Read the `personalProfile` slice with the controller's domain shape. */
-const personalOf = (profile: unknown): PersonalProfileShape | undefined => {
-  if (!profile || typeof profile !== 'object') return undefined;
-  const slice = (profile as { personalProfile?: unknown }).personalProfile;
-  return (slice ?? undefined) as PersonalProfileShape | undefined;
-};
-
-/** Preferences for a (possibly populated) profile ref, for match scoring. */
-const prefsOf = (profile: unknown): RoommatePreferences | undefined =>
-  personalOf(profile)?.settings?.roommate?.preferences;
-
-// Get all roommate profiles with enriched Oxy user data
+/**
+ * Candidate profiles with roommate matching enabled, scored against the
+ * caller's own stated preferences.
+ *
+ * `minMatchPercentage` is the one filter that cannot be a `WHERE` clause: the
+ * score is computed from the caller's preferences against each candidate's, so
+ * it is applied to the page after it comes back — which is where every one of
+ * these filters used to run. The consequence is stated rather than hidden: a
+ * page can come back shorter than `total` implies when that parameter is used.
+ */
 const getRoommateProfiles = async (req: Request, res: Response): Promise<Response | void> => {
   try {
-    const { page = 1, limit = 20, minMatchPercentage, maxBudget, withPets, nonSmoking, ageRange, gender, location } = req.query;
-
     const oxyUserId = resolveOxyUserId(req);
     if (!oxyUserId) {
       return res.status(401).json({ error: 'Authentication required' });
     }
 
-    // Resolve the caller's active profile server-side so we can exclude it and
-    // score candidates against its preferences.
-    const currentProfile = await Profile.findByOxyUserId(oxyUserId);
+    const db = getDb();
+    // The caller's profile is resolved from the SESSION, never from a body or a
+    // query parameter — `AGENTS.md`'s rule, and the reason the repository is
+    // keyed by `oxyUserId` rather than by a profile id.
+    const currentProfile = await findProfileByOxyUserId(db, oxyUserId);
     if (!currentProfile) {
       return res.status(404).json({ error: 'Profile not found' });
     }
 
-    // Build base query for personal profiles with roommate matching enabled
-    const query: Record<string, unknown> = {
-      'personalProfile.settings.roommate.enabled': true,
-      oxyUserId: { $ne: oxyUserId },
-    };
+    const page = positiveInteger(req.query.page, 1);
+    const limit = positiveInteger(
+      req.query.limit,
+      DEFAULT_DISCOVER_PAGE_SIZE,
+      MAX_DISCOVER_PAGE_SIZE,
+    );
 
-    // Add basic filters that apply to profile data (not preferences)
-    if (gender && gender !== 'any') {
-      query['personalProfile.gender'] = gender;
+    let filters: RoommateCandidateQuery;
+    try {
+      filters = parseCandidateFilters(req.query, oxyUserId, limit, (page - 1) * limit);
+    } catch (error) {
+      if (error instanceof InvalidFilterError) {
+        return res.status(400).json({ error: error.message });
+      }
+      throw error;
     }
 
-    if (location) {
-      query['personalProfile.location'] = { $regex: location, $options: 'i' };
-    }
+    const { candidates, total } = await searchRoommateCandidates(db, filters);
 
-    if (ageRange) {
-      const { min, max } = JSON.parse(String(ageRange)) as { min: number; max: number };
-      const currentYear = new Date().getFullYear();
-      query['personalProfile.dateOfBirth'] = {
-        $gte: new Date(currentYear - max, 0, 1),
-        $lte: new Date(currentYear - min, 11, 31)
-      };
-    }
-
-    const pageNum = parseInt(String(page), 10) || 1;
-    const limitNum = parseInt(String(limit), 10) || 20;
-    const skip = (pageNum - 1) * limitNum;
-
-    const profiles = await Profile.find(query)
-      .skip(skip)
-      .limit(limitNum)
-      .sort({ updatedAt: -1 });
-
-    const total = await Profile.countDocuments(query);
-    const totalPages = Math.ceil(total / limitNum);
-
-    const currentUserPrefs = prefsOf(currentProfile);
-
-    type EnrichedProfile = Record<string, unknown> & { matchPercentage: number };
-    let profilesWithMatches: EnrichedProfile[] = profiles.map((profile: IProfile) => ({
-      ...profile.toObject(),
-      matchPercentage: 0,
+    const mine = toMatchInputs(currentProfile);
+    let scored = candidates.map((candidate) => ({
+      ...toProfileDTO(candidate, 'public'),
+      matchPercentage: calculateMatchPercentage(mine, toMatchInputs(candidate.profile)),
     }));
 
-    if (currentUserPrefs) {
-      profilesWithMatches = profiles.map((profile: IProfile) => {
-        const profilePrefs = prefsOf(profile);
-        const matchPercentage = calculateMatchPercentage(currentUserPrefs, profilePrefs);
-
-        return {
-          ...profile.toObject(),
-          matchPercentage,
-        };
-      });
-
-      // Apply preference-based filters
-      if (maxBudget) {
-        const budget = parseInt(String(maxBudget), 10);
-        profilesWithMatches = profilesWithMatches.filter((profile) => {
-          const profilePrefs = personalOf(profile)?.settings?.roommate?.preferences;
-          const profileMax = profilePrefs?.budget?.max;
-          if (typeof profileMax !== 'number') return true;
-          return profileMax >= budget;
-        });
+    const minMatchPercentage = req.query.minMatchPercentage;
+    if (minMatchPercentage !== undefined && minMatchPercentage !== '') {
+      const threshold = Number(minMatchPercentage);
+      if (!Number.isFinite(threshold)) {
+        return res.status(400).json({ error: 'minMatchPercentage must be a number' });
       }
-
-      if (withPets === 'true') {
-        profilesWithMatches = profilesWithMatches.filter((profile) => {
-          const profilePrefs = personalOf(profile)?.settings?.roommate?.preferences;
-          if (!profilePrefs?.lifestyle?.pets) return true;
-          return profilePrefs.lifestyle.pets === 'yes';
-        });
-      }
-
-      if (nonSmoking === 'true') {
-        profilesWithMatches = profilesWithMatches.filter((profile) => {
-          const profilePrefs = personalOf(profile)?.settings?.roommate?.preferences;
-          if (!profilePrefs?.lifestyle?.smoking) return true;
-          return profilePrefs.lifestyle.smoking === 'no';
-        });
-      }
-
-      // Filter by minimum match percentage if specified
-      if (minMatchPercentage) {
-        const minPct = parseInt(String(minMatchPercentage), 10);
-        profilesWithMatches = profilesWithMatches.filter(
-          (profile) => profile.matchPercentage >= minPct,
-        );
-      }
-
-      // Sort by match percentage
-      profilesWithMatches.sort((a, b) => b.matchPercentage - a.matchPercentage);
+      scored = scored.filter((candidate) => candidate.matchPercentage >= threshold);
     }
 
-    // No Oxy enrichment, just return profiles
+    // A stable sort, so candidates who score the same keep the `updated_at`
+    // order the query returned them in.
+    scored.sort((first, second) => second.matchPercentage - first.matchPercentage);
+
     res.json({
-      profiles: profilesWithMatches,
+      profiles: scored,
       total,
-      page: pageNum,
-      totalPages
+      page,
+      totalPages: Math.ceil(total / limit),
     });
   } catch (error) {
     logger.error('Failed to fetch roommate profiles', { error: errorMessage(error) });
@@ -212,69 +261,73 @@ const getRoommateProfiles = async (req: Request, res: Response): Promise<Respons
 const getMyRoommatePreferences = async (req: Request, res: Response): Promise<Response | void> => {
   try {
     const oxyUserId = resolveOxyUserId(req);
-
     if (!oxyUserId) {
       return res.status(401).json({ error: 'Authentication required' });
     }
 
-    // Get user's active profile
-    const profile = await Profile.findByOxyUserId(oxyUserId);
-
+    const profile = await findProfileByOxyUserId(getDb(), oxyUserId);
     if (!profile) {
       return res.status(404).json({ error: 'Profile not found' });
     }
 
-    const prefs = personalOf(profile)?.settings?.roommate?.preferences;
-    if (!prefs) {
-      return res.json({ data: null });
-    }
-
-    res.json({ data: prefs });
+    // `null` means "never answered", and it is a different answer from an
+    // object full of nulls — see `hasStatedRoommatePreferences`.
+    res.json({
+      data: hasStatedRoommatePreferences(profile) ? toRoommatePreferencesDTO(profile) : null,
+    });
   } catch (error) {
     logger.error('Failed to fetch roommate preferences', { error: errorMessage(error) });
     res.status(500).json({ error: 'Failed to fetch roommate preferences' });
   }
 };
 
-// Update roommate preferences
+/**
+ * Update the caller's roommate preferences.
+ *
+ * PARTIAL at the field level, which is what the Mongo version's per-path `$set`
+ * did: a body naming `budget` alone must not blank `lifestyle`. That is the
+ * whole difference from `PUT /api/profiles/me`, which sends the block and
+ * replaces it — and it is expressed by WHICH fields are passed to
+ * `roommatePreferenceColumns`, not by a second mapping.
+ */
 const updateRoommatePreferences = async (req: Request, res: Response): Promise<Response | void> => {
   try {
     const oxyUserId = resolveOxyUserId(req);
-
     if (!oxyUserId) {
       return res.status(401).json({ error: 'Authentication required' });
     }
 
-    // Get user's active profile
-    const profile = await Profile.findByOxyUserId(oxyUserId);
-
+    const db = getDb();
+    const profile = await findProfileByOxyUserId(db, oxyUserId);
     if (!profile) {
       return res.status(404).json({ error: 'Profile not found' });
     }
 
-    const picked = pickFields<RoommatePreferences>(
+    const picked = pickFields<Record<string, unknown>>(
       req.body,
       EDITABLE_ROOMMATE_PREFERENCE_FIELDS,
     );
-
-    const updateData: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(picked)) {
-      updateData[`personalProfile.settings.roommate.preferences.${key}`] = value;
-    }
-    if (typeof req.body?.enabled === 'boolean') {
-      updateData['personalProfile.settings.roommate.enabled'] = req.body.enabled;
-    }
-
-    const updatedProfile = await Profile.findByIdAndUpdate(
-      profile._id,
-      updateData,
-      { new: true }
+    // Filtered from the tuple rather than read off `Object.keys(picked)`, so the
+    // field names stay the literal union the mapper switches over instead of
+    // being cast back to it.
+    const present: EditableRoommatePreferenceField[] = EDITABLE_ROOMMATE_PREFERENCE_FIELDS.filter(
+      (field) => field in picked,
     );
+    const columns = roommatePreferenceColumns(picked, present);
+    if (typeof req.body?.enabled === 'boolean') {
+      columns.settingsRoommateEnabled = req.body.enabled;
+    }
 
-    const updatedRoommate = personalOf(updatedProfile)?.settings?.roommate;
+    // ONE transaction: `updateProfile` issues several statements, and a partial
+    // application would leave the person's preferences in a state that was
+    // never saved.
+    const updated = await db.transaction((tx) => updateProfile(tx, oxyUserId, { columns }));
+
     res.json({
-      data: updatedRoommate?.preferences ?? null,
-      enabled: updatedRoommate?.enabled ?? false,
+      data: hasStatedRoommatePreferences(updated.profile)
+        ? toRoommatePreferencesDTO(updated.profile)
+        : null,
+      enabled: updated.profile.settingsRoommateEnabled ?? false,
     });
   } catch (error) {
     logger.error('Failed to update roommate preferences', { error: errorMessage(error) });
@@ -282,32 +335,37 @@ const updateRoommatePreferences = async (req: Request, res: Response): Promise<R
   }
 };
 
-// Toggle roommate matching
+/**
+ * Turn roommate matching on or off.
+ *
+ * A non-boolean `enabled` is a 400. Mongoose CAST whatever arrived to the
+ * column's declared Boolean and stored the result, so `'yes'` was an error and
+ * `'true'` was silently a `true`; the sibling handler above already treats a
+ * non-boolean `enabled` as "not provided". For an endpoint whose entire payload
+ * is that one flag, guessing is worse than saying so.
+ */
 const toggleRoommateMatching = async (req: Request, res: Response): Promise<Response | void> => {
   try {
-    const { enabled } = req.body;
     const oxyUserId = resolveOxyUserId(req);
-
     if (!oxyUserId) {
       return res.status(401).json({ error: 'Authentication required' });
     }
 
-    // Get user's active profile
-    const profile = await Profile.findByOxyUserId(oxyUserId);
+    const { enabled } = req.body ?? {};
+    if (typeof enabled !== 'boolean') {
+      return res.status(400).json({ error: 'enabled must be a boolean' });
+    }
 
+    const db = getDb();
+    const profile = await findProfileByOxyUserId(db, oxyUserId);
     if (!profile) {
       return res.status(404).json({ error: 'Profile not found' });
     }
 
-    const updateData = {
-      'personalProfile.settings.roommate.enabled': enabled,
-    };
-
-    const updatedProfile = await Profile.findByIdAndUpdate(profile._id, updateData, { new: true });
-
-    const updatedEnabled = Boolean(
-      personalOf(updatedProfile)?.settings?.roommate?.enabled,
+    const updated = await db.transaction((tx) =>
+      updateProfile(tx, oxyUserId, { columns: { settingsRoommateEnabled: enabled } }),
     );
+    const updatedEnabled = updated.profile.settingsRoommateEnabled ?? false;
 
     res.json({
       message: `Roommate matching ${updatedEnabled ? 'enabled' : 'disabled'} successfully`,
@@ -319,27 +377,44 @@ const toggleRoommateMatching = async (req: Request, res: Response): Promise<Resp
   }
 };
 
+/**
+ * The participant profiles and Oxy display names for a set of Oxy account ids.
+ *
+ * One batched profile read for the whole list rather than one per participant,
+ * and one `POST /users/by-ids` beside it — the two lists below are the only
+ * callers and both need exactly this pair.
+ */
+async function loadParticipants(oxyUserIds: readonly string[]): Promise<{
+  profiles: Map<string, HydratedProfile>;
+  displayNames: Map<string, string>;
+}> {
+  const [profiles, displayNames] = await Promise.all([
+    findHydratedProfilesByOxyUserIds(getDb(), oxyUserIds),
+    hydrateDisplayNames(oxyUserIds),
+  ]);
+  return { profiles, displayNames };
+}
+
 /** Serialize a single request row with hydrated display names + score. */
 const serializeRequest = (
   request: RoommateRequestRow,
-  profileByOxyUserId: Map<string, PopulatedProfileLike>,
+  profileByOxyUserId: Map<string, HydratedProfile>,
   displayNames: Map<string, string>,
 ) => {
-  const sender = serializeRoommateProfile(profileByOxyUserId.get(request.fromOxyUserId), displayNames);
-  const receiver = serializeRoommateProfile(profileByOxyUserId.get(request.toOxyUserId), displayNames);
-  const matchScore = calculateMatchPercentage(
-    prefsOf(profileByOxyUserId.get(request.fromOxyUserId)),
-    prefsOf(profileByOxyUserId.get(request.toOxyUserId)),
-  );
+  const senderProfile = profileByOxyUserId.get(request.fromOxyUserId);
+  const receiverProfile = profileByOxyUserId.get(request.toOxyUserId);
   return {
     id: request.id,
     senderOxyUserId: request.fromOxyUserId,
     receiverOxyUserId: request.toOxyUserId,
-    sender,
-    receiver,
+    sender: serializeRoommateProfile(senderProfile, displayNames),
+    receiver: serializeRoommateProfile(receiverProfile, displayNames),
     status: request.status,
     message: request.message,
-    matchScore,
+    matchScore: calculateMatchPercentage(
+      senderProfile && toMatchInputs(senderProfile.profile),
+      receiverProfile && toMatchInputs(receiverProfile.profile),
+    ),
     createdAt: request.createdAt,
   };
 };
@@ -348,12 +423,11 @@ const serializeRequest = (
 const getRoommateRequests = async (req: Request, res: Response): Promise<Response | void> => {
   try {
     const oxyUserId = resolveOxyUserId(req);
-
     if (!oxyUserId) {
       return res.status(401).json({ error: 'Authentication required' });
     }
 
-    const profile = await Profile.findByOxyUserId(oxyUserId);
+    const profile = await findProfileByOxyUserId(getDb(), oxyUserId);
     if (!profile) {
       return res.status(404).json({ error: 'Profile not found' });
     }
@@ -365,18 +439,12 @@ const getRoommateRequests = async (req: Request, res: Response): Promise<Respons
         [...sent, ...received].flatMap((request) => [request.fromOxyUserId, request.toOxyUserId]),
       ),
     );
-    const profiles = await Profile.find({ oxyUserId: { $in: participantOxyUserIds } })
-      .select(ROOMMATE_PROFILE_FIELDS)
-      .lean();
-    const profileByOxyUserId = new Map<string, PopulatedProfileLike>(
-      profiles.map((entry: PopulatedProfileLike & { oxyUserId: string }) => [String(entry.oxyUserId), entry as PopulatedProfileLike]),
-    );
-    const displayNames = await hydrateDisplayNames(participantOxyUserIds);
+    const { profiles, displayNames } = await loadParticipants(participantOxyUserIds);
 
     res.json({
       data: {
-        sent: sent.map((request) => serializeRequest(request, profileByOxyUserId, displayNames)),
-        received: received.map((request) => serializeRequest(request, profileByOxyUserId, displayNames)),
+        sent: sent.map((request) => serializeRequest(request, profiles, displayNames)),
+        received: received.map((request) => serializeRequest(request, profiles, displayNames)),
       },
     });
   } catch (error) {
@@ -396,7 +464,8 @@ const sendRoommateRequest = async (req: Request, res: Response): Promise<Respons
       return res.status(401).json({ error: 'Authentication required' });
     }
 
-    const currentProfile = await Profile.findByOxyUserId(oxyUserId);
+    const db = getDb();
+    const currentProfile = await findProfileByOxyUserId(db, oxyUserId);
     if (!currentProfile) {
       return res.status(404).json({ error: 'Profile not found' });
     }
@@ -409,12 +478,12 @@ const sendRoommateRequest = async (req: Request, res: Response): Promise<Respons
       return res.status(400).json({ error: 'You cannot send a roommate request to yourself' });
     }
 
-    const targetProfile = await Profile.findByOxyUserId(targetOxyUserId);
+    const targetProfile = await findProfileByOxyUserId(db, targetOxyUserId);
     if (!targetProfile) {
       return res.status(404).json({ error: 'Target user profile not found' });
     }
 
-    if (!personalOf(targetProfile)?.settings?.roommate?.enabled) {
+    if (targetProfile.settingsRoommateEnabled !== true) {
       return res.status(400).json({ error: 'Target user does not have roommate matching enabled' });
     }
 
@@ -425,7 +494,7 @@ const sendRoommateRequest = async (req: Request, res: Response): Promise<Respons
     // no single-column index can express.
     let request;
     try {
-      request = await createRoommateRequest(getDb(), {
+      request = await createRoommateRequest(db, {
         fromOxyUserId: oxyUserId,
         toOxyUserId: targetOxyUserId,
         message: typeof message === 'string' ? message : undefined,
@@ -463,13 +532,17 @@ const sendRoommateRequest = async (req: Request, res: Response): Promise<Respons
  * loudly instead of producing a second, invisible row for the same two people.
  */
 const createRelationshipForAcceptedRequest = async (request: RoommateRequestRow) => {
+  const db = getDb();
   const [fromProfile, toProfile] = await Promise.all([
-    Profile.findOne({ oxyUserId: request.fromOxyUserId }).select('personalProfile'),
-    Profile.findOne({ oxyUserId: request.toOxyUserId }).select('personalProfile'),
+    findProfileByOxyUserId(db, request.fromOxyUserId),
+    findProfileByOxyUserId(db, request.toOxyUserId),
   ]);
-  const matchScore = calculateMatchPercentage(prefsOf(fromProfile), prefsOf(toProfile));
+  const matchScore = calculateMatchPercentage(
+    fromProfile && toMatchInputs(fromProfile),
+    toProfile && toMatchInputs(toProfile),
+  );
 
-  return ensureActiveRelationship(getDb(), {
+  return ensureActiveRelationship(db, {
     requestId: request.id,
     fromOxyUserId: request.fromOxyUserId,
     toOxyUserId: request.toOxyUserId,
@@ -538,35 +611,29 @@ const declineRoommateRequest = async (req: Request, res: Response): Promise<Resp
 /** Serialize a relationship row with hydrated display names. */
 const serializeRelationship = (
   relationship: RoommateRelationshipRow,
-  profileByOxyUserId: Map<string, PopulatedProfileLike>,
+  profileByOxyUserId: Map<string, HydratedProfile>,
   displayNames: Map<string, string>,
-) => {
-  const profile1 = serializeRoommateProfile(profileByOxyUserId.get(relationship.oxyUser1Id), displayNames);
-  const profile2 = serializeRoommateProfile(profileByOxyUserId.get(relationship.oxyUser2Id), displayNames);
-  return {
-    id: relationship.id,
-    oxyUser1Id: relationship.oxyUser1Id,
-    oxyUser2Id: relationship.oxyUser2Id,
-    profile1,
-    profile2,
-    status: relationship.status,
-    matchScore: relationship.matchScore,
-    startDate: relationship.startDate,
-    endDate: relationship.endDate,
-  };
-};
+) => ({
+  id: relationship.id,
+  oxyUser1Id: relationship.oxyUser1Id,
+  oxyUser2Id: relationship.oxyUser2Id,
+  profile1: serializeRoommateProfile(profileByOxyUserId.get(relationship.oxyUser1Id), displayNames),
+  profile2: serializeRoommateProfile(profileByOxyUserId.get(relationship.oxyUser2Id), displayNames),
+  status: relationship.status,
+  matchScore: relationship.matchScore,
+  startDate: relationship.startDate,
+  endDate: relationship.endDate,
+});
 
 // Get roommate relationships for the current profile
 const getRoommateRelationships = async (req: Request, res: Response): Promise<Response | void> => {
   try {
     const oxyUserId = resolveOxyUserId(req);
-
     if (!oxyUserId) {
       return res.status(401).json({ error: 'Authentication required' });
     }
 
-    const profile = await Profile.findByOxyUserId(oxyUserId);
-
+    const profile = await findProfileByOxyUserId(getDb(), oxyUserId);
     if (!profile) {
       return res.status(404).json({ error: 'Profile not found' });
     }
@@ -578,17 +645,11 @@ const getRoommateRelationships = async (req: Request, res: Response): Promise<Re
         relationships.flatMap((relationship) => [relationship.oxyUser1Id, relationship.oxyUser2Id]),
       ),
     );
-    const profiles = await Profile.find({ oxyUserId: { $in: participantOxyUserIds } })
-      .select(ROOMMATE_PROFILE_FIELDS)
-      .lean();
-    const profileByOxyUserId = new Map<string, PopulatedProfileLike>(
-      profiles.map((entry: PopulatedProfileLike & { oxyUserId: string }) => [String(entry.oxyUserId), entry as PopulatedProfileLike]),
-    );
-    const displayNames = await hydrateDisplayNames(participantOxyUserIds);
+    const { profiles, displayNames } = await loadParticipants(participantOxyUserIds);
 
     res.json({
       data: relationships.map((relationship) =>
-        serializeRelationship(relationship, profileByOxyUserId, displayNames),
+        serializeRelationship(relationship, profiles, displayNames),
       ),
     });
   } catch (error) {
@@ -607,8 +668,7 @@ const endRoommateRelationship = async (req: Request, res: Response): Promise<Res
       return res.status(401).json({ error: 'Authentication required' });
     }
 
-    const profile = await Profile.findByOxyUserId(oxyUserId);
-
+    const profile = await findProfileByOxyUserId(getDb(), oxyUserId);
     if (!profile) {
       return res.status(404).json({ error: 'Profile not found' });
     }
@@ -645,77 +705,33 @@ const endRoommateRelationship = async (req: Request, res: Response): Promise<Res
   }
 };
 
-// Helper function to calculate match percentage
-const calculateMatchPercentage = (
-  prefs1: RoommatePreferences | undefined,
-  prefs2: RoommatePreferences | undefined
-): number => {
-  if (!prefs1 || !prefs2) return 0;
-
-  let matchScore = 0;
-  let totalFactors = 0;
-
-  // Budget compatibility
-  if (prefs1.budget && prefs2.budget) {
-    const max1 = prefs1.budget.max ?? 0;
-    const max2 = prefs2.budget.max ?? 0;
-    const min1 = prefs1.budget.min ?? 0;
-    const min2 = prefs2.budget.min ?? 0;
-    const overlap = Math.min(max1, max2) - Math.max(min1, min2);
-    if (overlap > 0) {
-      matchScore += 20;
-    }
-    totalFactors += 20;
-  }
-
-  // Lifestyle compatibility
-  if (prefs1.lifestyle && prefs2.lifestyle) {
-    if (prefs1.lifestyle.smoking === prefs2.lifestyle.smoking) matchScore += 15;
-    if (prefs1.lifestyle.pets === prefs2.lifestyle.pets) matchScore += 15;
-    if (prefs1.lifestyle.cleanliness === prefs2.lifestyle.cleanliness) matchScore += 15;
-    if (prefs1.lifestyle.schedule === prefs2.lifestyle.schedule) matchScore += 15;
-    totalFactors += 60;
-  }
-
-  // Interests compatibility
-  if (prefs1.interests && prefs2.interests) {
-    const interests2 = prefs2.interests;
-    const commonInterests = prefs1.interests.filter((interest: string) =>
-      interests2.includes(interest)
-    );
-    const interestScore = (commonInterests.length / Math.max(prefs1.interests.length, prefs2.interests.length)) * 20;
-    matchScore += interestScore;
-    totalFactors += 20;
-  }
-
-  return totalFactors > 0 ? Math.round((matchScore / totalFactors) * 100) : 0;
-};
-
-// Get current user's roommate status with Oxy user data
+/**
+ * The caller's own matching status.
+ *
+ * `id` and not `_id`: the Mongoose `toJSON` transform renamed it, this handler
+ * bypassed the transform by reading `profile._id` directly, and #287 made the
+ * rename the wire contract.
+ */
 const getCurrentUserRoommateStatus = async (req: Request, res: Response): Promise<Response | void> => {
   try {
     const oxyUserId = resolveOxyUserId(req);
-
     if (!oxyUserId) {
       return res.status(401).json({ error: 'Authentication required' });
     }
 
-    // Get user's active profile
-    const profile = await Profile.findByOxyUserId(oxyUserId);
-
+    const profile = await findProfileByOxyUserId(getDb(), oxyUserId);
     if (!profile) {
       return res.status(404).json({ error: 'Profile not found' });
     }
 
-    const roommateSlice = personalOf(profile)?.settings?.roommate;
-    const hasRoommateMatching = Boolean(roommateSlice?.enabled);
-
     res.json({
-      hasRoommateMatching,
+      hasRoommateMatching: profile.settingsRoommateEnabled === true,
       profile: {
-        id: profile._id,
+        id: profile.id,
         oxyUserId: profile.oxyUserId,
-        roommatePreferences: roommateSlice?.preferences || null,
+        roommatePreferences: hasStatedRoommatePreferences(profile)
+          ? toRoommatePreferencesDTO(profile)
+          : null,
       },
     });
   } catch (error) {

--- a/packages/backend/db/MIGRATION-CONTRACT.md
+++ b/packages/backend/db/MIGRATION-CONTRACT.md
@@ -70,6 +70,39 @@ at all; a viewing rollup comparing `ownerOxyUserId` against a PROFILE id; and an
 while leaving the selectors alone would have been the worst available outcome —
 three queries ported, still answering 0, and looking done.
 
+### `strictQuery: false` turns a mis-declared FILTER into a silent empty page
+
+The `analyticsController` defects above are the WRITE-side version of mongoose
+strict mode (a path the schema does not declare is dropped from the update).
+The roommate port found the READ-side version, and the two produce opposite
+symptoms from the same misspelling, so it is worth naming which one this
+package is exposed to.
+
+`database/connection.ts:39` sets `mongoose.set('strictQuery', false)`. With
+`strictQuery: true` an undeclared path is stripped from the FILTER, which makes
+the query too BROAD — it returns rows the caller meant to exclude. With `false`
+it is passed through to MongoDB, where a path no document has matches
+**nothing**. `getRoommateProfiles` filtered on `personalProfile.gender`,
+`personalProfile.location` and `personalProfile.dateOfBirth`;
+`personalProfileSchema` declares none of the three, so `?gender=`, `?location=`
+and `?ageRange=` returned an empty page for the whole life of the feature.
+
+The rule this yields for the rest of the migration: **a Mongo selector naming a
+path the schema does not declare is not a bug to port, and porting it faithfully
+is the worst available outcome** — it answers zero just as reliably in Postgres
+and looks finished. Re-point it at the fact the product really stores, or delete
+it, and say which in the PR. Where the stored fact does not exist at all (the
+roommate `location` filter, and the `interests` the compatibility score reads),
+the field is usually already ACCEPTED by a write allow-list and discarded by
+strict mode on the way in — so the fix is an additive column, registered in
+`schema/unmappedColumns.ts` with the other columns that have no Mongo source.
+
+`?ageRange=` is the case where no honest column exists: there is no date of
+birth in either store and there must not be one (Oxy owns identity). It is
+re-expressed as an OVERLAP against the candidate's own stated preferred age
+range — a different question with the same intent, recorded here because it is
+the kind of semantic change a later reader would otherwise take for a bug.
+
 ## A fixture has to sit on the side of the distinction the test exists to make
 
 The tidiest fixture is often the one that makes a check vacuous, and a green run

--- a/packages/backend/db/backfill/data.ts
+++ b/packages/backend/db/backfill/data.ts
@@ -70,6 +70,7 @@ import { findHasImagesDisagreements, syncAllHasImages } from '../hasImages';
 import type { Database } from '../postgres';
 import * as schema from '../schema';
 import { cities, images, regions } from '../schema';
+import { unmappedColumnNames } from '../schema/unmappedColumns';
 import { GEO_IMAGE_ENTITY_TYPES, ResolutionLog, type SourceDocument } from './geoPlan';
 import {
   DATA_COPY_ORDER,
@@ -808,6 +809,12 @@ async function compareSample(
         continue;
       }
 
+      // A column with NO Mongo source is not the copy's to reproduce, and after
+      // the cutover the application may already have written one — so a stored
+      // value where the mapper omitted the key is correct rather than a
+      // fidelity failure. See `schema/unmappedColumns.ts`, which explains why
+      // the `hasDefault` escape below cannot cover this case.
+      const unmapped = unmappedColumnNames(target);
       const rowIds = rows.map((row) => String(row.id));
       const stored = await database
         .select()
@@ -848,6 +855,7 @@ async function compareSample(
           // and it is checked.
           if (want === undefined) {
             if (columns[column]?.hasDefault) continue;
+            if (unmapped.has(column)) continue;
             if (actual[column] === null) continue;
             mismatches.push(
               `${table}/${String(expected.id)}.${column}: expected NULL, stored ${JSON.stringify(actual[column])}`,

--- a/packages/backend/db/backfill/dataPlan.ts
+++ b/packages/backend/db/backfill/dataPlan.ts
@@ -36,6 +36,7 @@
  * | `properties.hasImages` | DERIVED after the copy by `db/hasImages.ts`, the column's one writer. Production holds a row whose stored flag disagrees with its own array, so copying it would import a known-wrong answer into the primary sort key of every discovery feed. |
  * | `properties.coverImageIndex` | `-1` on all 17,644 rows; the meaning moved to `property_images.is_primary`. |
  * | `properties.title` / `views` | Absent from `PropertySchema`, so mongoose strict mode has been dropping them from every write. There is nothing to copy — see `schema/unmappedColumns.ts`. |
+ * | `profiles.settings_roommate_preferences_location` / `_interests` | The same discard one schema over: `personalProfileSchema` declares neither, so `updateRoommatePreferences` has never been able to store what its own allow-list accepts. Nothing to copy — see `schema/unmappedColumns.ts`. |
  * | `Region.imageIds[]` / `City.imageIds[]` | Dropped with the column: the relation already exists as `images.(entity_type, entity_id)`. |
  */
 

--- a/packages/backend/db/backfill/reconcile.ts
+++ b/packages/backend/db/backfill/reconcile.ts
@@ -47,6 +47,7 @@ import { eq, getTableColumns, inArray, sql } from 'drizzle-orm';
 import type { PgTable } from 'drizzle-orm/pg-core';
 import { Logger } from '../../utils/logger';
 import type { Database } from '../postgres';
+import { unmappedColumnNames } from '../schema/unmappedColumns';
 import { sameValue } from './geo';
 import { columnNames } from './geoPlan';
 import type { CandidateRow } from './rowAudit';
@@ -218,6 +219,7 @@ export async function reconcileTable(options: {
   const { database, table, tableName, produced, scopedTo, allowDeletes, dryRun } = options;
   const columns = getTableColumns(table);
   const idColumn = columns.id;
+  const unmapped = unmappedColumnNames(table);
   const writable: string[] = columnNames(table).filter(
     (column: string) => column !== 'id' && columns[column]?.generated === undefined,
   );
@@ -280,9 +282,16 @@ export async function reconcileTable(options: {
     //
     // Where the column has NO default, `undefined` does mean NULL and IS
     // compared: that is the difference between "the schema filled this in" and
-    // "the copy lost it".
+    // "the copy lost it". The one exception is a column REGISTERED as having no
+    // Mongo source, which the application may legitimately have written since
+    // the copy — `profiles.settings_roommate_preferences_location` is nullable,
+    // has no default, and is written by `PUT /api/roommates/preferences`, so
+    // without the registry every profile carrying one would be reported as
+    // differing on every pass, forever.
     const comparable = writable.filter(
-      (column: string) => row[column] !== undefined || columns[column]?.hasDefault !== true,
+      (column: string) =>
+        row[column] !== undefined ||
+        (columns[column]?.hasDefault !== true && !unmapped.has(column)),
     );
     // `?? null` on BOTH sides. For a nullable column with no default an omitted
     // key stores NULL, so `undefined` and `null` are the same fact here — and

--- a/packages/backend/db/profiles/profileRepository.ts
+++ b/packages/backend/db/profiles/profileRepository.ts
@@ -43,10 +43,24 @@
  * session. A profile is a sidecar to an Oxy account, so the account id IS the
  * key — and a lookup by row id authorised in a second statement is an IDOR the
  * moment somebody forgets the second statement.
+ *
+ * {@link searchRoommateCandidates} is the one read that is not keyed by an
+ * account id, and it takes the caller's as an EXCLUSION rather than a lookup:
+ * it answers "who else is looking", so the session id is what keeps a person
+ * out of their own results.
+ *
+ * ## This module owns every read of `profiles`
+ *
+ * Including the roommate discover feed, which filters that table and no other.
+ * Putting the filter in `db/roommates/` would give one table two repositories,
+ * and the two would drift on the question this one has just had to answer
+ * carefully: what a NULL column means (see `roommateCandidateFilter`).
  */
 
-import { asc, eq, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, ilike, inArray, isNull, lte, ne, or, sql } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
 import type { DatabaseOrTransaction } from '../postgres';
+import { escapeLikePattern } from '../likePattern';
 import {
   profileChatMessages,
   profilePreferredLocations,
@@ -55,6 +69,9 @@ import {
   profileRoommateHistory,
   profiles,
 } from '../schema';
+// `db/schema/index.ts` is TABLES ONLY, so the vocabulary comes from the module
+// that declares it beside the column it constrains.
+import type { GENDER_PREFERENCES } from '../schema/profiles';
 import { type HydratedProfile, type ProfileRow, profileSelection } from './profileSerializer';
 
 /**
@@ -125,12 +142,17 @@ export async function findProfileByOxyUserId(
 }
 
 /**
- * Every child collection for one profile.
+ * Every child collection for a SET of profiles, grouped by profile id.
  *
  * Five statements in parallel rather than one join: the collections are
  * independent of each other, so a join would multiply their rows together and
  * the reader would have to undo five cartesian products to recover what five
  * plain reads already return.
+ *
+ * Five statements for ONE page rather than five per profile, which is the
+ * reason this takes a list. The roommate discover feed hydrates up to a page of
+ * candidates at a time, and the per-profile version issued underneath it would
+ * be 5 × N round trips for a browse screen.
  *
  * **Every ordering here names a real sort column and uses the id only to break a
  * tie.** A `text` primary key holds a 24-char ObjectId hex for a pre-cutover row
@@ -139,34 +161,75 @@ export async function findProfileByOxyUserId(
  * this year begins `6…`, so a lexicographic sort puts every new row FIRST. See
  * `db/conversations/conversationRepository.ts`, which carries the measurement.
  */
-async function loadChildren(
+async function loadChildrenByProfileId(
   db: DatabaseOrTransaction,
-  profileId: string,
-): Promise<Omit<HydratedProfile, 'profile'>> {
+  profileIds: readonly string[],
+): Promise<Map<string, Omit<HydratedProfile, 'profile'>>> {
+  const grouped = new Map<string, Omit<HydratedProfile, 'profile'>>();
+  if (profileIds.length === 0) return grouped;
+
+  const ids = [...profileIds];
   const [references, rentalHistory, preferredLocations, roommateHistory, chatHistory] =
     await Promise.all([
-      db.select().from(profileReferences).where(eq(profileReferences.profileId, profileId)),
+      db.select().from(profileReferences).where(inArray(profileReferences.profileId, ids)),
       db
         .select()
         .from(profileRentalHistory)
-        .where(eq(profileRentalHistory.profileId, profileId))
+        .where(inArray(profileRentalHistory.profileId, ids))
         .orderBy(asc(profileRentalHistory.startDate), asc(profileRentalHistory.id)),
       db
         .select()
         .from(profilePreferredLocations)
-        .where(eq(profilePreferredLocations.profileId, profileId)),
+        .where(inArray(profilePreferredLocations.profileId, ids)),
       db
         .select()
         .from(profileRoommateHistory)
-        .where(eq(profileRoommateHistory.profileId, profileId))
+        .where(inArray(profileRoommateHistory.profileId, ids))
         .orderBy(asc(profileRoommateHistory.startDate), asc(profileRoommateHistory.id)),
       db
         .select()
         .from(profileChatMessages)
-        .where(eq(profileChatMessages.profileId, profileId))
+        .where(inArray(profileChatMessages.profileId, ids))
         .orderBy(asc(profileChatMessages.position), asc(profileChatMessages.timestamp)),
     ]);
-  return { references, rentalHistory, preferredLocations, roommateHistory, chatHistory };
+
+  // Bucketing preserves the statement's own `ORDER BY` inside each group, since
+  // rows arrive sorted and are appended in arrival order.
+  const byProfile = <T extends { profileId: string }>(rows: readonly T[]): Map<string, T[]> => {
+    const map = new Map<string, T[]>();
+    for (const row of rows) {
+      const existing = map.get(row.profileId);
+      if (existing) existing.push(row);
+      else map.set(row.profileId, [row]);
+    }
+    return map;
+  };
+
+  const referencesByProfile = byProfile(references);
+  const rentalHistoryByProfile = byProfile(rentalHistory);
+  const preferredLocationsByProfile = byProfile(preferredLocations);
+  const roommateHistoryByProfile = byProfile(roommateHistory);
+  const chatHistoryByProfile = byProfile(chatHistory);
+
+  for (const profileId of ids) {
+    grouped.set(profileId, {
+      references: referencesByProfile.get(profileId) ?? [],
+      rentalHistory: rentalHistoryByProfile.get(profileId) ?? [],
+      preferredLocations: preferredLocationsByProfile.get(profileId) ?? [],
+      roommateHistory: roommateHistoryByProfile.get(profileId) ?? [],
+      chatHistory: chatHistoryByProfile.get(profileId) ?? [],
+    });
+  }
+  return grouped;
+}
+
+/** Every child collection for one profile. */
+async function loadChildren(
+  db: DatabaseOrTransaction,
+  profileId: string,
+): Promise<Omit<HydratedProfile, 'profile'>> {
+  const grouped = await loadChildrenByProfileId(db, [profileId]);
+  return grouped.get(profileId) ?? emptyChildren();
 }
 
 /**
@@ -196,6 +259,224 @@ export async function findHydratedProfile(
     .where(eq(profiles.id, profile.id))
     .limit(1);
   return { profile, ...children, ownerOnly: { annualIncome: income?.annualIncome ?? null } };
+}
+
+/**
+ * Several profiles, hydrated, keyed by their Oxy account id.
+ *
+ * The batched form of {@link findHydratedProfile}, for the two roommate lists
+ * that hold a set of participant ids and need a profile for each. There is no
+ * `scope` parameter and there will not be one: a batch is by construction a set
+ * of OTHER people, so the owner view has no meaning here and the protected
+ * income column stays unreachable — `profileSelection()` excludes it at the
+ * type level.
+ *
+ * Absent ids are simply absent from the map. A participant with no profile row
+ * is a real state (the roommate tables carry no foreign key to `profiles`,
+ * because their columns hold Oxy account ids), and the caller renders `null`
+ * for them exactly as it did when the Mongo `$in` returned fewer documents than
+ * it was given ids.
+ */
+export async function findHydratedProfilesByOxyUserIds(
+  db: DatabaseOrTransaction,
+  oxyUserIds: readonly string[],
+): Promise<Map<string, HydratedProfile>> {
+  const hydrated = new Map<string, HydratedProfile>();
+  if (oxyUserIds.length === 0) return hydrated;
+
+  const rows = await db
+    .select(profileSelection())
+    .from(profiles)
+    .where(inArray(profiles.oxyUserId, [...oxyUserIds]));
+  const children = await loadChildrenByProfileId(db, rows.map((row) => row.id));
+  for (const row of rows) {
+    hydrated.set(row.oxyUserId, { profile: row, ...(children.get(row.id) ?? emptyChildren()) });
+  }
+  return hydrated;
+}
+
+/**
+ * What `GET /api/roommates` filters candidates on.
+ *
+ * Every field here is a property of the CANDIDATE's own row, which is what
+ * makes them expressible as a `WHERE` clause; the caller-relative filter
+ * (`minMatchPercentage`) is not, and stays in the controller.
+ */
+export interface RoommateCandidateQuery {
+  /** The caller. Excluded from their own results. */
+  readonly excludeOxyUserId: string;
+  readonly gender?: (typeof GENDER_PREFERENCES)[number];
+  readonly location?: string;
+  readonly ageRange?: { readonly min: number; readonly max: number };
+  readonly maxBudget?: number;
+  readonly withPets?: boolean;
+  readonly nonSmoking?: boolean;
+  readonly limit: number;
+  readonly offset: number;
+}
+
+export interface RoommateCandidatePage {
+  readonly candidates: readonly HydratedProfile[];
+  /** Rows matching the filters, before the page was cut. */
+  readonly total: number;
+}
+
+/**
+ * The predicate behind {@link searchRoommateCandidates}, split out so the count
+ * and the page cannot disagree about what they are counting.
+ *
+ * ## Three of these filters used to match NOTHING, and they are REPAIRED here
+ *
+ * The Mongo query filtered `personalProfile.gender`, `personalProfile.location`
+ * and `personalProfile.dateOfBirth`. `personalProfileSchema` declares none of
+ * the three, and `database/connection.ts` sets `strictQuery: false` — so rather
+ * than being stripped from the filter, all three were passed through to
+ * MongoDB, where they matched no document. Setting any of `?gender=`,
+ * `?location=` or `?ageRange=` returned an empty page, always. Porting the
+ * selectors verbatim would have moved that to Postgres, where they would answer
+ * zero just as reliably and look finished; so each is re-pointed at the fact
+ * this product actually stores:
+ *
+ *  - **`gender`** → `settings_roommate_preferences_gender`, the CHECK-constrained
+ *    column whose vocabulary (`male | female | any`) is the same one
+ *    `RoommateFilters.gender` is typed with. It means "candidates who said they
+ *    want to live with X", which is the only stored fact the filter can mean.
+ *  - **`ageRange`** → an OVERLAP against
+ *    `settings_roommate_preferences_age_range_{min,max}`. There is no date of
+ *    birth in either store and there must not be one: Oxy owns identity and
+ *    Homiio does not mirror it. So "people aged 25-30" becomes "people whose
+ *    stated preferred age range overlaps 25-30", which is a different question
+ *    with the same intent.
+ *  - **`location`** → `settings_roommate_preferences_location`, a column added
+ *    by migration 0008 because the write allow-list accepted the field while
+ *    mongoose strict mode discarded it. `ILIKE` over `escapeLikePattern` is the
+ *    port of `{ $regex, $options: 'i' }`; escaping matters because `%` and `_`
+ *    are LIKE metacharacters that mean nothing to a regex, so an unescaped
+ *    `100%` would silently stop filtering.
+ *
+ * ## An unknown answer ADMITS the candidate, everywhere
+ *
+ * `maxBudget` in the Mongo controller read `if (typeof profileMax !== 'number')
+ * return true` — a candidate who stated no budget was kept. Every predicate
+ * here follows that rule (`is null or …`), including both halves of the age
+ * overlap, so a filter narrows the field by what people SAID and never hides
+ * the ones who have not answered yet.
+ *
+ * ## …and they run in SQL rather than over the page
+ *
+ * `maxBudget`, `withPets` and `nonSmoking` were applied in JavaScript AFTER
+ * `skip`/`limit` had already cut the page, so they returned short pages beside
+ * a `total` that counted rows the page had just dropped. Their per-candidate
+ * meaning is unchanged; only the pagination arithmetic is now correct.
+ */
+function roommateCandidateFilter(query: RoommateCandidateQuery): SQL | undefined {
+  // `SQL | undefined`, the repository-wide idiom (`db/properties/propertyFilters.ts`):
+  // `and(...)` drops the absent ones, so an inapplicable filter contributes
+  // nothing instead of needing a branch around the push.
+  const conditions: (SQL | undefined)[] = [
+    eq(profiles.settingsRoommateEnabled, true),
+    ne(profiles.oxyUserId, query.excludeOxyUserId),
+  ];
+
+  if (query.gender) {
+    conditions.push(eq(profiles.settingsRoommatePreferencesGender, query.gender));
+  }
+
+  if (query.location) {
+    conditions.push(
+      ilike(
+        profiles.settingsRoommatePreferencesLocation,
+        `%${escapeLikePattern(query.location)}%`,
+      ),
+    );
+  }
+
+  if (query.ageRange) {
+    // Closed-interval overlap: `[a, b]` meets `[c, d]` iff `a <= d and b >= c`.
+    // Written with an explicit `is null` on each side rather than a `coalesce`
+    // to ±infinity, because a NULL bound means "did not say" and the two halves
+    // are answered independently — somebody who gave only a minimum is still
+    // comparable on that minimum.
+    const { min, max } = query.ageRange;
+    conditions.push(
+      or(
+        isNull(profiles.settingsRoommatePreferencesAgeRangeMin),
+        lte(profiles.settingsRoommatePreferencesAgeRangeMin, max),
+      ),
+      or(
+        isNull(profiles.settingsRoommatePreferencesAgeRangeMax),
+        gte(profiles.settingsRoommatePreferencesAgeRangeMax, min),
+      ),
+    );
+  }
+
+  if (typeof query.maxBudget === 'number') {
+    conditions.push(
+      or(
+        isNull(profiles.settingsRoommatePreferencesBudgetMax),
+        gte(profiles.settingsRoommatePreferencesBudgetMax, query.maxBudget),
+      ),
+    );
+  }
+
+  if (query.withPets) {
+    conditions.push(
+      or(
+        isNull(profiles.settingsRoommatePreferencesLifestylePets),
+        eq(profiles.settingsRoommatePreferencesLifestylePets, 'yes'),
+      ),
+    );
+  }
+
+  if (query.nonSmoking) {
+    conditions.push(
+      or(
+        isNull(profiles.settingsRoommatePreferencesLifestyleSmoking),
+        eq(profiles.settingsRoommatePreferencesLifestyleSmoking, 'no'),
+      ),
+    );
+  }
+
+  return and(...conditions);
+}
+
+/**
+ * One page of roommate candidates, hydrated, plus how many there are in total.
+ *
+ * Ordered by `updated_at` descending like the Mongo query, with the id as a
+ * TIEBREAK so two rows saved in the same millisecond cannot swap places between
+ * the page that shows them and the page that should. The id is never the sort
+ * key itself: a `text` primary key mixes ObjectId hex with uuid v7 and the two
+ * shapes do not interleave in creation order.
+ */
+export async function searchRoommateCandidates(
+  db: DatabaseOrTransaction,
+  query: RoommateCandidateQuery,
+): Promise<RoommateCandidatePage> {
+  const filter = roommateCandidateFilter(query);
+
+  const [rows, [counted]] = await Promise.all([
+    db
+      .select(profileSelection())
+      .from(profiles)
+      .where(filter)
+      .orderBy(desc(profiles.updatedAt), asc(profiles.id))
+      .limit(query.limit)
+      .offset(query.offset),
+    db
+      .select({ total: sql<number>`count(*)::int` })
+      .from(profiles)
+      .where(filter),
+  ]);
+
+  const children = await loadChildrenByProfileId(db, rows.map((row) => row.id));
+  return {
+    candidates: rows.map((row) => ({
+      profile: row,
+      ...(children.get(row.id) ?? emptyChildren()),
+    })),
+    total: counted.total,
+  };
 }
 
 /**

--- a/packages/backend/db/profiles/profileSerializer.ts
+++ b/packages/backend/db/profiles/profileSerializer.ts
@@ -193,6 +193,81 @@ function toChatMessageDTO(row: ProfileChatMessageRow): Record<string, unknown> {
 }
 
 /**
+ * Whether the person has stated ANY roommate preference.
+ *
+ * The flattened columns cost one distinction that Mongo got for free:
+ * `personalProfile` was declared with no `default`, so mongoose never
+ * materialised it and `settings.roommate.preferences` was genuinely
+ * `undefined` for anybody who had not filled the form in. Every column here is
+ * nullable precisely to keep that fact, and this is the predicate that reads
+ * it back — `GET /api/roommates/preferences` answers `data: null` on it, and
+ * `controllers/roommate/matching.ts` decides whether a person can be scored at
+ * all on the same question.
+ *
+ * `enabled` is NOT consulted: it says whether they want to appear in the feed,
+ * not what they are looking for.
+ */
+export function hasStatedRoommatePreferences(profile: ProfileRow): boolean {
+  return [
+    profile.settingsRoommatePreferencesAgeRangeMin,
+    profile.settingsRoommatePreferencesAgeRangeMax,
+    profile.settingsRoommatePreferencesGender,
+    profile.settingsRoommatePreferencesLifestyleSmoking,
+    profile.settingsRoommatePreferencesLifestylePets,
+    profile.settingsRoommatePreferencesLifestylePartying,
+    profile.settingsRoommatePreferencesLifestyleCleanliness,
+    profile.settingsRoommatePreferencesLifestyleSchedule,
+    profile.settingsRoommatePreferencesBudgetMin,
+    profile.settingsRoommatePreferencesBudgetMax,
+    profile.settingsRoommatePreferencesMoveInDate,
+    profile.settingsRoommatePreferencesLeaseDuration,
+    profile.settingsRoommatePreferencesLocation,
+    profile.settingsRoommatePreferencesInterests,
+  ].some((value) => value !== null && value !== undefined);
+}
+
+/**
+ * `settings.roommate.preferences`, as the roommate screens and the profile edit
+ * form both read it.
+ *
+ * Exported because `controllers/roommateController.ts` answers
+ * `GET /api/roommates/preferences` and `PUT /api/roommates/preferences` with
+ * exactly this object, and TWO definitions of one wire shape can disagree — the
+ * roommate endpoint would then serve a subtree the profile endpoint does not,
+ * and the edit form round-trips whichever one it last read. {@link
+ * toPersonalProfile} calls this rather than inlining it, so there is one
+ * definition and both routes are served by it.
+ *
+ * `interests` and `location` are here for the first time: their columns were
+ * added by migration 0008 because mongoose strict mode had made them
+ * unstorable — see `db/schema/profiles.ts`.
+ */
+export function toRoommatePreferencesDTO(profile: ProfileRow): Record<string, unknown> {
+  return {
+    ageRange: {
+      min: profile.settingsRoommatePreferencesAgeRangeMin,
+      max: profile.settingsRoommatePreferencesAgeRangeMax,
+    },
+    gender: profile.settingsRoommatePreferencesGender,
+    lifestyle: {
+      smoking: profile.settingsRoommatePreferencesLifestyleSmoking,
+      pets: profile.settingsRoommatePreferencesLifestylePets,
+      partying: profile.settingsRoommatePreferencesLifestylePartying,
+      cleanliness: profile.settingsRoommatePreferencesLifestyleCleanliness,
+      schedule: profile.settingsRoommatePreferencesLifestyleSchedule,
+    },
+    budget: {
+      min: profile.settingsRoommatePreferencesBudgetMin,
+      max: profile.settingsRoommatePreferencesBudgetMax,
+    },
+    moveInDate: profile.settingsRoommatePreferencesMoveInDate,
+    leaseDuration: profile.settingsRoommatePreferencesLeaseDuration,
+    interests: profile.settingsRoommatePreferencesInterests,
+    location: profile.settingsRoommatePreferencesLocation,
+  };
+}
+
+/**
  * The `personalProfile` subtree, rebuilt from the flattened columns and the
  * child rows.
  *
@@ -284,26 +359,7 @@ function toPersonalProfile(
       },
       roommate: {
         enabled: profile.settingsRoommateEnabled,
-        preferences: {
-          ageRange: {
-            min: profile.settingsRoommatePreferencesAgeRangeMin,
-            max: profile.settingsRoommatePreferencesAgeRangeMax,
-          },
-          gender: profile.settingsRoommatePreferencesGender,
-          lifestyle: {
-            smoking: profile.settingsRoommatePreferencesLifestyleSmoking,
-            pets: profile.settingsRoommatePreferencesLifestylePets,
-            partying: profile.settingsRoommatePreferencesLifestylePartying,
-            cleanliness: profile.settingsRoommatePreferencesLifestyleCleanliness,
-            schedule: profile.settingsRoommatePreferencesLifestyleSchedule,
-          },
-          budget: {
-            min: profile.settingsRoommatePreferencesBudgetMin,
-            max: profile.settingsRoommatePreferencesBudgetMax,
-          },
-          moveInDate: profile.settingsRoommatePreferencesMoveInDate,
-          leaseDuration: profile.settingsRoommatePreferencesLeaseDuration,
-        },
+        preferences: toRoommatePreferencesDTO(profile),
         history: hydrated.roommateHistory.map(toRoommateHistoryDTO),
       },
       language: profile.settingsLanguage,

--- a/packages/backend/db/schema/profiles.ts
+++ b/packages/backend/db/schema/profiles.ts
@@ -42,11 +42,22 @@
  *
  * ## Arrays
  *
- * Two scalar arrays stay native `text[]` (`preferences.propertyTypes`,
- * `preferences.preferredAmenities`) — both are read whole and neither is ever
- * queried by element. The five arrays that carry STRUCTURE become child tables,
- * because a native array of a composite type is not queryable, not constrainable
- * and not indexable in any useful way.
+ * Three scalar arrays stay native `text[]` (`preferences.propertyTypes`,
+ * `preferences.preferredAmenities` and the roommate `interests` this migration
+ * ADDS) — each is read whole and none is ever queried by element. The five
+ * arrays that carry STRUCTURE become child tables, because a native array of a
+ * composite type is not queryable, not constrainable and not indexable in any
+ * useful way.
+ *
+ * ## Two columns here have NO Mongo source, deliberately
+ *
+ * `settings_roommate_preferences_location` and
+ * `settings_roommate_preferences_interests` are not ports of stored fields —
+ * they are the fix for a field that was accepted, sent, and silently discarded.
+ * Each carries its own reason where it is declared. They are the profile
+ * counterpart of `schema/unmappedColumns.ts`'s `properties.views` /
+ * `properties.title`: a column starting to hold data after the cutover is the
+ * EXPECTED condition, not a copy failure.
  */
 
 import { boolean, check, doublePrecision, index, pgTable, text, uniqueIndex } from 'drizzle-orm/pg-core';
@@ -237,6 +248,42 @@ export const profiles = pgTable(
     settingsRoommatePreferencesBudgetMax: doublePrecision(),
     settingsRoommatePreferencesMoveInDate: timestamptz(),
     settingsRoommatePreferencesLeaseDuration: text({ enum: LEASE_DURATIONS }),
+    /**
+     * Where the person wants to share a home — free text, the way the roommate
+     * filter has always collected it ("Barcelona", "Gràcia").
+     *
+     * **This column has no Mongo counterpart, and that is the defect it exists
+     * to close rather than an omission being carried forward.**
+     * `EDITABLE_ROOMMATE_PREFERENCE_FIELDS` accepts `location`,
+     * `RoommateFilters` sends it, and `updateRoommatePreferences` wrote it to
+     * `personalProfile.settings.roommate.preferences.location` — a path
+     * `personalProfileSchema` never declared, so mongoose strict mode (ON for
+     * writes, always) dropped it from every update. Nothing errored and nothing
+     * was ever stored, which is why the discover filter that reads it has never
+     * returned a row.
+     *
+     * Filtered with `ILIKE` over `escapeLikePattern` (`db/likePattern.ts`) —
+     * the port of the `{ $regex, $options: 'i' }` the Mongo filter used. No
+     * index: the table holds five rows, and `CONVENTIONS.md` forbids a
+     * speculative one.
+     */
+    settingsRoommatePreferencesLocation: text(),
+    /**
+     * The person's own interests, as free-text tags.
+     *
+     * Same defect as {@link settingsRoommatePreferencesLocation} — accepted by
+     * the write allow-list, sent by the client, and silently dropped by strict
+     * mode — with a second consequence that is invisible from the write side:
+     * `calculateMatchPercentage`'s interests branch is worth 20 of the 100
+     * compatibility points and is guarded by `prefs1.interests &&
+     * prefs2.interests`, so with the field unstorable it could NEVER fire. The
+     * scorer has been running on 80 points for its whole life.
+     *
+     * A native `text[]`, matching `preferences_preferred_amenities`: it is read
+     * whole to intersect two people's tags and is never queried by element, so a
+     * child table would be the over-normalization `CONVENTIONS.md` forbids.
+     */
+    settingsRoommatePreferencesInterests: text().array(),
 
     // ── personalProfile.settings (locale) ──
     settingsLanguage: text(),

--- a/packages/backend/db/schema/unmappedColumns.ts
+++ b/packages/backend/db/schema/unmappedColumns.ts
@@ -23,23 +23,56 @@
  * protects nothing and reports nothing, the same failure mode
  * `protectedColumns.ts` guards against.
  *
- * ## Both entries are the same bug, seen from the database
+ * ## The registry is READ by the backfill, and the two roommate entries are why
  *
- * `views` and `title` are not new features. They are fields the PRODUCT already
- * believes in — `retrieve.ts:31` and `roomController.ts:203` both issue
- * `$inc: { views: 1 }`, and a 43.51 MiB Mongo text index has been indexing
- * `title` — and that mongoose STRICT MODE has been silently discarding, because
- * neither is declared in `PropertySchema`. The census measured both as absent
- * on all 17,644 rows.
+ * It was documentation until the roommate port. The copy's verifier and
+ * `--reconcile` both handled `views` and `title` by a HEURISTIC —
+ * `views` is `NOT NULL DEFAULT 0` so an omitted key is skipped as
+ * "the schema decided this", and `title` is nullable with nothing writing it,
+ * so an omitted key and a stored NULL agree. Neither escape works for a column
+ * that has no default AND that the application really writes: the verifier
+ * reads a value where it expected NULL and reports a fidelity MISMATCH, which
+ * fails the run (`data.ts:1400`), and `--reconcile` reports the row as
+ * differing on every pass.
+ *
+ * `settings_roommate_preferences_location` is exactly that shape — nullable, no
+ * default, and written by `PUT /api/roommates/preferences` from the day the
+ * roommate port ships, while Mongo has nothing to compare it against. So
+ * {@link unmappedColumnNames} exists and both readers consult it, which is what
+ * turns the paragraph above from a claim into a mechanism.
+ *
+ * It covers `compareSample` and `reconcileTable`, and NOT `compareMintedRows` —
+ * that path serves tables whose ids are minted, and neither table named here is
+ * one (`mintsIds` is empty for both plans). Add the check there too if a minted
+ * table ever gains an entry.
+ *
+ * ## Every entry is the same bug, seen from the database
+ *
+ * None of these is a new feature. They are fields the PRODUCT already believes
+ * in — `retrieve.ts:31` and `roomController.ts:203` both issue
+ * `$inc: { views: 1 }`, a 43.51 MiB Mongo text index has been indexing `title`,
+ * and `EDITABLE_ROOMMATE_PREFERENCE_FIELDS` accepts `location` and `interests`
+ * while `RoommateFilters` sends both — and that mongoose STRICT MODE has been
+ * silently discarding, because none of them is declared in its schema. The
+ * census measured `views` and `title` as absent on all 17,644 property rows;
+ * the two roommate fields are absent on all five profiles for the same reason.
  *
  * Declaring them here rather than leaving them out is a deliberate choice, and
  * it is the cheaper one: adding a column to `properties` later is a migration
- * against the largest table in the schema, while the two facts that make them
- * safe to declare now — that they have no data and that the code which will
- * fill them already exists — are measured rather than hoped for.
+ * against the largest table in the schema, while the facts that make them safe
+ * to declare now — that they have no data and that the code which will fill
+ * them already exists — are measured rather than hoped for.
+ *
+ * The two `profiles` entries go one step further than the two `properties`
+ * ones: their readers were REPAIRED in the same change that added them (the
+ * discover `location` filter and `calculateMatchPercentage`'s interests
+ * branch), so they start being written the moment the roommate port ships
+ * rather than waiting for a later batch.
  */
 
+import { getTableName } from 'drizzle-orm';
 import type { PgTable } from 'drizzle-orm/pg-core';
+import { profiles } from './profiles';
 import { properties } from './properties';
 
 /** A column the backfill deliberately never writes. */
@@ -83,4 +116,47 @@ export const UNMAPPED_COLUMNS: readonly UnmappedColumn[] = [
       'Postgres. Nullable rather than defaulted, because "no headline" is a ' +
       'real state a listing can be in.',
   },
+  {
+    table: profiles,
+    property: 'settingsRoommatePreferencesLocation',
+    reason:
+      'ABSENT on all five production profiles, and unstorable rather than ' +
+      'unused: `personalProfileSchema` declares no ' +
+      '`settings.roommate.preferences.location`, so mongoose strict mode drops ' +
+      'it out of the `$set` `updateRoommatePreferences` builds from its own ' +
+      'allow-list — which DOES list it, as does the client\'s ' +
+      '`RoommateFilters`. The consequence is a discover filter that has ' +
+      'matched nothing for its whole life. There is nothing to copy; the ' +
+      'column starts empty and the roommate port is what begins writing it.',
+  },
+  {
+    table: profiles,
+    property: 'settingsRoommatePreferencesInterests',
+    reason:
+      'ABSENT on all five production profiles, discarded by the same strict ' +
+      'mode as `settings.roommate.preferences.location` above. Its second ' +
+      'consequence is invisible from the write side: ' +
+      '`calculateMatchPercentage`\'s interests branch is worth 20 of 100 ' +
+      'points and is guarded by `prefs1.interests && prefs2.interests`, so no ' +
+      'roommate score has ever been able to include it. Nullable rather than ' +
+      'defaulted to `{}`, because "never listed any" and "listed none" are ' +
+      'different answers and only the second is an empty array.',
+  },
 ];
+
+/**
+ * The TypeScript property names registered for one table.
+ *
+ * Compared by table NAME rather than by object identity: the backfill reaches
+ * its targets through `requireTable(...)`, and an identity comparison would
+ * silently match nothing if that ever handed back a different instance of the
+ * same table — the vacuous-check failure this whole file exists to avoid.
+ */
+export function unmappedColumnNames(table: PgTable): ReadonlySet<string> {
+  const name = getTableName(table);
+  return new Set(
+    UNMAPPED_COLUMNS.filter((entry) => getTableName(entry.table) === name).map(
+      (entry) => entry.property,
+    ),
+  );
+}

--- a/packages/backend/drizzle/0009_roommate_preferences_location_interests.sql
+++ b/packages/backend/drizzle/0009_roommate_preferences_location_interests.sql
@@ -1,0 +1,20 @@
+-- oxy:deploy-phase=pre
+--
+-- Two roommate-preference columns that have NO Mongo source, added rather than
+-- ported.
+--
+-- `EDITABLE_ROOMMATE_PREFERENCE_FIELDS` accepts `location` and `interests`,
+-- `RoommateFilters` sends both, and `updateRoommatePreferences` wrote them to
+-- `personalProfile.settings.roommate.preferences.{location,interests}` — paths
+-- `personalProfileSchema` never declared, so mongoose strict mode discarded
+-- them from every update. Two things depended on values that could not exist:
+-- the discover `location` filter, and `calculateMatchPercentage`'s interests
+-- branch, worth 20 of its 100 points.
+--
+-- ADDITIVE and therefore `pre`: nothing drops, nothing narrows, and the
+-- previous image neither reads nor writes either column. `profiles` holds five
+-- production rows, so the ALTER is instantaneous. Both nullable, like every
+-- other column on this table — NULL is how "never answered" is represented once
+-- the `personalProfile` block is flattened away (see `db/schema/profiles.ts`).
+ALTER TABLE "profiles" ADD COLUMN "settings_roommate_preferences_location" text;--> statement-breakpoint
+ALTER TABLE "profiles" ADD COLUMN "settings_roommate_preferences_interests" text[];

--- a/packages/backend/drizzle/meta/0009_snapshot.json
+++ b/packages/backend/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,11083 @@
+{
+  "id": "94344289-6061-4dc1-8815-96d2920e4aff",
+  "prevId": "acc6945b-5c66-4522-aba3-116212457912",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.addresses": {
+      "name": "addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "neighborhood_id": {
+          "name": "neighborhood_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "building_name": {
+          "name": "building_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrance": {
+          "name": "entrance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "floor": {
+          "name": "floor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subunit": {
+          "name": "subunit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district": {
+          "name": "district",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_lines": {
+          "name": "address_lines",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "po_box": {
+          "name": "po_box",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_plot_block": {
+          "name": "land_plot_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_plot_lot": {
+          "name": "land_plot_lot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_plot_parcel": {
+          "name": "land_plot_parcel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extras": {
+          "name": "extras",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "ST_MakePoint(longitude, latitude)::geography",
+            "type": "stored"
+          }
+        },
+        "address_level": {
+          "name": "address_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "\n      case\n        when coalesce(floor, '') <> '' or coalesce(unit, '') <> ''\n          or coalesce(subunit, '') <> '' then 'UNIT'\n        when coalesce(number, '') <> '' or coalesce(building_name, '') <> ''\n          or coalesce(block, '') <> '' or coalesce(entrance, '') <> '' then 'BUILDING'\n        else 'STREET'\n      end\n    ",
+            "type": "stored"
+          }
+        },
+        "normalized_key": {
+          "name": "normalized_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "addresses_normalized_key_key": {
+          "name": "addresses_normalized_key_key",
+          "columns": [
+            {
+              "expression": "normalized_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"addresses\".\"normalized_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_geo_gist": {
+          "name": "addresses_geo_gist",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "addresses_city_id_idx": {
+          "name": "addresses_city_id_idx",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_region_id_idx": {
+          "name": "addresses_region_id_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_country_id_idx": {
+          "name": "addresses_country_id_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_neighborhood_id_idx": {
+          "name": "addresses_neighborhood_id_idx",
+          "columns": [
+            {
+              "expression": "neighborhood_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_postal_code_country_idx": {
+          "name": "addresses_postal_code_country_idx",
+          "columns": [
+            {
+              "expression": "postal_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "country_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_street_trgm_idx": {
+          "name": "addresses_street_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"street\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "addresses_country_id_countries_id_fk": {
+          "name": "addresses_country_id_countries_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "addresses_region_id_regions_id_fk": {
+          "name": "addresses_region_id_regions_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "addresses_city_id_cities_id_fk": {
+          "name": "addresses_city_id_cities_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "addresses_neighborhood_id_neighborhoods_id_fk": {
+          "name": "addresses_neighborhood_id_neighborhoods_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "neighborhoods",
+          "columnsFrom": [
+            "neighborhood_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "addresses_address_level_check": {
+          "name": "addresses_address_level_check",
+          "value": "\"addresses\".\"address_level\" in ('STREET', 'BUILDING', 'UNIT')"
+        },
+        "addresses_coordinates_range_check": {
+          "name": "addresses_coordinates_range_check",
+          "value": "\"addresses\".\"longitude\" between -180 and 180 and \"addresses\".\"latitude\" between -90 and 90"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agencies": {
+      "name": "agencies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "agencies_normalized_name_key": {
+          "name": "agencies_normalized_name_key",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agencies_slug_key": {
+          "name": "agencies_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agencies_name_trgm_idx": {
+          "name": "agencies_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agencies_normalized_name_not_empty_check": {
+          "name": "agencies_normalized_name_not_empty_check",
+          "value": "length(\"agencies\".\"normalized_name\") > 0"
+        },
+        "agencies_slug_not_empty_check": {
+          "name": "agencies_slug_not_empty_check",
+          "value": "length(\"agencies\".\"slug\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing": {
+      "name": "billing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plus_active": {
+          "name": "plus_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "plus_since": {
+          "name": "plus_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plus_canceled_at": {
+          "name": "plus_canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plus_stripe_subscription_id": {
+          "name": "plus_stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_credits": {
+          "name": "file_credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_payment_at": {
+          "name": "last_payment_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founder_supporter": {
+          "name": "founder_supporter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "founder_since": {
+          "name": "founder_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "billing_oxy_user_id_key": {
+          "name": "billing_oxy_user_id_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_plus_active_idx": {
+          "name": "billing_plus_active_idx",
+          "columns": [
+            {
+              "expression": "plus_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"billing\".\"plus_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_plus_stripe_subscription_id_key": {
+          "name": "billing_plus_stripe_subscription_id_key",
+          "columns": [
+            {
+              "expression": "plus_stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"billing\".\"plus_stripe_subscription_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_file_credits_non_negative_check": {
+          "name": "billing_file_credits_non_negative_check",
+          "value": "\"billing\".\"file_credits\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_processed_sessions": {
+      "name": "billing_processed_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_id": {
+          "name": "billing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "billing_processed_sessions_key": {
+          "name": "billing_processed_sessions_key",
+          "columns": [
+            {
+              "expression": "billing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_processed_sessions_billing_id_billing_id_fk": {
+          "name": "billing_processed_sessions_billing_id_billing_id_fk",
+          "tableFrom": "billing_processed_sessions",
+          "tableTo": "billing",
+          "columnsFrom": [
+            "billing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cities": {
+      "name": "cities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "population": {
+          "name": "population",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_rent": {
+          "name": "average_rent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "properties_count": {
+          "name": "properties_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "cities_region_name_key": {
+          "name": "cities_region_name_key",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_country_id_idx": {
+          "name": "cities_country_id_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_active_popularity_idx": {
+          "name": "cities_active_popularity_idx",
+          "columns": [
+            {
+              "expression": "\"properties_count\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"cities\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_name_lower_idx": {
+          "name": "cities_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_region_name_lower_idx": {
+          "name": "cities_region_name_lower_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_name_trgm_idx": {
+          "name": "cities_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cities_country_id_countries_id_fk": {
+          "name": "cities_country_id_countries_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cities_region_id_regions_id_fk": {
+          "name": "cities_region_id_regions_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cities_cover_image_id_images_id_fk": {
+          "name": "cities_cover_image_id_images_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "images",
+          "columnsFrom": [
+            "cover_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cities_currency_check": {
+          "name": "cities_currency_check",
+          "value": "\"cities\".\"currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.commissions": {
+      "name": "commissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "partner_id": {
+          "name": "partner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "basis_offering": {
+          "name": "basis_offering",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "basis_deal_value": {
+          "name": "basis_deal_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "basis_kind": {
+          "name": "basis_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "basis_rate": {
+          "name": "basis_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basis_flat": {
+          "name": "basis_flat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "commissions_property_id_key": {
+          "name": "commissions_property_id_key",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commissions_partner_created_idx": {
+          "name": "commissions_partner_created_idx",
+          "columns": [
+            {
+              "expression": "partner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commissions_status_idx": {
+          "name": "commissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commissions_partner_id_partners_id_fk": {
+          "name": "commissions_partner_id_partners_id_fk",
+          "tableFrom": "commissions",
+          "tableTo": "partners",
+          "columnsFrom": [
+            "partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "commissions_property_id_properties_id_fk": {
+          "name": "commissions_property_id_properties_id_fk",
+          "tableFrom": "commissions",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "commissions_status_check": {
+          "name": "commissions_status_check",
+          "value": "\"commissions\".\"status\" in ('pending', 'approved', 'paid', 'cancelled')"
+        },
+        "commissions_basis_offering_check": {
+          "name": "commissions_basis_offering_check",
+          "value": "\"commissions\".\"basis_offering\" in ('rent', 'sale', 'exchange')"
+        },
+        "commissions_basis_kind_check": {
+          "name": "commissions_basis_kind_check",
+          "value": "\"commissions\".\"basis_kind\" in ('percentOfMonthlyRent', 'flat')"
+        },
+        "commissions_basis_components_check": {
+          "name": "commissions_basis_components_check",
+          "value": "(\n        \"commissions\".\"basis_kind\" = 'percentOfMonthlyRent'\n          and \"commissions\".\"basis_rate\" is not null and \"commissions\".\"basis_flat\" is null\n      ) or (\n        \"commissions\".\"basis_kind\" = 'flat'\n          and \"commissions\".\"basis_flat\" is not null and \"commissions\".\"basis_rate\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_message_attachments": {
+      "name": "conversation_message_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_message_attachments_message_id_idx": {
+          "name": "conversation_message_attachments_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_message_attachments_message_id_conversation_messages_id_fk": {
+          "name": "conversation_message_attachments_message_id_conversation_messages_id_fk",
+          "tableFrom": "conversation_message_attachments",
+          "tableTo": "conversation_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_message_attachments_type_check": {
+          "name": "conversation_message_attachments_type_check",
+          "value": "\"conversation_message_attachments\".\"type\" in ('file', 'image', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_messages": {
+      "name": "conversation_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversation_messages_conversation_position_key": {
+          "name": "conversation_messages_conversation_position_key",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_messages_conversation_id_conversations_id_fk": {
+          "name": "conversation_messages_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_messages_role_check": {
+          "name": "conversation_messages_role_check",
+          "value": "\"conversation_messages\".\"role\" in ('user', 'assistant', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "metadata_initial_message": {
+          "name": "metadata_initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "metadata_language": {
+          "name": "metadata_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "metadata_tags": {
+          "name": "metadata_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "sharing_is_shared": {
+          "name": "sharing_is_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharing_share_token": {
+          "name": "sharing_share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharing_shared_at": {
+          "name": "sharing_shared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharing_expires_at": {
+          "name": "sharing_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analytics_last_activity": {
+          "name": "analytics_last_activity",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analytics_total_tokens": {
+          "name": "analytics_total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "conversations_oxy_user_created_idx": {
+          "name": "conversations_oxy_user_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_oxy_user_status_updated_idx": {
+          "name": "conversations_oxy_user_status_updated_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_share_token_key": {
+          "name": "conversations_share_token_key",
+          "columns": [
+            {
+              "expression": "sharing_share_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversations\".\"sharing_share_token\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_sharing_expires_at_idx": {
+          "name": "conversations_sharing_expires_at_idx",
+          "columns": [
+            {
+              "expression": "sharing_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations\".\"sharing_expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_status_check": {
+          "name": "conversations_status_check",
+          "value": "\"conversations\".\"status\" in ('active', 'archived', 'deleted')"
+        },
+        "conversations_topic_check": {
+          "name": "conversations_topic_check",
+          "value": "\"conversations\".\"topic\" in ('rent', 'repairs', 'lease', 'rights', 'general')"
+        },
+        "conversations_metadata_source_check": {
+          "name": "conversations_metadata_source_check",
+          "value": "\"conversations\".\"metadata_source\" in ('quick_action', 'example', 'manual', 'url_share')"
+        },
+        "conversations_sharing_coherent_check": {
+          "name": "conversations_sharing_coherent_check",
+          "value": "(\n        \"conversations\".\"sharing_is_shared\"\n          and \"conversations\".\"sharing_share_token\" is not null\n          and \"conversations\".\"sharing_shared_at\" is not null\n          and \"conversations\".\"sharing_expires_at\" is not null\n      ) or (\n        not \"conversations\".\"sharing_is_shared\"\n          and \"conversations\".\"sharing_share_token\" is null\n          and \"conversations\".\"sharing_shared_at\" is null\n          and \"conversations\".\"sharing_expires_at\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.countries": {
+      "name": "countries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "flag": {
+          "name": "flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_locale": {
+          "name": "default_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "countries_code_key": {
+          "name": "countries_code_key",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "countries_name_lower_idx": {
+          "name": "countries_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "countries_currency_check": {
+          "name": "countries_currency_check",
+          "value": "\"countries\".\"currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_attendees": {
+      "name": "eviction_case_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rsvped_at": {
+          "name": "rsvped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_case_attendees_case_user_key": {
+          "name": "eviction_case_attendees_case_user_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_attendees_case_id_eviction_cases_id_fk": {
+          "name": "eviction_case_attendees_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_case_attendees",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_updates": {
+      "name": "eviction_case_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_scheduled_at": {
+          "name": "new_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_case_updates_case_created_idx": {
+          "name": "eviction_case_updates_case_created_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_updates_case_id_eviction_cases_id_fk": {
+          "name": "eviction_case_updates_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_case_updates",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_case_updates_new_status_check": {
+          "name": "eviction_case_updates_new_status_check",
+          "value": "\"eviction_case_updates\".\"new_status\" in ('upcoming', 'stopped', 'postponed', 'executed', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_cases": {
+      "name": "eviction_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_label": {
+          "name": "location_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_longitude": {
+          "name": "location_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_latitude": {
+          "name": "location_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_geo": {
+          "name": "location_geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "ST_MakePoint(location_longitude, location_latitude)::geography",
+            "type": "stored"
+          }
+        },
+        "location_precision": {
+          "name": "location_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approximate'"
+        },
+        "location_city": {
+          "name": "location_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_country_code": {
+          "name": "location_country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        },
+        "agency_id": {
+          "name": "agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_telegram": {
+          "name": "contact_telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_whatsapp": {
+          "name": "contact_whatsapp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_instructions": {
+          "name": "contact_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_reminder_sent_at": {
+          "name": "outcome_reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_cases_status_scheduled_idx": {
+          "name": "eviction_cases_status_scheduled_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_cases_oxy_user_created_idx": {
+          "name": "eviction_cases_oxy_user_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_cases_location_geo_gist": {
+          "name": "eviction_cases_location_geo_gist",
+          "columns": [
+            {
+              "expression": "location_geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "eviction_cases_agency_id_idx": {
+          "name": "eviction_cases_agency_id_idx",
+          "columns": [
+            {
+              "expression": "agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"eviction_cases\".\"agency_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_cases_agency_id_agencies_id_fk": {
+          "name": "eviction_cases_agency_id_agencies_id_fk",
+          "tableFrom": "eviction_cases",
+          "tableTo": "agencies",
+          "columnsFrom": [
+            "agency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "eviction_cases_cover_image_id_images_id_fk": {
+          "name": "eviction_cases_cover_image_id_images_id_fk",
+          "tableFrom": "eviction_cases",
+          "tableTo": "images",
+          "columnsFrom": [
+            "cover_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_cases_status_check": {
+          "name": "eviction_cases_status_check",
+          "value": "\"eviction_cases\".\"status\" in ('upcoming', 'stopped', 'postponed', 'executed', 'cancelled')"
+        },
+        "eviction_cases_location_precision_check": {
+          "name": "eviction_cases_location_precision_check",
+          "value": "\"eviction_cases\".\"location_precision\" in ('exact', 'approximate')"
+        },
+        "eviction_cases_coordinates_range_check": {
+          "name": "eviction_cases_coordinates_range_check",
+          "value": "\"eviction_cases\".\"location_longitude\" between -180 and 180\n        and \"eviction_cases\".\"location_latitude\" between -90 and 90"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_comments": {
+      "name": "eviction_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_comments_case_created_idx": {
+          "name": "eviction_comments_case_created_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_comments_oxy_user_id_idx": {
+          "name": "eviction_comments_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_comments_case_id_eviction_cases_id_fk": {
+          "name": "eviction_comments_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_comments",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_reports": {
+      "name": "eviction_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_oxy_user_id": {
+          "name": "reporter_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_reports_status_created_idx": {
+          "name": "eviction_reports_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_reports_case_status_idx": {
+          "name": "eviction_reports_case_status_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_reports_open_reporter_key": {
+          "name": "eviction_reports_open_reporter_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"eviction_reports\".\"status\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_reports_case_id_eviction_cases_id_fk": {
+          "name": "eviction_reports_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_reports",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_reports_reason_check": {
+          "name": "eviction_reports_reason_check",
+          "value": "\"eviction_reports\".\"reason\" in ('inaccurate', 'scam', 'inappropriate', 'unavailable', 'privacy', 'unsafe', 'other')"
+        },
+        "eviction_reports_status_check": {
+          "name": "eviction_reports_status_check",
+          "value": "\"eviction_reports\".\"status\" in ('open', 'reviewing', 'resolved', 'dismissed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.exchange_requests": {
+      "name": "exchange_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_oxy_user_id": {
+          "name": "requester_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_oxy_user_id": {
+          "name": "host_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offered_property_id": {
+          "name": "offered_property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_window_start": {
+          "name": "requested_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_window_end": {
+          "name": "requested_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offered_window_start": {
+          "name": "offered_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offered_window_end": {
+          "name": "offered_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "exchange_requests_requested_window_gist": {
+          "name": "exchange_requests_requested_window_gist",
+          "columns": [
+            {
+              "expression": "tstzrange(\"requested_window_start\", \"requested_window_end\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "exchange_requests_property_status_idx": {
+          "name": "exchange_requests_property_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exchange_requests_requester_status_created_idx": {
+          "name": "exchange_requests_requester_status_created_idx",
+          "columns": [
+            {
+              "expression": "requester_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exchange_requests_host_status_created_idx": {
+          "name": "exchange_requests_host_status_created_idx",
+          "columns": [
+            {
+              "expression": "host_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_requests_property_id_properties_id_fk": {
+          "name": "exchange_requests_property_id_properties_id_fk",
+          "tableFrom": "exchange_requests",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "exchange_requests_offered_property_id_properties_id_fk": {
+          "name": "exchange_requests_offered_property_id_properties_id_fk",
+          "tableFrom": "exchange_requests",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "offered_property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exchange_requests_mode_check": {
+          "name": "exchange_requests_mode_check",
+          "value": "\"exchange_requests\".\"mode\" in ('swap', 'host', 'both')"
+        },
+        "exchange_requests_status_check": {
+          "name": "exchange_requests_status_check",
+          "value": "\"exchange_requests\".\"status\" in ('pending', 'confirmed', 'declined', 'cancelled', 'completed')"
+        },
+        "exchange_requests_requested_window_order_check": {
+          "name": "exchange_requests_requested_window_order_check",
+          "value": "\"exchange_requests\".\"requested_window_end\" > \"exchange_requests\".\"requested_window_start\""
+        },
+        "exchange_requests_offered_window_check": {
+          "name": "exchange_requests_offered_window_check",
+          "value": "(\n        \"exchange_requests\".\"offered_window_start\" is null and \"exchange_requests\".\"offered_window_end\" is null\n      ) or (\n        \"exchange_requests\".\"offered_window_start\" is not null and \"exchange_requests\".\"offered_window_end\" is not null\n          and \"exchange_requests\".\"offered_window_end\" > \"exchange_requests\".\"offered_window_start\"\n      )"
+        },
+        "exchange_requests_host_mode_offers_nothing_check": {
+          "name": "exchange_requests_host_mode_offers_nothing_check",
+          "value": "\"exchange_requests\".\"mode\" <> 'host' or (\n        \"exchange_requests\".\"offered_property_id\" is null\n        and \"exchange_requests\".\"offered_window_start\" is null\n        and \"exchange_requests\".\"offered_window_end\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.exchange_reviews": {
+      "name": "exchange_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "exchange_request_id": {
+          "name": "exchange_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_oxy_user_id": {
+          "name": "reviewer_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_oxy_user_id": {
+          "name": "subject_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories_communication": {
+          "name": "categories_communication",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories_cleanliness": {
+          "name": "categories_cleanliness",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories_accuracy": {
+          "name": "categories_accuracy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories_hospitality": {
+          "name": "categories_hospitality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "exchange_reviews_request_reviewer_key": {
+          "name": "exchange_reviews_request_reviewer_key",
+          "columns": [
+            {
+              "expression": "exchange_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reviewer_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exchange_reviews_subject_created_idx": {
+          "name": "exchange_reviews_subject_created_idx",
+          "columns": [
+            {
+              "expression": "subject_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_reviews_exchange_request_id_exchange_requests_id_fk": {
+          "name": "exchange_reviews_exchange_request_id_exchange_requests_id_fk",
+          "tableFrom": "exchange_reviews",
+          "tableTo": "exchange_requests",
+          "columnsFrom": [
+            "exchange_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exchange_reviews_rating_check": {
+          "name": "exchange_reviews_rating_check",
+          "value": "\"exchange_reviews\".\"rating\" between 1 and 5"
+        },
+        "exchange_reviews_categories_range_check": {
+          "name": "exchange_reviews_categories_range_check",
+          "value": "(\"exchange_reviews\".\"categories_communication\" is null or \"exchange_reviews\".\"categories_communication\" between 1 and 5)\n        and (\"exchange_reviews\".\"categories_cleanliness\" is null or \"exchange_reviews\".\"categories_cleanliness\" between 1 and 5)\n        and (\"exchange_reviews\".\"categories_accuracy\" is null or \"exchange_reviews\".\"categories_accuracy\" between 1 and 5)\n        and (\"exchange_reviews\".\"categories_hospitality\" is null or \"exchange_reviews\".\"categories_hospitality\" between 1 and 5)"
+        },
+        "exchange_reviews_distinct_parties_check": {
+          "name": "exchange_reviews_distinct_parties_check",
+          "value": "\"exchange_reviews\".\"reviewer_oxy_user_id\" <> \"exchange_reviews\".\"subject_oxy_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keys_original": {
+          "name": "keys_original",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keys_small": {
+          "name": "keys_small",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keys_medium": {
+          "name": "keys_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keys_large": {
+          "name": "keys_large",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urls_original": {
+          "name": "urls_original",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urls_small": {
+          "name": "urls_small",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urls_medium": {
+          "name": "urls_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urls_large": {
+          "name": "urls_large",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "images_entity_order_idx": {
+          "name": "images_entity_order_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "images_entity_type_check": {
+          "name": "images_entity_type_check",
+          "value": "\"images\".\"entity_type\" in ('property', 'city', 'region', 'country', 'profile')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_co_tenants": {
+      "name": "lease_co_tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'secondary'"
+        },
+        "signed_date": {
+          "name": "signed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "lease_co_tenants_lease_id_idx": {
+          "name": "lease_co_tenants_lease_id_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_co_tenants_lease_id_leases_id_fk": {
+          "name": "lease_co_tenants_lease_id_leases_id_fk",
+          "tableFrom": "lease_co_tenants",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_co_tenants_role_check": {
+          "name": "lease_co_tenants_role_check",
+          "value": "\"lease_co_tenants\".\"role\" in ('primary', 'secondary', 'guarantor')"
+        },
+        "lease_co_tenants_status_check": {
+          "name": "lease_co_tenants_status_check",
+          "value": "\"lease_co_tenants\".\"status\" in ('pending', 'signed', 'declined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_documents": {
+      "name": "lease_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "uploaded_by_oxy_user_id": {
+          "name": "uploaded_by_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_date": {
+          "name": "uploaded_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lease_documents_lease_id_idx": {
+          "name": "lease_documents_lease_id_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_documents_lease_id_leases_id_fk": {
+          "name": "lease_documents_lease_id_leases_id_fk",
+          "tableFrom": "lease_documents",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_documents_type_check": {
+          "name": "lease_documents_type_check",
+          "value": "\"lease_documents\".\"type\" in ('lease_agreement', 'addendum', 'inspection_report', 'insurance', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_inspection_findings": {
+      "name": "lease_inspection_findings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area": {
+          "name": "area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        }
+      },
+      "indexes": {
+        "lease_inspection_findings_inspection_id_idx": {
+          "name": "lease_inspection_findings_inspection_id_idx",
+          "columns": [
+            {
+              "expression": "inspection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_inspection_findings_inspection_id_lease_inspections_id_fk": {
+          "name": "lease_inspection_findings_inspection_id_lease_inspections_id_fk",
+          "tableFrom": "lease_inspection_findings",
+          "tableTo": "lease_inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_inspection_findings_condition_check": {
+          "name": "lease_inspection_findings_condition_check",
+          "value": "\"lease_inspection_findings\".\"condition\" in ('excellent', 'good', 'fair', 'poor', 'needs_repair')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_inspections": {
+      "name": "lease_inspections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inspector": {
+          "name": "inspector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_by_tenant": {
+          "name": "signed_by_tenant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signed_by_landlord": {
+          "name": "signed_by_landlord",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "lease_inspections_lease_id_idx": {
+          "name": "lease_inspections_lease_id_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_inspections_lease_id_leases_id_fk": {
+          "name": "lease_inspections_lease_id_leases_id_fk",
+          "tableFrom": "lease_inspections",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_inspections_type_check": {
+          "name": "lease_inspections_type_check",
+          "value": "\"lease_inspections\".\"type\" in ('move_in', 'move_out', 'periodic', 'maintenance')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_payment_schedule": {
+      "name": "lease_payment_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "paid_date": {
+          "name": "paid_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lease_payment_schedule_lease_due_idx": {
+          "name": "lease_payment_schedule_lease_due_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lease_payment_schedule_due_status_idx": {
+          "name": "lease_payment_schedule_due_status_idx",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_payment_schedule_lease_id_leases_id_fk": {
+          "name": "lease_payment_schedule_lease_id_leases_id_fk",
+          "tableFrom": "lease_payment_schedule",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_payment_schedule_type_check": {
+          "name": "lease_payment_schedule_type_check",
+          "value": "\"lease_payment_schedule\".\"type\" in ('rent', 'deposit', 'fee', 'utility')"
+        },
+        "lease_payment_schedule_status_check": {
+          "name": "lease_payment_schedule_status_check",
+          "value": "\"lease_payment_schedule\".\"status\" in ('pending', 'paid', 'overdue', 'cancelled')"
+        },
+        "lease_payment_schedule_method_check": {
+          "name": "lease_payment_schedule_method_check",
+          "value": "\"lease_payment_schedule\".\"payment_method\" in ('cash', 'check', 'bank_transfer', 'credit_card', 'debit_card', 'digital_wallet')"
+        },
+        "lease_payment_schedule_paid_evidence_check": {
+          "name": "lease_payment_schedule_paid_evidence_check",
+          "value": "(\n        \"lease_payment_schedule\".\"status\" = 'paid'\n          and \"lease_payment_schedule\".\"paid_date\" is not null and \"lease_payment_schedule\".\"paid_amount\" is not null\n      ) or (\n        \"lease_payment_schedule\".\"status\" <> 'paid'\n          and \"lease_payment_schedule\".\"paid_date\" is null and \"lease_payment_schedule\".\"paid_amount\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_shared_utility_costs": {
+      "name": "lease_shared_utility_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility": {
+          "name": "utility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_percentage": {
+          "name": "split_percentage",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lease_shared_utility_costs_lease_id_idx": {
+          "name": "lease_shared_utility_costs_lease_id_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_shared_utility_costs_lease_id_leases_id_fk": {
+          "name": "lease_shared_utility_costs_lease_id_leases_id_fk",
+          "tableFrom": "lease_shared_utility_costs",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_shared_utility_costs_utility_check": {
+          "name": "lease_shared_utility_costs_utility_check",
+          "value": "\"lease_shared_utility_costs\".\"utility\" in ('electricity', 'gas', 'water', 'trash', 'internet', 'cable', 'heat', 'air_conditioning')"
+        },
+        "lease_shared_utility_costs_split_check": {
+          "name": "lease_shared_utility_costs_split_check",
+          "value": "\"lease_shared_utility_costs\".\"split_percentage\" between 0 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.leases": {
+      "name": "leases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landlord_oxy_user_id": {
+          "name": "landlord_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_oxy_user_id": {
+          "name": "tenant_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_terms_start_date": {
+          "name": "lease_terms_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_terms_end_date": {
+          "name": "lease_terms_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_terms_renewal_options": {
+          "name": "lease_terms_renewal_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "lease_terms_renewal_notice_required": {
+          "name": "lease_terms_renewal_notice_required",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "lease_terms_termination_notice_required": {
+          "name": "lease_terms_termination_notice_required",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "rent_details_monthly_rent": {
+          "name": "rent_details_monthly_rent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rent_details_currency": {
+          "name": "rent_details_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "rent_details_due_date": {
+          "name": "rent_details_due_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "rent_details_late_fee_amount": {
+          "name": "rent_details_late_fee_amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rent_details_late_fee_grace_period": {
+          "name": "rent_details_late_fee_grace_period",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "rent_details_security_deposit": {
+          "name": "rent_details_security_deposit",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rent_details_pet_deposit": {
+          "name": "rent_details_pet_deposit",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "utilities_included": {
+          "name": "utilities_included",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "utilities_tenant_responsible": {
+          "name": "utilities_tenant_responsible",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rules_pets_allowed": {
+          "name": "rules_pets_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_pets_types": {
+          "name": "rules_pets_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rules_pets_max_number": {
+          "name": "rules_pets_max_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rules_pets_restrictions": {
+          "name": "rules_pets_restrictions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rules_smoking": {
+          "name": "rules_smoking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_guests_overnight_allowed": {
+          "name": "rules_guests_overnight_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rules_guests_overnight_max_consecutive_days": {
+          "name": "rules_guests_overnight_max_consecutive_days",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "rules_guests_overnight_max_days_per_month": {
+          "name": "rules_guests_overnight_max_days_per_month",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "rules_guests_parties": {
+          "name": "rules_guests_parties",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_subletting": {
+          "name": "rules_subletting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_alterations": {
+          "name": "rules_alterations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signatures_landlord_signed": {
+          "name": "signatures_landlord_signed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signatures_landlord_signed_date": {
+          "name": "signatures_landlord_signed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatures_landlord_digital_signature": {
+          "name": "signatures_landlord_digital_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatures_tenant_signed": {
+          "name": "signatures_tenant_signed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signatures_tenant_signed_date": {
+          "name": "signatures_tenant_signed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatures_tenant_digital_signature": {
+          "name": "signatures_tenant_digital_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_given_by_oxy_user_id": {
+          "name": "termination_notice_given_by_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_given_date": {
+          "name": "termination_notice_given_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_effective_date": {
+          "name": "termination_notice_effective_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_reason": {
+          "name": "termination_notice_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_acknowledged": {
+          "name": "termination_notice_acknowledged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "termination_notice_acknowledged_date": {
+          "name": "termination_notice_acknowledged_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "leases_property_status_idx": {
+          "name": "leases_property_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "leases_landlord_status_idx": {
+          "name": "leases_landlord_status_idx",
+          "columns": [
+            {
+              "expression": "landlord_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "leases_tenant_status_idx": {
+          "name": "leases_tenant_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "leases_term_range_gist": {
+          "name": "leases_term_range_gist",
+          "columns": [
+            {
+              "expression": "tstzrange(\"lease_terms_start_date\", \"lease_terms_end_date\", '[]')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "leases_active_end_date_idx": {
+          "name": "leases_active_end_date_idx",
+          "columns": [
+            {
+              "expression": "lease_terms_end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"leases\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "leases_property_id_properties_id_fk": {
+          "name": "leases_property_id_properties_id_fk",
+          "tableFrom": "leases",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "leases_room_id_properties_id_fk": {
+          "name": "leases_room_id_properties_id_fk",
+          "tableFrom": "leases",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "leases_status_check": {
+          "name": "leases_status_check",
+          "value": "\"leases\".\"status\" in ('draft', 'pending_signatures', 'active', 'expired', 'terminated', 'cancelled')"
+        },
+        "leases_renewal_options_check": {
+          "name": "leases_renewal_options_check",
+          "value": "\"leases\".\"lease_terms_renewal_options\" in ('none', 'automatic', 'optional')"
+        },
+        "leases_rent_currency_check": {
+          "name": "leases_rent_currency_check",
+          "value": "\"leases\".\"rent_details_currency\" in ('USD', 'EUR', 'GBP', 'CAD')"
+        },
+        "leases_utilities_included_check": {
+          "name": "leases_utilities_included_check",
+          "value": "\"leases\".\"utilities_included\" <@ array['electricity', 'gas', 'water', 'trash', 'internet', 'cable', 'heat', 'air_conditioning']::text[]"
+        },
+        "leases_utilities_tenant_responsible_check": {
+          "name": "leases_utilities_tenant_responsible_check",
+          "value": "\"leases\".\"utilities_tenant_responsible\" <@ array['electricity', 'gas', 'water', 'trash', 'internet', 'cable', 'heat', 'air_conditioning']::text[]"
+        },
+        "leases_rules_pets_types_check": {
+          "name": "leases_rules_pets_types_check",
+          "value": "\"leases\".\"rules_pets_types\" <@ array['dog', 'cat', 'bird', 'fish', 'reptile', 'other']::text[]"
+        },
+        "leases_rent_due_date_check": {
+          "name": "leases_rent_due_date_check",
+          "value": "\"leases\".\"rent_details_due_date\" between 1 and 31"
+        },
+        "leases_term_order_check": {
+          "name": "leases_term_order_check",
+          "value": "\"leases\".\"lease_terms_end_date\" > \"leases\".\"lease_terms_start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.listing_reports": {
+      "name": "listing_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_oxy_user_id": {
+          "name": "reporter_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "listing_reports_status_created_idx": {
+          "name": "listing_reports_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listing_reports_property_status_idx": {
+          "name": "listing_reports_property_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listing_reports_open_reporter_key": {
+          "name": "listing_reports_open_reporter_key",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"listing_reports\".\"status\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listing_reports_property_id_properties_id_fk": {
+          "name": "listing_reports_property_id_properties_id_fk",
+          "tableFrom": "listing_reports",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "listing_reports_reason_check": {
+          "name": "listing_reports_reason_check",
+          "value": "\"listing_reports\".\"reason\" in ('inaccurate', 'scam', 'inappropriate', 'unavailable', 'privacy', 'unsafe', 'other')"
+        },
+        "listing_reports_status_check": {
+          "name": "listing_reports_status_check",
+          "value": "\"listing_reports\".\"status\" in ('open', 'reviewing', 'resolved', 'dismissed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_enforcements": {
+      "name": "moderation_enforcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_action": {
+          "name": "recommended_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_reason": {
+          "name": "skipped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state_property_moderation_restricted": {
+          "name": "previous_state_property_moderation_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state_review_moderation_status": {
+          "name": "previous_state_review_moderation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_enforcements_decision_action_key": {
+          "name": "moderation_enforcements_decision_action_key",
+          "columns": [
+            {
+              "expression": "decision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_enforcements_subject_created_idx": {
+          "name": "moderation_enforcements_subject_created_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_enforcements_case_id_idx": {
+          "name": "moderation_enforcements_case_id_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_enforcements_action_check": {
+          "name": "moderation_enforcements_action_check",
+          "value": "\"moderation_enforcements\".\"action\" in ('none', 'restrict', 'restore', 'flag_for_review', 'unflag', 'manual_review')"
+        },
+        "moderation_enforcements_mode_check": {
+          "name": "moderation_enforcements_mode_check",
+          "value": "\"moderation_enforcements\".\"mode\" in ('observe', 'manual', 'automatic')"
+        },
+        "moderation_enforcements_previous_review_status_check": {
+          "name": "moderation_enforcements_previous_review_status_check",
+          "value": "\"moderation_enforcements\".\"previous_state_review_moderation_status\" in ('active', 'under_review', 'removed')"
+        },
+        "moderation_enforcements_decision_revision_check": {
+          "name": "moderation_enforcements_decision_revision_check",
+          "value": "\"moderation_enforcements\".\"decision_revision\" >= 1"
+        },
+        "moderation_enforcements_applied_at_check": {
+          "name": "moderation_enforcements_applied_at_check",
+          "value": "\"moderation_enforcements\".\"applied\" = (\"moderation_enforcements\".\"applied_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_events": {
+      "name": "moderation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claimed'"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_events_case_id_idx": {
+          "name": "moderation_events_case_id_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"moderation_events\".\"case_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_events_expires_at_idx": {
+          "name": "moderation_events_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_events_state_received_idx": {
+          "name": "moderation_events_state_received_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_events_state_check": {
+          "name": "moderation_events_state_check",
+          "value": "\"moderation_events\".\"state\" in ('claimed', 'queued', 'ignored')"
+        },
+        "moderation_events_queued_at_check": {
+          "name": "moderation_events_queued_at_check",
+          "value": "(\"moderation_events\".\"state\" = 'queued') = (\"moderation_events\".\"queued_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_outbox": {
+      "name": "moderation_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_outbox_due_idx": {
+          "name": "moderation_outbox_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_outbox_lease_idx": {
+          "name": "moderation_outbox_lease_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_outbox_expires_at_idx": {
+          "name": "moderation_outbox_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_outbox_report_id_moderation_reports_id_fk": {
+          "name": "moderation_outbox_report_id_moderation_reports_id_fk",
+          "tableFrom": "moderation_outbox",
+          "tableTo": "moderation_reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_outbox_kind_check": {
+          "name": "moderation_outbox_kind_check",
+          "value": "\"moderation_outbox\".\"kind\" in ('report.submit', 'decision.apply')"
+        },
+        "moderation_outbox_status_check": {
+          "name": "moderation_outbox_status_check",
+          "value": "\"moderation_outbox\".\"status\" in ('pending', 'processing', 'processed', 'dead_letter')"
+        },
+        "moderation_outbox_attempts_check": {
+          "name": "moderation_outbox_attempts_check",
+          "value": "\"moderation_outbox\".\"attempts\" >= 0"
+        },
+        "moderation_outbox_lease_pair_check": {
+          "name": "moderation_outbox_lease_pair_check",
+          "value": "(\"moderation_outbox\".\"lease_owner\" is null) = (\"moderation_outbox\".\"lease_until\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_reports": {
+      "name": "moderation_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reported_type": {
+          "name": "reported_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_id": {
+          "name": "reported_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_oxy_user_id": {
+          "name": "reporter_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_status": {
+          "name": "local_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "local_status_reason": {
+          "name": "local_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_report_id": {
+          "name": "crowd_source_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_case_id": {
+          "name": "crowd_source_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_merged": {
+          "name": "crowd_source_merged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_outcome": {
+          "name": "decision_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_status": {
+          "name": "decision_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforced_action": {
+          "name": "enforced_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforced_at": {
+          "name": "enforced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_snapshot_hash": {
+          "name": "content_snapshot_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivery_error": {
+          "name": "last_delivery_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_reports_reporter_object_key": {
+          "name": "moderation_reports_reporter_object_key",
+          "columns": [
+            {
+              "expression": "reporter_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reported_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reported_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_reports_local_status_created_idx": {
+          "name": "moderation_reports_local_status_created_idx",
+          "columns": [
+            {
+              "expression": "local_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_reports_object_idx": {
+          "name": "moderation_reports_object_idx",
+          "columns": [
+            {
+              "expression": "reported_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reported_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_reports_case_id_idx": {
+          "name": "moderation_reports_case_id_idx",
+          "columns": [
+            {
+              "expression": "crowd_source_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"moderation_reports\".\"crowd_source_case_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_reports_reported_type_check": {
+          "name": "moderation_reports_reported_type_check",
+          "value": "\"moderation_reports\".\"reported_type\" in ('property', 'review', 'eviction_case')"
+        },
+        "moderation_reports_local_status_check": {
+          "name": "moderation_reports_local_status_check",
+          "value": "\"moderation_reports\".\"local_status\" in ('received', 'queued', 'submitted', 'delivery_failed', 'closed')"
+        },
+        "moderation_reports_enforced_action_check": {
+          "name": "moderation_reports_enforced_action_check",
+          "value": "\"moderation_reports\".\"enforced_action\" in ('none', 'restrict', 'restore', 'flag_for_review', 'unflag', 'manual_review')"
+        },
+        "moderation_reports_decision_revision_check": {
+          "name": "moderation_reports_decision_revision_check",
+          "value": "\"moderation_reports\".\"decision_revision\" is null or \"moderation_reports\".\"decision_revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.neighborhoods": {
+      "name": "neighborhoods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_west": {
+          "name": "bbox_west",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_south": {
+          "name": "bbox_south",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_east": {
+          "name": "bbox_east",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_north": {
+          "name": "bbox_north",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "neighborhoods_city_name_key": {
+          "name": "neighborhoods_city_name_key",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "neighborhoods_name_lower_idx": {
+          "name": "neighborhoods_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "neighborhoods_city_name_lower_idx": {
+          "name": "neighborhoods_city_name_lower_idx",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "neighborhoods_name_trgm_idx": {
+          "name": "neighborhoods_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "neighborhoods_city_id_cities_id_fk": {
+          "name": "neighborhoods_city_id_cities_id_fk",
+          "tableFrom": "neighborhoods",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "neighborhoods_bbox_complete_check": {
+          "name": "neighborhoods_bbox_complete_check",
+          "value": "(\n        \"neighborhoods\".\"bbox_west\" is null and \"neighborhoods\".\"bbox_south\" is null\n        and \"neighborhoods\".\"bbox_east\" is null and \"neighborhoods\".\"bbox_north\" is null\n      ) or (\n        \"neighborhoods\".\"bbox_west\" is not null and \"neighborhoods\".\"bbox_south\" is not null\n        and \"neighborhoods\".\"bbox_east\" is not null and \"neighborhoods\".\"bbox_north\" is not null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_oxy_user_id": {
+          "name": "recipient_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'homiio'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_created_idx": {
+          "name": "notifications_recipient_created_idx",
+          "columns": [
+            {
+              "expression": "recipient_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_unread_idx": {
+          "name": "notifications_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "not \"notifications\".\"read\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_type_created_idx": {
+          "name": "notifications_recipient_type_created_idx",
+          "columns": [
+            {
+              "expression": "recipient_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_priority_check": {
+          "name": "notifications_priority_check",
+          "value": "\"notifications\".\"priority\" in ('low', 'medium', 'high', 'urgent')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.partners": {
+      "name": "partners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referral_code": {
+          "name": "referral_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "points": {
+          "name": "points",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "partners_oxy_user_id_key": {
+          "name": "partners_oxy_user_id_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partners_referral_code_key": {
+          "name": "partners_referral_code_key",
+          "columns": [
+            {
+              "expression": "referral_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partners_status_idx": {
+          "name": "partners_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "partners_status_check": {
+          "name": "partners_status_check",
+          "value": "\"partners\".\"status\" in ('active', 'inactive')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.place_poi_categories": {
+      "name": "place_poi_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "place_poi_id": {
+          "name": "place_poi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "present": {
+          "name": "present",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "count": {
+          "name": "count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "nearest_m": {
+          "name": "nearest_m",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "place_poi_categories_poi_key_key": {
+          "name": "place_poi_categories_poi_key_key",
+          "columns": [
+            {
+              "expression": "place_poi_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "place_poi_categories_place_poi_id_place_pois_id_fk": {
+          "name": "place_poi_categories_place_poi_id_place_pois_id_fk",
+          "tableFrom": "place_poi_categories",
+          "tableTo": "place_pois",
+          "columnsFrom": [
+            "place_poi_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "place_poi_categories_key_check": {
+          "name": "place_poi_categories_key_check",
+          "value": "\"place_poi_categories\".\"key\" in ('pharmacy', 'school', 'hospital', 'police', 'fire_station', 'supermarket', 'transit', 'park', 'bank', 'restaurant', 'gym', 'spa')"
+        },
+        "place_poi_categories_count_check": {
+          "name": "place_poi_categories_count_check",
+          "value": "\"place_poi_categories\".\"count\" >= 0"
+        },
+        "place_poi_categories_coherent_check": {
+          "name": "place_poi_categories_coherent_check",
+          "value": "(\"place_poi_categories\".\"present\" = (\"place_poi_categories\".\"count\" > 0))\n        and (\"place_poi_categories\".\"nearest_m\" is null or \"place_poi_categories\".\"present\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.place_pois": {
+      "name": "place_pois",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cell_key": {
+          "name": "cell_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "radius_m": {
+          "name": "radius_m",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "place_pois_cell_key_key": {
+          "name": "place_pois_cell_key_key",
+          "columns": [
+            {
+              "expression": "cell_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "place_pois_expires_at_idx": {
+          "name": "place_pois_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "place_pois_radius_check": {
+          "name": "place_pois_radius_check",
+          "value": "\"place_pois\".\"radius_m\" >= 1"
+        },
+        "place_pois_coordinates_range_check": {
+          "name": "place_pois_coordinates_range_check",
+          "value": "\"place_pois\".\"lat\" between -90 and 90 and \"place_pois\".\"lng\" between -180 and 180"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profile_chat_messages": {
+      "name": "profile_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_chat_messages_profile_position_idx": {
+          "name": "profile_chat_messages_profile_position_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_chat_messages_profile_id_profiles_id_fk": {
+          "name": "profile_chat_messages_profile_id_profiles_id_fk",
+          "tableFrom": "profile_chat_messages",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profile_chat_messages_role_check": {
+          "name": "profile_chat_messages_role_check",
+          "value": "\"profile_chat_messages\".\"role\" in ('user', 'assistant', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profile_preferred_locations": {
+      "name": "profile_preferred_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "radius": {
+          "name": "radius",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profile_preferred_locations_profile_id_idx": {
+          "name": "profile_preferred_locations_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_preferred_locations_profile_id_profiles_id_fk": {
+          "name": "profile_preferred_locations_profile_id_profiles_id_fk",
+          "tableFrom": "profile_preferred_locations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_references": {
+      "name": "profile_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "profile_references_profile_id_idx": {
+          "name": "profile_references_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_references_profile_id_profiles_id_fk": {
+          "name": "profile_references_profile_id_profiles_id_fk",
+          "tableFrom": "profile_references",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profile_references_relationship_check": {
+          "name": "profile_references_relationship_check",
+          "value": "\"profile_references\".\"relationship\" in ('landlord', 'employer', 'personal', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profile_rental_history": {
+      "name": "profile_rental_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_rent": {
+          "name": "monthly_rent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_for_leaving": {
+          "name": "reason_for_leaving",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landlord_contact_name": {
+          "name": "landlord_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landlord_contact_phone": {
+          "name": "landlord_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landlord_contact_email": {
+          "name": "landlord_contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "profile_rental_history_profile_id_idx": {
+          "name": "profile_rental_history_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_rental_history_profile_id_profiles_id_fk": {
+          "name": "profile_rental_history_profile_id_profiles_id_fk",
+          "tableFrom": "profile_rental_history",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profile_rental_history_reason_for_leaving_check": {
+          "name": "profile_rental_history_reason_for_leaving_check",
+          "value": "\"profile_rental_history\".\"reason_for_leaving\" in ('lease_ended', 'bought_home', 'job_relocation', 'family_reasons', 'upgrade', 'other')"
+        },
+        "profile_rental_history_order_check": {
+          "name": "profile_rental_history_order_check",
+          "value": "\"profile_rental_history\".\"end_date\" is null or \"profile_rental_history\".\"end_date\" >= \"profile_rental_history\".\"start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profile_roommate_history": {
+      "name": "profile_roommate_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roommate_count": {
+          "name": "roommate_count",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profile_roommate_history_profile_id_idx": {
+          "name": "profile_roommate_history_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_roommate_history_profile_id_profiles_id_fk": {
+          "name": "profile_roommate_history_profile_id_profiles_id_fk",
+          "tableFrom": "profile_roommate_history",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profile_roommate_history_order_check": {
+          "name": "profile_roommate_history_order_check",
+          "value": "\"profile_roommate_history\".\"end_date\" is null or \"profile_roommate_history\".\"end_date\" >= \"profile_roommate_history\".\"start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personal_info_bio": {
+          "name": "personal_info_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_occupation": {
+          "name": "personal_info_occupation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_employer": {
+          "name": "personal_info_employer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_annual_income": {
+          "name": "personal_info_annual_income",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_employment_status": {
+          "name": "personal_info_employment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_move_in_date": {
+          "name": "personal_info_move_in_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_lease_duration": {
+          "name": "personal_info_lease_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_property_types": {
+          "name": "preferences_property_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_max_rent": {
+          "name": "preferences_max_rent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_price_unit": {
+          "name": "preferences_price_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_min_bedrooms": {
+          "name": "preferences_min_bedrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_min_bathrooms": {
+          "name": "preferences_min_bathrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_preferred_amenities": {
+          "name": "preferences_preferred_amenities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_pet_friendly": {
+          "name": "preferences_pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_smoking_allowed": {
+          "name": "preferences_smoking_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_furnished": {
+          "name": "preferences_furnished",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_parking_required": {
+          "name": "preferences_parking_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_accessibility": {
+          "name": "preferences_accessibility",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_identity": {
+          "name": "verification_identity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_income": {
+          "name": "verification_income",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_background": {
+          "name": "verification_background",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_rental_history": {
+          "name": "verification_rental_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_references": {
+          "name": "verification_references",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_email": {
+          "name": "settings_notifications_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_push": {
+          "name": "settings_notifications_push",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_sms": {
+          "name": "settings_notifications_sms",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_property_alerts": {
+          "name": "settings_notifications_property_alerts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_viewing_reminders": {
+          "name": "settings_notifications_viewing_reminders",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_lease_updates": {
+          "name": "settings_notifications_lease_updates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_profile_visibility": {
+          "name": "settings_privacy_profile_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_show_contact_info": {
+          "name": "settings_privacy_show_contact_info",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_show_income": {
+          "name": "settings_privacy_show_income",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_show_rental_history": {
+          "name": "settings_privacy_show_rental_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_show_references": {
+          "name": "settings_privacy_show_references",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_enabled": {
+          "name": "settings_roommate_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_age_range_min": {
+          "name": "settings_roommate_preferences_age_range_min",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_age_range_max": {
+          "name": "settings_roommate_preferences_age_range_max",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_gender": {
+          "name": "settings_roommate_preferences_gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_smoking": {
+          "name": "settings_roommate_preferences_lifestyle_smoking",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_pets": {
+          "name": "settings_roommate_preferences_lifestyle_pets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_partying": {
+          "name": "settings_roommate_preferences_lifestyle_partying",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_cleanliness": {
+          "name": "settings_roommate_preferences_lifestyle_cleanliness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_schedule": {
+          "name": "settings_roommate_preferences_lifestyle_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_budget_min": {
+          "name": "settings_roommate_preferences_budget_min",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_budget_max": {
+          "name": "settings_roommate_preferences_budget_max",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_move_in_date": {
+          "name": "settings_roommate_preferences_move_in_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lease_duration": {
+          "name": "settings_roommate_preferences_lease_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_location": {
+          "name": "settings_roommate_preferences_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_interests": {
+          "name": "settings_roommate_preferences_interests",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_language": {
+          "name": "settings_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_timezone": {
+          "name": "settings_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_currency": {
+          "name": "settings_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "profiles_oxy_user_id_key": {
+          "name": "profiles_oxy_user_id_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profiles_personal_info_employment_status_check": {
+          "name": "profiles_personal_info_employment_status_check",
+          "value": "\"profiles\".\"personal_info_employment_status\" in ('employed', 'self_employed', 'student', 'retired', 'unemployed', 'other')"
+        },
+        "profiles_personal_info_lease_duration_check": {
+          "name": "profiles_personal_info_lease_duration_check",
+          "value": "\"profiles\".\"personal_info_lease_duration\" in ('monthly', '3_months', '6_months', 'yearly', 'flexible')"
+        },
+        "profiles_preferences_price_unit_check": {
+          "name": "profiles_preferences_price_unit_check",
+          "value": "\"profiles\".\"preferences_price_unit\" in ('day', 'night', 'week', 'month', 'year')"
+        },
+        "profiles_preferences_property_types_check": {
+          "name": "profiles_preferences_property_types_check",
+          "value": "\"profiles\".\"preferences_property_types\" <@ array['apartment', 'house', 'room', 'studio', 'couchsurfing', 'roommates', 'coliving', 'hostel', 'guesthouse', 'campsite', 'boat', 'treehouse', 'yurt', 'other']::text[]"
+        },
+        "profiles_settings_privacy_profile_visibility_check": {
+          "name": "profiles_settings_privacy_profile_visibility_check",
+          "value": "\"profiles\".\"settings_privacy_profile_visibility\" in ('public', 'private', 'contacts_only')"
+        },
+        "profiles_settings_roommate_gender_check": {
+          "name": "profiles_settings_roommate_gender_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_gender\" in ('male', 'female', 'any')"
+        },
+        "profiles_settings_roommate_smoking_check": {
+          "name": "profiles_settings_roommate_smoking_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_smoking\" in ('yes', 'no', 'prefer_not')"
+        },
+        "profiles_settings_roommate_pets_check": {
+          "name": "profiles_settings_roommate_pets_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_pets\" in ('yes', 'no', 'prefer_not')"
+        },
+        "profiles_settings_roommate_partying_check": {
+          "name": "profiles_settings_roommate_partying_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_partying\" in ('yes', 'no', 'prefer_not')"
+        },
+        "profiles_settings_roommate_cleanliness_check": {
+          "name": "profiles_settings_roommate_cleanliness_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_cleanliness\" in ('very_clean', 'clean', 'average', 'relaxed')"
+        },
+        "profiles_settings_roommate_schedule_check": {
+          "name": "profiles_settings_roommate_schedule_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_schedule\" in ('early_bird', 'night_owl', 'flexible')"
+        },
+        "profiles_settings_roommate_lease_duration_check": {
+          "name": "profiles_settings_roommate_lease_duration_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lease_duration\" in ('monthly', '3_months', '6_months', 'yearly', 'flexible')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.properties": {
+      "name": "properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_external": {
+          "name": "is_external",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourced_by_partner_id": {
+          "name": "sourced_by_partner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourced_by_referral_code": {
+          "name": "sourced_by_referral_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agency_id": {
+          "name": "agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_phone": {
+          "name": "external_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_email": {
+          "name": "external_contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_whatsapp": {
+          "name": "external_contact_whatsapp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_name": {
+          "name": "external_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_agency_name": {
+          "name": "external_contact_agency_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_kind": {
+          "name": "external_contact_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_students_only": {
+          "name": "listing_flags_students_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_room_not_full_unit": {
+          "name": "listing_flags_room_not_full_unit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_temporary_only": {
+          "name": "listing_flags_temporary_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_gender_restricted": {
+          "name": "listing_flags_gender_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_workers_only": {
+          "name": "listing_flags_workers_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_agency_fee_payable": {
+          "name": "listing_flags_agency_fee_payable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_no_pets": {
+          "name": "listing_flags_no_pets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_no_smoking": {
+          "name": "listing_flags_no_smoking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_no_couples": {
+          "name": "listing_flags_no_couples",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_no_dss": {
+          "name": "listing_flags_no_dss",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_detected_language": {
+          "name": "listing_flags_detected_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('homiio_simple', coalesce(description, ''))",
+            "type": "stored"
+          }
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_address_number": {
+          "name": "show_address_number",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'apartment'"
+        },
+        "housing_type": {
+          "name": "housing_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "layout_type": {
+          "name": "layout_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'traditional'"
+        },
+        "bedrooms": {
+          "name": "bedrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bathrooms": {
+          "name": "bathrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "square_footage": {
+          "name": "square_footage",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "floor": {
+          "name": "floor",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "year_built": {
+          "name": "year_built",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_elevator": {
+          "name": "has_elevator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_balcony": {
+          "name": "has_balcony",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_garden": {
+          "name": "has_garden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "utilities_included": {
+          "name": "utilities_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proximity_to_transport": {
+          "name": "proximity_to_transport",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proximity_to_schools": {
+          "name": "proximity_to_schools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proximity_to_shopping": {
+          "name": "proximity_to_shopping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_eco_friendly": {
+          "name": "is_eco_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "offerings": {
+          "name": "offerings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "amenities": {
+          "name": "amenities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "furnished_status": {
+          "name": "furnished_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_specified'"
+        },
+        "pet_policy": {
+          "name": "pet_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_specified'"
+        },
+        "pet_fee": {
+          "name": "pet_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "parking_type": {
+          "name": "parking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "parking_spaces": {
+          "name": "parking_spaces",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_term": {
+          "name": "lease_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "cancellation_policy": {
+          "name": "cancellation_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_from": {
+          "name": "available_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "smoking_allowed": {
+          "name": "smoking_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parties_allowed": {
+          "name": "parties_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "guests_allowed": {
+          "name": "guests_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "max_guests": {
+          "name": "max_guests",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "long_term_rent_monthly_amount": {
+          "name": "long_term_rent_monthly_amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_currency": {
+          "name": "long_term_rent_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_deposit": {
+          "name": "long_term_rent_deposit",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_application_fee": {
+          "name": "long_term_rent_application_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_late_fee": {
+          "name": "long_term_rent_late_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_utilities": {
+          "name": "long_term_rent_utilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_nightly_rate": {
+          "name": "short_term_rent_nightly_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_currency": {
+          "name": "short_term_rent_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_cleaning_fee": {
+          "name": "short_term_rent_cleaning_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_service_fee": {
+          "name": "short_term_rent_service_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_taxes_percent": {
+          "name": "short_term_rent_taxes_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_min_nights": {
+          "name": "short_term_rent_min_nights",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_max_nights": {
+          "name": "short_term_rent_max_nights",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_instant_book": {
+          "name": "short_term_rent_instant_book",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_deposit": {
+          "name": "short_term_rent_deposit",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_price": {
+          "name": "sale_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_currency": {
+          "name": "sale_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_price_per_sqm": {
+          "name": "sale_price_per_sqm",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_estimated_yield": {
+          "name": "sale_estimated_yield",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_is_price_reduced": {
+          "name": "sale_is_price_reduced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_chain_status": {
+          "name": "sale_chain_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_mode": {
+          "name": "exchange_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_min_stay": {
+          "name": "exchange_min_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_max_stay": {
+          "name": "exchange_max_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_welcome_note": {
+          "name": "exchange_welcome_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_languages": {
+          "name": "exchange_languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_meals_included": {
+          "name": "exchange_meals_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_requires_reciprocity": {
+          "name": "exchange_requires_reciprocity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_sleeping_arrangement": {
+          "name": "accommodation_details_sleeping_arrangement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_hostel_room_type": {
+          "name": "accommodation_details_hostel_room_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_campsite_type": {
+          "name": "accommodation_details_campsite_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_max_stay": {
+          "name": "accommodation_details_max_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_min_age": {
+          "name": "accommodation_details_min_age",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_max_age": {
+          "name": "accommodation_details_max_age",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_cultural_exchange": {
+          "name": "accommodation_details_cultural_exchange",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accommodation_details_meals_included": {
+          "name": "accommodation_details_meals_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accommodation_details_wifi_password": {
+          "name": "accommodation_details_wifi_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_roommate_preferences": {
+          "name": "accommodation_details_roommate_preferences",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "accommodation_details_coliving_features": {
+          "name": "accommodation_details_coliving_features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "accommodation_details_languages": {
+          "name": "accommodation_details_languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "accommodation_details_house_rules": {
+          "name": "accommodation_details_house_rules",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "availability_is_available": {
+          "name": "availability_is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "availability_available_from": {
+          "name": "availability_available_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "availability_minimum_stay": {
+          "name": "availability_minimum_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "availability_maximum_stay": {
+          "name": "availability_maximum_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 12
+        },
+        "rules_pets": {
+          "name": "rules_pets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_smoking": {
+          "name": "rules_smoking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_parties": {
+          "name": "rules_parties",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_guests": {
+          "name": "rules_guests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rules_max_occupancy": {
+          "name": "rules_max_occupancy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "moderation_restricted": {
+          "name": "moderation_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "moderation_restricted_at": {
+          "name": "moderation_restricted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_restricted_by_decision_id": {
+          "name": "moderation_restricted_by_decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_ethical_suggested": {
+          "name": "price_ethics_ethical_suggested",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_ethical_max": {
+          "name": "price_ethics_ethical_max",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_within_ethical": {
+          "name": "price_ethics_within_ethical",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_market_verdict": {
+          "name": "price_ethics_market_verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_percent_diff_from_avg": {
+          "name": "price_ethics_percent_diff_from_avg",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_is_fair_price": {
+          "name": "price_ethics_is_fair_price",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_fairness_score": {
+          "name": "price_ethics_fairness_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_scored_at": {
+          "name": "price_ethics_scored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_average": {
+          "name": "rating_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rating_count": {
+          "name": "rating_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "views": {
+          "name": "views",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_images": {
+          "name": "has_images",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_saved": {
+          "name": "last_saved",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "parent_property_id": {
+          "name": "parent_property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "properties_source_source_id_key": {
+          "name": "properties_source_source_id_key",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"properties\".\"source_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_has_images_created_at_idx": {
+          "name": "properties_has_images_created_at_idx",
+          "columns": [
+            {
+              "expression": "\"has_images\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_created_at_idx": {
+          "name": "properties_created_at_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_search_vector_gin": {
+          "name": "properties_search_vector_gin",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "properties_oxy_user_id_status_idx": {
+          "name": "properties_oxy_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_oxy_user_id_created_at_idx": {
+          "name": "properties_oxy_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_address_id_idx": {
+          "name": "properties_address_id_idx",
+          "columns": [
+            {
+              "expression": "address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_type_available_idx": {
+          "name": "properties_type_available_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "availability_is_available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_status_available_idx": {
+          "name": "properties_status_available_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "availability_is_available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_bedrooms_bathrooms_idx": {
+          "name": "properties_bedrooms_bathrooms_idx",
+          "columns": [
+            {
+              "expression": "bedrooms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bathrooms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_amenities_gin": {
+          "name": "properties_amenities_gin",
+          "columns": [
+            {
+              "expression": "amenities",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "properties_offerings_gin": {
+          "name": "properties_offerings_gin",
+          "columns": [
+            {
+              "expression": "offerings",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "properties_long_term_rent_amount_idx": {
+          "name": "properties_long_term_rent_amount_idx",
+          "columns": [
+            {
+              "expression": "long_term_rent_monthly_amount",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_short_term_rent_rate_idx": {
+          "name": "properties_short_term_rent_rate_idx",
+          "columns": [
+            {
+              "expression": "short_term_rent_nightly_rate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_sale_price_idx": {
+          "name": "properties_sale_price_idx",
+          "columns": [
+            {
+              "expression": "sale_price",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_price_ethics_is_fair_idx": {
+          "name": "properties_price_ethics_is_fair_idx",
+          "columns": [
+            {
+              "expression": "price_ethics_is_fair_price",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_price_ethics_score_idx": {
+          "name": "properties_price_ethics_score_idx",
+          "columns": [
+            {
+              "expression": "\"price_ethics_fairness_score\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_agency_id_idx": {
+          "name": "properties_agency_id_idx",
+          "columns": [
+            {
+              "expression": "agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"properties\".\"agency_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_sourced_by_partner_id_idx": {
+          "name": "properties_sourced_by_partner_id_idx",
+          "columns": [
+            {
+              "expression": "sourced_by_partner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"properties\".\"sourced_by_partner_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_parent_property_id_idx": {
+          "name": "properties_parent_property_id_idx",
+          "columns": [
+            {
+              "expression": "parent_property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"properties\".\"parent_property_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_expires_at_idx": {
+          "name": "properties_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"properties\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "properties_sourced_by_partner_id_partners_id_fk": {
+          "name": "properties_sourced_by_partner_id_partners_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "partners",
+          "columnsFrom": [
+            "sourced_by_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "properties_agency_id_agencies_id_fk": {
+          "name": "properties_agency_id_agencies_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "agencies",
+          "columnsFrom": [
+            "agency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "properties_address_id_addresses_id_fk": {
+          "name": "properties_address_id_addresses_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "properties_parent_property_id_properties_id_fk": {
+          "name": "properties_parent_property_id_properties_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "parent_property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "properties_source_check": {
+          "name": "properties_source_check",
+          "value": "\"properties\".\"source\" in ('internal', 'fixture', 'idealista', 'fotocasa', 'habitaclia', 'blueground', 'apartments_com', 'zillow', 'realtor_com', 'hotpads', 'redfin', 'pisos', 'milanuncios', 'yaencontre', 'indomio', 'idealista_it', 'immobiliare', 'casa_it', 'subito', 'rightmove', 'zoopla', 'onthemarket', 'openrent', 'immobilienscout24', 'immowelt', 'kleinanzeigen', 'storia', 'imobiliare_ro', 'olx_ro', 'bienici', 'leboncoin', 'seloger', 'properati_ec', 'zonaprop', 'argenprop', 'mercadolibre_ar', 'properati', 'plusvalia', 'mercadolibre_ec', 'propiedades', 'vivanuncios', 'lamudi', 'inmuebles24', 'mercadolibre_co', 'mercadolibre_cl', 'mercadolibre_pe', 'mercadolibre_mx', 'idealista_pt', 'metrocuadrado', 'realestate_com_au', 'realtor_ca', 'bayut', 'daft', 'immoweb', 'otodom', 'funda')"
+        },
+        "properties_type_check": {
+          "name": "properties_type_check",
+          "value": "\"properties\".\"type\" in ('apartment', 'house', 'room', 'studio', 'couchsurfing', 'roommates', 'coliving', 'hostel', 'guesthouse', 'campsite', 'boat', 'treehouse', 'yurt', 'other')"
+        },
+        "properties_status_check": {
+          "name": "properties_status_check",
+          "value": "\"properties\".\"status\" in ('draft', 'published', 'reserved', 'rented', 'sold', 'inactive', 'archived')"
+        },
+        "properties_housing_type_check": {
+          "name": "properties_housing_type_check",
+          "value": "\"properties\".\"housing_type\" in ('private', 'public')"
+        },
+        "properties_layout_type_check": {
+          "name": "properties_layout_type_check",
+          "value": "\"properties\".\"layout_type\" in ('open', 'shared', 'partitioned', 'traditional', 'studio', 'other')"
+        },
+        "properties_furnished_status_check": {
+          "name": "properties_furnished_status_check",
+          "value": "\"properties\".\"furnished_status\" in ('furnished', 'unfurnished', 'partially_furnished', 'not_specified')"
+        },
+        "properties_pet_policy_check": {
+          "name": "properties_pet_policy_check",
+          "value": "\"properties\".\"pet_policy\" in ('allowed', 'not_allowed', 'case_by_case', 'not_specified')"
+        },
+        "properties_parking_type_check": {
+          "name": "properties_parking_type_check",
+          "value": "\"properties\".\"parking_type\" in ('none', 'street', 'assigned', 'garage')"
+        },
+        "properties_lease_term_check": {
+          "name": "properties_lease_term_check",
+          "value": "\"properties\".\"lease_term\" in ('monthly', '3_months', '6_months', 'yearly', 'flexible')"
+        },
+        "properties_cancellation_policy_check": {
+          "name": "properties_cancellation_policy_check",
+          "value": "\"properties\".\"cancellation_policy\" in ('flexible', 'moderate', 'strict', 'super_strict')"
+        },
+        "properties_external_contact_kind_check": {
+          "name": "properties_external_contact_kind_check",
+          "value": "\"properties\".\"external_contact_kind\" in ('owner', 'agency', 'private', 'unknown')"
+        },
+        "properties_detected_language_check": {
+          "name": "properties_detected_language_check",
+          "value": "\"properties\".\"listing_flags_detected_language\" in ('es', 'ca', 'en', 'fr', 'nl', 'de', 'it')"
+        },
+        "properties_long_term_rent_currency_check": {
+          "name": "properties_long_term_rent_currency_check",
+          "value": "\"properties\".\"long_term_rent_currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        },
+        "properties_long_term_rent_utilities_check": {
+          "name": "properties_long_term_rent_utilities_check",
+          "value": "\"properties\".\"long_term_rent_utilities\" in ('included', 'excluded', 'partial')"
+        },
+        "properties_short_term_rent_currency_check": {
+          "name": "properties_short_term_rent_currency_check",
+          "value": "\"properties\".\"short_term_rent_currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        },
+        "properties_sale_currency_check": {
+          "name": "properties_sale_currency_check",
+          "value": "\"properties\".\"sale_currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        },
+        "properties_sale_chain_status_check": {
+          "name": "properties_sale_chain_status_check",
+          "value": "\"properties\".\"sale_chain_status\" in ('no_chain', 'chain', 'unknown')"
+        },
+        "properties_exchange_mode_check": {
+          "name": "properties_exchange_mode_check",
+          "value": "\"properties\".\"exchange_mode\" in ('swap', 'host', 'both')"
+        },
+        "properties_market_verdict_check": {
+          "name": "properties_market_verdict_check",
+          "value": "\"properties\".\"price_ethics_market_verdict\" in ('good_deal', 'below_average', 'average', 'above_average')"
+        },
+        "properties_sleeping_arrangement_check": {
+          "name": "properties_sleeping_arrangement_check",
+          "value": "\"properties\".\"accommodation_details_sleeping_arrangement\" in ('couch', 'air_mattress', 'floor', 'tent', 'hammock')"
+        },
+        "properties_hostel_room_type_check": {
+          "name": "properties_hostel_room_type_check",
+          "value": "\"properties\".\"accommodation_details_hostel_room_type\" in ('dormitory', 'private_room', 'mixed_dorm', 'female_dorm', 'male_dorm')"
+        },
+        "properties_campsite_type_check": {
+          "name": "properties_campsite_type_check",
+          "value": "\"properties\".\"accommodation_details_campsite_type\" in ('tent_site', 'rv_site', 'cabin', 'glamping', 'backcountry')"
+        },
+        "properties_offerings_check": {
+          "name": "properties_offerings_check",
+          "value": "\"properties\".\"offerings\" <@ array['long_term_rent', 'short_term_rent', 'sale', 'exchange']::text[]"
+        },
+        "properties_offering_long_term_rent_check": {
+          "name": "properties_offering_long_term_rent_check",
+          "value": "('long_term_rent' = any(\"properties\".\"offerings\")) = (\"properties\".\"long_term_rent_monthly_amount\" is not null)"
+        },
+        "properties_offering_short_term_rent_check": {
+          "name": "properties_offering_short_term_rent_check",
+          "value": "('short_term_rent' = any(\"properties\".\"offerings\")) = (\"properties\".\"short_term_rent_nightly_rate\" is not null)"
+        },
+        "properties_offering_sale_check": {
+          "name": "properties_offering_sale_check",
+          "value": "('sale' = any(\"properties\".\"offerings\")) = (\"properties\".\"sale_price\" is not null)"
+        },
+        "properties_offering_exchange_check": {
+          "name": "properties_offering_exchange_check",
+          "value": "('exchange' = any(\"properties\".\"offerings\")) = (\"properties\".\"exchange_mode\" is not null)"
+        },
+        "properties_long_term_rent_block_check": {
+          "name": "properties_long_term_rent_block_check",
+          "value": "\"properties\".\"long_term_rent_monthly_amount\" is not null or (\n        \"properties\".\"long_term_rent_currency\" is null and \"properties\".\"long_term_rent_deposit\" is null\n        and \"properties\".\"long_term_rent_application_fee\" is null and \"properties\".\"long_term_rent_late_fee\" is null\n        and \"properties\".\"long_term_rent_utilities\" is null\n      )"
+        },
+        "properties_short_term_rent_block_check": {
+          "name": "properties_short_term_rent_block_check",
+          "value": "\"properties\".\"short_term_rent_nightly_rate\" is not null or (\n        \"properties\".\"short_term_rent_currency\" is null and \"properties\".\"short_term_rent_cleaning_fee\" is null\n        and \"properties\".\"short_term_rent_service_fee\" is null and \"properties\".\"short_term_rent_taxes_percent\" is null\n        and \"properties\".\"short_term_rent_min_nights\" is null and \"properties\".\"short_term_rent_max_nights\" is null\n        and \"properties\".\"short_term_rent_instant_book\" is null and \"properties\".\"short_term_rent_deposit\" is null\n      )"
+        },
+        "properties_sale_block_check": {
+          "name": "properties_sale_block_check",
+          "value": "\"properties\".\"sale_price\" is not null or (\n        \"properties\".\"sale_currency\" is null and \"properties\".\"sale_price_per_sqm\" is null\n        and \"properties\".\"sale_estimated_yield\" is null and \"properties\".\"sale_is_price_reduced\" is null\n        and \"properties\".\"sale_chain_status\" is null\n      )"
+        },
+        "properties_exchange_block_check": {
+          "name": "properties_exchange_block_check",
+          "value": "\"properties\".\"exchange_mode\" is not null or (\n        \"properties\".\"exchange_min_stay\" is null and \"properties\".\"exchange_max_stay\" is null\n        and \"properties\".\"exchange_welcome_note\" is null and \"properties\".\"exchange_languages\" is null\n        and \"properties\".\"exchange_meals_included\" is null and \"properties\".\"exchange_requires_reciprocity\" is null\n      )"
+        },
+        "properties_external_source_url_check": {
+          "name": "properties_external_source_url_check",
+          "value": "not \"properties\".\"is_external\" or \"properties\".\"source_url\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.property_availability_windows": {
+      "name": "property_availability_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        }
+      },
+      "indexes": {
+        "property_availability_windows_range_gist": {
+          "name": "property_availability_windows_range_gist",
+          "columns": [
+            {
+              "expression": "tstzrange(\"starts_at\", \"ends_at\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "property_availability_windows_property_scope_idx": {
+          "name": "property_availability_windows_property_scope_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "property_availability_windows_property_id_properties_id_fk": {
+          "name": "property_availability_windows_property_id_properties_id_fk",
+          "tableFrom": "property_availability_windows",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "property_availability_windows_scope_check": {
+          "name": "property_availability_windows_scope_check",
+          "value": "\"property_availability_windows\".\"scope\" in ('listing', 'exchange')"
+        },
+        "property_availability_windows_status_check": {
+          "name": "property_availability_windows_status_check",
+          "value": "\"property_availability_windows\".\"status\" in ('available', 'blocked', 'booked')"
+        },
+        "property_availability_windows_order_check": {
+          "name": "property_availability_windows_order_check",
+          "value": "\"property_availability_windows\".\"ends_at\" > \"property_availability_windows\".\"starts_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.property_documents": {
+      "name": "property_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        }
+      },
+      "indexes": {
+        "property_documents_property_id_idx": {
+          "name": "property_documents_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "property_documents_property_id_properties_id_fk": {
+          "name": "property_documents_property_id_properties_id_fk",
+          "tableFrom": "property_documents",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "property_documents_type_check": {
+          "name": "property_documents_type_check",
+          "value": "\"property_documents\".\"type\" in ('lease', 'inspection', 'insurance', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.property_images": {
+      "name": "property_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "urls_original": {
+          "name": "urls_original",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urls_small": {
+          "name": "urls_small",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urls_medium": {
+          "name": "urls_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urls_large": {
+          "name": "urls_large",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "property_images_property_order_idx": {
+          "name": "property_images_property_order_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "property_images_one_primary_key": {
+          "name": "property_images_one_primary_key",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"property_images\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "property_images_image_id_idx": {
+          "name": "property_images_image_id_idx",
+          "columns": [
+            {
+              "expression": "image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "property_images_property_id_properties_id_fk": {
+          "name": "property_images_property_id_properties_id_fk",
+          "tableFrom": "property_images",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "property_images_image_id_images_id_fk": {
+          "name": "property_images_image_id_images_id_fk",
+          "tableFrom": "property_images",
+          "tableTo": "images",
+          "columnsFrom": [
+            "image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recently_viewed": {
+      "name": "recently_viewed",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "recently_viewed_owner_property_key": {
+          "name": "recently_viewed_owner_property_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recently_viewed_owner_viewed_at_idx": {
+          "name": "recently_viewed_owner_viewed_at_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"viewed_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recently_viewed_property_id_properties_id_fk": {
+          "name": "recently_viewed_property_id_properties_id_fk",
+          "tableFrom": "recently_viewed",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "regions_country_name_key": {
+          "name": "regions_country_name_key",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_name_lower_idx": {
+          "name": "regions_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_country_name_lower_idx": {
+          "name": "regions_country_name_lower_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "regions_country_id_countries_id_fk": {
+          "name": "regions_country_id_countries_id_fk",
+          "tableFrom": "regions",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "regions_cover_image_id_images_id_fk": {
+          "name": "regions_cover_image_id_images_id_fk",
+          "tableFrom": "regions",
+          "tableTo": "images",
+          "columnsFrom": [
+            "cover_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reservations": {
+      "name": "reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_oxy_user_id": {
+          "name": "guest_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_oxy_user_id": {
+          "name": "host_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_in": {
+          "name": "check_in",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_out": {
+          "name": "check_out",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_count": {
+          "name": "guest_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nights": {
+          "name": "nights",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nightly_rate": {
+          "name": "nightly_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cleaning_fee": {
+          "name": "cleaning_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "service_fee": {
+          "name": "service_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "taxes": {
+          "name": "taxes",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total": {
+          "name": "total",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "instant_booked": {
+          "name": "instant_booked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancellation_policy": {
+          "name": "cancellation_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "special_requests": {
+          "name": "special_requests",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "reservations_stay_range_gist": {
+          "name": "reservations_stay_range_gist",
+          "columns": [
+            {
+              "expression": "tstzrange(\"check_in\", \"check_out\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "reservations_property_check_in_idx": {
+          "name": "reservations_property_check_in_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "check_in",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reservations_guest_status_idx": {
+          "name": "reservations_guest_status_idx",
+          "columns": [
+            {
+              "expression": "guest_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reservations_host_status_created_idx": {
+          "name": "reservations_host_status_created_idx",
+          "columns": [
+            {
+              "expression": "host_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reservations_property_id_properties_id_fk": {
+          "name": "reservations_property_id_properties_id_fk",
+          "tableFrom": "reservations",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reservations_status_check": {
+          "name": "reservations_status_check",
+          "value": "\"reservations\".\"status\" in ('pending', 'confirmed', 'cancelled', 'completed', 'declined')"
+        },
+        "reservations_cancellation_policy_check": {
+          "name": "reservations_cancellation_policy_check",
+          "value": "\"reservations\".\"cancellation_policy\" in ('flexible', 'moderate', 'strict', 'super_strict')"
+        },
+        "reservations_stay_order_check": {
+          "name": "reservations_stay_order_check",
+          "value": "\"reservations\".\"check_out\" > \"reservations\".\"check_in\""
+        },
+        "reservations_nights_check": {
+          "name": "reservations_nights_check",
+          "value": "\"reservations\".\"nights\" >= 1"
+        },
+        "reservations_guest_count_check": {
+          "name": "reservations_guest_count_check",
+          "value": "\"reservations\".\"guest_count\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.review_helpful_votes": {
+      "name": "review_helpful_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "review_helpful_votes_review_user_key": {
+          "name": "review_helpful_votes_review_user_key",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_helpful_votes_review_id_reviews_id_fk": {
+          "name": "review_helpful_votes_review_id_reviews_id_fk",
+          "tableFrom": "review_helpful_votes",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_reports": {
+      "name": "review_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "review_reports_review_user_key": {
+          "name": "review_reports_review_user_key",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_reports_review_id_reviews_id_fk": {
+          "name": "review_reports_review_id_reviews_id_fk",
+          "tableFrom": "review_reports",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "review_reports_reason_check": {
+          "name": "review_reports_reason_check",
+          "value": "\"review_reports\".\"reason\" in ('fake', 'offensive', 'personal_data', 'spam', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_level": {
+          "name": "address_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street_level_id": {
+          "name": "street_level_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "building_level_id": {
+          "name": "building_level_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_level_id": {
+          "name": "unit_level_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neighborhood_id": {
+          "name": "neighborhood_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agency_id": {
+          "name": "agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "green_house": {
+          "name": "green_house",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "lived_from": {
+          "name": "lived_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lived_to": {
+          "name": "lived_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lived_for_months": {
+          "name": "lived_for_months",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation": {
+          "name": "recommendation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion": {
+          "name": "opinion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pros_items": {
+          "name": "pros_items",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "cons_items": {
+          "name": "cons_items",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "advice_to_agency": {
+          "name": "advice_to_agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advice_to_landlord": {
+          "name": "advice_to_landlord",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "positive_comment": {
+          "name": "positive_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "negative_comment": {
+          "name": "negative_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rating": {
+          "name": "rating",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summer_temperature": {
+          "name": "summer_temperature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winter_temperature": {
+          "name": "winter_temperature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise": {
+          "name": "noise",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "light": {
+          "name": "light",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition_and_maintenance": {
+          "name": "condition_and_maintenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "landlord_treatment": {
+          "name": "landlord_treatment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "problem_response": {
+          "name": "problem_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deposit_returned": {
+          "name": "deposit_returned",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "staircase_neighbors": {
+          "name": "staircase_neighbors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tourist_apartments": {
+          "name": "tourist_apartments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neighbor_relations": {
+          "name": "neighbor_relations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleaning": {
+          "name": "cleaning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_tourists": {
+          "name": "area_tourists",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_security": {
+          "name": "area_security",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_noise": {
+          "name": "area_noise",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_cleanliness": {
+          "name": "area_cleanliness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_status": {
+          "name": "moderation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "reviews_address_created_idx": {
+          "name": "reviews_address_created_idx",
+          "columns": [
+            {
+              "expression": "address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_street_level_idx": {
+          "name": "reviews_street_level_idx",
+          "columns": [
+            {
+              "expression": "street_level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_building_level_idx": {
+          "name": "reviews_building_level_idx",
+          "columns": [
+            {
+              "expression": "building_level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_unit_level_idx": {
+          "name": "reviews_unit_level_idx",
+          "columns": [
+            {
+              "expression": "unit_level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_agency_created_idx": {
+          "name": "reviews_agency_created_idx",
+          "columns": [
+            {
+              "expression": "agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_city_created_idx": {
+          "name": "reviews_city_created_idx",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_neighborhood_created_idx": {
+          "name": "reviews_neighborhood_created_idx",
+          "columns": [
+            {
+              "expression": "neighborhood_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_oxy_user_created_idx": {
+          "name": "reviews_oxy_user_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_moderation_queue_idx": {
+          "name": "reviews_moderation_queue_idx",
+          "columns": [
+            {
+              "expression": "moderation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_author_address_key": {
+          "name": "reviews_author_address_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_address_id_addresses_id_fk": {
+          "name": "reviews_address_id_addresses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_street_level_id_addresses_id_fk": {
+          "name": "reviews_street_level_id_addresses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "street_level_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_building_level_id_addresses_id_fk": {
+          "name": "reviews_building_level_id_addresses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "building_level_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_unit_level_id_addresses_id_fk": {
+          "name": "reviews_unit_level_id_addresses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "unit_level_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_city_id_cities_id_fk": {
+          "name": "reviews_city_id_cities_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_neighborhood_id_neighborhoods_id_fk": {
+          "name": "reviews_neighborhood_id_neighborhoods_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "neighborhoods",
+          "columnsFrom": [
+            "neighborhood_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_agency_id_agencies_id_fk": {
+          "name": "reviews_agency_id_agencies_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "agencies",
+          "columnsFrom": [
+            "agency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reviews_address_level_check": {
+          "name": "reviews_address_level_check",
+          "value": "\"reviews\".\"address_level\" in ('BUILDING', 'UNIT')"
+        },
+        "reviews_unit_level_check": {
+          "name": "reviews_unit_level_check",
+          "value": "(\"reviews\".\"address_level\" = 'UNIT') = (\"reviews\".\"unit_level_id\" is not null)"
+        },
+        "reviews_moderation_status_check": {
+          "name": "reviews_moderation_status_check",
+          "value": "\"reviews\".\"moderation_status\" in ('active', 'under_review', 'removed')"
+        },
+        "reviews_currency_check": {
+          "name": "reviews_currency_check",
+          "value": "\"reviews\".\"currency\" in ('USD', 'EUR', 'GBP', 'CAD')"
+        },
+        "reviews_summer_temperature_check": {
+          "name": "reviews_summer_temperature_check",
+          "value": "\"reviews\".\"summer_temperature\" in ('very_cold', 'cold', 'moderate', 'warm', 'very_warm')"
+        },
+        "reviews_winter_temperature_check": {
+          "name": "reviews_winter_temperature_check",
+          "value": "\"reviews\".\"winter_temperature\" in ('very_cold', 'cold', 'moderate', 'warm', 'very_warm')"
+        },
+        "reviews_noise_check": {
+          "name": "reviews_noise_check",
+          "value": "\"reviews\".\"noise\" in ('very_quiet', 'quiet', 'moderate', 'noisy', 'very_noisy')"
+        },
+        "reviews_light_check": {
+          "name": "reviews_light_check",
+          "value": "\"reviews\".\"light\" in ('very_dark', 'dark', 'moderate', 'bright', 'very_bright')"
+        },
+        "reviews_condition_check": {
+          "name": "reviews_condition_check",
+          "value": "\"reviews\".\"condition_and_maintenance\" in ('poor', 'fair', 'good', 'very_good', 'excellent')"
+        },
+        "reviews_services_check": {
+          "name": "reviews_services_check",
+          "value": "\"reviews\".\"services\" <@ array['internet', 'cable_tv', 'parking', 'laundry', 'gym', 'pool', 'concierge', 'security', 'maintenance', 'cleaning']::text[]"
+        },
+        "reviews_landlord_treatment_check": {
+          "name": "reviews_landlord_treatment_check",
+          "value": "\"reviews\".\"landlord_treatment\" in ('very_poor', 'poor', 'fair', 'good', 'excellent')"
+        },
+        "reviews_problem_response_check": {
+          "name": "reviews_problem_response_check",
+          "value": "\"reviews\".\"problem_response\" in ('never_responded', 'very_slow', 'slow', 'reasonable', 'fast', 'very_fast')"
+        },
+        "reviews_deposit_returned_check": {
+          "name": "reviews_deposit_returned_check",
+          "value": "\"reviews\".\"deposit_returned\" in ('full', 'partial', 'no')"
+        },
+        "reviews_staircase_neighbors_check": {
+          "name": "reviews_staircase_neighbors_check",
+          "value": "\"reviews\".\"staircase_neighbors\" in ('very_unfriendly', 'unfriendly', 'neutral', 'friendly', 'very_friendly')"
+        },
+        "reviews_neighbor_relations_check": {
+          "name": "reviews_neighbor_relations_check",
+          "value": "\"reviews\".\"neighbor_relations\" in ('very_poor', 'poor', 'fair', 'good', 'excellent')"
+        },
+        "reviews_cleaning_check": {
+          "name": "reviews_cleaning_check",
+          "value": "\"reviews\".\"cleaning\" in ('very_dirty', 'dirty', 'acceptable', 'clean', 'very_clean')"
+        },
+        "reviews_area_tourists_check": {
+          "name": "reviews_area_tourists_check",
+          "value": "\"reviews\".\"area_tourists\" in ('none', 'few', 'moderate', 'many', 'overwhelming')"
+        },
+        "reviews_area_security_check": {
+          "name": "reviews_area_security_check",
+          "value": "\"reviews\".\"area_security\" in ('very_unsafe', 'unsafe', 'neutral', 'safe', 'very_safe')"
+        },
+        "reviews_area_noise_check": {
+          "name": "reviews_area_noise_check",
+          "value": "\"reviews\".\"area_noise\" in ('very_quiet', 'quiet', 'moderate', 'noisy', 'very_noisy')"
+        },
+        "reviews_area_cleanliness_check": {
+          "name": "reviews_area_cleanliness_check",
+          "value": "\"reviews\".\"area_cleanliness\" in ('very_dirty', 'dirty', 'acceptable', 'clean', 'very_clean')"
+        },
+        "reviews_rating_check": {
+          "name": "reviews_rating_check",
+          "value": "\"reviews\".\"rating\" between 1 and 5"
+        },
+        "reviews_lived_order_check": {
+          "name": "reviews_lived_order_check",
+          "value": "\"reviews\".\"lived_to\" > \"reviews\".\"lived_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.roommate_relationships": {
+      "name": "roommate_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user1_id": {
+          "name": "oxy_user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user2_id": {
+          "name": "oxy_user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "roommate_relationships_active_pair_key": {
+          "name": "roommate_relationships_active_pair_key",
+          "columns": [
+            {
+              "expression": "oxy_user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"roommate_relationships\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roommate_relationships_user1_idx": {
+          "name": "roommate_relationships_user1_idx",
+          "columns": [
+            {
+              "expression": "oxy_user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roommate_relationships_user2_idx": {
+          "name": "roommate_relationships_user2_idx",
+          "columns": [
+            {
+              "expression": "oxy_user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roommate_relationships_request_id_roommate_requests_id_fk": {
+          "name": "roommate_relationships_request_id_roommate_requests_id_fk",
+          "tableFrom": "roommate_relationships",
+          "tableTo": "roommate_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "roommate_relationships_status_check": {
+          "name": "roommate_relationships_status_check",
+          "value": "\"roommate_relationships\".\"status\" in ('active', 'ended')"
+        },
+        "roommate_relationships_sorted_pair_check": {
+          "name": "roommate_relationships_sorted_pair_check",
+          "value": "\"roommate_relationships\".\"oxy_user1_id\" < \"roommate_relationships\".\"oxy_user2_id\""
+        },
+        "roommate_relationships_match_score_check": {
+          "name": "roommate_relationships_match_score_check",
+          "value": "\"roommate_relationships\".\"match_score\" between 0 and 100"
+        },
+        "roommate_relationships_order_check": {
+          "name": "roommate_relationships_order_check",
+          "value": "\"roommate_relationships\".\"end_date\" is null or \"roommate_relationships\".\"end_date\" >= \"roommate_relationships\".\"start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.roommate_requests": {
+      "name": "roommate_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_oxy_user_id": {
+          "name": "from_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_oxy_user_id": {
+          "name": "to_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "roommate_requests_pending_pair_key": {
+          "name": "roommate_requests_pending_pair_key",
+          "columns": [
+            {
+              "expression": "from_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"roommate_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roommate_requests_from_idx": {
+          "name": "roommate_requests_from_idx",
+          "columns": [
+            {
+              "expression": "from_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roommate_requests_to_status_idx": {
+          "name": "roommate_requests_to_status_idx",
+          "columns": [
+            {
+              "expression": "to_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "roommate_requests_status_check": {
+          "name": "roommate_requests_status_check",
+          "value": "\"roommate_requests\".\"status\" in ('pending', 'accepted', 'declined')"
+        },
+        "roommate_requests_distinct_parties_check": {
+          "name": "roommate_requests_distinct_parties_check",
+          "value": "\"roommate_requests\".\"from_oxy_user_id\" <> \"roommate_requests\".\"to_oxy_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_items": {
+      "name": "saved_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "saved_items_owner_target_key": {
+          "name": "saved_items_owner_target_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_items_folder_id_idx": {
+          "name": "saved_items_folder_id_idx",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"saved_items\".\"folder_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_items_target_idx": {
+          "name": "saved_items_target_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_items_target_id_properties_id_fk": {
+          "name": "saved_items_target_id_properties_id_fk",
+          "tableFrom": "saved_items",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_items_folder_id_saved_property_folders_id_fk": {
+          "name": "saved_items_folder_id_saved_property_folders_id_fk",
+          "tableFrom": "saved_items",
+          "tableTo": "saved_property_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "saved_items_target_type_check": {
+          "name": "saved_items_target_type_check",
+          "value": "\"saved_items\".\"target_type\" in ('property')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_property_folder_items": {
+      "name": "saved_property_folder_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "saved_property_folder_items_key": {
+          "name": "saved_property_folder_items_key",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_property_folder_items_property_id_idx": {
+          "name": "saved_property_folder_items_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_property_folder_items_folder_id_saved_property_folders_id_fk": {
+          "name": "saved_property_folder_items_folder_id_saved_property_folders_id_fk",
+          "tableFrom": "saved_property_folder_items",
+          "tableTo": "saved_property_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_property_folder_items_property_id_properties_id_fk": {
+          "name": "saved_property_folder_items_property_id_properties_id_fk",
+          "tableFrom": "saved_property_folder_items",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_property_folders": {
+      "name": "saved_property_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3B82F6'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder-outline'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "saved_property_folders_owner_name_key": {
+          "name": "saved_property_folders_owner_name_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_searches": {
+      "name": "saved_searches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "saved_searches_owner_name_key": {
+          "name": "saved_searches_owner_name_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_searches_owner_created_idx": {
+          "name": "saved_searches_owner_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_searches_notifications_enabled_idx": {
+          "name": "saved_searches_notifications_enabled_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"saved_searches\".\"notifications_enabled\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenant_application_documents": {
+      "name": "tenant_application_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tenant_application_documents_application_id_idx": {
+          "name": "tenant_application_documents_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_application_documents_application_id_tenant_applications_id_fk": {
+          "name": "tenant_application_documents_application_id_tenant_applications_id_fk",
+          "tableFrom": "tenant_application_documents",
+          "tableTo": "tenant_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenant_application_documents_type_check": {
+          "name": "tenant_application_documents_type_check",
+          "value": "\"tenant_application_documents\".\"type\" in ('id', 'income', 'reference', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenant_application_references": {
+      "name": "tenant_application_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tenant_application_references_application_id_idx": {
+          "name": "tenant_application_references_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_application_references_application_id_tenant_applications_id_fk": {
+          "name": "tenant_application_references_application_id_tenant_applications_id_fk",
+          "tableFrom": "tenant_application_references",
+          "tableTo": "tenant_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenant_application_references_relationship_check": {
+          "name": "tenant_application_references_relationship_check",
+          "value": "\"tenant_application_references\".\"relationship\" in ('landlord', 'employer', 'personal', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenant_applications": {
+      "name": "tenant_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_oxy_user_id": {
+          "name": "applicant_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "landlord_oxy_user_id": {
+          "name": "landlord_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "move_in_date": {
+          "name": "move_in_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_term_months": {
+          "name": "lease_term_months",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_income": {
+          "name": "monthly_income",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employment_status": {
+          "name": "employment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "tenant_applications_property_status_idx": {
+          "name": "tenant_applications_property_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_applications_applicant_status_idx": {
+          "name": "tenant_applications_applicant_status_idx",
+          "columns": [
+            {
+              "expression": "applicant_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_applications_landlord_status_submitted_idx": {
+          "name": "tenant_applications_landlord_status_submitted_idx",
+          "columns": [
+            {
+              "expression": "landlord_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"submitted_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_applications_property_id_properties_id_fk": {
+          "name": "tenant_applications_property_id_properties_id_fk",
+          "tableFrom": "tenant_applications",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenant_applications_status_check": {
+          "name": "tenant_applications_status_check",
+          "value": "\"tenant_applications\".\"status\" in ('submitted', 'reviewing', 'approved', 'rejected', 'withdrawn')"
+        },
+        "tenant_applications_employment_status_check": {
+          "name": "tenant_applications_employment_status_check",
+          "value": "\"tenant_applications\".\"employment_status\" in ('employed', 'self_employed', 'student', 'retired', 'unemployed', 'other')"
+        },
+        "tenant_applications_decided_at_check": {
+          "name": "tenant_applications_decided_at_check",
+          "value": "(\"tenant_applications\".\"status\" in ('approved', 'rejected', 'withdrawn'))\n        = (\"tenant_applications\".\"decided_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.viewing_requests": {
+      "name": "viewing_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_oxy_user_id": {
+          "name": "requester_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_oxy_user_id": {
+          "name": "owner_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cancelled_by": {
+          "name": "cancelled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "viewing_requests_property_scheduled_status_idx": {
+          "name": "viewing_requests_property_scheduled_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "viewing_requests_owner_scheduled_status_idx": {
+          "name": "viewing_requests_owner_scheduled_status_idx",
+          "columns": [
+            {
+              "expression": "owner_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "viewing_requests_requester_idx": {
+          "name": "viewing_requests_requester_idx",
+          "columns": [
+            {
+              "expression": "requester_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "viewing_requests_property_id_properties_id_fk": {
+          "name": "viewing_requests_property_id_properties_id_fk",
+          "tableFrom": "viewing_requests",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "viewing_requests_status_check": {
+          "name": "viewing_requests_status_check",
+          "value": "\"viewing_requests\".\"status\" in ('pending', 'approved', 'declined', 'cancelled')"
+        },
+        "viewing_requests_cancelled_by_check": {
+          "name": "viewing_requests_cancelled_by_check",
+          "value": "\"viewing_requests\".\"cancelled_by\" in ('requester', 'owner')"
+        },
+        "viewing_requests_cancelled_by_status_check": {
+          "name": "viewing_requests_cancelled_by_status_check",
+          "value": "(\"viewing_requests\".\"status\" = 'cancelled') = (\"viewing_requests\".\"cancelled_by\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/drizzle/meta/_journal.json
+++ b/packages/backend/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1786276987466,
       "tag": "0008_review_author_address_key",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1786280361533,
+      "tag": "0009_roommate_preferences_location_interests",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared-types/src/profile.ts
+++ b/packages/shared-types/src/profile.ts
@@ -107,6 +107,19 @@ export interface RoommatePreferences {
     };
     moveInDate?: string;
     leaseDuration?: LeaseDuration;
+    /**
+     * Free-text tags the compatibility score intersects, worth 20 of its 100
+     * points, and free text the discover feed filters on with `ILIKE`.
+     *
+     * Both were already accepted by the backend's write allow-list
+     * (`EDITABLE_ROOMMATE_PREFERENCE_FIELDS`) and already sent by
+     * `RoommateFilters`, while being declared NOWHERE — neither here nor in
+     * `personalProfileSchema`, which is why mongoose strict mode discarded
+     * every write of them. Declaring them is the type catching up with the
+     * contract two other places already state.
+     */
+    interests?: string[];
+    location?: string;
   };
   history?: Array<{
     startDate: string;


### PR DESCRIPTION
Closes the roommate + profile reads (#281, task #31). `roommateController` no
longer imports `../models` at all.

> **Rebased onto `main` after #325.** Both branches originally generated a
> `0008`; this one is regenerated as
> `0009_roommate_preferences_location_interests` so the journal indexes stay
> monotonic — drizzle applies by index against the ledger's high-water mark, so
> a lower index arriving after a higher one is silently skipped rather than
> refused. `analyticsController.ts` also conflicted and resolved cleanly to
> **no `../models` import at all**: #324 ported `City`/`Property` away and this
> branch ported `Profile` away, so between them the file is fully off Mongoose.

## Census

Comment-stripped, directory pathspecs, positive control 232 files scanned /
models-barrel importers 13 → 12:

| file | before | after |
|---|--:|--:|
| `controllers/roommateController.ts` | 18 | **0** |
| `controllers/analyticsController.ts` | 1 | **0** |
| `controllers/property/retrieve.ts` | 1 | 1 *(not in scope — see below)* |

All eleven roommate handlers moved, plus `analyticsController.getAnalytics`'s
profile gate.

## The headline: three selectors that have never matched anything

`getRoommateProfiles` filtered `personalProfile.gender`,
`personalProfile.location` and `personalProfile.dateOfBirth` — three paths
`personalProfileSchema` does not declare. Mongoose strict mode drops an
undeclared path on write, so no document has ever had them; with
`strictQuery: false` the clause is still sent to Mongo, so each filter matched
**nothing**. Setting any of those three returned an empty page, always.

**Confirmed empirically, not reasoned about** — a throwaway case against real
mongoose 8.24 and the real `ProfileSchema` (run, then deleted): each original
selector returns 0 rows against a seeded matching profile while the same query
without the undeclared clause returns 1. That contrast *is* the discriminator:
under `strictQuery: true` the clause would be stripped and the row returned, so
"matched nothing" is right and "silently ignored" is wrong.

A faithful port would move a broken selector to Postgres where it still answers
zero and looks done. So each is repaired:

- **`?gender=`** → `settings_roommate_preferences_gender` (CHECK-constrained
  `male|female|any`, the vocabulary `RoommateFilters.gender` is already typed
  with). Means "candidates whose stated roommate gender preference is X". `any`
  is treated as *no filter*, matching the client's own meaning; an
  out-of-vocabulary value is a 400, not an unfiltered page.
- **`?ageRange=`** → an **overlap** against
  `settings_roommate_preferences_age_range_{min,max}`. **This is a semantic
  change**: "people aged 25-30" becomes "people whose stated preferred age range
  overlaps 25-30". There is no date of birth in either store and there must not
  be one — Oxy owns identity. Bounds are closed; a NULL bound is answered per
  side, so a candidate who gave only a minimum is still comparable on it.
- **`?location=`** → a **new column**, `settings_roommate_preferences_location`,
  filtered with `ILIKE` over `escapeLikePattern` (`db/likePattern.ts`, reused
  rather than re-derived). Nothing stored this anywhere before.

**User-visible effect: three filters that returned an empty page for every value
now return real results.**

## A second, independent defect: two accepted fields were silently discarded

`EDITABLE_ROOMMATE_PREFERENCE_FIELDS` accepts `location` and `interests`,
`RoommateFilters` sends both, and `updateRoommatePreferences` wrote them to
paths `personalProfileSchema` never declared — so strict mode dropped both from
every update. Verified on the write side both via `Profile.create` and via the
exact `$set` path the controller used, with the declared sibling `budget`
surviving as the positive control.

The consequence that is invisible from the write side:
`calculateMatchPercentage`'s interests branch is worth **20 of the 100**
compatibility points and is guarded by `prefs1.interests && prefs2.interests`,
so it could never fire. **The scorer has run on 80 points for its whole life.**

Fixed by adding the two columns (migration `0008`, `-- oxy:deploy-phase=pre`,
additive, both nullable) rather than by deleting the fields — the write
allowlist's own comment says they are intentional, the scorer is written to use
them, and the client sends them. `shared-types` is updated to match.

## Also repaired while porting

`maxBudget` / `withPets` / `nonSmoking` moved from JavaScript into the `WHERE`
clause. Per-candidate meaning is unchanged ("unknown admits", exactly as
`if (typeof profileMax !== 'number') return true` did) — but they used to run
*after* `skip`/`limit`, so pages came back short beside a `total` that counted
rows the page had already dropped.

**Privacy:** participant and candidate profiles are now serialized at `public`
visibility. The old lists attached `personalProfile` verbatim — annual income,
references, landlord phone numbers, the Sindi chat transcript — to anyone who
had exchanged a roommate request. `personal_info_annual_income` is now
unreachable at the type level.

Malformed filters are **400** rather than a 500 (`JSON.parse` on `ageRange`) or
a silently empty page (`parseInt('abc')` → `NaN`); `PATCH /toggle` requires a
boolean; `?limit=` is clamped (a negative value made the `OFFSET` invalid).

## Hooks, statics and the `toJSON` transform

- `ProfileSchema` has **no `pre`/`post` hooks** — confirmed, not assumed.
- `findByOxyUserId` → `findProfileByOxyUserId(db, oxyUserId)`, still session-keyed;
  nothing takes a profile id from a caller.
- **`toJSON` transform** (`_id`→`id`, strip `__v`): these endpoints always
  *bypassed* it — they `.lean()`-ed and projected by hand, emitting `_id`. The
  rename is now applied by `toProfileDTO` and pinned by a test asserting `id`
  present and `_id`/`__v` absent on **all four** roommate payloads. This is the
  wire-contract class of regression that has bitten this app before.
- `RoommateRequestSchema` / `RoommateRelationshipSchema`: no hooks; untouched.

## An integration point closed during self-audit

`db/schema/unmappedColumns.ts` was documentation — nothing read it. Its two
escapes do not cover a column that has **no default and that the application
writes**, which is exactly `settings_roommate_preferences_location`: the copy's
verifier reads a stored value where it expected NULL and **fails the run**
(`data.ts:1491`), and `--reconcile` reports the row as differing forever. So
`unmappedColumnNames()` now exists and is consumed by `compareSample` and
`reconcileTable`, each with a real-Mongo + real-Postgres case, each
independently mutation-tested.

## Tests

New `__tests__/db/roommateDiscovery.test.ts` (21 cases); `roommateOwnership`
rewritten to Postgres fixtures (36); `profilePostgres`, `viewingStragglers`,
`dataBackfill`, `unmappedColumns` extended.

Mutation-tested, each turning a named case red: strict age bound on **both**
sides of the overlap; unescaped LIKE; `ilike`→`like`; "unknown admits" dropped
on budget; gender filter dropped; batched hydration ignoring `profile_id`;
empty-interests counted (NaN → wire `null`); `hasStatedRoommatePreferences`
always true; serializer dropping the two new fields; a per-field update becoming
a block replacement; both registry readers.

One honest bound is recorded in the test itself: the "two blank profiles score
0" case only goes red when **both** guards are removed, because
`hasStatedRoommatePreferences` and the per-block presence checks are
independently sufficient.

Gates: backend `tsc --noEmit` clean, frontend `tsc --noEmit` clean,
`shared-types` builds, lint 0 errors, `check:lockfile` in sync.

**Suite stability, measured rather than assumed:** the full backend suite is
flaky on this harness *independently of this change*. On untouched `55338ac`,
`dataBackfill.test.ts › DRY RUN writes no UPDATE either` fails in a whole-file
run and passes in isolation (reproduced on two separate clean containers). With
this change 3 of 6 full runs were fully green and the rest failed a *moving* set
of files that never reference `profiles`. The six suites here run green
together, repeatedly, and each passes alone.

## Left behind, deliberately

- **`controllers/property/retrieve.ts:66`** — the last live `Profile.*` in the
  backend, and worse than a stale read: it resolves a Mongo profile for a
  `profileId`, then `RecentlyViewed.findOneAndUpdate({ profileId, propertyId })`
  against **Mongo**, while `recently_viewed` is already on Postgres keyed by
  `oxy_user_id`. `RecentlyViewedSchema` does not declare `profileId` at all, so
  the write is a third instance of this same defect class and records nothing
  readable. `controllers/property/list.ts` holds the second stale
  `RecentlyViewed.*` site. **Two stale writers, no symptom** — worth its own
  issue.
- `analyticsController`: 4 `Property.*` + 1 `City.*` remain in `getAppStats`,
  per that file's own comment (catalogue aggregates belong to the property batch).
- **Frontend, out of scope:** `RoommateMatch` passes `profile.id` to
  `onSendRequest`/`onViewProfile`, both of which want an **Oxy account id**.
  Today `profile.id` is `undefined` in the discover feed; after this change it is
  a real profile row id — still the wrong entity, still a 404. The correct value
  (`profile.oxyUserId`) is in the payload before and after. One-line fix in
  `app/roommates/index.tsx` + `components/RoommateMatch.tsx`.
- `location`/`interests` have no UI in `app/roommates/preferences.tsx` yet; the
  API round-trips them now.
- `?minMatchPercentage=` still filters the page after it is cut — it is
  caller-relative and cannot be a `WHERE` clause. Stated in the handler docblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
