### PR TITLE
fix(properties): give by-ids and by-owner a status filter that can match (#290)

### DIFF
--- a/packages/backend/__tests__/integration/propertyBatchReads.test.ts
+++ b/packages/backend/__tests__/integration/propertyBatchReads.test.ts
@@ -1,0 +1,263 @@
+/**
+ * The two batch listing reads, against a REAL Postgres (#290).
+ *
+ * Both endpoints filtered `status = 'active'` — a value outside
+ * `PropertyStatus` and unstorable under `properties_status_check` — so both
+ * returned an empty page for every request ever made. The fix is a status set
+ * per endpoint, and the whole risk of it is what the new sets let THROUGH.
+ *
+ * So the fixture is built to make a wrong filter fail, which a tidier one would
+ * not:
+ *
+ *  - **Every status in the vocabulary is seeded, not just the interesting
+ *    ones.** A fixture where every listing is `published` cannot tell the new
+ *    filter from no filter at all — both return the same rows — and cannot tell
+ *    it from the old broken one either, since "everything" and "nothing" are
+ *    indistinguishable when the set has one member and you assert on a count.
+ *    Each case therefore asserts the exact ID SET, so the two failure
+ *    directions (too few, too many) are separately visible.
+ *  - **`archived` is seeded TWICE, in its two real shapes.** A user deletion
+ *    (`softDeleteProperty`) sets `status = 'archived'` AND stamps `deleted_at`;
+ *    an expired portal listing (`expireExternalProperty`) sets the status and
+ *    leaves `deleted_at` NULL. Only the second distinguishes the status clause
+ *    from the `deleted_at` clause, so without it `statusVisibleToNonOwner`
+ *    could be deleted entirely and this suite would stay green.
+ *  - **A moderation-restricted listing is `published`**, so it is excluded by
+ *    the moderation clause alone and by nothing else. Neither endpoint had that
+ *    clause before this change, and `by-ids` is an UNAUTHENTICATED route.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { OfferingType, PropertyStatus, PropertyType } from '@homiio/shared-types';
+
+import { getPropertiesByIds, getPropertiesByOwner } from '../../controllers/property/batch';
+import { errorHandler } from '../../middlewares/errorHandler';
+import { serializeWireIds } from '../../middlewares/wireIds';
+import {
+  resetGeoTables,
+  seedAddress,
+  seedGeoChain,
+  seedProperty,
+} from '../helpers/postgresGeoFixtures';
+
+const OWNER = 'oxy-owner-290';
+/** A second owner, so `by-owner` is proven to SCOPE rather than merely to filter. */
+const OTHER_OWNER = 'oxy-other-290';
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(serializeWireIds);
+  app.get('/properties/by-ids', getPropertiesByIds);
+  app.get('/properties/owner/:oxyUserId', getPropertiesByOwner);
+  app.use(errorHandler);
+  return app;
+}
+
+/** Every listing in this suite differs from its siblings ONLY in what is overridden. */
+async function seedListing(
+  addressId: string,
+  overrides: Parameters<typeof seedProperty>[0]['overrides'],
+): Promise<string> {
+  return seedProperty({
+    addressId,
+    overrides: {
+      oxyUserId: OWNER,
+      type: PropertyType.APARTMENT,
+      availabilityIsAvailable: true,
+      offerings: [OfferingType.LONG_TERM_RENT],
+      longTermRentMonthlyAmount: 1000,
+      longTermRentCurrency: 'EUR',
+      ...overrides,
+    },
+  });
+}
+
+/** One listing per interesting state, all on one address and one owner. */
+async function seedEveryState() {
+  const chain = await seedGeoChain({ cityName: 'Barcelona', countryCode: 'ES-batch' });
+  const addressId = await seedAddress({
+    chain,
+    street: 'Carrer de Mallorca',
+    longitude: 2.1734,
+    latitude: 41.3851,
+  });
+
+  return {
+    // Visible to a non-owner who holds the id.
+    published: await seedListing(addressId, { status: PropertyStatus.PUBLISHED }),
+    reserved: await seedListing(addressId, { status: PropertyStatus.RESERVED }),
+    rented: await seedListing(addressId, { status: PropertyStatus.RENTED }),
+    sold: await seedListing(addressId, { status: PropertyStatus.SOLD }),
+    inactive: await seedListing(addressId, { status: PropertyStatus.INACTIVE }),
+
+    // Hidden from everybody but the owner.
+    draft: await seedListing(addressId, { status: PropertyStatus.DRAFT }),
+    /** The `expireExternalProperty` shape: archived, `deleted_at` still NULL. */
+    expired: await seedListing(addressId, { status: PropertyStatus.ARCHIVED }),
+    /** The `softDeleteProperty` shape: archived AND stamped. */
+    softDeleted: await seedListing(addressId, {
+      status: PropertyStatus.ARCHIVED,
+      deletedAt: new Date(),
+    }),
+    /**
+     * Stamped `deleted_at` while still `published` — the shape that makes the
+     * `deleted_at` clause disagree with the status clause.
+     *
+     * No writer produces it today (`softDeleteProperty` always sets both), which
+     * is exactly why it has to be seeded: without it `notDeleted()` could be
+     * deleted from either endpoint and every assertion here would stay green,
+     * so the clause would be untested rather than merely redundant. `deleted_at`
+     * is the canonical soft-delete test and the status coupling is one writer's
+     * implementation detail; this fixture is what keeps the two independent.
+     */
+    deletedButPublished: await seedListing(addressId, {
+      status: PropertyStatus.PUBLISHED,
+      deletedAt: new Date(),
+    }),
+    /** Published, and excluded by the moderation clause alone. */
+    restricted: await seedListing(addressId, {
+      status: PropertyStatus.PUBLISHED,
+      moderationRestricted: true,
+    }),
+
+    /** Published and healthy, but somebody else's — only `by-owner` should care. */
+    otherOwner: await seedListing(addressId, {
+      status: PropertyStatus.PUBLISHED,
+      oxyUserId: OTHER_OWNER,
+    }),
+  };
+}
+
+type Seeded = Awaited<ReturnType<typeof seedEveryState>>;
+
+/** Ask for EVERY seeded listing, so what comes back is decided only by the filter. */
+function allIds(seeded: Seeded): string[] {
+  return Object.values(seeded);
+}
+
+describe('batch listing reads (Postgres)', () => {
+  beforeEach(async () => {
+    await resetGeoTables();
+  });
+
+  describe('GET /properties/by-ids — hydration of ids the caller already holds', () => {
+    it('returns every status except draft and archived, and never a restricted listing', async () => {
+      const seeded = await seedEveryState();
+
+      const res = await request(buildApp()).get(
+        `/properties/by-ids?ids=${allIds(seeded).join(',')}`,
+      );
+
+      expect(res.status).toBe(200);
+      const returned = new Set<string>(res.body.data.map((entry: { id: string }) => entry.id));
+
+      // The INCLUDED half. Asserted one status at a time rather than as a count,
+      // so a filter that drops exactly one of them names which.
+      expect(returned.has(seeded.published)).toBe(true);
+      expect(returned.has(seeded.reserved)).toBe(true);
+      expect(returned.has(seeded.rented)).toBe(true);
+      expect(returned.has(seeded.sold)).toBe(true);
+      expect(returned.has(seeded.inactive)).toBe(true);
+      // Not scoped to an owner: this endpoint hydrates ids, whoever owns them.
+      expect(returned.has(seeded.otherOwner)).toBe(true);
+
+      // The EXCLUDED half — the half that fails in the direction nobody notices.
+      expect(returned.has(seeded.draft)).toBe(false);
+      expect(returned.has(seeded.expired)).toBe(false);
+      expect(returned.has(seeded.softDeleted)).toBe(false);
+      expect(returned.has(seeded.deletedButPublished)).toBe(false);
+      expect(returned.has(seeded.restricted)).toBe(false);
+
+      // And the exact set, so a filter that lets something ELSE through — a
+      // status added to the vocabulary later, say — is not silently tolerated.
+      expect(returned).toEqual(
+        new Set([
+          seeded.published,
+          seeded.reserved,
+          seeded.rented,
+          seeded.sold,
+          seeded.inactive,
+          seeded.otherOwner,
+        ]),
+      );
+    });
+
+    it('hydrates a rented listing on its own, which is the saved-list case', async () => {
+      const seeded = await seedEveryState();
+
+      // Asked for by itself, because the set assertion above would still pass if
+      // `rented` only ever arrived alongside a `published` sibling.
+      const res = await request(buildApp()).get(`/properties/by-ids?ids=${seeded.rented}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].id).toBe(seeded.rented);
+      expect(res.body.data[0].status).toBe(PropertyStatus.RENTED);
+    });
+
+    it('returns an empty page for a draft asked for by id, rather than 404ing', async () => {
+      const seeded = await seedEveryState();
+
+      const res = await request(buildApp()).get(`/properties/by-ids?ids=${seeded.draft}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+    });
+  });
+
+  describe('GET /properties/owner/:oxyUserId — discovery of somebody else’s listings', () => {
+    it('returns only published listings, not the reserved/rented/sold ones by-ids shows', async () => {
+      const seeded = await seedEveryState();
+
+      const res = await request(buildApp()).get(`/properties/owner/${OWNER}?limit=50`);
+
+      expect(res.status).toBe(200);
+      const returned = new Set<string>(res.body.data.map((entry: { id: string }) => entry.id));
+
+      // Exactly one of this owner's ten listings qualifies. Stated as the full
+      // set because "somebody else's listings" is the whole subject: a count
+      // alone could be satisfied by the WRONG single listing.
+      expect(returned).toEqual(new Set([seeded.published]));
+
+      // Named individually too, because this is the endpoint where each
+      // exclusion is a separate product decision rather than one clause.
+      expect(returned.has(seeded.draft)).toBe(false);
+      expect(returned.has(seeded.reserved)).toBe(false);
+      expect(returned.has(seeded.rented)).toBe(false);
+      expect(returned.has(seeded.sold)).toBe(false);
+      expect(returned.has(seeded.inactive)).toBe(false);
+      expect(returned.has(seeded.expired)).toBe(false);
+      expect(returned.has(seeded.softDeleted)).toBe(false);
+      expect(returned.has(seeded.deletedButPublished)).toBe(false);
+      expect(returned.has(seeded.restricted)).toBe(false);
+      // Scoping, not just filtering: another owner's published listing is out.
+      expect(returned.has(seeded.otherOwner)).toBe(false);
+
+      // The pagination envelope counts the same filtered set, not the table.
+      expect(res.body.pagination.total).toBe(1);
+    });
+
+    it('scopes to the owner named in the path', async () => {
+      const seeded = await seedEveryState();
+
+      const res = await request(buildApp()).get(`/properties/owner/${OTHER_OWNER}?limit=50`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.map((entry: { id: string }) => entry.id)).toEqual([seeded.otherOwner]);
+    });
+
+    it('honours ?exclude, which is how a detail page drops the listing being viewed', async () => {
+      const seeded = await seedEveryState();
+
+      const res = await request(buildApp()).get(
+        `/properties/owner/${OWNER}?limit=50&exclude=${seeded.published}`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+      expect(res.body.pagination.total).toBe(0);
+    });
+  });
+});

--- a/packages/backend/__tests__/integration/wireIdContract.test.ts
+++ b/packages/backend/__tests__/integration/wireIdContract.test.ts
@@ -238,7 +238,7 @@ describe('the wire contract, over a real request', () => {
    * not which layer happens to produce it.
    */
   it('emits no `_id` from any public endpoint that returns entities', async () => {
-    const { cityId } = await seedCityProperty();
+    const { cityId, propertyId } = await seedCityProperty();
     const chain = await seedGeoChain({ cityName: 'Barcelona', propertiesCount: 3 });
 
     const entityPaths = [
@@ -248,16 +248,17 @@ describe('the wire contract, over a real request', () => {
       `/api/cities/${chain.cityId}`,
       `/api/cities/${cityId}/properties?limit=8`,
       '/api/properties',
+      // Joined the sweep once #290 gave it a status filter that can match. It
+      // was excluded here for as long as `controllers/property/batch.ts`
+      // filtered `status: 'active'` — a value outside `PropertyStatus`, so the
+      // body was permanently empty and would have passed the `_id` scan for the
+      // wrong reason. That exclusion is what surfaced the bug; this line is the
+      // other end of it, and the `empty` floor below is what keeps it honest.
+      `/api/properties/by-ids?ids=${propertyId}`,
     ];
-    // Two public GETs are deliberately absent, and neither absence is laziness:
-    //   - `/api/analytics/stats` returns aggregates, not entities, so it has no
-    //     `id` to floor on. It has its own case below.
-    //   - `/api/properties/by-ids` filters `status: 'active'`, which is not a
-    //     value in `PropertyStatus` (draft/published/reserved/rented/sold/
-    //     inactive/archived), so it cannot return a row for any fixture. That is
-    //     a pre-existing bug in `controllers/property/batch.ts`, unrelated to
-    //     this contract; listing it here would only buy a permanently empty body
-    //     that passes the `_id` scan for the wrong reason.
+    // `/api/analytics/stats` is deliberately absent and it is not laziness: it
+    // returns aggregates, not entities, so it has no `id` to floor on. It has
+    // its own case below.
 
     const leaked: string[] = [];
     const empty: string[] = [];

--- a/packages/backend/controllers/property/batch.ts
+++ b/packages/backend/controllers/property/batch.ts
@@ -1,16 +1,36 @@
 /**
  * Batch and owner listing reads.
  *
- * Both endpoints filtered on `status: 'active'`, which is NOT a member of
- * `PropertyStatus` and therefore matches nothing — the value has been
- * `published` since the status vocabulary was settled, and `properties_status_check`
- * would now refuse to store `active` at all. The filter is carried across
- * VERBATIM rather than corrected: these two endpoints have been returning empty
- * pages for as long as the vocabulary has been wrong, and fixing that here would
- * turn a read port into an unreviewed change of what two endpoints return. It is
- * recorded in the PR body so it is fixed deliberately, with the count in front of
- * whoever fixes it.
+ * Both endpoints used to filter on `status: 'active'`, which is not a member of
+ * `PropertyStatus` — `properties_status_check` would refuse to store it — so
+ * both returned an empty page for every request ever made to them. The Postgres
+ * port carried the value across verbatim rather than guessing at a replacement,
+ * because picking one is a product decision about what each endpoint may reveal
+ * and not a detail of a read port (#290).
+ *
+ * They get DIFFERENT answers, because they answer different questions.
+ *
+ *  - **`by-ids` hydrates ids the caller already holds** (a saved list, a batch
+ *    of chat references), so it is the bulk form of `GET /properties/:id`. A
+ *    listing that has since been rented is exactly what such a caller needs to
+ *    render — hiding it would blank a row the user saved themselves. It filters
+ *    `statusVisibleToNonOwner()`: everything except `draft` and `archived`.
+ *  - **`owner/:oxyUserId` is a DISCOVERY feed** — any authenticated caller may
+ *    name any owner — so it answers "what is this landlord offering", and
+ *    converges on `published`, the same answer `cityController` and
+ *    `reviewController.getAgencyProperties` give for the other two "somebody
+ *    else's listings" surfaces. An owner's own full view, drafts included, is
+ *    `GET /properties/me/list`, which is scoped to the session.
+ *
+ * `notDeleted()` and `notModerationRestricted()` are new on BOTH, and they are
+ * not belt-and-braces. Neither endpoint had them, which cost nothing while the
+ * status filter matched nothing; the moment it matches rows, their absence is a
+ * live leak of soft-deleted and jury-restricted listings — on `by-ids`, from an
+ * unauthenticated route. They are the same pair every other public read applies
+ * (`commonFilters.ts`, `searchQueryBuilder.ts`, `reviewController`).
  */
+
+import { PropertyStatus } from '@homiio/shared-types';
 
 import { successResponse, paginationResponse, AppError } from '../../middlewares/errorHandler';
 import {
@@ -20,7 +40,15 @@ import {
   propertyOrderBy,
   NEWEST_FIRST,
 } from '../../db/properties/propertyReads';
-import { idIn, idNotIn, ownedBy, statusIs } from '../../db/properties/propertyFilters';
+import {
+  idIn,
+  idNotIn,
+  notDeleted,
+  notModerationRestricted,
+  ownedBy,
+  statusIs,
+  statusVisibleToNonOwner,
+} from '../../db/properties/propertyFilters';
 import { serializeProperty } from '../../db/properties/propertySerializer';
 import type { ControllerNext, ControllerRequest, ControllerResponse } from '../controllerTypes';
 import { getQueryInteger, getQueryString } from '../queryParams';
@@ -41,7 +69,9 @@ export async function getPropertiesByIds(req: ControllerRequest, res: Controller
     const list = parseIdList(String(ids));
     if (!list.length) return res.json(paginationResponse([], 1, 0, 0, 'No valid IDs provided'));
 
-    const hydrated = await findProperties({ where: allOf([idIn(list), statusIs('active')]) });
+    const hydrated = await findProperties({
+      where: allOf([idIn(list), notDeleted(), notModerationRestricted(), statusVisibleToNonOwner()]),
+    });
     return res.json(successResponse(hydrated.map(serializeProperty), 'Properties fetched by IDs'));
   } catch (error) { next(error); }
 }
@@ -58,7 +88,9 @@ export async function getPropertiesByOwner(req: ControllerRequest, res: Controll
 
     const where = allOf([
       ownedBy(oxyUserId),
-      statusIs('active'),
+      notDeleted(),
+      notModerationRestricted(),
+      statusIs(PropertyStatus.PUBLISHED),
       exclude ? idNotIn([exclude]) : undefined,
     ]);
     const skip = (page - 1) * limit;

--- a/packages/backend/controllers/property/stats.ts
+++ b/packages/backend/controllers/property/stats.ts
@@ -62,12 +62,25 @@ export async function getPropertyStats(
       // The three room counts in ONE pass, as filtered aggregates. Three
       // separate `countDocuments` could each see a different instant, so an
       // `occupiedRooms` could exceed the `totalRooms` reported beside it.
+      // Both status literals here were outside `PropertyStatus` — `'occupied'`
+      // and `'active'` are as unstorable as each other under
+      // `properties_status_check` — so `occupiedRooms`, `availableRooms` and the
+      // `occupancyRate` derived from them have always reported 0. Same dead
+      // vocabulary as `controllers/property/batch.ts` (#290), found by the same
+      // census.
+      //
+      // `available` becomes `published AND is_available`, which is exactly
+      // `searchQueryBuilder`'s `publishedAndAvailable` pair. `occupied` becomes
+      // `rented`, the one member of the vocabulary that means somebody is
+      // living there; `reserved` is deliberately in NEITHER count, because a
+      // listing under offer is honestly neither free nor occupied and inventing
+      // an answer for it here would put a product decision in an aggregate.
       getDb()
         .select({
           total: sql<number>`count(*)::int`,
-          occupied: sql<number>`count(*) filter (where ${properties.status} = 'occupied')::int`,
+          occupied: sql<number>`count(*) filter (where ${properties.status} = 'rented')::int`,
           available: sql<number>`count(*) filter (
-            where ${properties.status} = 'active' and ${properties.availabilityIsAvailable}
+            where ${properties.status} = 'published' and ${properties.availabilityIsAvailable}
           )::int`,
         })
         .from(properties)

--- a/packages/backend/controllers/telegramController.ts
+++ b/packages/backend/controllers/telegramController.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Request, Response, NextFunction } from 'express';
+import { PropertyStatus } from '@homiio/shared-types';
 
 import { telegramService } from '../services';
 import { AppError, successResponse } from '../middlewares/errorHandler';
@@ -17,7 +18,15 @@ import {
   findPropertyById,
   NEWEST_FIRST,
 } from '../db/properties/propertyReads';
-import { idIn, inCity, inDateRange, statusIs, typeIn } from '../db/properties/propertyFilters';
+import {
+  idIn,
+  inCity,
+  inDateRange,
+  notDeleted,
+  notModerationRestricted,
+  statusIs,
+  typeIn,
+} from '../db/properties/propertyFilters';
 import { serializeProperty } from '../db/properties/propertySerializer';
 import { resolveAddressDisplay, type AddressGeoLike } from '../services/geoDisplayService';
 import { resolveCityId } from '../services/geoQueryService';
@@ -294,11 +303,28 @@ class TelegramController {
       const limitNum = parseInt(String(limit), 10) || 5;
       const hoursNum = parseInt(String(hours), 10) || 24;
 
-      // Get recent properties
+      // Get recent properties.
+      //
+      // This filtered `status = 'active'`, which is not a member of
+      // `PropertyStatus` and so matched nothing — the third and last site of the
+      // dead value #290 was opened about. It mattered more here than on a read:
+      // the endpoint below sends REAL messages to public Telegram groups, and an
+      // empty result meant it has always reported "no recent properties" and
+      // sent none.
+      //
+      // `published` rather than the broader set `by-ids` uses, because this
+      // BROADCASTS: a reserved, rented or deactivated listing is not something
+      // to announce to a city group, and a soft-deleted or jury-restricted one
+      // certainly is not.
       const sinceDate = new Date(Date.now() - hoursNum * 60 * 60 * 1000);
       const recentProperties = (
         await findProperties({
-          where: allOf([inDateRange(properties.createdAt, sinceDate, undefined), statusIs('active')]),
+          where: allOf([
+            inDateRange(properties.createdAt, sinceDate, undefined),
+            notDeleted(),
+            notModerationRestricted(),
+            statusIs(PropertyStatus.PUBLISHED),
+          ]),
           orderBy: [NEWEST_FIRST],
           limit: limitNum,
         })

--- a/packages/backend/db/properties/propertyFilters.ts
+++ b/packages/backend/db/properties/propertyFilters.ts
@@ -67,6 +67,29 @@ export function statusIsNot(status: string): SQL {
   return sql`${properties.status} <> ${status}`;
 }
 
+/**
+ * The two statuses that hide a listing from everybody except its owner.
+ *
+ * Neither is redundant with {@link notDeleted}, and the second is the one that
+ * surprises: `softDeleteProperty` sets `status = 'archived'` AND stamps
+ * `deleted_at`, so a user-deleted listing is caught by either clause — but
+ * `expireExternalProperty` archives a lapsed portal listing by STATUS ALONE,
+ * leaving `deleted_at` null. A read that gated only on `deleted_at` would
+ * therefore keep serving every expired external listing in the catalogue.
+ *
+ * `draft` is the other half and the more obvious one: a listing its owner has
+ * never published is theirs alone to see.
+ *
+ * The remaining five (`published`, `reserved`, `rented`, `sold`, `inactive`)
+ * are all states of a listing that really was published, so a caller that
+ * already holds the id may see it — see the header of
+ * `controllers/property/batch.ts` for why a hydration read wants that and a
+ * discovery feed does not.
+ */
+export function statusVisibleToNonOwner(): SQL {
+  return notInArray(properties.status, ['draft', 'archived']);
+}
+
 export function isAvailable(available: boolean): SQL {
   return eq(properties.availabilityIsAvailable, available);
 }


### PR DESCRIPTION
Both handlers in `controllers/property/batch.ts` filtered `status = 'active'` — not a member of `PropertyStatus` (`draft | published | reserved | rented | sold | inactive | archived`) and unstorable under `properties_status_check` — so both returned `[]` for every request ever made to them.

The issue asked for the callers to be checked before changing anything, and for the replacement to be a deliberate product decision rather than a string swap. Both below.

---

## 1. Caller census

**Real route paths** (read from `routes/`, not assumed — the issue's `/api/properties/user/:id` does not exist):

| endpoint | router | auth |
|---|---|---|
| `GET /api/properties/by-ids?ids=a,b,c` | `routes/public.ts:58` | **none — unauthenticated** |
| `GET /api/properties/owner/:oxyUserId` | `routes/properties.ts:34` | authenticated, but the owner is a **path param**, so any caller may name any owner |

**Result: zero callers of either endpoint, anywhere in the repo.** Nothing depends on the always-empty behaviour, because nothing calls them.

Commands, with full matched lines:

```bash
git grep -n -I -e "by-ids" -e "byIds" -e "properties/owner" \
  -e "getPropertiesByOwner" -e "getPropertiesByIds" -- packages/
git grep -n -I "/owner/" -- packages/
```

Backend: only `batch.ts` itself, the two route declarations, and prose (`MIGRATION-CONTRACT.md`, `wireIds.ts`). The `by-ids` hits in `controllers/roommate/serialize.ts` and `hooks/useOxyAvatars.ts` are Oxy's **`POST /users/by-ids`**, an unrelated upstream API.

Frontend: nothing.

### Positive control

An inventory answering "who uses this?" cannot tell "I found less" from "there is less", so the same method was run against two endpoints known to have callers — it returns them:

```
mark-transacted → packages/frontend/services/propertyService.ts:462
me/list         → packages/frontend/services/propertyService.ts:130
```

### The near-miss, recorded because the method was what was wrong

The route-string sweep alone would have been **insufficient**, and it is worth stating rather than presenting a clean census. `components/property/LandlordSection.tsx` renders a "More by this owner" carousel — exactly what `by-owner` is for — fed from `app/properties/[id]/index.tsx` via `propertyService.getOwnerProperties(...)`. That name does not contain `owner/` in a path position and reverses the handler's word order, so no grep above matched it.

Tracing it settles the question rather than reopening it: `getOwnerProperties` (`propertyService.ts:146`) calls **`GET /api/properties?oxyUserId=…&excludeIds=…`** — the list feed in `list.ts` — not `/properties/owner/:id`. So the conclusion is unchanged, but it was confirmed by a second, independently-built sweep that enumerates *every* `api.<verb>(…)` path string in the frontend and inspects the residual, rather than by grepping for terms chosen in advance:

```bash
git grep -h -I -oE "api\.(get|post|put|patch|delete)(<[^>]*>)?\(\s*\`[^\`]+\`|…" -- packages/frontend/ | sort -u
```

No `by-ids` and no `/owner/` in the deduped list of ~60 paths.

Git history agrees: a `getOwnerProperties` hitting `/api/properties/owner/${ownerId}` was **added** in `bcff8817` and **deleted** in `5ce499be`. `by-ids` has never had a frontend caller.

**One caveat that cannot be settled from this repo:** `by-ids` is public and unauthenticated, so a third-party consumer is not observable here. The change only ever widens what it returns, so such a consumer sees rows where it saw none — not an error.

## 2. The status decision

There is **no canonical "publicly visible" predicate** to converge on, and `commonFilters.ts`'s own header explains why that is deliberate: the gating half is shared, the status half genuinely differs per surface. So this follows the existing split.

- **The gating half already has single definitions** — `notDeleted()` and `notModerationRestricted()` in `db/properties/propertyFilters.ts`, applied as a pair by `commonFilters.ts`, `searchQueryBuilder.ts` and `reviewController`. Both endpoints now call them. No new abstraction.
- **The status half** is one new predicate, in the filters module so the decision has one home: `statusVisibleToNonOwner()`.

| endpoint | status filter | reasoning |
|---|---|---|
| `by-ids` | everything except `draft`, `archived` | Hydration: the caller already holds the id, so this is the bulk form of `GET /properties/:id`. A saved listing that is now `rented` must still render; another user's `draft` must not. |
| `owner/:oxyUserId` | `published` | Discovery. Converges on what `cityController:399` and `reviewController.getAgencyProperties:899` already answer for somebody else's listings. The owner's own full view is `GET /properties/me/list`, session-scoped. |

### Rejected alternatives

- **`published` for `by-ids` too** (the issue floats `published`, or `published + reserved`). Rejected: it is the one choice that breaks the endpoint's actual job. Saved-property and batch-hydration callers hold ids for listings whose status has moved on; filtering to `published` blanks precisely those rows, and the caller cannot tell "gone" from "rented".
- **`statusVisibleToNonOwner()` for `by-owner` as well**, i.e. one rule for both. Rejected: a discovery feed listing somebody's `inactive` and `sold` properties is a different product than the two existing "somebody else's listings" surfaces, and diverging from them silently is worse than either answer. Mutation **M7** below pins this: swapping in the other endpoint's set turns the suite red.
- **`published + reserved` for `by-owner`.** Defensible — a reserved listing is arguably still on the market — but no existing surface makes that distinction, so it would have been invented here. `published` is the conservative choice and the one that un-hides least.

### Two clauses that are not redundant, and one that only looks it

`notDeleted()` and the `archived` half of the status filter overlap for a **user** deletion — `softDeleteProperty` sets `status = 'archived'` *and* stamps `deleted_at` — but not otherwise:

- `expireExternalProperty` archives a lapsed portal listing by **status alone**, leaving `deleted_at` NULL. Without the status clause, every expired external listing in the catalogue would be served. (Mutation **M8**.)
- Conversely, `deleted_at` is the canonical soft-delete test and the status coupling is one writer's implementation detail. A fixture stamping `deleted_at` while still `published` is seeded deliberately, because without it `notDeleted()` could be deleted from either endpoint with the suite still green — untested rather than merely redundant. (Mutations **M4**, **M11**.)

## 3. Two further sites the census turned up

The issue names `by-ids`; the same dead vocabulary was carried in two more places, both fixed here.

- **`telegramController.testRecentProperties`** — filtered `statusIs('active')`, so `GET /api/telegram/test-recent-properties` has always reported "no recent properties". **This one sends real messages to public Telegram groups**, so fixing it makes a dormant broadcast path live. Flagging it explicitly rather than burying it: it now uses `published` + both gates (stricter than `by-ids`, because a reserved/rented/deactivated listing is not something to announce to a city group). It only fires when somebody deliberately calls the endpoint, and `POST /telegram/bulk-notify` already sends unguarded, so no new abuse surface is opened.
- **`getPropertyStats`** — carried **two** dead values, `'active'` *and* `'occupied'`, so `occupiedRooms`, `availableRooms` and the `occupancyRate` derived from them have always been 0. `available` becomes `published AND is_available` (exactly `searchQueryBuilder`'s existing `publishedAndAvailable` pair); `occupied` becomes `rented`. **`reserved` is deliberately in neither count** — a listing under offer is honestly neither, and inventing an answer would put a product decision inside an aggregate. This endpoint currently has no frontend consumer (`git grep occupiedRooms -- packages/frontend/` → nothing), so the fix is unobserved today.

Everything else matching `'active'` in the backend is a **legitimate** status in another vocabulary — leases, roommate relationships, conversations, partners, review moderation — and is untouched. `__tests__/db/propertyVocabularies.test.ts:67` asserts the CHECK constraint rejects `'active'` for properties and stays as is.

## 4. `wireIdContract` — closing the loop

`by-ids` was excluded from the `_id` coverage sweep in #289 *because* its body was permanently empty, and that exclusion is what surfaced this bug. It now joins the sweep, and the comment recording the exclusion is replaced rather than left asserting behaviour that is gone. The suite's existing `empty` floor is what keeps that honest: a body with no `"id":` fails.

## 5. Mutation evidence

The fixture seeds **every** status plus both archived shapes, a restricted listing, a `deleted_at`-while-published listing, and a second owner — because a fixture where everything is `published` cannot tell the new filter from no filter, nor from the old broken one. Assertions are on exact **ID sets**, so "too few" and "too many" are separately visible.

Each mutation was verified to have **landed** before the suite ran (md5 before/after plus the mutated line printed) — a replacement that does not match leaves the file untouched and the suite green, which is indistinguishable from a surviving mutation. Restores were `cat pristine > target` from a copy under a private scratch path, never `git restore` (which would revert uncommitted work in the same file), each verified by md5 identity **and** a marker from the edit.

Baseline before mutating: `Tests: 6 passed, 6 total`, exit 0.

| # | mutation | result |
|---|---|---|
| M1 | `by-ids` status → `statusIs('active')` (the original bug) | **RED** — 2 failed |
| M2 | `by-ids` — **no status filter at all** | **RED** — 2 failed |
| M3 | `by-ids` — `notModerationRestricted()` removed | **RED** — 1 failed |
| M4 | `by-ids` — `notDeleted()` removed | **RED** — 1 failed |
| M5 | `by-owner` status → `statusIs('active')` | **RED** — 2 failed |
| M6 | `by-owner` — **no status filter at all** | **RED** — 2 failed |
| M7 | `by-owner` status → the `by-ids` set | **RED** — 2 failed |
| M8 | `statusVisibleToNonOwner` drops `'archived'` | **RED** — 1 failed |
| M9 | `statusVisibleToNonOwner` drops `'draft'` | **RED** — 2 failed |
| M10 | `by-owner` — `notModerationRestricted()` removed | **RED** — 2 failed |
| M11 | `by-owner` — `notDeleted()` removed | **RED** — 2 failed |

Sample, showing the landed-check and the restore:

```
############ M1: by-ids status back to the original bug, statusIs('active') ############
APPLY: landed (md5 4e063ba73eed8de822e827fa62de4734 -> 2880f013ee17c328330a9d04ec534f14); mutated line:
73:      where: allOf([idIn(list), notDeleted(), notModerationRestricted(), statusIs('active')]),
--- run ---
FAIL __tests__/integration/propertyBatchReads.test.ts
  ● … › returns every status except draft and archived, and never a restricted listing
  ● … › hydrates a rented listing on its own, which is the saved-list case
Tests:       2 failed, 4 passed, 6 total
SUITE EXIT=1
RESTORE: ok (md5 matches pristine, marker present)

############ M8: statusVisibleToNonOwner drops 'archived' ############
APPLY: landed (md5 4782a11dd87f24bf1e7c5e28e739a99f -> ff3348afc8d2f36876f2ebde734b69b1); mutated line:
90:  return notInArray(properties.status, ['draft']);
Tests:       1 failed, 5 passed, 6 total
SUITE EXIT=1
RESTORE: ok (md5 matches pristine, marker present)
```

After all 11, both files are byte-identical to the pristine copies and the suite is green again:

```
4e063ba73eed8de822e827fa62de4734  …/packages/backend/controllers/property/batch.ts
4e063ba73eed8de822e827fa62de4734  …/pristine/batch.ts
4782a11dd87f24bf1e7c5e28e739a99f  …/packages/backend/db/properties/propertyFilters.ts
4782a11dd87f24bf1e7c5e28e739a99f  …/pristine/propertyFilters.ts
PASS __tests__/integration/propertyBatchReads.test.ts
Tests:       6 passed, 6 total
SUITE EXIT=0
```

## 6. Gates

```
$ bun x tsc --noEmit -p packages/backend/tsconfig.json
TSC EXIT=0
```
(A first run reported 24 errors, all `TS6305`/`TS18046` from an unbuilt `packages/listing-providers/dist` — build skew, not code. `bun run --filter @homiio/listing-providers build` first, then clean. Baseline on the untouched tree was also 0.)

```
$ bun run --cwd packages/backend test          # TEST_DATABASE_URL → 127.0.0.1:5434
Test Suites: 130 passed, 130 total
Tests:       1686 passed, 1686 total
FULL SUITE EXIT=0
```

```
$ bun x eslint <the six files in this diff>
MY-FILES LINT EXIT=0        # zero output: no errors, no warnings
```

`bun run lint` across the monorepo exits 1, on **three pre-existing errors in files this PR does not touch** — verified against `origin/main` rather than assumed:

- `packages/frontend/components/SindiExplanationBottomSheet.tsx:136` `react-hooks/set-state-in-effect` — the finding `AGENTS.md` records as deliberately deferred pending an authenticated session.
- `packages/backend/server.ts:6` unused `NextFunction` — `git show origin/main:packages/backend/server.ts | sed -n 6p` shows the same import.
- `packages/backend/__tests__/db/placePoiCache.test.ts:28` unused `eq` — likewise on `origin/main`.

`bun install` exited 0 with no `error:` in its output and left `bun.lock` unchanged; no manifest changed.

## 7. Frontend impact

**None, and nothing was changed.** Zero callers, per §1. Checked specifically for a screen that would newly render rows or newly show a `rented` listing: the only surface that looks like a consumer, the "More by this owner" carousel, goes through the list feed instead.

Worth recording as a **pre-existing** inconsistency, not touched here: that carousel therefore shows `statusIsNot('draft')` — broader than the `published` this PR gives `by-owner`, and it includes the expired-external `archived` shape, since `list.ts`'s default excludes only `draft` and `commonFilters`' `notDeleted()` does not catch a status-only archive. Whether that surface should move onto `by-owner` is a separate product call.

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
