### PR TITLE
test(mongo): drop the last test-side Mongo seeds for domains already on Postgres

### DIFF
--- a/packages/backend/__tests__/db/conversationOrdering.test.ts
+++ b/packages/backend/__tests__/db/conversationOrdering.test.ts
@@ -30,7 +30,6 @@
 
 import { asc, eq } from 'drizzle-orm';
 import { uuidv7 } from '@oxyhq/db';
-import { Types } from 'mongoose';
 import { closePostgres, connectPostgres, type Database } from '../../db/postgres';
 import {
   appendMessages,
@@ -38,9 +37,18 @@ import {
   listMessages,
 } from '../../db/conversations/conversationRepository';
 import { conversationMessages, conversations } from '../../db/schema';
+import { objectIdHex } from '../helpers/postgresGeoFixtures';
 
-/** A 24-char ObjectId hex, exactly as every pre-cutover row carries. */
-const legacyId = (): string => new Types.ObjectId().toHexString();
+/**
+ * A 24-char ObjectId hex, exactly as every pre-cutover row carries.
+ *
+ * The shared minter rather than a second local one: this file used
+ * `new Types.ObjectId().toHexString()`, which was the last reason it imported
+ * mongoose at all — it seeds nothing in Mongo. The property the cases below
+ * actually rest on (a fresh ObjectId hex sorts AFTER a fresh uuid v7) is not
+ * assumed either way; the first `describe` measures it.
+ */
+const legacyId = objectIdHex;
 
 let db: Database;
 

--- a/packages/backend/__tests__/helpers/factories.ts
+++ b/packages/backend/__tests__/helpers/factories.ts
@@ -1,9 +1,13 @@
 /**
  * Test data factories.
  *
- * The property and address factories write POSTGRES — the store the controllers
- * and services under test actually read and write. The Mongoose models are
- * still re-exported below for the domains that have not moved yet.
+ * Every factory here writes POSTGRES — the store the controllers and services
+ * under test actually read and write. Nothing in this file reaches a Mongoose
+ * model any more, and nothing should: a suite that genuinely needs a Mongo
+ * document (the backfill suites, and the handful of tests still pinned to a
+ * domain that has not moved) imports the model it wants directly, where the
+ * dependency is visible in that file rather than acquired by anyone who imports
+ * a factory.
  *
  * Ids are returned as `id`, never `_id`: that is the wire contract (#287) and
  * the column name, and a factory that spelled it the old way would keep every
@@ -13,11 +17,8 @@
 import { eq } from 'drizzle-orm';
 import { OfferingType, PropertyType, PropertyStatus } from '@homiio/shared-types';
 
-import * as models from '../../models';
 import { getDb } from '../../db/postgres';
 import { addresses, cities, countries, properties, regions } from '../../db/schema';
-import { assertFound } from './assertFound';
-const { Lease } = models;
 
 /**
  * The shared geo hierarchy, created once per test and reused within it.
@@ -89,53 +90,6 @@ export async function createAddress(): Promise<{ id: string }> {
   return created;
 }
 
-/**
- * A MONGO address, for the fixtures of domains that have not moved yet.
- *
- * `Review.addressId` / `streetLevelId` / `buildingLevelId` are still Mongoose
- * `ObjectId` paths pointing at the Mongo `Address` collection, and
- * `reviewController` still writes through `Address.findOrCreateCanonical` — so
- * a review fixture handed a Postgres address id fails validation with a
- * `BSONError`. That is a property of where REVIEWS live, not of the address
- * port: production is self-consistent on both sides today.
- *
- * This goes when reviews move, and it is deliberately a SECOND function rather
- * than a flag on {@link createAddress}, so no caller can pick the wrong store
- * without saying which one it means.
- */
-export async function createMongoAddress(): Promise<{ _id: unknown }> {
-  const country = await models.Country.findOneAndUpdate(
-    { code: 'ES' },
-    { $setOnInsert: { code: 'ES', name: 'Spain' } },
-    { upsert: true, new: true, setDefaultsOnInsert: true },
-  );
-  assertFound(country, 'country');
-  const region = await models.Region.findOneAndUpdate(
-    { countryId: country._id, name: 'Catalonia' },
-    { $setOnInsert: { countryId: country._id, name: 'Catalonia' } },
-    { upsert: true, new: true, setDefaultsOnInsert: true },
-  );
-  assertFound(region, 'region');
-  const city = await models.City.findOneAndUpdate(
-    { regionId: region._id, name: 'Barcelona' },
-    { $setOnInsert: { countryId: country._id, regionId: region._id, name: 'Barcelona' } },
-    { upsert: true, new: true, setDefaultsOnInsert: true },
-  );
-  assertFound(city, 'city');
-
-  const existing = await models.Address.findOne({ street: 'Carrer de Mallorca 100' });
-  if (existing) return existing;
-  return models.Address.create({
-    countryId: country._id,
-    regionId: region._id,
-    cityId: city._id,
-    countryCode: 'ES',
-    street: 'Carrer de Mallorca 100',
-    postal_code: '08013',
-    coordinates: { type: 'Point', coordinates: [2.17, 41.39] },
-  });
-}
-
 export interface CreatePropertyOptions {
   oxyUserId: string;
   status?: string;
@@ -174,26 +128,3 @@ export async function createRentProperty(
   return { id: created.id, oxyUserId: created.oxyUserId ?? options.oxyUserId, status: created.status };
 }
 
-export interface CreateLeaseOptions {
-  propertyId: unknown;
-  landlordOxyUserId: string;
-  tenantOxyUserId: string;
-  status?: string;
-}
-
-export async function createLease(
-  options: CreateLeaseOptions,
-): Promise<{ _id: unknown; status: string }> {
-  const now = new Date();
-  const end = new Date(now.getTime() + 365 * 24 * 60 * 60 * 1000);
-  return Lease.create({
-    propertyId: options.propertyId,
-    landlordOxyUserId: options.landlordOxyUserId,
-    tenantOxyUserId: options.tenantOxyUserId,
-    status: options.status ?? 'draft',
-    leaseTerms: { startDate: now, endDate: end },
-    rentDetails: { monthlyRent: 1200, currency: 'EUR', dueDay: 1 },
-  });
-}
-
-export { models };

--- a/packages/backend/__tests__/integration/neighborhoodMetrics.test.ts
+++ b/packages/backend/__tests__/integration/neighborhoodMetrics.test.ts
@@ -7,15 +7,23 @@
  * Also covers the "no neighborhood → 404 / hidden" and unknown-city → empty
  * paths, plus popular-by-listing-count ranking and nearest-by-location lookup.
  *
- * ## The fixtures straddle both stores, because the controller does
+ * ## The fixtures are Postgres-only, and no longer straddle two stores
  *
- * Geo and addresses are Postgres; `properties` lands in batch 3, so the listings
- * are still Mongo documents whose `addressId` names a Postgres address row. That
- * is not a testing convenience — it is exactly the state the branch is in, and
- * it works for the same reason the cutover works: ids are preserved verbatim, so
- * an address id is the SAME string in both stores. `seedAddress` mints 24-char
- * ObjectId hex for that reason (a uuid v7 cannot live in a Mongoose `ObjectId`
- * path), which is also what every backfilled row will carry.
+ * Geo, addresses and listings are all Postgres, so every row this file seeds
+ * goes there. It used to also create a Mongo `Profile` per test, purely to
+ * obtain an `oxyUserId` to own the listings with — the neighborhood router
+ * never read it, in either store. Measured: with the in-memory Mongo switched
+ * off, exactly the seven tests that called that fixture failed, and they failed
+ * inside the fixture rather than at an assertion.
+ *
+ * That is worth naming rather than quietly deleting, because a seed against a
+ * store the code under test does not read is worse than a redundant one: it
+ * passes while proving nothing about the store production uses, and it keeps
+ * `mongoose` in this file's module graph, which is what stops it leaving
+ * `package.json`.
+ *
+ * An owner id is just a string here — Oxy owns identity and these columns carry
+ * no foreign key — so {@link nextOwnerId} mints one directly.
  */
 
 import express, { type Express } from 'express';
@@ -23,7 +31,6 @@ import request from 'supertest';
 import { OfferingType, PropertyType, PropertyStatus } from '@homiio/shared-types';
 
 import neighborhoodRoutes from '../../routes/neighborhoods';
-import { models } from '../helpers/factories';
 import { errorHandler } from '../../middlewares/errorHandler';
 import {
   resetGeoTables,
@@ -33,8 +40,6 @@ import {
   seedProperty,
   type GeoChain,
 } from '../helpers/postgresGeoFixtures';
-
-const { Profile } = models;
 
 function buildApp(): Express {
   const app = express();
@@ -60,9 +65,18 @@ async function seedStreet(
   });
 }
 
-async function seedProfile(): Promise<{ oxyUserId: string }> {
-  const oxyUserId = `oxy-${Math.random().toString(36).slice(2)}`;
-  return Profile.create({ oxyUserId, personalProfile: {} });
+/**
+ * A fresh owner id per test — the same cardinality the Mongo `Profile` fixture
+ * this replaced produced, so no case gains or loses an owner boundary.
+ *
+ * A counter rather than the previous `Math.random()`, because a failure naming
+ * `oxy-neighborhood-owner-3` says which case seeded the row and a random suffix
+ * does not.
+ */
+let ownerSeq = 0;
+function nextOwnerId(): string {
+  ownerSeq += 1;
+  return `oxy-neighborhood-owner-${ownerSeq}`;
 }
 
 /**
@@ -103,9 +117,9 @@ describe('GET /api/neighborhoods/by-property/:propertyId', () => {
   it('returns real, listing-derived metrics for the property neighborhood', async () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
     const gracia = await seedNeighborhood({ cityId: chain.cityId, name: 'Gracia' });
-    const profile = await seedProfile();
+    const ownerId = nextOwnerId();
     const addressId = await seedStreet(chain, gracia);
-    const listingId = await seedListing(profile.oxyUserId, addressId, 1000);
+    const listingId = await seedListing(ownerId, addressId, 1000);
 
     const res = await request(buildApp()).get(`/api/neighborhoods/by-property/${listingId}`);
 
@@ -127,9 +141,9 @@ describe('GET /api/neighborhoods/by-property/:propertyId', () => {
 
   it('404s when the property has no resolved neighborhood', async () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
-    const profile = await seedProfile();
+    const ownerId = nextOwnerId();
     const addressId = await seedStreet(chain, undefined);
-    const listingId = await seedListing(profile.oxyUserId, addressId, 1000);
+    const listingId = await seedListing(ownerId, addressId, 1000);
 
     const res = await request(buildApp()).get(`/api/neighborhoods/by-property/${listingId}`);
 
@@ -149,11 +163,11 @@ describe('GET /api/neighborhoods/by-name', () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
     const gracia = await seedNeighborhood({ cityId: chain.cityId, name: 'Gracia' });
     const eixample = await seedNeighborhood({ cityId: chain.cityId, name: 'Eixample' });
-    const profile = await seedProfile();
+    const ownerId = nextOwnerId();
 
     // Gracia: one 800€ listing. Eixample: one 2000€ listing. City avg = 1400€.
-    await seedListing(profile.oxyUserId, await seedStreet(chain, gracia), 800);
-    await seedListing(profile.oxyUserId, await seedStreet(chain, eixample), 2000);
+    await seedListing(ownerId, await seedStreet(chain, gracia), 800);
+    await seedListing(ownerId, await seedStreet(chain, eixample), 2000);
 
     const res = await request(buildApp())
       .get('/api/neighborhoods/by-name')
@@ -183,12 +197,12 @@ describe('GET /api/neighborhoods/popular', () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
     const gracia = await seedNeighborhood({ cityId: chain.cityId, name: 'Gracia' });
     const eixample = await seedNeighborhood({ cityId: chain.cityId, name: 'Eixample' });
-    const profile = await seedProfile();
+    const ownerId = nextOwnerId();
 
     // Gracia: 2 listings, Eixample: 1 listing.
-    await seedListing(profile.oxyUserId, await seedStreet(chain, gracia), 900);
-    await seedListing(profile.oxyUserId, await seedStreet(chain, gracia), 1100);
-    await seedListing(profile.oxyUserId, await seedStreet(chain, eixample), 2000);
+    await seedListing(ownerId, await seedStreet(chain, gracia), 900);
+    await seedListing(ownerId, await seedStreet(chain, gracia), 1100);
+    await seedListing(ownerId, await seedStreet(chain, eixample), 2000);
 
     const res = await request(buildApp())
       .get('/api/neighborhoods/popular')
@@ -210,13 +224,13 @@ describe('GET /api/neighborhoods/popular', () => {
   it('averages over listings, not over addresses', async () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
     const gracia = await seedNeighborhood({ cityId: chain.cityId, name: 'Gracia' });
-    const profile = await seedProfile();
+    const ownerId = nextOwnerId();
     // Two listings at one address, one at another: an average of per-address
     // averages would give (1000 + 4000) / 2 = 2500 rather than the true 2000.
     const busy = await seedStreet(chain, gracia);
-    await seedListing(profile.oxyUserId, busy, 500);
-    await seedListing(profile.oxyUserId, busy, 1500);
-    await seedListing(profile.oxyUserId, await seedStreet(chain, gracia), 4000);
+    await seedListing(ownerId, busy, 500);
+    await seedListing(ownerId, busy, 1500);
+    await seedListing(ownerId, await seedStreet(chain, gracia), 4000);
 
     const res = await request(buildApp())
       .get('/api/neighborhoods/popular')
@@ -245,8 +259,8 @@ describe('GET /api/neighborhoods/search', () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
     const gracia = await seedNeighborhood({ cityId: chain.cityId, name: 'Gracia' });
     await seedNeighborhood({ cityId: chain.cityId, name: 'Eixample' });
-    const profile = await seedProfile();
-    await seedListing(profile.oxyUserId, await seedStreet(chain, gracia), 1000);
+    const ownerId = nextOwnerId();
+    await seedListing(ownerId, await seedStreet(chain, gracia), 1000);
 
     const res = await request(buildApp())
       .get('/api/neighborhoods/search')
@@ -297,13 +311,13 @@ describe('GET /api/neighborhoods/by-location', () => {
     const chain = await seedGeoChain({ cityName: 'Barcelona' });
     const gracia = await seedNeighborhood({ cityId: chain.cityId, name: 'Gracia' });
     const eixample = await seedNeighborhood({ cityId: chain.cityId, name: 'Eixample' });
-    const profile = await seedProfile();
+    const ownerId = nextOwnerId();
     const near = await seedStreet(chain, gracia, [2.17, 41.39]);
     // ~1.6 km east: inside the 5 km radius, so it is only excluded by being
     // FARTHER — which is what makes this an ordering assertion rather than a
     // "something came back" one.
     await seedStreet(chain, eixample, [2.189, 41.39]);
-    await seedListing(profile.oxyUserId, near, 1000);
+    await seedListing(ownerId, near, 1000);
 
     const res = await request(buildApp())
       .get('/api/neighborhoods/by-location')

--- a/packages/backend/__tests__/unit/mongoUnreachable.test.ts
+++ b/packages/backend/__tests__/unit/mongoUnreachable.test.ts
@@ -71,13 +71,18 @@ const BACKFILL_PREFIX = 'db/backfill/';
  * it. DELETE a line when its port lands; an empty list is the signal that
  * `MONGODB_URI` can come off the task definition.
  *
- * Measured at origin/main 55e1ec4a.
+ * Measured at origin/main 4d697bea.
+ *
+ * `controllers/analyticsController.ts` and `controllers/roommateController.ts`
+ * were on this list at 55e1ec4a and came off in #326, which landed between this
+ * gate being written and being merged — so `main` carried a red "no stale
+ * pending entry" for that window. That is the gate working exactly as its
+ * header describes: a finished port shows up here as a line to DELETE, not as a
+ * silent tolerance.
  */
 const PENDING_MONGO_FILES: ReadonlyMap<string, string> = new Map([
   ['controllers/billingController.ts', 'homiio-billing — task #40, ~30 Billing call sites'],
   ['routes/profiles.ts', 'homiio-billing — 3 Billing sites incl. a `new Billing({...})` write'],
-  ['controllers/analyticsController.ts', 'analytics port in flight'],
-  ['controllers/roommateController.ts', 'homiio-reviews-roommates — roommates + profiles'],
   ['services/geoResolutionService.ts', 'homiio-property-writes — geo services'],
   ['scripts/requeue-pisos-coordinates.ts', 'homiio-property-writes — live tooling, needs a real port'],
   ['scripts/seedImages.ts', 'unassigned — decide port vs delete like the other one-offs'],


### PR DESCRIPTION
## What

Four **test** files. No production file is touched.

Each one seeds or reaches Mongo for a domain whose production code reads Postgres — which is worse than redundant: it passes while exercising a store production no longer uses, and it is what keeps `mongoose` in these files' module graph.

| file | what it did | why it is safe to stop |
|---|---|---|
| `integration/neighborhoodMetrics.test.ts` | `Profile.create` per test, only to get an `oxyUserId` | the neighborhood router never read it, in either store |
| `helpers/factories.ts` | `createMongoAddress`, `createLease`, `export { models }` | **zero consumers** for the first two; one for the third (the file above). Reviews moved in #325, which the `createMongoAddress` doc named as its own expiry |
| `db/conversationOrdering.test.ts` | `new Types.ObjectId().toHexString()` | seeds nothing in Mongo — now uses the shared `objectIdHex` from #330 rather than a second local minter |
| `unit/mongoUnreachable.test.ts` | two stale `PENDING_MONGO_FILES` entries | see below — this one is **red on `main` right now** |

## `mongoUnreachable` is red on main, and this fixes it

#329's `PENDING_MONGO_FILES` was measured at `55e1ec4a`; #326 landed between that gate being written and merged, so `controllers/analyticsController.ts` and `controllers/roommateController.ts` no longer reach Mongo and its `has no stale pending entry` case fails.

Verified as **pre-existing** by running that file alone on an untouched `4d697bea` before attributing it to this branch. Deleting the two lines is exactly what the gate's own header prescribes ("finishing a file means DELETING a line here").

## Measurement

Real Postgres (`postgis/postgis:17-3.5`), same tree, nothing else changed:

```
base 4d697bea: 130 suites / 1735 passed / 1 failed   <- the stale entry above
after:         130 suites / 1736 passed / 0 failed
```

Per-file pass counts: **one file moved** — `mongoUnreachable.test.ts` 6 to 7, its previously-failing case now passing. `neighborhoodMetrics` 17 to 17. `conversationOrdering` unchanged. No file lost a test.

Identical counts prove nothing, so the substantive change was mutation-tested:

| mutation | result |
|---|---|
| `neighborhoodController` `averageRent` + 1 | **4 of the 17 `neighborhoodMetrics` cases RED** |

All four are among the **seven** whose fixture this PR rewrote, so those assertions still catch a real defect in the code under test rather than merely still running. The `factories.ts` deletions are covered by `tsc`, which rejects any surviving consumer of a deleted export.

## Context: what still needs Mongo

Measured on `bb309d41` by disabling the in-memory replica set and running the whole suite **serially** (a parallel run reports 8 — two of them are Postgres `too many clients already`, not a Mongo dependency):

| file | Mongo-dependent tests | owner |
|---|---|---|
| `db/dataBackfill.test.ts` | 57 / 57 | the backfill itself, by design |
| `db/geoBackfill.test.ts` | 16 / 41 | the backfill itself, by design |
| `integration/neighborhoodMetrics.test.ts` | 7 / 17 | **this PR** |
| `integration/reviewSystem.test.ts` | 1 / 33 | reviews |
| `integration/stripeWebhook.test.ts` | 2 / 5 | billing |
| `integration/wireIdContract.test.ts` | 1 / 13 | tail — `renameWireIds` reducing a real Mongoose document |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
