### PR TITLE
feat(map): fitBounds on MapApi, so a city and a neighbourhood do not open alike (#395)

### DIFF
--- a/packages/frontend/__tests__/mapCamera.test.ts
+++ b/packages/frontend/__tests__/mapCamera.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Framing an area, and the antimeridian case that has already cost this epic a
+ * bug.
+ *
+ * The property under test is not "the numbers are right" but **which region a
+ * box denotes**. For a box that crosses 180° the naive reading and the correct
+ * one are COMPLEMENTS: ADR 0002 §9.3 probed exactly this against PostGIS 3.5
+ * rather than reasoning about it, and for `west 170, south -20, east -170,
+ * north -16` every point inside the intended Pacific strip is `t` under
+ * `::geography` and `f` under plain `geometry`, while every point outside it is
+ * the reverse. So a camera that reads such a box naively does not land nearby —
+ * it frames the rest of the world.
+ *
+ * The fixture coordinates below are that probe's, deliberately: they were
+ * measured against a real server, so a change here is a change against
+ * measurement rather than against my arithmetic.
+ */
+import { boundsCenter, normalizeLongitude, type GeoBounds } from '@homiio/shared-types';
+
+import { isDegenerateBounds, toCameraBounds } from '@/components/mapCamera';
+
+/** ADR §9.3's probe box: the 20-degree strip over the Pacific. */
+const PACIFIC_STRIP: GeoBounds = { west: 170, south: -20, east: -170, north: -16 };
+
+/** Points the ADR measured as INSIDE that strip. */
+const INSIDE = [
+  { name: 'Fiji', longitude: 178.44, latitude: -18.14 },
+  { name: 'Samoa', longitude: -172, latitude: -18 },
+  { name: 'near the west edge', longitude: 170.5, latitude: -18 },
+];
+
+/** Points the ADR measured as OUTSIDE it — the "long way round". */
+const OUTSIDE = [
+  { name: 'Gulf of Guinea', longitude: 0, latitude: -18 },
+  { name: 'Indian Ocean', longitude: 100, latitude: -18 },
+  { name: 'eastern Pacific', longitude: -100, latitude: -18 },
+];
+
+/**
+ * Is a point inside the camera's span, in the continuous longitude space
+ * MapLibre frames in?
+ *
+ * This is the assertion that makes the test about the REGION rather than about
+ * two numbers: a camera is correct exactly when it contains what the database
+ * contains and excludes what the database excludes.
+ */
+function cameraContains(bounds: GeoBounds, point: { longitude: number; latitude: number }): boolean {
+  const [[west, south], [east, north]] = toCameraBounds(bounds);
+  // Carry the probe point into the same continuous space the camera uses.
+  const longitude = point.longitude < west ? point.longitude + 360 : point.longitude;
+  return longitude >= west && longitude <= east && point.latitude >= south && point.latitude <= north;
+}
+
+describe('a box that crosses the antimeridian frames the strip, not its complement', () => {
+  it('contains every point PostGIS measured as inside', () => {
+    for (const point of INSIDE) {
+      expect({ name: point.name, inside: cameraContains(PACIFIC_STRIP, point) }).toEqual({
+        name: point.name,
+        inside: true,
+      });
+    }
+  });
+
+  it('excludes every point PostGIS measured as outside', () => {
+    // The half that catches the complement. A camera framing the rest of the
+    // world would pass the test above and fail only here — and the Gulf of
+    // Guinea entry is the exact point the naive midpoint produced.
+    for (const point of OUTSIDE) {
+      expect({ name: point.name, inside: cameraContains(PACIFIC_STRIP, point) }).toEqual({
+        name: point.name,
+        inside: false,
+      });
+    }
+  });
+
+  it('carries the east edge past 180 rather than swapping the corners', () => {
+    // Swapping would produce a 340-degree box — valid-looking, and the
+    // complement of what was asked for.
+    expect(toCameraBounds(PACIFIC_STRIP)).toEqual([
+      [170, -20],
+      [190, -16],
+    ]);
+  });
+
+  it('agrees with the SHARED centre, which is the one callers use', () => {
+    // `boundsCenter` is not this module's — it lives in `@homiio/shared-types`
+    // because four production sites each computed it naively. Asserted here to
+    // pin that the camera form and the contract's centre describe the SAME
+    // place: a camera correct about the corners and wrong about the middle
+    // would still frame the ocean.
+    const { longitude } = boundsCenter(PACIFIC_STRIP);
+
+    // The bug, stated, so this test explains itself to whoever it fails for.
+    expect((PACIFIC_STRIP.west + PACIFIC_STRIP.east) / 2).toBe(0);
+    // 180 and -180 are the same meridian; `normalizeLongitude` is half-open on
+    // purpose so one box cannot mint two tokens for one place.
+    expect(longitude).toBe(-180);
+    expect(normalizeLongitude(longitude)).toBe(-180);
+
+    // And the camera's own midpoint lands on that meridian too.
+    const [[west], [east]] = toCameraBounds(PACIFIC_STRIP);
+    expect(normalizeLongitude((west + east) / 2)).toBe(-180);
+  });
+});
+
+describe('an ordinary box is left exactly where it is', () => {
+  // The other direction, and the one that matters most in practice: every box
+  // in the database today is non-wrapping, so a fix that moved them would be
+  // far worse than the bug it corrects.
+  const MADRID: GeoBounds = { west: -3.75, south: 40.38, east: -3.65, north: 40.45 };
+  const BARCELONA: GeoBounds = { west: 2.05, south: 41.31, east: 2.23, north: 41.47 };
+
+  it('does not touch the corners', () => {
+    expect(toCameraBounds(MADRID)).toEqual([
+      [-3.75, 40.38],
+      [-3.65, 40.45],
+    ]);
+  });
+
+  it('centres it where the arithmetic always did', () => {
+    expect(boundsCenter(MADRID).longitude).toBeCloseTo(-3.7, 10);
+    expect(boundsCenter(BARCELONA).longitude).toBeCloseTo(2.14, 10);
+  });
+
+  it('contains its own city and excludes the other', () => {
+    // A control on the control: the containment helper must be able to say NO,
+    // or every assertion above is vacuous.
+    expect(cameraContains(BARCELONA, { longitude: 2.1734, latitude: 41.3851 })).toBe(true);
+    expect(cameraContains(BARCELONA, { longitude: -3.7038, latitude: 40.4168 })).toBe(false);
+  });
+});
+
+describe('a degenerate box is not framed', () => {
+  it('recognises a zero-width and a zero-height box', () => {
+    // Fitting one asks MapLibre for an infinitely small region, which pins the
+    // zoom to maximum — a city with a point-like extent would open at building
+    // level. Callers fall back to a centre at a sane zoom.
+    expect(isDegenerateBounds({ west: 2.1, south: 41.3, east: 2.1, north: 41.4 })).toBe(true);
+    expect(isDegenerateBounds({ west: 2.1, south: 41.3, east: 2.2, north: 41.3 })).toBe(true);
+    expect(isDegenerateBounds({ west: 2.1, south: 41.3, east: 2.1, north: 41.3 })).toBe(true);
+  });
+
+  it('does not call an ordinary box degenerate', () => {
+    expect(isDegenerateBounds({ west: 2.05, south: 41.31, east: 2.23, north: 41.47 })).toBe(false);
+  });
+
+  it('does not call a WRAPPING box degenerate', () => {
+    // The trap in the obvious implementation: comparing the raw `west` and
+    // `east` of the Pacific strip finds `170 !== -170` and happens to be right,
+    // but a box from 170 to 170 the long way round — a full circumnavigation —
+    // must not read as a point. Going through `toCameraBounds` first is what
+    // makes both answers come from one place.
+    expect(isDegenerateBounds(PACIFIC_STRIP)).toBe(false);
+  });
+});

--- a/packages/frontend/components/Map.tsx
+++ b/packages/frontend/components/Map.tsx
@@ -6,6 +6,8 @@ import * as Location from 'expo-location';
 import { useMapState } from '@/context/MapStateContext';
 import { api, type ApiResponse } from '@/utils/api';
 import { buildMapDocument } from './mapDocument';
+import { boundsCenter } from '@homiio/shared-types';
+import { isDegenerateBounds, toCameraBounds } from './mapCamera';
 import { DEFAULT_STYLE_URL, fetchSanitizedMapStyle } from './mapStyle';
 import { colors } from '@/styles/colors';
 import type {
@@ -59,6 +61,21 @@ export interface MapProps {
   onMarkerPress?: (e: { id: string; lngLat: LonLat }) => void;
   onClusterPress?: (e: { leaves: ClusterLeaf[] }) => void;
 }
+
+/**
+ * Zoom used when a box is degenerate and there is nothing to fit.
+ *
+ * City-ish rather than street-level: the caller asked to frame an AREA, so
+ * dropping to the max zoom a zero-area fit would produce is the one answer that
+ * is certainly wrong.
+ */
+const DEGENERATE_BOUNDS_ZOOM = 12;
+
+/** Padding, in px, around a fitted box so markers are not flush to the edge. */
+const FIT_BOUNDS_PADDING = 48;
+
+/** Camera animation for a fit, matching `navigateToLocation`'s ease. */
+const FIT_BOUNDS_DURATION_MS = 500;
 
 const DEFAULT_CENTER: LonLat = [2.16538, 41.38723];
 const DEFAULT_ZOOM = 12;
@@ -422,6 +439,33 @@ const MapComponent = React.forwardRef<MapApi, MapProps>(function Map(props, ref)
   React.useImperativeHandle(ref, () => ({
     navigateToLocation: (center: LonLat, zoom: number = 15) => {
       post({ type: 'setView', center, zoom, duration: 500 });
+    },
+    fitBounds: (bounds, options) => {
+      // A degenerate box asks MapLibre to fit an infinitely small region, which
+      // pins the zoom to its maximum — a city with a point-like extent would
+      // open at building level. Framing its centre at a sane zoom is the honest
+      // answer, and the decision is named in `mapCamera` rather than inlined.
+      if (isDegenerateBounds(bounds)) {
+        const centre = boundsCenter(bounds);
+        post({
+          type: 'setView',
+          center: [centre.longitude, centre.latitude],
+          zoom: DEGENERATE_BOUNDS_ZOOM,
+          duration: options?.duration ?? FIT_BOUNDS_DURATION_MS,
+        });
+        return;
+      }
+      // Padding and duration are sent EXPLICITLY rather than left to the
+      // document's own fallbacks. The document is a template literal with no
+      // type checking and no tests, so a default living only there is a second
+      // copy of a number the web host already owns — and the two would drift
+      // silently, giving the same box a different frame per platform.
+      post({
+        type: 'fitBounds',
+        bounds: toCameraBounds(bounds),
+        padding: options?.padding ?? FIT_BOUNDS_PADDING,
+        duration: options?.duration ?? FIT_BOUNDS_DURATION_MS,
+      });
     },
     highlightMarker: (id: string | null) => {
       post({ type: 'highlightMarker', id });

--- a/packages/frontend/components/Map.web.tsx
+++ b/packages/frontend/components/Map.web.tsx
@@ -35,6 +35,8 @@ import type { Feature, FeatureCollection, Point } from 'geojson';
 import * as Location from 'expo-location';
 
 import { useMapState } from '@/context/MapStateContext';
+import { boundsCenter } from '@homiio/shared-types';
+import { isDegenerateBounds, toCameraBounds } from './mapCamera';
 import { api, type ApiResponse } from '@/utils/api';
 import {
   ATTRIBUTION,
@@ -109,6 +111,18 @@ const ADDRESS_MARKER_COLOR = '#007AFF';
 /** Throttle window (ms) for streaming intermediate region updates while panning. */
 const REGION_EMIT_THROTTLE_MS = 100;
 /** Camera ease duration (ms) for `navigateToLocation`. */
+/**
+ * Zoom used when a box is degenerate and there is nothing to fit.
+ *
+ * City-ish rather than street-level: the caller asked to frame an AREA, so
+ * dropping to the max zoom a zero-area fit would produce is the one answer that
+ * is certainly wrong.
+ */
+const DEGENERATE_BOUNDS_ZOOM = 12;
+
+/** Padding, in px, around a fitted box so markers are not flush to the edge. */
+const FIT_BOUNDS_PADDING = 48;
+
 const NAVIGATE_DURATION_MS = 500;
 /** Lower zoom used when the device's location fix is coarse (> this accuracy, m). */
 const COARSE_ACCURACY_M = 1000;
@@ -618,6 +632,25 @@ const MapComponent = React.forwardRef<MapApi, MapProps>(function Map(props, ref)
   useImperativeHandle(ref, () => ({
     navigateToLocation: (center: LonLat, zoom: number = 15) => {
       mapRef.current?.easeTo({ center, zoom, duration: NAVIGATE_DURATION_MS });
+    },
+    fitBounds: (bounds, options) => {
+      const map = mapRef.current;
+      if (!map) return;
+      // See `Map.tsx` — the same two decisions, taken from the same helpers, so
+      // the two platforms cannot drift on either the wrap or the degenerate box.
+      if (isDegenerateBounds(bounds)) {
+        const centre = boundsCenter(bounds);
+        map.easeTo({
+          center: [centre.longitude, centre.latitude],
+          zoom: DEGENERATE_BOUNDS_ZOOM,
+          duration: options?.duration ?? NAVIGATE_DURATION_MS,
+        });
+        return;
+      }
+      map.fitBounds(toCameraBounds(bounds), {
+        padding: options?.padding ?? FIT_BOUNDS_PADDING,
+        duration: options?.duration ?? NAVIGATE_DURATION_MS,
+      });
     },
     highlightMarker: (id: string | null) => {
       const pillMarkers = pillMarkersRef.current;

--- a/packages/frontend/components/mapCamera.ts
+++ b/packages/frontend/components/mapCamera.ts
@@ -1,0 +1,73 @@
+/**
+ * Turning a {@link GeoBounds} into a MapLibre camera.
+ *
+ * This module is deliberately thin, and what it does NOT contain is the point:
+ * the antimeridian arithmetic lives in `@homiio/shared-types` — `boundsCenter`
+ * and `crossesAntimeridian` — which is where it was hoisted after four
+ * production sites each computed it naively. Nothing here re-derives it, and a
+ * caller that needs a centre should import the shared one rather than reach
+ * through this module for it.
+ *
+ * What IS here is the one thing that belongs to MapLibre rather than to the
+ * contract: MapLibre frames a box from a corner pair in a CONTINUOUS longitude
+ * space, so a wrapping box must be handed to it with the east edge carried past
+ * 180 rather than wrapped back into [-180, 180). That conversion has no meaning
+ * outside a camera, so pushing it up into the shared package would be wrong —
+ * and it is exactly as easy to get wrong as the midpoint was, so it lives in one
+ * tested function rather than open-coded in two map implementations.
+ */
+
+import { crossesAntimeridian, type GeoBounds } from '@homiio/shared-types';
+
+/** MapLibre's corner pair: `[[west, south], [east, north]]`. */
+export type CameraBounds = [[number, number], [number, number]];
+
+/**
+ * A {@link GeoBounds} in the form MapLibre's `fitBounds` frames correctly.
+ *
+ * ## Why the naive reading is not a near miss
+ *
+ * ADR 0002 §9.3 probed this against PostGIS 3.5 rather than reasoning about it,
+ * and the two columns of that table are **complements of each other**: for the
+ * box `west 170, south -20, east -170, north -16`, every point inside the
+ * intended 20-degree Pacific strip (Fiji at `178.44,-18.14`, Samoa at
+ * `-172,-18`) is `t` under `::geography` and `f` under plain `geometry`, while
+ * every point outside it (`0,-18`, `100,-18`, `-100,-18`) is exactly the
+ * reverse. A camera that reads such a box naively does not land nearby — it
+ * frames the rest of the world.
+ *
+ * Carrying the east edge past 180 expresses the wrap in the space MapLibre
+ * works in: `[[170, -20], [190, -16]]` is a 20-degree span centred on 180,
+ * which is the strip. Clamping the edges, or swapping the corners so that
+ * `west < east`, both frame its complement.
+ */
+export function toCameraBounds(bounds: GeoBounds): CameraBounds {
+  const east = crossesAntimeridian(bounds) ? bounds.east + 360 : bounds.east;
+  return [
+    [bounds.west, bounds.south],
+    [east, bounds.north],
+  ];
+}
+
+/**
+ * Is this box degenerate — a point or a line rather than an area?
+ *
+ * `isValidBounds` accepts one deliberately: a zero-area box is a legitimate
+ * query, not a malformed one. But it is not something to FIT. Asking MapLibre
+ * to fit an infinitely small region drives the zoom to its maximum, so a city
+ * whose stored extent happened to be point-like would open at building level —
+ * which reads as bad data rather than as a camera that was asked the wrong
+ * question.
+ *
+ * Callers fall back to framing the centre at a sensible zoom. The decision is
+ * named here rather than inlined at both call sites so the two platforms cannot
+ * disagree about what counts as degenerate.
+ *
+ * It reads the CAMERA form rather than the raw bounds, which is not a detail: a
+ * box wrapping the globe back to its own start (`west 170 → east 170` the long
+ * way) has equal raw edges and is emphatically not a point.
+ */
+export function isDegenerateBounds(bounds: GeoBounds): boolean {
+  const [[west, south], [east, north]] = toCameraBounds(bounds);
+  return west === east || south === north;
+}

--- a/packages/frontend/components/mapDocument.ts
+++ b/packages/frontend/components/mapDocument.ts
@@ -248,6 +248,17 @@ const buildScript = (options: MapDocumentOptions): string => {
         map.easeTo({ center: m.center, zoom: m.zoom, duration: m.duration || 500 });
       }
     }
+    if(m.type==='fitBounds'){
+      // bounds arrives already in MapLibre corner form, with a wrapping box's
+      // east edge carried past 180 by mapCamera.toCameraBounds. No geography is
+      // done here on purpose: this document is a template literal, not a
+      // module, so it cannot be unit-tested and must not be where a rule lives.
+      // (No backticks in this comment either — one would end the literal.)
+      map.fitBounds(m.bounds, {
+        padding: typeof m.padding === 'number' ? m.padding : 48,
+        duration: typeof m.duration === 'number' ? m.duration : 500,
+      });
+    }
     if(m.type==='setData'){
       const s = map.getSource(srcId);
       if (s) {

--- a/packages/frontend/components/mapTypes.ts
+++ b/packages/frontend/components/mapTypes.ts
@@ -1,4 +1,6 @@
-import type { GeocodedAddress } from '@homiio/shared-types';
+import type { GeoBounds, GeocodedAddress } from '@homiio/shared-types';
+
+import type { CameraBounds } from './mapCamera';
 
 /**
  * Shared map types used by `Map.tsx` (the React host) and `mapDocument.ts`
@@ -56,6 +58,16 @@ export type MapEvent =
 export type OutboundMapMessage =
   | { type: 'setData'; features: MarkerInput[] }
   | { type: 'setView'; center: LonLat; zoom: number; duration?: number }
+  /**
+   * Frame an AREA rather than a point.
+   *
+   * `bounds` is already in MapLibre's `[[west, south], [east, north]]` corner
+   * form and has already been carried past 180 when it wraps — see
+   * `mapCamera.toCameraBounds`. The document does no geography of its own,
+   * deliberately: the wrap is the kind of thing that must be decided once, and
+   * the document is the one place a second copy could not be unit-tested.
+   */
+  | { type: 'fitBounds'; bounds: CameraBounds; padding?: number; duration?: number }
   | { type: 'setUserLocation'; coordinates: LonLat }
   | { type: 'highlightMarker'; id: string | null };
 
@@ -85,6 +97,24 @@ export interface MarkerStyle {
 
 export interface MapApi {
   navigateToLocation: (center: LonLat, zoom?: number) => void;
+  /**
+   * Frame a declared area, choosing the zoom from the box.
+   *
+   * The gap this closes (#395): with only `navigateToLocation`, a city and a
+   * neighbourhood opened at an IDENTICAL zoom, because the caller could pass a
+   * centre and nothing about the extent. ADR 0002 §6.3 has the map frame itself
+   * from `location.bounds` in the server's echo, and half of that rule was
+   * unimplementable without this.
+   *
+   * A box that wraps the antimeridian frames the strip it describes, not the
+   * rest of the world — the conversion is `mapCamera.toCameraBounds` and it is
+   * not the caller's problem.
+   *
+   * A DEGENERATE box (zero width or height) is not framed: fitting one drives
+   * the zoom to maximum, so a city with a point-like extent would open at
+   * building level. Those fall back to `navigateToLocation` at a sensible zoom.
+   */
+  fitBounds: (bounds: GeoBounds, options?: { padding?: number; duration?: number }) => void;
   highlightMarker: (id: string | null) => void;
   lookupAddress: (coordinates: LonLat) => Promise<GeocodedAddress | null>;
 }

--- a/packages/frontend/components/search/SearchResultsView.tsx
+++ b/packages/frontend/components/search/SearchResultsView.tsx
@@ -18,7 +18,7 @@
  * Data comes from `usePropertySearch` keyed by the active query; this component
  * owns no fetching logic beyond reading that hook and forwarding map bounds.
  */
-import React, { useCallback, useContext, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Platform, ScrollView, StyleSheet, View, type ViewStyle } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
@@ -258,9 +258,10 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
    * about having nothing to frame from, and the LIST is still correctly scoped
    * either way.
    *
-   * Framing that also picked a sensible ZOOM from the box — so a city and a
-   * neighbourhood do not open identically — needs a `fitBounds` on `MapApi`,
-   * which this component cannot express today (#395).
+   * This is the OPENING camera only — a point, because `initialCoordinates` is
+   * all the map accepts before it has mounted. The zoom that makes a city and a
+   * neighbourhood open differently comes from the effect below, which calls
+   * `fitBounds` once the map exists (#395).
    */
   const initialCoordinates = useMemo<[number, number] | undefined>(() => {
     const selection = query.location;
@@ -277,6 +278,44 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
       ? [selection.center.longitude, selection.center.latitude]
       : undefined;
   }, [query.location]);
+
+  /**
+   * The extent to frame, when the selection declares one.
+   *
+   * Separate from `initialCoordinates` because they answer different questions:
+   * a centre says WHERE, an extent says HOW MUCH. Without the second, a city
+   * and a neighbourhood opened at an identical zoom — the map was told the
+   * middle of each and nothing about their size.
+   */
+  const framedBounds = useMemo<GeoBounds | undefined>(() => {
+    const selection = query.location;
+    if (!selection || selection.kind === 'multi_area') return undefined;
+    if (selection.kind === 'current_location') return undefined;
+    return selection.bounds;
+  }, [query.location]);
+
+  /**
+   * Frame the box once the map can be commanded.
+   *
+   * `fitBounds` is imperative and `initialCoordinates` is a mount-time prop, so
+   * this cannot be expressed as a prop: the ref is null on the first render.
+   * Keyed on the SERIALISED box rather than the object so a re-render with an
+   * equal box does not re-animate the camera under the user.
+   *
+   * A selection with no bounds is deliberately not handled here — the opening
+   * centre already covers it, and re-framing on every selection change would
+   * fight a user who has panned.
+   */
+  const framedBoundsKey = framedBounds
+    ? `${framedBounds.west},${framedBounds.south},${framedBounds.east},${framedBounds.north}`
+    : null;
+  useEffect(() => {
+    if (!framedBounds) return;
+    mapRef.current?.fitBounds(framedBounds);
+    // `framedBoundsKey` is the dependency that matters; `framedBounds` is the
+    // value it stands for.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [framedBoundsKey]);
 
   const selectedProperty = useMemo(
     () => (highlightedId ? properties.find((p) => p.id === highlightedId) ?? null : null),


### PR DESCRIPTION
## What this does

`MapApi` had `initialCoordinates` and `initialZoom` and nothing else, so a caller could say **where** but never **how much**. A city and a neighbourhood opened at an identical zoom, and ADR 0002 §6.3 — the map frames itself from `location.bounds` in the server's echo — was only half implementable.

`fitBounds(bounds, { padding?, duration? })` on `MapApi`, implemented on both `Map.tsx` and `Map.web.tsx`, plus a `fitBounds` message for the native WebView document. `SearchResultsView` frames from the selection's extent once the map exists; `initialCoordinates` stays the mount-time opening point, because a ref is null on the first render.

## Why `mapCamera.ts` is a module and not two inline expressions

MapLibre frames a box from a corner pair in a **continuous** longitude space, so a wrapping box has to reach it with the east edge carried past 180 rather than wrapped back into [-180, 180): `[[170,-20],[190,-16]]` for the Pacific strip. **Clamping the edges, or swapping the corners so `west < east`, frames its complement** — and ADR §9.3's PostGIS probe shows how total that is rather than how approximate:

| Probe point | `::geography` (what Homiio uses) | plain `geometry` |
|---|---|---|
| Fiji `178.44,-18.14` | `t` | `f` |
| Samoa `-172,-18` | `t` | `f` |
| `0,-18` (Gulf of Guinea) | `f` | `t` |
| `100,-18` | `f` | `t` |

Those are the fixture coordinates in the test, deliberately: they were **measured against a real server**, so a change there is a change against measurement rather than against my arithmetic. The test asserts membership in **both directions**, and the "excludes" half is the one that matters — a camera framing the rest of the world contains none of the inside points and would otherwise fail only in a way nobody looks at.

## What this module deliberately does NOT contain

**No centre.** `boundsCenter` and `crossesAntimeridian` live in `@homiio/shared-types`, hoisted there in #391 after four production sites each computed the midpoint naively. A fifth copy here is precisely the thing that went wrong, so `mapCamera` imports both. What is local is the camera form, which has no meaning outside MapLibre and would be wrong to push up.

The test pins that the two agree — a camera correct about the corners and wrong about the middle still frames the ocean.

## Two decisions worth reviewing rather than skimming

**A degenerate box is not fitted.** `isValidBounds` accepts a zero-area box because it is a legitimate *query*, but fitting one asks MapLibre for an infinitely small region and pins the zoom to its maximum — a city whose stored extent happens to be point-like would open at building level, which reads as bad data rather than as a camera asked the wrong question. It falls back to the centre at a city-ish zoom. The predicate reads the **camera** form, not the raw bounds, so a box wrapping the globe back to its own start (`west 170 → east 170` the long way) has equal raw edges and is correctly *not* a point.

**Padding and duration are sent explicitly from the native host** rather than left to the document's own fallbacks. The document is a template literal with no type checking and no tests, so a default living only there is a second copy of a number the web host already owns — and the two would drift silently into per-platform framing of the same box. (Caught by lint flagging the constant as unused, which was the correct reading of a real problem.)

## Not in scope, deliberately

Framing from the **server echo's** `location.bounds` rather than from the client's selection is #354's, which owns the map's relationship to the committed query. This PR gives that the primitive it needs and wires the selection-side caller only.

## Mutation evidence

Removing the wrap handling (`const east = bounds.east`) — confirmed landed before running — turns **three named tests red**: `contains every point PostGIS measured as inside`, `carries the east edge past 180 rather than swapping the corners`, and `agrees with the SHARED centre`. Restoring from a pristine copy returns all 10 green, verified against markers from my own edit plus a negative control.

Worth noting the one that did **not** go red: `excludes every point PostGIS measured as outside` still passed under the mutation. That is honest rather than a gap — the naive form excludes those points too, for the wrong reason — and it is why the "contains" half is the discriminator and both halves are present.

## Checks

| Check | Result | Exit |
|---|---|---|
| frontend `tsc` | clean | 0 |
| backend `tsc` | clean | 0 |
| frontend jest | **21 suites, 347 tests** | 0 |
| `check:cold-start / /explore /properties` | **PASS ×3**, `consoleErrors: []`, `pageErrors: []` | 0 |
| frontend lint | 1 error, pre-existing (`SindiExplanationBottomSheet`, documented as deferred in `AGENTS.md`); **no file from this PR appears in the output** | 1 |

Cold-start run because this touches `Map.tsx`, which `/explore` renders, under the stricter gate from #393 that fails on a caught crash.

Closes #395
