### PR TITLE
test(db): drop two allowlist entries whose ports landed before the gate did

### DIFF
--- a/packages/backend/__tests__/unit/mongoUnreachable.test.ts
+++ b/packages/backend/__tests__/unit/mongoUnreachable.test.ts
@@ -71,13 +71,17 @@ const BACKFILL_PREFIX = 'db/backfill/';
  * it. DELETE a line when its port lands; an empty list is the signal that
  * `MONGODB_URI` can come off the task definition.
  *
- * Measured at origin/main 55e1ec4a.
+ * Measured at origin/main 4d697bea.
+ *
+ * A list measured at one revision and merged at a later one arrives stale, which
+ * is what happened to this one: it was written against 55e1ec4a and merged at
+ * 7ad466b, by which point the analytics and roommate ports had already landed
+ * (6799317a, bb309d41). Re-measure against the tip you are merging to, not the
+ * tip you branched from.
  */
 const PENDING_MONGO_FILES: ReadonlyMap<string, string> = new Map([
   ['controllers/billingController.ts', 'homiio-billing — task #40, ~30 Billing call sites'],
   ['routes/profiles.ts', 'homiio-billing — 3 Billing sites incl. a `new Billing({...})` write'],
-  ['controllers/analyticsController.ts', 'analytics port in flight'],
-  ['controllers/roommateController.ts', 'homiio-reviews-roommates — roommates + profiles'],
   ['services/geoResolutionService.ts', 'homiio-property-writes — geo services'],
   ['scripts/requeue-pisos-coordinates.ts', 'homiio-property-writes — live tooling, needs a real port'],
   ['scripts/seedImages.ts', 'unassigned — decide port vs delete like the other one-offs'],


### PR DESCRIPTION
## `main` is red, and so is every open PR

`__tests__/unit/mongoUnreachable.test.ts` → `has no stale pending entry` fails on
`controllers/analyticsController.ts` and `controllers/roommateController.ts`.
Neither reaches Mongo any more: analytics was ported in 6799317a, roommates in
bb309d41 — **both before #329 introduced the gate.**

Measured on untouched `origin/main` (4d697bea) before touching anything:

```
Tests: 1 failed, 6 passed
● has no stale pending entry
+   "controllers/analyticsController.ts",
+   "controllers/roommateController.ts",
```

PR #331 (billing) fails on **this and nothing else** — `1 failed, 1745 passed`.
So this one assertion is currently blocking the whole queue.

## This is the gate working, not a nuisance

`PENDING_MONGO_FILES` is a progress ledger whose entire value is that the day it
empties is the day `MONGODB_URI` can come off the task definition. An entry left
behind after its port landed would hide that moment, so a stale line is a
failure *by design*.

What made it stale is now recorded in the file, because it will happen again:
the list was measured at `55e1ec4a` and merged at `7ad466b`, and three ports
landed in between. Re-measure against the tip you are merging **to**.

## Scope

Test-only; two lines deleted and a comment. No production file is touched.

Deliberately **separate** from the Mongo connection removal it unblocks. That
change stops the runtime opening a connection at all, so it must land after the
last LIVE Mongo reader — `Billing`, i.e. #331 — is on Postgres. This repair is
needed now, by everyone, and carries none of that risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)