### PR TITLE
test(mongo): make the in-memory replica set opt-in, so what still needs Mongo is a grep and not a measurement

### DIFF
--- a/packages/backend/__tests__/db/dataBackfill.test.ts
+++ b/packages/backend/__tests__/db/dataBackfill.test.ts
@@ -51,6 +51,11 @@ import {
 import { RowAuditor, UniqueKeyAuditor, type CandidateRow } from '../../db/backfill/rowAudit';
 import { isLiveEntityId, uuidv7 } from '@oxyhq/db';
 import { ResolutionLog } from '../../db/backfill/geoPlan';
+import { useMongoMemoryServer } from '../helpers/mongoMemory';
+
+// The backfill READS Mongo — that is its whole job — so this suite is one of
+// the five that still boot a replica set. See `helpers/mongoMemory.ts`.
+useMongoMemoryServer();
 
 /** The property rules, reached through the PLAN so the test cannot drift from it. */
 const PROPERTY_RULES = DATA_PLANS.properties.rules.properties ?? [];

--- a/packages/backend/__tests__/db/geoBackfill.test.ts
+++ b/packages/backend/__tests__/db/geoBackfill.test.ts
@@ -46,6 +46,10 @@ import {
   type SourceDocument,
 } from '../../db/backfill/geoPlan';
 import type { CandidateRow } from '../../db/backfill/rowAudit';
+import { useMongoMemoryServer } from '../helpers/mongoMemory';
+
+// Same reason as `dataBackfill`: the source store is Mongo by definition.
+useMongoMemoryServer();
 
 const oid = () => new mongoose.Types.ObjectId();
 const noCovers: CoverContext = { existingImageIds: new Set() };

--- a/packages/backend/__tests__/helpers/mongoMemory.ts
+++ b/packages/backend/__tests__/helpers/mongoMemory.ts
@@ -1,0 +1,112 @@
+/**
+ * The in-memory Mongo replica set — OPT IN, per suite.
+ *
+ * This used to live in `__tests__/jest.setup.ts`, which meant every one of the
+ * 132 backend suites booted a `mongod` it did not use. FOUR need it, and the
+ * count is measured rather than assumed: switching the replica set off and
+ * running the whole suite serially turns exactly these files red —
+ *
+ *     db/dataBackfill.test.ts             57 of 57 tests
+ *     db/geoBackfill.test.ts              16 of 41
+ *     integration/reviewSystem.test.ts     1 of 33
+ *     integration/wireIdContract.test.ts   1 of 13
+ *
+ * — 75 tests of 1,789, and nothing else moves. Measured at 5eb1bc51; re-derive
+ * it the same way rather than trusting this list, because it shrinks with every
+ * port. `integration/stripeWebhook.test.ts` was on it until the billing port
+ * landed and was taken off in the same change that added this file.
+ *
+ * ## Why opt-in is worth a helper rather than being left global
+ *
+ * The dependency this file names is on its way OUT. `mongoose` and
+ * `mongodb-memory-server` cannot leave `package.json` while anything boots
+ * Mongo, so what matters is that the remaining users are ENUMERABLE — the list
+ * now lives in the repository instead of in whoever last ran the measurement
+ * above:
+ *
+ *     grep -rl '^useMongoMemoryServer();' __tests__     # 4 files
+ *
+ * The `^` anchor is load-bearing and was arrived at by running the alternatives:
+ * the call is always at column 0 (see the ordering note below), while every
+ * other mention — this file's own definition, the prose here, the
+ * cross-references in `jest.setup.ts` and `unit/mongoUnreachable.test.ts` — is
+ * indented inside a comment. Unanchored, the same grep answers 6 and the bare
+ * name answers 7, so an unanchored form would overstate the remaining work and
+ * never reach zero.
+ *
+ * Retiring the last caller is then a deletion of this file and four call sites,
+ * not a rewrite of the global setup.
+ *
+ * The two other effects are real but secondary: 128 suites stop paying a
+ * replica-set boot, and they stop holding a `mongod` process each while the
+ * whole suite shares one Postgres server.
+ *
+ * ## Why a REPLICA SET rather than a standalone `MongoMemoryServer`
+ *
+ * Kept verbatim from the setup file, because it is still the reason: a
+ * standalone `mongod` refuses `session.withTransaction` outright, and the
+ * moderation intake's whole guarantee is that a report and its delivery event
+ * commit together — a test running against a standalone server could only ever
+ * assert the halves separately, which is precisely the bug that guarantee exists
+ * to prevent. One node, not three: a transaction needs a replica set, not
+ * redundancy.
+ *
+ * ## Call it at the TOP of the file, before any other hook
+ *
+ * It registers `beforeAll`/`afterEach`/`afterAll` in the caller's scope. At file
+ * top level those are outermost, so the connection is open before any
+ * `describe`'s own `beforeAll` and the cleanup runs after every test — the same
+ * ordering the global setup gave. Called from inside a `describe`, it would
+ * connect too late for a sibling block.
+ */
+
+import mongoose from 'mongoose';
+import { MongoMemoryReplSet } from 'mongodb-memory-server';
+
+/**
+ * Boot an in-memory Mongo replica set for THIS suite and connect mongoose to it.
+ *
+ * Also publishes `MONGODB_URI`, which is not decoration: `db/backfill/data.ts`
+ * reads it from the environment at call time and throws
+ * "MONGODB_URI is not set; there is nothing to copy from." without it. That is
+ * the only remaining production reader of the variable, and it is one of the
+ * callers here.
+ */
+export function useMongoMemoryServer(): void {
+  let server: MongoMemoryReplSet | undefined;
+  let previousUri: string | undefined;
+
+  beforeAll(async () => {
+    server = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
+    const uri = server.getUri();
+    previousUri = process.env.MONGODB_URI;
+    // `MONGODB_URI` ONLY — never `DATABASE_URL`, which names this worker's
+    // throwaway POSTGRES database (`jest.setupWorkerDatabase.cjs`). Writing a
+    // `mongodb://` URI over it would make every Postgres read in the same file
+    // fail on a protocol mismatch.
+    process.env.MONGODB_URI = uri;
+    await mongoose.connect(uri);
+  });
+
+  afterEach(async () => {
+    const { collections } = mongoose.connection;
+    await Promise.all(
+      Object.values(collections).map((collection) => collection.deleteMany({})),
+    );
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    if (server) {
+      await server.stop();
+    }
+    // Restored rather than deleted: jest gives each worker its own process, but
+    // a suite that ran earlier in the same worker must not leave a dead URI
+    // behind for a later one to connect to and hang on.
+    if (previousUri === undefined) {
+      delete process.env.MONGODB_URI;
+    } else {
+      process.env.MONGODB_URI = previousUri;
+    }
+  });
+}

--- a/packages/backend/__tests__/integration/reviewSystem.test.ts
+++ b/packages/backend/__tests__/integration/reviewSystem.test.ts
@@ -32,6 +32,13 @@ import { findOrCreateAgencyByName } from '../../db/agencies/agencyWrites';
 import { findOwnerOxyUserIdsAtAddresses } from '../../db/properties/propertyReads';
 import { Review } from '../../models';
 import { agencies, reviewReports, reviews as reviewsTable } from '../../db/schema';
+import { useMongoMemoryServer } from '../helpers/mongoMemory';
+
+// ONE case here needs a live Mongo: `leaves no review rows behind in Mongo`,
+// which proves the ported controller writes nothing to the old store. It is a
+// NEGATIVE assertion, so it is unwritable once `models/` is deleted — this
+// call and that case retire together. See `helpers/mongoMemory.ts`.
+useMongoMemoryServer();
 
 /** One city per RUN, so a rerun against the worker's database cannot meet its own rows. */
 const SUITE = uuidv7().slice(-8);

--- a/packages/backend/__tests__/integration/wireIdContract.test.ts
+++ b/packages/backend/__tests__/integration/wireIdContract.test.ts
@@ -35,6 +35,11 @@ import {
   seedProperty,
 } from '../helpers/postgresGeoFixtures';
 import { OfferingType, PropertyStatus, PropertyType } from '@homiio/shared-types';
+import { useMongoMemoryServer } from '../helpers/mongoMemory';
+
+// ONE case here needs a live Mongo: the `toJSON` reduction, which is ABOUT a
+// real Mongoose document. See `helpers/mongoMemory.ts`.
+useMongoMemoryServer();
 
 function buildApp(): Express {
   const app = express();

--- a/packages/backend/__tests__/jest.setup.ts
+++ b/packages/backend/__tests__/jest.setup.ts
@@ -1,29 +1,24 @@
 /**
  * Global Jest setup for the backend test suite.
  *
- * Spins up an in-memory MongoDB once per test process and connects Mongoose to
- * it BEFORE any model module is required (the model files call
- * `mongoose.model(...)` at import time and read the active connection). The DB
- * URI is set on `process.env` so anything reading `config.database.url` lands on
- * the memory server too. Collections are cleared after every test for isolation.
+ * Publishes the environment `config` captures at module load, and opens the
+ * Postgres pool — the store every suite here reads.
  *
- * Tests that are pure (no DB) are unaffected — they simply never touch a model.
+ * ## Mongo is NOT booted from this file any more
  *
- * ## Why a REPLICA SET rather than a standalone `MongoMemoryServer`
+ * It used to spin up an in-memory replica set for every one of the 130 suites.
+ * Five need one, measured by switching it off and running the whole suite
+ * serially: 77 tests of 1,751 turn red, all inside `dataBackfill`,
+ * `geoBackfill`, `reviewSystem`, `stripeWebhook` and `wireIdContract`. Those
+ * five now call `useMongoMemoryServer()` from
+ * `__tests__/helpers/mongoMemory.ts`, which is also where the reasoning about
+ * replica sets and `MONGODB_URI` moved.
  *
- * A standalone `mongod` refuses `session.withTransaction` outright, and the
- * moderation intake's whole guarantee is that a report and its delivery event
- * commit together — a test running against a standalone server could only ever
- * assert the halves separately, which is precisely the bug that guarantee
- * exists to prevent. Production is a replica set (`rs0`, `oxy-infra`
- * `terraform-uswest2/mongo.tf`), so a single-node replica set here is also the
- * closer match to what the code actually runs against.
- *
- * One node, not three: a transaction needs a replica set, not redundancy.
+ * The point is enumerability rather than speed: `mongoose` and
+ * `mongodb-memory-server` are leaving `package.json`, and a `grep -rl
+ * useMongoMemoryServer __tests__` now answers "what is still in the way"
+ * from the repository instead of from a measurement somebody has to redo.
  */
-
-import mongoose from 'mongoose';
-import { MongoMemoryReplSet } from 'mongodb-memory-server';
 
 // Give config a real https public URL so self-hosted image URLs
 // (`${publicUrl}/api/images/file/...`) are accepted by the Property image-URL
@@ -55,20 +50,8 @@ process.env.CROWDSOURCE_WEBHOOK_SECRET =
 process.env.CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS =
   process.env.CROWDSOURCE_WEBHOOK_SECRET_PREVIOUS || 'test-previous-secret-at-least-16-chars';
 
-let mongoServer: MongoMemoryReplSet | undefined;
-
 beforeAll(async () => {
-  mongoServer = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
-  const uri = mongoServer.getUri();
-  // `MONGODB_URI` ONLY. `DATABASE_URL` used to be set here too, back when
-  // `config.database.url` fell back to it — it now names the POSTGRES database
-  // (`jest.setupWorkerDatabase.cjs` points it at this worker's throwaway one),
-  // so writing a `mongodb://` URI over it would make every Postgres suite
-  // connect to the memory server and fail on a protocol mismatch.
-  process.env.MONGODB_URI = uri;
-  await mongoose.connect(uri);
-
-  // Postgres too, for every suite rather than only the `__tests__/db` ones:
+  // Postgres, for every suite rather than only the `__tests__/db` ones:
   // from batch 1 on, request-path code (geo, addresses, cities, neighborhoods)
   // reads it through `getDb()`, which THROWS when no pool has been published. A
   // suite that forgot to connect would fail with "PostgreSQL is not connected"
@@ -91,22 +74,14 @@ beforeAll(async () => {
   await connectPostgres();
 });
 
-afterEach(async () => {
-  const { collections } = mongoose.connection;
-  await Promise.all(
-    Object.values(collections).map((collection) => collection.deleteMany({})),
-  );
-});
-
-afterAll(async () => {
-  await mongoose.disconnect();
-  if (mongoServer) {
-    await mongoServer.stop();
-  }
-  // The Postgres pool is deliberately NOT closed here. A root `afterAll`
-  // declared in a setup file runs BEFORE the test file's own, so closing it
-  // would pull the pool out from under any suite that cleans its fixtures up in
-  // an `afterAll` — which the `__tests__/db` files do. Those files close it
-  // themselves; the pool is per worker process and dies with it, and
-  // `jest.globalTeardown.ts` drops the databases either way.
-});
+// There is deliberately no root `afterAll` here.
+//
+// The Postgres pool must NOT be closed from one: a root `afterAll` declared in a
+// setup file runs BEFORE the test file's own, so closing it would pull the pool
+// out from under any suite that cleans its fixtures up in an `afterAll` — which
+// the `__tests__/db` files do. Those files close it themselves; the pool is per
+// worker process and dies with it, and `jest.globalTeardown.ts` drops the
+// databases either way.
+//
+// The Mongo half of the old teardown moved to `helpers/mongoMemory.ts`, where it
+// belongs to the suites that actually opened a connection.

--- a/packages/backend/__tests__/unit/mongoUnreachable.test.ts
+++ b/packages/backend/__tests__/unit/mongoUnreachable.test.ts
@@ -23,6 +23,26 @@ import path from 'path';
  * secret can be removed. A file that reaches Mongo and is not on the list fails
  * the build.
  *
+ * ## An empty allowlist retires the SECRET, not the npm dependency
+ *
+ * Worth stating because the two are easy to conflate, are cleared by different
+ * people, and this list is now EMPTY — so the distinction is live rather than
+ * hypothetical. {@link SCANNED_ROOTS} covers production only; `__tests__` is
+ * deliberately not scanned, since a suite may legitimately need a Mongo the
+ * runtime never opens. An empty list therefore means `MONGODB_URI` can come off
+ * the task definition and SSM, which is exactly what it claims — and says
+ * nothing about `mongoose` and `mongodb-memory-server`, which stay in
+ * `package.json` while any suite boots an in-memory replica set.
+ *
+ * The test-side half has its own enumeration, by construction rather than by
+ * measurement:
+ *
+ *     grep -rl '^useMongoMemoryServer();' __tests__
+ *
+ * documented in `__tests__/helpers/mongoMemory.ts`, which also explains why the
+ * `^` is load-bearing. Both lists must be empty before the dependency goes; at
+ * the time of writing that one holds four suites and this one holds none.
+ *
  * ## Why an affirmative scan
  *
  * Enumeration is `git ls-files`, never a directory walk, so the scan cannot


### PR DESCRIPTION
## What

`__tests__/jest.setup.ts` booted a `MongoMemoryReplSet` for every one of the **133** backend suites. **Four** need one.

Those four now call `useMongoMemoryServer()` from the new `__tests__/helpers/mongoMemory.ts`. The setup file keeps only the environment it publishes and the Postgres pool. **No production file is touched.**

## Which four, measured rather than asserted

Switching the replica set off and running the whole suite serially turns exactly these red:

| suite | tests needing Mongo | retires with |
|---|---|---|
| `db/dataBackfill.test.ts` | 57 / 57 | the backfill itself — reading Mongo is its job |
| `db/geoBackfill.test.ts` | 16 / 41 | same |
| `integration/reviewSystem.test.ts` | 1 / 33 | `models/` — its case is the NEGATIVE assertion *"leaves no review rows behind in Mongo"*, unwritable once the models are gone |
| `integration/wireIdContract.test.ts` | 1 / 13 | `models/` — its case is `renameWireIds` reducing a real Mongoose document through `toJSON` |

75 tests of 1,790, and nothing else moves.

`integration/stripeWebhook.test.ts` was the fifth until the billing port (#339) landed mid-rebase; its opt-in is **removed here rather than carried**, which is the list working as intended.

## Why this is on the critical path rather than a tidy-up

`mongoose` and `mongodb-memory-server` cannot leave `package.json` while anything boots Mongo, however clean production gets — and production is now clean: `PENDING_MONGO_FILES` is **empty**, with only the deliberately-exempt `db/backfill/` still holding a Mongo client.

What was missing was a statement **in the repository** of which *suites* are still in the way. There now is one:

```
grep -rl '^useMongoMemoryServer();' __tests__     # 4 files
```

The `^` anchor was arrived at by running the alternatives, not assumed: the call sits at column 0, while every other mention is indented inside a comment. Unanchored the same grep answers **6**, and the bare name answers **7** — all three counts verified, because an enumeration that can never reach zero is worse than none. Each call site names the port that retires it, so the final removal is a deletion of one helper and four lines.

`mongoUnreachable.test.ts` gains a note for the same reason, and it matters more now that its list is empty: **an empty allowlist retires the SECRET, not the npm dependency.** `SCANNED_ROOTS` is production-only and `__tests__` is deliberately unscanned, so `MONGODB_URI` coming off the task definition and SSM is exactly what an empty list licenses — and it says nothing about `package.json`. Two lists, cleared by different people, both must be empty.

## Measurement

Base `a5fd7ad4` vs this branch, on a Postgres with connection headroom:

```
Serial (--runInBand)
  before: 133 suites / 1790 passed / 0 failed   78.0s
  after:  133 suites / 1790 passed / 0 failed   44.8s

Parallel (the mode CI runs)
  before: 133 suites / 1790 passed / 0 failed   39.5s
  after:  133 suites / 1790 passed / 0 failed   24.4s
```

Per-file pass counts identical in both modes; no file moved.

Identical counts prove nothing alone, so the helper was **mutation-tested**: made a no-op, it turns 4 suites and 75 tests red — and the failure set is **identical, file by file and count by count**, to the measurement taken by disabling the replica set in the old global setup. So the helper does exactly the job the setup file did, for exactly the suites that need it and no others.

## One environment finding, recorded because it cost a run to attribute

On a saturated machine **both** revisions blow past `max_connections` — sampled peak **103** (base) and **104** (this branch) against a limit of 100 — and both go red with `sorry, too many clients already`. Pre-existing over-subscription, not this change: 2 workers at `PG_MAX_POOL_SIZE=8` should peak near 16, so something in the harness holds pools across files. This branch shows *more* reds at the ceiling only because it finishes the same work in ~60% of the wall time, so more tests land inside the saturated window. With the ceiling raised so the environment is not the limiter, both are fully green — that is the run quoted above.

Separately and on unmodified `main`: the base's first parallel run of that pair was red (10 tests in `db/geoBackfill.test.ts`, a `Failed query` on `regions`, passing alone on re-run). Same signature, same cause.

Not fixed here — it belongs to whoever owns the Postgres harness and is unrelated to Mongo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
