### PR TITLE
qa(observability): a versioned event schema that cannot carry an address, and an honest E2E matrix (#350)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,12 @@ jobs:
       # glob that stops matching all produce an empty green run, and that reads as
       # coverage forever because nothing contradicts it.
       #
+      # RAISED FROM 1450 TO 1520 by the privacy-safe observability work (#350),
+      # which added 73 tests across three backend files: the redaction and
+      # event-schema suite, the ingest suite, and the location/housing-identity
+      # divergence invariants. Measured 1680 -> 1753. Same convention as every
+      # step below — keep roughly the headroom the previous figure carried.
+      #
       # RAISED FROM 1415 TO 1450 by the ViewingRequest stragglers (the
       # retention sweep and the owner analytics). Before that it went
       # 1380 -> 1415 for the reservations port — the last tenancy
@@ -196,7 +202,7 @@ jobs:
         if: always()
         run: >-
           bun .github/scripts/assert-test-floor.mjs
-          "$RUNNER_TEMP/backend-tests.json" packages/backend 1450
+          "$RUNNER_TEMP/backend-tests.json" packages/backend 1520
 
   frontend:
     runs-on: ubuntu-24.04
@@ -217,11 +223,15 @@ jobs:
           bun run --cwd packages/frontend test --
           --json --outputFile="$RUNNER_TEMP/frontend-tests.json"
 
+      # RAISED FROM 38 TO 43 by #350's cross-package observability contract
+      # test, which is what proves the shared redaction layer resolves and
+      # behaves from THIS workspace rather than only from the backend's.
+      # Measured 40 -> 45.
       - name: Assert the suite actually ran
         if: always()
         run: >-
           bun .github/scripts/assert-test-floor.mjs
-          "$RUNNER_TEMP/frontend-tests.json" packages/frontend 38
+          "$RUNNER_TEMP/frontend-tests.json" packages/frontend 43
 
   # Deliberately no job for shared-types or listing-providers. shared-types' `test`
   # script is `echo "No tests specified" && exit 0` — there is no suite. And

--- a/docs/qa/location-and-housing-identity-e2e-matrix.md
+++ b/docs/qa/location-and-housing-identity-e2e-matrix.md
@@ -1,0 +1,252 @@
+# End-to-end matrix: location and housing identity
+
+Companion to issue #350, under epic #344.
+
+This document is deliberately unflattering. Most of the journeys the issue lists
+cannot be automated today, because the features they exercise do not exist yet —
+they land in #351 to #366. Writing them down as "automated" would be the exact
+failure this whole issue exists to prevent: a check that reports success while
+measuring nothing. Every row below therefore carries an honest status, and every
+deferral names the issue that unblocks it.
+
+What DOES exist today, and is executed on every pull request, is listed under
+"What CI runs now".
+
+---
+
+## Status vocabulary
+
+| Status | Meaning |
+|---|---|
+| **AUTOMATED-NOW** | A test in this repository executes it and fails when it breaks. Runs in CI. |
+| **AUTOMATABLE-AFTER-#N** | The assertion exists or is trivially expressible; the feature or surface it needs lands in issue #N. |
+| **MANUAL** | Needs a device capability, a third-party failure, or a human judgement that no harness here reproduces. |
+
+A row marked AUTOMATABLE-AFTER is not a promise that somebody will write it. It
+is a statement that the blocker is the feature, not the harness — the invariant
+it would assert is already implemented and tested in
+`packages/shared-types/src/observability/invariants.ts`.
+
+---
+
+## What CI runs now
+
+Three suites, on every pull request, through the existing `ci.yml` jobs. No new
+workflow was added; the tests live in the packages whose suites already run.
+
+| Suite | File | Job |
+|---|---|---|
+| Redaction and the event schema | `packages/backend/__tests__/unit/observabilityRedaction.test.ts` | `backend` |
+| Ingest, through the real Express app | `packages/backend/__tests__/unit/observabilityIngest.test.ts` | `backend` |
+| The seven divergence invariants | `packages/backend/__tests__/unit/locationDivergenceInvariants.test.ts` | `backend` |
+| Cross-package contract and pinned digests | `packages/frontend/__tests__/observabilityContract.test.ts` | `frontend` |
+
+Both jobs carry a count floor (`.github/scripts/assert-test-floor.mjs`), so a
+suite that stops running is a failure rather than a quieter green run.
+
+### Running the full matrix locally
+
+```bash
+# Postgres is a hard prerequisite of the backend suite; it does not skip.
+docker compose -f docker-compose.postgres.yml up -d
+
+bun run --filter @homiio/shared-types build
+bun run --filter @homiio/listing-providers build
+
+bun x tsc --noEmit -p packages/backend/tsconfig.json
+bun run --cwd packages/frontend typecheck
+
+TEST_DATABASE_URL=postgres://homiio:homiio@127.0.0.1:5434/postgres \
+  bun run --cwd packages/backend test -- --testPathPattern='(observability|locationDivergence)'
+bun run --cwd packages/frontend test -- --testPathPattern='observabilityContract'
+```
+
+The MANUAL rows below have no command. They are run by a person against a real
+build on the platform named, and their outcome is recorded on the pull request
+that changes the surface in question.
+
+---
+
+## Group 1 — First open
+
+| # | Journey | Web | iOS | Android | Notes |
+|---|---|---|---|---|---|
+| 1.1 | Location permission granted | MANUAL | MANUAL | MANUAL | The browser and OS prompts are outside the app. `location_permission_resolved` records the outcome once #353 emits it. |
+| 1.2 | Permission denied | MANUAL | MANUAL | MANUAL | The important half: denial must yield a chosen scope, never a worldwide feed. The invariant is automated (`checkGeocoderFallbackScope`); the permission path is not. |
+| 1.3 | Granted then revoked mid-session | MANUAL | MANUAL | MANUAL | iOS and Android revoke out of process and restart the app on some versions. No harness here reproduces it. |
+| 1.4 | Coordinates unavailable despite a grant | AUTOMATABLE-AFTER-#353 | MANUAL | MANUAL | Web geolocation can be stubbed; the native fix cannot. `coordinatesAvailable` distinguishes it from a denial. |
+| 1.5 | Returning user with a saved last city | AUTOMATABLE-AFTER-#352 | AUTOMATABLE-AFTER-#352 | AUTOMATABLE-AFTER-#352 | Needs the `LocationSelection` contract to persist and restore. |
+| 1.6 | Returning user with several saved searches | AUTOMATABLE-AFTER-#356 | AUTOMATABLE-AFTER-#356 | AUTOMATABLE-AFTER-#356 | Saved areas and alerts. |
+
+---
+
+## Group 2 — Search and map
+
+| # | Journey | Web | iOS | Android | Notes |
+|---|---|---|---|---|---|
+| 2.1 | Search Barcelona, confirm results are in Barcelona | AUTOMATABLE-AFTER-#355 | AUTOMATABLE-AFTER-#355 | AUTOMATABLE-AFTER-#355 | The assertion is `checkVisibleAreaMatchesQueriedArea`, automated now against the fixtures. |
+| 2.2 | Move the map to Madrid and press "Search this area" | AUTOMATABLE-AFTER-#354 | AUTOMATABLE-AFTER-#354 | AUTOMATABLE-AFTER-#354 | `map_area_search_committed` carries `previousQueryId` and `priorScopeCleared` for exactly this. |
+| 2.3 | Confirm no Barcelona parameter survives the move | **AUTOMATED-NOW** | **AUTOMATED-NOW** | **AUTOMATED-NOW** | Platform-independent: `checkQueryIdentityMatch` on two descriptors that differ only in a surviving `cityKey`. The bounds are identical, so a bounds-only check passes it. |
+| 2.4 | Switch between list and map keeping one query | **AUTOMATED-NOW** | **AUTOMATED-NOW** | **AUTOMATED-NOW** | The digest is what makes "the same query" checkable. Wiring the two surfaces to produce it is #354. |
+| 2.5 | Open a result, go back, keep position and query | AUTOMATABLE-AFTER-#355 | AUTOMATABLE-AFTER-#355 | AUTOMATABLE-AFTER-#355 | Needs the scroll-restoration behaviour that screen owns. |
+| 2.6 | Geocoder timeout, 429, 500 and empty response | AUTOMATABLE-AFTER-#351 | AUTOMATABLE-AFTER-#351 | AUTOMATABLE-AFTER-#351 | Once the geocoder is behind Homiio's own gateway its failures can be injected. All four outcomes are already asserted against `checkGeocoderFallbackScope`. |
+| 2.7 | Two cities with the same name | **AUTOMATED-NOW** | **AUTOMATED-NOW** | **AUTOMATED-NOW** | Barcelona ES against Barcelona VE; see the fixtures below. The end-to-end picker is #295. |
+| 2.8 | Free text inside a specific area | **AUTOMATED-NOW** | **AUTOMATED-NOW** | **AUTOMATED-NOW** | The digest treats text and scope as separate dimensions; changing either changes the id. |
+| 2.9 | Bounding box crossing the antimeridian | **AUTOMATED-NOW** | **AUTOMATED-NOW** | **AUTOMATED-NOW** | Both directions: identical boxes must match, complementary boxes must not. |
+| 2.10 | Zero results with no worldwide fallback | **AUTOMATED-NOW** | **AUTOMATED-NOW** | **AUTOMATED-NOW** | `checkGeocoderFallbackScope` refuses a `global` fallback unconditionally, and an unscoped result after any non-`ok` geocoder outcome. |
+
+---
+
+## Group 3 — Addresses and housing
+
+| # | Journey | Web | iOS | Android | Notes |
+|---|---|---|---|---|---|
+| 3.1 | Two units in one building | **AUTOMATED-NOW** | **AUTOMATED-NOW** | **AUTOMATED-NOW** | Asserted at the identity level: two units must not share a reference while the building reference is shared. The screen is #362. |
+| 3.2 | Two buildings, same street, different numbers | AUTOMATABLE-AFTER-#360 | AUTOMATABLE-AFTER-#360 | AUTOMATABLE-AFTER-#360 | Needs canonical materialisation to have a key to compare. |
+| 3.3 | Rural address, or one with no number | AUTOMATABLE-AFTER-#359 | AUTOMATABLE-AFTER-#359 | AUTOMATABLE-AFTER-#359 | `address_candidate_selected.precisionLevel` already carries `street` / `locality` / `area`. |
+| 3.4 | External candidate never materialised | **AUTOMATED-NOW** | **AUTOMATED-NOW** | **AUTOMATED-NOW** | `checkListingHasHousingIdentity` must PERMIT this, which is the half a naive implementation gets wrong by requiring a link on every listing. |
+| 3.5 | An address with no active listing | AUTOMATABLE-AFTER-#362 | AUTOMATABLE-AFTER-#362 | AUTOMATABLE-AFTER-#362 | The persistent profile independent of live listings. |
+| 3.6 | Three external listings of one dwelling | **AUTOMATED-NOW** | **AUTOMATED-NOW** | **AUTOMATED-NOW** | Grouping and the median effect are both asserted. The grouping engine is #368. |
+| 3.7 | Correction or merge without losing relations | AUTOMATABLE-AFTER-#360 | AUTOMATABLE-AFTER-#360 | AUTOMATABLE-AFTER-#360 | Merge and split workflows. |
+
+---
+
+## Group 4 — Reviews and privacy
+
+| # | Journey | Web | iOS | Android | Notes |
+|---|---|---|---|---|---|
+| 4.1 | Review linked to a unit, published at building level | AUTOMATABLE-AFTER-#365 | AUTOMATABLE-AFTER-#365 | AUTOMATABLE-AFTER-#365 | The unit-versus-building distinction is fixture-backed today. |
+| 4.2 | Residence document absent from every public response | AUTOMATABLE-AFTER-#364 | AUTOMATABLE-AFTER-#364 | AUTOMATABLE-AFTER-#364 | Private evidence does not exist yet. The event layer already refuses a document reference outright, which is asserted now. |
+| 4.3 | Anonymous or pseudonymous authorship per policy | AUTOMATABLE-AFTER-#365 | AUTOMATABLE-AFTER-#365 | AUTOMATABLE-AFTER-#365 | |
+| 4.4 | Right of reply without altering the original | AUTOMATABLE-AFTER-#365 | AUTOMATABLE-AFTER-#365 | AUTOMATABLE-AFTER-#365 | |
+| 4.5 | Address and coordinates redacted to the expected level | **AUTOMATED-NOW** | **AUTOMATED-NOW** | **AUTOMATED-NOW** | `checkPublicPrecisionWithinPolicy`, including the float-noise case a "we rounded it" implementation misses. The policy itself is #347's. |
+| 4.6 | Review-step abandonment measurable without identifying a person | **AUTOMATED-NOW** | **AUTOMATED-NOW** | **AUTOMATED-NOW** | `review_step_completed` and `review_abandoned` carry an opaque per-draft reference and a duration bucket, nothing else. The wizard is #363. |
+
+---
+
+## Group 5 — Evictions
+
+| # | Journey | Web | iOS | Android | Notes |
+|---|---|---|---|---|---|
+| 5.1 | Local board by area | AUTOMATABLE-AFTER-#358 | AUTOMATABLE-AFTER-#358 | AUTOMATABLE-AFTER-#358 | |
+| 5.2 | Public coordinate is approximate | **AUTOMATED-NOW** | **AUTOMATED-NOW** | **AUTOMATED-NOW** | Same mechanism as 4.5, and the reason it takes a policy argument rather than hard-coding one level. |
+| 5.3 | Private contacts absent from the public listing | AUTOMATABLE-AFTER-#358 | AUTOMATABLE-AFTER-#358 | AUTOMATABLE-AFTER-#358 | The event layer refuses a contact today; the DTO allowlist is #358's. |
+| 5.4 | Event updated, postponed and cancelled | AUTOMATABLE-AFTER-#358 | AUTOMATABLE-AFTER-#358 | AUTOMATABLE-AFTER-#358 | |
+| 5.5 | Authorised access to more precise data | AUTOMATABLE-AFTER-#347 | AUTOMATABLE-AFTER-#347 | AUTOMATABLE-AFTER-#347 | Needs the publication ladder the ADR defines. |
+
+---
+
+## Discriminating fixtures
+
+Defined in `packages/backend/__tests__/helpers/locationIdentityFixtures.ts`. The
+rule that shaped every one: **a fixture on which a correct and an incorrect
+implementation agree proves nothing**, however elaborate it looks. What a wrong
+implementation produces is stated for each, here and in the fixture's own
+comment.
+
+| Fixture | What a WRONG implementation produces |
+|---|---|
+| **Barcelona, Catalonia (ES)** and **Barcelona, Anzoátegui (VE)** | A scope keyed on the NAME cannot tell them apart: the same query id, full area overlap, and a search for either answered with listings from both. 7 200 km and two hemispheres apart, so no tolerance can excuse it. |
+| **Madrid (ES)**, 505 km from Barcelona | "Search this area" that moves the viewport without clearing the previous city filter answers a Madrid map with Barcelona listings. The two descriptors have IDENTICAL bounds, so a bounds-only check passes it — only the query id catches it. |
+| **Antimeridian viewport** (179°E → −179°W) and its complement | `east - west` gives −358. The box then reads as empty (an identical pair looks divergent) or as the whole planet (every comparison passes — the dangerous direction). The complement shares not one square degree and must never match. |
+| **Two units of one building**, review scores 2 and 5 | Keying identity on the ADDRESS collapses them into one profile showing 3.5, which describes neither home. The scores are far apart on purpose: two 4s would print the same number under both implementations. |
+| **One flat, three portal listings** (1 200 / 1 250 / 1 290 EUR, different ids and photo counts) | Grouping on the LISTING id gives three groups of one instead of one group of three, `listing_duplicate_group_opened` never fires, and the price sample counts the flat three times. The prices are close so a merge is invisible in any single figure. |
+| **EUR / USD / PLN / RON**, all quoted 1 200 | `(max − min) / min` reports a 0% spread. The real gap between 1 200 PLN and 1 200 USD is roughly fourfold. The correct answer is not a converted number but the ABSENCE of one — which is why `priceSpreadBucketPct` is optional in the schema. |
+| **Price sample with the duplicate counted three times** | Eight listings give a median of 1 225; six dwellings give 1 125. A hundred euros in the number somebody is told is fair. It works only because the duplicate sits in the MIDDLE of the distribution — at either extreme both readings move together and the fixture proves nothing. |
+| **Exact location** (41.38743, 2.1686) and its **public approximation** (41.39, 2.17) | Publishing the exact value puts a household's door on a public map. The two render identically at any zoom a person uses; only a decimal-place count tells them apart. |
+| **Float-noise approximation** (41.39000000000001) | An implementation that trusts "we rounded it" instead of measuring the stored value publishes fourteen decimal places while believing it published two. |
+
+---
+
+## Divergence invariants
+
+Implemented in `packages/shared-types/src/observability/invariants.ts`, each
+returning `{ ok, code, safe }` where `safe` carries classifications, booleans and
+small integers only. The suite runs every `safe` map through the same sensitive
+value sweep the redaction layer uses, so a production divergence check cannot
+log a coordinate or a place name.
+
+| Invariant | Function | Status |
+|---|---|---|
+| One query identifier for list and map | `checkQueryIdentityMatch` | Real now |
+| Visible area against queried area | `checkVisibleAreaMatchesQueriedArea` | Real now |
+| Visible label against current selection | `checkVisibleLabelMatchesSelection` | Contract for #352 |
+| A result for a superseded query id | `checkResultIsForCurrentQuery` | Real now |
+| A fallback after a geocoder error | `checkGeocoderFallbackScope` | Real now |
+| Published precision above policy | `checkPublicPrecisionWithinPolicy` | Real now; policy owned by #347 |
+| A listing with no housing identity | `checkListingHasHousingIdentity` | Contract for #360 / #361 |
+
+The three marked "contract" take a minimal structural interface declared beside
+the function rather than importing a type that does not exist. They are called
+by the suite with real fixtures today; what the later issue supplies is a
+production caller, not the assertion.
+
+---
+
+## Sources of flakiness, and limitations
+
+Stated because the acceptance criteria demand it, and because an undocumented
+flake becomes a disabled test.
+
+**In what runs today**
+
+- **The backend suite requires a reachable Postgres and does not skip without
+  one.** That is deliberate (`packages/backend/jest.globalSetup.ts`), and it
+  means these tests cannot run in an environment without Docker even though none
+  of them touches the database. The failure is loud, not silent.
+- **Parallel jest workers share one Postgres server.** A file-level failure whose
+  path is repeated in brackets while `Tests: 0 failed` is contention, not a
+  regression. Re-run the file alone before believing it.
+- **The pinned digests are pinned twice on purpose** — once in the backend suite,
+  once in the frontend one. Changing the canonicalisation reds both, which is the
+  intent: it must be a decision, not a side effect.
+- **`jest-expo` runs on Node, not Hermes.** The frontend contract test proves the
+  package resolves and the digest agrees under Babel; it does NOT prove the
+  digest on a device. `deriveQueryId` avoids `BigInt` and
+  `String.prototype.normalize` for that reason, but the guarantee is by
+  construction and by review, not by measurement.
+
+**In the matrix as a whole**
+
+- **A geocoder failure cannot be injected until #351.** Until the geocoder is
+  behind Homiio's own gateway, the four failure outcomes are asserted against the
+  invariant rather than against a real provider.
+- **Native permission prompts are out of process.** iOS and Android grant, deny
+  and revoke outside the app, and revocation restarts it on some versions.
+  Nothing here reproduces that; those rows stay MANUAL.
+- **A map viewport is floating-point and device-dependent.** The area invariant
+  therefore uses a tolerance (`DEFAULT_MIN_AREA_OVERLAP`, half the union) rather
+  than equality, and the query id quantises coordinates to three decimals. A pair
+  straddling a grid cell boundary DOES get two ids — quantisation, not a
+  tolerance — which is why the geometric check works on real numbers instead.
+- **Timing.** Latency and duration are bucketed, so a slow CI machine changes
+  which bucket an event lands in. No assertion here depends on a bucket boundary
+  for a measured duration; the tests bucket fixed numbers.
+
+---
+
+## What this issue deliberately did NOT build
+
+- **No third-party analytics SDK.** The issue forbids one without an explicit
+  privacy review. Measured before writing anything: `posthog`, `mixpanel`,
+  `amplitude`, `@segment/` and `firebase/analytics` return zero matches across
+  the tracked tree, and `@bitdrift/react-native` appears only as an Expo
+  config-plugin entry with no JavaScript import anywhere. There was nothing to
+  extend, so this is a first-party pipeline into Homiio's own backend.
+- **No events table and no dashboards.** The sink is the structured logger, and
+  retention is the log group's retention — one setting owned by `oxy-infra`. A
+  table would make this the business-intelligence system the issue puts out of
+  scope.
+- **No frontend emitter wiring.** Eight of the thirteen events originate on a
+  client, and not one of the surfaces that would emit them exists yet (#351 to
+  #356, #363). A poster with no callers is the speculative framework this issue
+  warns against. The shared emitter already runs in that environment — the
+  frontend suite proves it resolves and behaves — and the ingest route is live,
+  so wiring a transport is a small piece of whichever issue first has something
+  to send.
+- **No metrics computation.** The issue's minimum metric list (resolved-location
+  ratio, permission ratio, geocoder latency by provider, zero-result rate,
+  "search this area" usage, review-step abandonment, materialised candidates,
+  duplicate groups, insufficient-data price evaluations, blocked or redacted
+  privacy events) is all derivable from the vocabulary as specified. Deriving it
+  is a query against the log, not code in this repository.

--- a/docs/qa/location-and-housing-identity-e2e-matrix.md
+++ b/docs/qa/location-and-housing-identity-e2e-matrix.md
@@ -27,6 +27,25 @@ is a statement that the blocker is the feature, not the harness — the invarian
 it would assert is already implemented and tested in
 `packages/shared-types/src/observability/invariants.ts`.
 
+### Coverage today
+
+**34 journeys: 12 AUTOMATED-NOW, 18 AUTOMATABLE-AFTER, 3 MANUAL, and one (1.4)
+mixed** — automatable on web, manual on both native platforms. Per platform
+cell, that is 36 automated, 55 blocked on a feature, 11 manual, out of 102.
+
+Recount rather than trusting those figures; they go stale the moment a row
+changes, and a number carried from memory is an assertion, not a measurement:
+
+```bash
+grep -cE '^\| *[0-9]+\.[0-9]+ *\|' docs/qa/location-and-housing-identity-e2e-matrix.md   # rows
+grep -oE 'AUTOMATED-NOW|AUTOMATABLE-AFTER-#[0-9]+|MANUAL' \
+  docs/qa/location-and-housing-identity-e2e-matrix.md | sed 's/-#[0-9]*//' | sort | uniq -c
+```
+
+(The second command counts the status vocabulary table and the prose too, so it
+over-counts by a fixed handful — it answers "did a whole group lose its
+statuses?", not the exact figure.)
+
 ---
 
 ## What CI runs now

--- a/packages/backend/__tests__/helpers/locationIdentityFixtures.ts
+++ b/packages/backend/__tests__/helpers/locationIdentityFixtures.ts
@@ -1,0 +1,283 @@
+/**
+ * Discriminating fixtures for the location and housing-identity suite (#350).
+ *
+ * THE RULE THAT SHAPED EVERY ONE OF THESE: a fixture on which a correct and an
+ * incorrect implementation agree proves nothing, however elaborate it looks.
+ * Each block below therefore records, in its own comment, what a WRONG
+ * implementation produces from it — and `docs/qa/location-and-housing-identity-
+ * e2e-matrix.md` repeats that list so the reasoning survives outside the code.
+ *
+ * Coordinates are real. Barcelona in Anzoátegui, Venezuela is a real city of
+ * that name in another country, which is what makes the homonym case a
+ * measurement rather than a mock.
+ */
+
+import type {
+  GeoBounds,
+  GeoPoint,
+  PricedListing,
+  QueryDescriptor,
+} from '@homiio/shared-types';
+
+export interface PlaceFixture {
+  /** A stable key, never a display string — see `LocationScopeContract`. */
+  readonly placeKey: string;
+  readonly countryCode: string;
+  readonly center: GeoPoint;
+  readonly bounds: GeoBounds;
+}
+
+/**
+ * Barcelona, Catalonia, Spain.
+ *
+ * WRONG IMPLEMENTATION: one that scopes by NAME rather than by place key
+ * cannot tell this apart from {@link BARCELONA_VE} below, and will answer a
+ * search for either with listings from both.
+ */
+export const BARCELONA_ES: PlaceFixture = {
+  placeKey: 'es-cat-barcelona',
+  countryCode: 'ES',
+  center: { lat: 41.3874, lng: 2.1686 },
+  bounds: { west: 2.052, south: 41.317, east: 2.228, north: 41.468 },
+};
+
+/**
+ * Barcelona, Anzoátegui, Venezuela — 7 200 km away and in the other hemisphere.
+ *
+ * WRONG IMPLEMENTATION: a name-keyed scope produces the SAME query id as
+ * {@link BARCELONA_ES}; the area check reports full overlap because it never
+ * compares geometry at all.
+ */
+export const BARCELONA_VE: PlaceFixture = {
+  placeKey: 've-anz-barcelona',
+  countryCode: 'VE',
+  center: { lat: 10.1333, lng: -64.6833 },
+  bounds: { west: -64.76, south: 10.06, east: -64.6, north: 10.21 },
+};
+
+/**
+ * Madrid — 505 km from Barcelona, far enough that no rounding, tolerance or
+ * viewport slop can make the two boxes overlap.
+ *
+ * WRONG IMPLEMENTATION: "search this area" that moves the map without clearing
+ * the previous city filter answers a Madrid viewport with Barcelona listings.
+ * The two descriptors differ only in `filters.cityKey`, so a check that
+ * compares BOUNDS alone passes it and only the query id catches it.
+ */
+export const MADRID_ES: PlaceFixture = {
+  placeKey: 'es-mad-madrid',
+  countryCode: 'ES',
+  center: { lat: 40.4168, lng: -3.7038 },
+  bounds: { west: -3.889, south: 40.312, east: -3.518, north: 40.564 },
+};
+
+/**
+ * A viewport across the antimeridian: Fiji, 179°E to −179°W. Two degrees wide.
+ *
+ * WRONG IMPLEMENTATION: `east - west` gives −358, so the viewport reads as
+ * either empty or as the whole planet. Both readings are silent — the first
+ * makes an identical pair look divergent, the second makes every comparison
+ * pass, which is the dangerous direction.
+ */
+export const ANTIMERIDIAN_VIEWPORT: GeoBounds = {
+  west: 179,
+  south: -18,
+  east: -179,
+  north: -16,
+};
+
+/** Its complement: everything BUT the box above. Shares not one square degree. */
+export const ANTIMERIDIAN_COMPLEMENT: GeoBounds = {
+  west: -179,
+  south: -18,
+  east: 179,
+  north: -16,
+};
+
+/** A city-scoped query for a place fixture, as both a list and a map would build it. */
+export function cityQuery(
+  place: PlaceFixture,
+  filters: Readonly<Record<string, string | number | boolean>> = {},
+): QueryDescriptor {
+  return {
+    locationKind: 'city',
+    countryCode: place.countryCode,
+    placeKey: place.placeKey,
+    center: place.center,
+    bounds: place.bounds,
+    filters: { cityKey: place.placeKey, ...filters },
+    sort: 'relevance',
+  };
+}
+
+/** A viewport-scoped query, as "search this area" would build it. */
+export function viewportQuery(
+  bounds: GeoBounds,
+  filters: Readonly<Record<string, string | number | boolean>> = {},
+): QueryDescriptor {
+  return {
+    locationKind: 'bbox',
+    bounds,
+    filters,
+    sort: 'relevance',
+  };
+}
+
+/* ── Two dwellings in one building ────────────────────────────────────────── */
+
+export interface DwellingFixture {
+  readonly buildingKey: string;
+  readonly unitKey: string;
+  readonly reviewScore: number;
+}
+
+/**
+ * Two units at the same street address with genuinely different experiences —
+ * the ground-floor flat above a bar and the quiet fourth floor.
+ *
+ * WRONG IMPLEMENTATION: keying housing identity on the ADDRESS (or on the
+ * building) collapses them into one profile, so both units show the average of
+ * 2 and 5 and neither resident's review describes the home somebody is about to
+ * rent. The fixture discriminates because the two scores are far apart: had
+ * both been 4, a building-keyed and a unit-keyed implementation would print the
+ * same number and the test would pass either way.
+ */
+export const SAME_BUILDING_UNITS: readonly [DwellingFixture, DwellingFixture] = [
+  { buildingKey: 'es-cat-barcelona-mallorca-401', unitKey: 'unit-1-1', reviewScore: 2 },
+  { buildingKey: 'es-cat-barcelona-mallorca-401', unitKey: 'unit-4-2', reviewScore: 5 },
+];
+
+/* ── One dwelling, three portal listings ──────────────────────────────────── */
+
+export interface ListingFixture {
+  readonly listingKey: string;
+  readonly provider: string;
+  readonly unitKey: string;
+  readonly price: PricedListing;
+  readonly photoCount: number;
+}
+
+/**
+ * One flat, listed by three portals with different ids, different photo counts
+ * and prices that differ by agency fees.
+ *
+ * WRONG IMPLEMENTATION: grouping on the LISTING id yields three groups of one
+ * rather than one group of three, so `listing_duplicate_group_opened` never
+ * fires and the price sample below counts the same flat three times. The prices
+ * are deliberately close (1 200 / 1 250 / 1 290) so that a merge is invisible in
+ * any single figure and only shows in the median.
+ */
+export const DUPLICATE_LISTING_GROUP: readonly ListingFixture[] = [
+  {
+    listingKey: 'idealista-98217361',
+    provider: 'idealista',
+    unitKey: 'unit-4-2',
+    price: { amount: 1200, currency: 'EUR' },
+    photoCount: 18,
+  },
+  {
+    listingKey: 'fotocasa-171-3390022',
+    provider: 'fotocasa',
+    unitKey: 'unit-4-2',
+    price: { amount: 1250, currency: 'EUR' },
+    photoCount: 21,
+  },
+  {
+    listingKey: 'habitaclia-i9927744',
+    provider: 'habitaclia',
+    unitKey: 'unit-4-2',
+    price: { amount: 1290, currency: 'EUR' },
+    photoCount: 17,
+  },
+];
+
+/**
+ * A group whose members are quoted in different currencies.
+ *
+ * WRONG IMPLEMENTATION: `(max - min) / min` over these reports a spread of
+ * 0% — every amount is 1 200 — while the real gap between 1 200 PLN and
+ * 1 200 USD is roughly fourfold. The correct answer is not a converted number,
+ * it is the absence of one.
+ */
+export const MIXED_CURRENCY_GROUP: readonly PricedListing[] = [
+  { amount: 1200, currency: 'EUR' },
+  { amount: 1200, currency: 'USD' },
+  { amount: 1200, currency: 'PLN' },
+  { amount: 1200, currency: 'RON' },
+];
+
+/**
+ * A neighbourhood price sample in which the duplicate above appears three times.
+ *
+ * WRONG IMPLEMENTATION: counting every listing gives an eight-value sample
+ * (900, 980, 1050, 1200, 1250, 1290, 1600, 1800) with a median of 1 225;
+ * deduplicating to one row per dwelling — the lowest asking price for the flat
+ * — gives six values (900, 980, 1050, 1200, 1600, 1800) and a median of 1 125.
+ * A hundred euros of difference in the number a person is told is fair, and it
+ * exists only because the duplicate sits in the MIDDLE of the distribution: a
+ * duplicate at either extreme moves the median the same way under both
+ * readings and would prove nothing.
+ */
+export const PRICE_SAMPLE_WITH_DUPLICATE: readonly ListingFixture[] = [
+  {
+    listingKey: 'local-a',
+    provider: 'homiio',
+    unitKey: 'unit-1-1',
+    price: { amount: 900, currency: 'EUR' },
+    photoCount: 8,
+  },
+  {
+    listingKey: 'local-b',
+    provider: 'homiio',
+    unitKey: 'unit-2-1',
+    price: { amount: 980, currency: 'EUR' },
+    photoCount: 6,
+  },
+  {
+    listingKey: 'local-c',
+    provider: 'homiio',
+    unitKey: 'unit-3-1',
+    price: { amount: 1050, currency: 'EUR' },
+    photoCount: 9,
+  },
+  ...DUPLICATE_LISTING_GROUP,
+  {
+    listingKey: 'local-d',
+    provider: 'homiio',
+    unitKey: 'unit-5-1',
+    price: { amount: 1600, currency: 'EUR' },
+    photoCount: 12,
+  },
+  {
+    listingKey: 'local-e',
+    provider: 'homiio',
+    unitKey: 'unit-6-1',
+    price: { amount: 1800, currency: 'EUR' },
+    photoCount: 14,
+  },
+];
+
+/* ── An exact location and its public approximation ───────────────────────── */
+
+/**
+ * Where the dwelling actually is: five decimal places, roughly one metre.
+ *
+ * WRONG IMPLEMENTATION: publishing this verbatim on an eviction board or a
+ * review puts a household's door on a public map. It renders identically to the
+ * approximation at any zoom a person is likely to look at, which is exactly why
+ * nothing but a decimal-place check catches it.
+ */
+export const EXACT_LOCATION: GeoPoint = { lat: 41.38743, lng: 2.1686 };
+
+/** The same place at locality precision: two decimals, roughly a kilometre. */
+export const PUBLIC_APPROXIMATION: GeoPoint = { lat: 41.39, lng: 2.17 };
+
+/**
+ * A rounding that produced float noise. `41.39000000000001` is what
+ * `Math.round(41.38743 * 100) / 100` can yield on some inputs, and it carries
+ * fourteen decimal places.
+ *
+ * WRONG IMPLEMENTATION: one that trusts "we rounded it" instead of measuring
+ * the stored value publishes full precision while believing it did not.
+ */
+export const FLOAT_NOISE_APPROXIMATION: GeoPoint = { lat: 41.39000000000001, lng: 2.17 };

--- a/packages/backend/__tests__/unit/locationDivergenceInvariants.test.ts
+++ b/packages/backend/__tests__/unit/locationDivergenceInvariants.test.ts
@@ -1,0 +1,411 @@
+/**
+ * The seven divergence invariants (#350), against the discriminating fixtures.
+ *
+ * Every case here is chosen so that a correct and an incorrect implementation
+ * produce DIFFERENT results. The wrong result each fixture provokes is written
+ * beside the fixture itself in
+ * `packages/backend/__tests__/helpers/locationIdentityFixtures.ts` and repeated
+ * in `docs/qa/location-and-housing-identity-e2e-matrix.md`. A symmetric fixture
+ * — two Barcelonas with the same score, a duplicate at the edge of a price
+ * distribution, a viewport that does not cross the antimeridian — would pass
+ * under both implementations and prove nothing, which is the failure mode this
+ * whole file exists to avoid.
+ */
+
+import {
+  INVARIANT_CODES,
+  PUBLIC_PRECISION_MAX_DECIMALS,
+  canonicalQueryDescriptor,
+  checkGeocoderFallbackScope,
+  checkListingHasHousingIdentity,
+  checkPublicPrecisionWithinPolicy,
+  checkQueryIdentityMatch,
+  checkResultIsForCurrentQuery,
+  checkVisibleAreaMatchesQueriedArea,
+  checkVisibleLabelMatchesSelection,
+  decimalPlaces,
+  deriveOpaqueRef,
+  deriveQueryId,
+  priceSpreadBucketPct,
+  scanForSensitiveValues,
+  type InvariantResult,
+} from '@homiio/shared-types';
+
+import {
+  ANTIMERIDIAN_COMPLEMENT,
+  ANTIMERIDIAN_VIEWPORT,
+  BARCELONA_ES,
+  BARCELONA_VE,
+  DUPLICATE_LISTING_GROUP,
+  EXACT_LOCATION,
+  FLOAT_NOISE_APPROXIMATION,
+  MADRID_ES,
+  MIXED_CURRENCY_GROUP,
+  PRICE_SAMPLE_WITH_DUPLICATE,
+  PUBLIC_APPROXIMATION,
+  SAME_BUILDING_UNITS,
+  cityQuery,
+  viewportQuery,
+} from '../helpers/locationIdentityFixtures';
+
+/** Median of a numeric sample. Used only to show that the fixture discriminates. */
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  const upper = sorted[middle];
+  const lower = sorted[middle - 1];
+  if (upper === undefined) return Number.NaN;
+  if (sorted.length % 2 === 1) return upper;
+  return lower === undefined ? upper : (lower + upper) / 2;
+}
+
+describe('invariant results are safe to log', () => {
+  it('covers every declared invariant code', () => {
+    // A completeness floor: an invariant added to the union without a case here
+    // fails rather than silently going untested.
+    const exercised: InvariantResult[] = [
+      checkQueryIdentityMatch(cityQuery(BARCELONA_ES), cityQuery(BARCELONA_VE)),
+      checkVisibleAreaMatchesQueriedArea(BARCELONA_ES.bounds, MADRID_ES.bounds),
+      checkVisibleLabelMatchesSelection(
+        { renderedFrom: { kind: 'city', countryCode: 'ES', placeKey: BARCELONA_ES.placeKey } },
+        { kind: 'city', countryCode: 'ES', placeKey: MADRID_ES.placeKey },
+      ),
+      checkResultIsForCurrentQuery('0123456789abcdef', 'fedcba9876543210'),
+      checkGeocoderFallbackScope('timeout', 'none', 'none'),
+      checkPublicPrecisionWithinPolicy(EXACT_LOCATION, 'locality'),
+      checkListingHasHousingIdentity({ addressIsCanonical: true, hasHousingIdentity: false }),
+    ];
+
+    expect(exercised.map((result) => result.code).sort()).toEqual([...INVARIANT_CODES].sort());
+    // Every one of them is a FAILING case, which is what makes the next
+    // assertion meaningful: a failure's detail is where a value would leak.
+    expect(exercised.every((result) => result.ok === false)).toBe(true);
+  });
+
+  it('reports classifications only — never a coordinate, a name or a query', () => {
+    const results: InvariantResult[] = [
+      checkQueryIdentityMatch(cityQuery(BARCELONA_ES), cityQuery(BARCELONA_VE)),
+      checkVisibleAreaMatchesQueriedArea(BARCELONA_ES.bounds, MADRID_ES.bounds),
+      checkPublicPrecisionWithinPolicy(EXACT_LOCATION, 'locality'),
+      checkGeocoderFallbackScope('error', 'none', 'global'),
+    ];
+
+    for (const result of results) {
+      // The same sweep the redaction layer runs on an outgoing event, applied
+      // to what a production divergence check would log.
+      expect(scanForSensitiveValues(result.safe, new Set())).toEqual([]);
+    }
+  });
+});
+
+describe('the query digest is pinned, not recomputed', () => {
+  // The SAME descriptor and the SAME expected strings as
+  // `packages/frontend/__tests__/observabilityContract.test.ts`. A list on the
+  // server and a map on a phone can only be compared if both tiers derive the
+  // identifier identically, and the two suites run through different
+  // transforms (ts-jest here, Babel there) and resolve the package by different
+  // routes (source path mapping here, `dist` there). Pinning the literal in
+  // both is what makes a divergence between them a red build rather than a
+  // silent false alarm in production.
+  const PINNED_QUERY = {
+    locationKind: 'city',
+    countryCode: 'ES',
+    placeKey: 'es-cat-barcelona',
+    center: { lat: 41.3874, lng: 2.1686 },
+    filters: { bedrooms: 2 },
+    sort: 'relevance',
+  } as const;
+
+  it('produces the pinned canonical form and id', () => {
+    expect(canonicalQueryDescriptor(PINNED_QUERY)).toBe(
+      'q1|kind=city|country=ES|place=es-cat-barcelona|center=41.387,2.169|radius=|bounds=|text=|sort=relevance|filters=bedrooms:2',
+    );
+    expect(deriveQueryId(PINNED_QUERY)).toBe('e795565c163c5c95');
+    expect(deriveOpaqueRef('unit', 'unit-4-2')).toBe('5fc3683bd64ae56a');
+  });
+});
+
+describe('1. list and map must be showing the same query', () => {
+  it('separates two cities that share a name', () => {
+    const result = checkQueryIdentityMatch(cityQuery(BARCELONA_ES), cityQuery(BARCELONA_VE));
+
+    expect(result.ok).toBe(false);
+    // A name-keyed scope would make these identical; the stable place key is
+    // the only field that differs in a way an implementation cannot fake.
+    expect(deriveQueryId(cityQuery(BARCELONA_ES))).not.toBe(
+      deriveQueryId(cityQuery(BARCELONA_VE)),
+    );
+    expect(canonicalQueryDescriptor(cityQuery(BARCELONA_ES))).toContain(BARCELONA_ES.placeKey);
+  });
+
+  it('agrees when two surfaces built the same query independently', () => {
+    // The positive control. Without it, an implementation that reports
+    // divergence for everything would pass every case above.
+    expect(checkQueryIdentityMatch(cityQuery(BARCELONA_ES), cityQuery(BARCELONA_ES)).ok).toBe(
+      true,
+    );
+  });
+
+  it('is stable across float noise inside the published grid cell', () => {
+    const nudged = {
+      ...cityQuery(BARCELONA_ES),
+      center: { lat: BARCELONA_ES.center.lat + 0.00004, lng: BARCELONA_ES.center.lng - 0.00004 },
+    };
+
+    // ~4 m, well inside the 3-decimal cell. Two surfaces that disagree at this
+    // scale are showing the same query, and a check that fires here is a check
+    // people switch off. Stated honestly: this is quantisation, not a
+    // tolerance — a pair straddling a cell boundary DOES get two ids, which is
+    // why the geometric invariant above works on real numbers instead.
+    expect(deriveQueryId(nudged)).toBe(deriveQueryId(cityQuery(BARCELONA_ES)));
+  });
+
+  it('catches a city filter that survived a move to another city', () => {
+    // The cross-filter leak: the map is over Madrid, and the request still
+    // carries Barcelona's city key. Bounds alone would not see this — the two
+    // descriptors have the SAME viewport.
+    const mapQuery = viewportQuery(MADRID_ES.bounds);
+    const listQuery = viewportQuery(MADRID_ES.bounds, { cityKey: BARCELONA_ES.placeKey });
+
+    expect(checkQueryIdentityMatch(listQuery, mapQuery).ok).toBe(false);
+    expect(
+      checkVisibleAreaMatchesQueriedArea(MADRID_ES.bounds, MADRID_ES.bounds).ok,
+    ).toBe(true);
+  });
+
+  it('treats free text and geographic scope as separate dimensions', () => {
+    // Principle 5 of the epic. Changing either one changes the query, and a
+    // digest that folded them together would let a text change silently reuse
+    // the previous area's results — or the reverse.
+    const inArea = viewportQuery(MADRID_ES.bounds);
+    const inAreaWithText = { ...inArea, freeText: 'ático con terraza' };
+    const elsewhereWithText = { ...viewportQuery(BARCELONA_ES.bounds), freeText: 'ático con terraza' };
+
+    expect(deriveQueryId(inAreaWithText)).not.toBe(deriveQueryId(inArea));
+    expect(deriveQueryId(inAreaWithText)).not.toBe(deriveQueryId(elsewhereWithText));
+    // Case and stray whitespace are keyboard noise, not a different search.
+    expect(deriveQueryId({ ...inArea, freeText: '  Ático CON terraza ' })).toBe(
+      deriveQueryId({ ...inArea, freeText: 'ático con terraza' }),
+    );
+  });
+
+  it('ignores the order filters were written in', () => {
+    const a = viewportQuery(MADRID_ES.bounds, { bedrooms: 2, furnished: true });
+    const b = viewportQuery(MADRID_ES.bounds, { furnished: true, bedrooms: 2 });
+
+    expect(deriveQueryId(a)).toBe(deriveQueryId(b));
+  });
+});
+
+describe('2. the visible area must be the queried area', () => {
+  it('rejects a Madrid viewport answered with Barcelona bounds', () => {
+    const result = checkVisibleAreaMatchesQueriedArea(MADRID_ES.bounds, BARCELONA_ES.bounds);
+
+    expect(result.ok).toBe(false);
+    expect(result.safe.overlapClass).toBe('none');
+  });
+
+  it('rejects two cities that share a name and nothing else', () => {
+    expect(
+      checkVisibleAreaMatchesQueriedArea(BARCELONA_ES.bounds, BARCELONA_VE.bounds).ok,
+    ).toBe(false);
+  });
+
+  it('accepts an antimeridian viewport compared with itself', () => {
+    // `east - west` on this box is -358. An implementation that computes the
+    // span that way reads it as empty or as the whole planet, and BOTH readings
+    // are silent — the second makes every comparison pass.
+    const result = checkVisibleAreaMatchesQueriedArea(
+      ANTIMERIDIAN_VIEWPORT,
+      ANTIMERIDIAN_VIEWPORT,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.safe.overlapClass).toBe('match');
+    expect(result.safe.visibleCrossesAntimeridian).toBe(true);
+  });
+
+  it('rejects an antimeridian viewport compared with its complement', () => {
+    // Same four numbers, west and east swapped: the rest of the planet. The
+    // pair shares not one square degree, so an implementation that treats the
+    // box as 358° wide reports a near-perfect match here.
+    const result = checkVisibleAreaMatchesQueriedArea(
+      ANTIMERIDIAN_VIEWPORT,
+      ANTIMERIDIAN_COMPLEMENT,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.safe.overlapClass).toBe('none');
+  });
+
+  it('tolerates a nudged viewport', () => {
+    const nudged = {
+      west: BARCELONA_ES.bounds.west + 0.005,
+      south: BARCELONA_ES.bounds.south + 0.005,
+      east: BARCELONA_ES.bounds.east + 0.005,
+      north: BARCELONA_ES.bounds.north + 0.005,
+    };
+
+    expect(checkVisibleAreaMatchesQueriedArea(nudged, BARCELONA_ES.bounds).ok).toBe(true);
+  });
+});
+
+describe('3. the visible label must describe the current selection', () => {
+  it('catches a header still reading Barcelona while Madrid is selected', () => {
+    const result = checkVisibleLabelMatchesSelection(
+      { renderedFrom: { kind: 'city', countryCode: 'ES', placeKey: BARCELONA_ES.placeKey } },
+      { kind: 'city', countryCode: 'ES', placeKey: MADRID_ES.placeKey },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.safe.placeMatch).toBe(false);
+    // Same kind, same country — only the place differs, which is exactly the
+    // case a coarse "is a location selected?" check would pass.
+    expect(result.safe.kindMatch).toBe(true);
+    expect(result.safe.countryMatch).toBe(true);
+  });
+
+  it('accepts a label rendered from the current selection', () => {
+    const scope = { kind: 'city', countryCode: 'ES', placeKey: BARCELONA_ES.placeKey } as const;
+    expect(checkVisibleLabelMatchesSelection({ renderedFrom: scope }, scope).ok).toBe(true);
+  });
+});
+
+describe('4. a result must answer the query that is current', () => {
+  it('flags a result for a superseded query', () => {
+    const first = deriveQueryId(cityQuery(BARCELONA_ES));
+    const second = deriveQueryId(cityQuery(MADRID_ES));
+
+    expect(checkResultIsForCurrentQuery(first, second).ok).toBe(false);
+    expect(checkResultIsForCurrentQuery(second, second).ok).toBe(true);
+  });
+});
+
+describe('5. a geocoder failure must never widen the scope to the world', () => {
+  const failures = ['timeout', 'rate_limited', 'error', 'empty'] as const;
+
+  it.each(failures)('refuses an unscoped search after a %s', (outcome) => {
+    // The silent shape: no fallback was "applied", the scope simply never
+    // existed, and the result reads as an ordinary unfiltered browse.
+    expect(checkGeocoderFallbackScope(outcome, 'none', 'none').ok).toBe(false);
+  });
+
+  it('refuses a worldwide fallback even when the geocoder succeeded', () => {
+    expect(checkGeocoderFallbackScope('ok', 'city', 'global').ok).toBe(false);
+  });
+
+  it('accepts a widened radius after a failure — a narrower scope is still a scope', () => {
+    const result = checkGeocoderFallbackScope('timeout', 'radius', 'widened_radius');
+
+    expect(result.ok).toBe(true);
+    expect(result.safe.worldwideFallback).toBe(false);
+  });
+
+  it('accepts the ordinary success path', () => {
+    expect(checkGeocoderFallbackScope('ok', 'city', 'none').ok).toBe(true);
+  });
+});
+
+describe('6. published precision must not exceed the policy', () => {
+  it('refuses an exact location published at locality precision', () => {
+    const result = checkPublicPrecisionWithinPolicy(EXACT_LOCATION, 'locality');
+
+    expect(result.ok).toBe(false);
+    expect(result.safe.observedDecimals).toBe(5);
+    expect(result.safe.allowedDecimals).toBe(PUBLIC_PRECISION_MAX_DECIMALS.locality);
+  });
+
+  it('accepts the approximation of the same place', () => {
+    // Renders identically at any zoom a person looks at. Only the decimal count
+    // tells them apart, which is why nothing but this check catches it.
+    expect(checkPublicPrecisionWithinPolicy(PUBLIC_APPROXIMATION, 'locality').ok).toBe(true);
+  });
+
+  it('catches float noise from a rounding that looked correct', () => {
+    const result = checkPublicPrecisionWithinPolicy(FLOAT_NOISE_APPROXIMATION, 'locality');
+
+    expect(result.ok).toBe(false);
+    expect(result.safe.observedDecimals).toBeGreaterThan(5);
+  });
+
+  it('counts decimals in exponent notation, where a naive scan reports zero', () => {
+    expect(decimalPlaces(1e-7)).toBe(7);
+    expect(decimalPlaces(41.38743)).toBe(5);
+    expect(decimalPlaces(41)).toBe(0);
+  });
+
+  it('permits unit precision where the policy allows it', () => {
+    expect(checkPublicPrecisionWithinPolicy(EXACT_LOCATION, 'unit').ok).toBe(true);
+  });
+});
+
+describe('7. a listing on a canonical address must carry its housing identity', () => {
+  it('flags an unlinked listing on a materialised address', () => {
+    expect(
+      checkListingHasHousingIdentity({ addressIsCanonical: true, hasHousingIdentity: false }).ok,
+    ).toBe(false);
+  });
+
+  it('permits an unlinked listing whose address is still a candidate', () => {
+    // Before materialisation there is nothing to link to, so requiring a link
+    // would fail every freshly ingested external listing.
+    expect(
+      checkListingHasHousingIdentity({ addressIsCanonical: false, hasHousingIdentity: false }).ok,
+    ).toBe(true);
+  });
+});
+
+describe('housing identity fixtures discriminate', () => {
+  it('keeps two units of one building apart', () => {
+    const [ground, fourth] = SAME_BUILDING_UNITS;
+
+    const groundRef = deriveOpaqueRef('unit', ground.unitKey);
+    const fourthRef = deriveOpaqueRef('unit', fourth.unitKey);
+    const buildingRef = deriveOpaqueRef('building', ground.buildingKey);
+
+    // An implementation keyed on the BUILDING gives these two the same
+    // reference and averages a 2 and a 5 into a 3.5 that describes neither home.
+    expect(groundRef).not.toBe(fourthRef);
+    expect(deriveOpaqueRef('building', fourth.buildingKey)).toBe(buildingRef);
+    expect(Math.abs(ground.reviewScore - fourth.reviewScore)).toBeGreaterThanOrEqual(3);
+  });
+
+  it('collapses three portal listings of one flat into one group', () => {
+    const unitKeys = new Set(DUPLICATE_LISTING_GROUP.map((listing) => listing.unitKey));
+    const listingKeys = new Set(DUPLICATE_LISTING_GROUP.map((listing) => listing.listingKey));
+
+    // Grouping on the listing id gives three groups of one; grouping on the
+    // dwelling gives one group of three.
+    expect(listingKeys.size).toBe(3);
+    expect(unitKeys.size).toBe(1);
+  });
+
+  it('changes the neighbourhood median when the duplicate is counted three times', () => {
+    const everyListing = PRICE_SAMPLE_WITH_DUPLICATE.map((listing) => listing.price.amount);
+
+    const lowestPerDwelling = new Map<string, number>();
+    for (const listing of PRICE_SAMPLE_WITH_DUPLICATE) {
+      const seen = lowestPerDwelling.get(listing.unitKey);
+      if (seen === undefined || listing.price.amount < seen) {
+        lowestPerDwelling.set(listing.unitKey, listing.price.amount);
+      }
+    }
+
+    expect(median(everyListing)).toBe(1225);
+    expect(median([...lowestPerDwelling.values()])).toBe(1125);
+  });
+
+  it('refuses to state a price spread across currencies', () => {
+    // Every amount is 1 200, so a naive spread reports 0%. The gap between
+    // 1 200 PLN and 1 200 USD is roughly fourfold, and the honest answer is the
+    // absence of a number rather than a converted one.
+    expect(priceSpreadBucketPct(MIXED_CURRENCY_GROUP)).toBeUndefined();
+  });
+
+  it('states the spread when the group is comparable', () => {
+    // 1 200 → 1 290 is 7.5%.
+    expect(priceSpreadBucketPct(DUPLICATE_LISTING_GROUP.map((listing) => listing.price))).toBe(
+      '5-15',
+    );
+  });
+});

--- a/packages/backend/__tests__/unit/observabilityIngest.test.ts
+++ b/packages/backend/__tests__/unit/observabilityIngest.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The ingest path: what a CLIENT sends, and what the sink actually records.
+ *
+ * The client already redacts before it posts. That is not a reason for the
+ * server to trust the result — an old bundle, a modified bundle, or something
+ * that is not our client at all reaches the same public route — so the server
+ * redacts again, and this file asserts on the transport's side of that second
+ * pass. It is the strongest available form of "inspect the final payload":
+ * everything upstream of this point could be wrong and these assertions would
+ * still be about the bytes that get recorded.
+ *
+ * The requests are exercised through the real Express app, not through the
+ * controller function, so the route's mounting, its body parser and its status
+ * contract are all part of what is verified.
+ */
+
+import express from 'express';
+import bodyParser from 'body-parser';
+import request from 'supertest';
+
+import {
+  OBSERVABILITY_SCHEMA_VERSION,
+  type ObservabilityEvent,
+} from '@homiio/shared-types';
+
+import { createIngestEventsHandler } from '../../controllers/observabilityController';
+import { ingestObservabilityEvents } from '../../observability/serverObservability';
+
+function appWithCapture(maxEvents = 20): {
+  app: express.Express;
+  captured: ObservabilityEvent[];
+} {
+  const captured: ObservabilityEvent[] = [];
+  const app = express();
+  app.use(bodyParser.json({ limit: '1mb' }));
+  app.post(
+    '/api/observability/events',
+    createIngestEventsHandler({
+      transport: (event) => captured.push(event),
+      maxEvents,
+    }),
+  );
+  return { app, captured };
+}
+
+/** A well-formed client event, envelope stamps and all. */
+const CLIENT_EVENT = {
+  event: 'map_area_search_committed',
+  schemaVersion: OBSERVABILITY_SCHEMA_VERSION,
+  occurredAt: 1_770_000_000_000,
+  surface: 'ios',
+  sessionId: 'abcdef0123456789',
+  queryId: '0123456789abcdef',
+  previousQueryId: 'fedcba9876543210',
+  countryCode: 'ES',
+  areaBucketKm2: '100-1000',
+  zoomBucket: 'city',
+  crossesAntimeridian: false,
+  priorScopeCleared: true,
+} as const;
+
+describe('POST /api/observability/events', () => {
+  it('records a well-formed client event verbatim, keeping its own surface and clock', () => {
+    const { app, captured } = appWithCapture();
+
+    return request(app)
+      .post('/api/observability/events')
+      .send({ events: [CLIENT_EVENT] })
+      .expect(202)
+      .then((response) => {
+        expect(response.body.data.accepted).toBe(1);
+        expect(response.body.data.refused).toBe(0);
+        expect(captured).toHaveLength(1);
+        // A phone's event relabelled `server` would be a lie about where it
+        // happened, so ingest preserves the client's surface and instant.
+        expect(captured[0]).toEqual({ ...CLIENT_EVENT });
+      });
+  });
+
+  it('refuses a client event carrying an exact address, and still answers 202', () => {
+    const { app, captured } = appWithCapture();
+
+    return request(app)
+      .post('/api/observability/events')
+      .send({
+        events: [{ ...CLIENT_EVENT, address: 'Carrer de Mallorca 401, 08013 Barcelona' }],
+      })
+      .expect(202)
+      .then((response) => {
+        // The STATUS never carries the verdict: a 4xx here teaches a client to
+        // retry, and a retry loop driven by telemetry is a self-inflicted
+        // outage. The body reports it instead.
+        expect(captured).toEqual([]);
+        expect(response.body.data.accepted).toBe(0);
+        expect(response.body.data.refused).toBe(1);
+        expect(response.body.data.violationsByCode).toMatchObject({ sensitive_value: 1 });
+      });
+  });
+
+  it('refuses exact coordinates smuggled through the wire', () => {
+    const { app, captured } = appWithCapture();
+
+    return request(app)
+      .post('/api/observability/events')
+      .send({ events: [{ ...CLIENT_EVENT, lat: 41.38743, lng: 2.1686 }] })
+      .expect(202)
+      .then(() => {
+        expect(captured).toEqual([]);
+      });
+  });
+
+  it('never echoes the offending value back to the caller', () => {
+    const { app } = appWithCapture();
+
+    return request(app)
+      .post('/api/observability/events')
+      .send({ events: [{ ...CLIENT_EVENT, reviewBody: 'The landlord kept the deposit' }] })
+      .expect(202)
+      .then((response) => {
+        // The response body is the one place a rejected value could come back
+        // out — into a client log, a proxy log, or a screenshot.
+        expect(JSON.stringify(response.body)).not.toContain('landlord');
+        expect(JSON.stringify(response.body)).not.toContain('deposit');
+      });
+  });
+
+  it('accepts the good events in a mixed batch and refuses only the bad ones', () => {
+    const { app, captured } = appWithCapture();
+
+    return request(app)
+      .post('/api/observability/events')
+      .send({
+        events: [
+          CLIENT_EVENT,
+          { ...CLIENT_EVENT, contactPhone: '+34600123456' },
+          { ...CLIENT_EVENT, queryId: 'not-an-opaque-id' },
+        ],
+      })
+      .expect(202)
+      .then((response) => {
+        // A broken event must not cost a client its good ones — otherwise a
+        // single client bug erases a whole cohort's telemetry.
+        expect(captured).toHaveLength(1);
+        expect(response.body.data.accepted).toBe(1);
+        expect(response.body.data.refused).toBe(2);
+      });
+  });
+
+  it('caps a batch rather than accepting an unbounded one, and reports the overflow', () => {
+    const { app, captured } = appWithCapture(2);
+
+    return request(app)
+      .post('/api/observability/events')
+      .send({ events: [CLIENT_EVENT, CLIENT_EVENT, CLIENT_EVENT, CLIENT_EVENT] })
+      .expect(202)
+      .then((response) => {
+        expect(captured).toHaveLength(2);
+        expect(response.body.data.overflowed).toBe(2);
+      });
+  });
+
+  it('answers 202 for a body that is not a batch at all', () => {
+    const { app, captured } = appWithCapture();
+
+    return request(app)
+      .post('/api/observability/events')
+      .send({ nonsense: true })
+      .expect(202)
+      .then((response) => {
+        expect(captured).toEqual([]);
+        expect(response.body.data.accepted).toBe(0);
+      });
+  });
+});
+
+describe('ingestObservabilityEvents', () => {
+  it('never throws, whatever it is handed', () => {
+    const inputs: unknown[] = [undefined, null, 'a string', 42, {}, [null, 'x', 7]];
+
+    for (const input of inputs) {
+      expect(() =>
+        ingestObservabilityEvents(input, { transport: () => {}, maxEvents: 10 }),
+      ).not.toThrow();
+    }
+  });
+
+  it('counts a throwing transport as a refusal instead of propagating it', () => {
+    const outcome = ingestObservabilityEvents([CLIENT_EVENT], {
+      transport: () => {
+        throw new Error('sink unavailable');
+      },
+      maxEvents: 10,
+    });
+
+    expect(outcome.accepted).toBe(0);
+    expect(outcome.refused).toBe(1);
+  });
+});

--- a/packages/backend/__tests__/unit/observabilityRedaction.test.ts
+++ b/packages/backend/__tests__/unit/observabilityRedaction.test.ts
@@ -1,0 +1,483 @@
+/**
+ * The redaction layer, tested against THE PAYLOAD THE TRANSPORT RECEIVES.
+ *
+ * That distinction is the whole point of this file, and it is why every
+ * assertion below reads from a captured array rather than from the object the
+ * caller passed in. Inspecting the pre-redaction object proves that the test
+ * author knew what they meant to send; only the captured payload proves what
+ * would have left the process.
+ *
+ * The careless caller is modelled with `Object.assign` onto a well-typed
+ * object rather than with a cast. That is not squeamishness about `as`: it is
+ * the faithful model. A field nobody declared arrives from a JavaScript call
+ * site, an older bundle, or a hand-written `fetch` — never from a call the
+ * compiler saw and approved — so a test that had to defeat the type system to
+ * express it would be testing a situation that cannot occur.
+ *
+ * Three anti-vacuity defences, because a redaction test that has silently
+ * stopped exercising anything looks exactly like one that passes:
+ *
+ *   1. a POSITIVE CONTROL — a well-formed event must be captured, so "nothing
+ *      was captured" cannot pass as "nothing sensitive was captured";
+ *   2. a COUNT FLOOR on the sensitive-payload table, so losing cases from it is
+ *      a failure rather than a quieter run;
+ *   3. an assertion that each refusal names the OFFENDING FIELD, so a refusal
+ *      for an unrelated reason — a typo in a fixture, a missing required field
+ *      — cannot be mistaken for the redaction working.
+ *
+ * Mutation evidence is in the pull-request body: breaking the allowlist and
+ * breaking the final sweep each turn specific named cases red.
+ */
+
+import {
+  OBSERVABILITY_SCHEMA_VERSION,
+  assertSchemaIsWellFormed,
+  createObservabilityEmitter,
+  redactObservabilityEvent,
+  scanForSensitiveValues,
+  type ObservabilityEmitInput,
+  type ObservabilityEvent,
+  type ObservabilityViolation,
+} from '@homiio/shared-types';
+
+/** A capturing transport. What lands here is what would have left the process. */
+function capturingTransport(): {
+  captured: ObservabilityEvent[];
+  transport: (event: ObservabilityEvent) => void;
+} {
+  const captured: ObservabilityEvent[] = [];
+  return { captured, transport: (event) => captured.push(event) };
+}
+
+const FIXED_NOW = 1_770_000_000_000;
+
+function emitterWithCapture(): {
+  captured: ObservabilityEvent[];
+  refusals: { event: string | null; violations: readonly ObservabilityViolation[] }[];
+  emitter: ReturnType<typeof createObservabilityEmitter>;
+} {
+  const { captured, transport } = capturingTransport();
+  const refusals: { event: string | null; violations: readonly ObservabilityViolation[] }[] = [];
+  const emitter = createObservabilityEmitter({
+    surface: 'web',
+    transport,
+    now: () => FIXED_NOW,
+    onRefused: (event, violations) => refusals.push({ event, violations }),
+  });
+  return { captured, refusals, emitter };
+}
+
+/** A valid `search_results_loaded` — the shape the issue documents as permitted. */
+const GOOD_SEARCH_RESULTS = {
+  queryId: '0123456789abcdef',
+  locationKind: 'city',
+  countryCode: 'ES',
+  resultCountBucket: '20-49',
+  radiusBucketKm: '10-25',
+  mapMode: true,
+  latencyBucketMs: '250-500',
+  stale: false,
+} as const;
+
+/** The same event with something a caller attached that the compiler never saw. */
+function carelessSearchResults(
+  extra: Record<string, unknown>,
+): ObservabilityEmitInput<'search_results_loaded'> {
+  const fields: ObservabilityEmitInput<'search_results_loaded'> = { ...GOOD_SEARCH_RESULTS };
+  Object.assign(fields, extra);
+  return fields;
+}
+
+describe('observability schema', () => {
+  it('is well formed', () => {
+    expect(assertSchemaIsWellFormed()).toEqual([]);
+  });
+
+  it('accepts the exact payload the issue documents as permitted', () => {
+    const { captured, emitter } = emitterWithCapture();
+
+    const result = emitter.emit('search_results_loaded', GOOD_SEARCH_RESULTS);
+
+    expect(result.status).toBe('emitted');
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toEqual({
+      event: 'search_results_loaded',
+      schemaVersion: OBSERVABILITY_SCHEMA_VERSION,
+      occurredAt: FIXED_NOW,
+      surface: 'web',
+      ...GOOD_SEARCH_RESULTS,
+    });
+  });
+
+  it('stamps version, clock and surface itself, whatever the caller supplied', () => {
+    const { captured, emitter } = emitterWithCapture();
+
+    emitter.emit(
+      'search_results_loaded',
+      // A caller cannot backdate an event, relabel which platform it came from,
+      // or claim a schema version the consumer does not support: the emitter
+      // applies its own stamps after the caller's fields, not before.
+      carelessSearchResults({
+        occurredAt: 1_700_000_000_000,
+        surface: 'server',
+        schemaVersion: 99,
+      }),
+    );
+
+    const [event] = captured;
+    expect(event?.occurredAt).toBe(FIXED_NOW);
+    expect(event?.surface).toBe('web');
+    expect(event?.schemaVersion).toBe(OBSERVABILITY_SCHEMA_VERSION);
+  });
+});
+
+/**
+ * Every one of these is something somebody could plausibly attach to an event,
+ * and every one must be absent from what the transport receives.
+ *
+ * `offender` is the field name the refusal must cite. Asserting only that a
+ * refusal happened is not enough: a fixture malformed for an unrelated reason
+ * is also refused, and would read as the redaction working.
+ */
+const SENSITIVE_PAYLOADS: readonly {
+  readonly what: string;
+  readonly offender: string;
+  readonly extra: Record<string, unknown>;
+}[] = [
+  {
+    what: 'a full street address',
+    offender: 'address',
+    extra: { address: 'Carrer de Mallorca 401, 08013 Barcelona' },
+  },
+  {
+    what: 'exact coordinates as numbers',
+    offender: 'lat',
+    extra: { lat: 41.38743, lng: 2.1686 },
+  },
+  {
+    what: 'exact coordinates smuggled into a string',
+    offender: 'coords',
+    extra: { coords: '41.38743,2.16860' },
+  },
+  {
+    what: 'a residence document reference',
+    offender: 'residencyDocument',
+    extra: { residencyDocument: 'padron-2026-4471982' },
+  },
+  {
+    what: 'a contact email',
+    offender: 'contactEmail',
+    extra: { contactEmail: 'inquilina@example.com' },
+  },
+  {
+    what: 'a contact phone with no separators',
+    offender: 'contactPhone',
+    extra: { contactPhone: '+34600123456' },
+  },
+  {
+    what: 'the text of a review',
+    offender: 'reviewBody',
+    extra: { reviewBody: 'The landlord kept the deposit and stopped answering' },
+  },
+  {
+    what: 'a free-text search term',
+    offender: 'freeText',
+    extra: { freeText: 'mallorca 401' },
+  },
+  {
+    what: 'a nested object that could hide anything at all',
+    offender: 'context',
+    extra: { context: { address: 'Carrer de Mallorca 401' } },
+  },
+];
+
+/**
+ * The other half of the rule: a value the sweep cannot fault is DROPPED and the
+ * event proceeds, because an older server must not lose a newer client's whole
+ * event over a field it has not heard of.
+ *
+ * The last two entries are the ones that matter most, and they are not
+ * harmless. A postcode and an account reference are label-shaped — short, no
+ * punctuation, no long digit run — so the sweep has nothing to object to. The
+ * ALLOWLIST is the only thing standing between them and a log line, which is
+ * why it is the primary mechanism and the sweep is the backstop rather than the
+ * other way round. Mutation-testing the allowlist turns exactly these cases red.
+ *
+ * Both halves of the rule are asserted, because having only the refusal half
+ * would let somebody "simplify" the drop path into a blanket refusal, breaking
+ * every deployment with a version skew, with a green suite.
+ */
+const DROPPED_BY_ALLOWLIST: readonly {
+  readonly what: string;
+  readonly field: string;
+  readonly extra: Record<string, unknown>;
+}[] = [
+  {
+    what: 'a field from a newer client build',
+    field: 'experimentArm',
+    // Distinctive enough that the absence assertion below means something: a
+    // one-character value occurs inside half the other fields by chance.
+    extra: { experimentArm: 'variant_b' },
+  },
+  {
+    what: 'an identifier of the wrong shape in the session field',
+    field: 'sessionId',
+    extra: { sessionId: '68f4a1b2c3d4e5f6a7b8c9d0' },
+  },
+  {
+    what: 'a postcode, which no value-level rule can recognise',
+    field: 'postcode',
+    extra: { postcode: '08013' },
+  },
+  {
+    what: 'an account reference shaped exactly like a permitted label',
+    field: 'landlordRef',
+    extra: { landlordRef: 'a1b2c3d4e5f6a7b8' },
+  },
+];
+
+describe('observability redaction — negative cases', () => {
+  it('has not lost its cases', () => {
+    // A floor, not an equality: adding a case is progress, losing one is not.
+    expect(SENSITIVE_PAYLOADS.length).toBeGreaterThanOrEqual(9);
+    expect(DROPPED_BY_ALLOWLIST.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it.each(SENSITIVE_PAYLOADS)('never lets $what reach the transport', ({ offender, extra }) => {
+    const { captured, refusals, emitter } = emitterWithCapture();
+
+    emitter.emit('search_results_loaded', carelessSearchResults(extra));
+
+    // THE ASSERTION THAT MATTERS: nothing at all reached the transport.
+    expect(captured).toEqual([]);
+
+    // And it was refused for the right reason, naming the right field.
+    const cited = refusals.flatMap((refusal) => refusal.violations);
+    expect(cited.map((violation) => violation.field)).toContain(offender);
+  });
+
+  it.each(DROPPED_BY_ALLOWLIST)(
+    'drops $what and lets the rest of the event through',
+    ({ field, extra }) => {
+      const { captured, refusals, emitter } = emitterWithCapture();
+
+      const result = emitter.emit('search_results_loaded', carelessSearchResults(extra));
+
+      expect(result.status).toBe('emitted');
+      expect(captured).toHaveLength(1);
+      // The field is gone from what the transport received, and so is its value.
+      expect(captured[0]).not.toHaveProperty(field);
+      expect(JSON.stringify(captured[0])).not.toContain(String(Object.values(extra)[0]));
+      // Dropped is not the same as unnoticed: the drop is reported, because a
+      // caller passing an undeclared field usually thinks it is passing
+      // something useful.
+      expect(refusals.flatMap((refusal) => refusal.violations).map((v) => v.field)).toContain(
+        field,
+      );
+    },
+  );
+
+  it('never puts the offending VALUE into the violation it reports', () => {
+    const { refusals, emitter } = emitterWithCapture();
+    const secret = 'Carrer de Mallorca 401, 08013 Barcelona';
+
+    emitter.emit('search_results_loaded', carelessSearchResults({ address: secret }));
+
+    // A violation record is itself logged. Putting the value in it would leak
+    // precisely what the refusal prevented.
+    expect(refusals).not.toHaveLength(0);
+    expect(JSON.stringify(refusals)).not.toContain('Mallorca');
+    expect(JSON.stringify(refusals)).not.toContain(secret);
+  });
+
+  it('refuses an event whose required field is missing rather than emitting a partial one', () => {
+    const { captured, emitter } = emitterWithCapture();
+
+    const result = emitter.emit(
+      'search_results_loaded',
+      carelessSearchResults({ resultCountBucket: undefined }),
+    );
+
+    expect(result.status).toBe('refused');
+    expect(captured).toEqual([]);
+    expect(result.violations).toContainEqual({
+      field: 'resultCountBucket',
+      code: 'missing_required',
+    });
+  });
+
+  it('refuses a bucket label that is not in the declared set', () => {
+    const { captured, emitter } = emitterWithCapture();
+
+    // `47` is the real count. A label outside the set is how an exact number
+    // gets out, and the closed enum is what stops it.
+    const result = emitter.emit(
+      'search_results_loaded',
+      carelessSearchResults({ resultCountBucket: '47' }),
+    );
+
+    expect(result.status).toBe('refused');
+    expect(captured).toEqual([]);
+    expect(result.violations).toContainEqual({
+      field: 'resultCountBucket',
+      code: 'invalid_value',
+    });
+  });
+
+  it('refuses an unknown event name outright', () => {
+    const result = redactObservabilityEvent({
+      event: 'user_signed_in',
+      schemaVersion: OBSERVABILITY_SCHEMA_VERSION,
+      occurredAt: FIXED_NOW,
+      surface: 'web',
+    });
+
+    expect(result.status).toBe('refused');
+    expect(result.event).toBeNull();
+    expect(result.violations).toContainEqual({ field: 'event', code: 'unknown_event' });
+  });
+
+  it('refuses an event stamped with a schema version this build does not support', () => {
+    const result = redactObservabilityEvent({
+      ...GOOD_SEARCH_RESULTS,
+      event: 'search_results_loaded',
+      schemaVersion: OBSERVABILITY_SCHEMA_VERSION + 1,
+      occurredAt: FIXED_NOW,
+      surface: 'web',
+    });
+
+    expect(result.status).toBe('refused');
+    expect(result.violations).toContainEqual({
+      field: 'schemaVersion',
+      code: 'unsupported_schema_version',
+    });
+  });
+
+  it('refuses a timestamp that is not a plausible instant', () => {
+    // 41.3874 is a latitude. It is also a number, and `occurredAt` is a number
+    // field — the epoch band is the only thing that tells them apart.
+    const result = redactObservabilityEvent({
+      ...GOOD_SEARCH_RESULTS,
+      event: 'search_results_loaded',
+      schemaVersion: OBSERVABILITY_SCHEMA_VERSION,
+      occurredAt: 41.3874,
+      surface: 'web',
+    });
+
+    expect(result.status).toBe('refused');
+    // Classified `sensitive_value` rather than merely invalid: a fractional
+    // number in a timestamp field is what an exact coordinate looks like.
+    expect(result.violations).toContainEqual({ field: 'occurredAt', code: 'sensitive_value' });
+  });
+
+  it('refuses anything that is not an object', () => {
+    const inputs: unknown[] = ['a string', 42, null, undefined, [GOOD_SEARCH_RESULTS]];
+    for (const input of inputs) {
+      const result = redactObservabilityEvent(input);
+      expect(result.status).toBe('refused');
+      expect(result.event).toBeNull();
+    }
+  });
+});
+
+describe('observability emitter behaviour', () => {
+  it('never throws when the transport does, and reports it instead', () => {
+    const emitter = createObservabilityEmitter({
+      surface: 'web',
+      now: () => FIXED_NOW,
+      transport: () => {
+        throw new Error('sink unavailable');
+      },
+    });
+
+    // Observability must not be able to break the action it observes.
+    const result = emitter.emit('search_results_loaded', GOOD_SEARCH_RESULTS);
+
+    expect(result.status).toBe('transport_error');
+    expect(emitter.stats().transportErrors).toBe(1);
+    expect(emitter.stats().emitted).toBe(0);
+  });
+
+  it('samples successful events but never samples a refusal away', () => {
+    const { captured, transport } = capturingTransport();
+    const emitter = createObservabilityEmitter({
+      surface: 'web',
+      transport,
+      now: () => FIXED_NOW,
+      // Drops everything the sampler is allowed to drop.
+      sampling: { default: 0 },
+      random: () => 0.999,
+    });
+
+    emitter.emit('search_results_loaded', GOOD_SEARCH_RESULTS);
+    emitter.emit(
+      'search_results_loaded',
+      carelessSearchResults({ address: 'Carrer de Mallorca 401' }),
+    );
+
+    expect(captured).toEqual([]);
+    const stats = emitter.stats();
+    expect(stats.sampledOut).toBe(1);
+    // The refusal is counted in full. A privacy defect that sampling could hide
+    // is a privacy defect nobody would ever see.
+    expect(stats.refused).toBe(1);
+    expect(stats.violationsByCode.sensitive_value).toBe(1);
+  });
+
+  it('measures review-step abandonment without identifying anybody', () => {
+    const { captured, emitter } = emitterWithCapture();
+    const wizardId = 'a1b2c3d4e5f60718';
+
+    emitter.emit('review_step_completed', {
+      wizardId,
+      stepId: 'identify_address',
+      stepIndex: 0,
+      durationBucketS: '30-120',
+    });
+    emitter.emit('review_abandoned', {
+      wizardId,
+      lastStepId: 'evidence',
+      lastStepIndex: 5,
+      durationBucketS: '120-600',
+      reason: 'navigated_away',
+    });
+
+    // The funnel is answerable — which step, how long, why it ended — and the
+    // only thing tying the two events together is a per-draft opaque reference
+    // that resolves to nobody.
+    expect(captured.map((event) => event.event)).toEqual([
+      'review_step_completed',
+      'review_abandoned',
+    ]);
+    for (const event of captured) {
+      const keys = Object.keys(event);
+      expect(keys).not.toContain('oxyUserId');
+      expect(keys).not.toContain('profileId');
+      expect(keys).not.toContain('addressId');
+      expect(scanForSensitiveValues(event, new Set(['wizardId']))).toEqual([]);
+    }
+  });
+
+  it('honours a per-event sampling override', () => {
+    const { captured, transport } = capturingTransport();
+    const emitter = createObservabilityEmitter({
+      surface: 'web',
+      transport,
+      now: () => FIXED_NOW,
+      sampling: { default: 0, perEvent: { search_zero_results: 1 } },
+      random: () => 0.5,
+    });
+
+    emitter.emit('search_results_loaded', GOOD_SEARCH_RESULTS);
+    emitter.emit('search_zero_results', {
+      queryId: '0123456789abcdef',
+      locationKind: 'city',
+      countryCode: 'ES',
+      filterCount: 3,
+      hasFreeText: false,
+      fallbackApplied: 'none',
+    });
+
+    expect(captured.map((event) => event.event)).toEqual(['search_zero_results']);
+  });
+});

--- a/packages/backend/config.ts
+++ b/packages/backend/config.ts
@@ -18,6 +18,22 @@ function boundedInteger(
   return Math.min(Math.max(parsed, minimum), maximum);
 }
 
+/**
+ * A sampling probability in [0, 1], or 1 when the variable is absent or
+ * unparseable.
+ *
+ * The fallback direction matters and is the opposite of `boundedInteger`'s
+ * conservatism: a typo that read as 0 would silently stop recording while every
+ * gate stayed green, which is exactly the "check that cannot fail" shape this
+ * repository keeps finding. Recording too much is visible; recording nothing is
+ * not.
+ */
+function observabilitySampleRate(raw: string | undefined): number {
+  const parsed = Number.parseFloat(raw || '');
+  if (!Number.isFinite(parsed)) return 1;
+  return Math.min(Math.max(parsed, 0), 1);
+}
+
 const CROWDSOURCE_ENFORCEMENT_MODES: readonly ModerationEnforcementMode[] = [
   'observe',
   'manual',
@@ -130,6 +146,20 @@ export interface Config {
   logging: {
     level: string;
     file: string;
+  };
+  /**
+   * Privacy-safe product observability (#350). Off by default in every
+   * environment: an events pipeline that starts recording because somebody
+   * deployed is the opposite of the consent posture this feature is for.
+   *
+   * `sampleRate` applies to events that PASS redaction. Refusals are never
+   * sampled away — see `packages/shared-types/src/observability/emitter.ts`.
+   */
+  observability: {
+    enabled: boolean;
+    sampleRate: number;
+    /** Cap on events accepted from one ingest request. */
+    maxEventsPerRequest: number;
   };
   stripe?: {
     secretKey?: string;
@@ -373,7 +403,16 @@ const config: Config = {
     level: process.env.LOG_LEVEL || 'info',
     file: process.env.LOG_FILE || (process.env.VERCEL ? '/tmp/app.log' : './logs/app.log'),
   },
-  
+
+  // Privacy-safe product observability (#350). See the Config interface above:
+  // OFF unless explicitly enabled, and a malformed sample rate reads as 1
+  // rather than as 0 — a typo must not silently stop recording.
+  observability: {
+    enabled: process.env.OBSERVABILITY_ENABLED === 'true',
+    sampleRate: observabilitySampleRate(process.env.OBSERVABILITY_SAMPLE_RATE),
+    maxEventsPerRequest: boundedInteger(process.env.OBSERVABILITY_MAX_EVENTS_PER_REQUEST, 20, 1, 100),
+  },
+
   // Web frontend base URL — single source for server-built deep links.
   web: {
     baseUrl: process.env.FRONTEND_URL ||

--- a/packages/backend/controllers/observabilityController.ts
+++ b/packages/backend/controllers/observabilityController.ts
@@ -1,0 +1,81 @@
+/**
+ * Ingest for client-originated observability events (#350).
+ *
+ * PUBLIC AND UNAUTHENTICATED, deliberately. The most important events in the
+ * vocabulary happen before anybody signs in — the permission prompt on first
+ * open, the first search, the fallback after a geocoder failure — and requiring
+ * a session would leave exactly the cold-start path this exists to observe
+ * unobserved. Nothing here reads `req.user`, and the events carry no identity:
+ * `sessionId` is a rotating opaque reference the client mints and the
+ * `opaqueId` field kind refuses a user id outright.
+ *
+ * It inherits `server.ts`'s global `/api` rate limiter, which keys anonymous
+ * traffic on a salted HMAC of the client IP, so the route needs no limiter of
+ * its own.
+ *
+ * ALWAYS ANSWERS 202. A telemetry endpoint that returns 4xx or 5xx teaches a
+ * client to retry, and a retry loop driven by telemetry is an outage this
+ * service inflicted on itself. The body reports what was accepted and what was
+ * refused so a client (and a test) can see the difference; the STATUS never
+ * carries that information.
+ */
+
+import type { Request, Response } from 'express';
+
+import { successResponse } from '../middlewares/errorHandler';
+import config from '../config';
+import {
+  defaultIngestOptions,
+  ingestObservabilityEvents,
+  type ObservabilityIngestOptions,
+} from '../observability/serverObservability';
+
+/**
+ * `POST /api/observability/events`
+ *
+ * Body: `{ "events": [ <flat event>, ... ] }`. Anything else — a bare array, a
+ * string, a missing key — yields `accepted: 0` rather than an error, for the
+ * reason in the module header.
+ *
+ * A FACTORY rather than a bare handler with an optional third parameter: this
+ * is mounted through `asyncHandler`, so Express would pass `next` as that third
+ * argument and the "default" would never be reached. The seam has to be closed
+ * over, not defaulted.
+ */
+export function createIngestEventsHandler(
+  options?: ObservabilityIngestOptions,
+): (req: Request, res: Response) => Promise<void> {
+  return async (req: Request, res: Response): Promise<void> => {
+    // Resolved per call when not injected, so `config` is read after dotenv and
+    // a test that changes the flag does not need to reload the module.
+    const resolved = options ?? defaultIngestOptions();
+
+    const body: unknown = req.body;
+    const events =
+      typeof body === 'object' && body !== null && !Array.isArray(body)
+        ? (body as Record<string, unknown>).events
+        : undefined;
+
+    const outcome = ingestObservabilityEvents(events, resolved);
+
+    res.status(202).json(
+      successResponse(
+        {
+          accepted: outcome.accepted,
+          refused: outcome.refused,
+          overflowed: outcome.overflowed,
+          // Codes and counts. A caller learns THAT something was refused and
+          // under which rule, never which value tripped it.
+          violationsByCode: outcome.violationsByCode,
+          recording: config.observability.enabled,
+        },
+        'Accepted',
+      ),
+    );
+  };
+}
+
+/** The handler `routes/public.ts` mounts. */
+export const ingestEvents = createIngestEventsHandler();
+
+export default { createIngestEventsHandler, ingestEvents };

--- a/packages/backend/observability/serverObservability.ts
+++ b/packages/backend/observability/serverObservability.ts
@@ -1,0 +1,188 @@
+/**
+ * Homiio's own observability sink. No third-party SDK is involved, here or
+ * anywhere in this pipeline — the issue forbids adding one without an explicit
+ * privacy review, and nothing in the repository sends product telemetry to a
+ * vendor today (`grep -i posthog|mixpanel|amplitude|@segment/` over the tracked
+ * tree returns nothing, and `@bitdrift/react-native` appears only as an Expo
+ * config-plugin entry with no JS import).
+ *
+ * The sink is the structured logger, and that is a deliberate ceiling rather
+ * than a placeholder. A table would make this a business-intelligence system,
+ * which the issue puts explicitly out of scope; a log line is queryable by the
+ * same tooling that already reads this service, and RETENTION becomes the log
+ * group's retention — one setting, owned by `oxy-infra`, rather than a
+ * per-event policy nobody maintains.
+ *
+ * TWO ENTRY POINTS, AND THEY ARE NOT INTERCHANGEABLE
+ * --------------------------------------------------
+ *   - `serverObservability()` emits events this process ORIGINATES. It stamps
+ *     `surface: 'server'` and its own clock.
+ *   - `ingestObservabilityEvents()` accepts events a CLIENT originated. It must
+ *     preserve the client's `surface` and `occurredAt` — a phone's event
+ *     relabelled `server` is a lie about where it happened — so it redacts
+ *     without re-stamping, and does not sample (the client already did).
+ *
+ * Both go through `redactObservabilityEvent`. The client redacting first is not
+ * a reason for the server to trust the result: an old build, a modified build
+ * or something that is not our client at all reaches the same route.
+ */
+
+import {
+  createObservabilityEmitter,
+  redactObservabilityEvent,
+  type ObservabilityEmitter,
+  type ObservabilityEvent,
+  type ObservabilityEventName,
+  type ObservabilityTransport,
+  type ObservabilityViolation,
+  type ObservabilityViolationCode,
+} from '@homiio/shared-types';
+
+import config from '../config';
+import { logger } from '../middlewares/logging';
+
+/** The log message every observability line carries, so one query finds them all. */
+export const OBSERVABILITY_LOG_MESSAGE = 'observability_event';
+/** And the one every refusal carries. Field names and codes only, never values. */
+export const OBSERVABILITY_REFUSED_LOG_MESSAGE = 'observability_event_refused';
+
+/**
+ * The production transport: one structured log line per event.
+ *
+ * `logger.info` spreads its meta into the entry, so every field of the event
+ * lands at the top level of the line and is directly queryable.
+ */
+export function createLoggerTransport(): ObservabilityTransport {
+  return (event: ObservabilityEvent): void => {
+    logger.info(OBSERVABILITY_LOG_MESSAGE, { ...event });
+  };
+}
+
+function logRefusal(
+  eventName: ObservabilityEventName | null,
+  violations: readonly ObservabilityViolation[],
+): void {
+  logger.warn(OBSERVABILITY_REFUSED_LOG_MESSAGE, {
+    observedEvent: eventName ?? 'unknown',
+    // Names and codes. The value that caused the refusal is exactly what must
+    // not reach a log line — that is what the refusal prevented.
+    violations: violations.map((violation) => `${violation.field}:${violation.code}`),
+  });
+}
+
+/**
+ * A transport that discards.
+ *
+ * Used when `config.observability.enabled` is false, which is the default in
+ * every environment. Callers still run the full redaction path, so a payload
+ * defect is caught in development and in CI whether or not anything is being
+ * recorded — an event pipeline whose validation only runs when it is switched
+ * on would be first exercised in production.
+ */
+const discardingTransport: ObservabilityTransport = () => {};
+
+let emitter: ObservabilityEmitter | null = null;
+
+/**
+ * The process-wide emitter for server-originated events.
+ *
+ * Built lazily so that reading `config` at import time cannot reorder against
+ * the dotenv load, and memoised so `stats()` accumulates across the process.
+ */
+export function serverObservability(): ObservabilityEmitter {
+  if (emitter === null) {
+    emitter = createObservabilityEmitter({
+      surface: 'server',
+      transport: config.observability.enabled ? createLoggerTransport() : discardingTransport,
+      sampling: { default: config.observability.sampleRate },
+      onRefused: logRefusal,
+      onTransportError: (error: unknown) => {
+        logger.error('observability_transport_failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      },
+    });
+  }
+  return emitter;
+}
+
+/** Test seam: drop the memoised emitter so a test can rebuild it under new config. */
+export function resetServerObservability(): void {
+  emitter = null;
+}
+
+export interface ObservabilityIngestOutcome {
+  readonly accepted: number;
+  readonly refused: number;
+  readonly overflowed: number;
+  readonly violationsByCode: Readonly<Partial<Record<ObservabilityViolationCode, number>>>;
+}
+
+export interface ObservabilityIngestOptions {
+  /** Where accepted events go. Injected so a test can capture the FINAL payload. */
+  readonly transport: ObservabilityTransport;
+  readonly maxEvents: number;
+  readonly onRefused?: (
+    eventName: ObservabilityEventName | null,
+    violations: readonly ObservabilityViolation[],
+  ) => void;
+}
+
+/**
+ * Redact and forward a batch of client-originated events.
+ *
+ * Never throws, for any input. The caller is an HTTP handler whose only correct
+ * response to a broken telemetry payload is to accept the request and record
+ * that it refused the contents — a 500 here would teach a client to retry, and
+ * a retry loop driven by telemetry is a self-inflicted outage.
+ */
+export function ingestObservabilityEvents(
+  input: unknown,
+  options: ObservabilityIngestOptions,
+): ObservabilityIngestOutcome {
+  const batch = Array.isArray(input) ? input : [];
+  const considered = batch.slice(0, options.maxEvents);
+  const overflowed = batch.length - considered.length;
+
+  let accepted = 0;
+  let refused = 0;
+  const violationsByCode: Partial<Record<ObservabilityViolationCode, number>> = {};
+
+  for (const raw of considered) {
+    const result = redactObservabilityEvent(raw);
+    for (const violation of result.violations) {
+      violationsByCode[violation.code] = (violationsByCode[violation.code] ?? 0) + 1;
+    }
+
+    if (result.status === 'refused') {
+      refused += 1;
+      options.onRefused?.(result.eventName, result.violations);
+      continue;
+    }
+
+    if (result.violations.length > 0) {
+      options.onRefused?.(result.eventName, result.violations);
+    }
+
+    try {
+      options.transport(result.event);
+      accepted += 1;
+    } catch (error) {
+      refused += 1;
+      logger.error('observability_transport_failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return { accepted, refused, overflowed, violationsByCode };
+}
+
+/** The options the HTTP handler uses, split out so a test can assert them. */
+export function defaultIngestOptions(): ObservabilityIngestOptions {
+  return {
+    transport: config.observability.enabled ? createLoggerTransport() : discardingTransport,
+    maxEvents: config.observability.maxEventsPerRequest,
+    onRefused: logRefusal,
+  };
+}

--- a/packages/backend/routes/public.ts
+++ b/packages/backend/routes/public.ts
@@ -8,6 +8,7 @@ import neighborhoodRoutes from './neighborhoods';
 import cityController from '../controllers/cityController';
 import imageController from '../controllers/imageController';
 import geocodingController from '../controllers/geocodingController';
+import observabilityController from '../controllers/observabilityController';
 import * as propertyController from '../controllers/property';
 import telegramController from '../controllers/telegramController';
 import analyticsController from '../controllers/analyticsController';
@@ -66,6 +67,12 @@ export default function () {
   // Public geocoding routes
   router.get('/geocoding/reverse', asyncHandler(geocodingController.reverseGeocode));
   router.get('/geocoding/forward', asyncHandler(geocodingController.forwardGeocode));
+
+  // Privacy-safe product observability ingest (#350). Unauthenticated on
+  // purpose — the first-open, permission and geocoder-fallback events this
+  // exists to see all happen before anybody signs in. See the controller
+  // header; it always answers 202 and reads nothing from `req.user`.
+  router.post('/observability/events', asyncHandler(observabilityController.ingestEvents));
 
   // Public review READ routes (community notes). These are community-visible
   // building/unit reviews surfaced on the property-detail screen — the

--- a/packages/frontend/__tests__/observabilityContract.test.ts
+++ b/packages/frontend/__tests__/observabilityContract.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The observability contract, from the FRONTEND's side of the workspace.
+ *
+ * The redaction layer and the query-identity digest live in
+ * `@homiio/shared-types` because there must be exactly one implementation of
+ * each: eight of the thirteen events in the vocabulary originate on a phone or
+ * in a browser, and a second copy of the privacy rules is a second place for
+ * them to be wrong silently. This file is what makes that claim testable from
+ * here rather than asserted.
+ *
+ * WHAT IT PROVES AND WHAT IT DOES NOT
+ * -----------------------------------
+ * It proves three things the backend suite cannot: that the package RESOLVES
+ * from this workspace (the frontend reaches it through `dist`, not through the
+ * source path mapping the backend's jest uses); that it survives this app's
+ * Babel transform rather than the backend's ts-jest one; and that the digest
+ * agrees, byte for byte, with the value the backend suite pins.
+ *
+ * It does NOT prove Hermes. `jest-expo` runs on Node, so a divergence that only
+ * appears on a device — the reason `deriveQueryId` avoids `BigInt`,
+ * `String.prototype.normalize` and anything else Hermes may not carry — would
+ * still get past it. Saying so here rather than letting the file's existence
+ * imply otherwise.
+ */
+
+import {
+  canonicalQueryDescriptor,
+  deriveOpaqueRef,
+  deriveQueryId,
+  isOpaqueId,
+  redactObservabilityEvent,
+  OBSERVABILITY_SCHEMA_VERSION,
+  type QueryDescriptor,
+} from '@homiio/shared-types';
+
+/** The same descriptor the backend suite pins, field for field. */
+const BARCELONA_QUERY: QueryDescriptor = {
+  locationKind: 'city',
+  countryCode: 'ES',
+  placeKey: 'es-cat-barcelona',
+  center: { lat: 41.3874, lng: 2.1686 },
+  filters: { bedrooms: 2 },
+  sort: 'relevance',
+};
+
+describe('shared observability contract, as the frontend sees it', () => {
+  it('produces the pinned canonical form', () => {
+    // Pinned rather than recomputed: the point is that a change to the
+    // canonicalisation is a DELIBERATE, visible change. A test that recomputes
+    // the expected value with the same function passes under any refactor,
+    // including one that quietly stops including the place key.
+    expect(canonicalQueryDescriptor(BARCELONA_QUERY)).toBe(
+      'q1|kind=city|country=ES|place=es-cat-barcelona|center=41.387,2.169|radius=|bounds=|text=|sort=relevance|filters=bedrooms:2',
+    );
+  });
+
+  it('produces the pinned query id, identical to the backend suite', () => {
+    expect(deriveQueryId(BARCELONA_QUERY)).toBe('e795565c163c5c95');
+    expect(isOpaqueId(deriveQueryId(BARCELONA_QUERY))).toBe(true);
+  });
+
+  it('produces the pinned opaque reference', () => {
+    expect(deriveOpaqueRef('unit', 'unit-4-2')).toBe('5fc3683bd64ae56a');
+  });
+
+  it('refuses a client event carrying an address, here as on the server', () => {
+    const result = redactObservabilityEvent({
+      event: 'search_results_loaded',
+      schemaVersion: OBSERVABILITY_SCHEMA_VERSION,
+      occurredAt: 1_770_000_000_000,
+      surface: 'ios',
+      queryId: 'e795565c163c5c95',
+      locationKind: 'city',
+      countryCode: 'ES',
+      resultCountBucket: '20-49',
+      mapMode: true,
+      latencyBucketMs: '250-500',
+      stale: false,
+      address: 'Carrer de Mallorca 401, 08013 Barcelona',
+    });
+
+    expect(result.status).toBe('refused');
+    expect(result.event).toBeNull();
+    expect(result.violations.map((violation) => violation.field)).toContain('address');
+  });
+
+  it('accepts the same event without the address', () => {
+    // The positive control. Without it, a build in which every event is refused
+    // would pass the case above.
+    const result = redactObservabilityEvent({
+      event: 'search_results_loaded',
+      schemaVersion: OBSERVABILITY_SCHEMA_VERSION,
+      occurredAt: 1_770_000_000_000,
+      surface: 'ios',
+      queryId: 'e795565c163c5c95',
+      locationKind: 'city',
+      countryCode: 'ES',
+      resultCountBucket: '20-49',
+      mapMode: true,
+      latencyBucketMs: '250-500',
+      stale: false,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.violations).toEqual([]);
+  });
+});

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -64,3 +64,8 @@ export * from './utils/propertyTitle';
 
 // Ethical rental pricing calculator (shared frontend + backend)
 export * from './ethicalPricing';
+
+// Privacy-safe product observability: versioned event schema, central
+// redaction, bucketing, query identity and the location/identity divergence
+// invariants. Shared so the redaction rules have exactly one implementation.
+export * from './observability';

--- a/packages/shared-types/src/observability/buckets.ts
+++ b/packages/shared-types/src/observability/buckets.ts
@@ -1,0 +1,207 @@
+/**
+ * Bucketing helpers for privacy-safe product observability.
+ *
+ * Every quantity an event may carry is reduced to a LABEL from a closed set
+ * before it leaves the process. That is not a formatting preference: it is the
+ * mechanism that makes an exact value impossible to emit. A raw result count,
+ * a raw radius or a raw latency is a fingerprint that can be joined back to one
+ * person's session; a label out of six is not.
+ *
+ * The three bucket sets the issue's own example payload names — result count,
+ * radius and latency — use exactly the boundaries that example uses
+ * (`'20-49'`, `'10-25'`, `'250-500'`), so a payload written from the issue
+ * validates against this schema unchanged.
+ *
+ * Every function here is total: it accepts any finite number and returns a
+ * label. A non-finite or negative input returns the lowest band rather than
+ * throwing, because observability must never be able to break the action it is
+ * observing.
+ */
+
+/** How many results a query returned. */
+export const RESULT_COUNT_BUCKETS = ['0', '1-4', '5-19', '20-49', '50-199', '200+'] as const;
+export type ResultCountBucket = (typeof RESULT_COUNT_BUCKETS)[number];
+
+/** Search radius, in kilometres. */
+export const RADIUS_BUCKETS_KM = [
+  '0-1',
+  '1-5',
+  '5-10',
+  '10-25',
+  '25-50',
+  '50-100',
+  '100+',
+] as const;
+export type RadiusBucketKm = (typeof RADIUS_BUCKETS_KM)[number];
+
+/** Wall-clock latency of a single request, in milliseconds. */
+export const LATENCY_BUCKETS_MS = [
+  '0-100',
+  '100-250',
+  '250-500',
+  '500-1000',
+  '1000-3000',
+  '3000+',
+] as const;
+export type LatencyBucketMs = (typeof LATENCY_BUCKETS_MS)[number];
+
+/**
+ * How long a person spent on something, in seconds. Deliberately coarser than
+ * the latency scale: a per-step duration measured to the millisecond is close
+ * to a behavioural fingerprint, and the questions this answers ("which review
+ * step do people abandon?") are answered at this resolution.
+ */
+export const DURATION_BUCKETS_S = ['0-5', '5-30', '30-120', '120-600', '600+'] as const;
+export type DurationBucketS = (typeof DURATION_BUCKETS_S)[number];
+
+/** Area of a map viewport that was searched, in square kilometres. */
+export const AREA_BUCKETS_KM2 = [
+  '0-1',
+  '1-10',
+  '10-100',
+  '100-1000',
+  '1000-10000',
+  '10000+',
+] as const;
+export type AreaBucketKm2 = (typeof AREA_BUCKETS_KM2)[number];
+
+/**
+ * Map zoom expressed as what a person can see, not as a tile-server integer.
+ * The integer is a proxy for scale and its meaning differs per renderer; the
+ * label does not.
+ */
+export const ZOOM_BUCKETS = [
+  'world',
+  'country',
+  'region',
+  'city',
+  'district',
+  'street',
+] as const;
+export type ZoomBucket = (typeof ZOOM_BUCKETS)[number];
+
+/**
+ * Length of a free-text search term. The term itself is NEVER emitted — it can
+ * contain a street, a building name or a landlord's name — but whether people
+ * type at all, and roughly how much, is what tells us if free text and
+ * geographic scope are being confused for each other.
+ */
+export const TEXT_LENGTH_BUCKETS = ['0', '1-10', '11-30', '31-80', '80+'] as const;
+export type TextLengthBucket = (typeof TEXT_LENGTH_BUCKETS)[number];
+
+/** Spread between the cheapest and dearest member of a duplicate group, in per cent. */
+export const PERCENT_SPREAD_BUCKETS = ['0-5', '5-15', '15-30', '30-60', '60+'] as const;
+export type PercentSpreadBucket = (typeof PERCENT_SPREAD_BUCKETS)[number];
+
+/**
+ * Map a value onto a band by its upper bounds.
+ *
+ * `bounds[i]` is the exclusive upper bound of `labels[i]`; the last label is
+ * the overflow and has no bound. A non-finite or negative input lands in the
+ * first band — see the module header for why this cannot throw.
+ */
+function bucketBy<T extends string>(
+  value: number,
+  bounds: readonly number[],
+  labels: readonly T[],
+): T {
+  const first = labels[0];
+  const overflow = labels[labels.length - 1];
+  if (first === undefined || overflow === undefined) {
+    throw new Error('bucketBy requires a non-empty label list');
+  }
+  if (!Number.isFinite(value) || value < 0) return first;
+  for (let i = 0; i < bounds.length; i += 1) {
+    const bound = bounds[i];
+    const label = labels[i];
+    if (bound !== undefined && label !== undefined && value < bound) return label;
+  }
+  return overflow;
+}
+
+/** Bucket a result count. `0` is its own band — zero results is a distinct outcome. */
+export function resultCountBucket(count: number): ResultCountBucket {
+  return bucketBy(count, [1, 5, 20, 50, 200], RESULT_COUNT_BUCKETS);
+}
+
+/** Bucket a search radius in kilometres. */
+export function radiusBucketKm(km: number): RadiusBucketKm {
+  return bucketBy(km, [1, 5, 10, 25, 50, 100], RADIUS_BUCKETS_KM);
+}
+
+/** Bucket a request latency in milliseconds. */
+export function latencyBucketMs(ms: number): LatencyBucketMs {
+  return bucketBy(ms, [100, 250, 500, 1000, 3000], LATENCY_BUCKETS_MS);
+}
+
+/** Bucket a person-facing duration in seconds. */
+export function durationBucketS(seconds: number): DurationBucketS {
+  return bucketBy(seconds, [5, 30, 120, 600], DURATION_BUCKETS_S);
+}
+
+/** Bucket a viewport area in square kilometres. */
+export function areaBucketKm2(km2: number): AreaBucketKm2 {
+  return bucketBy(km2, [1, 10, 100, 1000, 10000], AREA_BUCKETS_KM2);
+}
+
+/** Bucket a free-text term by its length. The term itself never leaves. */
+export function textLengthBucket(length: number): TextLengthBucket {
+  return bucketBy(length, [1, 11, 31, 81], TEXT_LENGTH_BUCKETS);
+}
+
+/** Bucket a percentage spread. */
+export function percentSpreadBucket(percent: number): PercentSpreadBucket {
+  return bucketBy(percent, [5, 15, 30, 60], PERCENT_SPREAD_BUCKETS);
+}
+
+/** One member's asking price, with the currency it is quoted in. */
+export interface PricedListing {
+  readonly amount: number;
+  /** ISO-4217, e.g. `EUR`. */
+  readonly currency: string;
+}
+
+/**
+ * Spread across a duplicate group, or `undefined` when the group is not
+ * comparable.
+ *
+ * The refusal is the point. Homiio aggregates portals across EUR, USD, PLN and
+ * RON, so `(max - min) / min` over a mixed-currency group is arithmetic on
+ * unlike quantities: 1200 PLN beside 1200 EUR reads as a 0% spread when the
+ * real gap is roughly fourfold, and 350 000 RON beside 350 000 USD reads the
+ * same way. A converted figure would need a rate, a rate date and a provenance
+ * — which is #369's problem, not an observability event's — so the honest
+ * answer here is to omit the field. `priceSpreadBucketPct` is optional in the
+ * schema precisely so that "not comparable" has a representation.
+ *
+ * Also `undefined` for fewer than two members (nothing to spread) and for a
+ * non-positive minimum (a division that would report `Infinity`).
+ */
+export function priceSpreadBucketPct(
+  members: readonly PricedListing[],
+): PercentSpreadBucket | undefined {
+  if (members.length < 2) return undefined;
+
+  const first = members[0];
+  if (first === undefined) return undefined;
+  if (members.some((member) => member.currency !== first.currency)) return undefined;
+
+  const amounts = members.map((member) => member.amount).filter((amount) => Number.isFinite(amount));
+  if (amounts.length !== members.length) return undefined;
+
+  const min = Math.min(...amounts);
+  const max = Math.max(...amounts);
+  if (min <= 0) return undefined;
+
+  return percentSpreadBucket(((max - min) / min) * 100);
+}
+
+/**
+ * Map a map zoom level onto a scale label.
+ *
+ * The boundaries follow the web-mercator convention every renderer Homiio uses
+ * shares (MapLibre, Leaflet, Google): z0 is the whole world, z≈16 is a street.
+ */
+export function zoomBucket(zoom: number): ZoomBucket {
+  return bucketBy(zoom, [3, 6, 9, 12, 15], ZOOM_BUCKETS);
+}

--- a/packages/shared-types/src/observability/emitter.ts
+++ b/packages/shared-types/src/observability/emitter.ts
@@ -1,0 +1,191 @@
+/**
+ * The emitter every caller uses, on the client and on the server alike.
+ *
+ * Three properties it is built around, all of them requirements from the issue
+ * rather than preferences:
+ *
+ *   1. **It cannot block the action it observes.** `emit` is synchronous,
+ *      returns a status and never throws — not for a malformed payload, not for
+ *      a transport that rejects, not for a transport that throws outright. A
+ *      search must still run when telemetry is broken.
+ *   2. **Everything goes through `redactObservabilityEvent`.** There is no
+ *      second path to the transport, which is what makes the "inspect the final
+ *      payload" tests meaningful: what the transport receives IS what would
+ *      leave the process.
+ *   3. **Sampling is applied AFTER redaction, never before.** A dropped or
+ *      refused event is a defect signal, and sampling it away would hide the
+ *      one class of event nobody may lose. Refusals are always counted and
+ *      always reported to `onRefused`; only successful events are sampled.
+ *
+ * The transport is injected. In a test it is a capturing array; on the server
+ * it is the structured logger; on the client it is a batched POST to Homiio's
+ * own ingest route. No third-party SDK is involved anywhere in this pipeline.
+ */
+
+import {
+  OBSERVABILITY_SCHEMA_VERSION,
+  type ObservabilityEvent,
+  type ObservabilityEventName,
+  type ObservabilityPayloads,
+  type ObservabilitySurface,
+} from './schema';
+import {
+  redactObservabilityEvent,
+  type ObservabilityViolation,
+  type ObservabilityViolationCode,
+} from './redaction';
+
+/** Where a redacted event goes. Must not throw; the emitter guards it anyway. */
+export type ObservabilityTransport = (event: ObservabilityEvent) => void;
+
+export interface ObservabilitySamplingConfig {
+  /** Probability in [0, 1] applied to any event with no per-event override. */
+  readonly default: number;
+  readonly perEvent?: Partial<Record<ObservabilityEventName, number>>;
+}
+
+export interface ObservabilityEmitterConfig {
+  readonly surface: ObservabilitySurface;
+  readonly transport: ObservabilityTransport;
+  /** Omitted means "keep everything" — the right default for a low-volume vocabulary. */
+  readonly sampling?: ObservabilitySamplingConfig;
+  /** Injected so a test can pin sampling decisions. Defaults to `Math.random`. */
+  readonly random?: () => number;
+  /** Injected so a test can pin `occurredAt`. Defaults to `Date.now`. */
+  readonly now?: () => number;
+  /**
+   * Called for every refused event and every dropped field. Receives field
+   * NAMES and codes only — never values. Wire it to a log line: "events
+   * blocked or redacted" is one of the metrics this pipeline owes.
+   */
+  readonly onRefused?: (
+    eventName: ObservabilityEventName | null,
+    violations: readonly ObservabilityViolation[],
+  ) => void;
+  /**
+   * Called when the transport throws. Optional; the failure is also visible in
+   * `stats()` and in the returned status, so it is observable either way and
+   * never silently swallowed.
+   */
+  readonly onTransportError?: (error: unknown) => void;
+}
+
+export type ObservabilityEmitStatus =
+  | 'emitted'
+  | 'sampled_out'
+  | 'refused'
+  | 'transport_error';
+
+export interface ObservabilityEmitResult {
+  readonly status: ObservabilityEmitStatus;
+  readonly violations: readonly ObservabilityViolation[];
+}
+
+export interface ObservabilityStats {
+  readonly emitted: number;
+  readonly sampledOut: number;
+  readonly refused: number;
+  readonly transportErrors: number;
+  /** Count per violation code, across refusals AND dropped-but-emitted fields. */
+  readonly violationsByCode: Readonly<Partial<Record<ObservabilityViolationCode, number>>>;
+}
+
+/**
+ * Fields a caller supplies: the event's own payload, plus the rotating session
+ * reference. `schemaVersion`, `occurredAt` and `surface` are stamped by the
+ * emitter and are not the caller's to set.
+ */
+export type ObservabilityEmitInput<E extends ObservabilityEventName> =
+  ObservabilityPayloads[E] & { readonly sessionId?: string };
+
+export interface ObservabilityEmitter {
+  emit<E extends ObservabilityEventName>(
+    event: E,
+    fields: ObservabilityEmitInput<E>,
+  ): ObservabilityEmitResult;
+  stats(): ObservabilityStats;
+}
+
+export function createObservabilityEmitter(
+  config: ObservabilityEmitterConfig,
+): ObservabilityEmitter {
+  const now = config.now ?? Date.now;
+  const random = config.random ?? Math.random;
+
+  let emitted = 0;
+  let sampledOut = 0;
+  let refused = 0;
+  let transportErrors = 0;
+  const violationsByCode: Partial<Record<ObservabilityViolationCode, number>> = {};
+
+  const record = (violations: readonly ObservabilityViolation[]): void => {
+    for (const violation of violations) {
+      violationsByCode[violation.code] = (violationsByCode[violation.code] ?? 0) + 1;
+    }
+  };
+
+  const keep = (event: ObservabilityEventName): boolean => {
+    const sampling = config.sampling;
+    if (sampling === undefined) return true;
+    const rate = sampling.perEvent?.[event] ?? sampling.default;
+    if (rate >= 1) return true;
+    if (rate <= 0) return false;
+    return random() < rate;
+  };
+
+  return {
+    emit(event, fields) {
+      // The caller's object is never mutated, and the stamped fields go LAST so
+      // a caller cannot override the clock, the surface or the version.
+      const candidate = {
+        ...fields,
+        event,
+        schemaVersion: OBSERVABILITY_SCHEMA_VERSION,
+        occurredAt: now(),
+        surface: config.surface,
+      };
+
+      const result = redactObservabilityEvent(candidate);
+      record(result.violations);
+
+      if (result.status === 'refused') {
+        refused += 1;
+        config.onRefused?.(result.eventName, result.violations);
+        return { status: 'refused', violations: result.violations };
+      }
+
+      if (result.violations.length > 0) {
+        // Emitted, but with fields removed. Still a defect worth reporting:
+        // a caller passing an undeclared field is usually a caller that thinks
+        // it is passing something useful.
+        config.onRefused?.(result.eventName, result.violations);
+      }
+
+      if (!keep(result.eventName)) {
+        sampledOut += 1;
+        return { status: 'sampled_out', violations: result.violations };
+      }
+
+      try {
+        config.transport(result.event);
+      } catch (error) {
+        transportErrors += 1;
+        config.onTransportError?.(error);
+        return { status: 'transport_error', violations: result.violations };
+      }
+
+      emitted += 1;
+      return { status: 'emitted', violations: result.violations };
+    },
+
+    stats() {
+      return {
+        emitted,
+        sampledOut,
+        refused,
+        transportErrors,
+        violationsByCode: { ...violationsByCode },
+      };
+    },
+  };
+}

--- a/packages/shared-types/src/observability/index.ts
+++ b/packages/shared-types/src/observability/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Privacy-safe product observability for Homiio (#350).
+ *
+ * It lives in `@homiio/shared-types` because the redaction layer must be ONE
+ * implementation. The event vocabulary spans both tiers — a permission
+ * resolution and a map-area search happen on the client, a geocoder call and a
+ * result set happen on the server — and a second copy of the rules is a second
+ * place for them to drift, which for a privacy control means a second place to
+ * be wrong silently. This package is dependency-free and already ships runtime
+ * helpers of exactly this kind (`ethicalPricing`, `utils/propertyTitle`).
+ *
+ * Read `./schema` first: it is the privacy contract, not a data dictionary.
+ */
+
+export * from './buckets';
+export * from './schema';
+export * from './queryIdentity';
+export * from './redaction';
+export * from './emitter';
+export * from './invariants';

--- a/packages/shared-types/src/observability/invariants.ts
+++ b/packages/shared-types/src/observability/invariants.ts
@@ -1,0 +1,342 @@
+/**
+ * Divergence invariants — the seven checks the issue names.
+ *
+ * Each answers a question no unit test of a component can answer, because the
+ * failure is an AGREEMENT failure between two things that are individually
+ * correct: a map that frames Barcelona and a list that queries Madrid are both
+ * doing exactly what they were told.
+ *
+ * WHAT IS REAL HERE AND WHAT IS A CONTRACT
+ * ----------------------------------------
+ * Four of these run against shapes that exist today and are exercised by the
+ * suite. Three — the visible label, the public-precision policy and the housing
+ * identity link — describe features that land in #352, #347 and #360/#361. For
+ * those the function takes a MINIMAL STRUCTURAL CONTRACT declared right here
+ * rather than importing a type that does not exist, so the assertion is real
+ * code with real tests today and the later issue satisfies a written interface
+ * instead of inventing one. None of it is dead code pretending to run: every
+ * function below is called by the suite with the fixtures in
+ * `packages/backend/__tests__/helpers/locationIdentityFixtures.ts`.
+ *
+ * EVERY RESULT IS SAFE TO LOG.
+ * `safe` carries classifications, booleans and small integers only — never a
+ * coordinate, a label string, a place name or a query. That is asserted by the
+ * suite, which runs every invariant's `safe` map through the same sensitive
+ * value sweep the redaction layer uses. The issue is explicit that production
+ * divergence checks may record ids and classifications and nothing else, and a
+ * result object shaped so that the unsafe thing is simply absent is the only
+ * version of that which survives a careless caller.
+ */
+
+import { deriveQueryId, type GeoBounds, type GeoPoint, type QueryDescriptor } from './queryIdentity';
+import type { AddressPrecisionLevel, GeocoderOutcome, LocationKind, SearchFallback } from './schema';
+
+export type InvariantCode =
+  | 'query_identity_divergent'
+  | 'visible_area_divergent'
+  | 'visible_label_divergent'
+  | 'stale_result_rendered'
+  | 'unscoped_fallback_after_geocoder_error'
+  | 'public_precision_exceeded'
+  | 'listing_missing_housing_identity';
+
+/** Values an invariant may report. No shape here can hold a coordinate or a name. */
+export type SafeDetailValue = string | number | boolean;
+
+export interface InvariantResult {
+  /** `true` when the invariant HOLDS. */
+  readonly ok: boolean;
+  readonly code: InvariantCode;
+  readonly safe: Readonly<Record<string, SafeDetailValue>>;
+}
+
+/* ── 1. The list and the map must be showing the same query ───────────────── */
+
+/**
+ * Both surfaces derive an id from their own effective query; equal ids mean
+ * they agree. A test can print `canonicalQueryDescriptor` for each side when
+ * this fails — two hex digests say only that they differ.
+ */
+export function checkQueryIdentityMatch(
+  listQuery: QueryDescriptor,
+  mapQuery: QueryDescriptor,
+): InvariantResult {
+  const listId = deriveQueryId(listQuery);
+  const mapId = deriveQueryId(mapQuery);
+  return {
+    ok: listId === mapId,
+    code: 'query_identity_divergent',
+    safe: {
+      listKind: listQuery.locationKind,
+      mapKind: mapQuery.locationKind,
+      sameScopeKind: listQuery.locationKind === mapQuery.locationKind,
+      match: listId === mapId,
+    },
+  };
+}
+
+/* ── 2. The area on screen must be the area that was queried ──────────────── */
+
+/** How much of the two areas coincide, as a label rather than a number. */
+export type AreaOverlapClass = 'none' | 'partial' | 'most' | 'match';
+
+/**
+ * Default floor for {@link checkVisibleAreaMatchesQueriedArea}. Half the union
+ * is generous on purpose: a map that has been nudged, or a list whose radius
+ * was rounded, must not fire. The failures this exists to catch — a different
+ * city, a different country, a global fallback — score zero.
+ */
+export const DEFAULT_MIN_AREA_OVERLAP = 0.5;
+
+function crossesAntimeridian(bounds: GeoBounds): boolean {
+  return bounds.east < bounds.west;
+}
+
+/** A wrapping box becomes two non-wrapping longitude intervals. */
+function longitudeIntervals(bounds: GeoBounds): [number, number][] {
+  if (!crossesAntimeridian(bounds)) return [[bounds.west, bounds.east]];
+  return [
+    [bounds.west, 180],
+    [-180, bounds.east],
+  ];
+}
+
+function longitudeSpan(bounds: GeoBounds): number {
+  return crossesAntimeridian(bounds)
+    ? 360 - bounds.west + bounds.east
+    : bounds.east - bounds.west;
+}
+
+function latitudeSpan(bounds: GeoBounds): number {
+  return Math.max(0, bounds.north - bounds.south);
+}
+
+function longitudeOverlap(a: GeoBounds, b: GeoBounds): number {
+  let total = 0;
+  for (const [aWest, aEast] of longitudeIntervals(a)) {
+    for (const [bWest, bEast] of longitudeIntervals(b)) {
+      const low = Math.max(aWest, bWest);
+      const high = Math.min(aEast, bEast);
+      if (high > low) total += high - low;
+    }
+  }
+  return total;
+}
+
+function latitudeOverlap(a: GeoBounds, b: GeoBounds): number {
+  const low = Math.max(a.south, b.south);
+  const high = Math.min(a.north, b.north);
+  return high > low ? high - low : 0;
+}
+
+function overlapClass(ratio: number): AreaOverlapClass {
+  if (ratio <= 0) return 'none';
+  if (ratio < 0.5) return 'partial';
+  if (ratio < 0.9) return 'most';
+  return 'match';
+}
+
+/**
+ * Compare what is on screen with what was asked for.
+ *
+ * The ratio is intersection over union in DEGREES², not square kilometres: a
+ * ratio between two boxes at similar latitude is unaffected by the cosine
+ * distortion, and introducing a projection here would add a failure mode for no
+ * gain. Antimeridian-crossing boxes are handled by splitting them, which is the
+ * whole reason the issue lists that case: a naive `east - west` on a box
+ * spanning 179°E → -179°W reports a 358°-wide viewport and every comparison
+ * against it succeeds.
+ */
+export function checkVisibleAreaMatchesQueriedArea(
+  visible: GeoBounds,
+  queried: GeoBounds,
+  minOverlapRatio: number = DEFAULT_MIN_AREA_OVERLAP,
+): InvariantResult {
+  const visibleArea = longitudeSpan(visible) * latitudeSpan(visible);
+  const queriedArea = longitudeSpan(queried) * latitudeSpan(queried);
+  const intersection = longitudeOverlap(visible, queried) * latitudeOverlap(visible, queried);
+  const union = visibleArea + queriedArea - intersection;
+  const ratio = union > 0 ? intersection / union : 0;
+
+  return {
+    ok: ratio >= minOverlapRatio,
+    code: 'visible_area_divergent',
+    safe: {
+      overlapClass: overlapClass(ratio),
+      visibleCrossesAntimeridian: crossesAntimeridian(visible),
+      queriedCrossesAntimeridian: crossesAntimeridian(queried),
+    },
+  };
+}
+
+/* ── 3. The label on screen must describe the current selection ───────────── */
+
+/**
+ * The minimal shape #352's `LocationSelection` must expose for this check.
+ *
+ * `placeKey` is a STABLE KEY (a canonical place id), never the display string:
+ * comparing rendered text would make the check locale-dependent and would put a
+ * place name into a result that is meant to be loggable.
+ */
+export interface LocationScopeContract {
+  readonly kind: LocationKind;
+  readonly countryCode?: string;
+  readonly placeKey?: string;
+}
+
+/**
+ * The contract a rendered location label owes: it must carry the scope it was
+ * rendered FROM, so "the header still says Barcelona" is answerable without
+ * reading the header.
+ */
+export interface RenderedLocationLabelContract {
+  readonly renderedFrom: LocationScopeContract;
+}
+
+export function checkVisibleLabelMatchesSelection(
+  label: RenderedLocationLabelContract,
+  current: LocationScopeContract,
+): InvariantResult {
+  const kindMatch = label.renderedFrom.kind === current.kind;
+  const countryMatch = label.renderedFrom.countryCode === current.countryCode;
+  const placeMatch = label.renderedFrom.placeKey === current.placeKey;
+  return {
+    ok: kindMatch && countryMatch && placeMatch,
+    code: 'visible_label_divergent',
+    safe: { kindMatch, countryMatch, placeMatch, currentKind: current.kind },
+  };
+}
+
+/* ── 4. A result must answer the query that is current ────────────────────── */
+
+export function checkResultIsForCurrentQuery(
+  resultQueryId: string,
+  currentQueryId: string,
+): InvariantResult {
+  const stale = resultQueryId !== currentQueryId;
+  return {
+    ok: !stale,
+    code: 'stale_result_rendered',
+    safe: { stale },
+  };
+}
+
+/* ── 5. A geocoder failure must never widen the scope to the world ────────── */
+
+/**
+ * Principle 4 of the epic, made checkable.
+ *
+ * Two conditions, and the second is the stricter one:
+ *
+ *   - a `global` fallback is a violation ALWAYS, geocoder outcome or not. There
+ *     is no correct reason to answer a located search with a worldwide feed;
+ *   - after a non-`ok` geocoder outcome, the applied scope may not be `none`.
+ *     That is the silent version: no fallback was "applied", the scope simply
+ *     never existed, and the feed looks like a normal unfiltered browse.
+ */
+export function checkGeocoderFallbackScope(
+  outcome: GeocoderOutcome,
+  appliedScopeKind: LocationKind,
+  fallbackApplied: SearchFallback,
+): InvariantResult {
+  const worldwideFallback = fallbackApplied === 'global';
+  const unscopedAfterFailure = outcome !== 'ok' && appliedScopeKind === 'none';
+  return {
+    ok: !worldwideFallback && !unscopedAfterFailure,
+    code: 'unscoped_fallback_after_geocoder_error',
+    safe: { outcome, appliedScopeKind, fallbackApplied, worldwideFallback, unscopedAfterFailure },
+  };
+}
+
+/* ── 6. Published precision must not exceed the policy ────────────────────── */
+
+/**
+ * Decimal places permitted in a PUBLISHED coordinate, per precision level.
+ *
+ * Degrees of latitude: 1 dp ≈ 11 km, 2 ≈ 1.1 km, 3 ≈ 110 m, 4 ≈ 11 m, 5 ≈ 1 m.
+ * These are the mechanism's defaults; #347 owns the policy itself and may pass
+ * its own map. What must not happen is a surface picking its own number.
+ */
+export const PUBLIC_PRECISION_MAX_DECIMALS: Readonly<Record<AddressPrecisionLevel, number>> = {
+  area: 1,
+  locality: 2,
+  street: 3,
+  building: 4,
+  unit: 5,
+};
+
+/**
+ * How many decimal places a number carries.
+ *
+ * Exponent notation is handled explicitly: `String(1e-7)` is `"1e-7"`, and a
+ * naive scan for `.` reports zero decimals for the most precise value in the
+ * set — the failure direction that admits an exact coordinate.
+ */
+export function decimalPlaces(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  const text = String(value);
+  const exponentAt = text.indexOf('e');
+  if (exponentAt !== -1) {
+    const mantissa = text.slice(0, exponentAt);
+    const exponent = Number(text.slice(exponentAt + 1));
+    const dot = mantissa.indexOf('.');
+    const mantissaDecimals = dot === -1 ? 0 : mantissa.length - dot - 1;
+    return Math.max(0, mantissaDecimals - exponent);
+  }
+  const dot = text.indexOf('.');
+  return dot === -1 ? 0 : text.length - dot - 1;
+}
+
+export function checkPublicPrecisionWithinPolicy(
+  published: GeoPoint,
+  level: AddressPrecisionLevel,
+  maxDecimalsByLevel: Readonly<
+    Record<AddressPrecisionLevel, number>
+  > = PUBLIC_PRECISION_MAX_DECIMALS,
+): InvariantResult {
+  const allowed = maxDecimalsByLevel[level];
+  const observed = Math.max(decimalPlaces(published.lat), decimalPlaces(published.lng));
+  return {
+    ok: observed <= allowed,
+    code: 'public_precision_exceeded',
+    safe: { level, allowedDecimals: allowed, observedDecimals: observed },
+  };
+}
+
+/* ── 7. A listing on a canonical address must carry its housing identity ──── */
+
+/**
+ * The minimal shape #360/#361 must expose. `hasHousingIdentity` is whether the
+ * listing resolves to a canonical unit or building; `addressIsCanonical` is
+ * whether its address has been materialised out of candidate state. A listing
+ * on a materialised address with no identity is the case that makes three
+ * external listings of one flat read as three separate homes — and it inflates
+ * a price sample by counting the same rent three times.
+ */
+export interface ListingIdentityContract {
+  readonly addressIsCanonical: boolean;
+  readonly hasHousingIdentity: boolean;
+}
+
+export function checkListingHasHousingIdentity(listing: ListingIdentityContract): InvariantResult {
+  const ok = !listing.addressIsCanonical || listing.hasHousingIdentity;
+  return {
+    ok,
+    code: 'listing_missing_housing_identity',
+    safe: {
+      addressIsCanonical: listing.addressIsCanonical,
+      hasHousingIdentity: listing.hasHousingIdentity,
+    },
+  };
+}
+
+/** Every invariant this module declares, for a completeness assertion in tests. */
+export const INVARIANT_CODES: readonly InvariantCode[] = [
+  'query_identity_divergent',
+  'visible_area_divergent',
+  'visible_label_divergent',
+  'stale_result_rendered',
+  'unscoped_fallback_after_geocoder_error',
+  'public_precision_exceeded',
+  'listing_missing_housing_identity',
+];

--- a/packages/shared-types/src/observability/queryIdentity.ts
+++ b/packages/shared-types/src/observability/queryIdentity.ts
@@ -103,6 +103,23 @@ function hex8(value: number): string {
   return (value >>> 0).toString(16).padStart(8, '0');
 }
 
+/**
+ * Domain separator between a namespace and its value.
+ *
+ * Written as an ESCAPE, never as a literal byte. A NUL inside a source file
+ * makes git classify that file as binary, so it merges with no reviewable diff
+ * at all — every gate passes and no reviewer can see a line of it. That is the
+ * exact hazard `packages/backend/__tests__/unit/sourceFilesAreText.test.ts`
+ * exists to catch, and it caught this file in CI after a local full-suite run
+ * missed it: the local run happened while the file was still UNTRACKED, and
+ * that gate enumerates with `git ls-files`, which cannot see an untracked file.
+ *
+ * NUL is the right SEPARATOR — it cannot occur in a namespace or an id, so no
+ * pair of inputs can collide by concatenation. It is only the literal byte in
+ * SOURCE that is the problem, and the escape produces the identical digest.
+ */
+const NAMESPACE_SEPARATOR = '\u0000';
+
 /** 16 lowercase hex characters — the one shape the `opaqueId` field kind accepts. */
 export function digest16(input: string): string {
   return hex8(fnv1a32(input, FNV_OFFSET_A)) + hex8(fnv1a32(input, FNV_OFFSET_B));
@@ -212,7 +229,7 @@ export function deriveQueryId(descriptor: QueryDescriptor): string {
  * housing profile across the log.
  */
 export function deriveOpaqueRef(namespace: string, value: string): string {
-  return digest16(`${namespace} ${value}`);
+  return digest16(`${namespace}${NAMESPACE_SEPARATOR}${value}`);
 }
 
 /** Whether a value is in the one shape the `opaqueId` field kind accepts. */

--- a/packages/shared-types/src/observability/queryIdentity.ts
+++ b/packages/shared-types/src/observability/queryIdentity.ts
@@ -1,0 +1,238 @@
+/**
+ * Query identity — the one thing a list and a map must agree about.
+ *
+ * The defect class this exists for renders perfectly: the header says
+ * "Barcelona", the map frames Barcelona, and the list is answering a request
+ * that still carries Madrid's bounds. Nothing throws, no type is violated, and
+ * the only way to see it is to ask both surfaces which query they are showing
+ * and compare the answers. That comparison needs a single deterministic
+ * identifier derived from the EFFECTIVE query — not from whichever object each
+ * surface happens to hold.
+ *
+ * PRECISION IS DELIBERATELY COARSE, AND THAT IS THE PRIVACY CONTROL
+ * -----------------------------------------------------------------
+ * Coordinates are rounded to {@link QUERY_ID_COORD_DECIMALS} decimal places
+ * (~110 m at the equator) BEFORE hashing. A query id therefore cannot resolve
+ * finer than a city block even to somebody who inverts it, which is what makes
+ * it safe to emit. Two viewports 50 m apart produce the same id — accepted,
+ * because at that distance they are the same query for every question this
+ * pipeline answers.
+ *
+ * The in-app divergence checks in `./invariants` do NOT rely on the id for
+ * geometric comparisons; they work on the real numbers with an explicit
+ * tolerance, so the coarse grid here never masks a real area mismatch.
+ *
+ * RESIDUAL, STATED PLAINLY: the id is a hash of the whole effective query,
+ * free text included. Recovering it means guessing the entire descriptor —
+ * scope, filters, sort and text — not just the text. It is not a stable
+ * per-person identifier and it is not reversible to a dwelling. It is not a
+ * cryptographic commitment either, and nothing should treat it as one.
+ */
+
+import type { LocationKind } from './schema';
+
+/** ~110 m at the equator. See the module header for why this is not finer. */
+export const QUERY_ID_COORD_DECIMALS = 3;
+
+/** Prefix on every canonical string, so a future canonicalisation change is visible. */
+export const QUERY_CANONICAL_VERSION = 'q1';
+
+/** A west/south/east/north box in degrees, matching the geo layer's `bbox` order. */
+export interface GeoBounds {
+  readonly west: number;
+  readonly south: number;
+  readonly east: number;
+  readonly north: number;
+}
+
+/** A point in degrees. */
+export interface GeoPoint {
+  readonly lat: number;
+  readonly lng: number;
+}
+
+/** Filter values a query may carry. Arrays are order-insensitive. */
+export type QueryFilterValue = string | number | boolean | readonly string[];
+
+/**
+ * The effective query, as opposed to whatever intermediate state a screen
+ * holds. Every surface that renders results must be able to produce this, and
+ * two surfaces showing "the same search" must produce equal descriptors.
+ */
+export interface QueryDescriptor {
+  readonly locationKind: LocationKind;
+  readonly countryCode?: string;
+  /**
+   * A STABLE KEY for the place when the scope is a named place rather than a
+   * shape — the same key `LocationScopeContract.placeKey` carries, never a
+   * display string. Two cities called Barcelona differ here and nowhere else.
+   */
+  readonly placeKey?: string;
+  readonly center?: GeoPoint;
+  readonly radiusKm?: number;
+  readonly bounds?: GeoBounds;
+  readonly freeText?: string;
+  readonly filters?: Readonly<Record<string, QueryFilterValue | undefined>>;
+  readonly sort?: string;
+}
+
+const FNV_PRIME = 0x01000193;
+const FNV_OFFSET_A = 0x811c9dc5;
+/** A second, unrelated basis: two independent 32-bit digests make a 64-bit id. */
+const FNV_OFFSET_B = 0x9dc5811c;
+
+/**
+ * FNV-1a over UTF-16 code units, byte by byte.
+ *
+ * Written out rather than imported because this package is dependency-free by
+ * design and the digest must be byte-identical on Hermes, on Node and in a
+ * browser — a hash that disagrees across runtimes turns the divergence check
+ * into a false alarm on every cross-tier comparison.
+ */
+function fnv1a32(input: string, offsetBasis: number): number {
+  let hash = offsetBasis >>> 0;
+  for (let i = 0; i < input.length; i += 1) {
+    const code = input.charCodeAt(i);
+    hash = Math.imul(hash ^ (code & 0xff), FNV_PRIME);
+    hash = Math.imul(hash ^ ((code >>> 8) & 0xff), FNV_PRIME);
+  }
+  return hash >>> 0;
+}
+
+function hex8(value: number): string {
+  return (value >>> 0).toString(16).padStart(8, '0');
+}
+
+/** 16 lowercase hex characters — the one shape the `opaqueId` field kind accepts. */
+export function digest16(input: string): string {
+  return hex8(fnv1a32(input, FNV_OFFSET_A)) + hex8(fnv1a32(input, FNV_OFFSET_B));
+}
+
+/**
+ * Round a coordinate onto the published grid.
+ *
+ * `-0` is normalised to `0`: without it a viewport straddling Greenwich or the
+ * equator hashes differently depending on which side the float landed on, and
+ * the divergence check fires on two surfaces that agree.
+ */
+function coordinate(value: number): string {
+  if (!Number.isFinite(value)) return 'na';
+  const factor = 10 ** QUERY_ID_COORD_DECIMALS;
+  const rounded = Math.round(value * factor) / factor;
+  return (rounded === 0 ? 0 : rounded).toFixed(QUERY_ID_COORD_DECIMALS);
+}
+
+/** Radius is rounded to 100 m, the same order as the coordinate grid. */
+function radius(value: number): string {
+  if (!Number.isFinite(value)) return 'na';
+  return (Math.round(value * 10) / 10).toFixed(1);
+}
+
+/**
+ * Normalise free text so that trivial keyboard differences are not treated as
+ * different queries. Case and surrounding/repeated whitespace only — no
+ * accent folding, because `String.prototype.normalize` is not guaranteed on
+ * every Hermes build and a digest that differs by runtime is worse than one
+ * that treats "Lleida" and "lleida" alike but "Lérida" and "Lerida" apart.
+ */
+function freeText(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function filterValue(value: QueryFilterValue): string {
+  if (Array.isArray(value)) {
+    return [...(value as readonly string[])].map((entry) => String(entry)).sort().join(',');
+  }
+  return String(value);
+}
+
+/**
+ * The canonical string a query id is the digest of.
+ *
+ * Exported because a failing divergence assertion is far easier to act on when
+ * a test can print the two canonical forms side by side — a pair of hex
+ * digests tells you they differ and nothing about how.
+ */
+export function canonicalQueryDescriptor(descriptor: QueryDescriptor): string {
+  const parts: string[] = [
+    QUERY_CANONICAL_VERSION,
+    `kind=${descriptor.locationKind}`,
+    `country=${descriptor.countryCode === undefined ? '' : descriptor.countryCode.toUpperCase()}`,
+    `place=${descriptor.placeKey ?? ''}`,
+    `center=${
+      descriptor.center === undefined
+        ? ''
+        : `${coordinate(descriptor.center.lat)},${coordinate(descriptor.center.lng)}`
+    }`,
+    `radius=${descriptor.radiusKm === undefined ? '' : radius(descriptor.radiusKm)}`,
+    `bounds=${
+      descriptor.bounds === undefined
+        ? ''
+        : [
+            coordinate(descriptor.bounds.west),
+            coordinate(descriptor.bounds.south),
+            coordinate(descriptor.bounds.east),
+            coordinate(descriptor.bounds.north),
+          ].join(',')
+    }`,
+    `text=${descriptor.freeText === undefined ? '' : freeText(descriptor.freeText)}`,
+    `sort=${descriptor.sort ?? ''}`,
+  ];
+
+  const filters = descriptor.filters;
+  if (filters !== undefined) {
+    const encoded = Object.keys(filters)
+      .sort()
+      .flatMap((key) => {
+        const value = filters[key];
+        return value === undefined ? [] : [`${key}:${filterValue(value)}`];
+      });
+    parts.push(`filters=${encoded.join(';')}`);
+  } else {
+    parts.push('filters=');
+  }
+
+  return parts.join('|');
+}
+
+/**
+ * The identifier a list and a map must both be able to produce for the search
+ * they are showing. Deterministic, dependency-free and stable across runtimes.
+ */
+export function deriveQueryId(descriptor: QueryDescriptor): string {
+  return digest16(canonicalQueryDescriptor(descriptor));
+}
+
+/**
+ * Derive the opaque reference an event carries for a domain entity.
+ *
+ * The namespace keeps references from different domains from colliding and,
+ * more usefully, stops the same underlying id producing the same reference in
+ * two unrelated events — which would let a reader join a review draft to a
+ * housing profile across the log.
+ */
+export function deriveOpaqueRef(namespace: string, value: string): string {
+  return digest16(`${namespace} ${value}`);
+}
+
+/** Whether a value is in the one shape the `opaqueId` field kind accepts. */
+export function isOpaqueId(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-f]{16}$/.test(value);
+}
+
+/**
+ * Mint a fresh opaque id — a rotating session or wizard reference.
+ *
+ * `random` is injected so a test can pin the output; production passes
+ * `Math.random`. This is NOT a security token and must never be used as one:
+ * it identifies a sequence of events as belonging to one uninterrupted visit,
+ * and nothing else.
+ */
+export function newOpaqueId(random: () => number = Math.random): string {
+  let out = '';
+  while (out.length < 16) {
+    const chunk = Math.floor(random() * 0x100000000) >>> 0;
+    out += hex8(chunk);
+  }
+  return out.slice(0, 16);
+}

--- a/packages/shared-types/src/observability/redaction.ts
+++ b/packages/shared-types/src/observability/redaction.ts
@@ -1,0 +1,317 @@
+/**
+ * The central redaction layer.
+ *
+ * THIS IS THE ONLY WAY AN EVENT REACHES A TRANSPORT. `./emitter` calls it and
+ * has no path around it; the backend ingest handler calls it again on receipt.
+ * Both layers matter: the first stops a careless caller, the second stops a
+ * client build that is old, modified or not ours.
+ *
+ * WHAT IT GUARANTEES, AND HOW
+ * ---------------------------
+ * Two independent mechanisms, in this order, because either alone has a hole:
+ *
+ *   1. **Allowlist by field kind.** Only fields the schema declares survive;
+ *      anything else is DROPPED. A surviving field must satisfy its declared
+ *      kind, and no kind can hold free text or a fractional number (see
+ *      `./schema`). This is what makes a street name or an exact coordinate
+ *      structurally impossible rather than merely discouraged. It is also what
+ *      the hole is: it trusts the schema, so a future field declared with a
+ *      looser kind would pass. A dropped value is examined too — see the
+ *      comment at the drop site for why forward compatibility stops at a value
+ *      that is already disqualified.
+ *
+ *   2. **A kind-agnostic sweep of the FINAL object.** Every value that came out
+ *      of step 1 is re-examined without reference to what it was supposed to
+ *      be: strings must be short, must use a label charset with no `@`, `.`,
+ *      comma or space, and must not carry a long digit run; numbers must be
+ *      integers. A single failure REFUSES the whole event rather than trimming
+ *      it, because a payload that reached this point carrying a phone number is
+ *      evidence of a defect upstream, and emitting the rest of it would hide
+ *      that.
+ *
+ * VIOLATIONS CARRY FIELD NAMES, NEVER VALUES. A violation record is itself
+ * something that gets logged, and a "rejected: address=Carrer de Mallorca 401"
+ * log line leaks precisely what the rejection prevented.
+ *
+ * `opaqueId` fields are exempt from the sweep's string heuristics — and only
+ * those. Their kind check is `^[0-9a-f]{16}$`, which is stricter than anything
+ * the sweep could apply, and without the exemption the ~1-in-4700 id that
+ * happens to be all digits would be refused as a phone number.
+ */
+
+import {
+  OBSERVABILITY_ENVELOPE_SPEC,
+  OBSERVABILITY_EVENT_NAMES,
+  OBSERVABILITY_EVENT_SPECS,
+  OBSERVABILITY_SCHEMA_VERSION,
+  type ObservabilityEvent,
+  type ObservabilityEventName,
+  type ObservabilityEventSpec,
+  type ObservabilityFieldKind,
+} from './schema';
+import { isOpaqueId } from './queryIdentity';
+
+/** Why a field was dropped, or an event refused. */
+export type ObservabilityViolationCode =
+  | 'not_an_object'
+  | 'unknown_event'
+  | 'unsupported_schema_version'
+  | 'unknown_field'
+  | 'invalid_value'
+  | 'missing_required'
+  | 'sensitive_value';
+
+/** A single problem. The field NAME only — see the module header. */
+export interface ObservabilityViolation {
+  readonly field: string;
+  readonly code: ObservabilityViolationCode;
+}
+
+export type RedactionResult =
+  | {
+      readonly status: 'ok';
+      readonly eventName: ObservabilityEventName;
+      readonly event: ObservabilityEvent;
+      readonly violations: readonly ObservabilityViolation[];
+    }
+  | {
+      readonly status: 'refused';
+      readonly eventName: ObservabilityEventName | null;
+      readonly event: null;
+      readonly violations: readonly ObservabilityViolation[];
+    };
+
+/**
+ * The oldest and newest instants an `epochMs` field may carry: 2020-09-13 to
+ * 2100-01-01. Wide enough that no real clock skew trips it, narrow enough that
+ * a latitude, a price or a result count cannot pass as a timestamp.
+ */
+export const MIN_EPOCH_MS = 1_600_000_000_000;
+export const MAX_EPOCH_MS = 4_102_444_800_000;
+
+/** Longest label any enum in the schema declares, with headroom. */
+export const SAFE_LABEL_MAX_LENGTH = 24;
+
+/**
+ * Characters a label may use. Bucket labels need digits, `-` and `+`
+ * (`10-25`, `200+`); enum labels need letters and `_`. Nothing else — which is
+ * what excludes an email (`@`, `.`), a coordinate pair (`.`, `,`), an address
+ * or any sentence (spaces).
+ */
+const SAFE_LABEL_PATTERN = /^[A-Za-z0-9_+-]+$/;
+
+/**
+ * Seven consecutive digits. No label in the schema has more than five
+ * (`10000+`, `1000-10000`), and a compact phone number or a document number
+ * has more — the one PII shape the charset rule above lets through.
+ */
+const LONG_DIGIT_RUN = /\d{7,}/;
+
+const COUNTRY_CODE_PATTERN = /^[A-Z]{2}$/;
+
+function isValidForKind(kind: ObservabilityFieldKind, value: unknown): boolean {
+  switch (kind.kind) {
+    case 'enum':
+      return typeof value === 'string' && kind.values.includes(value);
+    case 'opaqueId':
+      return isOpaqueId(value);
+    case 'countryCode':
+      return typeof value === 'string' && COUNTRY_CODE_PATTERN.test(value);
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'smallInt':
+      return (
+        typeof value === 'number' &&
+        Number.isInteger(value) &&
+        value >= 0 &&
+        value <= kind.max
+      );
+    case 'epochMs':
+      return (
+        typeof value === 'number' &&
+        Number.isInteger(value) &&
+        value >= MIN_EPOCH_MS &&
+        value <= MAX_EPOCH_MS
+      );
+  }
+}
+
+/**
+ * Step 2: re-examine the surviving values without trusting what kind they were
+ * declared as. Returns the fields that must not be emitted.
+ *
+ * `opaqueIdFields` names the fields whose kind check is already stricter than
+ * anything here; see the module header.
+ */
+export function scanForSensitiveValues(
+  record: Readonly<Record<string, unknown>>,
+  opaqueIdFields: ReadonlySet<string>,
+): ObservabilityViolation[] {
+  const violations: ObservabilityViolation[] = [];
+
+  for (const [field, value] of Object.entries(record)) {
+    if (field === 'event') continue;
+
+    if (typeof value === 'boolean') continue;
+
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value) || !Number.isInteger(value)) {
+        violations.push({ field, code: 'sensitive_value' });
+      }
+      continue;
+    }
+
+    if (typeof value === 'string') {
+      if (opaqueIdFields.has(field)) continue;
+      if (
+        value.length === 0 ||
+        value.length > SAFE_LABEL_MAX_LENGTH ||
+        !SAFE_LABEL_PATTERN.test(value) ||
+        LONG_DIGIT_RUN.test(value)
+      ) {
+        violations.push({ field, code: 'sensitive_value' });
+      }
+      continue;
+    }
+
+    // Anything else — an object, an array, `null`, a function — has no place in
+    // a flat event and could nest arbitrary content below the sweep.
+    violations.push({ field, code: 'sensitive_value' });
+  }
+
+  return violations;
+}
+
+function isPlainRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === 'object' && input !== null && !Array.isArray(input);
+}
+
+/**
+ * Redact one event. Accepts `unknown` on purpose: the ingest endpoint's input
+ * is a parsed request body, and typing that as anything narrower would be a
+ * claim the network cannot make.
+ */
+export function redactObservabilityEvent(input: unknown): RedactionResult {
+  if (!isPlainRecord(input)) {
+    return {
+      status: 'refused',
+      eventName: null,
+      event: null,
+      violations: [{ field: '(root)', code: 'not_an_object' }],
+    };
+  }
+
+  const rawName = input.event;
+  if (
+    typeof rawName !== 'string' ||
+    !(OBSERVABILITY_EVENT_NAMES as readonly string[]).includes(rawName)
+  ) {
+    return {
+      status: 'refused',
+      eventName: null,
+      event: null,
+      violations: [{ field: 'event', code: 'unknown_event' }],
+    };
+  }
+  const eventName = rawName as ObservabilityEventName;
+
+  if (input.schemaVersion !== OBSERVABILITY_SCHEMA_VERSION) {
+    return {
+      status: 'refused',
+      eventName,
+      event: null,
+      violations: [{ field: 'schemaVersion', code: 'unsupported_schema_version' }],
+    };
+  }
+
+  const specs: Readonly<Record<string, ObservabilityEventSpec>> = OBSERVABILITY_EVENT_SPECS;
+  const eventSpec = specs[eventName];
+  // Unreachable while the schema is well formed — `assertSchemaIsWellFormed`
+  // is what keeps it so. Present because indexing by a runtime string cannot
+  // prove it to the compiler.
+  if (eventSpec === undefined) {
+    return {
+      status: 'refused',
+      eventName,
+      event: null,
+      violations: [{ field: 'event', code: 'unknown_event' }],
+    };
+  }
+
+  const combined: Record<string, { type: ObservabilityFieldKind; required: boolean }> = {
+    ...OBSERVABILITY_ENVELOPE_SPEC,
+    ...eventSpec,
+  };
+
+  const violations: ObservabilityViolation[] = [];
+  const kept: Record<string, unknown> = { event: eventName };
+  const opaqueIdFields = new Set<string>();
+  let droppedSomethingSensitive = false;
+
+  for (const [field, value] of Object.entries(input)) {
+    if (field === 'event') continue;
+    // An absent optional field is idiomatically written as `undefined`, not as
+    // a missing key. Treat the two the same rather than reporting a violation
+    // for `radiusBucketKm: maybeRadius`.
+    if (value === undefined) continue;
+
+    const fieldSpec = combined[field];
+    const dropCode: ObservabilityViolationCode | null =
+      fieldSpec === undefined
+        ? 'unknown_field'
+        : isValidForKind(fieldSpec.type, value)
+          ? null
+          : 'invalid_value';
+
+    if (dropCode !== null) {
+      // A dropped value is still EXAMINED, and this is the rule worth stating
+      // plainly, because the two halves pull in opposite directions.
+      //
+      // Dropping an unrecognised field rather than refusing the event is what
+      // makes the pipeline forward-compatible: a newer client sending a field
+      // an older server has not heard of must not lose its whole event.
+      //
+      // But that tolerance is for values that COULD have been legitimate. A
+      // value that is ALREADY disqualified — a sentence, an email, a
+      // fractional number — is not version skew, it is a defect, and letting
+      // the rest of the event through would leave it counted rather than
+      // noticed. So an innocuous unknown field is dropped and the event
+      // proceeds; a sensitive one refuses the event outright.
+      if (scanForSensitiveValues({ [field]: value }, new Set()).length > 0) {
+        violations.push({ field, code: 'sensitive_value' });
+        droppedSomethingSensitive = true;
+      } else {
+        violations.push({ field, code: dropCode });
+      }
+      continue;
+    }
+
+    if (fieldSpec !== undefined && fieldSpec.type.kind === 'opaqueId') opaqueIdFields.add(field);
+    kept[field] = value;
+  }
+
+  const missing = Object.entries(combined)
+    .filter(([field, fieldSpec]) => fieldSpec.required && !(field in kept))
+    .map(([field]): ObservabilityViolation => ({ field, code: 'missing_required' }));
+
+  const sensitive = scanForSensitiveValues(kept, opaqueIdFields);
+
+  if (missing.length > 0 || sensitive.length > 0 || droppedSomethingSensitive) {
+    return {
+      status: 'refused',
+      eventName,
+      event: null,
+      violations: [...violations, ...missing, ...sensitive],
+    };
+  }
+
+  return {
+    status: 'ok',
+    eventName,
+    // The shape has been checked field by field against the same spec the type
+    // is derived from; there is no narrower expression of that in the type
+    // system, because the input genuinely was `unknown`.
+    event: kept as ObservabilityEvent,
+    violations,
+  };
+}

--- a/packages/shared-types/src/observability/schema.ts
+++ b/packages/shared-types/src/observability/schema.ts
@@ -1,0 +1,445 @@
+/**
+ * Versioned event schema for Homiio's privacy-safe product observability.
+ *
+ * WHY A SCHEMA AT ALL, AND WHY THIS SHAPE
+ * ---------------------------------------
+ * The geographic defects this observability exists to catch do not throw. A
+ * screen can render perfectly while querying the wrong city, so the only way to
+ * know what a person actually saw is to record the query — and recording a
+ * query is exactly the thing that leaks where somebody lives. The resolution of
+ * that tension is structural rather than procedural: **no field in this schema
+ * has a kind that can hold free text or a fractional number.** There is no
+ * `string` kind. A street name, a review body, an email, a document reference
+ * and a pair of exact coordinates are therefore not "discouraged" values, they
+ * are values with nowhere to go.
+ *
+ * Every declared field is one of:
+ *
+ *   - `enum`       — a closed set of labels, which is also how every bucket is
+ *                    expressed (see `./buckets`);
+ *   - `opaqueId`   — exactly 16 lowercase hex characters, derived by hashing;
+ *   - `countryCode`— ISO-3166-1 alpha-2, the coarsest useful geography;
+ *   - `boolean`;
+ *   - `smallInt`   — a bounded, non-negative INTEGER (so a coordinate, a price
+ *                    or a timestamp cannot pass as one);
+ *   - `epochMs`    — the emitter's own clock stamp, bounded to a sane range.
+ *
+ * The TypeScript payload type of every event is DERIVED from the runtime spec
+ * below (see `ObservabilityPayloads`). They cannot drift, because there is only
+ * one declaration.
+ *
+ * VERSIONING
+ * ----------
+ * `OBSERVABILITY_SCHEMA_VERSION` is stamped on every event and checked on
+ * receipt. Adding an optional field is a compatible change and does not bump
+ * it. Removing a field, renaming one, changing a field's kind, or changing the
+ * MEANING of an existing bucket boundary all bump it — a consumer that averages
+ * `resultCountBucket` across a boundary change is computing a number that means
+ * nothing, and the version is what lets it notice.
+ */
+
+import {
+  AREA_BUCKETS_KM2,
+  DURATION_BUCKETS_S,
+  LATENCY_BUCKETS_MS,
+  PERCENT_SPREAD_BUCKETS,
+  RADIUS_BUCKETS_KM,
+  RESULT_COUNT_BUCKETS,
+  TEXT_LENGTH_BUCKETS,
+  ZOOM_BUCKETS,
+} from './buckets';
+
+/** Bumped only for an incompatible change. See the module header. */
+export const OBSERVABILITY_SCHEMA_VERSION = 1;
+
+/** The platform the event came from. */
+export const OBSERVABILITY_SURFACES = ['web', 'ios', 'android', 'server'] as const;
+export type ObservabilitySurface = (typeof OBSERVABILITY_SURFACES)[number];
+
+/**
+ * How coarse a location a query was scoped to. `none` is a first-class value
+ * and the most important one in this whole vocabulary: it is what makes an
+ * unscoped, worldwide search visible instead of indistinguishable from a
+ * correct city search.
+ */
+export const LOCATION_KINDS = [
+  'city',
+  'neighborhood',
+  'region',
+  'country',
+  'bbox',
+  'radius',
+  'none',
+] as const;
+export type LocationKind = (typeof LOCATION_KINDS)[number];
+
+/** Where a location scope came from. */
+export const LOCATION_SOURCES = [
+  'device',
+  'manual',
+  'saved',
+  'map',
+  'url',
+  'default',
+] as const;
+
+/** How precisely an address candidate resolves. Mirrors the publication ladder. */
+export const ADDRESS_PRECISION_LEVELS = [
+  'unit',
+  'building',
+  'street',
+  'locality',
+  'area',
+] as const;
+export type AddressPrecisionLevel = (typeof ADDRESS_PRECISION_LEVELS)[number];
+
+/**
+ * What a search fell back to when its intended scope could not be applied.
+ *
+ * `global` exists so that principle 4 of the epic — "a geocoding failure never
+ * falls silently to a worldwide feed" — is MEASURABLE rather than merely
+ * asserted in review. A deployment emitting any `global` here has the bug.
+ */
+export const SEARCH_FALLBACKS = [
+  'none',
+  'widened_radius',
+  'dropped_filters',
+  'last_known_area',
+  'global',
+] as const;
+export type SearchFallback = (typeof SEARCH_FALLBACKS)[number];
+
+/** The outcome of one geocoder call, classified rather than transcribed. */
+export const GEOCODER_OUTCOMES = ['ok', 'empty', 'timeout', 'rate_limited', 'error'] as const;
+export type GeocoderOutcome = (typeof GEOCODER_OUTCOMES)[number];
+
+/** The steps of the review wizard, for step-level abandonment. */
+export const REVIEW_STEPS = [
+  'identify_address',
+  'confirm_unit',
+  'stay_period',
+  'ratings',
+  'free_text',
+  'evidence',
+  'summary',
+  'submit',
+] as const;
+
+/** The event vocabulary. Adding a name here without a spec below fails to compile. */
+export const OBSERVABILITY_EVENT_NAMES = [
+  'location_permission_resolved',
+  'location_selection_started',
+  'location_selection_committed',
+  'geocoder_request_completed',
+  'search_submitted',
+  'map_area_search_committed',
+  'search_results_loaded',
+  'search_zero_results',
+  'housing_profile_opened',
+  'address_candidate_selected',
+  'review_step_completed',
+  'review_abandoned',
+  'listing_duplicate_group_opened',
+] as const;
+export type ObservabilityEventName = (typeof OBSERVABILITY_EVENT_NAMES)[number];
+
+/** The kinds a field may declare. There is deliberately no free-text kind. */
+export type ObservabilityFieldKind =
+  | { readonly kind: 'enum'; readonly values: readonly string[] }
+  | { readonly kind: 'opaqueId' }
+  | { readonly kind: 'countryCode' }
+  | { readonly kind: 'boolean' }
+  | { readonly kind: 'smallInt'; readonly max: number }
+  | { readonly kind: 'epochMs' };
+
+export interface ObservabilityFieldSpec {
+  readonly type: ObservabilityFieldKind;
+  readonly required: boolean;
+}
+
+export type ObservabilityEventSpec = Readonly<Record<string, ObservabilityFieldSpec>>;
+
+const required = (type: ObservabilityFieldKind): ObservabilityFieldSpec => ({
+  type,
+  required: true,
+});
+const optional = (type: ObservabilityFieldKind): ObservabilityFieldSpec => ({
+  type,
+  required: false,
+});
+
+const opaqueId = { kind: 'opaqueId' } as const;
+const countryCode = { kind: 'countryCode' } as const;
+const boolean = { kind: 'boolean' } as const;
+const enumOf = <T extends readonly string[]>(values: T) => ({ kind: 'enum', values }) as const;
+const smallInt = <M extends number>(max: M) => ({ kind: 'smallInt', max }) as const;
+
+/**
+ * Fields every event carries, whatever its name.
+ *
+ * `schemaVersion` and `occurredAt` are stamped by the emitter, never by the
+ * caller — a caller that supplies them has them overwritten. `sessionId` is an
+ * opaque id the client rotates; it is NOT derived from an Oxy user id, and the
+ * `opaqueId` kind refuses one anyway (a UUID does not match 16 hex characters).
+ * It exists so that step-level abandonment can be measured without knowing who
+ * abandoned.
+ */
+export const OBSERVABILITY_ENVELOPE_SPEC = {
+  schemaVersion: required(smallInt(999)),
+  occurredAt: required({ kind: 'epochMs' }),
+  surface: required(enumOf(OBSERVABILITY_SURFACES)),
+  sessionId: optional(opaqueId),
+} as const satisfies ObservabilityEventSpec;
+
+/**
+ * Keys the envelope owns. An event spec declaring one of these would silently
+ * shadow it in the flat payload shape, so `assertSchemaIsWellFormed` refuses it.
+ */
+export const OBSERVABILITY_RESERVED_KEYS = [
+  'event',
+  ...Object.keys(OBSERVABILITY_ENVELOPE_SPEC),
+] as const;
+
+/**
+ * The per-event field specs.
+ *
+ * Read this as the privacy contract, not as a data dictionary: everything a
+ * consumer will ever be able to ask of this pipeline is on this page.
+ */
+export const OBSERVABILITY_EVENT_SPECS = {
+  /** Whether the device gave us a location, and whether we asked. */
+  location_permission_resolved: {
+    permissionState: required(
+      enumOf(['granted', 'denied', 'undetermined', 'restricted', 'revoked'] as const),
+    ),
+    /** `true` when the grant is coarse-only (iOS "Precise: Off", Android COARSE). */
+    coarse: required(boolean),
+    promptShown: required(boolean),
+    /** Set when a grant was obtained but no fix could be read. */
+    coordinatesAvailable: optional(boolean),
+  },
+
+  /** Somebody opened a place picker. Pairs with `location_selection_committed`. */
+  location_selection_started: {
+    entryPoint: required(
+      enumOf(['home', 'search', 'explore', 'map', 'saved_search', 'deep_link'] as const),
+    ),
+    priorSelectionKind: required(enumOf(LOCATION_KINDS)),
+  },
+
+  /** A scope was chosen. `queryId` is what makes it comparable with what got queried. */
+  location_selection_committed: {
+    queryId: required(opaqueId),
+    locationKind: required(enumOf(LOCATION_KINDS)),
+    countryCode: optional(countryCode),
+    radiusBucketKm: optional(enumOf(RADIUS_BUCKETS_KM)),
+    source: required(enumOf(LOCATION_SOURCES)),
+    /**
+     * `true` when more than one place matched the text and we had to choose.
+     * Two cities called Barcelona is the canonical case (#295).
+     */
+    ambiguousMatch: optional(boolean),
+  },
+
+  /** One geocoder call. Provider health and latency without the search term. */
+  geocoder_request_completed: {
+    provider: required(enumOf(['internal', 'nominatim', 'photon', 'other'] as const)),
+    direction: required(enumOf(['forward', 'reverse'] as const)),
+    outcome: required(enumOf(GEOCODER_OUTCOMES)),
+    httpStatusClass: required(enumOf(['none', '2xx', '3xx', '4xx', '5xx'] as const)),
+    latencyBucketMs: required(enumOf(LATENCY_BUCKETS_MS)),
+    resultCountBucket: optional(enumOf(RESULT_COUNT_BUCKETS)),
+    cacheHit: required(boolean),
+  },
+
+  /** A search left the client. Free text is counted, never transcribed. */
+  search_submitted: {
+    queryId: required(opaqueId),
+    locationKind: required(enumOf(LOCATION_KINDS)),
+    countryCode: optional(countryCode),
+    hasFreeText: required(boolean),
+    freeTextLengthBucket: required(enumOf(TEXT_LENGTH_BUCKETS)),
+    filterCount: required(smallInt(64)),
+    radiusBucketKm: optional(enumOf(RADIUS_BUCKETS_KM)),
+    mapMode: required(boolean),
+  },
+
+  /** "Search this area" was pressed. The event that must prove the old scope died. */
+  map_area_search_committed: {
+    queryId: required(opaqueId),
+    /** The query the map replaced, so a survivor from the previous city is visible. */
+    previousQueryId: optional(opaqueId),
+    countryCode: optional(countryCode),
+    areaBucketKm2: required(enumOf(AREA_BUCKETS_KM2)),
+    zoomBucket: required(enumOf(ZOOM_BUCKETS)),
+    crossesAntimeridian: required(boolean),
+    /** `false` here with a changed viewport is the cross-city filter leak. */
+    priorScopeCleared: required(boolean),
+  },
+
+  /** Results rendered. `stale` is the divergence the user cannot see. */
+  search_results_loaded: {
+    queryId: required(opaqueId),
+    locationKind: required(enumOf(LOCATION_KINDS)),
+    countryCode: optional(countryCode),
+    resultCountBucket: required(enumOf(RESULT_COUNT_BUCKETS)),
+    radiusBucketKm: optional(enumOf(RADIUS_BUCKETS_KM)),
+    mapMode: required(boolean),
+    latencyBucketMs: required(enumOf(LATENCY_BUCKETS_MS)),
+    /** `true` when this result answers a query id that is no longer current. */
+    stale: required(boolean),
+  },
+
+  /** Zero results, and — critically — what we did about it. */
+  search_zero_results: {
+    queryId: required(opaqueId),
+    locationKind: required(enumOf(LOCATION_KINDS)),
+    countryCode: optional(countryCode),
+    radiusBucketKm: optional(enumOf(RADIUS_BUCKETS_KM)),
+    filterCount: required(smallInt(64)),
+    hasFreeText: required(boolean),
+    fallbackApplied: required(enumOf(SEARCH_FALLBACKS)),
+  },
+
+  /** A persistent dwelling page was opened. */
+  housing_profile_opened: {
+    /** Opaque derivation of the canonical housing id — never the id itself. */
+    housingRef: required(opaqueId),
+    identityLevel: required(enumOf(['unit', 'building', 'street', 'unknown'] as const)),
+    countryCode: optional(countryCode),
+    activeListingCountBucket: required(enumOf(RESULT_COUNT_BUCKETS)),
+    hasReviews: required(boolean),
+  },
+
+  /** An address candidate was picked, and whether it became canonical. */
+  address_candidate_selected: {
+    candidateSource: required(
+      enumOf(['geocoder', 'internal', 'listing', 'map_pin'] as const),
+    ),
+    precisionLevel: required(enumOf(ADDRESS_PRECISION_LEVELS)),
+    materialized: required(boolean),
+    countryCode: optional(countryCode),
+  },
+
+  /** One review-wizard step finished. `wizardId` is opaque and per-draft. */
+  review_step_completed: {
+    wizardId: required(opaqueId),
+    stepId: required(enumOf(REVIEW_STEPS)),
+    stepIndex: required(smallInt(32)),
+    durationBucketS: required(enumOf(DURATION_BUCKETS_S)),
+  },
+
+  /** A review draft was abandoned. The funnel-loss counterpart of the above. */
+  review_abandoned: {
+    wizardId: required(opaqueId),
+    lastStepId: required(enumOf(REVIEW_STEPS)),
+    lastStepIndex: required(smallInt(32)),
+    durationBucketS: required(enumOf(DURATION_BUCKETS_S)),
+    reason: required(
+      enumOf(['navigated_away', 'closed', 'error', 'timeout', 'unknown'] as const),
+    ),
+  },
+
+  /** A duplicate group was expanded — the anti-double-counting surface. */
+  listing_duplicate_group_opened: {
+    groupRef: required(opaqueId),
+    memberCountBucket: required(enumOf(RESULT_COUNT_BUCKETS)),
+    providerCount: required(smallInt(32)),
+    priceSpreadBucketPct: optional(enumOf(PERCENT_SPREAD_BUCKETS)),
+    countryCode: optional(countryCode),
+  },
+} as const satisfies Readonly<Record<ObservabilityEventName, ObservabilityEventSpec>>;
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Payload types, DERIVED from the specs above so the two cannot disagree.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+type ValueOfKind<K extends ObservabilityFieldKind> = K extends { kind: 'enum'; values: infer V }
+  ? V extends readonly (infer Item)[]
+    ? Item
+    : never
+  : K extends { kind: 'opaqueId' }
+    ? string
+    : K extends { kind: 'countryCode' }
+      ? string
+      : K extends { kind: 'boolean' }
+        ? boolean
+        : K extends { kind: 'smallInt' }
+          ? number
+          : K extends { kind: 'epochMs' }
+            ? number
+            : never;
+
+type RequiredKeysOf<S extends ObservabilityEventSpec> = {
+  [K in keyof S]: S[K]['required'] extends true ? K : never;
+}[keyof S];
+
+type OptionalKeysOf<S extends ObservabilityEventSpec> = {
+  [K in keyof S]: S[K]['required'] extends true ? never : K;
+}[keyof S];
+
+type PayloadOf<S extends ObservabilityEventSpec> = {
+  [K in RequiredKeysOf<S>]: ValueOfKind<S[K]['type']>;
+} & {
+  [K in OptionalKeysOf<S>]?: ValueOfKind<S[K]['type']>;
+};
+
+/** The caller-supplied fields of each event, derived from its spec. */
+export type ObservabilityPayloads = {
+  [E in ObservabilityEventName]: PayloadOf<(typeof OBSERVABILITY_EVENT_SPECS)[E]>;
+};
+
+/** The envelope fields the emitter stamps, plus the optional session id. */
+export type ObservabilityEnvelopeFields = PayloadOf<typeof OBSERVABILITY_ENVELOPE_SPEC>;
+
+/**
+ * A complete event as it reaches a transport: FLAT, exactly the shape the issue
+ * documents, with the envelope fields alongside the event's own.
+ */
+export type ObservabilityEvent<E extends ObservabilityEventName = ObservabilityEventName> =
+  ObservabilityEnvelopeFields & { event: E } & ObservabilityPayloads[E];
+
+/**
+ * Structural checks on the schema itself, run by the test suite.
+ *
+ * A schema is data, and data drifts: an event added to the name list with no
+ * spec, a spec that shadows an envelope key, an enum declared empty (which
+ * would accept nothing and refuse every event carrying that field). None of
+ * those is a type error, and each one degrades the pipeline silently, so they
+ * are asserted rather than assumed. Returns the problems it found; an empty
+ * array is the passing case.
+ */
+export function assertSchemaIsWellFormed(): string[] {
+  const problems: string[] = [];
+  const specs: Readonly<Record<string, ObservabilityEventSpec>> = OBSERVABILITY_EVENT_SPECS;
+
+  for (const name of OBSERVABILITY_EVENT_NAMES) {
+    const spec = specs[name];
+    if (spec === undefined) {
+      problems.push(`event "${name}" has no field spec`);
+      continue;
+    }
+    if (Object.keys(spec).length === 0) {
+      problems.push(`event "${name}" declares no fields`);
+    }
+    for (const [field, fieldSpec] of Object.entries(spec)) {
+      if ((OBSERVABILITY_RESERVED_KEYS as readonly string[]).includes(field)) {
+        problems.push(`event "${name}" declares reserved envelope key "${field}"`);
+      }
+      if (fieldSpec.type.kind === 'enum' && fieldSpec.type.values.length === 0) {
+        problems.push(`event "${name}" field "${field}" declares an empty enum`);
+      }
+      if (fieldSpec.type.kind === 'smallInt' && fieldSpec.type.max <= 0) {
+        problems.push(`event "${name}" field "${field}" declares a non-positive max`);
+      }
+    }
+  }
+
+  for (const name of Object.keys(specs)) {
+    if (!(OBSERVABILITY_EVENT_NAMES as readonly string[]).includes(name)) {
+      problems.push(`spec "${name}" is not in the event vocabulary`);
+    }
+  }
+
+  return problems;
+}


### PR DESCRIPTION
## What this is

Privacy-safe product observability plus an honest end-to-end matrix for location
and housing identity. Small, real and tested — not a framework.

The defects this epic is about do not throw. A screen renders perfectly while
querying the wrong city, so the only way to know what somebody actually saw is
to record the query, and recording a query is exactly what leaks where they
live. The resolution here is structural rather than procedural.

## Evidence first: what already existed

Measured before writing anything, on this checkout:

```
$ for pat in posthog PostHog mixpanel amplitude segment.com "@segment/" firebase/analytics; do
    printf '%-20s -> ' "$pat"; git grep -i -c -- "$pat" | wc -l; done
posthog              -> 0 tracked files match
mixpanel             -> 0
amplitude            -> 0
@segment/            -> 0
firebase/analytics   -> 0

$ git grep -n "bitdrift" -- .
packages/frontend/app.config.js:145:  '@bitdrift/react-native',      # Expo config plugin only
packages/frontend/package.json:27
bun.lock:95, bun.lock:470
```

`@bitdrift/react-native` has **no JavaScript import anywhere** — it is a config
plugin entry and nothing else. The two files named `analytics` are unrelated:
`services/analyticsService.ts` fetches owner dashboards, and
`utils/metrics.ts` is the scraper cron's in-memory counter. **There was no
product-event pipeline to extend**, so this is a first-party one, and no
third-party SDK was added (the issue forbids one without a privacy review).

## Where it lives, and why

`packages/shared-types/src/observability/`. Eight of the thirteen events
originate on a client and five on the server, so a second copy of the redaction
rules would be a second place for them to be wrong silently. The package is
dependency-free and already ships runtime helpers of this kind
(`ethicalPricing`, `utils/propertyTitle`).

## The guarantee, and how it is enforced

**No field kind can hold free text or a fractional number.** There is no
`string` kind. Every value is a closed enum label, a 16-hex opaque reference, an
ISO-3166 alpha-2 country code, a boolean, a bounded non-negative integer, or a
clock stamp bounded to a plausible epoch band. An address, a review body, an
email, a document reference and a pair of exact coordinates are values with
nowhere to go.

Two mechanisms, because either alone has a hole:

1. **Allowlist by field kind.** Only declared fields survive. This is the only
   thing that can stop a *postcode* — `08013` is short, punctuation-free and has
   no long digit run, so no value-level rule has anything to object to.
2. **A kind-agnostic sweep of the FINAL object.** Strings must be short, use a
   label charset with no `@`, `.`, comma or space, and carry no run of seven or
   more digits; numbers must be integers. This is what still catches a payload
   whose schema entry gets loosened later.

A dropped value is examined too. Forward compatibility is for values that
*could* have been legitimate, so an unrecognised field is dropped and the event
proceeds (an older server must not lose a newer client's whole event), while an
unrecognised field carrying a sentence refuses the event outright.

**Violations carry field names, never values** — a violation record is itself
logged, and `rejected: address=Carrer de Mallorca 401` leaks precisely what the
rejection prevented. Asserted.

Sampling is applied **after** redaction, never before: a refusal is a defect
signal and sampling it away would hide the one class of event nobody may lose.

## What ships

- **`schema.ts`** — `OBSERVABILITY_SCHEMA_VERSION`, the thirteen events the
  issue names, per-field kinds, and TypeScript payload types **derived from the
  runtime spec** so the two cannot drift. `assertSchemaIsWellFormed()` catches
  an event with no spec, an empty enum, or a spec shadowing an envelope key.
- **`buckets.ts`** — result-count, radius and latency buckets using the exact
  boundaries the issue's own example payload uses (`20-49`, `10-25`, `250-500`),
  plus duration, area, zoom, text-length and price-spread. Also
  `priceSpreadBucketPct`, which returns `undefined` for a mixed-currency group
  rather than a converted number.
- **`queryIdentity.ts`** — the deterministic query digest a list and a map must
  both produce. Coordinates are quantised to 3 decimals (~110 m) **before**
  hashing, which is the privacy control; the geometric invariant works on real
  numbers so the grid never masks a real mismatch. FNV-1a written out rather
  than imported, avoiding `BigInt` and `String.prototype.normalize` so the
  digest is identical on Hermes, Node and a browser.
- **`redaction.ts`** — the central layer. The only path to a transport.
- **`emitter.ts`** — injectable transport, clock, RNG and sampling. `emit` is
  synchronous, returns a status and **never throws**, including when the
  transport does. Observability cannot block the action it observes.
- **`invariants.ts`** — the seven divergence checks, each returning
  `{ ok, code, safe }` with classifications only.
- **Backend**: `observability/serverObservability.ts` (logger sink, ingest,
  stats), `controllers/observabilityController.ts`, and
  `POST /api/observability/events` on the public router — unauthenticated on
  purpose, because the first-open, permission and geocoder-fallback events all
  happen before anybody signs in. It **always answers 202**: a 4xx teaches a
  client to retry, and a retry loop driven by telemetry is a self-inflicted
  outage.
- **Config**: `OBSERVABILITY_ENABLED` (**off by default in every environment**),
  `OBSERVABILITY_SAMPLE_RATE`, `OBSERVABILITY_MAX_EVENTS_PER_REQUEST`. A
  malformed sample rate reads as `1`, not `0` — a typo must not silently stop
  recording while every gate stays green.

## Mutation evidence

Three mutations, each confirmed to have LANDED in the file before the run (a
replacement that does not match leaves the file untouched and the suite green,
which looks identical to a surviving mutation). Restored from a namespaced
pristine copy, with a marker from my own edit re-checked afterwards.

**Baseline before mutating:** `Test Suites: 3 passed, Tests: 70 passed`.

**Mutation 1 — allowlist disabled** (unknown fields kept instead of dropped).
Edit landed (`grep -c MUTATION-1` = 1). Result: **3 red**, and they are exactly
the cases the sweep cannot see:

```
✕ drops a field from a newer client build and lets the rest of the event through
✕ drops a postcode, which no value-level rule can recognise and lets the rest of the event through
✕ drops an account reference shaped exactly like a permitted label and lets the rest of the event through
Tests: 3 failed, 24 passed, 27 total
```

This mutation initially reddened only ONE test — the address case survived
because the sweep caught it. That is defence in depth working, but it meant the
allowlist was under-tested, so I added the postcode and account-reference cases
before re-running. They are the proof the allowlist is load-bearing.

**Mutation 2 — final sweep disabled** (`scanForSensitiveValues` returns `[]`).
Edit landed. Result: **14 red across both suites**, including:

```
✕ never lets a full street address reach the transport
✕ never lets exact coordinates as numbers reach the transport
✕ never lets exact coordinates smuggled into a string reach the transport
✕ never lets a residence document reference reach the transport
✕ never lets a contact email reach the transport
✕ never lets a contact phone with no separators reach the transport
✕ never lets the text of a review reach the transport
✕ never lets a free-text search term reach the transport
✕ never lets a nested object that could hide anything at all reach the transport
✕ refuses a timestamp that is not a plausible instant
✕ samples successful events but never samples a refusal away
✕ POST /api/observability/events › refuses a client event carrying an exact address
✕ POST /api/observability/events › refuses exact coordinates smuggled through the wire
✕ POST /api/observability/events › accepts the good events in a mixed batch
Tests: 14 failed, 56 passed, 70 total
```

**Mutation 3 — naive antimeridian handling** (`east - west`, no interval split).
Edit landed (`grep -c MUTATION-3` = 2). Result: **1 red**, the exact case the
fixture exists for:

```
✕ accepts an antimeridian viewport compared with itself
Tests: 1 failed, 33 passed, 34 total
```

**After restoring all three:** `Tests: 70 passed, 70 total`, mutation markers
gone (`grep -c MUTATION` = 0 in both files), md5 identical to the pristine
copies, and my own edits still present.

## A finding from CI, worth more than the fix

The first CI run went RED on a job that had been green locally minutes earlier:
`__tests__/unit/sourceFilesAreText.test.ts` reported a **NUL byte** in
`packages/shared-types/src/observability/queryIdentity.ts`. `deriveOpaqueRef`
joined its namespace and value with a NUL that had gone into the source as a raw
byte.

**Why the local run missed it, and this is the transferable part:** that gate
enumerates with `git ls-files`. The file was still UNTRACKED when I ran the full
suite, so it was invisible to the gate BY CONSTRUCTION — "the suite is green"
said nothing whatsoever about a file I had not staged. Anything enumerating from
the index has this property; `git add` before trusting it.

**Why it matters more than a stray byte:** git classifies a file containing a NUL
as BINARY, so it merges with **no diff at all** — every gate green and no
reviewer able to see a line of it. That is the incident the gate was written for
(#296), and it did its job on the first real occurrence since.

NUL remains the correct SEPARATOR — it cannot occur in a namespace or an id, so
no pair of inputs can collide by concatenation. Only the literal byte in source
was wrong, so it is now a named constant written as an escape. **The digest is
unchanged**: `deriveOpaqueRef('unit', 'unit-4-2')` is still `5fc3683bd64ae56a`,
verified against the built package, which is what the pinned assertions in both
suites depend on. A byte-level scan of every file this branch touches now reports
zero.

One other discrepancy, checked rather than assumed: CI reported 133 suites /
1759 tests against 132 / 1753 locally. That is not a missing local suite — #382
merged `propertyBatchReads.test.ts` into main while this branch was open, and
GitHub runs the MERGE commit.

## Anti-vacuity defences

- A **positive control** in every negative suite — a well-formed event must be
  captured, so "nothing was captured" cannot pass as "nothing sensitive was
  captured".
- **Count floors** on both fixture tables (`>= 9` sensitive, `>= 4`
  allowlist-only), so losing a case is a failure rather than a quieter run.
- Every refusal must **name the offending field**, so a refusal for an unrelated
  reason cannot be mistaken for the redaction working.
- A **completeness floor** on the invariants: the set of codes exercised must
  equal `INVARIANT_CODES`, and all seven exercised cases must be *failing* ones,
  which is what makes the "no value leaked into `safe`" assertion meaningful.
- Every invariant's `safe` map is run through the **same sweep** the redaction
  layer uses.

## Discriminating fixtures

`packages/backend/__tests__/helpers/locationIdentityFixtures.ts`. Each records
what a **wrong** implementation produces; the matrix repeats the list.

| Fixture | What a WRONG implementation produces |
|---|---|
| Barcelona ES / Barcelona VE (real city, Anzoátegui) | A name-keyed scope gives the same query id and full overlap — a search for either answered with both. |
| Madrid, 505 km away | "Search this area" that keeps the old city filter: **identical bounds**, so a bounds-only check passes it; only the query id catches it. |
| Antimeridian viewport + its complement | `east - west` = −358: the box reads as empty (identical pair looks divergent) or as the planet (everything passes). |
| Two units, one building, scores 2 and 5 | Address-keyed identity averages to 3.5, describing neither home. Two 4s would prove nothing. |
| One flat, three portals (1200/1250/1290 EUR) | Listing-keyed grouping gives three groups of one; the price sample counts the flat three times. |
| EUR / USD / PLN / RON, all 1200 | `(max−min)/min` reports **0%** spread; the real gap is fourfold. Correct answer is the absence of a number. |
| Price sample with the duplicate | 8 listings → median **1225**; 6 dwellings → **1125**. Works only because the duplicate sits in the MIDDLE. |
| Exact 41.38743 vs public 41.39 | Publishing the exact value puts a door on a public map; identical at any zoom a person uses. |
| Float noise 41.39000000000001 | "We rounded it" publishes fourteen decimals while believing it published two. |

## Gates run

```
$ bun x tsc --noEmit -p packages/backend/tsconfig.json        BE_TSC_EXIT=0
$ bun run --cwd packages/frontend typecheck                   FE_TSC_EXIT=0
$ bun run --cwd packages/shared-types lint                    ST_LINT_EXIT=0
$ bunx eslint <every backend file I touched>                  BE_LINT_EXIT=0
$ bunx eslint packages/frontend/__tests__/observabilityContract.test.ts   FE_LINT_EXIT=0
$ bun run check:lockfile                                      LOCKFILE_EXIT=0
    bun.lock is in sync: it matches every package.json it records, and a plain
    `bun install` left it unchanged.   (no manifest changed, so no lockfile change)
$ bun run --cwd packages/backend test      Test Suites: 132 passed | Tests: 1753 passed   EXIT=0
$ bun run --cwd packages/frontend test     Test Suites: 5 passed   | Tests: 45 passed     EXIT=0
```

`bun run lint` at the root still exits 1 — **pre-existing and not mine**:
backend 2 errors / 102 warnings (`__tests__/db/placePoiCache.test.ts:28` unused
`eq`, `server.ts:6` unused `NextFunction`), frontend 1 error / 23 warnings
(`SindiExplanationBottomSheet.tsx:136`, the finding AGENTS.md records as
deliberately deferred). Grepping the full lint output for `observability`,
`locationIdentity` and `locationDivergence` returns nothing. The CI `lint` job
is gated off by `vars.HOMIIO_LINT_GATE`.

CI floors raised in the same change: backend **1450 → 1520** (measured
1680 → 1753), frontend **38 → 43** (measured 40 → 45). No new workflow — the
tests live in the packages whose suites already run.

## The matrix

`docs/qa/location-and-housing-identity-e2e-matrix.md`, all five groups across
web / iOS / Android. It is deliberately unflattering. Counted by parsing the
table, not from memory — **34 journeys: 12 AUTOMATED-NOW, 18
AUTOMATABLE-AFTER a named issue, 3 MANUAL, and one mixed row (1.4, automatable
on web and manual on both native platforms). Per platform cell: 36 / 55 / 11 out
of 102.** Marking the rest "automated" would be the exact failure this issue
exists to prevent. The figures and the commands that re-derive them are in the
document, because they go stale the moment a row changes.

(An earlier revision of this body said 13 / 19 / 5. That was written from
memory and never counted; the second commit on this branch corrects it and adds
the recount commands.) Flakiness sources and limitations are documented, including the one
that matters most: `jest-expo` runs on Node, so the frontend contract test
proves the package resolves and the digest agrees under Babel — it does **not**
prove Hermes.

## Deferred, and to where

- **Frontend emitter wiring** → **#351–#356, #363**. Not one surface that would
  emit the eight client-side events exists yet. A poster with no callers is the
  speculative framework this issue warns against. The shared emitter already
  runs there (proved by the frontend suite) and the ingest route is live, so a
  transport is ~20 lines inside whichever issue first has something to send.
- **Geocoder failure injection** (matrix 2.6) → **#351**, once the geocoder is
  behind Homiio's own gateway. All four outcomes are asserted against the
  invariant today.
- **`LocationSelection` label contract** (invariant 3) → **#352**. The assertion
  and its structural interface are here and tested; #352 supplies the caller.
- **Public precision policy** (invariant 6) → **#347**. The mechanism takes the
  policy as an argument and ships a documented default rather than hard-coding
  one level.
- **Housing-identity link** (invariant 7) → **#360 / #361**.
- **Duplicate grouping engine** → **#368**; **price methodology** → **#369**.
  The fixtures that discriminate them are here.
- **Metrics computation** — the issue's ten minimum metrics are all derivable
  from the vocabulary as specified. Deriving them is a query against the log,
  not code in this repository. No events table and no dashboards: that would be
  the business-intelligence system the issue puts out of scope.

Closes #350
