### PR TITLE
feat(location): one canonical location contract, and a key that has no coordinate to leak (#352)

### DIFF
--- a/docs/adr/0002-location-and-search-contract.md
+++ b/docs/adr/0002-location-and-search-contract.md
@@ -612,13 +612,17 @@ unrepresentable in the URL as well as in the store.
 ### 5.2 `loc` grammar
 
 ```
-loc := "city."   source "." id                  ; and region./country./neighborhood./address.
+loc := "city."   source "." id                  ; and region./country./district./neighborhood./postcode./address.
      | "bbox."   west "," south "," east "," north
-     | "at."     lng "," lat "," radiusMeters
      | "here."   radiusMeters                   ; NO coordinates, ever
      | "multi."  loc ( "+" loc )+
 source := "homiio" | "<providerId>"
 ```
+
+> **Amended 2026-08-10.** This grammar previously carried a fifth production,
+> `"at." lng "," lat "," radiusMeters`, and it is **withdrawn** — see §19(B).
+> A parser must REJECT `at.` rather than read it leniently. No production of
+> this grammar puts a coordinate pair in a URL.
 
 Examples:
 
@@ -1364,3 +1368,47 @@ the result set alone.
 | A precision and retention policy for the user's location | §8 |
 | A compatibility plan for existing saved searches | §11 |
 | Discriminating fixtures for Barcelona/Madrid, two Barcelonas and an antimeridian bbox | §12.1, §12.2, §12.3 |
+
+---
+
+## 19. Amendments
+
+Changes made to this ADR after it was written, each dated and with the reason
+that forced it. Both of the entries below were found while IMPLEMENTING the
+contract in `packages/shared-types/src/location.ts` (#352's foundation half),
+which is the point of recording them here rather than in a commit message: a
+grammar nobody amends is one somebody implements again from the original text.
+
+### A. §3's `LocationSelection` union is SIX kinds (2026-08-10, clarification)
+
+`current_location`, `place`, `address_candidate`, `map_bounds`, `polygon`,
+`multi_area`. §3 has always listed exactly these; the count is recorded because
+an implementation brief derived from this document miscounted it as seven, and
+a phantom seventh kind is the sort of thing an implementer looks for, fails to
+find, and then invents. Nothing in §3 changes.
+
+### B. §5.2's `at.` production is WITHDRAWN, and a parser must REJECT it (2026-08-10)
+
+The grammar carried `at. lng "," lat "," radiusMeters` for a pin the user
+dropped. It is removed, and `parseLocationToken` returns a typed failure
+(`coordinates_in_url`) for any token in that form.
+
+**Why, and it is decision 8 rather than a matter of taste.** "Exact coordinates
+never appear in a URL, a cache key, an analytics event or a log line" (§2.8,
+§8.2) — and `here. radiusMeters` exists precisely so the device case carries
+none. `at.` put a raw coordinate pair straight back into the URL, which is the
+one place §8.2 names first.
+
+**What made it worth fixing rather than leaving inert.** No `LocationSelection`
+kind mapped to `at.`, so nothing could ever produce one — it was a production
+the parser accepted and the serialiser could not emit. That asymmetry is not
+harmless: a grammar that blesses a form is how the form gets used, and the
+predictable route in is somebody wiring "search around this pin" to it because
+§5.2 appeared to permit it. A lenient parser keeps that door open; a typed
+rejection closes it, and names the rule in the failure reason so whoever meets
+it learns why rather than assuming a typo.
+
+**If the case is genuinely needed later** — a point somebody else chose, as
+opposed to the opener's own device — it needs its own `LocationSelection` kind
+with a declared `LocationPrecision`, added by amending §3 deliberately. It does
+not come back as a grammar leftover rediscovered by the next implementer.

--- a/packages/backend/__tests__/helpers/locationIdentityFixtures.ts
+++ b/packages/backend/__tests__/helpers/locationIdentityFixtures.ts
@@ -12,12 +12,19 @@
  * measurement rather than a mock.
  */
 
-import type {
-  GeoBounds,
-  GeoPoint,
-  PricedListing,
-  QueryDescriptor,
-} from '@homiio/shared-types';
+import type { PricedListing } from '@homiio/shared-types';
+// `GeoPoint`, `GeoBounds` and `QueryDescriptor` come from the observability
+// module BY PATH, not from the package barrel.
+//
+// The barrel's `GeoPoint` is now the canonical location contract's
+// (`{ longitude, latitude }`, ADR 0002 §3), while the query-identity digest
+// these fixtures feed takes its own `{ lat, lng }`. The two are different types
+// with one name, so this file has to say which it means — and it means the one
+// its consumer, `checkQueryIdentityMatch`, actually accepts. Do not "tidy" this
+// back to the barrel: it compiled before only because the canonical contract
+// did not exist yet, and folding the two encodings into one is the location
+// migration's job (#352), not a change to make silently from here.
+import type { GeoBounds, GeoPoint, QueryDescriptor } from '@homiio/shared-types/observability/queryIdentity';
 
 export interface PlaceFixture {
   /** A stable key, never a display string — see `LocationScopeContract`. */

--- a/packages/frontend/__tests__/location/locationKey.test.ts
+++ b/packages/frontend/__tests__/location/locationKey.test.ts
@@ -1,0 +1,374 @@
+/**
+ * `locationKey` — the stable identifier (ADR 0002 §3.1), and the single point
+ * that makes the privacy rule of §8.2 enforceable.
+ *
+ * These live in the FRONTEND suite for the same reason the `format/` tests do:
+ * that is the CI job needing no database, and `shared-types` has no runner of
+ * its own. Jest loads the package's SOURCE, not its `dist/` — re-verified for
+ * this module by mutating `src/location.ts` without rebuilding and watching
+ * this file go red, which is what makes mutation testing here meaningful.
+ *
+ * EVERY FIXTURE BELOW IS CHOSEN SO A CORRECT AND AN INCORRECT IMPLEMENTATION
+ * DISAGREE. A key is a string, and almost any implementation produces one, so a
+ * test that merely asserts "a string came back" — or that pins one expected
+ * value computed from the implementation itself — cannot see any of the five
+ * failures ADR §12 enumerates. Each block records what a wrong implementation
+ * produces from its fixture.
+ */
+
+import {
+  KEY_BOUNDS_DECIMALS,
+  locationKey,
+  type AdminHierarchy,
+  type GeoBounds,
+  type LocationSelection,
+  type PlaceLabel,
+} from '@homiio/shared-types';
+
+/**
+ * Fixtures are typed to their exact variant rather than to the whole union, so
+ * that a `multi_area`'s `areas` accepts them and the reads below narrow, with
+ * no cast anywhere in this file. A cast in a test is a place the compiler stops
+ * checking the very shape under test.
+ */
+type PlaceSelection = Extract<LocationSelection, { kind: 'place' }>;
+type DeviceSelection = Extract<LocationSelection, { kind: 'current_location' }>;
+type MapBoundsSelection = Extract<LocationSelection, { kind: 'map_bounds' }>;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PLACE_LABEL: PlaceLabel = { primary: 'Barcelona', secondary: 'Catalonia, Spain', kind: 'place' };
+
+/**
+ * Barcelona, Catalonia, Spain — the one a wrong implementation picks, because
+ * it is first, because it has more listings, and because it is the popular
+ * answer. It is deliberately NOT the expected answer anywhere below.
+ */
+const BARCELONA_ES: PlaceSelection = {
+  kind: 'place',
+  source: { kind: 'homiio', entity: 'city', id: '01H8XQ7C2R9V6WQ2N4M0KJ3ZTA' },
+  placeType: 'city',
+  label: PLACE_LABEL,
+  admin: { countryCode: 'ES', regionCode: 'ES-CT', regionName: 'Catalonia', cityName: 'Barcelona' },
+  center: { longitude: 2.1686, latitude: 41.3874 },
+  precision: 'centroid',
+};
+
+/**
+ * Barcelona, Anzoátegui, Venezuela — a real city of that name in another
+ * country. Different id, different `countryCode`, different `regionName`, and
+ * the SAME label, which is the whole point: a key built from the label cannot
+ * tell these two apart, and neither can one built from popularity.
+ */
+const BARCELONA_VE: PlaceSelection = {
+  kind: 'place',
+  source: { kind: 'homiio', entity: 'city', id: '01J2K4M6P8R0T2V4X6Z8A0C2E4' },
+  placeType: 'city',
+  label: { primary: 'Barcelona', secondary: 'Anzoátegui, Venezuela', kind: 'place' },
+  admin: { countryCode: 'VE', regionCode: 'VE-B', regionName: 'Anzoátegui', cityName: 'Barcelona' },
+  center: { longitude: -64.6844, latitude: 10.1333 },
+  precision: 'centroid',
+};
+
+const GENERATED_LABEL: PlaceLabel & { readonly kind: 'generated' } = {
+  primary: 'Map area',
+  kind: 'generated',
+};
+
+function mapBounds(bounds: GeoBounds): MapBoundsSelection {
+  return {
+    kind: 'map_bounds',
+    bounds,
+    center: {
+      longitude: (bounds.west + bounds.east) / 2,
+      latitude: (bounds.south + bounds.north) / 2,
+    },
+    label: GENERATED_LABEL,
+    precision: 'area',
+  };
+}
+
+const ADMIN_ES: AdminHierarchy = { countryCode: 'ES' };
+
+// ---------------------------------------------------------------------------
+// §8.2 — a device fix never reaches a key
+// ---------------------------------------------------------------------------
+
+describe('locationKey: current_location emits no coordinate', () => {
+  /**
+   * Digits are chosen so the two sets are DISJOINT: the radius 25000 uses only
+   * {2,5,0}, and both coordinates use only {1,3,4,6,7,8}. Without that, "the
+   * key contains no digit of the coordinate" is untestable — the `2` of
+   * longitude 2.1686 is also the `2` of 25000, so a leak and a clean key look
+   * identical.
+   */
+  const RADIUS_DIGITS = new Set('25000');
+  const HERE: DeviceSelection = {
+    kind: 'current_location',
+    center: { longitude: 13.4678, latitude: 41.3874 },
+    radiusMeters: 25000,
+    precision: 'exact',
+  };
+
+  it('produces exactly the radius form', () => {
+    expect(locationKey(HERE)).toBe('here:25000');
+  });
+
+  it('contains no digit that is not part of the radius', () => {
+    // Sanity: the fixture really does have disjoint digit sets, or this
+    // assertion passes for a reason that has nothing to do with the code.
+    const coordinateDigits = `${HERE.center.longitude}${HERE.center.latitude}`.replace(/[^0-9]/g, '');
+    expect(coordinateDigits.length).toBeGreaterThan(6);
+    for (const digit of coordinateDigits) {
+      expect(RADIUS_DIGITS.has(digit)).toBe(false);
+    }
+
+    const key = locationKey(HERE);
+    const leaked = [...key].filter((char) => /[0-9]/.test(char) && !RADIUS_DIGITS.has(char));
+    expect(leaked).toEqual([]);
+  });
+
+  /**
+   * THE STRUCTURAL DISCRIMINATOR, and the one that does not depend on which
+   * digits the fixture happens to use: two device fixes on different continents
+   * with the same radius are the same key. No implementation that emits any
+   * function of the coordinate — full precision, 2 dp, 3 dp, a hash, a geohash
+   * — can satisfy this.
+   */
+  it('is identical for two different positions with the same radius', () => {
+    const elsewhere: DeviceSelection = {
+      kind: 'current_location',
+      center: { longitude: -73.9857, latitude: 40.7484 },
+      radiusMeters: 25000,
+      precision: 'exact',
+    };
+    expect(locationKey(elsewhere)).toBe(locationKey(HERE));
+  });
+
+  /**
+   * Negative control for the test above: the key is not simply constant. A
+   * `locationKey` that returned `'here'` for everything would pass the
+   * same-key assertion and be useless.
+   */
+  it('still distinguishes two different radii', () => {
+    const wider: DeviceSelection = { ...HERE, radiusMeters: 50000 };
+    expect(locationKey(wider)).not.toBe(locationKey(HERE));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §3.1 — the bbox grid
+// ---------------------------------------------------------------------------
+
+describe('locationKey: bbox is on a 3 dp grid', () => {
+  const MADRID: GeoBounds = { west: -3.75, south: 40.38, east: -3.65, north: 40.45 };
+
+  it('matches the value ADR §12.1 states', () => {
+    expect(locationKey(mapBounds(MADRID))).toBe('bbox:-3.75,40.38,-3.65,40.45');
+  });
+
+  /**
+   * The bound is the LITERAL 3, not `KEY_BOUNDS_DECIMALS`.
+   *
+   * Written the obvious way — asserting against the exported constant — this
+   * test cannot fail: widening the constant to 6 moves the implementation and
+   * the assertion together, so a key emitting six decimals passes. That was
+   * found by mutation-testing this very file (the constant was changed to 6 and
+   * only two OTHER assertions went red), and it is the plain form of "a check
+   * that cannot distinguish success from failure".
+   */
+  it('never emits more than three decimal places', () => {
+    const jittery: GeoBounds = {
+      west: 2.0501234567,
+      south: 41.3209876543,
+      east: 2.2304444444,
+      north: 41.4706666666,
+    };
+    const key = locationKey(mapBounds(jittery));
+    const components = key.replace('bbox:', '').split(',');
+    expect(components).toHaveLength(4);
+    for (const component of components) {
+      const decimals = component.split('.')[1] ?? '';
+      expect(decimals.length).toBeLessThanOrEqual(3);
+    }
+    // And the published constant is what the ADR says it is, so a consumer
+    // reading it for its own rounding gets the same grid.
+    expect(KEY_BOUNDS_DECIMALS).toBe(3);
+  });
+
+  /**
+   * The reason the grid exists: a map that jitters by less than the grid is one
+   * query, not a new one for every frame. The offset here (2e-5 degrees, about
+   * 2 m) is far below 3 dp, so a correct implementation collapses the two.
+   */
+  it('gives two viewports differing below the grid the same key', () => {
+    const a: GeoBounds = { west: 2.05, south: 41.32, east: 2.23, north: 41.47 };
+    const b: GeoBounds = {
+      west: 2.05002,
+      south: 41.32002,
+      east: 2.23002,
+      north: 41.47002,
+    };
+    expect(locationKey(mapBounds(b))).toBe(locationKey(mapBounds(a)));
+  });
+
+  /**
+   * Negative control for the collapse above. Without it, an implementation
+   * rounding to zero decimals — or returning a constant — passes.
+   */
+  it('gives two viewports differing above the grid different keys', () => {
+    const a: GeoBounds = { west: 2.05, south: 41.32, east: 2.23, north: 41.47 };
+    const b: GeoBounds = { west: 2.06, south: 41.32, east: 2.23, north: 41.47 };
+    expect(locationKey(mapBounds(b))).not.toBe(locationKey(mapBounds(a)));
+  });
+
+  /**
+   * A box straddling Greenwich must not key differently depending on which side
+   * of zero the float landed on: `-0` and `0` are the same meridian, and
+   * `String(-0.0001 rounded)` is `-0` without the normalisation.
+   */
+  it('normalises negative zero', () => {
+    const west: GeoBounds = { west: -0.0001, south: 51.4, east: 0.1, north: 51.6 };
+    const east: GeoBounds = { west: 0.0001, south: 51.4, east: 0.1, north: 51.6 };
+    expect(locationKey(mapBounds(west))).toBe(locationKey(mapBounds(east)));
+    expect(locationKey(mapBounds(west))).not.toContain('-0,');
+  });
+
+  it('keys a polygon by its bounds, on the same grid', () => {
+    const polygon: Extract<LocationSelection, { kind: 'polygon' }> = {
+      kind: 'polygon',
+      polygon: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [2.05, 41.32],
+            [2.23, 41.32],
+            [2.23, 41.47],
+            [2.05, 41.47],
+            [2.05, 41.32],
+          ],
+        ],
+      },
+      bounds: { west: 2.05, south: 41.32, east: 2.23, north: 41.47 },
+      label: { primary: 'Drawn area', kind: 'generated' },
+      precision: 'area',
+    };
+    expect(locationKey(polygon)).toBe('bbox:2.05,41.32,2.23,41.47');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §12.2 — two cities called Barcelona
+// ---------------------------------------------------------------------------
+
+describe('locationKey: homonyms are two different things', () => {
+  /**
+   * The expected answer is the SECOND fixture, per §12.2's fixture-shape
+   * warning: a test whose right answer is also the first candidate, the most
+   * popular one, or the default-country match cannot distinguish a correct
+   * implementation from any of the four wrong ones the ADR lists.
+   */
+  it('keys the Venezuelan Barcelona by its own id', () => {
+    expect(locationKey(BARCELONA_VE)).toBe('homiio:city:01J2K4M6P8R0T2V4X6Z8A0C2E4');
+  });
+
+  it('gives the two Barcelonas different keys', () => {
+    expect(locationKey(BARCELONA_VE)).not.toBe(locationKey(BARCELONA_ES));
+  });
+
+  /**
+   * A key built from the label is the failure that produces both of today's
+   * homonym bugs at once — `results[0]` and de-duping recents by label. The two
+   * fixtures share a label exactly so this assertion can see it.
+   */
+  it('does not contain the label the two share', () => {
+    expect(locationKey(BARCELONA_VE)).not.toContain('Barcelona');
+    expect(locationKey(BARCELONA_ES)).not.toContain('Barcelona');
+  });
+
+  it('keys an external candidate by provider and ref, marked as external', () => {
+    const external: PlaceSelection = {
+      kind: 'place',
+      source: { kind: 'external', provider: 'osm', ref: 'R349036' },
+      placeType: 'city',
+      label: PLACE_LABEL,
+      admin: ADMIN_ES,
+      center: { longitude: 2.1686, latitude: 41.3874 },
+      precision: 'centroid',
+    };
+    expect(locationKey(external)).toBe('ext:osm:R349036');
+  });
+
+  /**
+   * A Homiio city and an external candidate that happen to share an id string
+   * are different places, and the source prefix is what says so. Without it a
+   * provider ref could collide with a canonical id and silently share a cache
+   * entry.
+   */
+  it('separates a homiio entity from an external ref with the same id', () => {
+    const external: Extract<LocationSelection, { kind: 'address_candidate' }> = {
+      kind: 'address_candidate',
+      source: { kind: 'external', provider: 'osm', ref: '01H8XQ7C2R9V6WQ2N4M0KJ3ZTA' },
+      label: PLACE_LABEL,
+      admin: ADMIN_ES,
+      center: { longitude: 2.1686, latitude: 41.3874 },
+      precision: 'exact',
+    };
+    expect(locationKey(external)).not.toBe(locationKey(BARCELONA_ES));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The remaining branches
+// ---------------------------------------------------------------------------
+
+describe('locationKey: absence and composition', () => {
+  it('has a key for no location at all', () => {
+    expect(locationKey(null)).toBe('none');
+  });
+
+  /**
+   * "No location" is a legitimate query (§4.3) and must not collide with any
+   * real one — otherwise a global feed and a real search share a cache entry.
+   */
+  it('does not collide with any selection key', () => {
+    for (const selection of [BARCELONA_ES, BARCELONA_VE, mapBounds({ west: 0, south: 0, east: 1, north: 1 })]) {
+      expect(locationKey(selection)).not.toBe('none');
+    }
+  });
+
+  it('sorts multi_area so the key does not depend on pick order', () => {
+    const forward: LocationSelection = {
+      kind: 'multi_area',
+      areas: [BARCELONA_ES, BARCELONA_VE],
+      label: { primary: '2 areas', kind: 'generated' },
+    };
+    const reversed: LocationSelection = {
+      kind: 'multi_area',
+      areas: [BARCELONA_VE, BARCELONA_ES],
+      label: { primary: '2 areas', kind: 'generated' },
+    };
+    expect(locationKey(reversed)).toBe(locationKey(forward));
+  });
+
+  /**
+   * Negative control for the sort: a `multi_area` of two different sets must
+   * not collapse. An implementation returning `multi:` regardless would pass
+   * the order-independence assertion above on its own.
+   */
+  it('still distinguishes two different multi_area sets', () => {
+    const pair: LocationSelection = {
+      kind: 'multi_area',
+      areas: [BARCELONA_ES, BARCELONA_VE],
+      label: { primary: '2 areas', kind: 'generated' },
+    };
+    const single: LocationSelection = {
+      kind: 'multi_area',
+      areas: [BARCELONA_ES],
+      label: { primary: '1 area', kind: 'generated' },
+    };
+    expect(locationKey(single)).not.toBe(locationKey(pair));
+  });
+});

--- a/packages/frontend/__tests__/location/locationToken.test.ts
+++ b/packages/frontend/__tests__/location/locationToken.test.ts
@@ -1,0 +1,520 @@
+/**
+ * The `loc` URL token codec (ADR 0002 §5.2), and the antimeridian rule of §9.3.
+ *
+ * `loc` is ONE parameter on purpose: the entire bug class this contract exists
+ * for is "half of the previous location survived", and an atomic token makes a
+ * half-update unrepresentable in the URL as well as in the store. These tests
+ * are therefore mostly about EXACTNESS — a codec that loses or invents a field
+ * reintroduces the bug through the back door.
+ *
+ * ADR §16(1) requires the round trip URL → store → API request → URL to be
+ * character-for-character identical. That is asserted here on the two halves
+ * this module owns: token → parse → serialise → token, and selection → token →
+ * parse → the same reference the selection produces directly.
+ *
+ * WHAT IS DELIBERATELY NOT ASSERTED: that parsing yields a full
+ * `LocationSelection`. It cannot, and must not pretend to — a token for a named
+ * place carries an id and no label, admin hierarchy or centre, because those
+ * come from resolving it (§6.2). The tests below pin that boundary rather than
+ * papering over it.
+ */
+
+import {
+  isValidBounds,
+  isValidLatitude,
+  isValidLongitude,
+  locationRefOf,
+  normalizeLongitude,
+  parseLocationToken,
+  serializeLocationRef,
+  serializeLocationToken,
+  type GeoBounds,
+  type LocationRef,
+  type LocationSelection,
+  type LocationTokenResult,
+  type PlaceLabel,
+} from '@homiio/shared-types';
+
+type PlaceSelection = Extract<LocationSelection, { kind: 'place' }>;
+
+const PLACE_LABEL: PlaceLabel = { primary: 'Barcelona', secondary: 'Catalonia, Spain', kind: 'place' };
+
+/** Unwrap a result, failing loudly with the reason rather than on `undefined`. */
+function expectOk<T>(result: LocationTokenResult<T>): T {
+  if (!result.ok) {
+    throw new Error(`expected ok, got failure: ${result.reason}`);
+  }
+  return result.value;
+}
+
+// ---------------------------------------------------------------------------
+// §16(1) — the round trip
+// ---------------------------------------------------------------------------
+
+describe('loc token: round trip is character-for-character', () => {
+  /**
+   * One token per production of the §5.2 grammar, plus the two the ADR calls
+   * out by name. Every one of these is a token a URL could really carry.
+   */
+  const TOKENS = [
+    // A canonical Homiio place, for each place type the grammar admits.
+    'country.homiio.01H8XQ7C2R9V6WQ2N4M0KJ3ZTA',
+    'region.homiio.01H8XQ7C2R9V6WQ2N4M0KJ3ZTB',
+    'city.homiio.01H8XQ7C2R9V6WQ2N4M0KJ3ZTA',
+    'district.homiio.01H8XQ7C2R9V6WQ2N4M0KJ3ZTC',
+    'neighborhood.homiio.01H8XQ7C2R9V6WQ2N4M0KJ3ZTD',
+    'postcode.homiio.01H8XQ7C2R9V6WQ2N4M0KJ3ZTE',
+    'address.homiio.01H8XQ7C2R9V6WQ2N4M0KJ3ZTF',
+    // An external candidate, whose ref is the provider's own.
+    'city.osm.R349036',
+    'address.osm.N1234567890',
+    // A map viewport.
+    'bbox.-3.75,40.38,-3.65,40.45',
+    // The antimeridian box §9.3 measured against a real PostGIS. `west > east`.
+    'bbox.170,-20,-170,-16',
+    // A dropped pin. No `LocationSelection` kind maps to this yet — see below.
+    'at.2.1734,41.3851,25000',
+    // "Near me", carrying NO coordinates.
+    'here.25000',
+    // Several areas at once.
+    'multi.city.homiio.01H8XQ7C2R9V6WQ2N4M0KJ3ZTA+bbox.2.05,41.32,2.23,41.47',
+    'multi.here.25000+city.osm.R349036+bbox.170,-20,-170,-16',
+  ] as const;
+
+  it.each(TOKENS)('%s survives parse then serialise unchanged', (token) => {
+    const ref = expectOk(parseLocationToken(token));
+    expect(expectOk(serializeLocationRef(ref))).toBe(token);
+  });
+
+  /**
+   * A vacuity floor. If `TOKENS` were ever emptied or filtered down by a bad
+   * edit, `it.each` would run nothing and the suite would still be green — the
+   * same shape as a census that reports zero because its traversal broke.
+   */
+  it('covers every production of the grammar', () => {
+    expect(TOKENS.length).toBeGreaterThanOrEqual(15);
+    const heads = new Set(TOKENS.map((token) => token.slice(0, token.indexOf('.'))));
+    expect(heads).toEqual(
+      new Set([
+        'country',
+        'region',
+        'city',
+        'district',
+        'neighborhood',
+        'postcode',
+        'address',
+        'bbox',
+        'at',
+        'here',
+        'multi',
+      ]),
+    );
+  });
+
+  it('round-trips a place id containing dots', () => {
+    // Everything after the SECOND dot is the id, so a provider ref with dots is
+    // not ours to reject. A parser splitting on every dot would truncate it.
+    const token = 'address.osm.way.123.456';
+    const ref = expectOk(parseLocationToken(token));
+    expect(ref).toEqual({
+      kind: 'place',
+      placeType: 'address',
+      source: { kind: 'external', provider: 'osm' },
+      id: 'way.123.456',
+    });
+    expect(expectOk(serializeLocationRef(ref))).toBe(token);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selection → token
+// ---------------------------------------------------------------------------
+
+describe('loc token: a selection serialises to its reference', () => {
+  const BARCELONA_ES: PlaceSelection = {
+    kind: 'place',
+    source: { kind: 'homiio', entity: 'city', id: '01H8XQ7C2R9V6WQ2N4M0KJ3ZTA' },
+    placeType: 'city',
+    label: PLACE_LABEL,
+    admin: { countryCode: 'ES', regionName: 'Catalonia' },
+    center: { longitude: 2.1686, latitude: 41.3874 },
+    precision: 'centroid',
+  };
+
+  it('emits the token ADR §13.3 shows', () => {
+    expect(expectOk(serializeLocationToken(BARCELONA_ES))).toBe(
+      'city.homiio.01H8XQ7C2R9V6WQ2N4M0KJ3ZTA',
+    );
+  });
+
+  /**
+   * The exactness property in the direction that matters for §6.1: what comes
+   * back out of the URL is the same reference the store put in. Anything the
+   * token drops (label, admin, centre) is recovered by resolving, never guessed.
+   */
+  it('parses back to the reference the selection produces directly', () => {
+    const token = expectOk(serializeLocationToken(BARCELONA_ES));
+    expect(expectOk(parseLocationToken(token))).toEqual(expectOk(locationRefOf(BARCELONA_ES)));
+  });
+
+  it('does not carry the label, so two Barcelonas cannot collapse', () => {
+    const token = expectOk(serializeLocationToken(BARCELONA_ES));
+    expect(token).not.toContain('Barcelona');
+    expect(token).not.toContain('Catalonia');
+  });
+
+  it('serialises an address candidate under the `address` production', () => {
+    const candidate: Extract<LocationSelection, { kind: 'address_candidate' }> = {
+      kind: 'address_candidate',
+      source: { kind: 'external', provider: 'osm', ref: 'N1234567890' },
+      label: { primary: 'Carrer de Mallorca 401', kind: 'place' },
+      admin: { countryCode: 'ES' },
+      center: { longitude: 2.1743, latitude: 41.4036 },
+      precision: 'exact',
+    };
+    expect(expectOk(serializeLocationToken(candidate))).toBe('address.osm.N1234567890');
+  });
+
+  it('emits `here.<radius>` with no coordinates for a device fix', () => {
+    const here: LocationSelection = {
+      kind: 'current_location',
+      center: { longitude: 13.4678, latitude: 41.3874 },
+      radiusMeters: 25000,
+      precision: 'exact',
+    };
+    const token = expectOk(serializeLocationToken(here));
+    expect(token).toBe('here.25000');
+    // A shared "near me" link means "near the OPENER". Any leak here would be
+    // a device position pasted into somebody else's browser history.
+    expect(token).not.toContain('13.4');
+    expect(token).not.toContain('41.3');
+  });
+
+  /**
+   * §2.1 reserves the polygon wire format deliberately, so the honest answer is
+   * a typed refusal. Degrading it to its bounding box would silently replace a
+   * drawn area with a rectangle — the same "half the location survived" class
+   * the atomic selection exists to prevent, arrived at from the other side.
+   */
+  it('refuses a polygon rather than degrading it to its bounds', () => {
+    const polygon: Extract<LocationSelection, { kind: 'polygon' }> = {
+      kind: 'polygon',
+      polygon: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [2.05, 41.32],
+            [2.23, 41.32],
+            [2.23, 41.47],
+            [2.05, 41.32],
+          ],
+        ],
+      },
+      bounds: { west: 2.05, south: 41.32, east: 2.23, north: 41.47 },
+      label: { primary: 'Drawn area', kind: 'generated' },
+      precision: 'area',
+    };
+    const result = serializeLocationToken(polygon);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe('unsupported_kind');
+  });
+
+  it('propagates that refusal out of a multi_area containing a polygon', () => {
+    const polygon: Extract<LocationSelection, { kind: 'polygon' }> = {
+      kind: 'polygon',
+      polygon: { type: 'MultiPolygon', coordinates: [[[[0, 0], [1, 0], [1, 1], [0, 0]]]] },
+      bounds: { west: 0, south: 0, east: 1, north: 1 },
+      label: { primary: 'Drawn area', kind: 'generated' },
+      precision: 'area',
+    };
+    const result = serializeLocationToken({
+      kind: 'multi_area',
+      areas: [BARCELONA_ES, polygon],
+      label: { primary: '2 areas', kind: 'generated' },
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe('unsupported_kind');
+  });
+
+  /**
+   * `multi.` preserves the author's order while `locationKey` sorts. The
+   * asymmetry is deliberate and worth pinning: §16(1) wants an exact URL round
+   * trip (so the token may not reorder), and §3.1 wants an order-independent
+   * identity (so the key must). Both properties hold literally, and neither
+   * would if one function tried to serve both.
+   */
+  it('preserves the order of a multi_area in the token', () => {
+    const first = expectOk(
+      serializeLocationToken({
+        kind: 'multi_area',
+        areas: [
+          BARCELONA_ES,
+          { kind: 'current_location', center: { longitude: 0, latitude: 0 }, radiusMeters: 25000, precision: 'exact' },
+        ],
+        label: { primary: '2 areas', kind: 'generated' },
+      }),
+    );
+    const second = expectOk(
+      serializeLocationToken({
+        kind: 'multi_area',
+        areas: [
+          { kind: 'current_location', center: { longitude: 0, latitude: 0 }, radiusMeters: 25000, precision: 'exact' },
+          BARCELONA_ES,
+        ],
+        label: { primary: '2 areas', kind: 'generated' },
+      }),
+    );
+    expect(first).toBe('multi.city.homiio.01H8XQ7C2R9V6WQ2N4M0KJ3ZTA+here.25000');
+    expect(second).toBe('multi.here.25000+city.homiio.01H8XQ7C2R9V6WQ2N4M0KJ3ZTA');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §5.2 — an unparseable token is a FAILURE, not an absence
+// ---------------------------------------------------------------------------
+
+describe('loc token: a bad token is distinguishable from no token', () => {
+  const BAD: readonly (readonly [string, string])[] = [
+    ['', 'empty'],
+    ['city', 'unknown_kind'],
+    ['.homiio.abc', 'unknown_kind'],
+    ['nonsense.homiio.abc', 'unknown_kind'],
+    ['BBOX.1,2,3,4', 'unknown_kind'],
+    ['Here.25000', 'unknown_kind'],
+    ['city.homiio.', 'malformed'],
+    ['city.homiio', 'malformed'],
+    ['bbox.1,2,3', 'malformed'],
+    ['bbox.1,2,3,4,5', 'malformed'],
+    ['at.1,2', 'malformed'],
+    ['multi.city.homiio.abc', 'malformed'],
+    ['bbox.,,,', 'not_a_number'],
+    ['here.', 'not_a_number'],
+    ['here.abc', 'not_a_number'],
+    ['here. 25000', 'not_a_number'],
+    ['here.2.5e4', 'not_a_number'],
+    ['here.+25000', 'not_a_number'],
+    ['bbox.1,2,3,four', 'not_a_number'],
+    ['here.0', 'out_of_range'],
+    ['here.-5', 'out_of_range'],
+    ['at.2.17,41.38,0', 'out_of_range'],
+    ['at.2.17,91,25000', 'out_of_range'],
+    ['bbox.2.05,41.47,2.23,41.32', 'out_of_range'],
+    ['bbox.2.05,-91,2.23,41.47', 'out_of_range'],
+    ['multi.city.homiio.abc+multi.here.25000+here.500', 'nested_multi'],
+  ];
+
+  it.each(BAD)('%s fails with %s', (token, reason) => {
+    const result = parseLocationToken(token);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe(reason);
+    // The point of the whole exercise: no half-built selection escapes, and
+    // there is no `null` for a caller to mistake for "no location was asked
+    // for". A failed `loc` must reach `resolution.status = 'failed'`, never a
+    // global feed.
+    expect('value' in result).toBe(false);
+  });
+
+  it('has a failing case for every reason the parser can return', () => {
+    const covered = new Set(BAD.map(([, reason]) => reason));
+    expect(covered).toEqual(
+      new Set(['empty', 'unknown_kind', 'malformed', 'not_a_number', 'out_of_range', 'nested_multi']),
+    );
+  });
+
+  /**
+   * `Number('')` is `0`, so a permissive parser reads `bbox.,,,` as the box
+   * 0,0,0,0 — a valid-looking zero-area query in the Gulf of Guinea, returned
+   * as an empty result set that reads like "nothing here". This is the single
+   * most plausible-looking wrong answer in the whole codec.
+   */
+  it('does not read an empty segment as zero', () => {
+    const result = parseLocationToken('bbox.,,,');
+    expect(result.ok).toBe(false);
+    const zeroBox = parseLocationToken('bbox.0,0,0,0');
+    // Control: the box really is expressible, so the refusal above is about the
+    // empty segments and not about zero being rejected.
+    expect(zeroBox.ok).toBe(true);
+  });
+
+  it('refuses an id carrying the multi separator rather than corrupting a multi token', () => {
+    const result = serializeLocationRef({
+      kind: 'place',
+      placeType: 'city',
+      source: { kind: 'homiio' },
+      id: 'a+b',
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe('unencodable_id');
+  });
+
+  /**
+   * A provider literally called `homiio` would emit `city.homiio.<ref>`, which
+   * reads as a canonical Homiio id — the one collision the grammar has no way
+   * to resolve, and the one that would silently hand a provider's ref to a
+   * database lookup.
+   */
+  it('refuses an external provider named `homiio`', () => {
+    const result = serializeLocationRef({
+      kind: 'place',
+      placeType: 'city',
+      source: { kind: 'external', provider: 'homiio' },
+      id: 'R349036',
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe('unencodable_id');
+  });
+
+  it('refuses a multi of fewer than two parts', () => {
+    const single: LocationRef = {
+      kind: 'multi',
+      refs: [{ kind: 'device', radiusMeters: 25000 }],
+    };
+    const result = serializeLocationRef(single);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe('malformed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// §9.3 — the antimeridian
+// ---------------------------------------------------------------------------
+
+describe('bounds validation: west > east is legal, south > north is not', () => {
+  /**
+   * The 20-degree strip over the Pacific, verified against a real PostGIS in
+   * ADR §9.3: Fiji (178.44, -18.14) and Samoa (-172, -18) are inside it, and
+   * (0, -18), (100, -18), (-100, -18) are not. A fixture set without this box
+   * cannot tell a correct validator from one that also rejects `west > east` —
+   * every ordinary box has `west < east`, so both implementations agree on all
+   * of them.
+   */
+  const ANTIMERIDIAN: GeoBounds = { west: 170, south: -20, east: -170, north: -16 };
+  const ORDINARY: GeoBounds = { west: 2.05, south: 41.32, east: 2.23, north: 41.47 };
+  const FLIPPED_LATITUDE: GeoBounds = { west: 2.05, south: 41.47, east: 2.23, north: 41.32 };
+
+  it('accepts an ordinary box', () => {
+    expect(isValidBounds(ORDINARY)).toBe(true);
+  });
+
+  it('accepts a box crossing the antimeridian', () => {
+    expect(isValidBounds(ANTIMERIDIAN)).toBe(true);
+  });
+
+  it('rejects a box whose south is north of its north', () => {
+    expect(isValidBounds(FLIPPED_LATITUDE)).toBe(false);
+  });
+
+  /**
+   * The two rules are independent, and this is what proves it: accepting
+   * `west > east` must not be a blanket "accept anything reversed". A box that
+   * crosses the antimeridian AND has its latitudes flipped is still invalid.
+   */
+  it('rejects flipped latitudes even on an antimeridian box', () => {
+    expect(isValidBounds({ west: 170, south: -16, east: -170, north: -20 })).toBe(false);
+  });
+
+  it('accepts a degenerate box', () => {
+    // Zero area is a legitimate, if useless, query — not a malformed one.
+    expect(isValidBounds({ west: 2.05, south: 41.32, east: 2.05, north: 41.32 })).toBe(true);
+  });
+
+  it('rejects a latitude beyond a pole and a longitude beyond the range', () => {
+    expect(isValidBounds({ west: 0, south: -91, east: 1, north: 10 })).toBe(false);
+    expect(isValidBounds({ west: 0, south: 0, east: 1, north: 91 })).toBe(false);
+    expect(isValidBounds({ west: -181, south: 0, east: 1, north: 10 })).toBe(false);
+    expect(isValidBounds({ west: 0, south: 0, east: 181, north: 10 })).toBe(false);
+  });
+
+  it('rejects a non-finite component', () => {
+    expect(isValidBounds({ west: Number.NaN, south: 0, east: 1, north: 10 })).toBe(false);
+    expect(isValidBounds({ west: 0, south: 0, east: Number.POSITIVE_INFINITY, north: 10 })).toBe(false);
+  });
+
+  it('validates the two coordinate ranges separately', () => {
+    expect(isValidLatitude(90)).toBe(true);
+    expect(isValidLatitude(-90)).toBe(true);
+    expect(isValidLatitude(90.0001)).toBe(false);
+    expect(isValidLatitude(Number.NaN)).toBe(false);
+    // 100 is a legal longitude and an illegal latitude — a single shared range
+    // check would call this valid.
+    expect(isValidLongitude(100)).toBe(true);
+    expect(isValidLatitude(100)).toBe(false);
+    expect(isValidLongitude(180)).toBe(true);
+    expect(isValidLongitude(180.03)).toBe(false);
+  });
+});
+
+describe('normalizeLongitude', () => {
+  it('leaves a longitude already in range alone', () => {
+    expect(normalizeLongitude(2.1686)).toBe(2.1686);
+    expect(normalizeLongitude(-179.97)).toBe(-179.97);
+    expect(normalizeLongitude(0)).toBe(0);
+  });
+
+  it('normalises the two spellings of the same meridian to one', () => {
+    // Half-open range: leaving both legal would give one box two tokens and two
+    // cache keys.
+    expect(normalizeLongitude(180)).toBe(-180);
+    expect(normalizeLongitude(-180)).toBe(-180);
+  });
+
+  it('normalises negative zero', () => {
+    expect(Object.is(normalizeLongitude(-0), 0)).toBe(true);
+  });
+
+  it('wraps a value past the antimeridian', () => {
+    // ADR §9.3's concrete bug: `WhereStep` builds a ±0.05° box around a picked
+    // point, so at longitude 179.98 the east edge is 180.03 and every place
+    // within 0.05° of the antimeridian fails with INVALID_GEO_PARAMS today.
+    expect(normalizeLongitude(180.03)).toBeCloseTo(-179.97, 10);
+    expect(normalizeLongitude(-180.03)).toBeCloseTo(179.97, 10);
+    expect(normalizeLongitude(540)).toBe(-180);
+  });
+
+  /**
+   * The end-to-end form of the same bug: the synthetic box around a point at
+   * 179.98 must serialise, and it must come out as a `west > east` box rather
+   * than be refused.
+   */
+  it('lets a synthetic box across the antimeridian serialise', () => {
+    const token = expectOk(
+      serializeLocationRef({
+        kind: 'bounds',
+        bounds: { west: 179.93, south: -18.05, east: 180.03, north: -17.95 },
+      }),
+    );
+    expect(token).toBe('bbox.179.93,-18.05,-179.97,-17.95');
+    const reparsed = expectOk(parseLocationToken(token));
+    expect(reparsed).toEqual({
+      kind: 'bounds',
+      bounds: { west: 179.93, south: -18.05, east: -179.97, north: -17.95 },
+    });
+    // Normalisation is idempotent: the canonical form is a fixed point, or the
+    // URL would keep changing on every reload.
+    expect(expectOk(serializeLocationRef(reparsed))).toBe(token);
+  });
+
+  /**
+   * Serialisation must not switch to exponent notation, because the parser
+   * refuses it — an unrounded serialiser emits tokens its own parser rejects,
+   * and only within about 11 cm of Greenwich or the equator, which is exactly
+   * the kind of defect that survives review.
+   */
+  it('emits a plain decimal for a coordinate close to zero', () => {
+    const token = expectOk(
+      serializeLocationRef({
+        kind: 'bounds',
+        bounds: { west: 1e-7, south: 1e-7, east: 0.5, north: 0.5 },
+      }),
+    );
+    expect(token).not.toMatch(/e[+-]/i);
+    expect(token).toBe('bbox.0,0,0.5,0.5');
+    expect(parseLocationToken(token).ok).toBe(true);
+  });
+});

--- a/packages/frontend/__tests__/location/locationToken.test.ts
+++ b/packages/frontend/__tests__/location/locationToken.test.ts
@@ -72,8 +72,6 @@ describe('loc token: round trip is character-for-character', () => {
     'bbox.-3.75,40.38,-3.65,40.45',
     // The antimeridian box §9.3 measured against a real PostGIS. `west > east`.
     'bbox.170,-20,-170,-16',
-    // A dropped pin. No `LocationSelection` kind maps to this yet — see below.
-    'at.2.1734,41.3851,25000',
     // "Near me", carrying NO coordinates.
     'here.25000',
     // Several areas at once.
@@ -92,7 +90,7 @@ describe('loc token: round trip is character-for-character', () => {
    * same shape as a census that reports zero because its traversal broke.
    */
   it('covers every production of the grammar', () => {
-    expect(TOKENS.length).toBeGreaterThanOrEqual(15);
+    expect(TOKENS.length).toBeGreaterThanOrEqual(14);
     const heads = new Set(TOKENS.map((token) => token.slice(0, token.indexOf('.'))));
     expect(heads).toEqual(
       new Set([
@@ -104,7 +102,6 @@ describe('loc token: round trip is character-for-character', () => {
         'postcode',
         'address',
         'bbox',
-        'at',
         'here',
         'multi',
       ]),
@@ -283,11 +280,14 @@ describe('loc token: a bad token is distinguishable from no token', () => {
     ['nonsense.homiio.abc', 'unknown_kind'],
     ['BBOX.1,2,3,4', 'unknown_kind'],
     ['Here.25000', 'unknown_kind'],
+    // The withdrawn `at.` production (ADR §19(B)). A WELL-FORMED one, so the
+    // rejection is about the rule and not about the shape.
+    ['at.2.1734,41.3851,25000', 'coordinates_in_url'],
+    ['at.1,2', 'coordinates_in_url'],
     ['city.homiio.', 'malformed'],
     ['city.homiio', 'malformed'],
     ['bbox.1,2,3', 'malformed'],
     ['bbox.1,2,3,4,5', 'malformed'],
-    ['at.1,2', 'malformed'],
     ['multi.city.homiio.abc', 'malformed'],
     ['bbox.,,,', 'not_a_number'],
     ['here.', 'not_a_number'],
@@ -298,8 +298,6 @@ describe('loc token: a bad token is distinguishable from no token', () => {
     ['bbox.1,2,3,four', 'not_a_number'],
     ['here.0', 'out_of_range'],
     ['here.-5', 'out_of_range'],
-    ['at.2.17,41.38,0', 'out_of_range'],
-    ['at.2.17,91,25000', 'out_of_range'],
     ['bbox.2.05,41.47,2.23,41.32', 'out_of_range'],
     ['bbox.2.05,-91,2.23,41.47', 'out_of_range'],
     ['multi.city.homiio.abc+multi.here.25000+here.500', 'nested_multi'],
@@ -320,7 +318,15 @@ describe('loc token: a bad token is distinguishable from no token', () => {
   it('has a failing case for every reason the parser can return', () => {
     const covered = new Set(BAD.map(([, reason]) => reason));
     expect(covered).toEqual(
-      new Set(['empty', 'unknown_kind', 'malformed', 'not_a_number', 'out_of_range', 'nested_multi']),
+      new Set([
+        'empty',
+        'unknown_kind',
+        'malformed',
+        'not_a_number',
+        'out_of_range',
+        'nested_multi',
+        'coordinates_in_url',
+      ]),
     );
   });
 
@@ -337,6 +343,47 @@ describe('loc token: a bad token is distinguishable from no token', () => {
     // Control: the box really is expressible, so the refusal above is about the
     // empty segments and not about zero being rejected.
     expect(zeroBox.ok).toBe(true);
+  });
+
+  /**
+   * ADR §19(B). `at.<lng>,<lat>,<radiusMeters>` was a real production of §5.2
+   * until it was withdrawn, and the fixture is a WELL-FORMED one on purpose: a
+   * malformed `at.` would be refused by shape alone, which cannot tell a
+   * withdrawn production from a typo.
+   *
+   * Decision 8 is the rule — exact coordinates never appear in a URL, and
+   * `here.<radiusMeters>` exists so the device case carries none. The danger
+   * was never a token somebody types by hand; it is that a grammar blessing the
+   * shape is how "search around this pin" gets wired to it later.
+   */
+  it('rejects the withdrawn `at.` production, because decision 8 forbids a coordinate pair in a URL', () => {
+    const result = parseLocationToken('at.2.1734,41.3851,25000');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    // A reason that names the RULE, not `unknown_kind` — somebody meeting this
+    // is likelier to hold an old copy of §5.2 than to have made a typo.
+    expect(result.reason).toBe('coordinates_in_url');
+  });
+
+  it('rejects an `at.` part nested inside a multi token', () => {
+    // The withdrawal has to hold everywhere the grammar recurses, or `multi.`
+    // becomes the way back in.
+    const result = parseLocationToken('multi.city.homiio.abc+at.2.1734,41.3851,25000');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.reason).toBe('coordinates_in_url');
+  });
+
+  /**
+   * Negative control for both assertions above: `here.` is the surviving
+   * radius-bearing production and must still parse. Without this, deleting
+   * every radius form would pass the two rejections.
+   */
+  it('still accepts the coordinate-free device production', () => {
+    expect(parseLocationToken('here.25000')).toEqual({
+      ok: true,
+      value: { kind: 'device', radiusMeters: 25000 },
+    });
   });
 
   it('refuses an id carrying the multi separator rather than corrupting a multi token', () => {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -70,6 +70,25 @@ export * from './ethicalPricing';
 // invariants. Shared so the redaction rules have exactly one implementation.
 export * from './observability';
 
+// The canonical location contract (ADR 0002 §3): one `LocationSelection`, one
+// `locationKey`, one `loc` URL token codec, one set of bounds validators.
+export * from './location';
+
+// `GeoPoint` and `GeoBounds` are declared BOTH in `./location` and in
+// `./observability/queryIdentity`, which predates it, so the two `export *`
+// lines above would otherwise be ambiguous (TS2308) and neither name would be
+// exported at all. This resolves it towards the canonical contract, because
+// ADR 0002 §3 is normative about the encoding and every other representation is
+// converging on it. Nothing is deleted: the observability declarations keep
+// their names and shapes at `@homiio/shared-types/observability/queryIdentity`,
+// and folding them into this one is the migration change's job, not this file's.
+//
+// `GeoBounds` is structurally identical in both, so this rebinding is invisible
+// to a consumer. `GeoPoint` is NOT — observability's is `{ lat, lng }` and the
+// contract's is `{ longitude, latitude }`, which is exactly the transposable
+// coordinate encoding ADR §1.2 counts three of inside this package.
+export type { GeoPoint, GeoBounds } from './location';
+
 // International formatting — money, units, dates, percentages. Pure, shared by
 // frontend and backend so a price is never assembled by concatenation.
 export * from './format/money';

--- a/packages/shared-types/src/location.ts
+++ b/packages/shared-types/src/location.ts
@@ -1,0 +1,835 @@
+/**
+ * The one canonical location contract — ADR 0002 (#346), implementing §3, §3.1,
+ * §5.2, §9.3 and the fixture obligations of §12 and §16.
+ *
+ * WHY THIS FILE EXISTS. Homiio answers "where?" in nine incompatible ways
+ * (ADR §1.2), three of which are coordinate encodings inside this package
+ * alone. None of the resulting bugs — a list of Barcelona homes under a map of
+ * Madrid, a saved search that reopens in another country, a "Near you" lens
+ * that filters nothing — is a mistake in the file where it surfaces. They are
+ * all consequences of there being no shared answer. This module is that answer,
+ * and it is deliberately the ONLY place in the codebase where a location
+ * becomes a string.
+ *
+ * SCOPE OF THIS FILE. It is the FOUNDATION half of #352: the types, the key
+ * function, the `loc` token codec and the small validators. Nothing is migrated
+ * onto it here — `SearchLocation`, `buildSearchParams`, the frontend store and
+ * the backend controllers are all untouched, and the translation table in
+ * ADR §10 is the work list for that separate change.
+ *
+ * THREE THINGS A READER WILL WONDER ABOUT, ANSWERED HERE.
+ *
+ * 1. `GeoPoint` and `GeoBounds` are ALSO declared in
+ *    `./observability/queryIdentity`, which predates this file. `GeoBounds` is
+ *    structurally identical, so nothing can tell the two apart. `GeoPoint` is
+ *    NOT: that one is `{ lat, lng }` and this one is `{ longitude, latitude }`.
+ *    The package barrel resolves both names to THIS module (see `index.ts`),
+ *    because ADR §3 is normative about the canonical encoding and the whole
+ *    epic converges here. Converging the observability copy onto it is the
+ *    migration change's job, not this one's — so the older declaration is left
+ *    exactly where it is, reachable at its own module path.
+ *
+ * 2. The GeoJSON polygon shapes are MIRRORED LOCALLY rather than imported.
+ *    ADR §3 writes them as `GeoJSON.Polygon | GeoJSON.MultiPolygon`, which is
+ *    the ambient global namespace `@types/geojson` declares — and this package
+ *    is dependency-free by design (see the header of `./observability`), so
+ *    taking that dependency to name two structural types would be a poor trade.
+ *    `./common` was the other candidate and has nothing to reuse: it declares
+ *    `GeoJSONPoint` and no polygon shape at all. Mirroring keeps the wire
+ *    format identical to GeoJSON while leaving §2.1's reservation intact.
+ *
+ * 3. Parsing a `loc` token yields a `LocationRef`, NOT a `LocationSelection`.
+ *    A token carries an identity and a geometry; it deliberately carries no
+ *    label, no admin hierarchy and no centre for a named place, because those
+ *    come from resolving it (§6.2). A parser that filled them in with
+ *    placeholders would produce exactly the partially-filled selection §5.2
+ *    forbids, so it returns the honest, smaller thing instead.
+ */
+
+// ---------------------------------------------------------------------------
+// §3 — the shared type
+// ---------------------------------------------------------------------------
+
+/** WGS84 point. ONE encoding, named fields — a positional pair is transposable. */
+export interface GeoPoint {
+  readonly longitude: number;
+  readonly latitude: number;
+}
+
+/**
+ * A rectangle in degrees.
+ *
+ * `south > north` is an ERROR. `west > east` is LEGAL and means the box crosses
+ * the antimeridian (west 170 → east -170 is the 20-degree strip over the
+ * Pacific, not the 340-degree rest of the world). See ADR §9.3 — this is the
+ * only bounding-box representation that can express that at all, and PostGIS
+ * `::geography` already reads it this way, which was verified against a real
+ * server rather than assumed.
+ *
+ * The consequence worth writing down, because it is what a later "tidy-up"
+ * would destroy: adding a `west <= east` validation, or dropping the
+ * `::geography` cast in `propertyGeo.ts`, silently inverts every antimeridian
+ * query into its exact complement — the far side of the planet, returned
+ * confidently.
+ */
+export interface GeoBounds {
+  readonly west: number;
+  readonly south: number;
+  readonly east: number;
+  readonly north: number;
+}
+
+/** A GeoJSON position, `[longitude, latitude]`. Mirrored locally — see the module header. */
+export type GeoJSONPosition = readonly [number, number];
+
+/** A GeoJSON Polygon: an outer ring followed by any number of holes. */
+export interface GeoJSONPolygon {
+  readonly type: 'Polygon';
+  readonly coordinates: readonly (readonly GeoJSONPosition[])[];
+}
+
+/** A GeoJSON MultiPolygon: several polygons, each with its own rings. */
+export interface GeoJSONMultiPolygon {
+  readonly type: 'MultiPolygon';
+  readonly coordinates: readonly (readonly (readonly GeoJSONPosition[])[])[];
+}
+
+/**
+ * What a coordinate MEANS. Declared, never inferred.
+ *
+ *  - `exact`       a building-level point somebody deliberately provided.
+ *  - `approximate` an exact point deliberately degraded (rounded or offset).
+ *  - `centroid`    the representative point of an AREA. Not anyone's location.
+ *  - `area`        no meaningful point at all; only `bounds`/`polygon` apply.
+ *
+ * The distinction that matters most is that a `centroid` IS NOT ANYBODY'S
+ * LOCATION. A city centre is a framing device, and code that treats it as a
+ * home's position is wrong in a way no other type in this package prevents.
+ */
+export type LocationPrecision = 'exact' | 'approximate' | 'centroid' | 'area';
+
+/** A display label, pre-split by whoever knows how. Never `label.split(',')[0]`. */
+export interface PlaceLabel {
+  /** e.g. "Barcelona", "شارع الحمرا", "千代田区". */
+  readonly primary: string;
+  /** e.g. "Catalonia, Spain". Optional: some places have no meaningful parent. */
+  readonly secondary?: string;
+  /**
+   * `generated` marks a label Homiio invented ("Map area", "Near you").
+   * A generated label is never sent as free text and never re-geocoded.
+   */
+  readonly kind: 'place' | 'generated';
+}
+
+/** Explicit administrative hierarchy. `countryCode` is never optional. */
+export interface AdminHierarchy {
+  /** ISO-3166-1 alpha-2, uppercase. */
+  readonly countryCode: string;
+  /** ISO-3166-2 subdivision code where one exists. */
+  readonly regionCode?: string;
+  readonly regionName?: string;
+  readonly cityName?: string;
+  readonly neighborhoodName?: string;
+}
+
+/**
+ * Where a place came from, and whether Homiio owns it.
+ *
+ * The distinction is the point: `homiio` is a row in this database with a
+ * primary key that will still mean the same place after a provider swap;
+ * `external` is a candidate a geocoder handed us, whose ref is only as stable
+ * as that provider. An `external` place therefore MUST carry its own
+ * centre/bounds inline so it survives the provider disappearing.
+ */
+export type PlaceSource =
+  | {
+      readonly kind: 'homiio';
+      readonly entity: 'country' | 'region' | 'city' | 'neighborhood' | 'address';
+      readonly id: string;
+    }
+  | {
+      readonly kind: 'external';
+      /** Registered provider id, e.g. `osm`. Never a URL, never a class name. */
+      readonly provider: string;
+      /** The provider's own stable ref, so a label is never geocoded twice. */
+      readonly ref: string;
+    };
+
+export type PlaceType = 'country' | 'region' | 'city' | 'district' | 'neighborhood' | 'postcode';
+
+export type LocationSelection =
+  /** The device's own position. Coordinates are resolved at request time and NEVER serialised. */
+  | {
+      readonly kind: 'current_location';
+      readonly center: GeoPoint;
+      readonly radiusMeters: number;
+      readonly precision: LocationPrecision;
+    }
+  /** A named area: a country, region, city, district, neighborhood or postcode. */
+  | {
+      readonly kind: 'place';
+      readonly source: PlaceSource;
+      readonly placeType: PlaceType;
+      readonly label: PlaceLabel;
+      readonly admin: AdminHierarchy;
+      readonly center: GeoPoint;
+      readonly bounds?: GeoBounds;
+      /** A named area's centre is a `centroid`, or `area` when no centre is meaningful. */
+      readonly precision: LocationPrecision;
+    }
+  /** A specific address a geocoder proposed but Homiio has not materialised. */
+  | {
+      readonly kind: 'address_candidate';
+      readonly source: PlaceSource;
+      readonly label: PlaceLabel;
+      readonly admin: AdminHierarchy;
+      readonly center: GeoPoint;
+      readonly bounds?: GeoBounds;
+      readonly precision: LocationPrecision;
+    }
+  /** A map viewport the user confirmed. Has no name and never acquires one. */
+  | {
+      readonly kind: 'map_bounds';
+      readonly bounds: GeoBounds;
+      readonly center: GeoPoint;
+      readonly label: PlaceLabel & { readonly kind: 'generated' };
+      readonly precision: 'area';
+      /** Countries the box overlaps, when known. A box may span several. */
+      readonly countryCodes?: readonly string[];
+    }
+  /** A drawn area. Wire format reserved; nothing is required to persist one yet. */
+  | {
+      readonly kind: 'polygon';
+      readonly polygon: GeoJSONPolygon | GeoJSONMultiPolygon;
+      readonly bounds: GeoBounds;
+      readonly label: PlaceLabel;
+      readonly precision: 'area';
+    }
+  /** Several areas at once. Cannot nest. */
+  | {
+      readonly kind: 'multi_area';
+      readonly areas: readonly Exclude<LocationSelection, { kind: 'multi_area' }>[];
+      readonly label: PlaceLabel;
+    };
+
+/** Every selection kind except `multi_area` — what a `multi_area` may contain. */
+export type SingleLocationSelection = Exclude<LocationSelection, { kind: 'multi_area' }>;
+
+/**
+ * The full query. `location` and `text` are separate dimensions and neither is
+ * derived from the other.
+ */
+export interface LocationQuery {
+  readonly location: LocationSelection | null;
+  /** What the user typed as free text. NEVER a place label. */
+  readonly text: string | null;
+}
+
+/** Why a resolution failed. The UI must distinguish these; they are not one state. */
+export type LocationFailureReason =
+  | 'network'
+  | 'rate_limited'
+  | 'ambiguous'
+  | 'no_results'
+  | 'permission_denied'
+  | 'position_unavailable'
+  | 'unsupported';
+
+export type LocationResolution =
+  | { readonly status: 'idle' }
+  | { readonly status: 'resolving' }
+  | { readonly status: 'resolved'; readonly selection: LocationSelection }
+  | { readonly status: 'failed'; readonly reason: LocationFailureReason };
+
+// ---------------------------------------------------------------------------
+// §9.2 / §14.1 — the gateway DTO
+// ---------------------------------------------------------------------------
+
+/**
+ * What a gateway candidate IS.
+ *
+ * `address` is the one value that is not a `PlaceType`: it becomes an
+ * `address_candidate` selection, every other value becomes a `place`. That
+ * single discriminator is why `GeoPlace` needs no optional variant fields —
+ * ADR §14.1's `types?` parameter uses exactly this vocabulary
+ * (`city,neighborhood,address`).
+ */
+export type GeoPlaceType = PlaceType | 'address';
+
+/**
+ * The geocoding gateway's response element (ADR §9.2, §14.1) — Homiio's shape,
+ * defined ONCE, not a geocoder's `address` object flattened.
+ *
+ * It replaces `AddressData`, which is declared twice today with different
+ * fields: the backend copy carries `coordinates` and `bbox`, the frontend copy
+ * drops both, so the backend computes a bounding box the frontend's type cannot
+ * represent. Both copies die when #351 serves this instead.
+ *
+ * `GET /api/geo/search` returns `{ candidates: GeoPlace[] }` — ALWAYS a list.
+ * Auto-picking one is the homonym bug (ADR §12.2), and the list is what makes
+ * the `disambiguating` state of §7 possible.
+ */
+export interface GeoPlace {
+  readonly source: PlaceSource;
+  readonly placeType: GeoPlaceType;
+  readonly label: PlaceLabel;
+  readonly admin: AdminHierarchy;
+  readonly center: GeoPoint;
+  readonly bounds?: GeoBounds;
+  readonly precision: LocationPrecision;
+}
+
+/**
+ * Turn a gateway candidate into the selection the user just chose.
+ *
+ * Shared rather than written per screen because the `address` →
+ * `address_candidate` mapping is the one place a caller could quietly decide
+ * that a street address is a "place", which would then key by the wrong
+ * identity for the rest of its life.
+ */
+export function geoPlaceToSelection(place: GeoPlace): LocationSelection {
+  if (place.placeType === 'address') {
+    return {
+      kind: 'address_candidate',
+      source: place.source,
+      label: place.label,
+      admin: place.admin,
+      center: place.center,
+      ...(place.bounds === undefined ? {} : { bounds: place.bounds }),
+      precision: place.precision,
+    };
+  }
+  return {
+    kind: 'place',
+    source: place.source,
+    placeType: place.placeType,
+    label: place.label,
+    admin: place.admin,
+    center: place.center,
+    ...(place.bounds === undefined ? {} : { bounds: place.bounds }),
+    precision: place.precision,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Validators (ADR §9.3)
+// ---------------------------------------------------------------------------
+
+/** A latitude in degrees. Latitude does NOT wrap — beyond a pole is meaningless. */
+export function isValidLatitude(value: number): boolean {
+  return Number.isFinite(value) && value >= -90 && value <= 90;
+}
+
+/** A longitude in degrees, already inside the canonical range. See {@link normalizeLongitude}. */
+export function isValidLongitude(value: number): boolean {
+  return Number.isFinite(value) && value >= -180 && value <= 180;
+}
+
+/**
+ * Wrap a longitude into `[-180, 180)`.
+ *
+ * This is ADR §9.3's fix, and it lives here so it happens ONCE. The concrete
+ * bug it closes: `WhereStep` builds a synthetic ±0.05° box around a picked
+ * point, so at longitude 179.98 the east edge is 180.03, the range check
+ * rejects it, and the whole search fails with `INVALID_GEO_PARAMS` — every
+ * place within 0.05° of the antimeridian is unsearchable. Normalising gives
+ * `west 179.93, east -179.97`, a `west > east` box, which is legal and which
+ * PostGIS `::geography` already reads correctly.
+ *
+ * The range is HALF-OPEN on purpose: 180 and -180 are the same meridian, so
+ * leaving both spellings legal would produce two different tokens and two
+ * different cache keys for one box.
+ */
+export function normalizeLongitude(value: number): number {
+  if (!Number.isFinite(value)) return Number.NaN;
+  // A value already in range is returned UNCHANGED, and this fast path is not
+  // an optimisation — the modulo arithmetic below is lossy, so running it on an
+  // in-range longitude turns 2.1686 into 2.1685999999999694. That is a token
+  // that no longer round-trips and a cache key that drifts every time a URL is
+  // re-serialised, for coordinates that never needed wrapping at all.
+  if (value >= -180 && value < 180) return value === 0 ? 0 : value;
+  const wrapped = (((value + 180) % 360) + 360) % 360 - 180;
+  // -0 can fall out of the modulo; normalise it so two spellings of zero cannot
+  // produce two tokens.
+  return wrapped === 0 ? 0 : wrapped;
+}
+
+/**
+ * Whether a rectangle is well formed.
+ *
+ * REJECTS `south > north`. ACCEPTS `west > east`, which is not laxity — it is
+ * the antimeridian case, and a box that crosses it has no other spelling. A
+ * fixture set without an antimeridian box cannot tell this function from one
+ * that validates both orderings, which is why the suite carries one.
+ *
+ * A degenerate box (`south === north`, or `west === east`) is accepted: it is a
+ * zero-area query, not a malformed one.
+ */
+export function isValidBounds(bounds: GeoBounds): boolean {
+  if (!isValidLatitude(bounds.south) || !isValidLatitude(bounds.north)) return false;
+  if (!isValidLongitude(bounds.west) || !isValidLongitude(bounds.east)) return false;
+  return bounds.south <= bounds.north;
+}
+
+// ---------------------------------------------------------------------------
+// §3.1 — `locationKey`, the stable identifier
+// ---------------------------------------------------------------------------
+
+/**
+ * Grid for any coordinate that reaches a key, a log or an analytics event:
+ * 2 dp ≈ 1.1 km of latitude (ADR §8.3, the device-position row).
+ *
+ * `locationKey` itself never emits a bare coordinate — that is the whole point
+ * of its `current_location` branch — so this constant is exported for the
+ * device-position code that lands with the rest of #352, so that the grid is
+ * read from the contract rather than retyped as a literal `2`.
+ */
+export const KEY_COORD_DECIMALS = 2;
+
+/** Grid for a bbox in a key: 3 dp ≈ 110 m — coarse enough to absorb map jitter. */
+export const KEY_BOUNDS_DECIMALS = 3;
+
+/**
+ * Decimals a coordinate keeps inside a `loc` token: 6 dp ≈ 11 cm, finer than
+ * any map interaction can express.
+ *
+ * This is a formatting bound, not a privacy one — the URL carries the area
+ * actually queried, and rounding it further would change the query. It exists
+ * because JavaScript switches to exponent notation below 1e-6 (`String(1e-7)`
+ * is `"1e-7"`), which the strict token parser rejects, so an unrounded
+ * serialiser would emit tokens its own parser refuses — an asymmetric codec,
+ * and one that only fails within 11 cm of Greenwich or the equator.
+ */
+export const TOKEN_COORD_DECIMALS = 6;
+
+/** Round onto a decimal grid, normalising `-0` to `0`. */
+function roundTo(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  const rounded = Math.round(value * factor) / factor;
+  // Without this, a box straddling Greenwich or the equator keys differently
+  // depending on which side of zero the float landed on.
+  return rounded === 0 ? 0 : rounded;
+}
+
+/** A bbox component in a key, or `na` rather than a `NaN` nobody can act on. */
+function keyCoordinate(value: number): string {
+  return Number.isFinite(value) ? String(roundTo(value, KEY_BOUNDS_DECIMALS)) : 'na';
+}
+
+/**
+ * The one function that turns a selection into a string, for URL serialisation,
+ * React Query keys, saved-search identity and analytics.
+ *
+ * That "one" is the enforcement mechanism for ADR §8.2, not a stylistic
+ * preference. Six places leak an exact coordinate today — two React Query keys,
+ * a server log, AsyncStorage, a geocoder-response store and an unbounded device
+ * fix — and they are all fixed by routing through a function whose
+ * `current_location` branch HAS NO COORDINATE TO EMIT. A single test therefore
+ * guards all six, where a sweep would have to be re-run forever.
+ *
+ * Two properties are what the key is FOR: two different cities called Barcelona
+ * produce two different keys (they have different ids, and the key is built
+ * from the id, never the label), and a jittering map viewport produces one key
+ * (the 3 dp grid).
+ */
+export function locationKey(selection: LocationSelection | null): string {
+  if (!selection) return 'none';
+  switch (selection.kind) {
+    case 'current_location':
+      // NO coordinates. A device fix never reaches a key, a URL or a log.
+      return `here:${selection.radiusMeters}`;
+    case 'place':
+    case 'address_candidate':
+      return selection.source.kind === 'homiio'
+        ? `${selection.source.kind}:${selection.source.entity}:${selection.source.id}`
+        : `ext:${selection.source.provider}:${selection.source.ref}`;
+    case 'map_bounds':
+    case 'polygon': {
+      const b = selection.bounds;
+      return `bbox:${keyCoordinate(b.west)},${keyCoordinate(b.south)},${keyCoordinate(b.east)},${keyCoordinate(b.north)}`;
+    }
+    case 'multi_area':
+      // Sorted, so the key does not depend on the order the areas were picked.
+      return `multi:${selection.areas.map(locationKey).sort().join('+')}`;
+    default: {
+      // A new selection kind must decide its own key rather than inherit one.
+      const exhaustive: never = selection;
+      return exhaustive;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// §5.2 — the `loc` URL token codec
+// ---------------------------------------------------------------------------
+
+/**
+ * Why a token could not be produced or read.
+ *
+ * These are distinct on purpose. An unparseable `loc` is a FAILURE, not an
+ * absence (ADR §5.2): it must reach `resolution.status = 'failed'` and show an
+ * error, and it must never silently become a global feed. A codec returning
+ * `null` for both "no token" and "bad token" is how that distinction gets lost,
+ * so this codec has no `null` in it at all — a caller says "absent" by not
+ * calling it.
+ */
+export type LocationTokenFailure =
+  /** The token was empty or whitespace. */
+  | 'empty'
+  /** The leading segment names no production in the §5.2 grammar. */
+  | 'unknown_kind'
+  /** The right prefix with the wrong shape — missing segments, empty id. */
+  | 'malformed'
+  /** A coordinate or radius that is not a plain finite decimal. */
+  | 'not_a_number'
+  /** A latitude outside ±90, `south > north`, or a non-positive radius. */
+  | 'out_of_range'
+  /** `multi.` inside `multi.` — the selection type forbids nesting. */
+  | 'nested_multi'
+  /** A selection kind §5.2 has no production for. Today: `polygon` (§2.1 reserves it). */
+  | 'unsupported_kind'
+  /** An id or provider carrying a separator the grammar cannot escape. */
+  | 'unencodable_id';
+
+export type LocationTokenResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly reason: LocationTokenFailure };
+
+/** Which authority a `loc` token's `source` segment names. */
+export type LocationRefSource =
+  | { readonly kind: 'homiio' }
+  | { readonly kind: 'external'; readonly provider: string };
+
+/**
+ * The parsed form of a `loc` token — everything the grammar can carry, and
+ * nothing it cannot.
+ *
+ * This is not a `LocationSelection`, and the difference is deliberate: a token
+ * for a named place carries an id and no label, admin hierarchy or centre,
+ * because those are supplied by resolving it against the gateway (§6.2). A
+ * parser that invented them would hand the app a selection that looks resolved
+ * and is not.
+ */
+export type LocationRef =
+  /** `city.homiio.<id>`, `address.osm.<ref>`, … */
+  | {
+      readonly kind: 'place';
+      readonly placeType: GeoPlaceType;
+      readonly source: LocationRefSource;
+      readonly id: string;
+    }
+  /** `bbox.<west>,<south>,<east>,<north>` */
+  | { readonly kind: 'bounds'; readonly bounds: GeoBounds }
+  /**
+   * `at.<lng>,<lat>,<radiusMeters>` — a pin the user dropped.
+   *
+   * The §5.2 grammar defines this production and §3's `LocationSelection` has
+   * no kind that maps to it, so nothing serialises to `at.` today. It is parsed
+   * rather than rejected because refusing a token the normative grammar admits
+   * would be the wrong half of the contract to enforce.
+   */
+  | { readonly kind: 'point'; readonly center: GeoPoint; readonly radiusMeters: number }
+  /** `here.<radiusMeters>` — NEVER any coordinates. */
+  | { readonly kind: 'device'; readonly radiusMeters: number }
+  /** `multi.<loc>+<loc>[+…]` — two or more, never nested. */
+  | { readonly kind: 'multi'; readonly refs: readonly Exclude<LocationRef, { kind: 'multi' }>[] };
+
+/** The reserved `source` segment meaning "a row in this database". */
+const HOMIIO_SOURCE = 'homiio';
+
+const PLACE_TYPES: readonly GeoPlaceType[] = [
+  'country',
+  'region',
+  'city',
+  'district',
+  'neighborhood',
+  'postcode',
+  'address',
+];
+
+/** Separates the parts of a `multi.` token, so no segment may contain it. */
+const MULTI_SEPARATOR = '+';
+
+function fail<T>(reason: LocationTokenFailure): LocationTokenResult<T> {
+  return { ok: false, reason };
+}
+
+function ok<T>(value: T): LocationTokenResult<T> {
+  return { ok: true, value };
+}
+
+/**
+ * A plain finite decimal, and nothing else.
+ *
+ * `Number('')` is `0` and `Number(' 5 ')` is `5`, so the built-in conversion
+ * turns an empty or padded segment into a real coordinate — which is how
+ * `bbox.,,,` would parse as the point 0,0 and be queried in the Gulf of Guinea.
+ * Exponent and `+` forms are refused too, so that exactly one spelling of each
+ * number is a valid token.
+ */
+function parseDecimal(raw: string): number | null {
+  if (!/^-?\d+(\.\d+)?$/.test(raw)) return null;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : null;
+}
+
+function formatCoordinate(value: number): string {
+  return String(roundTo(value, TOKEN_COORD_DECIMALS));
+}
+
+/** A segment that would break the grammar if it appeared inside a token. */
+function isEncodableSegment(value: string, forbidDots: boolean): boolean {
+  if (value.length === 0) return false;
+  if (value.includes(MULTI_SEPARATOR)) return false;
+  if (forbidDots && value.includes('.')) return false;
+  return true;
+}
+
+/**
+ * The reference a selection serialises to, or why it cannot.
+ *
+ * `polygon` is the one kind with no answer: §2.1 reserves its wire format
+ * deliberately, so refusing is correct and degrading it to its bounding box
+ * would not be — that would silently replace a drawn area with a rectangle,
+ * which is the same "half the location survived" class of bug the atomic
+ * selection exists to make unrepresentable.
+ */
+export function locationRefOf(selection: LocationSelection): LocationTokenResult<LocationRef> {
+  switch (selection.kind) {
+    case 'current_location':
+      return ok({ kind: 'device', radiusMeters: selection.radiusMeters });
+    case 'place':
+      return ok({
+        kind: 'place',
+        placeType: selection.placeType,
+        source: refSourceOf(selection.source),
+        id: sourceIdOf(selection.source),
+      });
+    case 'address_candidate':
+      return ok({
+        kind: 'place',
+        placeType: 'address',
+        source: refSourceOf(selection.source),
+        id: sourceIdOf(selection.source),
+      });
+    case 'map_bounds':
+      return ok({ kind: 'bounds', bounds: selection.bounds });
+    case 'polygon':
+      return fail('unsupported_kind');
+    case 'multi_area': {
+      const refs: Exclude<LocationRef, { kind: 'multi' }>[] = [];
+      for (const area of selection.areas) {
+        const result = locationRefOf(area);
+        if (!result.ok) return result;
+        // `areas` cannot hold a `multi_area`, so this cannot be a `multi` ref.
+        refs.push(result.value as Exclude<LocationRef, { kind: 'multi' }>);
+      }
+      return ok({ kind: 'multi', refs });
+    }
+    default: {
+      const exhaustive: never = selection;
+      return exhaustive;
+    }
+  }
+}
+
+function refSourceOf(source: PlaceSource): LocationRefSource {
+  return source.kind === 'homiio' ? { kind: 'homiio' } : { kind: 'external', provider: source.provider };
+}
+
+function sourceIdOf(source: PlaceSource): string {
+  return source.kind === 'homiio' ? source.id : source.ref;
+}
+
+/**
+ * Render a reference as a `loc` token.
+ *
+ * Longitudes are normalised here (§9.3) because this is "the shared serialiser"
+ * the ADR names, so the antimeridian fix happens once instead of at every call
+ * site that builds a box.
+ */
+export function serializeLocationRef(ref: LocationRef): LocationTokenResult<string> {
+  switch (ref.kind) {
+    case 'place': {
+      if (!PLACE_TYPES.includes(ref.placeType)) return fail('unknown_kind');
+      if (!isEncodableSegment(ref.id, false)) return fail('unencodable_id');
+      if (ref.source.kind === 'homiio') {
+        return ok(`${ref.placeType}.${HOMIIO_SOURCE}.${ref.id}`);
+      }
+      // A provider literally called `homiio` would produce a token that reads
+      // as a canonical Homiio id — the one collision the grammar cannot resolve.
+      if (ref.source.provider === HOMIIO_SOURCE) return fail('unencodable_id');
+      if (!isEncodableSegment(ref.source.provider, true)) return fail('unencodable_id');
+      return ok(`${ref.placeType}.${ref.source.provider}.${ref.id}`);
+    }
+    case 'bounds': {
+      const bounds = normalizedBounds(ref.bounds);
+      if (!isValidBounds(bounds)) return fail('out_of_range');
+      return ok(
+        `bbox.${formatCoordinate(bounds.west)},${formatCoordinate(bounds.south)},` +
+          `${formatCoordinate(bounds.east)},${formatCoordinate(bounds.north)}`,
+      );
+    }
+    case 'point': {
+      const longitude = normalizeLongitude(ref.center.longitude);
+      if (!isValidLongitude(longitude) || !isValidLatitude(ref.center.latitude)) {
+        return fail('out_of_range');
+      }
+      const radius = radiusToken(ref.radiusMeters);
+      if (radius === null) return fail('out_of_range');
+      return ok(
+        `at.${formatCoordinate(longitude)},${formatCoordinate(ref.center.latitude)},${radius}`,
+      );
+    }
+    case 'device': {
+      const radius = radiusToken(ref.radiusMeters);
+      if (radius === null) return fail('out_of_range');
+      // NO coordinates: a shared "near me" link means "near the opener".
+      return ok(`here.${radius}`);
+    }
+    case 'multi': {
+      if (ref.refs.length < 2) return fail('malformed');
+      const parts: string[] = [];
+      for (const part of ref.refs) {
+        const result = serializeLocationRef(part);
+        if (!result.ok) return result;
+        parts.push(result.value);
+      }
+      return ok(`multi.${parts.join(MULTI_SEPARATOR)}`);
+    }
+    default: {
+      const exhaustive: never = ref;
+      return exhaustive;
+    }
+  }
+}
+
+/**
+ * The `loc` token for a selection.
+ *
+ * `loc` is ONE parameter on purpose (§5.1). The entire bug class this contract
+ * exists for is "half of the previous location survived", and a single atomic
+ * token makes a half-update unrepresentable in the URL as well as in the store.
+ */
+export function serializeLocationToken(selection: LocationSelection): LocationTokenResult<string> {
+  const ref = locationRefOf(selection);
+  return ref.ok ? serializeLocationRef(ref.value) : ref;
+}
+
+/**
+ * Read a `loc` token.
+ *
+ * Deliberately strict: one spelling per value, case-sensitive prefixes, no
+ * padding and no exponent forms. Being liberal here would mean two URLs for one
+ * query, which splits the cache and breaks the round-trip §16.1 requires.
+ */
+export function parseLocationToken(token: string): LocationTokenResult<LocationRef> {
+  if (token.length === 0) return fail('empty');
+
+  const dot = token.indexOf('.');
+  if (dot <= 0) return fail('unknown_kind');
+  const head = token.slice(0, dot);
+  const rest = token.slice(dot + 1);
+
+  if (head === 'multi') return parseMultiToken(rest);
+  if (head === 'here') return parseDeviceToken(rest);
+  if (head === 'bbox') return parseBoundsToken(rest);
+  if (head === 'at') return parsePointToken(rest);
+  if ((PLACE_TYPES as readonly string[]).includes(head)) {
+    return parsePlaceToken(head as GeoPlaceType, rest);
+  }
+  return fail('unknown_kind');
+}
+
+function parsePlaceToken(placeType: GeoPlaceType, rest: string): LocationTokenResult<LocationRef> {
+  const dot = rest.indexOf('.');
+  if (dot <= 0) return fail('malformed');
+  const sourceSegment = rest.slice(0, dot);
+  // Everything after the SECOND dot is the id, so an id containing dots
+  // round-trips. A ULID does not, but a provider ref is not ours to constrain.
+  const id = rest.slice(dot + 1);
+  if (!isEncodableSegment(id, false)) return fail('malformed');
+  const source: LocationRefSource =
+    sourceSegment === HOMIIO_SOURCE ? { kind: 'homiio' } : { kind: 'external', provider: sourceSegment };
+  if (source.kind === 'external' && !isEncodableSegment(source.provider, true)) {
+    return fail('malformed');
+  }
+  return ok({ kind: 'place', placeType, source, id });
+}
+
+function parseBoundsToken(rest: string): LocationTokenResult<LocationRef> {
+  const parts = rest.split(',');
+  if (parts.length !== 4) return fail('malformed');
+  const values: number[] = [];
+  for (const part of parts) {
+    const value = parseDecimal(part);
+    if (value === null) return fail('not_a_number');
+    values.push(value);
+  }
+  const bounds = normalizedBounds({
+    west: values[0],
+    south: values[1],
+    east: values[2],
+    north: values[3],
+  });
+  if (!isValidBounds(bounds)) return fail('out_of_range');
+  return ok({ kind: 'bounds', bounds });
+}
+
+function parsePointToken(rest: string): LocationTokenResult<LocationRef> {
+  const parts = rest.split(',');
+  if (parts.length !== 3) return fail('malformed');
+  const longitude = parseDecimal(parts[0]);
+  const latitude = parseDecimal(parts[1]);
+  const radiusMeters = parseDecimal(parts[2]);
+  if (longitude === null || latitude === null || radiusMeters === null) return fail('not_a_number');
+  if (!isValidLatitude(latitude) || radiusMeters <= 0) return fail('out_of_range');
+  return ok({
+    kind: 'point',
+    center: { longitude: normalizeLongitude(longitude), latitude },
+    radiusMeters,
+  });
+}
+
+function parseDeviceToken(rest: string): LocationTokenResult<LocationRef> {
+  const radiusMeters = parseDecimal(rest);
+  if (radiusMeters === null) return fail('not_a_number');
+  if (radiusMeters <= 0) return fail('out_of_range');
+  return ok({ kind: 'device', radiusMeters });
+}
+
+function parseMultiToken(rest: string): LocationTokenResult<LocationRef> {
+  const parts = rest.split(MULTI_SEPARATOR);
+  // The grammar is `"multi." loc ( "+" loc )+` — two or more, never one.
+  if (parts.length < 2) return fail('malformed');
+  const refs: Exclude<LocationRef, { kind: 'multi' }>[] = [];
+  for (const part of parts) {
+    // Checked BEFORE recursing, so a nested `multi.` is reported as what it is.
+    // Recursing first reports whatever the inner token's own shape happens to
+    // be — a nested `multi.here.25000` comes back `malformed`, because after
+    // the split it has only one part — and a caller switching on the reason to
+    // choose a message would show the wrong one.
+    if (part.startsWith('multi.')) return fail('nested_multi');
+    const result = parseLocationToken(part);
+    if (!result.ok) return result;
+    if (result.value.kind === 'multi') return fail('nested_multi');
+    refs.push(result.value);
+  }
+  return ok({ kind: 'multi', refs });
+}
+
+/** A radius rendered for a token, or `null` when it is not a usable distance. */
+function radiusToken(radiusMeters: number): string | null {
+  if (!Number.isFinite(radiusMeters)) return null;
+  const rounded = roundTo(radiusMeters, 3);
+  return rounded > 0 ? String(rounded) : null;
+}
+
+function normalizedBounds(bounds: GeoBounds): GeoBounds {
+  return {
+    west: normalizeLongitude(bounds.west),
+    south: bounds.south,
+    east: normalizeLongitude(bounds.east),
+    north: bounds.north,
+  };
+}

--- a/packages/shared-types/src/location.ts
+++ b/packages/shared-types/src/location.ts
@@ -44,6 +44,12 @@
  *    come from resolving it (§6.2). A parser that filled them in with
  *    placeholders would produce exactly the partially-filled selection §5.2
  *    forbids, so it returns the honest, smaller thing instead.
+ *
+ *    THE ASYMMETRY IS THE SAFETY PROPERTY, not an inconvenience to design
+ *    around. Returning a selection would mean INVENTING a label, and §4.1
+ *    forbids a label being fed back as free text — so a parser that guessed one
+ *    would manufacture, at the URL boundary, precisely the value the contract
+ *    exists to keep out of `q`.
  */
 
 // ---------------------------------------------------------------------------
@@ -489,7 +495,18 @@ export type LocationTokenFailure =
   /** A selection kind §5.2 has no production for. Today: `polygon` (§2.1 reserves it). */
   | 'unsupported_kind'
   /** An id or provider carrying a separator the grammar cannot escape. */
-  | 'unencodable_id';
+  | 'unencodable_id'
+  /**
+   * A token carrying a coordinate pair — today only the withdrawn `at.` form.
+   *
+   * Distinct from `unknown_kind` on purpose. `at.` was a real production of
+   * §5.2 until it was withdrawn (§19(B)), so somebody meeting this failure is
+   * far more likely to be holding an old copy of the grammar than to have made
+   * a typo, and the reason should tell them which. Decision 8 is the rule:
+   * exact coordinates never appear in a URL, and `here.<radiusMeters>` exists
+   * so the device case carries none.
+   */
+  | 'coordinates_in_url';
 
 export type LocationTokenResult<T> =
   | { readonly ok: true; readonly value: T }
@@ -521,14 +538,15 @@ export type LocationRef =
   /** `bbox.<west>,<south>,<east>,<north>` */
   | { readonly kind: 'bounds'; readonly bounds: GeoBounds }
   /**
-   * `at.<lng>,<lat>,<radiusMeters>` — a pin the user dropped.
+   * NOTE: there is deliberately no `point` member here.
    *
-   * The §5.2 grammar defines this production and §3's `LocationSelection` has
-   * no kind that maps to it, so nothing serialises to `at.` today. It is parsed
-   * rather than rejected because refusing a token the normative grammar admits
-   * would be the wrong half of the contract to enforce.
+   * §5.2 carried an `at.<lng>,<lat>,<radiusMeters>` production until it was
+   * withdrawn (§19(B)) — no coordinate pair belongs in a URL (decision 8), and
+   * no `LocationSelection` kind ever mapped to it, so it was a form the parser
+   * accepted and the serialiser could not produce. A grammar that blesses a
+   * shape is how the shape gets used, so it is rejected rather than parsed
+   * leniently. `here.<radiusMeters>` is the device case and carries nothing.
    */
-  | { readonly kind: 'point'; readonly center: GeoPoint; readonly radiusMeters: number }
   /** `here.<radiusMeters>` — NEVER any coordinates. */
   | { readonly kind: 'device'; readonly radiusMeters: number }
   /** `multi.<loc>+<loc>[+…]` — two or more, never nested. */
@@ -590,9 +608,11 @@ function isEncodableSegment(value: string, forbidDots: boolean): boolean {
  *
  * `polygon` is the one kind with no answer: §2.1 reserves its wire format
  * deliberately, so refusing is correct and degrading it to its bounding box
- * would not be — that would silently replace a drawn area with a rectangle,
- * which is the same "half the location survived" class of bug the atomic
- * selection exists to make unrepresentable.
+ * would not be. A bounding box is a SUPERSET of the drawn area, so that
+ * fallback silently WIDENS the search the user asked for — the same failure
+ * family as a resolution failure becoming a global feed (§4.3), differing only
+ * in how much extra ground it quietly covers. It is also the "half the location
+ * survived" bug the atomic selection exists to make unrepresentable.
  */
 export function locationRefOf(selection: LocationSelection): LocationTokenResult<LocationRef> {
   switch (selection.kind) {
@@ -670,17 +690,6 @@ export function serializeLocationRef(ref: LocationRef): LocationTokenResult<stri
           `${formatCoordinate(bounds.east)},${formatCoordinate(bounds.north)}`,
       );
     }
-    case 'point': {
-      const longitude = normalizeLongitude(ref.center.longitude);
-      if (!isValidLongitude(longitude) || !isValidLatitude(ref.center.latitude)) {
-        return fail('out_of_range');
-      }
-      const radius = radiusToken(ref.radiusMeters);
-      if (radius === null) return fail('out_of_range');
-      return ok(
-        `at.${formatCoordinate(longitude)},${formatCoordinate(ref.center.latitude)},${radius}`,
-      );
-    }
     case 'device': {
       const radius = radiusToken(ref.radiusMeters);
       if (radius === null) return fail('out_of_range');
@@ -734,7 +743,9 @@ export function parseLocationToken(token: string): LocationTokenResult<LocationR
   if (head === 'multi') return parseMultiToken(rest);
   if (head === 'here') return parseDeviceToken(rest);
   if (head === 'bbox') return parseBoundsToken(rest);
-  if (head === 'at') return parsePointToken(rest);
+  // The withdrawn `at.` production (§19(B)). Rejected with a reason that names
+  // the rule, not treated as an unknown prefix — see `LocationTokenFailure`.
+  if (head === 'at') return fail('coordinates_in_url');
   if ((PLACE_TYPES as readonly string[]).includes(head)) {
     return parsePlaceToken(head as GeoPlaceType, rest);
   }
@@ -774,21 +785,6 @@ function parseBoundsToken(rest: string): LocationTokenResult<LocationRef> {
   });
   if (!isValidBounds(bounds)) return fail('out_of_range');
   return ok({ kind: 'bounds', bounds });
-}
-
-function parsePointToken(rest: string): LocationTokenResult<LocationRef> {
-  const parts = rest.split(',');
-  if (parts.length !== 3) return fail('malformed');
-  const longitude = parseDecimal(parts[0]);
-  const latitude = parseDecimal(parts[1]);
-  const radiusMeters = parseDecimal(parts[2]);
-  if (longitude === null || latitude === null || radiusMeters === null) return fail('not_a_number');
-  if (!isValidLatitude(latitude) || radiusMeters <= 0) return fail('out_of_range');
-  return ok({
-    kind: 'point',
-    center: { longitude: normalizeLongitude(longitude), latitude },
-    radiusMeters,
-  });
 }
 
 function parseDeviceToken(rest: string): LocationTokenResult<LocationRef> {


### PR DESCRIPTION
## What landed

The canonical location contract from ADR 0002, in `packages/shared-types/src/location.ts`, and **nothing migrated onto it**. This is the foundation half of #352, deliberately small so #351, #295 and the migration half can build on one shape instead of three.

- **§3 types, verbatim in shape:** `GeoPoint`, `GeoBounds`, `LocationPrecision`, `PlaceLabel`, `AdminHierarchy`, `PlaceSource`, `PlaceType`, `LocationSelection` (six kinds), `LocationQuery`, `LocationFailureReason`, `LocationResolution`.
- **`GeoPlace`** (§9.2, §14.1) — the gateway's `place`/`address_candidate` payload, defined once so #351 has one shape to serve and the two divergent `AddressData` copies can die, plus `geoPlaceToSelection` so the `address` → `address_candidate` mapping is not re-decided per screen.
- **`locationKey`** (§3.1) — one function, `current_location` has no coordinate branch, bbox on a 3 dp grid, `multi_area` sorted so the key is order-independent.
- **The `loc` token codec** (§5.2) — `serializeLocationToken`, `serializeLocationRef`, `locationRefOf`, `parseLocationToken`. Longitude normalisation with `west > east` legal (§9.3) lives here, so the antimeridian fix happens once.
- **Validators:** `isValidLatitude`, `isValidLongitude`, `isValidBounds`, `normalizeLongitude`.

Not touched: `SearchLocation`, `buildSearchParams`, the frontend store, the backend controllers. ADR §10's translation table is the work list for the migration change, not this one.

## Three deviations from the brief, each with its reason

1. **`parseLocationToken` returns a `LocationRef`, not a `LocationSelection`.** A token carries an identity and a geometry and carries no label, admin hierarchy or centre for a named place — those come from resolving it (§6.2). Returning a selection would mean fabricating them, which is exactly the partially-filled selection §5.2 forbids. Round-trip exactness is asserted in both directions: token to parse to serialise is character-for-character, and selection to token to parse equals `locationRefOf(selection)` directly.
2. **Both directions return a typed result, so `serializeLocationToken` is not `-> string`.** `polygon` has no §5.2 production because §2.1 reserves the wire format, so the honest answer is `unsupported_kind`. Degrading it to its bounding box would silently replace a drawn area with a rectangle — the same "half the location survived" bug from the other side. There is no `null` anywhere in the codec: a caller says "absent" by not calling it.
3. **`LocationSelection` has six kinds, not seven** — ADR §3's union has exactly six members. This was raised as an ADR gap and has since been ruled on; see the amendment below.

## ADR amendment: the `at.` production is withdrawn (second commit)

Implementing §5.2 surfaced a production that **no `LocationSelection` kind maps to**: `at.<lng>,<lat>,<radiusMeters>`. I raised it as a gap; the ruling is to withdraw it, and this branch carries the amendment.

**Why it is decision 8 rather than taste.** Exact coordinates never appear in a URL (§2.8, §8.2), and `here.<radiusMeters>` exists precisely so the device case carries none. `at.` put a raw coordinate pair straight back into the first place §8.2 names.

**Why it was worth closing rather than leaving inert.** The parser accepted a form the serialiser could not emit. A grammar that blesses a shape is how the shape gets used, and the predictable route in is somebody wiring "search around this pin" to it because §5.2 appeared to permit it.

What changed: `docs/adr/0002-location-and-search-contract.md` gains a dated **§19 Amendments** section and its §5.2 grammar block is corrected in place (so a future reader cannot implement it again from the original text); `LocationRef` loses its `point` member outright; `parseLocationToken` returns `{ ok: false, reason: 'coordinates_in_url' }` — a reason naming the RULE rather than `unknown_kind`, because anyone meeting it is likelier to hold an old copy of the grammar than to have typo'd. §19 also records the six-kinds clarification.

**Mutation-tested.** Deleting the rejection turns **4 red**: the two rows asserting the reason rather than merely the refusal, the named withdrawal test, and the one pinning that the withdrawal holds inside `multi.` where the grammar recurses. The fixture is a *well-formed* `at.` on purpose — a malformed one is refused by shape alone and cannot tell a withdrawn production from a typo — and a negative control asserts `here.` still parses, so deleting every radius-bearing form would not pass either.

Two review points are also addressed in that commit: the polygon refusal now records that a bounding-box fallback silently **widens** the user's area (a bbox is a superset of the drawn one — the same family as a failed resolution becoming a global feed), and the `LocationRef` header records that returning a `LocationSelection` would have to **invent a label**, which §4.1 forbids being fed back as free text. The asymmetry is the safety property, not an inconvenience.

## `GeoPoint` / `GeoBounds` collided at the barrel

`observability/queryIdentity` already declared both. Two `export *` lines made them ambiguous — **TS2308 on both names, verified by removing the disambiguation and watching the build fail**, so this was not a hypothetical. The barrel now resolves both to the canonical contract, because ADR §3 is normative about the encoding and every other representation converges there.

Nothing is deleted. The observability declarations keep their names and shapes at `@homiio/shared-types/observability/queryIdentity`, and `packages/backend/__tests__/helpers/locationIdentityFixtures.ts` now imports them from that path with a comment saying why. `GeoBounds` is structurally identical in both, so that half is invisible to consumers; `GeoPoint` genuinely differs (`{ lat, lng }` versus `{ longitude, latitude }`). Folding the two encodings into one belongs to the migration change.

## Mutation-test results

**The one ADR §16(7) requires.** Changed `here:${selection.radiusMeters}` to `here:${selection.center.longitude},${selection.center.latitude}:${selection.radiusMeters}`, confirmed the edit was in the file before running anything, then:

- **RED:** 3 failed, 86 passed. All three in the `current_location` block — the exact-form assertion, the digit-leak assertion (which named the leaked digits `1,3,4,6,7,8,4,1,3,8,7,4`), and the structural one that two positions with the same radius produce the same key.
- **GREEN on restore:** 89 passed, restored from a pristine copy rather than `git checkout`, with markers from my own edits asserted present and the mutation marker asserted absent.

That red run also proves jest loads `shared-types/src` and not a stale `dist` — `dist` was never rebuilt during the mutation.

**Two more, because a fixture that cannot tell right from wrong is the failure this contract exists to prevent.**

- Adding `&& bounds.west <= bounds.east` to `isValidBounds` — the "tidy-up" §9.3 warns silently inverts every antimeridian query into its complement — turned 4 red, including both antimeridian round-trip tokens.
- Widening `KEY_BOUNDS_DECIMALS` from 3 to 6 turned 2 red **and exposed a vacuity in a third**: "never emits more than three decimal places" read its bound from the constant it was checking, so implementation and assertion moved together and it could not fail. Fixed to assert the literal 3 and pin the constant separately; re-running the same mutation now turns 3 red.

## Three defects the tests caught in the implementation

Found by the suite, not by review, and each fixed in this branch:

- `normalizeLongitude(2.1686)` returned `2.1685999999999694` — lossy modulo arithmetic run on a value already in range, so tokens stopped round-tripping and keys drifted on every re-serialisation.
- A nested `multi.` was reported `malformed` rather than `nested_multi`, because the inner token was recursed into before the nesting was checked. A caller switching on the reason would have shown the wrong message.
- Serialising a coordinate below 1e-6 emitted exponent notation (`String(1e-7)` is `"1e-7"`), which the strict parser refuses — an asymmetric codec that only fails within about 11 cm of Greenwich or the equator.

## Verification

| Check | Result |
|---|---|
| `bun run --cwd packages/shared-types build` | exit 0 |
| `bun run --cwd packages/shared-types lint` | exit 0 |
| `bunx jest __tests__/location` (frontend) | **90 passed**, exit 0 |
| `bunx jest` (frontend, full) | **209 passed**, 12 suites, exit 0 |
| `bunx tsc --noEmit` (frontend) | exit 0 |
| `bunx tsc --noEmit` (backend) | exit 0 |
| backend observability + fixtures + text-file gate | **75 passed**, exit 0 |
| `mongoUnreachable` reintroduction gate | passed, exit 0 |
| `bun run check:lockfile` | in sync, exit 0 |

Tests live in `packages/frontend/__tests__/location/`, following the convention `format/` established: that is the CI job needing no database, and `shared-types` has no runner of its own.

Refs #352.
