### PR TITLE
fix(gates): the cold-start check passed on a caught crash, because an error boundary renders content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -678,7 +678,7 @@ boot-mounted component calling a suspenseful hook deadlocks the render, so the
 init effect never runs and the promise never resolves: a blank page with ZERO
 console output. Provider ordering fails the same silent way.
 
-Three properties worth keeping if you edit it:
+Four properties worth keeping if you edit it:
 
 - It asserts `document.visibilityState === 'visible'` **before** any verdict and
   exits INCONCLUSIVE (3) otherwise. A backgrounded tab pauses
@@ -686,8 +686,23 @@ Three properties worth keeping if you edit it:
   that has cost this ecosystem a debugging session.
 - It asserts rendered CONTENT, not merely that nothing threw. "Nothing threw" is
   not the property.
-- It carries a mutation test that breaks the entry bundle and requires the check
-  to notice, so it can tell "ran and found nothing" from "did not run".
+- **It fails on any error logged during boot, because AN ERROR BOUNDARY IS
+  CONTENT.** A content assertion cannot tell a booted app from a caught crash:
+  React's boundary renders "Something went wrong" and logs to `console.error`,
+  throwing no uncaught exception. Measured 2026-08-10 on `/explore` — an
+  infinite render loop produced 33 elements, a visible error, and **exit 0**.
+  The two channels differ and only one used to be gated: `pageErrors`
+  (`Runtime.exceptionThrown`) is uncaught and usually means nothing mounted;
+  `consoleErrors` (`Runtime.consoleAPICalled`, `type: 'error'`) is what a
+  boundary produces. The allow-list of benign messages is deliberately EMPTY,
+  and that is a measurement — eight routes on `main` produced zero console
+  errors, so strictness costs nothing. Prefer fixing the source over adding an
+  entry; a gate that reds on noise gets switched off, and an off gate is worse
+  than the hole.
+- It carries a mutation test **per failing condition** — a broken entry bundle
+  (nothing mounts) and an injected console error (a caught crash that still
+  renders) — so it can tell "ran and found nothing" from "did not run". Add a
+  condition, add a mutation only it catches, and confirm the others still pass.
 
 **Standing rule when reading its output, or any check's here: print the full
 output and the exit code.** Do not ask a grep whether it matched, because an

--- a/packages/frontend/scripts/check-cold-start.mjs
+++ b/packages/frontend/scripts/check-cold-start.mjs
@@ -32,14 +32,42 @@
  *    passing or failing, because a blank reading would mean nothing.
  *  - Content, not merely absence of errors. "Nothing threw" is not the property;
  *    "the app rendered something" is.
+ *  - AND no error logged during boot — see immediately below, which is the
+ *    condition that was missing.
+ *
+ * THE HOLE THIS CLOSED: AN ERROR BOUNDARY IS CONTENT
+ *
+ * "Assert content" cannot distinguish a booted app from a CAUGHT CRASH, because
+ * React's error boundary renders content of its own — "Something went wrong".
+ * Measured 2026-08-10 on `/explore`: an infinite render loop (React #185, a
+ * store-sync effect firing on every render) produced a page with 33 elements
+ * and a visible error message, and this script printed `PASS` and exited 0. The
+ * only evidence was in the `consoleErrors` array, which it collected, printed,
+ * and did not act on.
+ *
+ * The two error channels are NOT the same thing, which is why the hole existed:
+ *
+ *  - `Runtime.exceptionThrown` (`pageErrors`) is an UNCAUGHT exception. Nothing
+ *    handled it, usually nothing mounted. Already gated before this change.
+ *  - `Runtime.consoleAPICalled` with `type: 'error'` (`consoleErrors`) is what a
+ *    React error boundary produces when it CATCHES a component crash. The app
+ *    mounts, renders a fallback, throws no uncaught exception, and every
+ *    existing condition passes.
+ *
+ * The second is the one a boundary hides, so the second is now a FAIL.
  *
  * A STANDING RULE FOR CHANGING THIS FILE
  *
  * When you check its output, print the FULL output and the exit code. Do not
  * ask a grep whether it matched: an empty match reads identically to a pass,
- * and that mistake was made three separate times while building this. The
- * accompanying `test-check-cold-start.mjs` mutation-tests exactly that — it
- * breaks the bundle and requires this script to notice.
+ * and that mistake was made three separate times while building this.
+ *
+ * `test-check-cold-start.mjs` mutation-tests every condition that can fail,
+ * which is what stops this file drifting into decoration. It breaks the entry
+ * bundle (nothing mounts) AND injects a console error (a caught crash that
+ * still renders). If you add a condition, add a mutation that only it can
+ * catch, and check the OTHER mutations still pass — a condition that fires on
+ * everything proves as little as one that fires on nothing.
  */
 import { spawn } from 'node:child_process';
 import { mkdtempSync, rmSync, existsSync } from 'node:fs';
@@ -53,8 +81,50 @@ const ROUTES = process.argv.slice(2).filter((a) => !a.startsWith('--'));
 const BOOT_WAIT_MS = Number(process.env.COLD_START_WAIT_MS ?? 9000);
 const CHROME = process.env.COLD_START_CHROME ?? '/usr/bin/chromium';
 
-/** Below this many DOM nodes we call it blank; a mounted app is far above it. */
+/**
+ * Below this many DOM nodes we call it blank; a mounted app is far above it.
+ *
+ * Deliberately NOT raised to catch an error boundary, although the numbers
+ * tempt it — measured 2026-08-10, the boundary rendered 33 elements while the
+ * eight real routes measured 199 (`/contracts`, the sparsest) to 400 (`/`), so
+ * any threshold in 34–199 would have discriminated. That is exactly the kind of
+ * number that rots: it encodes today's densest and sparsest screens, and the
+ * first genuinely sparse route added breaks it in the direction that reads as a
+ * real failure. The console-error condition below catches the same case by its
+ * MECHANISM rather than by a proxy for it, so this stays a blankness floor and
+ * nothing more.
+ */
 const MIN_ELEMENTS = 20;
+
+/**
+ * Console-error messages that are known-benign and must not fail a boot.
+ *
+ * **It is empty, and that is a measurement, not an oversight.** Eight routes
+ * (`/`, `/explore`, `/properties`, `/reviews`, `/contracts`, `/saved`, `/tips`,
+ * `/profile`) were checked on 2026-08-10 against `main` and every one produced
+ * ZERO console errors. So gating on all of them costs nothing today — there is
+ * no wolf to cry, which is the whole reason this can be strict rather than a
+ * curated list of crash signatures that goes stale with the next React release.
+ *
+ * Before adding an entry, try to fix the source instead. A gate that reds on
+ * noise gets switched off by whoever hits it next, and an off gate is worse
+ * than the hole this closed — but an allow-list that grows on contact is how a
+ * gate becomes decorative. If you must add one:
+ *
+ *  - make the pattern narrow enough that it cannot also match a crash (anchor
+ *    on a library's own prefix, never a bare word like `Warning`),
+ *  - write WHY it is benign and what would let it be removed, and
+ *  - re-run the eight routes above, so the next person inherits a measurement
+ *    rather than an assumption.
+ */
+const ALLOWED_CONSOLE_ERROR_PATTERNS = [];
+
+/** Console errors that are not on the allow-list — the ones that fail a boot. */
+function unexpectedConsoleErrors(messages) {
+  return messages.filter(
+    (message) => !ALLOWED_CONSOLE_ERROR_PATTERNS.some((pattern) => pattern.test(message)),
+  );
+}
 
 if (!existsSync(DIST)) {
   console.error(`No export at ${DIST}. Run \`bun run build\` in packages/frontend first.`);
@@ -212,6 +282,8 @@ for (const route of ROUTES.length ? ROUTES : ['/']) {
   });
   const probe = result.value;
 
+  const badConsoleErrors = unexpectedConsoleErrors(consoleErrors);
+
   console.log(JSON.stringify({ route, ...probe, consoleErrors, pageErrors }, null, 2));
 
   if (probe.visibility !== 'visible') {
@@ -222,6 +294,19 @@ for (const route of ROUTES.length ? ROUTES : ['/']) {
     failures += 1;
   } else if (pageErrors.length) {
     console.error(`FAIL ${route}: uncaught exception during boot.`);
+    failures += 1;
+  } else if (badConsoleErrors.length) {
+    // Content IS present here, and that is the point: this is the branch an
+    // error boundary used to walk straight past. The message says so, and names
+    // the first error, because "the check failed" without the reason sends the
+    // reader back to the JSON above to work out which of the two error channels
+    // fired.
+    console.error(
+      `FAIL ${route}: the app rendered (${probe.elements} elements) but logged ` +
+        `${badConsoleErrors.length} error(s) during boot — a caught crash renders ` +
+        `a fallback, so content alone does not mean it booted.`,
+    );
+    console.error(`  first error: ${badConsoleErrors[0].slice(0, 300)}`);
     failures += 1;
   } else {
     console.error(`PASS ${route}: ${probe.elements} elements, visibility=${probe.visibility}.`);

--- a/packages/frontend/scripts/test-check-cold-start.mjs
+++ b/packages/frontend/scripts/test-check-cold-start.mjs
@@ -1,21 +1,45 @@
 #!/usr/bin/env node
 /**
- * Mutation-tests check-cold-start.mjs against a deliberately broken export.
+ * Mutation-tests check-cold-start.mjs against deliberately broken exports.
  *
- * The failure that costs something is the check PASSING on a blank app, because
- * then it reads as boot coverage forever and nobody looks again. So this breaks
- * the thing it guards — replaces the entry bundle with a `throw` — and requires
- * the check to exit non-zero AND say the app rendered nothing.
+ * The failure that costs something is the check PASSING on an app that did not
+ * boot, because then it reads as boot coverage forever and nobody looks again.
+ * So this breaks the thing it guards and requires the check to notice — twice
+ * over, because there are two distinct ways not to boot and they present
+ * completely differently:
  *
- * It asserts the clean case first, because a check that failed on every input
- * would satisfy the non-zero half on its own.
+ *  1. **Nothing mounts.** The entry bundle throws, the page stays empty, and
+ *     the check must say the app rendered nothing.
+ *  2. **Something mounts and a component crashed.** A React error boundary
+ *     catches it, renders "Something went wrong", and logs to `console.error`.
+ *     There is NO uncaught exception and there IS content — so every condition
+ *     the check had before this case was added passed happily. Measured on
+ *     `/explore` 2026-08-10: 33 elements, a visible error message, exit 0.
+ *
+ * Case 2 is the one worth having. It reproduces the failure through the same
+ * channel the real bug used — a `console.error` during boot with no
+ * `Runtime.exceptionThrown` — which is precisely what makes an error boundary
+ * invisible to a content assertion. What it does not do is re-derive a React
+ * render crash from a minified bundle; the observable is the console call, and
+ * that is what the gate reads.
+ *
+ * Every case asserts the clean export FIRST, because a check that failed on
+ * every input would satisfy the non-zero half on its own.
  *
  * Note this deliberately reads the FULL output and the exit code rather than
  * grepping for a pattern: an empty match is indistinguishable from a pass, which
  * is the mistake this whole family of scripts exists to avoid.
  */
 import { spawnSync } from 'node:child_process';
-import { cpSync, rmSync, mkdtempSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import {
+  cpSync,
+  rmSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  readdirSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -84,6 +108,31 @@ if (!entry) {
 }
 writeFileSync(join(jsDir, entry), 'throw new Error("mutation probe: entry bundle broken");\n');
 expect('a broken bundle is caught and named', run(broken), 1, 'rendered nothing');
+
+// 3. A CAUGHT crash must FAIL too, even though the app renders.
+//
+// This is the case an error boundary hides. The app mounts normally and the
+// only trace is a `console.error` — no uncaught exception — so before this
+// condition existed the check reported PASS on a page whose whole content was
+// "Something went wrong".
+//
+// The probe goes in `index.html` rather than in a bundle: it has to fire
+// WITHOUT producing an uncaught exception, which is the property that made the
+// real bug invisible. A `throw` anywhere would be caught by
+// `Runtime.exceptionThrown` and hit the previous condition instead, proving
+// nothing about this one. The message is React-shaped so the failure output is
+// recognisable as the thing it stands in for.
+const caught = join(work, 'dist-caught-crash');
+cpSync(DIST, caught, { recursive: true });
+const indexHtml = join(caught, 'index.html');
+const CONSOLE_PROBE =
+  '<script>console.error("Error: Minified React error #185; ' +
+  'mutation probe: a component crashed and an error boundary caught it");</script>';
+writeFileSync(
+  indexHtml,
+  readFileSync(indexHtml, 'utf8').replace('</head>', `${CONSOLE_PROBE}</head>`),
+);
+expect('a caught crash is caught, despite the app rendering', run(caught), 1, 'logged 1 error(s)');
 
 if (failures) {
   console.error(`\n${failures} mutation(s) went undetected.`);


### PR DESCRIPTION
The cold-start check is documented as the only thing in this repository that can see a white-screen boot. **It returned exit 0 on a boot that crashed.**

## The hole

Measured 2026-08-10 on `/explore` while implementing #352: an infinite render loop (React #185 — a store-sync effect firing on every render) mounted the app, React's error boundary caught it, and the page rendered "Something went wrong". 33 elements, `visibility=visible`, no uncaught exception. Every condition the check had was satisfied, so it printed `PASS /explore: 33 elements` and exited 0. `tsc`, `jest` and `expo export` were all green.

**An error boundary is content.** "Assert the app rendered something" therefore cannot distinguish a booted app from a caught crash — and the two error channels the check already collected are different things, of which only one was ever acted on:

| Channel | Means | Before |
|---|---|---|
| `Runtime.exceptionThrown` (`pageErrors`) | uncaught; usually nothing mounted | **FAIL** |
| `Runtime.consoleAPICalled`, `type: 'error'` (`consoleErrors`) | what a boundary produces when it **catches** a component crash | collected, printed, **ignored** |

The second is the one a boundary hides, so it is now a FAIL. The message says content was present and names the first error, because the entire difficulty of this bug was that the page looked fine.

## The severity question, answered by measurement rather than by taste

The obvious risk in gating on `console.error` is crying wolf — and a gate that reds on noise gets switched off by whoever hits it next, which is worse than the hole. So I measured before choosing. Eight routes against `main`:

| Route | elements | consoleErrors | pageErrors |
|---|---|---|---|
| `/` | 400 | 0 | 0 |
| `/explore` | 322 | 0 | 0 |
| `/properties` | 284 | 0 | 0 |
| `/reviews` | 246 | 0 | 0 |
| `/contracts` | 199 | 0 | 0 |
| `/saved` | 241 | 0 | 0 |
| `/tips` | 245 | 0 | 0 |
| `/profile` | 220 | 0 | 0 |

**Zero, everywhere.** Strictness costs nothing today, so `ALLOWED_CONSOLE_ERROR_PATTERNS` ships **empty** — and its emptiness is a measurement rather than an oversight, which is stated where it lives. That is what makes this viable as a strict gate instead of a curated list of crash signatures that goes stale with the next React release. The rule for adding an entry (fix the source first; anchor narrowly; say why it is benign and what would remove it; re-measure) is written beside it.

## `MIN_ELEMENTS` deliberately NOT raised

The numbers tempt it — 33 for the boundary against 199 (`/contracts`, sparsest) to 400 (`/`), so any threshold in 34–199 would have discriminated. That is exactly the kind of number that rots: it encodes today's sparsest screen, and the first genuinely sparse route added breaks it in the direction that reads as a real failure. The console condition catches the same case by its **mechanism** rather than by a proxy for it, so this stays a blankness floor and nothing more. The reasoning and the measured margin are in the code so a later reader can revisit it with data instead of re-deriving.

## Mutation-tested per condition, and proven load-bearing

`test-check-cold-start.mjs` gains a third case: inject a `console.error` into the built `index.html`. Deliberately **not** a `throw` — an uncaught exception would trip the *previous* condition and prove nothing about this one. The observable it produces (a console error during boot, no `Runtime.exceptionThrown`) is exactly the channel the real bug used.

```
ok   a working export passes
ok   a broken bundle is caught and named
ok   a caught crash is caught, despite the app rendering
All mutations detected.
```

**And the new branch was verified load-bearing rather than assumed.** Disabling just it (`false && badConsoleErrors.length`, confirmed landed by diffing against a pristine copy before running):

```
ok   a working export passes
ok   a broken bundle is caught and named
FAIL a caught crash is caught, despite the app rendering: expected exit 1, got 0
1 mutation(s) went undetected.
```

`expected exit 1, got 0` is the original hole, reproduced exactly — and the other two cases still pass, so the disabling is surgical rather than breaking everything. Restored from the pristine copy and re-verified by `md5sum`, four fixed-string markers from my own edit, and a negative control for the mutation token.

## Verification

| Check | Exit |
|---|---|
| `check:cold-start` on all 8 routes above | **0** (all PASS) |
| `check:cold-start:test` (3 mutations) | **0** |
| Same, with the new condition disabled | **1** — the mutation goes undetected |
| `node scripts/check-docs.mjs` (after the `AGENTS.md` edit) | **0** |
| `lint` on both changed scripts | no findings |

## Docs updated, because both stated a property the script did not have

The script header now explains the two channels and why the second is gated; `AGENTS.md`'s cold-start section goes from three properties to four, with the measurement and the "prefer fixing the source" rule. Both previously described a content assertion as sufficient, which is the claim this PR disproves.



## Where exactly the line is, and why it is not drawn at "crash vs warning"

The obvious rule is "red on a caught render failure, not on a third-party warning". It is defensible and I did **not** implement it, for a reason worth stating rather than leaving as a gap.

Telling those two apart from the outside means pattern-matching React's own crash strings — `Minified React error #NNN`, boundary text, whatever the next major changes them to. That is a curated signature list, and it fails in the WORST direction: when it stops matching, the gate goes quiet and still reports PASS, which is the exact failure this PR exists to remove, reintroduced one React upgrade later. A gate that can silently stop detecting is worse than one that is occasionally noisy, because nobody finds out.

So the line is drawn at **"any error logged during boot"**, and the defence against wolf-crying is not leniency, it is that **the escape valve is cheaper than the off switch**:

- The allow-list is a mechanism that already exists and ships empty. The first person inconvenienced adds one narrow, reviewed, commented pattern — a one-line diff with a stated reason — rather than deleting a condition or setting `CI: false`.
- It is in code, not an env var, deliberately. An env-var opt-out gets set once in a workflow file and is invisible thereafter; a code entry shows up in review every time somebody reads the file.
- The measurement is what makes this affordable rather than optimistic: **zero console errors across eight routes on `main` today**, so the valve is not expected to be reached at all. If it starts getting reached, that is evidence the line is in the wrong place — and the right response then is to look at what is actually firing, which is only possible because the strict version surfaced it.

In short: strict by default, with a documented narrow relief that is less work than disabling. The discrimination between a crash and a benign warning goes in the allow-list **when there is real evidence to base it on**, rather than being guessed in advance against messages nobody has seen.
