### PR TITLE
fix(location): a place may have no centre, and (0,0) is a real place

### DIFF
--- a/docs/adr/0002-location-and-search-contract.md
+++ b/docs/adr/0002-location-and-search-contract.md
@@ -1499,3 +1499,29 @@ conclusions — one made its own `center` optional and said so; the other emitte
 Null Island — which is the measurable cost of a definition contradicted by a
 declaration in the same section. `area` now says what it actually distinguishes:
 whether the point IS the place or merely a way to FRAME it.
+
+**The follow-on hole, and why it is a PREDICATE rather than a constraint.** With
+`center` and `bounds` both optional, a place with NEITHER became expressible — a
+place nothing can frame — and closing a hole that produced a wrong point by
+opening one that produces no point at all would be a poor trade, because the
+second failure is quieter: a map handed such a place renders nothing and reports
+no error, which looks exactly like a map still loading.
+
+It is nevertheless **not forbiddable on the type**, and the reason is measured
+rather than argued. A city Homiio knows by id and name but holds no coordinates
+for is a legitimate **disambiguation candidate**: `/api/cities/lookup` returns
+one today, deliberately, and asserts it carries no `center` and
+`precision: 'area'`. A user choosing between two cities called Riverside can
+pick that one, and the search that follows scopes by `cityId`, which needs no
+geometry whatsoever. Requiring geometry on the DTO would force that candidate to
+be dropped from the list — putting back a homonym the user can no longer reach,
+which is the defect §12.2 exists to prevent — or to have geometry invented for
+it, which is the defect this amendment just removed.
+
+So the invariant binds at a narrower boundary than the type: **a place being
+RESOLVED for display must be framable; a place being OFFERED for selection need
+not be.** `GET /api/geo/resolve` answers 404 rather than returning an unframable
+place; `GET /api/geo/search` may list one. §3 gains `isFramablePlace` so both
+sides read one predicate instead of each spelling the condition out, and it is
+mutation-tested: making it answer `true` unconditionally — the shape that lets an
+unframable place reach a map — turns its test red.

--- a/docs/adr/0002-location-and-search-contract.md
+++ b/docs/adr/0002-location-and-search-contract.md
@@ -321,9 +321,36 @@ export interface GeoBounds {
  *  - `exact`       a building-level point somebody deliberately provided.
  *  - `approximate` an exact point deliberately degraded (rounded or offset).
  *  - `centroid`    the representative point of an AREA. Not anyone's location.
- *  - `area`        no meaningful point at all; only `bounds`/`polygon` apply.
+ *  - `area`        the EXTENT is the meaning. Any point is derived framing
+ *                  rather than the place's own location, and there may be
+ *                  none at all. AMENDED — see §19(C); this line previously
+ *                  read "no meaningful point at all", which `map_bounds`
+ *                  below contradicts, and two implementers read the two
+ *                  statements to opposite conclusions.
  */
 export type LocationPrecision = 'exact' | 'approximate' | 'centroid' | 'area';
+
+/**
+ * Whether a place HAS a representative point. Added by §19(C).
+ *
+ * `center` used to be required beside a `precision` that could say `area`, so
+ * a country — which Homiio stores no centroid for — had nowhere honest to go,
+ * and the gateway emitted `(0, 0)`. `(0, 0)` is a real place, so absence needs
+ * its own state. `center?: never` rather than a plain optional: an optional
+ * still ACCEPTS `{ precision: 'area', center }`, leaving the contradiction
+ * discouraged rather than unrepresentable.
+ */
+export type PlaceGeometry =
+  | {
+      readonly precision: 'exact' | 'approximate' | 'centroid';
+      readonly center: GeoPoint;
+      readonly bounds?: GeoBounds;
+    }
+  | {
+      readonly precision: 'area';
+      readonly center?: never;
+      readonly bounds?: GeoBounds;
+    };
 
 /** A display label, pre-split by whoever knows how. Never `label.split(',')[0]`. */
 export interface PlaceLabel {
@@ -380,31 +407,33 @@ export type LocationSelection =
       readonly kind: 'current_location';
       readonly center: GeoPoint;
       readonly radiusMeters: number;
-      readonly precision: LocationPrecision;
+      /** §19(C): a device fix is a POINT. `centroid`/`area` were never meaningful here. */
+      readonly precision: 'exact' | 'approximate';
     }
   /** A named area: a country, region, city, district, neighborhood or postcode. */
-  | {
+  | ({
       readonly kind: 'place';
       readonly source: PlaceSource;
       readonly placeType: PlaceType;
       readonly label: PlaceLabel;
       readonly admin: AdminHierarchy;
-      readonly center: GeoPoint;
-      readonly bounds?: GeoBounds;
-      /** A named area's centre is a `centroid`, or `area` when no centre is meaningful. */
-      readonly precision: LocationPrecision;
-    }
+    } & PlaceGeometry)
   /** A specific address a geocoder proposed but Homiio has not materialised. */
-  | {
+  | ({
       readonly kind: 'address_candidate';
       readonly source: PlaceSource;
       readonly label: PlaceLabel;
       readonly admin: AdminHierarchy;
-      readonly center: GeoPoint;
-      readonly bounds?: GeoBounds;
-      readonly precision: LocationPrecision;
-    }
-  /** A map viewport the user confirmed. Has no name and never acquires one. */
+    } & PlaceGeometry)
+  /**
+   * A map viewport the user confirmed. Has no name and never acquires one.
+   *
+   * `precision: 'area'` with a REQUIRED centre, which is why `PlaceGeometry`
+   * is NOT applied here (§19(C)): a viewport's centre is real and is supplied
+   * by whoever built the viewport. Deriving it downstream is a trap — the
+   * naive midpoint of an antimeridian box is wrong (`west 170, east -170`
+   * gives 0, the Gulf of Guinea, when the true centre is 180).
+   */
   | {
       readonly kind: 'map_bounds';
       readonly bounds: GeoBounds;
@@ -1412,3 +1441,61 @@ it learns why rather than assuming a typo.
 opposed to the opener's own device — it needs its own `LocationSelection` kind
 with a declared `LocationPrecision`, added by amending §3 deliberately. It does
 not come back as a grammar leftover rediscovered by the next implementer.
+
+### C. A place may have NO centre, and §3 made that unsayable (2026-08-10)
+
+§3 declared `center: GeoPoint` as REQUIRED on `place`, on `address_candidate`
+and on `GeoPlace`, while `LocationPrecision` offered `area` — which the same
+section described as *"no meaningful point at all"*. **The type therefore said a
+place could have no meaningful point and simultaneously demanded one.**
+
+**What it produced, measured rather than imagined.** Homiio's schema stores no
+centroid for a country or a region, so the geocoding gateway had nowhere honest
+to put that fact and emitted `{ longitude: 0, latitude: 0 }` for every one of
+them. The search screen's fallback then drew a ±0.05° box around that point, so
+choosing "Spain" issued a query over an 11 km square in the Gulf of Guinea and
+returned **zero listings**, under a map of open ocean. Nothing threw. Zero
+results is the plausible-looking failure — it reads as "no homes in Spain", not
+as "we invented a centre" — which is why it survived into review.
+
+**`(0, 0)` is a real coordinate.** It is a point in the Atlantic, and longitude
+zero runs through Greenwich, Accra and Tema. A type that forces it as the "no
+centre" value cannot distinguish ABSENT from THERE — the same family as a check
+that cannot distinguish success from failure. Absence needs its own state.
+
+**The fix, and why it is structural rather than an optional field.** §3 gains
+`PlaceGeometry`, a two-member union carried by `place`, `address_candidate` and
+`GeoPlace`: either a real point (`exact` / `approximate` / `centroid`, with
+`center` required) or an extent (`area`, with `center?: never`). A plain
+`center?: GeoPoint` was tried against the compiler first and **still accepts**
+`{ precision: 'area', center }`, which would have left the contradiction
+discouraged rather than unrepresentable; `never` refuses it as an object literal
+AND through a variable, which is the form the gateway writes. It also makes the
+mirror unrepresentable for free — a `centroid` with no centre no longer
+compiles — and a one-directional guard here would have been half a guard.
+
+`bounds` stays optional on the `area` branch deliberately: requiring it would
+move the fabrication one field across, forcing a country with no stored bbox to
+invent a rectangle instead of a point.
+
+**Two things that did NOT change, and the reasons are the interesting part.**
+
+- **`map_bounds` keeps `precision: 'area'` with a REQUIRED centre**, which is
+  why `PlaceGeometry` is not applied to it. A viewport's centre is real and is
+  supplied by whoever built the viewport. Deriving it downstream instead is a
+  trap: the naive midpoint of an antimeridian box is wrong — for
+  `west 170, east -170` it computes `(170 + -170) / 2 = 0` and lands in the Gulf
+  of Guinea, when the true centre is 180. The field prevents exactly the bug
+  this amendment is about, arrived at from the other direction.
+- **`current_location.precision` narrows to `'exact' | 'approximate'`.** A
+  device fix is a point; `centroid` and `area` are properties of an area and
+  were never meaningful there, so the same lie was expressible in a second
+  place.
+
+**The root cause was prose, not structure.** `area` was documented as "no
+meaningful point at all" while `map_bounds`, forty lines below, carried `area`
+AND a required centre. Two implementers read that sentence and reached opposite
+conclusions — one made its own `center` optional and said so; the other emitted
+Null Island — which is the measurable cost of a definition contradicted by a
+declaration in the same section. `area` now says what it actually distinguishes:
+whether the point IS the place or merely a way to FRAME it.

--- a/packages/frontend/__tests__/location/placeGeometry.test.ts
+++ b/packages/frontend/__tests__/location/placeGeometry.test.ts
@@ -1,0 +1,218 @@
+/**
+ * `PlaceGeometry` — a place either has a representative point or says it has
+ * none, and the two contradictions in between do not compile.
+ *
+ * WHAT THIS EXISTS FOR. `center` used to be REQUIRED beside a `precision` that
+ * could say `area`, so a country — which has no centroid in Homiio's schema —
+ * had nowhere honest to go. The geocoding gateway emitted
+ * `{ longitude: 0, latitude: 0 }` for every country and region, the search
+ * screen drew its ±0.05° fallback box around that, and picking "Spain" returned
+ * zero listings over a map of the Gulf of Guinea. Nothing threw. Zero results is
+ * the plausible-looking failure, which is why it reached review unnoticed.
+ *
+ * TWO KINDS OF ASSERTION LIVE HERE, AND ONLY ONE OF THEM IS JEST'S.
+ *
+ * The `Assert<…>` aliases below are checked by `tsc`, not by this runner —
+ * babel strips types, so jest never sees them. They fail the frontend's
+ * `tsc --noEmit` (and `shared-types`' build) if the constraint breaks, which is
+ * the point: the guarantee is that the bad state cannot be WRITTEN, and a
+ * runtime test cannot observe a value that does not exist. Mutating
+ * `center?: never` back to `center?: GeoPoint` turns them red under `tsc`;
+ * that was measured, not assumed.
+ *
+ * The `it(…)` blocks below cover what remains observable at runtime: that
+ * absence survives a round trip, that it is distinguishable from a real
+ * coordinate, and that the key and the token are indifferent to it.
+ */
+
+import {
+  geoPlaceToSelection,
+  locationKey,
+  serializeLocationToken,
+  type AdminHierarchy,
+  type GeoPlace,
+  type GeoPoint,
+  type LocationSelection,
+  type PlaceLabel,
+  type PlaceSource,
+} from '@homiio/shared-types';
+
+// ---------------------------------------------------------------------------
+// Compile-time assertions (checked by tsc, not by jest — see the header)
+// ---------------------------------------------------------------------------
+
+/** Fails to compile unless `T` is exactly `true`. */
+type Assert<T extends true> = T;
+/** `[A] extends [B]` rather than `A extends B`, so a union is not distributed. */
+type IsAssignable<A, B> = [A] extends [B] ? true : false;
+type NotAssignable<A, B> = IsAssignable<A, B> extends true ? false : true;
+
+type PlaceIdentity = {
+  readonly source: PlaceSource;
+  readonly placeType: 'city';
+  readonly label: PlaceLabel;
+  readonly admin: AdminHierarchy;
+};
+
+/**
+ * The bug itself: `area` may not carry a centre.
+ *
+ * A plain `center?: GeoPoint` beside an open `precision` would ACCEPT this —
+ * verified against the compiler before choosing the shape — leaving the
+ * contradiction discouraged rather than unrepresentable. `center?: never`
+ * refuses it, and refuses it through a variable too, not only as an object
+ * literal, which is the form the gateway actually writes.
+ */
+export type _AreaMayNotCarryACentre = Assert<
+  NotAssignable<PlaceIdentity & { precision: 'area'; center: GeoPoint }, GeoPlace>
+>;
+
+/**
+ * The mirror, which a one-directional guard would miss: a `centroid` with no
+ * centre is equally incoherent, and claiming a representative point while
+ * having none is how a consumer ends up reading `undefined.longitude`.
+ */
+export type _CentroidMustCarryACentre = Assert<
+  NotAssignable<PlaceIdentity & { precision: 'centroid' }, GeoPlace>
+>;
+
+/** Both legal shapes still are legal — or the two above pass vacuously. */
+export type _CentroidWithACentreIsFine = Assert<
+  IsAssignable<PlaceIdentity & { precision: 'centroid'; center: GeoPoint }, GeoPlace>
+>;
+export type _AreaWithoutACentreIsFine = Assert<
+  IsAssignable<PlaceIdentity & { precision: 'area' }, GeoPlace>
+>;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const LABEL: PlaceLabel = { primary: 'Spain', kind: 'place' };
+const ADMIN: AdminHierarchy = { countryCode: 'ES' };
+
+/** A country: real, named, resolvable by id, and with no centroid in this schema. */
+const SPAIN: GeoPlace = {
+  source: { kind: 'homiio', entity: 'country', id: '01H8XQ7C2R9V6WQ2N4M0KJ3ZTA' },
+  placeType: 'country',
+  label: LABEL,
+  admin: ADMIN,
+  precision: 'area',
+};
+
+/**
+ * A GENUINE place whose centre is exactly `(0, 0)`.
+ *
+ * The fixture exists so that nothing can later "simplify" absence into a
+ * sentinel — an `isNullIsland()` check, or `center.longitude === 0 &&
+ * center.latitude === 0` treated as "no centre". `(0, 0)` is a real point in
+ * the Atlantic, and longitude zero runs through Greenwich, Accra and Tema, so a
+ * sentinel would silently delete the centre of every place on the prime
+ * meridian. This is the fixture that makes that regression fail.
+ */
+const AT_NULL_ISLAND: GeoPlace = {
+  source: { kind: 'external', provider: 'osm', ref: 'N9999999999' },
+  placeType: 'city',
+  label: { primary: 'Soul Buoy', secondary: 'Atlantic Ocean', kind: 'place' },
+  admin: { countryCode: 'GH' },
+  center: { longitude: 0, latitude: 0 },
+  precision: 'centroid',
+};
+
+/** On the prime meridian, and unambiguously a place people live in. */
+const GREENWICH: GeoPlace = {
+  source: { kind: 'external', provider: 'osm', ref: 'N1111111111' },
+  placeType: 'district',
+  label: { primary: 'Greenwich', secondary: 'London, United Kingdom', kind: 'place' },
+  admin: { countryCode: 'GB', cityName: 'London' },
+  center: { longitude: 0, latitude: 51.4779 },
+  precision: 'centroid',
+};
+
+// ---------------------------------------------------------------------------
+// Runtime behaviour
+// ---------------------------------------------------------------------------
+
+describe('a place with no representative point', () => {
+  it('converts to a selection that also has none', () => {
+    const selection = geoPlaceToSelection(SPAIN);
+    expect(selection.kind).toBe('place');
+    // Not `toBeUndefined()`: the key property is that the field is ABSENT, so a
+    // consumer spreading the selection cannot resurrect a `center` key holding
+    // `undefined` and then read `.longitude` off it.
+    expect('center' in selection).toBe(false);
+    expect(selection).toMatchObject({ precision: 'area' });
+  });
+
+  it('is not confused with a place that really is at (0, 0)', () => {
+    const absent = geoPlaceToSelection(SPAIN);
+    const present = geoPlaceToSelection(AT_NULL_ISLAND);
+    expect('center' in absent).toBe(false);
+    expect('center' in present).toBe(true);
+    expect(present).toMatchObject({ center: { longitude: 0, latitude: 0 } });
+  });
+
+  it('keeps the centre of a place on the prime meridian', () => {
+    // A `longitude === 0 ? absent : present` shortcut would delete this one.
+    expect(geoPlaceToSelection(GREENWICH)).toMatchObject({
+      center: { longitude: 0, latitude: 51.4779 },
+    });
+  });
+
+  it('carries bounds through when it has them, and invents none when it does not', () => {
+    const withBounds = geoPlaceToSelection({
+      ...SPAIN,
+      bounds: { west: -9.3, south: 36, east: 3.3, north: 43.8 },
+    });
+    expect(withBounds).toMatchObject({
+      precision: 'area',
+      bounds: { west: -9.3, south: 36, east: 3.3, north: 43.8 },
+    });
+    // Requiring `bounds` on the `area` branch would only move the fabrication
+    // one field across: a country with no bbox would have to invent a rectangle
+    // instead of a point.
+    expect('bounds' in geoPlaceToSelection(SPAIN)).toBe(false);
+  });
+});
+
+describe('the key and the token are indifferent to a missing centre', () => {
+  /**
+   * This is what keeps the blast radius small, so it is pinned rather than
+   * asserted in a PR description: `locationKey` keys a place on its `source`
+   * and a place token carries no coordinates, so making `center` optional
+   * changes neither. Only code that READS `.center` had to move.
+   */
+  const centreless = geoPlaceToSelection(SPAIN);
+  const withCentre: LocationSelection = {
+    kind: 'place',
+    source: { kind: 'homiio', entity: 'country', id: '01H8XQ7C2R9V6WQ2N4M0KJ3ZTA' },
+    placeType: 'country',
+    label: LABEL,
+    admin: ADMIN,
+    center: { longitude: -3.7, latitude: 40.4 },
+    precision: 'centroid',
+  };
+
+  it('produces the same key either way, because the key is the identity', () => {
+    expect(locationKey(centreless)).toBe('homiio:country:01H8XQ7C2R9V6WQ2N4M0KJ3ZTA');
+    expect(locationKey(centreless)).toBe(locationKey(withCentre));
+  });
+
+  it('produces the same token either way', () => {
+    const a = serializeLocationToken(centreless);
+    const b = serializeLocationToken(withCentre);
+    expect(a).toEqual({ ok: true, value: 'country.homiio.01H8XQ7C2R9V6WQ2N4M0KJ3ZTA' });
+    expect(a).toEqual(b);
+  });
+
+  /**
+   * Negative control for both: the key and the token DO still distinguish two
+   * different places. Without this, an implementation returning a constant
+   * would satisfy the two assertions above.
+   */
+  it('still distinguishes a different place', () => {
+    const other = geoPlaceToSelection(GREENWICH);
+    expect(locationKey(other)).not.toBe(locationKey(centreless));
+    expect(serializeLocationToken(other)).not.toEqual(serializeLocationToken(centreless));
+  });
+});

--- a/packages/frontend/__tests__/location/placeGeometry.test.ts
+++ b/packages/frontend/__tests__/location/placeGeometry.test.ts
@@ -27,6 +27,7 @@
 
 import {
   geoPlaceToSelection,
+  isFramablePlace,
   locationKey,
   serializeLocationToken,
   type AdminHierarchy,
@@ -172,6 +173,57 @@ describe('a place with no representative point', () => {
     // one field across: a country with no bbox would have to invent a rectangle
     // instead of a point.
     expect('bounds' in geoPlaceToSelection(SPAIN)).toBe(false);
+  });
+});
+
+describe('a place with neither a centre nor an extent', () => {
+  /**
+   * `center` and `bounds` are both optional, so a place with NEITHER is
+   * expressible. That is deliberate and it is not a hole in the type: a city
+   * Homiio knows by id and name but has no coordinates for is a real
+   * DISAMBIGUATION CANDIDATE — a user choosing between two cities called
+   * Riverside can pick it, and the search that follows scopes by `cityId`,
+   * which needs no geometry. Forbidding it would drop that candidate from the
+   * list and put the homonym back.
+   *
+   * What must not happen is such a place reaching a MAP, so the invariant binds
+   * at the resolve boundary instead, and this predicate is what both sides read.
+   */
+  const UNFRAMABLE: GeoPlace = {
+    source: { kind: 'homiio', entity: 'city', id: '01J0000000000000000000000' },
+    placeType: 'city',
+    label: { primary: 'Riverside', secondary: 'North, Elsewhere', kind: 'place' },
+    admin: { countryCode: 'XX', regionName: 'North' },
+    precision: 'area',
+  };
+
+  it('is expressible, because a candidate list needs it', () => {
+    expect(geoPlaceToSelection(UNFRAMABLE)).toMatchObject({ kind: 'place', precision: 'area' });
+    expect('center' in geoPlaceToSelection(UNFRAMABLE)).toBe(false);
+  });
+
+  it('is not framable, which is the fact a map must act on', () => {
+    expect(isFramablePlace(UNFRAMABLE)).toBe(false);
+  });
+
+  it('becomes framable with an extent alone', () => {
+    expect(
+      isFramablePlace({ ...UNFRAMABLE, bounds: { west: -9.3, south: 36, east: 3.3, north: 43.8 } }),
+    ).toBe(true);
+  });
+
+  /**
+   * The other three shapes, so the predicate cannot pass by answering `false`
+   * to everything — or `true`, which is the mutation that matters, since it is
+   * the one that lets an unframable place reach a map.
+   */
+  it('is framable with a centre, with or without an extent', () => {
+    expect(isFramablePlace(GREENWICH)).toBe(true);
+    expect(
+      isFramablePlace({ ...GREENWICH, bounds: { west: -0.1, south: 51.4, east: 0.1, north: 51.5 } }),
+    ).toBe(true);
+    // A place at (0, 0) is framable — the sentinel trap again, one layer up.
+    expect(isFramablePlace(AT_NULL_ISLAND)).toBe(true);
   });
 });
 

--- a/packages/shared-types/src/location.ts
+++ b/packages/shared-types/src/location.ts
@@ -106,13 +106,72 @@ export interface GeoJSONMultiPolygon {
  *  - `exact`       a building-level point somebody deliberately provided.
  *  - `approximate` an exact point deliberately degraded (rounded or offset).
  *  - `centroid`    the representative point of an AREA. Not anyone's location.
- *  - `area`        no meaningful point at all; only `bounds`/`polygon` apply.
+ *  - `area`        the EXTENT is the meaning. Any point is derived framing
+ *                  rather than the place's own location, and there may be no
+ *                  point at all.
  *
  * The distinction that matters most is that a `centroid` IS NOT ANYBODY'S
  * LOCATION. A city centre is a framing device, and code that treats it as a
  * home's position is wrong in a way no other type in this package prevents.
+ *
+ * `area` PREVIOUSLY READ "no meaningful point at all", and that was wrong in a
+ * way that mattered — see §19(C) of the ADR. `map_bounds` has always carried
+ * `precision: 'area'` AND a required centre, because a viewport's centre is
+ * real, so the old wording contradicted a variant sitting forty lines below it.
+ * Two implementers read that sentence and reached opposite conclusions. What
+ * `area` actually distinguishes is whether the point is the PLACE or merely a
+ * way to FRAME it; whether a point exists at all is now said structurally, by
+ * {@link PlaceGeometry}.
  */
 export type LocationPrecision = 'exact' | 'approximate' | 'centroid' | 'area';
+
+/**
+ * Whether a place has a representative point, said in the type rather than in a
+ * comment nobody is obliged to read.
+ *
+ * THE BUG THIS CLOSES, MEASURED. `center` used to be REQUIRED beside a
+ * `precision` that could say `area`, so a country — which has no centroid in
+ * this schema — could not be expressed honestly. The geocoding gateway
+ * therefore emitted `{ longitude: 0, latitude: 0 }` for every country and
+ * region, and the search screen drew its fallback box around that, so picking
+ * "Spain" returned zero listings over a map of the Gulf of Guinea. Nothing
+ * threw; zero results is the plausible-looking failure, which is why it
+ * survived review.
+ *
+ * `(0, 0)` IS A REAL COORDINATE — it is a point in the Atlantic, and longitude
+ * zero runs through Greenwich, Accra and Tema. So a type that forces it as the
+ * "no centre" value cannot distinguish ABSENT from THERE, which is the same
+ * family as a check that cannot distinguish success from failure. Absence has
+ * to be its own state.
+ *
+ * `center?: never` rather than a plain optional, and the difference is not
+ * stylistic: a plain `center?: GeoPoint` beside an open `precision` still
+ * ACCEPTS `{ precision: 'area', center }` — verified — so it would leave the
+ * contradiction discouraged rather than unrepresentable. `never` refuses it
+ * both as an object literal and through a variable, which is the shape the
+ * gateway actually writes. It also makes the MIRROR unrepresentable for free: a
+ * `centroid` with no centre no longer compiles, and a one-directional guard
+ * here would only be half a guard.
+ *
+ * `bounds` stays OPTIONAL on the `area` branch on purpose. Requiring it would
+ * simply move the fabrication one field across — a country with no bbox in this
+ * schema would have to invent a rectangle instead of a point, which is the same
+ * lie with a larger footprint. A place with neither is honestly unframeable,
+ * and the caller must say so rather than guess.
+ */
+export type PlaceGeometry =
+  | {
+      /** A real point: the place's own location, or a deliberate degradation of it. */
+      readonly precision: 'exact' | 'approximate' | 'centroid';
+      readonly center: GeoPoint;
+      readonly bounds?: GeoBounds;
+    }
+  | {
+      /** An extent. There is no representative point, and none may be supplied. */
+      readonly precision: 'area';
+      readonly center?: never;
+      readonly bounds?: GeoBounds;
+    };
 
 /** A display label, pre-split by whoever knows how. Never `label.split(',')[0]`. */
 export interface PlaceLabel {
@@ -169,31 +228,47 @@ export type LocationSelection =
       readonly kind: 'current_location';
       readonly center: GeoPoint;
       readonly radiusMeters: number;
-      readonly precision: LocationPrecision;
+      /**
+       * Narrowed to the two values a device fix can actually have. A position
+       * is a point: `centroid` and `area` are properties of an AREA and were
+       * never meaningful here, and the same lie this contract just removed from
+       * `place` was expressible here for the same reason.
+       */
+      readonly precision: 'exact' | 'approximate';
     }
-  /** A named area: a country, region, city, district, neighborhood or postcode. */
-  | {
+  /**
+   * A named area: a country, region, city, district, neighborhood or postcode.
+   *
+   * Its geometry comes from {@link PlaceGeometry}: a `centroid` with a centre,
+   * or `area` with none. A country has no centroid in this schema and says so
+   * rather than pointing at the Atlantic.
+   */
+  | ({
       readonly kind: 'place';
       readonly source: PlaceSource;
       readonly placeType: PlaceType;
       readonly label: PlaceLabel;
       readonly admin: AdminHierarchy;
-      readonly center: GeoPoint;
-      readonly bounds?: GeoBounds;
-      /** A named area's centre is a `centroid`, or `area` when no centre is meaningful. */
-      readonly precision: LocationPrecision;
-    }
+    } & PlaceGeometry)
   /** A specific address a geocoder proposed but Homiio has not materialised. */
-  | {
+  | ({
       readonly kind: 'address_candidate';
       readonly source: PlaceSource;
       readonly label: PlaceLabel;
       readonly admin: AdminHierarchy;
-      readonly center: GeoPoint;
-      readonly bounds?: GeoBounds;
-      readonly precision: LocationPrecision;
-    }
-  /** A map viewport the user confirmed. Has no name and never acquires one. */
+    } & PlaceGeometry)
+  /**
+   * A map viewport the user confirmed. Has no name and never acquires one.
+   *
+   * `precision: 'area'` with a REQUIRED centre, which is not the contradiction
+   * it looks like and is why {@link PlaceGeometry} is not applied here: a
+   * viewport's centre is real, and it is supplied by whoever built the viewport
+   * rather than derived downstream. That matters concretely — the naive
+   * midpoint of an antimeridian box is WRONG: for `west 170, east -170` it
+   * computes `(170 + -170) / 2 = 0` and lands in the Gulf of Guinea, when the
+   * true centre is 180. Dropping this field would push every consumer into
+   * exactly that arithmetic.
+   */
   | {
       readonly kind: 'map_bounds';
       readonly bounds: GeoBounds;
@@ -275,15 +350,12 @@ export type GeoPlaceType = PlaceType | 'address';
  * Auto-picking one is the homonym bug (ADR §12.2), and the list is what makes
  * the `disambiguating` state of §7 possible.
  */
-export interface GeoPlace {
+export type GeoPlace = {
   readonly source: PlaceSource;
   readonly placeType: GeoPlaceType;
   readonly label: PlaceLabel;
   readonly admin: AdminHierarchy;
-  readonly center: GeoPoint;
-  readonly bounds?: GeoBounds;
-  readonly precision: LocationPrecision;
-}
+} & PlaceGeometry;
 
 /**
  * Turn a gateway candidate into the selection the user just chose.
@@ -294,15 +366,27 @@ export interface GeoPlace {
  * identity for the rest of its life.
  */
 export function geoPlaceToSelection(place: GeoPlace): LocationSelection {
+  // Narrowed on `precision` and carried across whole, rather than rebuilt field
+  // by field. Spreading `center` conditionally would let an `area` place
+  // acquire one on the way through — the exact state `PlaceGeometry` exists to
+  // make unrepresentable, reintroduced by the function that is supposed to
+  // preserve it.
+  const geometry: PlaceGeometry =
+    place.precision === 'area'
+      ? { precision: 'area', ...(place.bounds === undefined ? {} : { bounds: place.bounds }) }
+      : {
+          precision: place.precision,
+          center: place.center,
+          ...(place.bounds === undefined ? {} : { bounds: place.bounds }),
+        };
+
   if (place.placeType === 'address') {
     return {
       kind: 'address_candidate',
       source: place.source,
       label: place.label,
       admin: place.admin,
-      center: place.center,
-      ...(place.bounds === undefined ? {} : { bounds: place.bounds }),
-      precision: place.precision,
+      ...geometry,
     };
   }
   return {
@@ -311,9 +395,7 @@ export function geoPlaceToSelection(place: GeoPlace): LocationSelection {
     placeType: place.placeType,
     label: place.label,
     admin: place.admin,
-    center: place.center,
-    ...(place.bounds === undefined ? {} : { bounds: place.bounds }),
-    precision: place.precision,
+    ...geometry,
   };
 }
 

--- a/packages/shared-types/src/location.ts
+++ b/packages/shared-types/src/location.ts
@@ -358,6 +358,37 @@ export type GeoPlace = {
 } & PlaceGeometry;
 
 /**
+ * Whether a place carries enough geometry to be put on a map.
+ *
+ * WHY THIS IS A PREDICATE AND NOT A CONSTRAINT ON THE TYPE. With `center` and
+ * `bounds` both optional, a place with NEITHER is expressible — and the first
+ * instinct is to forbid that, since a place nobody can frame looks like a place
+ * nobody wants. It is not forbiddable, because that place is REAL and is
+ * already returned deliberately: a city Homiio knows by id and name but has no
+ * coordinates for is a legitimate DISAMBIGUATION CANDIDATE. A user picking
+ * between two cities called Riverside can choose the one with no coordinates,
+ * and the search that follows scopes by `cityId`, which needs no geometry at
+ * all. Requiring geometry on the DTO would force that candidate to be dropped
+ * from the list — reintroducing a homonym the user can no longer reach — or to
+ * have geometry invented for it, which is the bug this module just removed.
+ *
+ * So the invariant is real but it binds at a NARROWER boundary than the type: a
+ * place being RESOLVED for display must be framable, while a place being
+ * OFFERED for selection need not be. `GET /api/geo/resolve` answers 404 rather
+ * than returning an unframable place; `GET /api/geo/search` may list one.
+ *
+ * The quiet failure this exists to prevent: a map handed a place with no
+ * geometry frames nothing and reports no error, which looks exactly like a map
+ * that has not finished loading.
+ */
+export function isFramablePlace(place: GeoPlace): boolean {
+  // The point branch always carries a centre — `PlaceGeometry` requires it — so
+  // `precision` settles it there, and only an `area` place has to be asked
+  // whether it brought an extent.
+  return place.precision === 'area' ? place.bounds !== undefined : true;
+}
+
+/**
  * Turn a gateway candidate into the selection the user just chose.
  *
  * Shared rather than written per screen because the `address` →


### PR DESCRIPTION
## The defect

`center` was **required** on `place`, `address_candidate` and `GeoPlace`, beside a `precision` that could say `area` — which ADR 0002 §3 described as *"no meaningful point at all"*. The type said a place could have no meaningful point and simultaneously demanded one.

I found this in my own contract while adversarially reviewing #390, which is where it had already turned into a user-visible bug.

## What it produced, measured

Homiio stores no centroid for a country or a region, so the geocoding gateway had nowhere honest to put that fact and emitted `{ longitude: 0, latitude: 0 }` for every one of them (`gateway.ts:299`, `:326`, plus centreless cities and neighborhoods at `:365`/`:420`). `WhereStep` then drew its ±0.05° fallback box around that point.

**So choosing "Spain" queried an 11 km square in the Gulf of Guinea and returned zero listings, under a map of open ocean.** Nothing threw. Zero results is the plausible-looking failure — it reads as "no homes in Spain", not as "we invented a centre" — which is why it reached review unnoticed, and why no test caught it.

**`(0, 0)` is a real coordinate.** It is a point in the Atlantic, and longitude zero runs through Greenwich, Accra and Tema. A type that forces it as the "no centre" value cannot distinguish ABSENT from THERE — the same family as a check that cannot distinguish success from failure.

## The fix is structural, and the optional-field version was tried first

`PlaceGeometry` is a two-member union carried by `place`, `address_candidate` and `GeoPlace`:

```ts
export type PlaceGeometry =
  | { readonly precision: 'exact' | 'approximate' | 'centroid'; readonly center: GeoPoint; readonly bounds?: GeoBounds }
  | { readonly precision: 'area'; readonly center?: never; readonly bounds?: GeoBounds };
```

`center?: never` rather than a plain optional, **and that was decided at the compiler rather than by taste**: a plain `center?: GeoPoint` beside an open `precision` still ACCEPTS `{ precision: 'area', center }`, which would have left the contradiction discouraged rather than unrepresentable. `never` refuses it as an object literal *and* through a variable — the form the gateway actually writes. It also makes the **mirror** unrepresentable for free: a `centroid` with no centre no longer compiles, and a one-directional guard here would have been half a guard.

`bounds` stays **optional** on the `area` branch deliberately. Requiring it would move the fabrication one field across, forcing a country with no stored bbox to invent a rectangle instead of a point.

### Two things deliberately unchanged

- **`map_bounds` keeps `precision: 'area'` with a REQUIRED centre**, which is why `PlaceGeometry` is not applied to it. A viewport's centre is real and is supplied by whoever built the viewport. Deriving it downstream is a trap: the naive midpoint of an antimeridian box is wrong — `west 170, east -170` computes `(170 + -170) / 2 = 0`, the Gulf of Guinea, when the true centre is 180. That field prevents this very bug, arrived at from the other direction.
- **`current_location.precision` narrows to `'exact' | 'approximate'`.** A device fix is a point; `centroid` and `area` are properties of an area, so the same lie was expressible in a second place.

## The root cause was prose, so the ADR is amended in place

`area` read "no meaningful point at all" while `map_bounds`, forty lines below, carried `area` **and** a required centre. Two implementers read the two statements to opposite conclusions — #389 made its own `center` optional and said why, #390 emitted Null Island — which is the measurable cost of a definition contradicted by a declaration in the same section.

So §3's normative block changes too, not just an annotation at the end: the `area` sentence, both variants, `current_location`, and `PlaceGeometry` added. §19(C) records the defect, the measurement and the reasoning.

## Mutation tests — both directions, at the compiler

The `Assert<…>` aliases in `placeGeometry.test.ts` are checked by `tsc`, not by jest (babel strips types), which is the point: the guarantee is that the bad state cannot be **written**, and a runtime test cannot observe a value that does not exist.

| Mutation | Result |
|---|---|
| `center?: never` → `center?: GeoPoint` | **RED** — `TS2344` at `_AreaMayNotCarryACentre` |
| point branch `center: GeoPoint` → `center?: GeoPoint` | **RED** — `TS2344` at `_CentroidMustCarryACentre` |
| both restored | **GREEN**, byte-identical to the pristine copy |

**One trap worth recording, because the first run of the first mutation reported a false pass.** The frontend typechecks `@homiio/shared-types` against `dist/` through project references, even though jest loads `src/`. Mutating `src` and running `tsc` without rebuilding measured nothing and exited 0 — the AGENTS.md "rebuild between mutating and running" rule, in a repo where the *same package* is read two different ways by two different tools. Both mutations above were re-run with a rebuild in between.

## Review addition: a place with no geometry at all

With `center` and `bounds` both optional, a place with **neither** became expressible. Closing a hole that produced a WRONG point by opening one that produces NO point would be a poor trade — the second failure is quieter, because a map handed such a place renders nothing and reports no error, which looks exactly like a map still loading.

**It is not forbiddable on the type, and the reason is measured rather than argued.** A city Homiio knows by id and name but holds no coordinates for is a legitimate **disambiguation candidate**. `/api/cities/lookup` returns one today, deliberately — #389's "leads with the city that has coordinates over the one that has none" asserts the second candidate carries no `center` and `precision: 'area'`. A user choosing between two cities called Riverside can pick it, and the search that follows scopes by `cityId`, which needs no geometry whatsoever. Requiring geometry on the DTO would force that candidate out of the list, **putting back a homonym the user can no longer reach** (the defect §12.2 exists to prevent), or force geometry to be invented for it (the defect this branch removes).

So the invariant binds at a **narrower boundary than the type**: a place being RESOLVED for display must be framable; a place being OFFERED for selection need not be. `GET /api/geo/resolve` answers 404 rather than returning an unframable place; `GET /api/geo/search` may list one. `isFramablePlace` is the one predicate both sides read instead of each spelling the condition out and drifting.

| Mutation | Result |
|---|---|
| `isFramablePlace` returns `true` unconditionally | **RED** — the shape that lets an unframable place reach a map |
| restored | **GREEN**, byte-identical to pristine |

The other three shapes (centre only, extent only, both) are asserted too, so the predicate cannot pass by answering `false` to everything — and the `(0,0)` fixture is checked here as well, since a sentinel would misread it one layer up.

## Blast radius, pinned rather than asserted

`locationKey` keys a place on its `source`, and a place token carries no coordinates, so **neither the key nor the `loc` codec changes**. `placeGeometry.test.ts` pins that, with a negative control proving the key and token still distinguish two different places. Only code that READS `.center` had to move — which is #390's `WhereStep` and four `gateway.ts` sites, both already being edited.

#389 needs **no change**: its `CityPlaceCandidate.center?` was already optional, for the right stated reason. This ratifies that rather than overruling it.

## Fixtures

A country with no centre; a **genuine place at exactly `(0, 0)`**; and Greenwich, on the prime meridian. The last two exist so nothing can later "simplify" absence into a sentinel — an `isNullIsland()` check, or `longitude === 0 && latitude === 0` treated as "no centre", would silently delete the centre of every place on the prime meridian, and these fixtures make that regression fail.

## Verification

| Check | Result |
|---|---|
| `bun run --cwd packages/shared-types build` / `lint` | exit 0 / exit 0 |
| `bunx jest` (frontend, full) | **244 passed**, 14 suites, exit 0 |
| `bunx tsc --noEmit` (frontend) | exit 0 |
| `bunx tsc --noEmit` (backend) | exit 0 |
| backend divergence + redaction + text-file + mongo gates | **74 passed**, exit 0 |
| `bun scripts/check-docs.mjs` | OK, 25 pages scanned, exit 0 |
| `bun run check:lockfile` | in sync, exit 0 |

Refs #352. **Blocks #390**, which must stop emitting `(0,0)` regardless of when this lands.
