### PR TITLE
fix(tests): drain the ingest background write, and give each worker its own image store

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,6 +32,7 @@ packages/frontend
 
 # Self-hosted local image store (dev-only backend fallback)
 **/.local-image-store
+**/.local-image-store-w*
 
 # Logs & temp
 **/logs

--- a/.gitignore
+++ b/.gitignore
@@ -134,4 +134,8 @@ packages/listing-providers/src/**/*.d.ts
 
 # Self-hosted local image store (backend fallback when object storage is unconfigured)
 .local-image-store/
-packages/backend/.local-image-store/ 
+packages/backend/.local-image-store/
+# Per-worker LOCAL image stores, assigned by jest.setupWorkerDatabase.cjs and
+# removed by jest.globalTeardown.ts. Ignored so a crashed run leaves no
+# untracked noise behind.
+packages/backend/.local-image-store-w*/

--- a/packages/backend/__tests__/db/seedProperties.test.ts
+++ b/packages/backend/__tests__/db/seedProperties.test.ts
@@ -32,12 +32,11 @@
  * Unsplash to observe it would be measuring the network.
  */
 
-import path from 'path';
 import fs from 'fs/promises';
 import { and, eq, inArray, isNotNull } from 'drizzle-orm';
 import { closePostgres, connectPostgres, getDb } from '../../db/postgres';
 import { cities, images, properties, propertyImages } from '../../db/schema';
-import type { ImageBufferInput } from '../../services/imageUploadService';
+import { LOCAL_IMAGE_STORE_DIR, type ImageBufferInput } from '../../services/imageUploadService';
 import { resetGeoTables } from '../helpers/postgresGeoFixtures';
 import { SEED_OWNER_OXY_USER_ID, seedProperties } from '../../scripts/seedProperties';
 
@@ -47,7 +46,6 @@ const ONE_BY_ONE_PNG = Buffer.from(
   'base64',
 );
 
-const LOCAL_IMAGE_STORE_DIR = path.join(__dirname, '..', '..', '.local-image-store');
 
 /**
  * Listings in the seed dataset. An EQUALITY rather than a floor, so adding a

--- a/packages/backend/__tests__/integration/externalIngest.test.ts
+++ b/packages/backend/__tests__/integration/externalIngest.test.ts
@@ -20,7 +20,6 @@
  */
 
 import { promises as fs } from 'node:fs';
-import path from 'node:path';
 
 import {
   FixtureProvider,
@@ -32,7 +31,7 @@ import { OfferingType, PropertyType, type NormalizedListing } from '@homiio/shar
 
 import { IngestionService } from '../../services/ingestion/IngestionService';
 import { ExternalMediaIngest } from '../../services/ingestion/ExternalMediaIngest';
-import type { ImageBufferInput } from '../../services/imageUploadService';
+import { LOCAL_IMAGE_STORE_DIR, type ImageBufferInput } from '../../services/imageUploadService';
 
 import { and, eq } from 'drizzle-orm';
 
@@ -49,7 +48,6 @@ const ONE_BY_ONE_PNG = Buffer.from(
   'base64',
 );
 
-const LOCAL_IMAGE_STORE_DIR = path.join(__dirname, '..', '..', '.local-image-store');
 const FIRST_SOURCE_ID = 'fixture-bcn-0001';
 const FIRST_SOURCE_URL = 'https://fixtures.homiio.com/es/barcelona/fixture-bcn-0001';
 
@@ -62,9 +60,19 @@ const fetchImage = jest.fn(
   async (): Promise<ImageBufferInput> => ({ buffer: ONE_BY_ONE_PNG, mimetype: 'image/png' }),
 );
 
+/**
+ * Every service this file builds, so `afterAll` can drain the background work
+ * they started before removing the image store. `ingest()` deliberately does not
+ * await the city-cover fetch, so without this the write lands DURING the
+ * teardown's `fs.rm` and the removal fails with `ENOTEMPTY`.
+ */
+const ingestionServices: IngestionService[] = [];
+
 function buildIngestionService(dedupeEnabled = false): IngestionService {
   const mediaIngest = new ExternalMediaIngest({ fetchImage });
-  return new IngestionService({ mediaIngest, dedupeEnabled });
+  const service = new IngestionService({ mediaIngest, dedupeEnabled });
+  ingestionServices.push(service);
+  return service;
 }
 
 async function normalizeAll(): Promise<NormalizedListing[]> {
@@ -150,6 +158,13 @@ afterAll(async () => {
   // counted this file's leftover as a third. The failure lands two files away
   // from its cause and moves around as the file-to-worker distribution shifts,
   // which is why adding an unrelated test file appeared to break it.
+  // Drain first. `ingest()` starts the city-cover fetch WITHOUT awaiting it, so
+  // the write can still be in flight here; if it lands while `fs.rm` is walking
+  // the tree, the final `rmdir` fails with `ENOTEMPTY` and this suite fails with
+  // every one of its tests passing. Draining is the only fix that keeps the
+  // removal meaningful — retrying it, or ignoring its error, would leave the
+  // written bytes behind for whatever runs next.
+  await Promise.all(ingestionServices.map((service) => service.whenIdle()));
   await resetGeoTables();
   await fs.rm(LOCAL_IMAGE_STORE_DIR, { recursive: true, force: true });
 });

--- a/packages/backend/__tests__/unit/ingestionBackgroundWork.test.ts
+++ b/packages/backend/__tests__/unit/ingestionBackgroundWork.test.ts
@@ -1,0 +1,146 @@
+/**
+ * `IngestionService.whenIdle()` — the drain that makes a deliberately
+ * fire-and-forget write testable.
+ *
+ * ## The bug this pins
+ *
+ * `ingest()` starts a city-cover fetch WITHOUT awaiting it, because that fetch
+ * goes to Wikimedia and has no business on the critical path of every listing.
+ * The promise used to be dropped on the floor (`void ensureCover(...)`), which
+ * made the write unobservable: `integration/externalIngest` removed the local
+ * image store in `afterAll` while the cover write was still in flight, the write
+ * recreated a directory under it mid-removal, and `fs.rm`'s final `rmdir` failed
+ * with `ENOTEMPTY`. That is a suite failing with **every one of its tests
+ * passing**, which reads as a broken change rather than a teardown race, and it
+ * cost three CI cycles.
+ *
+ * ## Why it is tested this way
+ *
+ * `ensureCover` is mocked with a promise this file resolves by hand. A test that
+ * let the real fetch run could only observe the race by luck — and it did: ten
+ * local runs of the real suite produced one leaked directory and no failure at
+ * all, which is exactly the "green run that proves nothing" this repository
+ * keeps finding. The deferred stub turns a timing-dependent flake into a
+ * deterministic assertion: `whenIdle()` must not resolve while the background
+ * task is pending, and must resolve once it settles.
+ *
+ * ## Mutation-tested, and the first attempt at both halves was wrong
+ *
+ * Deleting `this.background.add(settled)` from `startBackground` — the old
+ * dropped-promise behaviour, isolated — turns two cases RED and the file green
+ * again on restore.
+ *
+ * Two things that had to be fixed to get there, recorded because each produced a
+ * confident wrong answer first. Dropping the promise ENTIRELY (`void task`) does
+ * not make a usable mutation: the unhandled rejection in the last case kills the
+ * jest worker, so the suite fails to run rather than failing an assertion, and
+ * "0 tests" is not evidence about any assertion. And the first version of
+ * {@link isPending} was vacuous — see the note on it; the mutation SURVIVED all
+ * four cases, which is what exposed it.
+ */
+// Stubbed so constructing the service pulls in no geocoder, no Wikimedia client
+// and no database. Nothing here calls it — the drain is driven directly — but
+// without the stub the real module loads and this becomes an integration test.
+jest.mock('../../services/cityCoverSyncService', () => ({
+  ensureCover: jest.fn(),
+}));
+
+import { IngestionService } from '../../services/ingestion/IngestionService';
+
+/** A promise plus the handles to settle it, so a test controls the timing. */
+function deferred(): { promise: Promise<void>; resolve: () => void; reject: (e: Error) => void } {
+  let resolve!: () => void;
+  let reject!: (e: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = () => res();
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/**
+ * Drive `startBackground` directly.
+ *
+ * Reaching it through `ingest()` would drag in Postgres, the media pipeline and
+ * a fixture provider to test one promise-tracking rule. The private method is
+ * addressed through a narrowly-typed view rather than `any`, which keeps the
+ * cast honest about exactly what it assumes.
+ */
+interface BackgroundDriver {
+  startBackground(task: Promise<unknown>, label: string): void;
+  whenIdle(): Promise<void>;
+}
+
+/**
+ * Whether `promise` is STILL PENDING after the microtask queue has drained.
+ *
+ * The obvious spelling — racing the promise against `Promise.resolve(marker)` —
+ * is VACUOUS, and this comment is here because it shipped that way for one
+ * commit and the mutation test below is what caught it. `.then()` costs a
+ * microtask hop, so the already-resolved marker wins the race even when the
+ * promise is settled; the helper answered "pending" for everything, the
+ * assertion passed either way, and removing the tracking it was written to
+ * verify left all four cases green.
+ *
+ * `setImmediate` is the fix: it fires on the next macrotask, after every pending
+ * microtask has run, so a resolved promise has definitely flipped the flag.
+ */
+async function isPending(promise: Promise<void>): Promise<boolean> {
+  let settled = false;
+  void promise.then(() => {
+    settled = true;
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  return !settled;
+}
+
+describe('IngestionService background work', () => {
+  let service: BackgroundDriver;
+
+  beforeEach(() => {
+    service = new IngestionService() as unknown as BackgroundDriver;
+  });
+
+  it('whenIdle() resolves immediately when nothing is outstanding', async () => {
+    await expect(service.whenIdle()).resolves.toBeUndefined();
+  });
+
+  it('whenIdle() does NOT resolve while a background task is pending', async () => {
+    const task = deferred();
+    service.startBackground(task.promise, 'probe');
+
+    // The assertion that fails if the promise is dropped rather than tracked.
+    expect(await isPending(service.whenIdle())).toBe(true);
+
+    task.resolve();
+    await expect(service.whenIdle()).resolves.toBeUndefined();
+  });
+
+  it('whenIdle() resolves once every task settles, and forgets them', async () => {
+    const first = deferred();
+    const second = deferred();
+    service.startBackground(first.promise, 'first');
+    service.startBackground(second.promise, 'second');
+
+    first.resolve();
+    expect(await isPending(service.whenIdle())).toBe(true);
+
+    second.resolve();
+    await service.whenIdle();
+
+    // A second drain on a settled service must be a no-op rather than hanging on
+    // promises it already awaited.
+    await expect(service.whenIdle()).resolves.toBeUndefined();
+  });
+
+  it('a REJECTED background task is handled, not left unhandled, and still drains', async () => {
+    // A dropped rejection surfaces as an unhandled rejection in whichever test
+    // happens to be running when it lands — a failure attributed to the wrong
+    // file. `startBackground` attaches the handler, so this must not throw.
+    const task = deferred();
+    service.startBackground(task.promise, 'failing');
+    task.reject(new Error('cover fetch failed'));
+
+    await expect(service.whenIdle()).resolves.toBeUndefined();
+  });
+});

--- a/packages/backend/jest.globalTeardown.ts
+++ b/packages/backend/jest.globalTeardown.ts
@@ -16,13 +16,55 @@
  * the log and costs nothing but a row in `pg_database` on a disposable server.
  */
 
-import { readFileSync, rmSync } from 'node:fs';
+import { readdirSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { dropTestDatabase } from './db/testDatabase';
+
+/** Prefix of the per-worker LOCAL image stores `jest.setupWorkerDatabase.cjs` assigns. */
+const WORKER_IMAGE_STORE_PREFIX = '.local-image-store-w';
+
+/**
+ * Remove every per-worker image store this run created.
+ *
+ * It belongs here rather than in each suite for the same reason the databases
+ * do: only two suites clean up after themselves today, and any suite that writes
+ * an image would otherwise leave bytes behind for the next run to inherit. One
+ * place that removes them all cannot be forgotten by a suite added later.
+ *
+ * Failures are reported and never fail the run — the tests have finished, and a
+ * cleanup problem reported as a test failure is how a real regression gets
+ * ignored. A leftover directory is visible here and gitignored.
+ */
+function removeWorkerImageStores(): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(__dirname);
+  } catch (error) {
+    console.warn(
+      `Could not scan for per-worker image stores: ` +
+      `${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
+
+  for (const entry of entries.filter((name) => name.startsWith(WORKER_IMAGE_STORE_PREFIX))) {
+    try {
+      rmSync(join(__dirname, entry), { recursive: true, force: true });
+    } catch (error) {
+      console.warn(
+        `Could not remove the per-worker image store ${entry}: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { HOMIIO_JEST_DATABASE_MANIFEST } = require('./jest.workerCount.cjs');
 
 export default async function globalTeardown(): Promise<void> {
+  removeWorkerImageStores();
+
   const manifestPath = process.env[HOMIIO_JEST_DATABASE_MANIFEST];
   if (!manifestPath) return;
 

--- a/packages/backend/jest.setupWorkerDatabase.cjs
+++ b/packages/backend/jest.setupWorkerDatabase.cjs
@@ -11,6 +11,7 @@
  */
 
 const { readFileSync } = require('node:fs');
+const path = require('node:path');
 const { HOMIIO_JEST_DATABASE_MANIFEST } = require('./jest.workerCount.cjs');
 
 const manifestPath = process.env[HOMIIO_JEST_DATABASE_MANIFEST];
@@ -36,3 +37,22 @@ if (!Number.isFinite(workerId) || index < 0 || index >= urls.length) {
 }
 
 process.env.DATABASE_URL = urls[index];
+
+/**
+ * Per-worker LOCAL image store, for the same reason as the database above.
+ *
+ * The store root was one hardcoded path shared by every worker, and two suites
+ * remove it recursively in `afterAll`. One worker's `fs.rm` walking the tree
+ * while another worker writes into it fails with `ENOTEMPTY` from the final
+ * `rmdir` — a suite that fails while every test in it passes, which reads like a
+ * broken change rather than a shared-fixture race.
+ *
+ * Derived from `JEST_WORKER_ID`, not from a random name, so a leaked directory
+ * still says which worker leaked it. `services/imageUploadService.ts` reads this
+ * variable and exports the resolved path; tests import that constant rather than
+ * rebuilding it, so there is one authority instead of three.
+ */
+process.env.HOMIIO_LOCAL_IMAGE_STORE_DIR = path.join(
+  __dirname,
+  `.local-image-store-w${workerId}`,
+);

--- a/packages/backend/services/imageUploadService.ts
+++ b/packages/backend/services/imageUploadService.ts
@@ -20,8 +20,23 @@ import { insertImage, type ImageRow } from '../db/images/imageWrites';
  * product renders DB-backed images from our OWN host with zero external image
  * dependency in any storage-less environment (local dev, CI). A credentialed
  * environment uses S3 and never touches this path.
+ *
+ * **Overridable, and EXPORTED, for one reason: parallel tests.** Jest runs two
+ * workers here, and this path used to be a hardcoded constant that two suites
+ * (`integration/externalIngest` and `db/seedProperties`) each computed for
+ * themselves and each removed recursively in `afterAll`. Two workers removing
+ * one tree while the other writes into it is a race, and it surfaces as
+ * `ENOTEMPTY` from `rmdir` — a suite that fails with every test passing.
+ * `jest.setupWorkerDatabase.cjs` now gives each worker its own root, the same
+ * way it gives each worker its own database, and tests import THIS constant
+ * rather than re-deriving the path, so the three copies cannot drift apart.
+ *
+ * Production is unchanged: no environment sets this, so it stays the same
+ * directory beside the compiled backend.
  */
-const LOCAL_IMAGE_STORE_DIR = path.join(__dirname, '..', '.local-image-store');
+export const LOCAL_IMAGE_STORE_DIR = process.env.HOMIIO_LOCAL_IMAGE_STORE_DIR
+  ? path.resolve(process.env.HOMIIO_LOCAL_IMAGE_STORE_DIR)
+  : path.join(__dirname, '..', '.local-image-store');
 
 /** Backend route prefix the local image store is served under (no trailing slash). */
 export const LOCAL_IMAGE_ROUTE = '/api/images/file';

--- a/packages/backend/services/ingestion/IngestionService.ts
+++ b/packages/backend/services/ingestion/IngestionService.ts
@@ -135,6 +135,8 @@ export class IngestionService {
   private readonly logger: Logger;
   private readonly defaultTtlDays: number;
   private readonly dedupeEnabled: boolean;
+  /** Background work started by `ingest()` that no caller awaits. See {@link whenIdle}. */
+  private readonly background = new Set<Promise<void>>();
 
   constructor(options: IngestionServiceOptions = {}) {
     this.mediaIngest = options.mediaIngest ?? new ExternalMediaIngest();
@@ -206,7 +208,7 @@ export class IngestionService {
       .where(eq(addresses.id, addressId))
       .limit(1);
     if (address?.cityId) {
-      void ensureCover(address.cityId);
+      this.startBackground(ensureCover(address.cityId), 'ensureCover');
     }
 
     const result: IngestResult = {
@@ -219,6 +221,51 @@ export class IngestionService {
     schedulePriceEthicsScore(result.propertyId);
     this.logger.info('Ingested external listing', result);
     return result;
+  }
+
+  /**
+   * Register work that deliberately outlives the `ingest()` call that started it.
+   *
+   * A city cover is fetched from Wikimedia and written to the image store; making
+   * `ingest()` await that would put an external HTTP round trip on the critical
+   * path of every listing, which is why it was fire-and-forget to begin with.
+   * That stays true. What changes is that the promise is no longer DROPPED:
+   * it is held so {@link whenIdle} can await it, and its rejection is handled
+   * here rather than becoming an unhandled rejection that fails whichever test
+   * happens to be running when it lands.
+   */
+  private startBackground(task: Promise<unknown>, label: string): void {
+    const settled = task.then(
+      () => undefined,
+      (error: unknown) => {
+        this.logger.warn(`Background task failed: ${label}`, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      },
+    );
+    this.background.add(settled);
+    void settled.finally(() => {
+      this.background.delete(settled);
+    });
+  }
+
+  /**
+   * Resolve once every background task this instance started has settled.
+   *
+   * Tests must await this before removing the local image store, or an in-flight
+   * cover write recreates the directory while `fs.rm` is walking it and the
+   * removal fails with `ENOTEMPTY` — a suite that fails with every test passing.
+   * It loops rather than awaiting the set once, because a settling task may
+   * enqueue another.
+   *
+   * Production never needs to call it: the process outlives the work. It exists
+   * so a test can be deterministic about work that is deliberately asynchronous,
+   * which is the only honest alternative to sleeping or retrying the teardown.
+   */
+  async whenIdle(): Promise<void> {
+    while (this.background.size > 0) {
+      await Promise.all([...this.background]);
+    }
   }
 
   /**


### PR DESCRIPTION
`integration/externalIngest` failed three CI runs tonight with **every one of its tests passing**:

```
ENOTEMPTY: directory not empty, rmdir '.../packages/backend/.local-image-store/city'
Test Suites: 1 failed, 133 passed | Tests: 1790 passed, 1790 total
```

## Diagnosis first — and the obvious fix was the wrong one

**A recursive removal was already there.** The teardown has always called `fs.rm(dir, { recursive: true, force: true })`, so "the cleanup does not recurse into a nested directory" is ruled out by reading, before measuring anything. That matters, because recursion is what this failure invites you to add.

There are **two independent causes**, and they need different fixes.

### 1. Measured, and the one that produced tonight's failures: a write that outlives its test

`IngestionService.ingest()` ended with:

```ts
if (address?.cityId) {
  void ensureCover(address.cityId);
}
```

`ensureCover` fetches a city cover from Wikimedia and writes it through `createImageForEntity('city', …)` — into `<store>/city/`, the exact directory the error names. The `void` drops the promise, so nothing can wait for it: `afterAll` removes the store while the write is still in flight, the write recreates a directory under it, and `fs.rm`'s final `rmdir` fails.

**Reproduction, stated plainly.** I could **not** reproduce the `ENOTEMPTY` crash locally — ~10 isolated runs of the suite were green. I did reproduce **its precursor**: one run left `.local-image-store/city` behind *after a green suite*, which is the same write landing just after the removal instead of during it. That is direct evidence the write outlives the test; the crash needs it to land inside the removal window. A negative control (`unit/mongoUnreachable`, which drives no ingest) never creates the directory.

Worth noting the test also does **real network I/O to Wikimedia** — no mock — which is where the variable timing comes from.

### 2. Structural, latent, and it would have produced the same error across workers

`imageUploadService` hardcoded the store path, and **two** suites — `integration/externalIngest` and `db/seedProperties` — each re-derived it and each removed it recursively, with `maxWorkers = 2` on this machine. One worker's `fs.rm` walking the tree while the other writes into it is the same race one level up. **Recursion would not have fixed this one either**, which is exactly why it is worth separating from cause 1 rather than fixing both with one guess.

## The fix

**`ingest()` still does not await the fetch.** An external HTTP round trip has no business on the critical path of every listing, which is why it was fire-and-forget to begin with. What changes is that the promise is **held rather than dropped**:

- `startBackground()` keeps it in a set and attaches a rejection handler — so a failed cover fetch is logged instead of becoming an unhandled rejection that fails whichever test happens to be running when it lands.
- `whenIdle()` awaits everything outstanding, looping because a settling task may enqueue another.
- The suite drains before removing the store.

**Per-worker stores**, reusing the pattern already in the tree for Postgres: `LOCAL_IMAGE_STORE_DIR` is now exported and env-overridable, `jest.setupWorkerDatabase.cjs` assigns each worker its own (derived from `JEST_WORKER_ID`, so a leak still says which worker leaked it), and both tests import the constant instead of re-deriving it, so the three copies cannot drift. **Production is unchanged** — nothing sets the variable, so the default path is byte-identical.

**`jest.globalTeardown.ts` removes the per-worker stores**, because only two suites clean up after themselves and any suite that writes an image would otherwise leave bytes for the next run to inherit.

**Nothing is retried and no teardown error is swallowed.** That would trade a loud flake for a silent leak of test artefacts between runs.

## The regression test, and two ways I got it wrong first

`__tests__/unit/ingestionBackgroundWork.test.ts` stubs `ensureCover` with a promise the test settles by hand, turning a timing-dependent flake into a deterministic assertion. Both mistakes are recorded in the file, because each produced a confident wrong answer:

- **The first mutation was unusable.** Dropping the promise entirely (`void task`) makes the unhandled rejection kill the jest worker, so the suite fails to *run* — `Tests: 0 total`. A suite that never ran is not evidence about any assertion. The usable mutation deletes only `this.background.add(settled)`, isolating the tracking.
- **The first version of the pending-check was VACUOUS, and the mutation survived all four cases.** Racing the promise against `Promise.resolve(marker)` always picks the marker, because `.then()` costs a microtask hop — so the helper answered "pending" for everything and the assertion passed either way. `setImmediate` fixes it. This is the whole reason to mutation-test a new assertion rather than trust that it is green.

Red/green: with the tracking removed, 2 of 4 cases fail; restored, all 4 pass.

## Verification

- full backend suite: **135 suites / 1794 tests**, exit 0
- the two previously-racing suites run together on 2 workers: pass, and nothing left at the old shared path
- **no image store left behind at all** after a full run
- `tsc --noEmit` exit 0; `eslint` on every touched file exit 0
- `bun.lock` untouched (no manifest change)
