### PR TITLE
port(seed): move the two seed scripts off Mongo and restore their idempotency

### DIFF
--- a/packages/backend/__tests__/db/seedProperties.test.ts
+++ b/packages/backend/__tests__/db/seedProperties.test.ts
@@ -1,0 +1,187 @@
+/**
+ * `scripts/seedProperties.ts` — the seeder converges, and a repeat is a genuine
+ * no-op.
+ *
+ * ## Why row counts alone are not the test
+ *
+ * "Run it twice and the row count is unchanged" is the obvious assertion and it
+ * is NOT sufficient here, because the implementation this replaced satisfied it
+ * while being the exact opposite of idempotent: it `TRUNCATE`d five tables and
+ * re-inserted everything, so the counts matched perfectly and every single id —
+ * every listing, address, photo — was different afterwards. A count is blind to
+ * the distinction the seeder exists to make.
+ *
+ * So the discriminating assertion is the ID SET, captured after run 1 and
+ * compared after run 2. Under truncate-and-reinsert it is disjoint; under a real
+ * `(source, source_id)` probe it is identical. Row counts are asserted too,
+ * because they are what catches the OTHER failure — a probe that never matches
+ * and appends 21 more listings on every run.
+ *
+ * The third assertion is the image fetcher's call count. `images` has no natural
+ * key to conflict on (its id is minted per upload), so a re-run that re-fetched
+ * would leave orphaned rows reachable from nothing — invisible to a `properties`
+ * count and visible here as a non-zero call count on the second pass.
+ *
+ * ## What is real and what is stubbed
+ *
+ * Postgres is real (`connectPostgres`, the worker's own throwaway database), the
+ * Sharp pipeline is real, and the repositories are real — a mocked drizzle would
+ * accept the statements a probe-less seeder issues and prove nothing. Only the
+ * NETWORK is stubbed, with a 1x1 PNG, following `externalIngest.test.ts`: the
+ * property under test is what the seeder writes on a repeat, and reaching
+ * Unsplash to observe it would be measuring the network.
+ */
+
+import path from 'path';
+import fs from 'fs/promises';
+import { and, eq, inArray, isNotNull } from 'drizzle-orm';
+import { closePostgres, connectPostgres, getDb } from '../../db/postgres';
+import { cities, images, properties, propertyImages } from '../../db/schema';
+import type { ImageBufferInput } from '../../services/imageUploadService';
+import { resetGeoTables } from '../helpers/postgresGeoFixtures';
+import { SEED_OWNER_OXY_USER_ID, seedProperties } from '../../scripts/seedProperties';
+
+// A 1x1 transparent PNG — a real, Sharp-decodable image with no network fetch.
+const ONE_BY_ONE_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+const LOCAL_IMAGE_STORE_DIR = path.join(__dirname, '..', '..', '.local-image-store');
+
+/**
+ * Listings in the seed dataset. An EQUALITY rather than a floor, so adding a
+ * listing without updating this fails loudly instead of silently weakening the
+ * vacuity guard below.
+ */
+const SEED_LISTING_COUNT = 21;
+
+const fetchImage = jest.fn(
+  async (): Promise<ImageBufferInput> => ({ buffer: ONE_BY_ONE_PNG, mimetype: 'image/png' }),
+);
+
+/** The seeded listings' own id set, plus the tables that hang off them. */
+interface Snapshot {
+  properties: string[];
+  addresses: string[];
+  images: string[];
+  propertyImages: string[];
+}
+
+/**
+ * Every query here is SCOPED to rows the seeder owns, never a bare `select id
+ * from <table>`.
+ *
+ * The first version counted whole tables and CI caught it: one `images` row
+ * left by another file in the same worker made the table 98 rows against 97
+ * fetches, and the suite went red for a reason that had nothing to do with the
+ * seeder. A global assertion silently makes every other suite in the worker
+ * part of this test's fixture — the same fragility that makes
+ * `propertyImages.test.ts`'s primary-photo assertion order-dependent. Scoping
+ * is what makes this file's result a property of the seeder alone.
+ */
+async function snapshot(): Promise<Snapshot> {
+  const db = getDb();
+
+  const seededProperties = await db
+    .select({ id: properties.id, addressId: properties.addressId })
+    .from(properties)
+    .where(eq(properties.oxyUserId, SEED_OWNER_OXY_USER_ID));
+  const propertyIds = seededProperties.map((row) => row.id);
+  const addressIds = [...new Set(seededProperties.map((row) => row.addressId))];
+
+  // A seeder run with zero listings must not silently produce empty `inArray`
+  // clauses that look like a clean comparison; the caller's vacuity floor
+  // asserts the count, and this keeps the queries well-formed meanwhile.
+  const propertyPhotos = propertyIds.length
+    ? await db
+        .select({ id: propertyImages.id })
+        .from(propertyImages)
+        .where(inArray(propertyImages.propertyId, propertyIds))
+    : [];
+
+  // The images this seeder creates are exactly: one per property photo, plus
+  // each seeded city's cover. Both are addressed by what points AT them, so a
+  // stray row belonging to another suite cannot enter the set.
+  const propertyImageRows = propertyIds.length
+    ? await db
+        .select({ id: images.id })
+        .from(images)
+        .where(and(eq(images.entityType, 'property'), inArray(images.entityId, propertyIds)))
+    : [];
+  const cityCovers = await db
+    .select({ id: cities.coverImageId })
+    .from(cities)
+    .where(isNotNull(cities.coverImageId));
+
+  return {
+    properties: [...propertyIds].sort(),
+    addresses: [...addressIds].sort(),
+    images: [
+      ...propertyImageRows.map((row) => row.id),
+      ...cityCovers.flatMap((row) => (row.id === null ? [] : [row.id])),
+    ].sort(),
+    propertyImages: propertyPhotos.map((row) => row.id).sort(),
+  };
+}
+
+beforeAll(async () => {
+  await connectPostgres();
+  // Clean on the way IN as well as out. This suite seeds the whole Spain geo
+  // hierarchy, so it must not inherit a half-populated one from an earlier file
+  // in the same worker.
+  await resetGeoTables();
+});
+
+afterAll(async () => {
+  // Leave the worker database exactly as this suite found it, through the SAME
+  // helper every other file uses rather than a hand-rolled truncate.
+  //
+  // This is not tidiness — it was measured. The first version truncated only
+  // `properties`/`property_images`/`addresses`/`images` and left the geo
+  // hierarchy `seedGeo` had written, which turned five UNRELATED suites red
+  // (`geoBackfill`, `geoQueryResolution`, `roommateDiscovery`, `roomOwnership`,
+  // `cityPropertiesPagination`) while this file passed in isolation. A
+  // `truncate ... cascade` on `cities` does not reach `regions`/`countries`,
+  // which is exactly the leftover that broke them. `resetGeoTables` deletes in
+  // FK order and covers all three.
+  await resetGeoTables();
+  await fs.rm(LOCAL_IMAGE_STORE_DIR, { recursive: true, force: true });
+  await closePostgres();
+});
+
+describe('seedProperties is idempotent', () => {
+  it('creates on the first run and changes nothing on the second', async () => {
+    // Run 1 — from a known-empty state, which is what `fresh` is for.
+    const first = await seedProperties({ fresh: true, fetchImage });
+    const afterFirst = await snapshot();
+
+    // Vacuity floor. Every assertion below is satisfied by a seeder that did
+    // NOTHING at all — two empty snapshots are trivially equal and zero fetches
+    // is trivially zero fetches. These four pin that run 1 really seeded.
+    expect(first).toEqual({ created: SEED_LISTING_COUNT, unchanged: 0 });
+    expect(afterFirst.properties).toHaveLength(SEED_LISTING_COUNT);
+    expect(afterFirst.images.length).toBeGreaterThan(90);
+    // One stored `images` row per fetch — the invariant that makes the
+    // "no fetches on run 2" assertion below mean "no new image rows".
+    expect(afterFirst.images).toHaveLength(fetchImage.mock.calls.length);
+
+    fetchImage.mockClear();
+
+    // Run 2 — the same invocation a developer repeats, WITHOUT `fresh`.
+    const second = await seedProperties({ fetchImage });
+    const afterSecond = await snapshot();
+
+    // Nothing was created, and every listing was recognised.
+    expect(second).toEqual({ created: 0, unchanged: SEED_LISTING_COUNT });
+
+    // THE assertion: identical id sets, not merely identical counts. This is
+    // what tells a no-op from a truncate-and-reinsert rewrite.
+    expect(afterSecond).toEqual(afterFirst);
+
+    // And a genuine no-op reaches for no bytes at all — so no orphaned `images`
+    // row can accumulate behind the `cities.cover_image_id` / `property_images`
+    // pointers.
+    expect(fetchImage).not.toHaveBeenCalled();
+  }, 300_000);
+});

--- a/packages/backend/__tests__/integration/externalIngest.test.ts
+++ b/packages/backend/__tests__/integration/externalIngest.test.ts
@@ -139,6 +139,18 @@ beforeEach(async () => {
 });
 
 afterAll(async () => {
+  // Reset on the way OUT as well as in. `beforeEach` above keeps THIS file
+  // consistent, but it leaves the last test's ingested listing — a property
+  // carrying a PRIMARY photo — in the worker's database for whatever file runs
+  // next, and jest reuses one database per worker for the whole run.
+  //
+  // That is not hypothetical: it is what intermittently reddened
+  // `db/propertyImages.test.ts`, whose "lets TWO DIFFERENT listings each have
+  // their own primary" case asserts over EVERY primary row in the table and so
+  // counted this file's leftover as a third. The failure lands two files away
+  // from its cause and moves around as the file-to-worker distribution shifts,
+  // which is why adding an unrelated test file appeared to break it.
+  await resetGeoTables();
   await fs.rm(LOCAL_IMAGE_STORE_DIR, { recursive: true, force: true });
 });
 

--- a/packages/backend/__tests__/unit/mongoUnreachable.test.ts
+++ b/packages/backend/__tests__/unit/mongoUnreachable.test.ts
@@ -99,6 +99,13 @@ const BACKFILL_PREFIX = 'db/backfill/';
  * pending entry" for that window. That is the gate working exactly as its
  * header describes: a finished port shows up here as a line to DELETE, not as a
  * silent tolerance.
+ *
+ * `scripts/seedProperties.ts` came off with the seed port, and what it cost is
+ * worth recording because the list made it look larger than it was: the
+ * seeder's write path had already moved in #281, so all that still reached
+ * Mongo was a `database/connection` import used for a single
+ * `database.disconnect()` in its CLI teardown. This list's LENGTH was never a
+ * measure of the remaining work — the same is true of the two entries above it.
  */
 const PENDING_MONGO_FILES: ReadonlyMap<string, string> = new Map([]);
 

--- a/packages/backend/scripts/seedImages.ts
+++ b/packages/backend/scripts/seedImages.ts
@@ -1,28 +1,32 @@
 /**
  * Seed Images helper
  *
- * Turns the demo dataset's image URLs into rows of the canonical Image
- * collection, then links them back to their owning entity. Two flows:
+ * Turns the demo dataset's image URLs into rows of the canonical `images`
+ * table, then links them back to their owning entity. Two flows:
  *
  *   - Property photos: each property's seed photo URLs are fetched once, run
- *     through the Sharp pipeline and persisted as `Image` docs
- *     (`entityType: 'property'`). The resolved `PropertyImageRef[]` (the
+ *     through the Sharp pipeline and persisted as `images` rows
+ *     (`entity_type: 'property'`). The resolved `PropertyImageRef[]` (the
  *     `{ url, caption, isPrimary }` shape the frontend already consumes, `url` =
  *     stored medium variant, plus the full variant `urls`) is returned so the
- *     seeder can embed it on the property — preserving the historical read shape
- *     while backing it with the Image collection.
+ *     seeder can point `property_images` at them.
  *
  *   - City covers (local demo seed only): the six curated city images (the SAME
  *     URLs the frontend `CITY_SHOWCASE` array hardcodes) are fetched ONCE,
- *     processed and stored as `Image` docs (`entityType: 'city'`). Production
+ *     processed and stored as `images` rows (`entity_type: 'city'`). Production
  *     covers use `cityCoverSyncService` (Wikimedia Commons), not this seed path.
  *
- * Storage caveat: when object storage is not configured (no S3 credentials —
- * e.g. this local seed environment), the Image documents are still created with
- * REAL Sharp-derived dimensions/format/byte sizes and the variant keys/urls
- * where the bytes WOULD live; only the upload of the processed bytes is skipped
- * (via `allowUnconfiguredStorage`). Nothing is faked — the structure and linkage
- * are correct, and a credentialed environment uploads the bytes unchanged.
+ * Storage: when object storage is not configured (no S3 credentials — e.g. this
+ * local seed environment) the processed bytes are persisted to the SELF-HOSTED
+ * local store and served by the backend at `/api/images/file/*`; a credentialed
+ * environment uploads the same bytes to S3 instead. Either way the `images` row
+ * carries REAL Sharp-derived dimensions/format/byte sizes and resolves to real
+ * bytes — nothing is faked.
+ *
+ * `allowUnconfiguredStorage` no longer skips the upload — `processAndUpload`
+ * reads `void skipUpload` and persists either way — so the flag now only means
+ * "this caller accepts the local store". Stated because the obvious reading of
+ * the name is the opposite one.
  */
 
 import type { ImageEntityType, PropertyImageRef } from '@homiio/shared-types';
@@ -73,8 +77,18 @@ export const CITY_COVER_IMAGE_URLS: Readonly<Record<string, string>> = {
     'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Bilbao_-_Museo_Guggenheim_01.jpg/1280px-Bilbao_-_Museo_Guggenheim_01.jpg',
 };
 
+/**
+ * How the seed obtains an image's bytes.
+ *
+ * Injectable for the same reason `ExternalMediaIngest` takes a `fetchImage`:
+ * the property under test is what the seed WRITES on a repeat, and a test that
+ * had to reach Unsplash to observe it would be measuring the network. The
+ * default is the real fetch, so the CLI is unchanged.
+ */
+export type SeedImageFetcher = (url: string) => Promise<ImageBufferInput>;
+
 /** Fetch one image URL into a buffer + its resolved MIME type. Throws on failure. */
-async function fetchImageBuffer(url: string): Promise<ImageBufferInput> {
+export async function fetchImageBuffer(url: string): Promise<ImageBufferInput> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
@@ -109,13 +123,14 @@ function shouldAllowUnconfiguredStorage(): boolean {
  */
 export async function seedPropertyImages(
   propertyId: string,
-  imageUrls: readonly string[]
+  imageUrls: readonly string[],
+  fetchImage: SeedImageFetcher = fetchImageBuffer
 ): Promise<PropertyImageRef[]> {
   const allowUnconfiguredStorage = shouldAllowUnconfiguredStorage();
   const created = [];
 
   for (let index = 0; index < imageUrls.length; index += 1) {
-    const input = await fetchImageBuffer(imageUrls[index]);
+    const input = await fetchImage(imageUrls[index]);
     const image = await imageUploadService.createImageForEntity('property', propertyId, input, {
       isPrimary: index === 0,
       order: index,
@@ -136,11 +151,12 @@ export async function seedEntityCoverImage(
   entityType: ImageEntityType,
   entityId: string,
   url: string | undefined,
-  caption: string
+  caption: string,
+  fetchImage: SeedImageFetcher = fetchImageBuffer
 ): Promise<string | null> {
   if (!url) return null;
   const allowUnconfiguredStorage = shouldAllowUnconfiguredStorage();
-  const input = await fetchImageBuffer(url);
+  const input = await fetchImage(url);
   const image = await imageUploadService.createImageForEntity(
     entityType,
     entityId,

--- a/packages/backend/scripts/seedProperties.ts
+++ b/packages/backend/scripts/seedProperties.ts
@@ -12,12 +12,23 @@
  * A listing may carry several offerings at once (e.g. monthly rent AND a nightly
  * rate, with DIFFERENT numbers), each in its own priced block.
  *
- * Idempotent: each listing has a stable (source, sourceId) key. Re-running
- * upserts in place instead of creating duplicates. Addresses are deduplicated
- * by their normalizedKey via Address.findOrCreateCanonical.
+ * Idempotent: each listing has a stable `(source, sourceId)` key, backed by the
+ * partial unique `properties_source_source_id_key`. A re-run probes that key and
+ * skips a listing it already wrote — so a second run inserts nothing, fetches no
+ * photos, and leaves every id it minted on the first run intact. Addresses are
+ * deduplicated by their `normalized_key` via `findOrCreateCanonicalAddress`, and
+ * the geo hierarchy by `seedGeo`'s own `ON CONFLICT DO UPDATE`.
+ *
+ * That property is pinned by `__tests__/db/seedProperties.test.ts`, which runs
+ * the seeder TWICE against a real Postgres and compares the ID SETS of
+ * `properties`, `addresses`, `images` and `property_images` — not merely their
+ * counts, which a truncate-and-reinsert satisfies just as well. A single run
+ * cannot tell idempotent from not, and a count cannot tell a no-op from a
+ * rewrite.
  *
  * Usage:
- *   bun run seed:properties
+ *   bun run seed:properties            # converge: create what is missing
+ *   bun run seed:properties -- --fresh # wipe the five seeded tables first
  *   # or
  *   ts-node --transpile-only scripts/seedProperties.ts
  */
@@ -39,6 +50,8 @@ import {
   seedEntityCoverImage,
   CITY_COVER_IMAGE_URLS,
   logStorageMode,
+  fetchImageBuffer,
+  type SeedImageFetcher,
 } from './seedImages';
 
 /**
@@ -55,7 +68,7 @@ const FurnishedStatus = {
 
 import { eq, sql } from 'drizzle-orm';
 
-import { connectPostgres, getDb } from '../db/postgres';
+import { closePostgres, connectPostgres, getDb } from '../db/postgres';
 // `properties` is aliased because this module's own seed DATA is called
 // `properties` — the table and the fixture list would otherwise shadow.
 import {
@@ -66,6 +79,7 @@ import {
   propertyImages,
 } from '../db/schema';
 import {
+  findPropertyBySource,
   insertProperty,
   replacePropertyImages,
   type PropertyWriteInput,
@@ -86,7 +100,8 @@ import { findOrCreateCanonicalAddress } from '../services/addressService';
  * because a real internal listing could share the source but never the owner.
  */
 const SEED_SOURCE = 'internal';
-const SEED_OWNER_OXY_USER_ID = 'seed-demo-host';
+/** Exported so a test can scope its assertions to rows this seeder owns. */
+export const SEED_OWNER_OXY_USER_ID = 'seed-demo-host';
 const CURRENCY = 'EUR';
 
 // Short-term availability runs from today for the next ~90 days.
@@ -774,7 +789,38 @@ function resolveOfferings(seed: SeedProperty): OfferingType[] {
   return offerings;
 }
 
-async function upsertProperty(seed: SeedProperty): Promise<'inserted' | 'updated'> {
+async function upsertProperty(
+  seed: SeedProperty,
+  fetchImage: SeedImageFetcher,
+): Promise<'created' | 'unchanged'> {
+  // The natural key IS the idempotency mechanism. `properties_source_source_id_key`
+  // is unique on `(source, source_id) WHERE source_id IS NOT NULL`, so a seeded
+  // listing is identified by `('internal', sourceId)` and nothing else — not by a
+  // minted id, which is the whole point: a fresh uuid v7 per run would never
+  // conflict and would duplicate all 21 listings on every invocation while the
+  // summary happily reported convergence.
+  //
+  // Probing BEFORE the insert (rather than inserting and catching `23505`) is
+  // what makes a repeat a genuine no-op instead of a rewrite: it also skips the
+  // photo fetch, so a second run performs zero network requests and writes zero
+  // `images` rows. `findPropertyBySource` returns the photo count for exactly
+  // this decision.
+  const existing = await findPropertyBySource(SEED_SOURCE, seed.sourceId);
+  if (existing) {
+    // Attach photos only if a previous run died between the listing insert and
+    // its images — a resumed partial run, the case the idempotence rule exists
+    // for. A listing that already has photos is left completely alone.
+    if (existing.imageCount === 0) {
+      const refs = await seedPropertyImages(
+        existing.id,
+        withUnsplashParams(seed.imageUrls),
+        fetchImage,
+      );
+      await replacePropertyImages(existing.id, refs);
+    }
+    return 'unchanged';
+  }
+
   const address = await findOrCreateCanonicalAddress({
     street: seed.address.street,
     number: seed.address.number,
@@ -855,7 +901,20 @@ async function upsertProperty(seed: SeedProperty): Promise<'inserted' | 'updated
     status: PropertyStatus.PUBLISHED,
     availability: {
       isAvailable: true,
-      availableFrom: today
+      availableFrom: today,
+      // Stated explicitly, and NOT cosmetically: `toPropertyColumns` maps this
+      // block through `member()`, which turns an absent key into an explicit
+      // NULL — and `availability_minimum_stay` / `_maximum_stay` are
+      // `notNull().default(1)` / `.default(12)`. An explicit NULL does not fall
+      // back to a column default, so omitting them fails `23502` on the FIRST
+      // listing. (Their sibling keys in the same block coalesce —
+      // `member(block,'isAvailable') ?? true` — these two do not; that gap is
+      // `db/properties/propertyWrites.ts`'s to close, and it breaks any caller
+      // sending a partial `availability` block, not just this seeder.)
+      // The values here are the column defaults, so the row is what the schema
+      // would have written on its own.
+      minimumStay: 1,
+      maximumStay: 12
     },
     availableFrom: today
   };
@@ -867,9 +926,8 @@ async function upsertProperty(seed: SeedProperty): Promise<'inserted' | 'updated
     }
   }
 
-  // Insert fresh (the table is wiped first in `run`). The cross-field
-  // `offerings`↔blocks rule that needed a whole Mongoose document as `this` is
-  // now four CHECK constraints on the table
+  // The cross-field `offerings`↔blocks rule that needed a whole Mongoose
+  // document as `this` is now four CHECK constraints on the table
   // (`properties_offering_{long_term_rent,short_term_rent,sale,exchange}_check`),
   // so it holds for every writer rather than only for `.save()`.
   doc.sourceId = seed.sourceId;
@@ -882,10 +940,11 @@ async function upsertProperty(seed: SeedProperty): Promise<'inserted' | 'updated
   const imageRefs = await seedPropertyImages(
     property.property.id,
     withUnsplashParams(seed.imageUrls),
+    fetchImage,
   );
   await replacePropertyImages(property.property.id, imageRefs);
 
-  return 'inserted';
+  return 'created';
 }
 
 /**
@@ -894,16 +953,31 @@ async function upsertProperty(seed: SeedProperty): Promise<'inserted' | 'updated
  * `entityId = city._id`) and set the city's `coverImageId` + `imageIds`. Runs
  * after geo is seeded so the City rows (and their `_id`s) exist.
  */
-async function seedCityCoverImages(): Promise<void> {
-  const cityRows = await getDb().select({ id: cities.id, name: cities.name }).from(cities);
+async function seedCityCoverImages(fetchImage: SeedImageFetcher): Promise<void> {
+  const cityRows = await getDb()
+    .select({ id: cities.id, name: cities.name, coverImageId: cities.coverImageId })
+    .from(cities);
   for (const city of cityRows) {
     const url = CITY_COVER_IMAGE_URLS[city.name as keyof typeof CITY_COVER_IMAGE_URLS];
     if (!url) {
       console.warn(`[seed-properties] No curated cover image for city "${city.name}" — skipping`);
       continue;
     }
+    // Already covered — leave it alone. `images` has no natural key to conflict
+    // on (its id is minted per upload), so without this probe every re-run would
+    // fetch six photos again and leave six ORPHANED `images` rows behind, with
+    // only the newest reachable through `cities.cover_image_id`. That is the
+    // duplicate-on-repeat failure the property-level probe above avoids, one
+    // table over.
+    if (city.coverImageId) continue;
     try {
-      const imageId = await seedEntityCoverImage('city', city.id, url, `${city.name} cityscape`);
+      const imageId = await seedEntityCoverImage(
+        'city',
+        city.id,
+        url,
+        `${city.name} cityscape`,
+        fetchImage,
+      );
       if (imageId) {
         // Only the cover pointer. The `imageIds[]` array the Mongo document
         // carried was dropped in the port: the membership it denormalized is
@@ -920,30 +994,51 @@ async function seedCityCoverImages(): Promise<void> {
   }
 }
 
-async function run(): Promise<void> {
-  console.log('[seed-properties] Connecting to database...');
-  await connectPostgres();
+/** Options for {@link seedProperties}. */
+export interface SeedPropertiesOptions {
+  /**
+   * Wipe listings, addresses, images and the geo hierarchy before seeding.
+   *
+   * OFF by default, which is the change that makes this script idempotent
+   * rather than merely convergent. A truncate does keep the row COUNT stable
+   * across runs, so it passes a naive "run it twice" check — but every run
+   * mints new ids for all 21 listings, their addresses and their photos, so
+   * anything holding a seeded id (a saved item, an open tab, a fixture) breaks,
+   * and it destroys any real local data in five shared tables on the way past.
+   * That is a rewrite, not a no-op.
+   */
+  fresh?: boolean;
+  /** Injected by the test so the repeat-is-a-no-op property is observable offline. */
+  fetchImage?: SeedImageFetcher;
+}
 
-  // Fresh reseed (no migration): wipe listings, addresses, the geo hierarchy AND
-  // every image row, then re-seed geo so addresses resolve against canonical
-  // rows.
-  //
-  // ONE `TRUNCATE ... CASCADE`, where the Mongo version fired seven parallel
-  // `deleteMany`s. It has to be one statement: these tables reference each other
-  // (`properties.address_id` is ON DELETE RESTRICT, `property_images.image_id`
-  // likewise), so any independent order fails on the first table something still
-  // points at. The parallel version only appeared to work because Mongo has no
-  // foreign keys — it was leaving dangling references, not avoiding them.
-  //
-  // Note this is a FULL wipe of `properties`, not just `source = 'seed'`: a
-  // truncate cannot be filtered, and the geo truncate below would cascade into
-  // every remaining listing anyway. That matches what the script already
-  // documents itself as — a development reseed, never something to point at a
-  // database holding real listings.
-  console.log('[seed-properties] Wiping listings, addresses, geo tables and images...');
-  await getDb().execute(
-    sql`truncate table ${propertiesTable}, ${propertyImages}, ${addresses}, ${images}, ${cities} cascade`,
-  );
+/** What one seeding pass did, per listing. */
+export interface SeedPropertiesSummary {
+  created: number;
+  unchanged: number;
+}
+
+export async function seedProperties(
+  options: SeedPropertiesOptions = {},
+): Promise<SeedPropertiesSummary> {
+  const fetchImage = options.fetchImage ?? fetchImageBuffer;
+
+  if (options.fresh) {
+    // ONE `TRUNCATE ... CASCADE`, where the Mongo version fired seven parallel
+    // `deleteMany`s. It has to be one statement: these tables reference each
+    // other (`properties.address_id` is ON DELETE RESTRICT,
+    // `property_images.image_id` likewise), so any independent order fails on
+    // the first table something still points at. The parallel version only
+    // appeared to work because Mongo has no foreign keys — it was leaving
+    // dangling references, not avoiding them.
+    //
+    // A truncate cannot be filtered to `oxy_user_id = 'seed-demo-host'`, so this
+    // is a FULL wipe of five shared tables. That is why it is opt-in.
+    console.log('[seed-properties] --fresh: wiping listings, addresses, geo tables and images...');
+    await getDb().execute(
+      sql`truncate table ${propertiesTable}, ${propertyImages}, ${addresses}, ${images}, ${cities} cascade`,
+    );
+  }
 
   logStorageMode();
 
@@ -952,23 +1047,23 @@ async function run(): Promise<void> {
   console.log(`[seed-properties] Geo seeded: ${geoSummary.countries} country, ${geoSummary.regions} regions, ${geoSummary.cities} cities, ${geoSummary.neighborhoods} neighborhoods`);
 
   // Seed each city's cover image: fetch the curated photo ONCE, store it as an
-  // Image doc (entityType 'city') in our own object storage, and link it via
-  // `coverImageId` — so the runtime never depends on an external image host.
+  // `images` row (entity_type 'city') in our own object storage, and link it via
+  // `cover_image_id` — so the runtime never depends on an external image host.
   console.log('[seed-properties] Seeding city cover images (fetch-once-then-store)...');
-  await seedCityCoverImages();
+  await seedCityCoverImages(fetchImage);
 
-  let inserted = 0;
-  let updated = 0;
+  let created = 0;
+  let unchanged = 0;
 
   for (const seed of properties) {
     try {
-      const result = await upsertProperty(seed);
-      if (result === 'inserted') {
-        inserted += 1;
+      const result = await upsertProperty(seed, fetchImage);
+      if (result === 'created') {
+        created += 1;
       } else {
-        updated += 1;
+        unchanged += 1;
       }
-      console.log(`[seed-properties] ${result.padEnd(8)} ${seed.sourceId} (${resolveOfferings(seed).join('+')})`);
+      console.log(`[seed-properties] ${result.padEnd(9)} ${seed.sourceId} (${resolveOfferings(seed).join('+')})`);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       console.error(`[seed-properties] FAILED ${seed.sourceId}: ${message}`);
@@ -1011,21 +1106,46 @@ async function run(): Promise<void> {
   const exchangeCount = await countSeed(OfferingType.EXCHANGE);
 
   console.log('[seed-properties] ----------------------------------------');
-  console.log(`[seed-properties] Inserted: ${inserted}  Updated: ${updated}`);
+  console.log(`[seed-properties] Created: ${created}  Unchanged: ${unchanged}`);
   console.log(`[seed-properties] Total seed properties:    ${totalSeed}`);
   console.log(`[seed-properties] Long-term-rent listings:  ${longTermCount}`);
   console.log(`[seed-properties] Short-term-rent listings: ${shortTermCount}`);
   console.log(`[seed-properties] Sale listings:            ${saleCount}`);
   console.log(`[seed-properties] Exchange listings:        ${exchangeCount}`);
   console.log('[seed-properties] Done.');
+
+  return { created, unchanged };
 }
 
-run()
-  .catch((err: unknown) => {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error('[seed-properties] FAILED:', message);
-    process.exitCode = 1;
-  })
-  .finally(() => {
-    process.exit(process.exitCode ?? 0);
-  });
+/** CLI entrypoint: connect, seed, close. `--fresh` wipes first. */
+async function run(): Promise<void> {
+  console.log('[seed-properties] Connecting to database...');
+  await connectPostgres();
+  await seedProperties({ fresh: process.argv.includes('--fresh') });
+}
+
+// Only auto-run when invoked directly, so the suite can import `seedProperties`
+// without the module seeding a database on require. `seedGeo` sets the
+// precedent; this file previously ran on import, which is why the two-run
+// idempotence property had no way to be observed by a test.
+if (require.main === module) {
+  run()
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('[seed-properties] FAILED:', message);
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      try {
+        // Close the pool this script actually opened. The teardown here used to
+        // be the Mongo `database.disconnect()` — a database the seeder had not
+        // opened since the write path moved — which left the Postgres pool for
+        // `process.exit` to reap.
+        await closePostgres();
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn('[seed-properties] disconnect error:', message);
+      }
+      process.exit(process.exitCode ?? 0);
+    });
+}


### PR DESCRIPTION
Ports `scripts/seedProperties.ts` and `scripts/seedImages.ts` off Mongo and
removes their two lines from `PENDING_MONGO_FILES`. They move together because
`seedImages` exists only to serve the seeder.

## What actually reached Mongo was small

#281 had already ported the write path, so the remaining Mongo surface was:

- `seedProperties.ts` — `import database from '../database/connection'`, whose
  only use was `database.disconnect()` in the CLI teardown. That closed a
  database the seeder no longer opens, while leaving the Postgres pool for
  `process.exit` to reap. Now `closePostgres()`, matching `seedGeo`.
- `seedImages.ts` — `import type { Types } from 'mongoose'` for two
  `Types.ObjectId | string` parameters. Now `string`.

The pending list made this look larger than it was, which is worth knowing for
the entries that remain: **the list's LENGTH is not the migration's remaining
work.** Recorded in the gate's own header.

## The idempotency was the real work

The header promised *"(source, sourceId) key, re-running upserts in place"*. The
ported code delivered that with a `TRUNCATE ... CASCADE` of five tables followed
by unconditional inserts — `upsertProperty` always returned `'inserted'` and the
`updated` counter was unreachable.

That converges on a stable row **count** while minting new ids for every
listing, address and photo on each run. It is a rewrite, not a no-op: anything
holding a seeded id breaks, and it destroys real local data in five shared
tables on the way past.

Restored by probing the natural key:

- **Listings** — `findPropertyBySource`, backed by the partial unique
  `properties_source_source_id_key`. A present listing is skipped entirely, so a
  repeat inserts nothing *and fetches no photos*.
- **City covers** — guarded on `cities.cover_image_id`. `images` has no natural
  key to conflict on, so an unguarded re-run left six orphaned rows reachable
  from nothing. No database constraint catches that; only the test does.
- **Addresses / geo** — already `findOrCreateCanonicalAddress` and `seedGeo`'s
  `ON CONFLICT DO UPDATE`.

The wipe survives as an explicit `--fresh` flag rather than being the default.

## How idempotency is proven

`__tests__/db/seedProperties.test.ts` — real Postgres, real Sharp, real
repositories; only the network is stubbed, with a 1x1 PNG (the `externalIngest`
precedent). It runs the seeder **twice** and compares **id sets**, not just
counts, plus the fetcher's call count.

Mutation-tested, because a green test proves nothing until breaking what it
guards fails it:

| Mutation | Caught by | Would a count-only test catch it? |
|---|---|---|
| Run 2 as `fresh` (truncate-and-reinsert) | id-set assertion, line 126 | **No** — 21 properties both runs |
| City-cover guard removed | id-set assertion (6 orphan `images`) | **No** — summary and property count both stay correct |

For the first mutation the summary assertion fires first, so it was re-run with
that assertion neutralized, to confirm the id-set assertion is independently
load-bearing rather than merely downstream of one that already failed.

Vacuity floor: run 1 asserts `created: 21`, more than 90 images, and one stored
image per fetch — every assertion after it is satisfied by a seeder that did
nothing at all.

## A pre-existing break, fixed

**The seeder has failed on its first listing since #281.** `toPropertyColumns`
maps the `availability` block through `member()`, which turns an absent key into
an explicit `NULL`, and `availability_minimum_stay` / `_maximum_stay` are
`NOT NULL`. Their sibling keys in the same block coalesce
(`member(block,'isAvailable') ?? true`); these two do not. The seed now states
both, using the column defaults.

**The underlying gap is `db/properties/propertyWrites.ts`'s and is NOT fixed
here** — it breaks any caller sending a partial `availability` block, not just
this seeder. Left to that file's owner (`homiio-property-writes`), whose files
this PR does not touch.

## Gates

- `packages/backend` tsc: **194 errors before and after**, none in these files.
  Measured on this tree rather than inherited.
- Full backend suite: **132/132 suites, 1747/1747 tests**.
- eslint clean on all four files.
- `bun.lock` unchanged — no dependency change.

The rebase onto #331 also dropped `scripts/requeue-pisos-coordinates.ts` from
the pending list (ported on main) alongside the two seed entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
