### PR TITLE
test(ingest): make the ingestion suites hermetic, and prove it rather than claim it

### DIFF
--- a/packages/backend/__tests__/helpers/noNetwork.ts
+++ b/packages/backend/__tests__/helpers/noNetwork.ts
@@ -1,0 +1,100 @@
+/**
+ * A guard that fails a suite which attempts an outbound request.
+ *
+ * ## Why a guard rather than a claim
+ *
+ * "This suite is hermetic" is exactly the shape of assertion this repository
+ * keeps catching: true when written, never re-checked, and the run that
+ * disproves it is a red CI on somebody else's PR blaming their change. A green
+ * suite that quietly reaches a third party means something different on two
+ * machines and in two different weeks.
+ *
+ * ## Rejecting is NOT enough, and that is the whole design
+ *
+ * The obvious guard replaces `fetch` with one that throws. It does not work
+ * here, and the reason generalises: **the call sites that reach the network are
+ * exactly the ones written to survive it failing.** `cityCoverSyncService`
+ * wraps its Wikimedia search in `try { … } catch { logger.warn(…) }` — entirely
+ * correct, since a cover is optional — so a throwing `fetch` is caught, logged,
+ * and the suite passes. The guard would report nothing while appearing to
+ * guard, which is worse than no guard.
+ *
+ * So every attempt is RECORDED, and `afterAll` asserts the record is empty. A
+ * swallowed rejection still fails the suite, because the evidence does not live
+ * in the exception. The rejection is kept as well, so no real request is made
+ * and nothing waits on a timeout.
+ *
+ * ## It reports the URL, because the URL is the finding
+ *
+ * When this fires the useful information is not "something used the network" —
+ * it is WHICH host, because that names the seam somebody has to stub.
+ *
+ * ## Scope, stated so nobody reads it as a sandbox
+ *
+ * It replaces the global `fetch`, which is what every outbound call in this
+ * backend uses today. It does NOT intercept `node:http` directly, a socket
+ * opened by a driver, or a native module. Postgres is deliberately unaffected:
+ * the throwaway database is a real local server and is the one dependency these
+ * suites are entitled to.
+ */
+
+/** The real `fetch`, captured once so a nested install cannot lose it. */
+const realFetch: typeof globalThis.fetch = globalThis.fetch;
+
+/** One attempted outbound request. */
+export interface NetworkAttempt {
+  readonly method: string;
+  readonly url: string;
+}
+
+/** Best-effort method + URL for whatever shape the caller passed `fetch`. */
+function describeRequest(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): NetworkAttempt {
+  const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+  if (typeof input === 'string') return { method, url: input };
+  if (input instanceof URL) return { method, url: input.toString() };
+  if (input instanceof Request) return { method, url: input.url };
+  return { method, url: String(input) };
+}
+
+/**
+ * Fail this suite if it attempts any `fetch`, and restore the real one after.
+ *
+ * Call at the top level of a test file. Returns the live attempt list, so a test
+ * can assert on it directly — which is how this helper's own guard-test proves
+ * the recording works rather than trusting it.
+ */
+export function installNoNetworkGuard(suiteName: string): NetworkAttempt[] {
+  const attempts: NetworkAttempt[] = [];
+
+  beforeAll(() => {
+    attempts.length = 0;
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const attempt = describeRequest(input, init);
+      attempts.push(attempt);
+      return Promise.reject(
+        new Error(`Outbound ${attempt.method} to ${attempt.url} blocked in ${suiteName}`),
+      );
+    }) as typeof globalThis.fetch;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = realFetch;
+
+    if (attempts.length > 0) {
+      const listed = attempts.map(({ method, url }) => `  ${method} ${url}`).join('\n');
+      throw new Error(
+        `${suiteName} attempted ${attempts.length} outbound request(s):\n${listed}\n\n` +
+          `This suite is required to be hermetic. Stub the seam that reaches the ` +
+          `network — prefer the narrowest one (the module the code under test ` +
+          `imports) over replacing fetch globally, which only hides the next call ` +
+          `somebody adds. If a suite genuinely needs the real request, it belongs ` +
+          `in a separate, clearly-labelled suite outside the default backend run.`,
+      );
+    }
+  });
+
+  return attempts;
+}

--- a/packages/backend/__tests__/integration/externalIngest.test.ts
+++ b/packages/backend/__tests__/integration/externalIngest.test.ts
@@ -41,6 +41,37 @@ import { findPropertyById } from '../../db/properties/propertyReads';
 import { serializeProperty } from '../../db/properties/propertySerializer';
 import { resetGeoTables } from '../helpers/postgresGeoFixtures';
 import { assertFound } from '../helpers/assertFound';
+import { installNoNetworkGuard } from '../helpers/noNetwork';
+
+/**
+ * The two seams this suite reaches the network through, stubbed at the module
+ * the code under test imports rather than by replacing `fetch` globally — a
+ * global stub would silence the guard above and hide the next call somebody adds.
+ *
+ * `cityCoverSyncService` searches Wikimedia Commons for a city photo. Ingest
+ * fires it per listing and does not await it, so this suite was making 44 live
+ * requests to a third party while asserting things about ingest logic.
+ *
+ * `geocodingService` calls Nominatim. It is a FALLBACK here — the fixtures carry
+ * their own coordinates (see `providers/fixture/fixtures.ts`) — so a stub
+ * reporting "no geocoder" exercises the same path a rate-limited or unreachable
+ * Nominatim would, which is the honest default for a suite that asserts nothing
+ * about geocoded values.
+ */
+jest.mock('../../services/cityCoverSyncService', () => ({
+  ensureCover: jest.fn(async () => undefined),
+  syncCovers: jest.fn(async () => 0),
+  syncMissingCovers: jest.fn(async () => 0),
+}));
+
+jest.mock('../../services/geocodingService', () => {
+  const unavailable = async () => ({ success: false, error: 'geocoder stubbed in tests' });
+  return {
+    reverseGeocode: jest.fn(unavailable),
+    forwardGeocode: jest.fn(unavailable),
+    default: { reverseGeocode: jest.fn(unavailable), forwardGeocode: jest.fn(unavailable) },
+  };
+});
 
 // A 1x1 transparent PNG — a real, Sharp-decodable image with no network fetch.
 const ONE_BY_ONE_PNG = Buffer.from(
@@ -168,6 +199,8 @@ afterAll(async () => {
   await resetGeoTables();
   await fs.rm(LOCAL_IMAGE_STORE_DIR, { recursive: true, force: true });
 });
+
+installNoNetworkGuard('externalIngest');
 
 describe('external listing ingest (fixture -> IngestionService)', () => {
   it('creates isExternal, published Properties with re-hosted Image refs', async () => {

--- a/packages/backend/__tests__/unit/gbIngest.test.ts
+++ b/packages/backend/__tests__/unit/gbIngest.test.ts
@@ -33,6 +33,31 @@ import { serializeProperty } from '../../db/properties/propertySerializer';
 import { resetGeoTables } from '../helpers/postgresGeoFixtures';
 import { assertFound } from '../helpers/assertFound';
 
+import { installNoNetworkGuard } from '../helpers/noNetwork';
+
+/**
+ * Wikimedia Commons, reached per-listing by ingest's fire-and-forget city-cover
+ * call. Nothing here asserts on a cover, so a live third-party round trip was
+ * pure flakiness — see `__tests__/helpers/noNetwork.ts`.
+ */
+jest.mock('../../services/cityCoverSyncService', () => ({
+  ensureCover: jest.fn(async () => undefined),
+  syncCovers: jest.fn(async () => 0),
+  syncMissingCovers: jest.fn(async () => 0),
+}));
+
+/** Nominatim. A FALLBACK for listings without coordinates; asserted on nowhere here. */
+jest.mock('../../services/geocodingService', () => {
+  const unavailable = async () => ({ success: false, error: 'geocoder stubbed in tests' });
+  return {
+    reverseGeocode: jest.fn(unavailable),
+    forwardGeocode: jest.fn(unavailable),
+    default: { reverseGeocode: jest.fn(unavailable), forwardGeocode: jest.fn(unavailable) },
+  };
+});
+
+installNoNetworkGuard('gbIngest');
+
 const ONE_BY_ONE_PNG = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
   'base64',

--- a/packages/backend/__tests__/unit/ingestionGeocode.test.ts
+++ b/packages/backend/__tests__/unit/ingestionGeocode.test.ts
@@ -27,6 +27,21 @@ import { addresses, properties } from '../../db/schema';
 import { assertFound } from '../helpers/assertFound';
 import { resetGeoTables } from '../helpers/postgresGeoFixtures';
 
+import { installNoNetworkGuard } from '../helpers/noNetwork';
+
+/**
+ * Wikimedia Commons, reached per-listing by ingest's fire-and-forget city-cover
+ * call. Nothing here asserts on a cover, so a live third-party round trip was
+ * pure flakiness — see `__tests__/helpers/noNetwork.ts`.
+ */
+jest.mock('../../services/cityCoverSyncService', () => ({
+  ensureCover: jest.fn(async () => undefined),
+  syncCovers: jest.fn(async () => 0),
+  syncMissingCovers: jest.fn(async () => 0),
+}));
+
+installNoNetworkGuard('ingestionGeocode');
+
 /** The listing's own row — this suite only ever asserts on scalars. */
 async function propertyRow(id: string) {
   const [row] = await getDb()


### PR DESCRIPTION
Closes #397.

`__tests__/integration/externalIngest.test.ts` reached third parties over the real network with **no fetch mock at all**. Measured with a guard rather than by reading: **50 outbound requests from that one suite** — 44 to `commons.wikimedia.org`, 6 to `nominatim.openstreetmap.org` — while all nine of its tests passed.

So a green run meant something different on two machines and in two different weeks, and a Wikimedia outage or rate-limit read as a code defect to whoever met it, in a suite about ingestion logic rather than connectivity. This is the half #396 did not remove: that PR fixed the teardown *race* whose input was this variable round-trip timing. The race is gone; the variability was not.

## The guard, and why rejecting is not enough

This is the part worth reviewing, because the obvious guard does not work here and fails silently.

**The call sites that reach the network are exactly the ones written to survive it failing.** `cityCoverSyncService` wraps its Wikimedia search in `try { … } catch { logger.warn(…) }` — entirely correct, a city cover is optional. So a `fetch` replaced with one that *throws* is caught, logged, and the suite passes. The guard would report nothing while appearing to guard, which is worse than having none.

`installNoNetworkGuard` therefore **records every attempt and asserts in `afterAll` that the record is empty**. A swallowed rejection still fails the suite, because the evidence does not live in the exception. It still rejects as well, so no real request is made and nothing waits on a timeout. The failure names the method and URL, because the host is what tells you which seam to stub.

Scope is stated in the helper rather than implied: it replaces global `fetch` — what every outbound call in this backend uses — and does **not** intercept `node:http`, a driver socket or a native module. It is not a sandbox and must not be described as one. Postgres is deliberately untouched; the throwaway database is the one dependency these suites are entitled to.

## Stubbed at the narrowest seam

`cityCoverSyncService` and `geocodingService` are mocked at the module the code under test imports, **not** by replacing `fetch` globally — a global stub would silence the guard and hide the next call somebody adds. Nothing in these suites asserts on a cover or a geocoded value, and the fixtures carry their own coordinates (`providers/fixture/fixtures.ts` says so), so a stub reporting "no geocoder" exercises the same path a rate-limited Nominatim would.

## Mutation evidence

Removing the cover stub turns the suite **RED** and lists all 44 URLs — **through the `catch` that swallows them**, which is the property the record-and-assert design exists for. Restoring it is green. Confirmed the mutation landed in the file before each run.

## Inventory — the census, and a positive control that I got wrong first

A temporary pass-through instrument over `fetch` (observe-only, **not committed**) ran the whole backend suite:

| suite | host | requests |
|---|---|---|
| `unit/ingestionGeocode.test.ts` | `commons.wikimedia.org` / `upload.wikimedia.org` | 20 |
| `unit/gbIngest.test.ts` | `commons` / `upload.wikimedia.org` / `nominatim` | 8 |
| `integration/conversationOwnership.test.ts` | `http://localhost:3001` | 2 |

Both Wikimedia/Nominatim suites are **fixed here** — same two seams, same helper. `conversationOwnership`'s call is to **localhost**, not a third party, so it is left alone and recorded rather than silently swept in.

**The positive control I chose was invalidated by my own fix, and I am reporting that rather than hiding it.** I predicted `externalIngest` would appear in the census; it did not — because the stubs had already landed. The instrument is non-vacuous on two grounds instead: it captured 30 calls across three other files, and `externalIngest` itself measured **50 before the fix and 0 after**, which is a positive control across time rather than across files.

## No separate live-network suite

Considered and declined, deliberately. Nothing here asserts on a cover or a geocoded value, so a real-request suite would assert only that a third party is reachable — a monitoring concern, not a test, and one that would fail for reasons no PR author can act on. If a genuine contract test against Wikimedia is ever wanted, the guard's failure message already says where it belongs.

## Verification

- full backend suite: **138 suites / 1886 tests**, exit 0
- `tsc --noEmit` exit 0; `eslint` on every touched file exit 0
- `bun.lock` untouched (no manifest change)
