### PR TITLE
fix(gates): one comment stripper, so a violation cannot hide in blanked code

### DIFF
--- a/packages/backend/__tests__/unit/mongoUnreachable.test.ts
+++ b/packages/backend/__tests__/unit/mongoUnreachable.test.ts
@@ -2,6 +2,8 @@ import { execFileSync } from 'child_process';
 import { readFileSync } from 'fs';
 import path from 'path';
 
+import { stripComments } from '@homiio/shared-types/testing/stripComments';
+
 /**
  * Homiio's runtime cannot reach Mongo — asserted, not claimed.
  *
@@ -145,6 +147,17 @@ const PENDING_MONGO_FILES: ReadonlyMap<string, string> = new Map([]);
  * raw-text scan matches their own explanation and fails on correct code. That
  * is not hypothetical: it happened while writing a sibling gate today.
  *
+ * **The stripping is deliberate, and it used to be unsound.** This file carried
+ * its own two-regex stripper, which let a block-comment opener MENTIONED inside
+ * a `//` comment open a real block and blank everything up to the next
+ * terminator. In
+ * `config.ts` that is 109 lines — a `mongoose` import anywhere inside them
+ * would have passed this gate silently, which is the one thing it exists to
+ * prevent. It now strips through `@homiio/shared-types/testing/stripComments`,
+ * shared with the currency gate that hit the same fault; the intent above is
+ * unchanged, only the implementation is sound. See
+ * `packages/frontend/__tests__/stripComments.test.ts`.
+ *
  * **`import` and `require` are BOTH covered for the barrel, not only for
  * mongoose**, and the asymmetry that used to sit here was load-bearing:
  * `scripts/seedCities.js` reached the models through
@@ -182,11 +195,6 @@ function trackedFiles(): string[] {
     .split('\n')
     .filter((line) => !line.endsWith('.d.ts'))
     .filter((line) => SOURCE_EXTENSIONS.some((extension) => line.endsWith(extension)));
-}
-
-/** Strip line and block comments. Crude by design — it only has to remove prose. */
-function stripComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
 }
 
 function isScanned(file: string): boolean {

--- a/packages/frontend/__tests__/noHardcodedCurrency.test.ts
+++ b/packages/frontend/__tests__/noHardcodedCurrency.test.ts
@@ -32,7 +32,13 @@
  *    the bug they fixed by quoting it (`what `€${amount}` did`), and a comment
  *    renders to nobody. Stripping them is the same call
  *    `__tests__/unit/mongoUnreachable.test.ts` makes in the backend, for the
- *    same reason.
+ *    same reason — and both now make it through the SAME implementation,
+ *    `@homiio/shared-types/testing/stripComments`. The two regexes that used to
+ *    sit here truncated a line at the `//` of a URL and let a `/*` mentioned
+ *    inside a `//` comment open a block, which blanked real code and made this
+ *    gate report a clean tree over 1,047 lines of it, across 128 files
+ *    (measured 2026-08-10 against this gate's own scanned set). See
+ *    `__tests__/stripComments.test.ts`, which pins both regressions.
  *
  * It lives in the FRONTEND suite because that CI job needs no database, and it
  * scans all three packages from the repository root; `shared-types` has no
@@ -41,6 +47,8 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+
+import { stripComments } from '@homiio/shared-types/testing/stripComments';
 
 /** Repository root — two levels up from `packages/frontend`. */
 const REPO_ROOT = join(__dirname, '..', '..', '..');
@@ -154,29 +162,6 @@ interface Finding {
   line: number;
   text: string;
   rule: string;
-}
-
-/**
- * Remove `//` and block comments, and the contents of import specifiers.
- *
- * Crude by design — it does not parse TypeScript — but it errs toward keeping
- * text (a `//` inside a string literal leaves the rest of the line stripped),
- * which is the safe direction here: it can only cause the gate to miss a line,
- * never to invent one, and the pinned-predicate case below proves it still
- * matches real code.
- */
-function stripComments(source: string): string {
-  return source
-    // Replace a block comment with its own newlines, not with nothing: the line
-    // NUMBERS in a finding have to point at the real line, and collapsing a
-    // 40-line header shifted every report in this file by 32.
-    .replace(/\/\*[\s\S]*?\*\//gu, (match) => match.replace(/[^\n]/gu, ''))
-    .split('\n')
-    .map((line) => {
-      const index = line.indexOf('//');
-      return index === -1 ? line : line.slice(0, index);
-    })
-    .join('\n');
 }
 
 /** Every offending line in `source`. */

--- a/packages/frontend/__tests__/stripComments.test.ts
+++ b/packages/frontend/__tests__/stripComments.test.ts
@@ -1,0 +1,247 @@
+/**
+ * The shared comment stripper, and the two regressions that produced it.
+ *
+ * Two repo gates scan comment-stripped source — the currency and locale gate in
+ * this directory (#357) and the backend's Mongo reintroduction gate. Both used
+ * the same pair of regexes, and both were wrong in the direction that reports a
+ * CLEAN tree. The cases below pin each fault against the exact naive code that
+ * had it, so a future "simplification" back to two regexes fails loudly instead
+ * of quietly reopening a blind spot.
+ *
+ * These live in the FRONTEND suite for the same reason the currency gate does:
+ * this CI job needs no database, and `shared-types` has no runner of its own.
+ */
+import { stripComments } from '@homiio/shared-types/testing/stripComments';
+
+/**
+ * The stripper `packages/backend/__tests__/unit/mongoUnreachable.test.ts`
+ * carried, verbatim. Reproduced so the regression is pinned against the real
+ * thing rather than a paraphrase of it.
+ */
+function naiveMongoStripper(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+/**
+ * The stripper `packages/frontend/__tests__/noHardcodedCurrency.test.ts`
+ * carried, verbatim.
+ */
+function naiveCurrencyStripper(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//gu, (match) => match.replace(/[^\n]/gu, ''))
+    .split('\n')
+    .map((line) => {
+      const index = line.indexOf('//');
+      return index === -1 ? line : line.slice(0, index);
+    })
+    .join('\n');
+}
+
+/** Non-empty, trimmed lines — what a gate actually matches against. */
+function codeLines(source: string): string[] {
+  return source
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+describe('stripComments', () => {
+  describe('REGRESSION: a URL is not a comment', () => {
+    // Verbatim from `packages/backend/config.ts` — the line that sent the
+    // currency gate's stripper off a cliff. Everything from `//` onward was
+    // discarded, taking the whole template literal with it.
+    const line = "  publicUrl: process.env.PUBLIC_API_URL || `http://localhost:${process.env.PORT || '4130'}`,";
+
+    it('keeps the whole line', () => {
+      expect(stripComments(line)).toBe(line);
+    });
+
+    it('is the fault the naive stripper had', () => {
+      // Pin the OLD behaviour too. If someone reverts the implementation, the
+      // case above fails; if someone deletes this one, the reason the case
+      // above exists stops being visible.
+      expect(naiveCurrencyStripper(line)).toBe('  publicUrl: process.env.PUBLIC_API_URL || `http:');
+      expect(naiveCurrencyStripper(line)).not.toContain('localhost');
+    });
+
+    it('survives a URL in every quoting style', () => {
+      for (const source of [
+        "const a = 'https://example.test/x';",
+        'const b = "https://example.test/x";',
+        'const c = `https://example.test/x`;',
+      ]) {
+        expect(stripComments(source)).toBe(source);
+      }
+    });
+  });
+
+  describe('REGRESSION: a block opener inside a line comment does not open a block', () => {
+    // Verbatim from `packages/backend/config.ts:383`. The route glob for the
+    // local image store ends in `/` `*`, which the naive regex read as a block
+    // comment opener; it then closed at the next `*/` 108 lines later and
+    // blanked 109 lines of real configuration.
+    const source = [
+      '  // self-hosted local image store served at `/api/images/file/*` when object',
+      '  // storage (S3) is not configured.',
+      "  publicUrl: process.env.PUBLIC_API_URL || 'https://api.homiio.com',",
+      '  rateLimit: {',
+      '    windowMs: 15 * 60 * 1000,',
+      '  },',
+      '  /* a genuine block comment, which is where the naive regex closed */',
+      '  logLevel: process.env.LOG_LEVEL,',
+    ].join('\n');
+
+    it('keeps every line of real code', () => {
+      expect(codeLines(stripComments(source))).toEqual([
+        "publicUrl: process.env.PUBLIC_API_URL || 'https://api.homiio.com',",
+        'rateLimit: {',
+        'windowMs: 15 * 60 * 1000,',
+        '},',
+        'logLevel: process.env.LOG_LEVEL,',
+      ]);
+    });
+
+    it('is the fault the naive stripper had — it ate the code between', () => {
+      const naive = naiveMongoStripper(source);
+      expect(naive).not.toContain('publicUrl');
+      expect(naive).not.toContain('windowMs');
+      expect(naive).not.toContain('rateLimit');
+      // And what it left behind is only the code AFTER the bogus block closed.
+      expect(codeLines(naive)).toEqual(['logLevel: process.env.LOG_LEVEL,']);
+    });
+
+    it('still removes a genuine block comment', () => {
+      const stripped = stripComments(source);
+      expect(stripped).not.toContain('a genuine block comment');
+      expect(stripped).not.toContain('self-hosted local image store');
+    });
+  });
+
+  describe('comment markers inside string literals', () => {
+    it('a block opener inside a string does not open a block', () => {
+      // A later, genuine `*/` is what gives the bogus opener something to close
+      // against — the same shape as the config.ts instance above. Without one
+      // the naive regex matches nothing, so a fixture lacking it would pass
+      // under the broken stripper too and prove nothing.
+      const source = [
+        "const marker = '/*';",
+        'const real = 1;',
+        '/** a later doc comment */',
+        'const after = 2;',
+      ].join('\n');
+
+      expect(codeLines(stripComments(source))).toEqual([
+        "const marker = '/*';",
+        'const real = 1;',
+        'const after = 2;',
+      ]);
+
+      // The naive stripper paired the string's `/*` with that doc comment's
+      // `*/` and swallowed the real code sitting between them.
+      const naive = naiveMongoStripper(source);
+      expect(naive).not.toContain('const real = 1;');
+      // What it leaves is the half of the opening line before the string's
+      // `/*`, then nothing until the doc comment's `*/`.
+      expect(codeLines(naive)).toEqual(["const marker = '", 'const after = 2;']);
+    });
+
+    it('a block closer inside a string does not close one', () => {
+      const source = ['const kept = 1;', 'const marker = "*/";'].join('\n');
+      expect(stripComments(source)).toBe(source);
+    });
+
+    it('a double slash inside a string is not a comment', () => {
+      for (const source of ['const s = "a//b";', "const s = 'a//b';", 'const s = `a//b`;']) {
+        expect(stripComments(source)).toBe(source);
+      }
+    });
+
+    it('an escaped quote does not end the string early', () => {
+      const source = "const s = 'it\\'s // not a comment';";
+      expect(stripComments(source)).toBe(source);
+    });
+
+    it('a comment marker inside a template interpolation IS a comment', () => {
+      const source = 'const t = `${value /* real */}`;';
+      const stripped = stripComments(source);
+      expect(stripped).not.toContain('real');
+      expect(stripped).toContain('${value');
+    });
+
+    it('an object literal inside an interpolation does not end it', () => {
+      const source = 'const t = `${fn({ a: 1 })} // still a string`;';
+      expect(stripComments(source)).toBe(source);
+    });
+  });
+
+  describe('regex literals', () => {
+    it('keeps a regex containing escaped slashes', () => {
+      const source = ['const r = /https?:\\/\\//;', 'const kept = 1;'].join('\n');
+      expect(stripComments(source)).toBe(source);
+    });
+
+    it('keeps a regex whose character class holds a slash and a star', () => {
+      const source = ['const r = /[/*]/;', 'const kept = 1;'].join('\n');
+      expect(stripComments(source)).toBe(source);
+    });
+
+    it('still treats division as division', () => {
+      const source = 'const q = total / count; // per item';
+      const stripped = stripComments(source);
+      expect(stripped).not.toContain('per item');
+      expect(stripped).toContain('const q = total / count;');
+    });
+  });
+
+  describe('blanking, not deleting', () => {
+    // Both gates report `file:line`. A stripper that deletes shifts every line
+    // after the comment, so every location it reports is wrong.
+    const source = ['/**', ' * A header.', ' */', 'const first = 1;', 'const second = 2; // trailing'].join('\n');
+
+    it('preserves the length of the file exactly', () => {
+      expect(stripComments(source)).toHaveLength(source.length);
+    });
+
+    it('preserves the line count and the line each statement sits on', () => {
+      const lines = stripComments(source).split('\n');
+      expect(lines).toHaveLength(source.split('\n').length);
+      expect(lines[3]).toBe('const first = 1;');
+      expect(lines[4].trimEnd()).toBe('const second = 2;');
+    });
+
+    it('is the fault the mongo stripper had — it collapsed the header away', () => {
+      const naive = naiveMongoStripper(source);
+      expect(naive.split('\n').length).toBeLessThan(source.split('\n').length);
+    });
+
+    it('replaces comment characters with spaces rather than removing them', () => {
+      const stripped = stripComments('const a = 1; // note');
+      expect(stripped).toMatch(/^const a = 1; +$/u);
+    });
+  });
+
+  describe('the things a stripper must still do', () => {
+    it('removes a line comment on its own line', () => {
+      expect(codeLines(stripComments(['// gone', 'const kept = 1;'].join('\n')))).toEqual(['const kept = 1;']);
+    });
+
+    it('removes a trailing line comment', () => {
+      expect(codeLines(stripComments('const kept = 1; // gone'))).toEqual(['const kept = 1;']);
+    });
+
+    it('removes a multi-line block comment', () => {
+      const source = ['/*', ' gone', '*/', 'const kept = 1;'].join('\n');
+      expect(codeLines(stripComments(source))).toEqual(['const kept = 1;']);
+    });
+
+    it('removes an unterminated block comment to the end of the file', () => {
+      const stripped = stripComments(['const kept = 1;', '/* runs off the end', 'not code'].join('\n'));
+      expect(codeLines(stripped)).toEqual(['const kept = 1;']);
+    });
+
+    it('leaves a file with no comments untouched', () => {
+      const source = ["import { a } from 'b';", 'export const c = a + 1;'].join('\n');
+      expect(stripComments(source)).toBe(source);
+    });
+  });
+});

--- a/packages/frontend/jest.config.js
+++ b/packages/frontend/jest.config.js
@@ -60,6 +60,14 @@ module.exports = {
   // Resolve the `@/...` path alias declared in tsconfig.json / babel.config.js.
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
+    // Shared-types SUBPATHS only. The bare specifier is deliberately left to
+    // node resolution (the built `dist`, as every existing test here uses it);
+    // this maps the subpath form the repo gates import
+    // (`@homiio/shared-types/testing/stripComments`), which has no `exports`
+    // entry to resolve through and would otherwise fail. Points at `src` so a
+    // gate reads the helper it is being edited alongside, not a stale `dist` —
+    // the same mapping the backend suite already declares.
+    '^@homiio/shared-types/(.*)$': '<rootDir>/../shared-types/src/$1',
   },
   // Only pick up our own specs; never descend into build output.
   testMatch: ['<rootDir>/__tests__/**/*.(test|spec).(ts|tsx)'],

--- a/packages/shared-types/src/testing/stripComments.ts
+++ b/packages/shared-types/src/testing/stripComments.ts
@@ -1,0 +1,218 @@
+/**
+ * Blank the comments out of a JavaScript/TypeScript source file, so a repo gate
+ * can scan CODE without matching the prose that describes it.
+ *
+ * ## Why this exists, and why it is not two regexes
+ *
+ * Two gates in this repository scan comment-stripped source — the currency and
+ * locale gate (`packages/frontend/__tests__/noHardcodedCurrency.test.ts`, #357)
+ * and the Mongo reintroduction gate
+ * (`packages/backend/__tests__/unit/mongoUnreachable.test.ts`). Both stripped
+ * comments with the same pair of regexes, and both were wrong in the direction
+ * that reports a CLEAN tree:
+ *
+ *  1. **`line.indexOf('//')` truncates a line at a URL's scheme separator.** The
+ *     `//` in `'https://example.test'` is not a comment, so everything from it
+ *     to the end of the line was thrown away — including, on a real line of
+ *     `packages/backend/config.ts`, the whole of a template literal.
+ *  2. **A block-comment OPENER mentioned inside a `//` comment was treated as a
+ *     real opener**, and the non-greedy block-comment regex then blanked
+ *     everything up to the next terminator. The measured instance is
+ *     `packages/backend/config.ts:383`, whose line comment mentions the route
+ *     glob for the local image store; the `/` and `*` at the end of that glob
+ *     open a block that the regex closes 108 lines later, taking 109 lines of
+ *     real configuration with it.
+ *
+ * Both faults DELETE code before the gate ever sees it, so a violation sitting
+ * in the blanked region passes silently. For the Mongo gate that is the whole
+ * point of the file: a reintroduced `mongoose` import inside such a region would
+ * not fail the build.
+ *
+ * ## What this does instead
+ *
+ * One pass, tracking the states a comment can hide inside: string literals
+ * (single, double, and template literals with nested interpolation), regular
+ * expression literals, and comments themselves.
+ *
+ * It **blanks rather than deletes** — every comment character becomes a space
+ * and every newline is kept, so the output has the same length and the same line
+ * numbering as the input. Both gates report `file:line`, and a stripper that
+ * shifts lines makes every location it reports wrong.
+ *
+ * ## Known limits, stated rather than papered over
+ *
+ * Deciding whether `/` opens a regular expression or is a division sign needs a
+ * parser; this uses the standard heuristic of looking at the preceding
+ * significant token. A `/` following `)` is read as division, so `if (x) /re/`
+ * would be misread — a shape that does not appear in this repository. Dropping
+ * regex tracking altogether was measured against the tree and does lose code
+ * (7 files, 10 lines), which is why the heuristic is here rather than omitted.
+ *
+ * Measured on 2026-08-10 at bf3ef48b, the two regexes this replaces hid 1,047
+ * lines of real code across 128 of the 952 files the currency gate scans, and
+ * 227 lines across 21 of the 254 the Mongo gate scans.
+ *
+ * JSX text is not JavaScript, and a `//` inside it is not a comment. This
+ * treats it as code, which is the safe direction: it can only leave text in for
+ * a gate to match, never take code out.
+ */
+
+/** Characters after which a `/` starts a regular expression rather than dividing. */
+const REGEX_CAN_FOLLOW = new Set([
+  '(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';', '+', '-', '*', '%', '<', '>', '~', '^',
+]);
+
+/** Keywords after which a `/` starts a regular expression. */
+const REGEX_CAN_FOLLOW_KEYWORD = new Set([
+  'return', 'typeof', 'instanceof', 'in', 'of', 'new', 'delete', 'void', 'case', 'do', 'else', 'yield', 'await',
+]);
+
+/**
+ * Where we are in the nesting of template literals.
+ *
+ * A template can contain an interpolation, which can contain another template.
+ * The interpolation frame counts braces so that an object literal inside it
+ * (`${ { a: 1 } }`) does not read as the end of the interpolation.
+ */
+type Frame = { readonly kind: 'template' } | { kind: 'interpolation'; depth: number };
+
+const IDENTIFIER = /[A-Za-z0-9_$]/;
+const WHITESPACE = /\s/;
+
+/**
+ * Replace every comment in `source` with spaces, preserving length, newlines and
+ * therefore line numbers. Code, string literals and regex literals are returned
+ * untouched.
+ */
+export function stripComments(source: string): string {
+  const out = source.split('');
+  const stack: Frame[] = [];
+  let index = 0;
+  let lastSignificant: string | undefined;
+  let lastWord = '';
+
+  const blank = (from: number, to: number): void => {
+    for (let at = from; at < to && at < out.length; at += 1) {
+      if (out[at] !== '\n') out[at] = ' ';
+    }
+  };
+
+  const inTemplate = (): boolean => stack.length > 0 && stack[stack.length - 1].kind === 'template';
+
+  /** Consume a quoted string, honouring escapes; a newline ends it (unterminated). */
+  const readQuoted = (quote: string): void => {
+    index += 1;
+    while (index < source.length) {
+      const char = source[index];
+      if (char === '\\') { index += 2; continue; }
+      if (char === '\n' || char === quote) { index += 1; return; }
+      index += 1;
+    }
+  };
+
+  /** Consume a regex literal; an unescaped `/` inside `[...]` does not close it. */
+  const readRegex = (): void => {
+    index += 1;
+    while (index < source.length) {
+      const char = source[index];
+      if (char === '\\') { index += 2; continue; }
+      if (char === '\n') { index += 1; return; }
+      if (char === '[') {
+        index += 1;
+        while (index < source.length && source[index] !== ']' && source[index] !== '\n') {
+          index += source[index] === '\\' ? 2 : 1;
+        }
+        index += 1;
+        continue;
+      }
+      if (char === '/') { index += 1; return; }
+      index += 1;
+    }
+  };
+
+  while (index < source.length) {
+    const char = source[index];
+    const next = source[index + 1];
+
+    if (inTemplate()) {
+      if (char === '\\') { index += 2; continue; }
+      if (char === '$' && next === '{') {
+        stack.push({ kind: 'interpolation', depth: 0 });
+        index += 2;
+        lastSignificant = '{';
+        lastWord = '';
+        continue;
+      }
+      if (char === '`') { stack.pop(); index += 1; lastSignificant = '`'; lastWord = ''; continue; }
+      index += 1;
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      const newline = source.indexOf('\n', index);
+      const stop = newline === -1 ? source.length : newline;
+      blank(index, stop);
+      index = stop;
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      const close = source.indexOf('*/', index + 2);
+      const stop = close === -1 ? source.length : close + 2;
+      blank(index, stop);
+      index = stop;
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      readQuoted(char);
+      lastSignificant = char;
+      lastWord = '';
+      continue;
+    }
+
+    if (char === '`') {
+      stack.push({ kind: 'template' });
+      index += 1;
+      continue;
+    }
+
+    if (char === '/') {
+      const opensRegex =
+        lastSignificant === undefined ||
+        REGEX_CAN_FOLLOW.has(lastSignificant) ||
+        REGEX_CAN_FOLLOW_KEYWORD.has(lastWord);
+      if (opensRegex) { readRegex(); lastSignificant = '/'; lastWord = ''; continue; }
+    }
+
+    const frame = stack[stack.length - 1];
+    if (frame !== undefined && frame.kind === 'interpolation') {
+      if (char === '{') frame.depth += 1;
+      else if (char === '}') {
+        if (frame.depth === 0) { stack.pop(); index += 1; lastSignificant = '}'; lastWord = ''; continue; }
+        frame.depth -= 1;
+      }
+    }
+
+    if (WHITESPACE.test(char)) {
+      if (char === '\n') lastWord = '';
+      index += 1;
+      continue;
+    }
+
+    if (IDENTIFIER.test(char)) {
+      let end = index;
+      while (end < source.length && IDENTIFIER.test(source[end])) end += 1;
+      lastWord = source.slice(index, end);
+      lastSignificant = source[end - 1];
+      index = end;
+      continue;
+    }
+
+    lastSignificant = char;
+    lastWord = '';
+    index += 1;
+  }
+
+  return out.join('');
+}


### PR DESCRIPTION
Two repo gates stripped comments before scanning, using the same pair of regexes, and both were wrong in the direction that reports a **clean tree**. A violation sitting in the code they blanked passed silently.

Found while building the gate for #351; the currency gate came from #357.

## The two faults

1. **`line.indexOf('//')` truncates a line at a URL's scheme separator.** `const u = 'https://example.test'` lost everything from `//` onward.
2. **A block-comment OPENER mentioned inside a `//` comment was treated as a real opener**, and the non-greedy block regex then blanked everything up to the next terminator.

The measured instance of (2) is `packages/backend/config.ts:383`:

```
  // self-hosted local image store served at `/api/images/file/*` when object
```

The `/` and `*` ending that route glob open a block comment that the regex closes at line 491 — **109 lines** of real configuration, invisible to both gates.

## My own measurement (re-derived, not carried over)

Measured **2026-08-10** at `bf3ef48b`, by two independently-built methods that agree **exactly** — a multiset deficit of trimmed code lines (robust to the Mongo stripper deleting lines) and a line-aligned per-line diff (exact for the currency stripper, which preserves line count):

| gate | files scanned | files with a blind spot | lines of real code lost |
|---|---|---|---|
| currency / locale (`noHardcodedCurrency`) | 952 | **128** | **1,047** |
| Mongo reintroduction (`mongoUnreachable`) | 254 | **21** | **227** |
| union | — | **141 distinct files** | — |

Worst offenders: `hooks/useSindiConversation.ts` (97), `db/profiles/profileSerializer.ts` (70), `__tests__/unit/residentialProxy.test.ts` (66), `config.ts` (65), `server.ts` (52).

Command (full script in the branch history of my scratch work; it imports the shipped helper, not a prototype):

```
git ls-files -- packages/frontend packages/backend packages/shared-types   # 952 source files
# for each: compare stripComments(src) against the naive stripper, count code lines lost
```

**This is larger than the 27 files / 512 lines reported to me.** I did not reconcile the difference by adjusting my method to match; I report what my two methods measured. The likely cause is a narrower definition of "lost" — my count includes lines truncated mid-line by fault (1), not only whole lines swallowed by fault (2). A hand-checkable anchor either way: `config.ts` alone loses 65 code lines inside a 109-line blanked span, verifiable with `sed -n '383,491p' packages/backend/config.ts`.

## Gates found and fixed — and how I enumerated them

Five independent searches over **all 1,406 tracked files** (not just `packages/`), because a search whose job is "is anything else doing this?" reads the same when it finds less as when there is less:

- by name: `git grep -in 'stripcomment'`
- by the block regex literal: `git grep -F '[\s\S]*?\*\/'`
- by the line-comment slice: `git grep -F "indexOf('//')"` and the double-quoted form
- by the anchored line-comment regex: `git grep -F '\/\/.*$'`
- files mentioning both "strip" and "comment"

My first attempt at the second search returned **zero** — the literal in source is `\*\/`, and my pattern was `\*/`. That is the vacuity signature, so I re-ran it with a positive control (must find ≥2) and a negative control (`stripCommentsXYZZY` → 0 hits).

Result: exactly **two** gates on `main`, both fixed here:

- `packages/frontend/__tests__/noHardcodedCurrency.test.ts`
- `packages/backend/__tests__/unit/mongoUnreachable.test.ts`

No third instance exists on `main`.

## The fix

One implementation: **`packages/shared-types/src/testing/stripComments.ts`**, imported directly by both gates (no barrel, no shim).

- Single pass tracking string literals (single, double, template with nested `${}` interpolation and brace-counting), regex literals, and comments.
- **Blanks rather than deletes** — same length, same newlines, so line numbers survive. Both gates report `file:line`; a stripper that shifts lines makes every location it reports wrong. The old Mongo stripper deleted block comments outright.
- Regex-literal tracking is kept because dropping it was **measured** to lose code (7 files, 10 lines) — not assumed.
- Known limits are stated in the file rather than papered over (a `/` after `)` reads as division; JSX text is treated as code, which is the safe direction).

### Why it lives in `shared-types`

There is no cross-package test-utility home in this repo — `packages/backend/__tests__/helpers/` is backend-only, and the currency gate must stay in the **frontend** suite because that CI job needs no database.

A repo-root helper is impossible for the backend gate: `packages/backend/tsconfig.json` sets `rootDir: "./"`, so any import from outside the package fails `tsc`. A new `packages/test-support` workspace would need a composite project, a build-ordering change, two `tsconfig` references and two jest mappers — and `packages/backend/Dockerfile` **rewrites `workspaces`** to a fixed three-package list, so a fourth member is a live deploy risk for a 60-line helper.

`@homiio/shared-types` is the one mechanism both packages already share. It is imported by **subpath**, so it never enters the runtime barrel. One line was added to the frontend jest `moduleNameMapper` for subpath resolution; the bare specifier is untouched.

## Tests

`packages/frontend/__tests__/stripComments.test.ts` — 24 cases. Both regressions are pinned **against the real naive code**, reproduced verbatim in the test, so a future "simplification" back to two regexes fails loudly:

- the real `config.ts` URL line survives, and the naive stripper is asserted to truncate it at `` `http: ``
- the real `config.ts:383` glob shape keeps every line of code between it and the next terminator, and the naive stripper is asserted to eat them
- a block opener inside a string, a block closer inside a string, `//` inside a string in all three quoting styles, escaped quotes, comments inside interpolations, object literals inside interpolations
- regex literals with escaped slashes and with `/` inside a character class; division still reads as division
- blanking: length preserved, line count preserved, each statement still on its own line

One fixture needed a correction while writing it: a string containing `/*` with **no later `*/`** passes under the broken stripper too (the regex matches nothing), so it would have proved nothing. The fixture now carries a genuine doc comment afterwards — the same shape as the real `config.ts` case.

## Mutation evidence — both halves

Two probes planted at `config.ts:425-426`, **inside the measured blind region (383–491)**, verified to have landed before each run:

| gate | probe | fixed stripper | old stripper |
|---|---|---|---|
| Mongo reintroduction | `mutationProbeMongo: require('mongoose')` | **RED** — `offenders: ["config.ts"]` | **GREEN — 8/8 passed** |
| currency / locale | a currency glyph glued to an interpolation | **RED** — `packages/backend/config.ts:426` | **GREEN — 4/4 passed** |

The Mongo half is the one that matters: a **live `require('mongoose')`** in `config.ts`, and the gate whose entire purpose is to stop Mongo returning by accident reported a clean tree. `AGENTS.md` states its `PENDING_MONGO_FILES` map is empty so any Mongo import fails the build; that was not true inside 227 lines.

The currency gate's red also reports **line 426** correctly, which demonstrates the blanking property end to end.

Discipline followed: each mutation was confirmed present in the file before the suite ran (a mutation that never applied is indistinguishable from one that survived — and the ambiguity only bites on a green run, which is exactly what the old-stripper half produces); pristine copies were kept under a per-agent namespaced scratch path and restored by copy, never `git checkout`; after restoring, markers from my own edit were asserted still present, `config.ts` confirmed byte-identical to `HEAD`, and a negative control confirmed absent.

I also caught and removed two **zero-width spaces** I had introduced while trying to write `*/` inside a block comment — verified gone with a detector proven non-vacuous against a planted probe.

## Both gates keep what they had

Vacuity floors, affirmative extension lists, `git ls-files` enumeration and the allow-list assertions are unchanged. The Mongo gate keeps its **deliberate** comment-stripping intent — several backend modules describe what they no longer do in exactly the vocabulary it matches on — and its header now records that the stripping used to be unsound and why.

## Verification

- `bun install` — exit 0, output scanned for `error:` (none)
- frontend suite — **11 suites, 143 tests, all pass**
- backend suite — **133 suites, 1,759 tests, all pass**
- `tsc --noEmit` — shared-types, backend, frontend: all exit 0
- lint — shared-types exit 0; my files exit 0 (one pre-existing `array-type` warning on a line I did not touch)
- `bun.lock` untouched (no manifest change)

A note on a baseline that looked like a regression: the backend `tsc` first reported 30 errors, all `TS6305` from an **unbuilt `listing-providers/dist`** plus cascading implicit-`any`s. Building the dependency clears every one. That is a stale-artefact property of the tree, not of this change.

## Overlap with #351

`geo-351` independently wrote a state machine for `packages/frontend/__tests__/noClientGeocoder.test.ts` on `feat/geocoding-gateway-351`, and its PR will land with a local copy. I asked for it verbatim so the repo would end up with one implementation; I had not received a reply by the time this was ready, so this carries my own.

**Whichever of the two merges second should switch to the shared helper.** If this lands first, the file to change is `packages/frontend/__tests__/noClientGeocoder.test.ts` — delete its local stripper and `import { stripComments } from '@homiio/shared-types/testing/stripComments';`. If #351 lands first I will rebase onto it and reconcile the two implementations rather than leaving both.
