### PR TITLE
test(location): pin the antimeridian midpoint at the shared helper, and link the two halves of the loc-drop argument

### DIFF
--- a/packages/frontend/__tests__/location/boundsCenter.test.ts
+++ b/packages/frontend/__tests__/location/boundsCenter.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `boundsCenter` — the representative point of a box, across the antimeridian.
+ *
+ * Tested at the HELPER rather than at each caller, because the helper is what
+ * makes the four sites that need a midpoint agree: `resolveLocationRef` (which
+ * writes the result into the committed selection), `mapBoundsSelection` (every
+ * "Search this area"), `SearchResultsView` (the map camera) and the geo
+ * gateway. Two corrected copies of a ±180 wrap is exactly the thing that
+ * diverges later, so there is one copy and this is its test.
+ *
+ * The Fiji and wraps-by-a-hair cases here are adapted from `geo-351`'s
+ * `antimeridianCenter.test.ts` on `handoff/antimeridian-center`, which found
+ * the bug. Its two per-file helpers were folded into this single shared one;
+ * its test cases were the better half of that patch and are kept.
+ */
+import { boundsCenter, normalizeLongitude, type GeoBounds } from '@homiio/shared-types';
+
+/** The Pacific strip ADR 0002 §9.3 measured against a real PostGIS. */
+const FIJI_STRIP: GeoBounds = { west: 170, south: -20, east: -170, north: -16 };
+
+describe('boundsCenter', () => {
+  it('does NOT put a Fiji viewport in the Gulf of Guinea', () => {
+    // The bug, stated as an assertion rather than described in prose. Keeping
+    // the naive expression here is deliberate: it documents what the old code
+    // produced, so nobody "simplifies" the helper back into it without this
+    // line turning red first.
+    expect((FIJI_STRIP.west + FIJI_STRIP.east) / 2).toBe(0);
+
+    // 0 is a real place — the Atlantic off West Africa, ~13,000 km from the
+    // box. That is what made this survive: not a crash, a plausible coordinate.
+    expect(boundsCenter(FIJI_STRIP).longitude).not.toBe(0);
+    expect(Math.abs(boundsCenter(FIJI_STRIP).longitude)).toBe(180);
+  });
+
+  it('spells the antimeridian `-180`, because that is the only spelling', () => {
+    // Same meridian either way, and worth pinning rather than leaving to
+    // chance: `normalizeLongitude`'s range is half-open on purpose, so one box
+    // cannot mint two tokens and two cache keys. A value disagreeing with its
+    // own prose is what gets "corrected" later.
+    expect(boundsCenter(FIJI_STRIP).longitude).toBe(-180);
+    expect(normalizeLongitude(180)).toBe(-180);
+  });
+
+  it('leaves an ordinary box exactly where it was', () => {
+    // The floor, and the reason this is a repair rather than a behaviour
+    // change: every box in production today is non-wrapping, so a fix that
+    // moved their centres would be worse than the bug it fixed.
+    expect(boundsCenter({ west: -3.75, south: 40.38, east: -3.65, north: 40.45 })).toEqual({
+      longitude: -3.7000000000000002,
+      latitude: 40.415000000000006,
+    });
+    expect(
+      boundsCenter({ west: 2.05, south: 41.32, east: 2.23, north: 41.47 }).longitude,
+    ).toBeCloseTo(2.14, 10);
+  });
+
+  it('handles a box that wraps by only a hair', () => {
+    // The realistic case: a map panned just across the line, not a
+    // deliberately-constructed 20-degree strip. The naive form gives 0 here
+    // too, and 0 is further from this box than from the wide one.
+    const hair: GeoBounds = { west: 179.98, south: -18, east: -179.98, north: -17 };
+
+    const centre = boundsCenter(hair).longitude;
+    expect(centre).not.toBe(0);
+    expect(Math.abs(Math.abs(centre) - 180)).toBeLessThan(0.1);
+  });
+
+  it('takes the latitude midpoint plainly, because latitude never wraps', () => {
+    // `south > north` is an ERROR rather than a convention, so there is no
+    // wrap to handle on this axis and the naive midpoint was always right.
+    expect(boundsCenter(FIJI_STRIP).latitude).toBe(-18);
+  });
+
+  it('is stable for a degenerate point box', () => {
+    // `coveringBounds` builds these when folding a centre-only area into a
+    // cover, so the helper has to survive one.
+    expect(boundsCenter({ west: 2.1, south: 41.3, east: 2.1, north: 41.3 })).toEqual({
+      longitude: 2.1,
+      latitude: 41.3,
+    });
+  });
+});

--- a/packages/frontend/__tests__/searchUrlRoundTrip.test.ts
+++ b/packages/frontend/__tests__/searchUrlRoundTrip.test.ts
@@ -213,15 +213,33 @@ describe('a polygon deliberately has no token, and does not degrade to its box',
     expect(params).not.toHaveProperty('loc');
     expect(params.q).toBe('loft');
 
-    // …and the omission is REPORTED, which is the half that matters. An absent
-    // `loc` is read by `parseSearchParams` as `{ kind: 'none' }` — "no location
-    // was requested" — so a silent drop turns a drawn area into a global
-    // search that reopens as somebody else's. Draw a polygon, reload the URL,
-    // get a different search presented as yours.
+    // …and the omission is REPORTED, which is the half that matters.
     expect(droppedLocation).toBe('unsupported_kind');
 
     // The round trip a caller must not attempt: no shareable href exists.
     expect(exploreHref(query({ location: polygon }))).toBeNull();
+  });
+
+  it('demonstrates WHY the omission must be reported: absence reads as "none"', () => {
+    // These two assertions are the whole argument, and they belong together so
+    // neither can be deleted as redundant.
+    //
+    // The params a silent drop would have produced are indistinguishable from a
+    // query that never had a location — and `parseSearchParams` reads that as
+    // "no location was requested, answer normally", which runs the search
+    // UNSCOPED. So dropping `loc` does not merely lose the polygon: it converts
+    // a committed location into a global feed on the next share or reload,
+    // presented to the user as their own search.
+    //
+    // That is why `buildSearchParamsForUrl` reports `droppedLocation` and
+    // `commitQuery` refuses to navigate rather than writing such a URL. If the
+    // case above is ever "simplified" to just assert the absence, this one
+    // states the consequence that makes the absence unacceptable.
+    expect(parseSearchParams({ q: 'loft' }).location.kind).toBe('none');
+
+    // …and `none` is the variant the screen answers normally, which is exactly
+    // what must NOT happen to a location the user committed.
+    expect(parseSearchParams({ loc: 'polygon.whatever' }).location.kind).toBe('invalid');
   });
 });
 


### PR DESCRIPTION
Follow-up to #391, which merged while these were being written. **Test-only** — the production fixes they cover are already on `main`.

## `boundsCenter` gets its own suite

Tested at the **shared helper** rather than at its four callers. `resolveLocationRef`, `mapBoundsSelection` (every "Search this area"), the map camera and the geo gateway all route through it, so one suite covers them by construction instead of four times over — and there is no second copy of a ±180 wrap to diverge.

Two cases are adapted from `geo-351`'s `handoff/antimeridian-center`, which found the bug. That patch also carried two per-file helpers; those were folded into the single shared helper in #391, and its **test was the better half**:

| Case | Why it earns its place |
|---|---|
| naive `(west + east) / 2` **=== 0** for the Fiji strip | The bug stated as an assertion, not described in prose. The helper cannot be "simplified" back into it without this line reddening first. |
| a box that wraps by a **hair** (`179.98 → -179.98`) | The realistic case — a map panned just across the line, not a constructed 20-degree strip. |
| an ordinary Madrid/Barcelona box **must not move** | The floor: every box in production is non-wrapping, so a fix that shifted their centres would be worse than the bug. Asserted on exact values. |

`0` is a real place — the Atlantic off West Africa, ~13,000 km from the box — which is precisely why this survived: not a crash, a plausible coordinate. And it failed in the quiet direction, since PostGIS reads the wrap correctly, so the **list was right and only the derived point was wrong**.

The `-180` spelling is pinned deliberately: `normalizeLongitude`'s range is half-open so one box cannot mint two tokens and two cache keys, and a value disagreeing with its own prose is what gets "corrected" later.

## The polygon round-trip case gains its other half

Refusing to degrade a polygon to `bbox.` is right, and the hazard is one layer down in what the **reader** does:

- `buildSearchParamsForUrl` omits `loc`
- `parseSearchParams` sees no `loc` → `{ kind: 'none' }` → *"no location was requested, answer normally"*
- the search runs **unscoped**

So a silent drop converts a committed location into a global feed on the next share or reload, presented as the user's own search. The two assertions now sit together and say so, so that if the first is ever trimmed to "asserts the absence", the second states the consequence that makes the absence unacceptable.

## Verification

| Check | Exit |
|---|---|
| `bun install` (0 `error:` lines, positive-controlled) | 0 |
| frontend `tsc --noEmit` | 0 |
| frontend suite — 21 suites, **344 tests** | 0 |

Nothing outside `packages/frontend/__tests__/` is touched, and #401's ingest-hermeticity work on `main` is untouched (this branch is cut fresh from `6c21632b` rather than carrying a stale base).