### PR TITLE
test(price-ethics): type the fixture as what the function takes, not as a Mongoose document

### DIFF
--- a/packages/backend/__tests__/unit/priceEthicsService.test.ts
+++ b/packages/backend/__tests__/unit/priceEthicsService.test.ts
@@ -1,6 +1,24 @@
+/**
+ * `computePriceEthics` scoring.
+ *
+ * ## The fixture is typed as what the function TAKES
+ *
+ * These cases used to build a `Partial<IProperty>` — a MONGOOSE document type —
+ * and hand it over with `as IProperty`. `computePriceEthics` has taken
+ * `ScorableProperty` since it was moved off the old store: the serialized WIRE
+ * shape, which is what `serializeProperty` produces from a Postgres row.
+ *
+ * The two happen to agree on the fields used here, so the cast compiled and the
+ * suite passed — which is the problem with it. An `as` on a fixture suppresses
+ * exactly the check that says whether the object still resembles what the
+ * function is called with in production, and this one additionally kept a unit
+ * test importing the Mongoose model barrel long after the module under test had
+ * stopped. Typed directly, with no cast, a drift on either side is a compile
+ * error.
+ */
+
 import { OfferingType, PropertyType } from '@homiio/shared-types';
-import type { IProperty } from '../../models/documentTypes';
-import { computePriceEthics } from '../../services/priceEthicsService';
+import { computePriceEthics, type ScorableProperty } from '../../services/priceEthicsService';
 import {
   computeMarketVerdictForProperty,
   type MarketVerdictResult,
@@ -18,7 +36,7 @@ const mockMarketVerdict = computeMarketVerdictForProperty as jest.MockedFunction
   typeof computeMarketVerdictForProperty
 >;
 
-function baseProperty(overrides: Partial<IProperty> = {}): IProperty {
+function baseProperty(overrides: Partial<ScorableProperty> = {}): ScorableProperty {
   return {
     offerings: [OfferingType.LONG_TERM_RENT],
     type: PropertyType.APARTMENT,
@@ -29,7 +47,7 @@ function baseProperty(overrides: Partial<IProperty> = {}): IProperty {
     amenities: [],
     isExternal: false,
     ...overrides,
-  } as IProperty;
+  };
 }
 
 function marketResult(


### PR DESCRIPTION
## What

`__tests__/unit/priceEthicsService.test.ts` built a `Partial<IProperty>` — the **Mongoose** document type — and handed it over with `as IProperty`.

`computePriceEthics` has taken `ScorableProperty` since it was moved off the old store: the serialized **wire** shape, which `serializeProperty` produces from a Postgres row. Its own doc comment already says so — *"typing it against a Mongoose document was what tied this module to the old store."*

The two agree on the fields these cases use, so the cast compiled and the suite passed. That is precisely the problem: an `as` on a fixture suppresses the one check that says whether the object still resembles what production calls the function with — and this one also kept a unit test importing the model barrel long after the module under test had stopped.

The cast is **removed** rather than re-pointed. The fixture now has to satisfy `ScorableProperty` structurally, and `tsc` is clean — which is itself the evidence that the object was always the wire shape rather than a document.

**No production file is touched.**

## Mutation — the cast was suppressing something real

Adding `profileId` to the fixture (a Mongo-only field: `models/documentTypes.ts:491` declares it on `IProperty`, nothing on the wire shape does) now fails the build:

```
TS2353: Object literal may only specify known properties,
        and 'profileId' does not exist in type 'ScorableProperty'.
```

Under `as IProperty` that same fixture compiled silently, because `profileId` is a perfectly good field on the type being asserted to.

## Counts

`13 → 13`. No case added or removed — this is a type change; the assertions are untouched, and the evidence they still hold is the mutation above plus a green run, not the count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
