### PR TITLE
billing: the repository, and routes/profiles on Postgres (#281)

### DIFF
--- a/packages/backend/__tests__/db/billingRepository.test.ts
+++ b/packages/backend/__tests__/db/billingRepository.test.ts
@@ -1,0 +1,183 @@
+/**
+ * The billing repository, against a REAL Postgres.
+ *
+ * ## What this suite is FOR
+ *
+ * `BillingSchema` carried a `pre('save')` hook and six instance methods. A
+ * Mongoose hook has no Postgres counterpart and vanishes silently — invisible
+ * in a schema diff, to `tsc`, and to any suite that only supplies valid input,
+ * because a rule that refuses bad input is unseen by every test that supplies
+ * good input. So each case below is written against the RULE the hook enforced,
+ * not against the happy path:
+ *
+ *  - the hook refused a second record per user → asserted by racing two
+ *    creates, not by creating one;
+ *  - `consumeFileCredit` refused to spend what was not there → asserted by
+ *    spending concurrently, which is the case a read-then-write loses;
+ *  - `addProcessedSession` was idempotent → asserted by claiming twice AND by
+ *    checking the row did not move.
+ *
+ * A mocked drizzle cannot reproduce any of them: there is no unique index to
+ * violate, no predicate for a concurrent update to lose against, and no `xmin`.
+ */
+
+import { eq, sql } from 'drizzle-orm';
+
+import { getDb } from '../../db/postgres';
+import { billing, billingProcessedSessions } from '../../db/schema';
+import {
+  addFileCredits,
+  claimStripeSession,
+  consumeFileCredit,
+  ensureBilling,
+  findBillingByOxyUserId,
+  findBillingByStripeSubscriptionId,
+  isStripeSessionProcessed,
+  listActiveSubscriptions,
+  listProcessedSessions,
+  setPlusActive,
+} from '../../db/billing/billingRepository';
+
+const OXY_USER = 'oxy-billing-subject';
+
+beforeEach(async () => {
+  await getDb().delete(billingProcessedSessions);
+  await getDb().delete(billing);
+});
+
+describe('billing repository', () => {
+  it('creates a record on first sight and returns the same one afterwards', async () => {
+    const first = await ensureBilling(OXY_USER);
+    const second = await ensureBilling(OXY_USER);
+
+    expect(second.id).toBe(first.id);
+    expect(first.plusActive).toBe(false);
+    expect(first.fileCredits).toBe(0);
+
+    const rows = await getDb().select({ id: billing.id }).from(billing);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('keeps ONE record when two creates race', async () => {
+    // The `pre('save')` hook did `findOne` then threw — a check with a window
+    // between it and the insert, so two concurrent first payments could both
+    // pass it. `billing_oxy_user_id_key` closes that window; this is the case
+    // that tells the index from the check.
+    const [a, b] = await Promise.all([ensureBilling(OXY_USER), ensureBilling(OXY_USER)]);
+
+    expect(a.id).toBe(b.id);
+    const rows = await getDb().select({ id: billing.id }).from(billing);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('spends a credit once, even when two requests spend at the same time', async () => {
+    // The defect a read-modify-write has: both readers see 1, both write 0, and
+    // one credit pays for two files. The guarded UPDATE cannot do that.
+    await ensureBilling(OXY_USER);
+    await addFileCredits(OXY_USER, 1);
+
+    const [first, second] = await Promise.all([
+      consumeFileCredit(OXY_USER),
+      consumeFileCredit(OXY_USER),
+    ]);
+
+    const consumed = [first, second].filter((result) => result.consumed);
+    expect(consumed).toHaveLength(1);
+
+    const record = await findBillingByOxyUserId(OXY_USER);
+    expect(record?.fileCredits).toBe(0);
+  });
+
+  it('refuses to spend when there are no credits', async () => {
+    await ensureBilling(OXY_USER);
+
+    const result = await consumeFileCredit(OXY_USER);
+
+    expect(result).toEqual({ consumed: false, remaining: 0, reason: 'no_credits' });
+    // And never below zero — `billing_file_credits_non_negative_check` is the
+    // backstop, but the predicate is what stops it being reached.
+    expect((await findBillingByOxyUserId(OXY_USER))?.fileCredits).toBe(0);
+  });
+
+  it('spends nothing for a Plus member', async () => {
+    await ensureBilling(OXY_USER);
+    await addFileCredits(OXY_USER, 3);
+    await setPlusActive(OXY_USER, { active: true });
+
+    expect(await consumeFileCredit(OXY_USER)).toEqual({ consumed: false, remaining: 'unlimited' });
+    // The credits are untouched, not merely unreported.
+    expect((await findBillingByOxyUserId(OXY_USER))?.fileCredits).toBe(3);
+  });
+
+  it('records and clears a subscription across the Plus lifecycle', async () => {
+    await ensureBilling(OXY_USER);
+
+    await setPlusActive(OXY_USER, { active: true, stripeSubscriptionId: 'sub_123' });
+    const active = await findBillingByOxyUserId(OXY_USER);
+    expect(active?.plusActive).toBe(true);
+    expect(active?.plusStripeSubscriptionId).toBe('sub_123');
+    expect(active?.plusSince).toBeInstanceOf(Date);
+    expect(await findBillingByStripeSubscriptionId('sub_123')).not.toBeNull();
+    expect(await listActiveSubscriptions()).toHaveLength(1);
+
+    await setPlusActive(OXY_USER, { active: false });
+    const cancelled = await findBillingByOxyUserId(OXY_USER);
+    expect(cancelled?.plusActive).toBe(false);
+    // The id is CLEARED, not left behind: a stale subscription id is what makes
+    // a webhook for somebody else's subscription land on this record.
+    expect(cancelled?.plusStripeSubscriptionId).toBeNull();
+    expect(cancelled?.plusCanceledAt).toBeInstanceOf(Date);
+    expect(await findBillingByStripeSubscriptionId('sub_123')).toBeNull();
+    expect(await listActiveSubscriptions()).toHaveLength(0);
+  });
+
+  it('claims a Stripe session exactly once', async () => {
+    const record = await ensureBilling(OXY_USER);
+
+    expect(await claimStripeSession(record.id, 'cs_1')).toBe(true);
+    expect(await claimStripeSession(record.id, 'cs_1')).toBe(false);
+    expect(await isStripeSessionProcessed(record.id, 'cs_1')).toBe(true);
+    expect(await listProcessedSessions(record.id)).toEqual(['cs_1']);
+  });
+
+  it('writes NOTHING on a repeat claim, not merely the same values', async () => {
+    // Stripe retries deliveries by design, so a repeat is ordinary rather than
+    // exceptional. `ON CONFLICT DO NOTHING` is a structural no-op: no tuple
+    // version, no timestamp, no lock. `xmin` is what tells that apart from a
+    // `DO UPDATE` careful enough to write the same values back — which WOULD
+    // move it, and would take a row lock the dedupe store does not need.
+    const record = await ensureBilling(OXY_USER);
+    await claimStripeSession(record.id, 'cs_retry');
+
+    const [before] = await getDb()
+      .select({ xmin: sql<string>`xmin::text` })
+      .from(billingProcessedSessions)
+      .where(eq(billingProcessedSessions.sessionId, 'cs_retry'));
+
+    expect(await claimStripeSession(record.id, 'cs_retry')).toBe(false);
+
+    const [after] = await getDb()
+      .select({ xmin: sql<string>`xmin::text` })
+      .from(billingProcessedSessions)
+      .where(eq(billingProcessedSessions.sessionId, 'cs_retry'));
+
+    expect(after.xmin).toBe(before.xmin);
+  });
+
+  it('scopes a claim to its own record', async () => {
+    // `UNIQUE(billing_id, session_id)`, not `UNIQUE(session_id)` — the same
+    // session id under a different record is a different claim, and a repository
+    // that keyed on the session alone would silently drop the second person's.
+    const mine = await ensureBilling(OXY_USER);
+    const theirs = await ensureBilling('oxy-someone-else');
+
+    expect(await claimStripeSession(mine.id, 'cs_shared')).toBe(true);
+    expect(await claimStripeSession(theirs.id, 'cs_shared')).toBe(true);
+    expect(await isStripeSessionProcessed(mine.id, 'cs_shared')).toBe(true);
+    expect(await isStripeSessionProcessed(theirs.id, 'cs_shared')).toBe(true);
+  });
+
+  it('answers null for a person who has never paid', async () => {
+    expect(await findBillingByOxyUserId('oxy-never-paid')).toBeNull();
+  });
+});

--- a/packages/backend/__tests__/db/conversationOrdering.test.ts
+++ b/packages/backend/__tests__/db/conversationOrdering.test.ts
@@ -30,7 +30,6 @@
 
 import { asc, eq } from 'drizzle-orm';
 import { uuidv7 } from '@oxyhq/db';
-import { Types } from 'mongoose';
 import { closePostgres, connectPostgres, type Database } from '../../db/postgres';
 import {
   appendMessages,
@@ -38,9 +37,18 @@ import {
   listMessages,
 } from '../../db/conversations/conversationRepository';
 import { conversationMessages, conversations } from '../../db/schema';
+import { objectIdHex } from '../helpers/postgresGeoFixtures';
 
-/** A 24-char ObjectId hex, exactly as every pre-cutover row carries. */
-const legacyId = (): string => new Types.ObjectId().toHexString();
+/**
+ * A 24-char ObjectId hex, exactly as every pre-cutover row carries.
+ *
+ * The shared minter rather than a second local one: this file used
+ * `new Types.ObjectId().toHexString()`, which was the last reason it imported
+ * mongoose at all — it seeds nothing in Mongo. The property the cases below
+ * actually rest on (a fresh ObjectId hex sorts AFTER a fresh uuid v7) is not
+ * assumed either way; the first `describe` measures it.
+ */
+const legacyId = objectIdHex;
 
 let db: Database;
 

--- a/packages/backend/__tests__/helpers/factories.ts
+++ b/packages/backend/__tests__/helpers/factories.ts
@@ -1,9 +1,13 @@
 /**
  * Test data factories.
  *
- * The property and address factories write POSTGRES — the store the controllers
- * and services under test actually read and write. The Mongoose models are
- * still re-exported below for the domains that have not moved yet.
+ * Every factory here writes POSTGRES — the store the controllers and services
+ * under test actually read and write. Nothing in this file reaches a Mongoose
+ * model any more, and nothing should: a suite that genuinely needs a Mongo
+ * document (the backfill suites, and the handful of tests still pinned to a
+ * domain that has not moved) imports the model it wants directly, where the
+ * dependency is visible in that file rather than acquired by anyone who imports
+ * a factory.
  *
  * Ids are returned as `id`, never `_id`: that is the wire contract (#287) and
  * the column name, and a factory that spelled it the old way would keep every
@@ -13,11 +17,8 @@
 import { eq } from 'drizzle-orm';
 import { OfferingType, PropertyType, PropertyStatus } from '@homiio/shared-types';
 
-import * as models from '../../models';
 import { getDb } from '../../db/postgres';
 import { addresses, cities, countries, properties, regions } from '../../db/schema';
-import { assertFound } from './assertFound';
-const { Lease } = models;
 
 /**
  * The shared geo hierarchy, created once per test and reused within it.
@@ -89,53 +90,6 @@ export async function createAddress(): Promise<{ id: string }> {
   return created;
 }
 
-/**
- * A MONGO address, for the fixtures of domains that have not moved yet.
- *
- * `Review.addressId` / `streetLevelId` / `buildingLevelId` are still Mongoose
- * `ObjectId` paths pointing at the Mongo `Address` collection, and
- * `reviewController` still writes through `Address.findOrCreateCanonical` — so
- * a review fixture handed a Postgres address id fails validation with a
- * `BSONError`. That is a property of where REVIEWS live, not of the address
- * port: production is self-consistent on both sides today.
- *
- * This goes when reviews move, and it is deliberately a SECOND function rather
- * than a flag on {@link createAddress}, so no caller can pick the wrong store
- * without saying which one it means.
- */
-export async function createMongoAddress(): Promise<{ _id: unknown }> {
-  const country = await models.Country.findOneAndUpdate(
-    { code: 'ES' },
-    { $setOnInsert: { code: 'ES', name: 'Spain' } },
-    { upsert: true, new: true, setDefaultsOnInsert: true },
-  );
-  assertFound(country, 'country');
-  const region = await models.Region.findOneAndUpdate(
-    { countryId: country._id, name: 'Catalonia' },
-    { $setOnInsert: { countryId: country._id, name: 'Catalonia' } },
-    { upsert: true, new: true, setDefaultsOnInsert: true },
-  );
-  assertFound(region, 'region');
-  const city = await models.City.findOneAndUpdate(
-    { regionId: region._id, name: 'Barcelona' },
-    { $setOnInsert: { countryId: country._id, regionId: region._id, name: 'Barcelona' } },
-    { upsert: true, new: true, setDefaultsOnInsert: true },
-  );
-  assertFound(city, 'city');
-
-  const existing = await models.Address.findOne({ street: 'Carrer de Mallorca 100' });
-  if (existing) return existing;
-  return models.Address.create({
-    countryId: country._id,
-    regionId: region._id,
-    cityId: city._id,
-    countryCode: 'ES',
-    street: 'Carrer de Mallorca 100',
-    postal_code: '08013',
-    coordinates: { type: 'Point', coordinates: [2.17, 41.39] },
-  });
-}
-
 export interface CreatePropertyOptions {
   oxyUserId: string;
   status?: string;
@@ -174,26 +128,3 @@ export async function createRentProperty(
   return { id: created.id, oxyUserId: created.oxyUserId ?? options.oxyUserId, status: created.status };
 }
 
-export interface CreateLeaseOptions {
-  propertyId: unknown;
-  landlordOxyUserId: string;
-  tenantOxyUserId: string;
-  status?: string;
-}
-
-export async function createLease(
-  options: CreateLeaseOptions,
-): Promise<{ _id: unknown; status: string }> {
-  const now = new Date();
-  const end = new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000);
-  return Lease.create({
-    propertyId: options.propertyId,
-    landlordOxyUserId: options.landlordOxyUserId,
-    tenantOxyUserId: options.tenantOxyUserId,
-    status: options.status ?? 'draft',
-    leaseTerms: { startDate: now, endDate: end },
-    rentDetails: { monthlyRent: 1200, currency: 'EUR', dueDay: 1 },
-  });
-}
-
-export { models };

--- a/packages/backend/__tests__/integration/neighborhoodMetrics.test.ts
+++ b/packages/backend/__tests__/integration/neighborhoodMetrics.test.ts
@@ -7,15 +7,23 @@
  * Also covers the "no neighborhood → 404 / hidden" and unknown-city → empty
  * paths, plus popular-by-listing-count ranking and nearest-by-location lookup.
  *
- * ## The fixtures straddle both stores, because the controller does
+ * ## The fixtures are Postgres-only, and no longer straddle two stores
  *
- * Geo and addresses are Postgres; `properties` lands in batch 3, so the listings
- * are still Mongo documents whose `addressId` names a Postgres address row. That
- * is not a testing convenience — it is exactly the state the branch is in, and
- * it works for the same reason the cutover works: ids are preserved verbatim, so
- * an address id is the SAME string in both stores. `seedAddress` mints 24-char
- * ObjectId hex for that reason (a uuid v7 cannot live in a Mongoose `ObjectId`
- * path), which is also what every backfilled row will carry.
+ * Geo, addresses and listings are all Postgres, so every row this file seeds
+ * goes there. It used to also create a Mongo `Profile` per test, purely to
+ * obtain an `oxyUserId` to own the listings with — the neighborhood router
+ * never read it, in either store. Measured: with the in-memory Mongo switched
+ * off, exactly the seven tests that called that fixture failed, and they failed
+ * inside the fixture rather than at an assertion.
+ *
+ * That is worth naming rather than quietly deleting, because a seed against a
+ * store the code under test does not read is worse than a redundant one: it
+ * passes while proving nothing about the store production uses, and it keeps
+ * `mongoose` in this file's module graph, which is what stops it leaving
+ * `package.json`.
+ *
+ * An owner id is just a string here — Oxy owns identity and these columns carry
+ * no foreign key — so {@link nextOwnerId} mints one directly.
  */
 
 import express, { type Express } from 'express';
@@ -23,7 +31,6 @@ import request from 'supertest';
 import { OfferingType, PropertyType, PropertyStatus } from '@homiio/shared-types';
 
 import neighborhoodRoutes from '../../routes/neighborhoods';
-import { models } from '../helpers/factories';
 import { errorHandler } from '../../middlewares/errorHandler';
 import {
   resetGeoTables,
@@ -33,8 +40,6 @@ import {
   seedProperty,
   type GeoChain,
 } from '../helpers/postgresGeoFixtures';
-
-const { Profile } = models;
 
 function buildApp(): Express {
   const app = express();
@@ -60,9 +65,18 @@ async function seedStreet(
   });
 }
 
-async function seedProfile(): Promise<{ oxyUserId: string }> {
-  const oxyUserId = `oxy-${Math.random().toString(36).slice(2)}`;
-  return Profile.create({ oxyUserId, personalProfile: {} });
+/**
+ * A fresh owner id per test — the same cardinality the Mongo `Profile` fixture
+ * this replaced produced, so no case gains or loses an owner boundary.
+ *
+ * A counter rather than the previous `Math.random()`, because a failure naming
+ * `oxy-neighborhood-owner-3` says which case seeded the row and a random suffix
+ * does not.
+ */
+let ownerSeq = 0;
+function nextOwnerId(): string {
+  ownerSeq += 1;
+  return `oxy-neighborhood-owner-${ownerSeq}`;
 }
 
 /**
@@ -103,9 +117,9 @@ describe('GET /api/neighborhoods/by-property/:propertyId', () => {
   it('returns real, listing-derived metrics for the property neighborhood', async () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
     const gracia = await seedNeighborhood({ cityId: chain.cityId, name: 'Gracia' });
-    const profile = await seedProfile();
+    const ownerId = nextOwnerId();
     const addressId = await seedStreet(chain, gracia);
-    const listingId = await seedListing(profile.oxyUserId, addressId, 1000);
+    const listingId = await seedListing(ownerId, addressId, 1000);
 
     const res = await request(buildApp()).get(`/api/neighborhoods/by-property/${listingId}`);
 
@@ -127,9 +141,9 @@ describe('GET /api/neighborhoods/by-property/:propertyId', () => {
 
   it('404s when the property has no resolved neighborhood', async () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
-    const profile = await seedProfile();
+    const ownerId = nextOwnerId();
     const addressId = await seedStreet(chain, undefined);
-    const listingId = await seedListing(profile.oxyUserId, addressId, 1000);
+    const listingId = await seedListing(ownerId, addressId, 1000);
 
     const res = await request(buildApp()).get(`/api/neighborhoods/by-property/${listingId}`);
 
@@ -149,11 +163,11 @@ describe('GET /api/neighborhoods/by-name', () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
     const gracia = await seedNeighborhood({ cityId: chain.cityId, name: 'Gracia' });
     const eixample = await seedNeighborhood({ cityId: chain.cityId, name: 'Eixample' });
-    const profile = await seedProfile();
+    const ownerId = nextOwnerId();
 
     // Gracia: one 800€ listing. Eixample: one 2000€ listing. City avg = 1400€.
-    await seedListing(profile.oxyUserId, await seedStreet(chain, gracia), 800);
-    await seedListing(profile.oxyUserId, await seedStreet(chain, eixample), 2000);
+    await seedListing(ownerId, await seedStreet(chain, gracia), 800);
+    await seedListing(ownerId, await seedStreet(chain, eixample), 2000);
 
     const res = await request(buildApp())
       .get('/api/neighborhoods/by-name')
@@ -183,12 +197,12 @@ describe('GET /api/neighborhoods/popular', () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
     const gracia = await seedNeighborhood({ cityId: chain.cityId, name: 'Gracia' });
     const eixample = await seedNeighborhood({ cityId: chain.cityId, name: 'Eixample' });
-    const profile = await seedProfile();
+    const ownerId = nextOwnerId();
 
     // Gracia: 2 listings, Eixample: 1 listing.
-    await seedListing(profile.oxyUserId, await seedStreet(chain, gracia), 900);
-    await seedListing(profile.oxyUserId, await seedStreet(chain, gracia), 1100);
-    await seedListing(profile.oxyUserId, await seedStreet(chain, eixample), 2000);
+    await seedListing(ownerId, await seedStreet(chain, gracia), 900);
+    await seedListing(ownerId, await seedStreet(chain, gracia), 1100);
+    await seedListing(ownerId, await seedStreet(chain, eixample), 2000);
 
     const res = await request(buildApp())
       .get('/api/neighborhoods/popular')
@@ -210,13 +224,13 @@ describe('GET /api/neighborhoods/popular', () => {
   it('averages over listings, not over addresses', async () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
     const gracia = await seedNeighborhood({ cityId: chain.cityId, name: 'Gracia' });
-    const profile = await seedProfile();
+    const ownerId = nextOwnerId();
     // Two listings at one address, one at another: an average of per-address
     // averages would give (1000 + 4000) / 2 = 2500 rather than the true 2000.
     const busy = await seedStreet(chain, gracia);
-    await seedListing(profile.oxyUserId, busy, 500);
-    await seedListing(profile.oxyUserId, busy, 1500);
-    await seedListing(profile.oxyUserId, await seedStreet(chain, gracia), 4000);
+    await seedListing(ownerId, busy, 500);
+    await seedListing(ownerId, busy, 1500);
+    await seedListing(ownerId, await seedStreet(chain, gracia), 4000);
 
     const res = await request(buildApp())
       .get('/api/neighborhoods/popular')
@@ -245,8 +259,8 @@ describe('GET /api/neighborhoods/search', () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
     const gracia = await seedNeighborhood({ cityId: chain.cityId, name: 'Gracia' });
     await seedNeighborhood({ cityId: chain.cityId, name: 'Eixample' });
-    const profile = await seedProfile();
-    await seedListing(profile.oxyUserId, await seedStreet(chain, gracia), 1000);
+    const ownerId = nextOwnerId();
+    await seedListing(ownerId, await seedStreet(chain, gracia), 1000);
 
     const res = await request(buildApp())
       .get('/api/neighborhoods/search')
@@ -297,13 +311,13 @@ describe('GET /api/neighborhoods/by-location', () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
     const gracia = await seedNeighborhood({ cityId: chain.cityId, name: 'Gracia' });
     const eixample = await seedNeighborhood({ cityId: chain.cityId, name: 'Eixample' });
-    const profile = await seedProfile();
+    const ownerId = nextOwnerId();
     const near = await seedStreet(chain, gracia, [2.17, 41.39]);
     // ~1.6 km east: inside the 5 km radius, so it is only excluded by being
     // FARTHER — which is what makes this an ordering assertion rather than a
     // "something came back" one.
     await seedStreet(chain, eixample, [2.189, 41.39]);
-    await seedListing(profile.oxyUserId, near, 1000);
+    await seedListing(ownerId, near, 1000);
 
     const res = await request(buildApp())
       .get('/api/neighborhoods/by-location')

--- a/packages/backend/__tests__/unit/mongoUnreachable.test.ts
+++ b/packages/backend/__tests__/unit/mongoUnreachable.test.ts
@@ -71,15 +71,18 @@ const BACKFILL_PREFIX = 'db/backfill/';
  * it. DELETE a line when its port lands; an empty list is the signal that
  * `MONGODB_URI` can come off the task definition.
  *
- * Measured at origin/main 55e1ec4a.
+ * Measured at origin/main 4d697bea.
+ *
+ * `controllers/analyticsController.ts` and `controllers/roommateController.ts`
+ * were on this list at 55e1ec4a and came off in #326, which landed between this
+ * gate being written and being merged — so `main` carried a red "no stale
+ * pending entry" for that window. That is the gate working exactly as its
+ * header describes: a finished port shows up here as a line to DELETE, not as a
+ * silent tolerance.
  */
 const PENDING_MONGO_FILES: ReadonlyMap<string, string> = new Map([
   ['controllers/billingController.ts', 'homiio-billing — task #40, ~30 Billing call sites'],
-  ['routes/profiles.ts', 'homiio-billing — 3 Billing sites incl. a `new Billing({...})` write'],
-  ['controllers/analyticsController.ts', 'analytics port in flight'],
-  ['controllers/roommateController.ts', 'homiio-reviews-roommates — roommates + profiles'],
   ['services/geoResolutionService.ts', 'homiio-property-writes — geo services'],
-  ['scripts/requeue-pisos-coordinates.ts', 'homiio-property-writes — live tooling, needs a real port'],
   ['scripts/seedImages.ts', 'unassigned — decide port vs delete like the other one-offs'],
   ['services/healthService.ts', 'reports Mongo connectivity; retires with the connection itself'],
   ['database/connection.ts', 'the Mongo connection module; deleted last, with models/'],

--- a/packages/backend/db/billing/billingRepository.ts
+++ b/packages/backend/db/billing/billingRepository.ts
@@ -1,0 +1,271 @@
+/**
+ * The billing repository — one row per Oxy user, plus the Stripe sessions
+ * already applied to it.
+ *
+ * Ported from `models/schemas/BillingSchema.ts`, whose behaviour lived in six
+ * instance methods, three statics and a `pre('save')` hook. Each is accounted
+ * for below rather than left to be noticed missing: a Mongoose hook has no
+ * Postgres counterpart and vanishes silently — invisible in a schema diff, to
+ * `tsc`, and to any suite that only supplies valid input.
+ *
+ * | Mongoose | here |
+ * |---|---|
+ * | `pre('save')` refusing a second record per user | `billing_oxy_user_id_key`, and {@link ensureBilling} handles the violation |
+ * | `findByOxyUserId` / `findByStripeSubscriptionId` / `findActiveSubscriptions` | the three finders below |
+ * | `addFileCredit` | {@link addFileCredits}, incremented IN SQL |
+ * | `consumeFileCredit` | {@link consumeFileCredit}, a guarded atomic decrement |
+ * | `activatePlus` / `deactivatePlus` | {@link setPlusActive} |
+ * | `addProcessedSession` / `isSessionProcessed` | {@link claimStripeSession} |
+ *
+ * ## The hook was a read-then-write, and the index is strictly stronger
+ *
+ * `pre('save')` did `findOne({ oxyUserId })` and threw if it found one — a
+ * check with a window between it and the insert, so two concurrent first
+ * payments for the same user could both pass it. `billing_oxy_user_id_key`
+ * closes that window, and {@link ensureBilling} INSERTs and handles `23505`
+ * rather than re-implementing the read. So the rule survives the port and gets
+ * a guarantee it never had.
+ *
+ * ## Credits are changed IN SQL, never read-modify-written
+ *
+ * `addFileCredit`/`consumeFileCredit` mutated a loaded document and saved it.
+ * Two concurrent consumes could each read `1` and each write `0`, spending one
+ * credit twice. Both are single statements here, and the decrement carries its
+ * own `file_credits > 0` predicate so the guard and the write cannot
+ * interleave. `billing_file_credits_non_negative_check` is the backstop
+ * underneath, not the mechanism.
+ */
+
+import { and, eq, gt, sql } from 'drizzle-orm';
+
+import { getDb } from '../postgres';
+import { billing, billingProcessedSessions } from '../schema';
+import { isUniqueViolation } from '../uniqueViolation';
+import type { DatabaseOrTransaction } from '../postgres';
+
+export type BillingRow = typeof billing.$inferSelect;
+
+/** One person's billing record, or null when they have never had one. */
+export async function findBillingByOxyUserId(
+  oxyUserId: string,
+  db: DatabaseOrTransaction = getDb(),
+): Promise<BillingRow | null> {
+  const [row] = await db.select().from(billing).where(eq(billing.oxyUserId, oxyUserId)).limit(1);
+  return row ?? null;
+}
+
+/** The record a Stripe subscription belongs to — the webhook's entry point. */
+export async function findBillingByStripeSubscriptionId(
+  subscriptionId: string,
+  db: DatabaseOrTransaction = getDb(),
+): Promise<BillingRow | null> {
+  const [row] = await db
+    .select()
+    .from(billing)
+    .where(eq(billing.plusStripeSubscriptionId, subscriptionId))
+    .limit(1);
+  return row ?? null;
+}
+
+/** Every record currently on Plus. */
+export async function listActiveSubscriptions(
+  db: DatabaseOrTransaction = getDb(),
+): Promise<BillingRow[]> {
+  return db.select().from(billing).where(eq(billing.plusActive, true));
+}
+
+/**
+ * The caller's record, created empty on first sight.
+ *
+ * INSERT-then-handle-`23505` rather than check-then-insert: the check is the
+ * race the unique index exists to close, and re-implementing it here would
+ * reintroduce it. A conflict means somebody else created the row a moment ago,
+ * which is success — so the row is read back rather than raised.
+ */
+export async function ensureBilling(
+  oxyUserId: string,
+  db: DatabaseOrTransaction = getDb(),
+): Promise<BillingRow> {
+  try {
+    const [created] = await db.insert(billing).values({ oxyUserId }).returning();
+    return created;
+  } catch (error) {
+    if (!isUniqueViolation(error, 'billing_oxy_user_id_key')) throw error;
+    const existing = await findBillingByOxyUserId(oxyUserId, db);
+    if (!existing) {
+      // The insert was refused for a duplicate that is then not there: not a
+      // race, a broken invariant, and it must surface rather than loop.
+      throw new Error(`Billing row for ${oxyUserId} conflicted but could not be read back`);
+    }
+    return existing;
+  }
+}
+
+/** Grant file credits and stamp the payment. Returns the updated record. */
+export async function addFileCredits(
+  oxyUserId: string,
+  amount: number,
+  db: DatabaseOrTransaction = getDb(),
+): Promise<BillingRow | null> {
+  const [row] = await db
+    .update(billing)
+    .set({
+      fileCredits: sql`${billing.fileCredits} + ${amount}`,
+      lastPaymentAt: new Date(),
+    })
+    .where(eq(billing.oxyUserId, oxyUserId))
+    .returning();
+  return row ?? null;
+}
+
+/** What a consume attempt did. `remaining` is `'unlimited'` for a Plus member. */
+export type ConsumeResult =
+  | { consumed: false; remaining: 'unlimited' }
+  | { consumed: true; remaining: number }
+  | { consumed: false; remaining: 0; reason: 'no_credits' };
+
+/**
+ * Spend one file credit.
+ *
+ * Plus members consume nothing — checked first, and read from the row rather
+ * than trusted from the caller. Otherwise ONE statement decrements under a
+ * `file_credits > 0` predicate: no row updated means there was nothing to
+ * spend, which is how "out of credits" is detected without a separate read
+ * that another request could invalidate in between.
+ */
+export async function consumeFileCredit(
+  oxyUserId: string,
+  db: DatabaseOrTransaction = getDb(),
+): Promise<ConsumeResult> {
+  const record = await findBillingByOxyUserId(oxyUserId, db);
+  if (record?.plusActive) return { consumed: false, remaining: 'unlimited' };
+
+  const [row] = await db
+    .update(billing)
+    .set({ fileCredits: sql`${billing.fileCredits} - 1` })
+    .where(and(eq(billing.oxyUserId, oxyUserId), gt(billing.fileCredits, 0)))
+    .returning({ fileCredits: billing.fileCredits });
+
+  if (!row) return { consumed: false, remaining: 0, reason: 'no_credits' };
+  return { consumed: true, remaining: row.fileCredits };
+}
+
+/**
+ * Turn Plus on or off.
+ *
+ * Activating stamps `plus_since` and `last_payment_at` and records the
+ * subscription id; deactivating clears the id and stamps `plus_canceled_at`.
+ * One function rather than two, because they write the same set of columns and
+ * splitting them is how the two halves drift into disagreeing about which
+ * columns belong to the state.
+ */
+export async function setPlusActive(
+  oxyUserId: string,
+  input: { active: true; stripeSubscriptionId?: string } | { active: false },
+  db: DatabaseOrTransaction = getDb(),
+): Promise<BillingRow | null> {
+  const now = new Date();
+  const columns = input.active
+    ? {
+        plusActive: true,
+        plusSince: now,
+        lastPaymentAt: now,
+        plusCanceledAt: null,
+        ...(input.stripeSubscriptionId === undefined
+          ? {}
+          : { plusStripeSubscriptionId: input.stripeSubscriptionId }),
+      }
+    : {
+        plusActive: false,
+        plusStripeSubscriptionId: null,
+        plusCanceledAt: now,
+      };
+
+  const [row] = await db
+    .update(billing)
+    .set(columns)
+    .where(eq(billing.oxyUserId, oxyUserId))
+    .returning();
+  return row ?? null;
+}
+
+/**
+ * Claim a Stripe session for this record, exactly once.
+ *
+ * The Stripe webhook dedupe store. `ON CONFLICT DO NOTHING` plus an empty vs
+ * one-row `RETURNING` IS the answer — a repeat writes nothing at all: no tuple
+ * version, no timestamp, no lock. That is a structural no-op rather than one
+ * that depends on writing the same values back, which matters because a repeat
+ * is ORDINARY here (Stripe retries deliveries by design).
+ *
+ * The conflict is deliberately not caught as an error: a real failure — a
+ * dropped connection, an exhausted pool — still propagates instead of being
+ * read as "already processed", which would silently drop a payment.
+ *
+ * @returns `true` when this call claimed it, `false` when it was already
+ *   claimed. The caller applies the payment only on `true`.
+ */
+export async function claimStripeSession(
+  billingId: string,
+  sessionId: string,
+  db: DatabaseOrTransaction = getDb(),
+): Promise<boolean> {
+  const claimed = await db
+    .insert(billingProcessedSessions)
+    .values({ billingId, sessionId })
+    .onConflictDoNothing()
+    .returning({ id: billingProcessedSessions.id });
+  return claimed.length > 0;
+}
+
+/** Whether a session has already been applied to this record. */
+export async function isStripeSessionProcessed(
+  billingId: string,
+  sessionId: string,
+  db: DatabaseOrTransaction = getDb(),
+): Promise<boolean> {
+  const rows = await db
+    .select({ id: billingProcessedSessions.id })
+    .from(billingProcessedSessions)
+    .where(
+      and(
+        eq(billingProcessedSessions.billingId, billingId),
+        eq(billingProcessedSessions.sessionId, sessionId),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+/** Every session id applied to a record, for the entitlements projection. */
+export async function listProcessedSessions(
+  billingId: string,
+  db: DatabaseOrTransaction = getDb(),
+): Promise<string[]> {
+  const rows = await db
+    .select({ sessionId: billingProcessedSessions.sessionId })
+    .from(billingProcessedSessions)
+    .where(eq(billingProcessedSessions.billingId, billingId));
+  return rows.map((row) => row.sessionId);
+}
+
+/**
+ * Apply an explicit column set to one record.
+ *
+ * The escape hatch for the handful of Stripe lifecycle writes that do not fit a
+ * named operation above (recording a customer id, a period end, a cancellation
+ * flag). Takes an explicit column object — never a request body — so it cannot
+ * become a mass-assignment surface.
+ */
+export async function updateBilling(
+  oxyUserId: string,
+  columns: Partial<typeof billing.$inferInsert>,
+  db: DatabaseOrTransaction = getDb(),
+): Promise<BillingRow | null> {
+  const [row] = await db
+    .update(billing)
+    .set(columns)
+    .where(eq(billing.oxyUserId, oxyUserId))
+    .returning();
+  return row ?? null;
+}

--- a/packages/backend/routes/profiles.ts
+++ b/packages/backend/routes/profiles.ts
@@ -11,7 +11,12 @@ import * as profileController from '../controllers/profile';
 import exchangeReviewController from '../controllers/exchangeReviewController';
 import { asyncHandler } from '../middlewares';
 import performanceMonitor from '../middlewares/performance';
-import { Billing } from '../models';
+import {
+  consumeFileCredit,
+  ensureBilling,
+  findBillingByOxyUserId,
+  listProcessedSessions,
+} from '../db/billing/billingRepository';
 
 export default function () {
   const router = express.Router();
@@ -42,14 +47,19 @@ export default function () {
       || (req as { user?: { id?: string; _id?: string } }).user?._id;
     if (!oxyUserId) return res.status(401).json({ success: false, error: { message: 'Authentication required' }});
 
-    const billing = await Billing.findOne({ oxyUserId }).lean();
-
-    const entitlements = billing || {
-      plusActive: false,
-      fileCredits: 0,
-      founderSupporter: false,
-      processedSessions: [],
-    };
+    // A person who has never paid has no row, and that is not an error — the
+    // zeroed shape below is what the client reads. Deliberately NOT created on
+    // read: an entitlements GET that mints a billing row would put a write on
+    // every page load.
+    const record = await findBillingByOxyUserId(oxyUserId);
+    const entitlements = record
+      ? { ...record, processedSessions: await listProcessedSessions(record.id) }
+      : {
+          plusActive: false,
+          fileCredits: 0,
+          founderSupporter: false,
+          processedSessions: [],
+        };
 
     return res.json({ success: true, entitlements });
   }));
@@ -59,25 +69,20 @@ export default function () {
       || (req as { user?: { id?: string; _id?: string } }).user?._id;
     if (!oxyUserId) return res.status(401).json({ success: false, error: { message: 'Authentication required' }});
 
-    let billing = await Billing.findOne({ oxyUserId });
-    if (!billing) {
-      billing = new Billing({
-        oxyUserId,
-        plusActive: false,
-        fileCredits: 0,
-        processedSessions: [],
-      });
-      await billing.save();
-    }
+    // Created on first spend rather than on read: this endpoint is a write
+    // either way, so it is the honest place for the row to appear.
+    await ensureBilling(oxyUserId);
 
-    const hasPlus = !!billing.plusActive;
-    if (hasPlus) return res.json({ success: true, remaining: 'unlimited', consumed: false });
-
-    if ((billing.fileCredits || 0) <= 0) {
+    // ONE guarded statement decides all three outcomes. The Mongo version read
+    // the record, checked `fileCredits > 0`, and then decremented — so two
+    // concurrent requests could each see 1 and each spend it. `consumeFileCredit`
+    // carries the predicate into the UPDATE, so the guard and the write cannot
+    // interleave, and "no row updated" IS the out-of-credits answer.
+    const result = await consumeFileCredit(oxyUserId);
+    if (!result.consumed && result.remaining !== 'unlimited') {
       return res.status(402).json({ success: false, error: { message: 'No file credits', code: 'NO_CREDITS' }});
     }
 
-    const result = await billing.consumeFileCredit();
     return res.json({
       success: true,
       remaining: result.remaining,

--- a/packages/backend/scripts/requeue-pisos-coordinates.ts
+++ b/packages/backend/scripts/requeue-pisos-coordinates.ts
@@ -25,7 +25,6 @@ import {
   parseRedisConnection,
   type FetchJobData,
 } from '../services/ingestion/queues';
-import database from '../database/connection';
 
 import { closePostgres, connectPostgres, getDb } from '../db/postgres';
 import { addresses, properties } from '../db/schema';


### PR DESCRIPTION
The foundation of the Billing slice. **`billingController.ts` (30 sites) is deliberately not in this PR** — reasoning at the bottom.

## `db/billing/billingRepository.ts`

`BillingSchema`'s hooks enumerated **before** porting, each re-expressed at a chokepoint with a test that fails without it:

| Mongoose | here |
|---|---|
| `pre('save')` refusing a second record per user | `billing_oxy_user_id_key` + `ensureBilling` handling `23505` |
| `addFileCredit` / `consumeFileCredit` | single statements, guarded |
| `activatePlus` / `deactivatePlus` | `setPlusActive` |
| `addProcessedSession` / `isSessionProcessed` | `claimStripeSession` |
| `findByOxyUserId` / `findByStripeSubscriptionId` / `findActiveSubscriptions` | three finders |

Two are worth spelling out because the port makes them *stronger*, not merely equivalent:

- **The hook was `findOne`-then-throw** — a check with a window between it and the insert, so two concurrent first payments for one user could both pass it. The unique index has no such window, and `ensureBilling` INSERTs and handles the violation rather than re-implementing the read that was the race.
- **Credits were read-modify-written.** Two concurrent consumes could each read `1` and each write `0` — one credit paying for two files. The decrement carries its own `file_credits > 0` predicate, so the guard and the write cannot interleave, and "no row updated" *is* the out-of-credits answer. The CHECK constraint is the backstop, not the mechanism.

## `routes/profiles.ts` — 3 sites, one a write

The entitlements `GET` no longer mints a billing row. A read that creates state put a write on every page load; the row now appears on first *spend*, which is a write either way.

## Tests

`__tests__/db/billingRepository.test.ts`, 10 cases, written against the **rules** rather than the happy path — because a rule that refuses bad input is invisible to every test that supplies good input. Two racing creates; two concurrent spends; a repeat claim checked by `xmin`.

**Mutation-tested twice**, since these are the guards that matter:
- removing the `file_credits > 0` predicate → **2 red**;
- swapping `DO NOTHING` for a same-values `DO UPDATE` → **2 red**, including the `xmin` case, which is the one that tells a true no-op from a careful rewrite.

Restored in place afterwards (`cat pristine > target`, not `git checkout`) and confirmed my own markers survived.

## A correction to the task's baseline

The task said main carried **194 pre-existing tsc errors**. Measured on current main (`de31b24a`): **zero**. That figure was taken at `f8c6000` while several ports were mid-flight and is stale — comparing deltas against it would have been comparing against a phantom.

## Why `billingController.ts` is not here

956 lines and 30 sites of Stripe subscription lifecycle — checkout, webhook, portal, manual activate/cancel, sync, reactivate. It is the highest-consequence code in this batch (real money), the patterns need per-handler judgement rather than a sweep, and the repository it needs is now in place and tested. Splitting it is the same call you invited earlier: a foundation that is verified, then the call sites.

Also of note: **#327 and my #328 both deleted `scripts/purge-lease-ip.ts`.** Git merged them cleanly (delete/delete is not a conflict) so there is no damage, but two agents reasoned about the same script independently — worth a word on ownership if the scripts area is still shared.

## Verification

tsc clean, eslint 0 errors, build green, `bun.lock` unchanged, full suite **129 suites / 1695 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)