### PR TITLE
refactor(geo): take the city candidate's geometry from PlaceGeometry, so the lie stops compiling

### DIFF
--- a/packages/backend/db/geo/placeLookup.ts
+++ b/packages/backend/db/geo/placeLookup.ts
@@ -56,7 +56,7 @@
  */
 
 import { and, asc, desc, eq, inArray, or, sql, type SQL } from 'drizzle-orm';
-import type { CityPlaceCandidate } from '@homiio/shared-types';
+import type { CityPlaceCandidate, PlaceGeometry } from '@homiio/shared-types';
 
 import { getDb } from '../postgres';
 import { cities, countries, regions } from '../schema';
@@ -411,6 +411,16 @@ export async function lookupCityPlaces(input: PlaceLookupInput): Promise<PlaceLo
       typeof row.latitude === 'number' && typeof row.longitude === 'number'
         ? { longitude: row.longitude, latitude: row.latitude }
         : undefined;
+    const bounds =
+      typeof row.bboxWest === 'number' &&
+      typeof row.bboxSouth === 'number' &&
+      typeof row.bboxEast === 'number' &&
+      typeof row.bboxNorth === 'number'
+        ? { west: row.bboxWest, south: row.bboxSouth, east: row.bboxEast, north: row.bboxNorth }
+        : undefined;
+    const geometry: PlaceGeometry = center
+      ? { precision: 'centroid', center, ...(bounds ? { bounds } : {}) }
+      : { precision: 'area', ...(bounds ? { bounds } : {}) };
     return {
       id: row.id,
       source: { kind: 'homiio', entity: 'city', id: row.id },
@@ -433,19 +443,18 @@ export async function lookupCityPlaces(input: PlaceLookupInput): Promise<PlaceLo
       regionId: row.regionId,
       slug: row.slug,
       qualifiedSlug: qualifiedSlugOf(row.slug, row.regionName, row.countryCode),
-      ...(center ? { center } : {}),
-      ...(typeof row.bboxWest === 'number' &&
-      typeof row.bboxSouth === 'number' &&
-      typeof row.bboxEast === 'number' &&
-      typeof row.bboxNorth === 'number'
-        ? { bounds: { west: row.bboxWest, south: row.bboxSouth, east: row.bboxEast, north: row.bboxNorth } }
-        : {}),
+      propertiesCount: row.propertiesCount,
+      matchedOn: row.isIdMatch ? 'id' : row.isNameMatch ? 'name' : 'slug',
       // A city centre is a `centroid` and never an `exact` point; without one
       // the row describes an AREA we cannot frame, which is a different fact
       // from "we have a point" and is said rather than papered over.
-      precision: center ? 'centroid' : 'area',
-      propertiesCount: row.propertiesCount,
-      matchedOn: row.isIdMatch ? 'id' : row.isNameMatch ? 'name' : 'slug',
+      //
+      // Built as a `PlaceGeometry` VALUE and spread, rather than as three
+      // sibling fields, because the union is what makes the contradiction
+      // unrepresentable — a spread of `...(center ? { center } : {})` beside an
+      // independently computed `precision` type-checks even when the two
+      // disagree, which is precisely the shape #392 removed from the contract.
+      ...geometry,
     };
   });
 

--- a/packages/shared-types/src/city.ts
+++ b/packages/shared-types/src/city.ts
@@ -10,9 +10,7 @@
 import { Coordinates, Pagination } from './common';
 import type {
   AdminHierarchy,
-  GeoBounds,
-  GeoPoint,
-  LocationPrecision,
+  PlaceGeometry,
   PlaceLabel,
   PlaceSource,
   PlaceType,
@@ -52,19 +50,22 @@ export interface CitiesResponse {
  * frames a map from `center`/`bounds` and renders the disambiguation list from
  * `label` and `admin`.
  *
- * ## It is a `GeoPlace` in all but one field, and that field is the honest part
+ * ## Its geometry comes from `PlaceGeometry`, so the dishonest shape will not
+ * compile
  *
- * `source`, `label`, `admin`, `center`, `bounds` and `precision` are the shared
- * primitives from `./location`, not copies of them, so a resolved candidate can
- * feed `geoPlaceToSelection` directly. The one difference: `GeoPlace.center` is
- * REQUIRED, because a geocoder candidate always has a point — while a Homiio
- * city row may have none. Production holds rows with null coordinates, and the
- * lookup ranks those below rows that have them rather than hiding them, so
- * `center` is optional here and `precision` says `area` when it is missing.
- * Inventing a centre to satisfy a type would be the one lie this whole contract
- * exists to stop.
+ * `source`, `label`, `admin` and the geometry are the shared primitives from
+ * `./location`, not copies of them, so a resolved candidate feeds
+ * `geoPlaceToSelection` directly.
+ *
+ * A Homiio city row may have NO coordinates — production holds such rows, and
+ * the lookup ranks them below rows that have them rather than hiding them. That
+ * is expressed by `PlaceGeometry`'s `area` branch, where `center?: never`: a
+ * candidate without a centre cannot acquire one, and a `centroid` without a
+ * centre does not compile either. An earlier revision of this type said the same
+ * thing with an optional `center` beside an open `precision`, which ACCEPTED the
+ * contradiction and merely discouraged it.
  */
-export interface CityPlaceCandidate {
+export type CityPlaceCandidate = {
   /**
    * The stable identity. Persist THIS, never the name or the slug.
    *
@@ -101,15 +102,6 @@ export interface CityPlaceCandidate {
    * to resolve.
    */
   readonly qualifiedSlug: string;
-  /** The city centre. A `centroid` (ADR §8.1), and so nobody's location. */
-  readonly center?: GeoPoint;
-  /**
-   * The city's extent. `west > east` crosses the antimeridian (ADR §9.3).
-   * Absent until #351's gateway populates it — never derived from listings.
-   */
-  readonly bounds?: GeoBounds;
-  /** `centroid` with a centre, `area` without one. Declared, never inferred. */
-  readonly precision: LocationPrecision;
   /** Published listings whose address resolves here. Ranking input, not identity. */
   readonly propertiesCount: number;
   /**
@@ -117,7 +109,12 @@ export interface CityPlaceCandidate {
    * its own; `name` and `slug` are labels and can be shared.
    */
   readonly matchedOn: 'id' | 'name' | 'slug';
-}
+  /**
+   * The centre (`centroid` — ADR §8.1, and so nobody's location) or the bare
+   * extent, from {@link PlaceGeometry}. `bounds` is absent until #351's gateway
+   * populates `cities.bbox_*`; `west > east` crosses the antimeridian (ADR §9.3).
+   */
+} & PlaceGeometry;
 
 /**
  * The result of a text/slug/id city lookup.


### PR DESCRIPTION
Follow-up to #295 (#389, merged) and #392. Small, and it closes a gap the merge ORDER opened rather than a defect either PR shipped.

## What happened

#389 landed `CityPlaceCandidate` with `center?: GeoPoint` beside an independently computed `precision: LocationPrecision`, and `precision: center ? 'centroid' : 'area'` at the one construction site.

That was the right **answer**. Review confirmed it twice: `GeoPlace.center` being required is what forced #390 to emit `{ longitude: 0, latitude: 0 }` for every country and region — Null Island, in the Gulf of Guinea, with a ±0.05° box drawn round it, so picking "Spain" returned zero listings from a request that succeeded. A Homiio city row genuinely may have no coordinates; the lookup ranks those below rows that have them rather than hiding them, and inventing a centre to satisfy a type is the one lie the location contract exists to stop.

But it was the weak **form**. `center?: GeoPoint` beside an open `precision` still ACCEPTS `{ precision: 'area', center }` — the contradiction was discouraged, not unrepresentable.

#392 landed `PlaceGeometry`, which says it structurally. **#389 merged at 05:19 and #392 at 05:51**, so the candidate never picked it up — nobody's mistake, just the order they landed in. This is the pickup.

## The change

`CityPlaceCandidate` composes `PlaceGeometry` the same way `GeoPlace` does, and `placeLookup` builds a `PlaceGeometry` **value** and spreads it rather than emitting three sibling fields:

```ts
const geometry: PlaceGeometry = center
  ? { precision: 'centroid', center, ...(bounds ? { bounds } : {}) }
  : { precision: 'area', ...(bounds ? { bounds } : {}) };
```

That last part is load-bearing, not tidying: a conditional spread (`...(center ? { center } : {})`) beside a separately computed `precision` type-checks **even when the two disagree**, which is precisely the shape being removed. Building the union as a value is what makes the compiler check the pairing.

## Verified, not assumed

A throwaway probe compiled against the real type — all four shapes, and the two that must fail are named in the compiler's own output:

| Shape | Expected | `tsc` |
|---|---|---|
| `precision: 'centroid'` + `center` | compiles | ✅ no error |
| `precision: 'area'`, no `center` | compiles | ✅ no error |
| `precision: 'area'` + `center` (**the lie**) | rejected | ❌ TS2322 |
| `precision: 'centroid'`, no `center` (**the mirror**) | rejected | ❌ TS2322 |

The mirror matters as much as the lie. A guard that only forbids one direction is half a guard, and the half it leaves open — a `centroid` with nothing to frame — is the one a caller would hit by forgetting a field rather than by writing a wrong one. The probe is deleted; it existed to make the claim in this description a measurement.

## Behaviour

**None changed.** The repository already only ever produced the correct pairing, so no test needed editing and none did. `cityPlaceLookup.test.ts`'s coordinate-less case — a candidate asserting `precision: 'area'` with `not.toHaveProperty('center')` — passes unchanged, and it is the fixture that made this whole class of bug visible twice: once here, and once in #390's `(0,0)`.

What changes is that the wrong pairing can no longer be written.

## Checks

| Check | Exit |
|---|---|
| `packages/shared-types` build | 0 |
| `packages/backend typecheck` | 0 |
| `packages/frontend typecheck` | 0 |
| `packages/backend test` — **138 suites, 1886 tests** | 0 |
| `packages/frontend test` — **16 suites, 258 tests** | 0 |

Branched from `main` at `ee13ea9b` so the diff is exactly these two files; #389's own commits are already on `main` via its squash and are not re-proposed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
