### PR TITLE
feat(search): one committed query the map, the list, the count and the server all agree on (#354)

### DIFF
--- a/packages/backend/__tests__/integration/searchGeoIndexes.test.ts
+++ b/packages/backend/__tests__/integration/searchGeoIndexes.test.ts
@@ -1,0 +1,128 @@
+/**
+ * The spatial predicates the search runs are INDEX-BACKED — checked against a
+ * real planner, not assumed from the schema.
+ *
+ * #354 asks for the PostGIS indexes for bbox and radius to be verified. The
+ * schema declaring `index('addresses_geo_gist').using('gist', table.geo)` is
+ * not that verification: a `geography` cast dropped from a predicate, a
+ * `ST_Distance(...) < r` written into a WHERE clause, or a functional index on
+ * a column the query no longer reads all leave that line untouched and turn
+ * every geo search into a sequential scan over every address on the planet.
+ * Only a plan can tell you.
+ *
+ * ## Why `enable_seqscan = off`, and why that is not cheating
+ *
+ * The test tables hold a handful of rows, so the planner correctly prefers a
+ * sequential scan — on eight rows an index is slower, and a test asserting
+ * "the plan uses the index" against a small table would be asserting something
+ * false about a healthy database. Turning the sequential scan off asks the
+ * question that actually matters and that scale does not change: **CAN this
+ * predicate use the index at all?** A predicate that cannot is invisible until
+ * production, where the table is large enough for the answer to hurt.
+ *
+ * Both halves are needed, and each catches what the other cannot: the
+ * catalogue check sees an index that was never created, the plan check sees an
+ * index that exists and cannot be used.
+ */
+
+import { sql } from 'drizzle-orm';
+
+import { getDb } from '../../db/postgres';
+import { addresses } from '../../db/schema';
+import { withinBoundingBox, withinCircle } from '../../db/properties/propertyGeo';
+import { resetGeoTables, seedAddress, seedGeoChain } from '../helpers/postgresGeoFixtures';
+
+const GEO_INDEX = 'addresses_geo_gist';
+
+const BARCELONA_BOX = { swLat: 41.32, swLng: 2.05, neLat: 41.47, neLng: 2.23 };
+const BARCELONA_CIRCLE = { longitude: 2.1686, latitude: 41.3874, radiusMeters: 25_000 };
+
+/**
+ * The plan for a statement, as one string.
+ *
+ * Read inside a transaction with `SET LOCAL`, because the pool hands out a
+ * different connection per statement — a session-level `SET` would land on one
+ * connection and the `EXPLAIN` on another, and the setting would silently have
+ * no effect. That failure reads as "the planner ignored us", which is exactly
+ * the answer this test is trying to distinguish.
+ */
+async function planFor(predicate: ReturnType<typeof withinCircle>, seqScan: 'on' | 'off'): Promise<string> {
+  return getDb().transaction(async (tx) => {
+    await tx.execute(sql.raw(`set local enable_seqscan = ${seqScan}`));
+    const rows = await tx.execute(
+      sql`explain select count(*) from ${addresses} where ${predicate}`,
+    );
+    return [...rows].map((row) => String(Object.values(row)[0])).join('\n');
+  });
+}
+
+describe('the geo predicates the search actually ships', () => {
+  beforeAll(async () => {
+    await resetGeoTables();
+    const chain = await seedGeoChain({
+      cityName: 'Barcelona',
+      regionName: 'Catalonia',
+      countryCode: 'ES-IDX',
+    });
+    // A handful of rows, so the plan is about a table that exists rather than
+    // an empty one the planner may shortcut entirely.
+    for (const [index, street] of ['Carrer Gran', 'Carrer Petit', 'Passeig'].entries()) {
+      await seedAddress({
+        chain,
+        street,
+        longitude: 2.1686 + index / 1000,
+        latitude: 41.3874 + index / 1000,
+      });
+    }
+  });
+
+  it('has a GiST index on the generated geography column', async () => {
+    const rows = await getDb().execute(
+      sql`select indexdef from pg_indexes where tablename = 'addresses' and indexname = ${GEO_INDEX}`,
+    );
+    const definitions = [...rows].map((row) => String(Object.values(row)[0]));
+
+    expect(definitions).toHaveLength(1);
+    expect(definitions[0]).toContain('USING gist');
+    expect(definitions[0]).toContain('geo');
+  });
+
+  it.each([
+    ['a bounding box', withinBoundingBox(BARCELONA_BOX)],
+    ['a centre and radius', withinCircle(BARCELONA_CIRCLE)],
+  ])('lets the planner reach that index for %s', async (_label, predicate) => {
+    const plan = await planFor(predicate, 'off');
+
+    // Vacuity floor: an empty or unrelated plan would make the assertion below
+    // pass or fail for reasons that have nothing to do with the index.
+    expect(plan).toContain('addresses');
+    expect(plan).toContain(GEO_INDEX);
+    expect(plan).toContain('Index Scan');
+  });
+
+  it.each([
+    ['a bounding box', withinBoundingBox(BARCELONA_BOX)],
+    ['a centre and radius', withinCircle(BARCELONA_CIRCLE)],
+  ])('and CHOOSES it unprompted for %s', async (_label, predicate) => {
+    // Measured rather than assumed, and it surprised the author: on a table of
+    // three rows the planner still prefers the GiST index (cost 20.65 against a
+    // sequential scan), so the `enable_seqscan = off` above is a robustness
+    // belt rather than the only way to see the index at all. Asserting the
+    // DEFAULT plan is the stronger statement — it is the plan production runs —
+    // and keeping both means a change that makes the predicate merely
+    // index-ABLE, rather than index-PREFERRED, still shows up as one failure
+    // instead of none.
+    const plan = await planFor(predicate, 'on');
+    expect(plan).toContain(GEO_INDEX);
+  });
+
+  it('does NOT name the geo index for a predicate that cannot use it', async () => {
+    // The negative control. Without it, "the plan mentions `addresses_geo_gist`"
+    // could be true of every plan on this table for a reason unrelated to the
+    // predicate — and every assertion above would pass while measuring nothing.
+    const plan = await planFor(sql`${addresses.street} = 'Carrer Gran'`, 'off');
+
+    expect(plan).toContain('addresses');
+    expect(plan).not.toContain(GEO_INDEX);
+  });
+});

--- a/packages/backend/__tests__/integration/searchLocationContract.test.ts
+++ b/packages/backend/__tests__/integration/searchLocationContract.test.ts
@@ -110,6 +110,236 @@ describe('search location contract', () => {
       expect(res.status).toBe(400);
       expect(res.body.error).toBe('INVALID_LOCATION');
     });
+
+    /**
+     * A SHAPE and a NAMED PLACE are two authoritative scopes, and ANDing them
+     * is the Barcelona/Madrid defect arriving over the wire instead of out of
+     * the store.
+     *
+     * "Inside Barcelona AND inside this Madrid rectangle" is empty, and empty
+     * is the plausible-looking answer that renders as "this area has no homes".
+     * No `LocationSelection` can produce both, so a request carrying both was
+     * assembled by merging two selections — a client bug every time, and the
+     * loud failure is the one that gets it fixed.
+     */
+    it.each([
+      ['a box and a city', 'swLat=41.3&swLng=2.0&neLat=41.5&neLng=2.3&city=barcelona'],
+      ['a box and a region', 'swLat=41.3&swLng=2.0&neLat=41.5&neLng=2.3&state=catalonia'],
+      ['a box and a neighborhood', 'swLat=41.3&swLng=2.0&neLat=41.5&neLng=2.3&neighborhood=gracia'],
+      ['a radius and a city', 'lat=41.38&lng=2.17&radius=25000&city=barcelona'],
+    ])('rejects %s with INVALID_LOCATION', async (_label, qs) => {
+      const res = await request(buildApp()).get(`/properties/search?${qs}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_LOCATION');
+      // The message names BOTH scopes, because the caller has to know which
+      // two it sent — "invalid location" alone sends people to the wrong half.
+      expect(res.body.message).toMatch(/bounding box|centre and radius/);
+      expect(res.body.message).toMatch(/city|state|neighborhood/);
+    });
+
+    it('still accepts place ids that NEST rather than compete', async () => {
+      // The negative control for the rule above, and it is not a formality:
+      // `resolveNeighborhoodId` deliberately uses the city to disambiguate a
+      // name, so a rule that refused every pair of geographic params would
+      // break the one combination the endpoint is built around.
+      const { chain, propertyId } = await seedBarcelonaListing();
+      const neighborhoodId = await seedNeighborhood({ cityId: chain.cityId, name: 'Gracia' });
+      await attachNeighborhood(propertyId, neighborhoodId);
+
+      const res = await request(buildApp()).get(
+        `/properties/search?city=${chain.cityId}&neighborhood=${neighborhoodId}`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.map((p: { id: string }) => p.id)).toEqual([propertyId]);
+      // The NARROWEST applied scope is what the echo names — it is the one
+      // that decided the result set.
+      expect(res.body.location).toMatchObject({
+        status: 'resolved',
+        appliedLocationKind: 'neighborhood',
+        cityId: chain.cityId,
+        neighborhoodId,
+      });
+    });
+  });
+
+  describe('`q` is free text, and a place name only when nothing else says where', () => {
+    /**
+     * The discriminating pair, and it needs both halves to mean anything.
+     *
+     * The listing sits in Barcelona and its own text says nothing about
+     * Barcelona — no title, no description, street "Carrer Gran". So the word
+     * can only match it through the PLACE expansion, which is exactly the
+     * behaviour under test.
+     */
+    it('does NOT expand `q` into a place when a box already scoped the query', async () => {
+      await seedBarcelonaListing();
+
+      const res = await request(buildApp()).get(
+        '/properties/search?swLat=41.32&swLng=2.05&neLat=41.47&neLng=2.23&q=Barcelona',
+      );
+
+      expect(res.status).toBe(200);
+      // Before the fix this returned the listing, because the query was
+      // `inside the box AND (text ~ Barcelona OR city = Barcelona)` and the
+      // city branch matched. A person who has already said WHERE by moving the
+      // map is describing the home when they type, not the city (ADR 0002
+      // §4.1) — and the same request with a Madrid box would have returned
+      // nothing while looking identical.
+      expect(res.body.data).toHaveLength(0);
+      expect(res.body.location).toMatchObject({ appliedLocationKind: 'bbox' });
+    });
+
+    it('DOES expand `q` into a place when nothing else says where', async () => {
+      // The other half. Without it, the assertion above would also pass
+      // against an endpoint that had simply stopped reading `q` at all.
+      const { propertyId } = await seedBarcelonaListing();
+
+      const res = await request(buildApp()).get('/properties/search?q=Barcelona');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.map((p: { id: string }) => p.id)).toEqual([propertyId]);
+      expect(res.body.location).toMatchObject({ appliedLocationKind: 'none' });
+    });
+
+    it('does NOT expand `q` into a place when a city id already scoped the query', async () => {
+      const { cityId } = await seedBarcelonaListing();
+
+      const res = await request(buildApp()).get(
+        `/properties/search?city=${cityId}&q=Barcelona`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(0);
+    });
+
+    it('still matches free text against the listing itself inside a scope', async () => {
+      // The floor under the three cases above: `q` is not ignored when a scope
+      // is present, it is READ AS TEXT. A listing whose own description
+      // carries the word still matches inside the box.
+      const chain = await seedGeoChain({
+        cityName: 'Barcelona',
+        regionName: 'Catalonia',
+        countryCode: 'ES-TXT',
+      });
+      const addressId = await seedAddress({ chain, street: 'Carrer Gran', ...BARCELONA });
+      const propertyId = await seedProperty({
+        addressId,
+        overrides: {
+          status: PropertyStatus.PUBLISHED,
+          type: PropertyType.APARTMENT,
+          availabilityIsAvailable: true,
+          offerings: [OfferingType.LONG_TERM_RENT],
+          longTermRentMonthlyAmount: 1200,
+          longTermRentCurrency: 'EUR',
+          description: 'Sunny loft with a terrace',
+        },
+      });
+
+      const res = await request(buildApp()).get(
+        '/properties/search?swLat=41.32&swLng=2.05&neLat=41.47&neLng=2.23&q=terrace',
+      );
+
+      expect(res.body.data.map((p: { id: string }) => p.id)).toEqual([propertyId]);
+    });
+  });
+
+  describe('the response is stamped with the identity it was asked under', () => {
+    const QUERY_ID = 'a1b2c3d4e5f60718';
+
+    it('echoes a well-formed query id verbatim', async () => {
+      await seedBarcelonaListing();
+
+      const res = await request(buildApp()).get(`/properties/search?queryId=${QUERY_ID}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.queryId).toBe(QUERY_ID);
+    });
+
+    it('echoes it on the unresolvable-place path too', async () => {
+      // The path that answers with an empty page. A client comparing ids would
+      // otherwise refuse the one answer it most needs to render — "we could
+      // not find that place" — as belonging to another query.
+      const res = await request(buildApp()).get(
+        `/properties/search?city=NoSuchPlaceAtAll&queryId=${QUERY_ID}`,
+      );
+
+      expect(res.body.queryId).toBe(QUERY_ID);
+      expect(res.body.location.status).toBe('unresolved');
+    });
+
+    it.each([
+      ['a value that is not an opaque id', 'not-an-id'],
+      ['an id of the wrong length', 'a1b2c3'],
+      ['uppercase hex, which is a second spelling of one id', 'A1B2C3D4E5F60718'],
+      ['a value carrying markup', '<script>alert(1)</script>'],
+    ])('drops %s rather than reflecting it', async (_label, value) => {
+      // An echo writes caller-supplied bytes into a JSON body. Validating it
+      // against the ONE shape the observability contract defines is what keeps
+      // that from becoming a payload — and the uppercase case matters for a
+      // second reason: two spellings of one id are two cache entries.
+      const res = await request(buildApp()).get(
+        `/properties/search?queryId=${encodeURIComponent(value)}`,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.queryId).toBeUndefined();
+    });
+
+    it('says nothing when the caller sent no id', async () => {
+      // Absent, not null: a client has to tell "this server does not stamp
+      // answers" from "this answer belongs to another query", and treating the
+      // two alike would black out its results against an older deployment.
+      const res = await request(buildApp()).get('/properties/search');
+      expect(res.body).not.toHaveProperty('queryId');
+    });
+  });
+
+  describe('the count answers the same question as the page', () => {
+    it('counts only what the scope matched, however small the page', async () => {
+      // A count assembled from a different `where` than the list is the defect
+      // this pins, and it does not look like one: "3 homes" over a single card
+      // reads as pagination. The fixture makes the two answers differ — one
+      // listing inside the box, two outside — so a count that dropped the geo
+      // predicate reports 3 and a count that shares the `where` reports 1.
+      const { propertyId } = await seedBarcelonaListing();
+      const madrid = await seedGeoChain({
+        cityName: 'Madrid',
+        regionName: 'Madrid',
+        countryCode: 'ES-CNT',
+      });
+      for (const street of ['Gran Via', 'Calle Mayor']) {
+        const addressId = await seedAddress({
+          chain: madrid,
+          street,
+          longitude: -3.7038,
+          latitude: 40.4168,
+        });
+        await seedProperty({
+          addressId,
+          overrides: {
+            status: PropertyStatus.PUBLISHED,
+            type: PropertyType.APARTMENT,
+            availabilityIsAvailable: true,
+            offerings: [OfferingType.LONG_TERM_RENT],
+            longTermRentMonthlyAmount: 1400,
+            longTermRentCurrency: 'EUR',
+          },
+        });
+      }
+
+      const unfiltered = await request(buildApp()).get('/properties/search');
+      expect(unfiltered.body.total).toBe(3);
+
+      const res = await request(buildApp()).get(
+        '/properties/search?swLat=41.32&swLng=2.05&neLat=41.47&neLng=2.23&limit=1',
+      );
+
+      expect(res.body.data.map((p: { id: string }) => p.id)).toEqual([propertyId]);
+      expect(res.body.total).toBe(1);
+      expect(res.body.hasMore).toBe(false);
+      expect(res.body.totalPages).toBe(1);
+    });
   });
 
   describe('the response says which location it applied', () => {
@@ -127,6 +357,7 @@ describe('search location contract', () => {
       expect(res.body.data).toHaveLength(0);
       expect(res.body.location).toEqual({
         status: 'unresolved',
+        appliedLocationKind: 'none',
         requested: { param: 'city', value: 'ThisCityDoesNotExistAnywhere' },
       });
     });
@@ -150,7 +381,11 @@ describe('search location contract', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.data.map((p: { id: string }) => p.id)).toEqual([propertyId]);
-      expect(res.body.location).toEqual({ status: 'resolved', cityId });
+      expect(res.body.location).toEqual({
+        status: 'resolved',
+        appliedLocationKind: 'city',
+        cityId,
+      });
     });
 
     it('echoes the bounding box a box search actually ran under', async () => {
@@ -164,6 +399,7 @@ describe('search location contract', () => {
       expect(res.body.data.map((p: { id: string }) => p.id)).toEqual([propertyId]);
       expect(res.body.location).toEqual({
         status: 'resolved',
+        appliedLocationKind: 'bbox',
         bounds: { west: 2.05, south: 41.32, east: 2.23, north: 41.47 },
       });
     });
@@ -182,6 +418,7 @@ describe('search location contract', () => {
       expect(res.body.data.map((p: { id: string }) => p.id)).toEqual([propertyId]);
       expect(res.body.location).toEqual({
         status: 'resolved',
+        appliedLocationKind: 'radius',
         center: { longitude: BARCELONA.longitude, latitude: BARCELONA.latitude },
         radiusMeters: 25000,
       });
@@ -203,7 +440,11 @@ describe('search location contract', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.data.map((p: { id: string }) => p.id)).toEqual([propertyId]);
-      expect(res.body.location).toEqual({ status: 'resolved', neighborhoodId });
+      expect(res.body.location).toEqual({
+        status: 'resolved',
+        appliedLocationKind: 'neighborhood',
+        neighborhoodId,
+      });
     });
 
     it('marks an unresolvable neighborhood as unresolved rather than ignoring it', async () => {
@@ -220,6 +461,7 @@ describe('search location contract', () => {
       expect(res.body.data).toHaveLength(0);
       expect(res.body.location).toEqual({
         status: 'unresolved',
+        appliedLocationKind: 'none',
         requested: { param: 'neighborhood', value: 'NoSuchBarrio' },
       });
     });
@@ -235,7 +477,7 @@ describe('search location contract', () => {
       // a heading can honestly say "everywhere" instead of naming a place the
       // query never used.
       expect(res.body.data.map((p: { id: string }) => p.id)).toEqual([propertyId]);
-      expect(res.body.location).toEqual({ status: 'none' });
+      expect(res.body.location).toEqual({ status: 'none', appliedLocationKind: 'none' });
     });
 
     it('distinguishes `none` from `unresolved` — the two empty-looking answers', async () => {

--- a/packages/backend/controllers/property/search.ts
+++ b/packages/backend/controllers/property/search.ts
@@ -37,6 +37,7 @@
 
 import type { Request, Response, NextFunction } from 'express';
 import type { SQL } from 'drizzle-orm';
+import type { LocationKind } from '@homiio/shared-types';
 
 import {
   buildSearchPlan,
@@ -100,6 +101,7 @@ interface ResolvedPlace {
 type LocationEcho =
   | {
       status: 'resolved';
+      appliedLocationKind: LocationKind;
       cityId?: string;
       regionId?: string;
       neighborhoodId?: string;
@@ -109,15 +111,45 @@ type LocationEcho =
     }
   | {
       status: 'unresolved';
+      appliedLocationKind: LocationKind;
       requested: { param: 'city' | 'state' | 'neighborhood'; value: string };
     }
-  | { status: 'none' };
+  | { status: 'none'; appliedLocationKind: LocationKind };
+
+/**
+ * The single coarse word for the scope that was APPLIED.
+ *
+ * Total rather than optional, and it is `'none'` in both empty cases: an
+ * unresolvable place applies no filter at all, so saying "none" is the truth
+ * about the query that ran, and `status` is what distinguishes it from a search
+ * that never named a place. Two fields, two different questions — collapsing
+ * them is how "we could not find that place" and "there are no homes here"
+ * became the same bytes in the first place.
+ *
+ * The vocabulary is `LOCATION_KINDS` from the observability contract rather
+ * than one invented here, so a scope reported in an event and a scope reported
+ * in a response cannot be described in two different words.
+ *
+ * Precedence when place ids nest: the NARROWEST wins, because that is the one
+ * that decides the result set. A shape scope cannot co-occur with a place —
+ * `buildSearchPlan` refuses that combination outright.
+ */
+function appliedLocationKind(params: ParsedSearchParams, place: ResolvedPlace): LocationKind {
+  if (place.unresolved) return 'none';
+  if (params.boundingBox) return 'bbox';
+  if (params.centerRadius) return 'radius';
+  if (place.neighborhoodId) return 'neighborhood';
+  if (place.cityId) return 'city';
+  if (place.regionId) return 'region';
+  return 'none';
+}
 
 /** Describe the geographic scope the query ran under. */
 function buildLocationEcho(params: ParsedSearchParams, place: ResolvedPlace): LocationEcho {
   if (place.unresolved && place.unresolvedParam) {
     return {
       status: 'unresolved',
+      appliedLocationKind: appliedLocationKind(params, place),
       requested: {
         param: place.unresolvedParam,
         value: params[place.unresolvedParam] ?? '',
@@ -136,10 +168,11 @@ function buildLocationEcho(params: ParsedSearchParams, place: ResolvedPlace): Lo
   // this contract forbids is a location REQUESTED AND LOST, never one that was
   // never asked for. Saying so explicitly is what lets a heading read "Homes
   // everywhere" honestly instead of naming a place nothing filtered on.
-  if (!hasScope) return { status: 'none' };
+  if (!hasScope) return { status: 'none', appliedLocationKind: 'none' };
 
   return {
     status: 'resolved',
+    appliedLocationKind: appliedLocationKind(params, place),
     ...(place.cityId ? { cityId: place.cityId } : {}),
     ...(place.regionId ? { regionId: place.regionId } : {}),
     ...(place.neighborhoodId ? { neighborhoodId: place.neighborhoodId } : {}),
@@ -232,6 +265,7 @@ function buildSearchResponse(
   total: number,
   message: string,
   location: LocationEcho,
+  queryId: string | undefined,
 ): Record<string, unknown> {
   const totalPages = Math.max(1, Math.ceil(total / limit));
   const hasMore = (page - 1) * limit + data.length < total;
@@ -243,6 +277,11 @@ function buildSearchResponse(
     totalPages,
     hasMore,
     location,
+    // Absent rather than null when the caller sent none, so "this server does
+    // not stamp answers" and "this answer belongs to another query" stay
+    // distinguishable — a client that treated them alike would black out its
+    // results surface against an older deployment.
+    ...(queryId === undefined ? {} : { queryId }),
   };
 }
 
@@ -274,23 +313,41 @@ export async function searchProperties(req: Request, res: Response, next: NextFu
         0,
         'No properties found for the specified location',
         buildLocationEcho(params, place),
+        params.queryId,
       ));
       return;
     }
     conditions.push(...place.conditions);
 
     // --- Free-text query ---
-    // Matches the listing's own text OR the place it is in, so a location word
-    // still works when the description does not carry it. The two place ids are
-    // resolved here rather than expanded into an address-id set.
+    //
+    // `q` is matched against the listing's own text and its street. It is ALSO
+    // read as a place name — but ONLY when nothing else said where, and that
+    // condition is the fix rather than a tuning knob.
+    //
+    // With a scope already applied the place expansion is at best redundant and
+    // at worst the bug: a viewport over Madrid plus `q=Barcelona` produced
+    // `inside Madrid AND (text matches Barcelona OR city = Barcelona)`, whose
+    // honest answer is zero, rendered as "this area is empty". A person who has
+    // said where by picking a place or moving the map has already answered the
+    // question `q` would be re-answering; what they typed is a description of
+    // the home, not of the city (ADR 0002 §4.1 — the two dimensions are
+    // independent, and only one of them is geographic).
+    //
+    // It also removes two place lookups per scoped request.
     if (params.text) {
-      const [textCityId, textRegionId] = await Promise.all([
-        resolveCityId(params.text),
-        resolveRegionId(params.text),
-      ]);
+      const scoped = appliedLocationKind(params, place) !== 'none';
+      const [textCityId, textRegionId] = scoped
+        ? [undefined, undefined]
+        : await Promise.all([resolveCityId(params.text), resolveRegionId(params.text)]);
       conditions.push(matchesText(params.text, { cityId: textCityId, regionId: textRegionId }));
     }
 
+    // ONE `where`, built once, handed to BOTH reads. The count and the page
+    // must answer the same question: a count assembled separately drifts from
+    // the list it is labelling the moment a predicate is added to one of them,
+    // and the result — "1,204 homes" over eleven cards — looks like paging
+    // rather than like a bug.
     const where = allOf(conditions);
     const orderBy = propertyOrderBy(...buildSort(params, params.text));
     const skip = (params.page - 1) * params.limit;
@@ -307,6 +364,7 @@ export async function searchProperties(req: Request, res: Response, next: NextFu
       total,
       'Search completed successfully',
       buildLocationEcho(params, place),
+      params.queryId,
     ));
   } catch (error) {
     // The parameter NAMES, never their values. This used to log `req.query`

--- a/packages/backend/controllers/property/searchQueryBuilder.ts
+++ b/packages/backend/controllers/property/searchQueryBuilder.ts
@@ -35,7 +35,13 @@
 
 import { asc, desc, type SQL } from 'drizzle-orm';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
-import { PropertyType, PropertyStatus, OfferingType, ExchangeMode } from '@homiio/shared-types';
+import {
+  PropertyType,
+  PropertyStatus,
+  OfferingType,
+  ExchangeMode,
+  isOpaqueId,
+} from '@homiio/shared-types';
 
 import { properties } from '../../db/schema';
 import {
@@ -345,6 +351,17 @@ export interface ParsedSearchParams {
   neighborhood?: string;
   boundingBox?: BoundingBox;
   centerRadius?: CenterRadius;
+  /**
+   * The client's identity for this search, echoed back untouched.
+   *
+   * Nothing here reads it as a filter — it exists so a response can be matched
+   * to the query it answers, which is the only way a list, a map, a heading and
+   * a count can prove they are describing one search rather than assuming it.
+   * Absent when the caller sent none, or sent something that is not the one
+   * shape the observability contract accepts (`isOpaqueId`): reflecting an
+   * arbitrary string back into a JSON body is how an echo becomes a payload.
+   */
+  queryId?: string;
   sortField: SortField;
   sortDirection: SortDirection;
   // Per-offering filters (mirror the conditions for downstream visibility).
@@ -501,17 +518,59 @@ export function buildSearchPlan(
     );
   }
 
+  const city = asString(query.city);
+  const state = asString(query.state);
+  const neighborhood = asString(query.neighborhood) ?? asString(query.neighborhoodId);
+
+  // A request names AT MOST ONE authoritative geographic scope, and a SHAPE and
+  // a PLACE are two of them.
+  //
+  // ANDing them is defensible arithmetic and the wrong answer: "inside
+  // Barcelona AND inside this Madrid rectangle" is empty, and empty is the
+  // plausible-looking failure that renders as "this area has no homes". It is
+  // the exact shape of the bug #354 exists to close, arriving from the wire
+  // instead of from the store, and it is a client bug every time — no selection
+  // in `LocationSelection` can produce both, so a request carrying both was
+  // assembled by merging two selections, which is what the atomic contract
+  // forbids. The loud failure is the one that gets it fixed.
+  //
+  // City, region and neighborhood together are NOT this case: they nest, and
+  // `resolveNeighborhoodId` deliberately uses the city to disambiguate a name.
+  const shapeScope = boundingBox ? 'a bounding box' : centerRadius ? 'a centre and radius' : null;
+  if (shapeScope) {
+    const namedPlaces = [
+      city === undefined ? null : 'city',
+      state === undefined ? null : 'state',
+      neighborhood === undefined ? null : 'neighborhood',
+    ].filter((name): name is string => name !== null);
+    if (namedPlaces.length > 0) {
+      throw new GeoParamError(
+        `A search may carry ${shapeScope} or a named place (${namedPlaces.join(', ')}), not both. ` +
+          'Send one geographic scope.',
+      );
+    }
+  }
+
+  // Validated rather than trusted: it is written straight back into the
+  // response body, so the one shape the observability contract defines for an
+  // opaque id is the whole of what may be reflected. Anything else is dropped —
+  // silently, because a caller that sends no id gets the same treatment and
+  // neither is an error.
+  const queryIdRaw = asString(query.queryId);
+  const queryId = queryIdRaw !== undefined && isOpaqueId(queryIdRaw) ? queryIdRaw : undefined;
+
   return {
     conditions,
     params: {
       page,
       limit,
       text: asString(query.q) ?? asString(query.query) ?? asString(query.search),
-      city: asString(query.city),
-      state: asString(query.state),
-      neighborhood: asString(query.neighborhood) ?? asString(query.neighborhoodId),
+      city,
+      state,
+      neighborhood,
       boundingBox,
       centerRadius,
+      queryId,
       sortField,
       sortDirection,
       offering,

--- a/packages/frontend/__tests__/buildSearchParams.test.ts
+++ b/packages/frontend/__tests__/buildSearchParams.test.ts
@@ -32,6 +32,7 @@ import {
 import {
   buildSearchParams,
   isUnscopeableLocation,
+  searchQueryId,
   searchQueryKey,
 } from '@/hooks/usePropertySearch';
 import type { SearchQuery } from '@/components/search/types';
@@ -278,8 +279,15 @@ describe('buildSearchParams', () => {
 
 describe('searchQueryKey', () => {
   it('drops page/limit so all pages of one search share a cache entry', () => {
-    const [namespace, , rest] = searchQueryKey(baseQuery({ priceMin: 800 }));
+    const query = baseQuery({ priceMin: 800 });
+    const [namespace, id, place, rest] = searchQueryKey(query);
     expect(namespace).toBe('propertySearch');
+    // The key's first discriminator IS the identity every other surface quotes
+    // — the heading, the count, the markers and the server's echo. A cache key
+    // that could disagree with it would put one search's pages under another's
+    // name (#354, invariant 1).
+    expect(id).toBe(searchQueryId(query));
+    expect(place).toBe('none');
     expect(rest).not.toHaveProperty('page');
     expect(rest).not.toHaveProperty('limit');
     expect(rest).toMatchObject({ priceMin: 800, offering: OfferingType.LONG_TERM_RENT });

--- a/packages/frontend/__tests__/mapMoveSource.test.ts
+++ b/packages/frontend/__tests__/mapMoveSource.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Both map adapters report WHO moved the camera — and this is the file that can
+ * see the native one.
+ *
+ * #354 requires the tests to cover the web and the native map adapter. They are
+ * not the same kind of artefact and cannot be checked the same way:
+ *
+ *  - **Web** drives a live `maplibre-gl` instance. It cannot be exercised under
+ *    jsdom (no WebGL), so what is asserted here is the property that decides
+ *    the outcome: every camera command in `Map.web.tsx` carries
+ *    `PROGRAMMATIC_MOVE`. A command that does not is reported as a user gesture
+ *    and arms "Search this area" over a viewport nobody chose.
+ *  - **Native** drives a WebView whose whole program is a template literal in
+ *    `mapDocument.ts`. It cannot be imported, typechecked or unit-tested as
+ *    code — the ONLY thing a test can do is read the string it produces, so
+ *    that is what this does.
+ *
+ * The document is also where the two halves of the protocol could silently
+ * disagree: the host reads `homiioProgrammatic` off the event, the document
+ * writes it, and the document cannot import the constant. Nothing but a test
+ * that reads both makes that agreement real.
+ *
+ * ## Design notes, because a scan like this fails silently
+ *
+ * Following `noHardcodedCurrency.test.ts`, this repo's reference for the shape:
+ * a VACUITY FLOOR on how much was scanned (a regex that stopped matching
+ * anything reads exactly like a clean result), and a PINNED PREDICATE case so
+ * a broken matcher fails instead of passing.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { PROGRAMMATIC_MOVE, moveSourceOf } from '@/components/mapTypes';
+import { buildMapDocument } from '@/components/mapDocument';
+
+const MARKER_KEY = 'homiioProgrammatic';
+
+const WEB_MAP_PATH = join(__dirname, '..', 'components', 'Map.web.tsx');
+const webMapSource = readFileSync(WEB_MAP_PATH, 'utf8');
+
+/**
+ * Every MapLibre call that moves the camera, and `resize`, which fires
+ * `movestart`/`move`/`moveend` too — that one lands as the split layout settles
+ * on first paint, which is exactly the "an initial programmatic move must not
+ * show the button" case.
+ */
+const CAMERA_COMMANDS = /\bmap(?:Ref\.current)?\??\.(easeTo|flyTo|jumpTo|fitBounds|resize)\(/g;
+
+describe('moveSourceOf', () => {
+  it('reads the marker a camera command attaches', () => {
+    expect(moveSourceOf(PROGRAMMATIC_MOVE)).toBe('programmatic');
+  });
+
+  it('treats an unmarked event as a gesture', () => {
+    // The safe direction: an unmarked command shows a button that need not be
+    // there, where the opposite reading would hide it for good and look like
+    // the feature was never built.
+    expect(moveSourceOf({ type: 'moveend' })).toBe('user');
+    expect(moveSourceOf(undefined)).toBe('user');
+    expect(moveSourceOf(null)).toBe('user');
+  });
+
+  it('accepts only the literal marker, not anything truthy under that name', () => {
+    // A fixture in the shape that makes a strict and a loose read disagree.
+    // `Boolean(event.homiioProgrammatic)` would pass every case above and this
+    // is the one that separates them.
+    expect(moveSourceOf({ [MARKER_KEY]: 'yes' })).toBe('user');
+  });
+});
+
+describe('the web adapter marks every camera command', () => {
+  const matches = [...webMapSource.matchAll(CAMERA_COMMANDS)];
+
+  it('found the commands at all', () => {
+    // Vacuity floor. `expect([]).toEqual([])` is what a broken regex produces,
+    // and it is indistinguishable from a clean file without this. Six were
+    // present when this was written (a cluster expansion, a device-position
+    // ease, `navigateToLocation`, the degenerate-box fallback, `fitBounds` and
+    // the resize observer).
+    expect(matches.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it.each(['easeTo', 'fitBounds', 'jumpTo', 'resize'])(
+    'has a pinned case for %s so the matcher cannot rot',
+    (method) => {
+      expect(CAMERA_COMMANDS.test(`map.${method}(`)).toBe(true);
+      CAMERA_COMMANDS.lastIndex = 0;
+    },
+  );
+
+  it('passes PROGRAMMATIC_MOVE to each one', () => {
+    // The whole call is read, not the line it starts on: these are multi-line,
+    // and a line-based check would answer about the opening parenthesis.
+    const unmarked = matches
+      .map((match) => {
+        const call = webMapSource.slice(match.index, match.index + 400);
+        return call.includes('PROGRAMMATIC_MOVE') ? null : `${match[1]} at index ${match.index}`;
+      })
+      .filter((entry): entry is string => entry !== null);
+
+    expect(unmarked).toEqual([]);
+  });
+});
+
+describe('the native document', () => {
+  const document = buildMapDocument({
+    center: [2.1686, 41.3874],
+    zoom: 12,
+    style: 'https://tiles.example/style.json',
+    markerStyle: { chipBg: '#000', chipText: '#fff', onMarkerZoom: 14 },
+    cluster: { enabled: true, radius: 50, maxZoom: 14, color: '#000', textColor: '#fff' },
+    enableAddressLookup: false,
+  });
+
+  it('declares the marker under the SAME key the host reads', () => {
+    // The host and the document cannot share a module — one is TypeScript, the
+    // other is a string that becomes a program inside a WebView. This is the
+    // only thing that makes them agree, so it reads the key off the exported
+    // constant rather than repeating the literal.
+    expect(Object.keys(PROGRAMMATIC_MOVE)).toEqual([MARKER_KEY]);
+    expect(document).toContain(`const PROGRAMMATIC_MOVE = { ${MARKER_KEY}: true }`);
+  });
+
+  it('stamps every region message with a source', () => {
+    expect(document).toContain(
+      `const source = (ev && ev.${MARKER_KEY} === true) ? 'programmatic' : 'user'`,
+    );
+    expect(document).toContain('source: source');
+  });
+
+  it('forwards the causing event into the emitter', () => {
+    // Without this the emitter has nothing to read the marker off and every
+    // movement reports 'user', including the frame that opens the search.
+    expect(document).toContain("map.on(ev, (e) => { emit(false, e); })");
+    expect(document).toContain("map.on(ev, (e) => { emit(true, e); })");
+  });
+
+  it('marks each of its own camera commands', () => {
+    const commands = [...document.matchAll(/map\.(easeTo|jumpTo|fitBounds)\(/g)];
+    // Vacuity floor: a cluster expansion, a `setView` jump, a `setView` ease
+    // and a `fitBounds` were present when this was written.
+    expect(commands.length).toBeGreaterThanOrEqual(4);
+
+    const unmarked = commands
+      .map((match) => {
+        const call = document.slice(match.index, match.index + 300);
+        return call.includes('PROGRAMMATIC_MOVE') ? null : `${match[1]} at index ${match.index}`;
+      })
+      .filter((entry): entry is string => entry !== null);
+
+    expect(unmarked).toEqual([]);
+  });
+});

--- a/packages/frontend/__tests__/noLabelAsFreeText.test.ts
+++ b/packages/frontend/__tests__/noLabelAsFreeText.test.ts
@@ -1,0 +1,230 @@
+/**
+ * The gate #354 asks for by name: a mutation that keeps the old place's label
+ * must FAIL, and must name the file that did it.
+ *
+ * ## What it forbids, and why a behavioural test is not enough on its own
+ *
+ * ADR 0002 §4.1: `location` and `text` are independent dimensions, and `q`
+ * carries what a person TYPED and nothing else. The bug this closes is one line
+ * long and looks like a kindness — send the place's name as free text too, so
+ * the search "also matches the city" — and its consequence is the defect the
+ * whole epic exists for:
+ *
+ *     buildSearchParams → { swLat: …Madrid…, q: 'Barcelona' }
+ *
+ * "Barcelona-matching listings physically inside Madrid" is an honest question
+ * with the honest answer zero, and zero renders as "this area is empty". No
+ * exception, no type error, no failing request.
+ *
+ * `searchThisAreaContract.test.ts` pins the BEHAVIOUR for the one path that
+ * exists today. This file pins the RULE, everywhere, including the paths
+ * somebody adds next week — and it is the half that survives a refactor,
+ * because a behavioural test only covers the call sites it happens to know
+ * about.
+ *
+ * ## Design notes, because every failure mode of a scan like this is silent
+ *
+ * Follows `noHardcodedCurrency.test.ts`, this repo's reference for the shape:
+ * `git ls-files` enumeration (build output excluded for free, and the file set
+ * cannot disagree with what git tracks), a directory pathspec rather than a
+ * doubled-star glob ending in an extension (that form matches only files in a
+ * SUBdirectory and drops every top-level one, which reads exactly like a clean
+ * result), an AFFIRMATIVE extension list, a vacuity floor on files scanned, and
+ * a pinned predicate case with a negative control beside it.
+ *
+ * Note for anyone mutation-testing it: enumeration is the git INDEX, so an
+ * UNSTAGED probe file is not in the scan and a mutation planted that way
+ * measures nothing and "passes". `git add -f` the probe first.
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { stripComments } from '@homiio/shared-types/testing/stripComments';
+
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+
+/**
+ * Directory pathspecs. Every package that can build a search request: the
+ * frontend assembles it, the backend reads it, and shared-types holds the
+ * contract that says the two dimensions are separate.
+ */
+const SCANNED_PACKAGES = ['packages/frontend/', 'packages/backend/', 'packages/shared-types/'];
+
+const SCANNED_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+
+/** Fewer files than this means the traversal broke, not that the tree is clean. */
+const MINIMUM_FILES_SCANNED = 800;
+
+/**
+ * The expressions that produce a PLACE's name.
+ *
+ * `label` covers `selection.label.primary` and every destructured form of it;
+ * the two helpers are the app's own label functions. `shortLabel` is here
+ * because it was the second half of the original bug — the old selection kept
+ * both — and its absence from today's types is not a reason to leave the door
+ * open.
+ */
+const LABEL_SOURCES = ['label', 'shortLabel', 'selectionLabel', 'locationDisplayLabel'];
+
+const LABEL_ALTERNATION = LABEL_SOURCES.join('|');
+
+/**
+ * `queryText: <anything mentioning a label>` — the store/query dimension.
+ *
+ * Case-sensitive on purpose: `\blabel\b` does not match `priceLabel`,
+ * `accessibilityLabel` or `stillShowingLabel`, because the capital L is a word
+ * character and the boundary never lands there. That is what keeps this gate
+ * from crying wolf on the dozens of legitimate `*Label` identifiers in the app.
+ */
+const QUERY_TEXT_FROM_LABEL = new RegExp(
+  `\\bqueryText\\s*[:=]\\s*[^,;\\n]*\\b(?:${LABEL_ALTERNATION})\\b`,
+  'u',
+);
+
+/** `setQueryText(<anything mentioning a label>)` — the store's only text writer. */
+const SET_QUERY_TEXT_FROM_LABEL = new RegExp(
+  `setQueryText\\(\\s*[^)\\n]*\\b(?:${LABEL_ALTERNATION})\\b`,
+  'u',
+);
+
+/** `q: <label>` / `params.q = <label>` — the request parameter itself. */
+const Q_PARAM_FROM_LABEL = new RegExp(
+  `\\bq\\s*[:=]\\s*[^,;\\n]*\\b(?:${LABEL_ALTERNATION})\\b`,
+  'u',
+);
+
+/**
+ * `{ ...mapBoundsSelection(box), label: … }` — the other half of the same bug,
+ * and the half that survives every rule above.
+ *
+ * `mapBoundsSelection` builds a COMPLETE `map_bounds` selection whose label is
+ * generated on purpose, and the request builder never sends a label, so keeping
+ * the old city's name here changes no parameter at all — it changes the
+ * HEADING. The map shows Madrid, the list is Madrid's, and the words above them
+ * say Barcelona. That is invariant 6 of #354 and it is invisible to any test
+ * that asserts on a request.
+ *
+ * A spread is the only way to reach it: the store's `commitLocation` takes a
+ * whole selection and there is no action that takes less, so forbidding the
+ * spread closes the door rather than asking people to remember.
+ */
+const SPREAD_MAP_BOUNDS_SELECTION = /\.\.\.\s*mapBoundsSelection\s*\(/u;
+
+interface Finding {
+  file: string;
+  line: number;
+  text: string;
+  rule: string;
+}
+
+function scanSource(file: string, source: string): Finding[] {
+  const findings: Finding[] = [];
+  stripComments(source)
+    .split('\n')
+    .forEach((text, index) => {
+      const rules: string[] = [];
+      if (QUERY_TEXT_FROM_LABEL.test(text)) rules.push("a place label written into `queryText`");
+      if (SET_QUERY_TEXT_FROM_LABEL.test(text)) rules.push('a place label passed to `setQueryText`');
+      if (Q_PARAM_FROM_LABEL.test(text)) rules.push('a place label sent as the `q` request param');
+      if (SPREAD_MAP_BOUNDS_SELECTION.test(text)) {
+        rules.push('a map-area selection assembled by spreading, which can keep the old label');
+      }
+      for (const rule of rules) {
+        findings.push({ file, line: index + 1, text: text.trim(), rule });
+      }
+    });
+  return findings;
+}
+
+function trackedSourceFiles(): string[] {
+  const output = execFileSync('git', ['ls-files', '--', ...SCANNED_PACKAGES], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return output
+    .split('\n')
+    .filter(Boolean)
+    .filter((file) => SCANNED_EXTENSIONS.some((extension) => file.endsWith(extension)))
+    // This file quotes the very patterns it forbids, so it cannot scan itself.
+    .filter((file) => !file.endsWith('__tests__/noLabelAsFreeText.test.ts'));
+}
+
+describe('a place label is never free text', () => {
+  const files = trackedSourceFiles();
+
+  it('scans enough files that a broken traversal cannot pass as clean', () => {
+    // `expect([]).toEqual([])` is exactly what a broken `git ls-files` produces.
+    expect(files.length).toBeGreaterThan(MINIMUM_FILES_SCANNED);
+  });
+
+  it('recognises every shape the old bug was written in', () => {
+    // The pinned predicate. If these stop matching, every assertion below has
+    // quietly become vacuous — which is the state this gate exists to prevent
+    // in the code it is watching.
+    const probe = [
+      "const next = { ...query, queryText: query.location.label.primary };",
+      "store.setQueryText(selectionLabel(selection)?.primary ?? null);",
+      "if (query.location) params.q = locationDisplayLabel(query.location, t);",
+      "const params = { q: selection.shortLabel, swLat: box.south };",
+      "onCommitLocation({ ...mapBoundsSelection(bounds), label: query.location.label });",
+    ].join('\n');
+
+    expect(scanSource('probe.ts', probe).map((finding) => finding.rule).sort()).toEqual([
+      'a map-area selection assembled by spreading, which can keep the old label',
+      'a place label passed to `setQueryText`',
+      'a place label sent as the `q` request param',
+      'a place label sent as the `q` request param',
+      'a place label written into `queryText`',
+    ]);
+  });
+
+  it('does NOT flag the correct forms, or it gets switched off by whoever hits it', () => {
+    expect(
+      scanSource(
+        'probe.tsx',
+        [
+          // The correct assignment: free text carries free text.
+          'if (query.queryText) params.q = query.queryText;',
+          'const next = { ...query, queryText: text.trim() || null };',
+          'store.setQueryText(draftText);',
+          // A place label rendered as a LABEL is the whole point of having one.
+          'const heading = locationDisplayLabel(query.location, t);',
+          'const name = savedSearchName(selection);',
+          // The dozens of legitimate `*Label` identifiers in the app.
+          'const priceLabel = formatMoney(amount, currency, locale);',
+          'accessibilityLabel={t("search.actions.searchArea")}',
+          'const stillShowingLabel = t("search.area.stillShowing", { place });',
+          // A single-letter `q` that is a query builder, not the search param.
+          'const q = sql`${properties.status} = ${status}`;',
+          // The correct call: the selection is committed whole, not spread.
+          'onCommitLocation(mapBoundsSelection(pendingViewport));',
+        ].join('\n'),
+      ),
+    ).toEqual([]);
+  });
+
+  it('finds no place label reaching the free-text dimension', () => {
+    const findings: Finding[] = [];
+    const unreadable: string[] = [];
+
+    for (const file of files) {
+      let source: string;
+      try {
+        source = readFileSync(join(REPO_ROOT, file), 'utf8');
+      } catch {
+        // Tracked but absent from the working tree. Recorded as a failure
+        // rather than skipped: an unread file is where a reintroduction hides.
+        unreadable.push(file);
+        continue;
+      }
+      findings.push(...scanSource(file, source));
+    }
+
+    expect(unreadable).toEqual([]);
+    expect(
+      findings.map((finding) => `${finding.file}:${finding.line}  [${finding.rule}]  ${finding.text}`),
+    ).toEqual([]);
+  });
+});

--- a/packages/frontend/__tests__/searchArea.test.ts
+++ b/packages/frontend/__tests__/searchArea.test.ts
@@ -1,0 +1,272 @@
+/**
+ * "Search this area" — armed by a person, never by the app.
+ *
+ * These are the rules #354 states as invariants 2 and 3 and as the acceptance
+ * criteria "moving the map without confirming changes nothing" and "an initial
+ * programmatic movement does not show the button". They are tested here, on the
+ * pure reducer, because that is the ONE place both map adapters decide it: the
+ * web component drives a MapLibre instance and the native one drives a WebView
+ * document, and neither can be asked afterwards who moved the camera.
+ *
+ * ## Every case below fails SILENTLY in production
+ *
+ * A button that appears when it should not is not an exception, a type error or
+ * a failed request — it is an offer to replace a city with a rectangle, made at
+ * a moment nobody asked for it. So each test states what a wrong implementation
+ * would show a user, not merely which boolean it would return.
+ */
+import type { GeoBounds } from '@homiio/shared-types';
+
+import {
+  INITIAL_SEARCH_AREA_STATE,
+  committedScopeBounds,
+  reduceMapMovement,
+  viewportsMatch,
+  VIEWPORT_MATCH_TOLERANCE_RATIO,
+  type SearchAreaState,
+} from '@/components/search/searchArea';
+
+/** Barcelona-sized: about 0.18° across. */
+const BARCELONA_VIEW: GeoBounds = { west: 2.05, south: 41.32, east: 2.23, north: 41.47 };
+const MADRID_VIEW: GeoBounds = { west: -3.75, south: 40.38, east: -3.65, north: 40.45 };
+
+/** Nudge every edge of a box by the same number of degrees. */
+function shift(bounds: GeoBounds, degrees: number): GeoBounds {
+  return {
+    west: bounds.west + degrees,
+    east: bounds.east + degrees,
+    south: bounds.south + degrees,
+    north: bounds.north + degrees,
+  };
+}
+
+describe('viewportsMatch', () => {
+  it('accepts a viewport that settled a few metres off', () => {
+    // An inertial pan does not stop on the pixel it started from. Without a
+    // tolerance the button flickers into existence after every gesture that
+    // was meant to return to where it began.
+    expect(viewportsMatch(BARCELONA_VIEW, shift(BARCELONA_VIEW, 0.0005))).toBe(true);
+  });
+
+  it('rejects a viewport a person could see had moved', () => {
+    // 0.02 degrees against a 0.18-degree span is 11%, five times the tolerance.
+    expect(viewportsMatch(BARCELONA_VIEW, shift(BARCELONA_VIEW, 0.02))).toBe(false);
+  });
+
+  it('scales the tolerance to the box, so it is not a fixed number of degrees', () => {
+    // The same absolute drift: inside tolerance on a continent-sized view, far
+    // outside it on a neighbourhood. A fixed threshold has to be wrong for one
+    // of the two, and both are ordinary map states.
+    const continent: GeoBounds = { west: -10, south: 35, east: 30, north: 60 };
+    const block: GeoBounds = { west: 2.17, south: 41.385, east: 2.18, north: 41.39 };
+    expect(viewportsMatch(continent, shift(continent, 0.05))).toBe(true);
+    expect(viewportsMatch(block, shift(block, 0.05))).toBe(false);
+  });
+
+  it('measures a drift ACROSS the antimeridian the short way round', () => {
+    // A 0.02-degree strip over the Pacific, dragged 0.0002 degrees east — far
+    // enough that it no longer wraps, close enough to be the same view. The
+    // west edges are 179.9999 and -179.9999: two ten-thousandths apart, and
+    // 359.9998 apart if subtracted. Read naively, a map barely touched has
+    // moved most of the way round the planet and the button arms.
+    const pacific: GeoBounds = { west: 179.9999, south: -18, east: -179.9801, north: -16 };
+    const nudged: GeoBounds = { west: -179.9999, south: -18, east: -179.9799, north: -16 };
+    expect(viewportsMatch(pacific, nudged)).toBe(true);
+  });
+
+  it('never calls a wrapping box and its complement the same area', () => {
+    // The two describe complementary strips of the planet — 20 degrees over
+    // the Pacific against the 340 degrees that is everywhere else — out of the
+    // same four numbers.
+    const wrapping: GeoBounds = { west: 170, south: -20, east: -170, north: -16 };
+    const complement: GeoBounds = { west: -170, south: -20, east: 170, north: -16 };
+    expect(viewportsMatch(wrapping, complement)).toBe(false);
+  });
+
+  it('separates a nearly-global box from a nearly-empty one', () => {
+    // The case the edge comparison alone cannot see: every edge is within a
+    // ten-thousandth of a degree and one box is the whole planet while the
+    // other is a slice of a street. Only the WIDTH tells them apart.
+    const nearlyEverything: GeoBounds = { west: 170, south: -20, east: 169.9999, north: -16 };
+    const nearlyNothing: GeoBounds = { west: 170, south: -20, east: 170.0001, north: -16 };
+    expect(viewportsMatch(nearlyEverything, nearlyNothing)).toBe(false);
+  });
+
+  it('is pinned against a deliberately loose tolerance', () => {
+    // A negative control for the two cases above: with the tolerance widened
+    // the "moved" case matches, so `viewportsMatch` is really reading the
+    // distance rather than returning a constant.
+    expect(viewportsMatch(BARCELONA_VIEW, shift(BARCELONA_VIEW, 0.02), 0.5)).toBe(true);
+    expect(VIEWPORT_MATCH_TOLERANCE_RATIO).toBeLessThan(0.5);
+  });
+});
+
+describe('reduceMapMovement', () => {
+  it('ignores a movement that is still in progress', () => {
+    // Streaming frames while a finger is down are not a statement about where
+    // to search; acting on them makes the button strobe through a pan.
+    const next = reduceMapMovement(INITIAL_SEARCH_AREA_STATE, {
+      bounds: MADRID_VIEW,
+      isFinal: false,
+      source: 'user',
+    });
+    expect(next).toBe(INITIAL_SEARCH_AREA_STATE);
+  });
+
+  it('does NOT arm on the app framing the committed selection', () => {
+    // The acceptance criterion, and the failure it prevents is worse than a
+    // stray button: pressing it re-searches the same place under a GENERATED
+    // label, so "Barcelona" silently becomes "Map area" and the city id is
+    // gone.
+    const next = reduceMapMovement(INITIAL_SEARCH_AREA_STATE, {
+      bounds: BARCELONA_VIEW,
+      isFinal: true,
+      source: 'programmatic',
+    });
+    expect(next.pending).toBeNull();
+    expect(next.anchor).toEqual(BARCELONA_VIEW);
+  });
+
+  it('arms when a person pans somewhere else', () => {
+    const framed = reduceMapMovement(INITIAL_SEARCH_AREA_STATE, {
+      bounds: BARCELONA_VIEW,
+      isFinal: true,
+      source: 'programmatic',
+    });
+    const panned = reduceMapMovement(framed, {
+      bounds: MADRID_VIEW,
+      isFinal: true,
+      source: 'user',
+    });
+
+    expect(panned.pending).toEqual(MADRID_VIEW);
+    // The anchor does NOT move: it is where the results are, and it is what
+    // "back to the searched area" has to return to.
+    expect(panned.anchor).toEqual(BARCELONA_VIEW);
+  });
+
+  it('disarms when the person pans back to where the search opened', () => {
+    const framed = reduceMapMovement(INITIAL_SEARCH_AREA_STATE, {
+      bounds: BARCELONA_VIEW,
+      isFinal: true,
+      source: 'programmatic',
+    });
+    const away = reduceMapMovement(framed, {
+      bounds: MADRID_VIEW,
+      isFinal: true,
+      source: 'user',
+    });
+    const back = reduceMapMovement(away, {
+      bounds: shift(BARCELONA_VIEW, 0.0004),
+      isFinal: true,
+      source: 'user',
+    });
+
+    expect(back.pending).toBeNull();
+  });
+
+  it('discards a pending viewport when the app frames something new', () => {
+    // Picking a city, applying a saved search or arriving on a new URL all
+    // frame the map. A pending box left over from the previous search would
+    // then be confirmable against results it has nothing to do with.
+    const away: SearchAreaState = { anchor: BARCELONA_VIEW, pending: MADRID_VIEW };
+    const reframed = reduceMapMovement(away, {
+      bounds: MADRID_VIEW,
+      isFinal: true,
+      source: 'programmatic',
+    });
+
+    expect(reframed.pending).toBeNull();
+    expect(reframed.anchor).toEqual(MADRID_VIEW);
+  });
+
+  it('arms on a user gesture even before anything has been framed', () => {
+    // A map that opened on its own default has no anchor. Moving it is still a
+    // real intent to search elsewhere, and refusing to arm there would make
+    // the button unreachable on an unscoped search.
+    const next = reduceMapMovement(INITIAL_SEARCH_AREA_STATE, {
+      bounds: MADRID_VIEW,
+      isFinal: true,
+      source: 'user',
+    });
+    expect(next.pending).toEqual(MADRID_VIEW);
+  });
+
+  it('returns the SAME state object when a resize reports the anchor again', () => {
+    // A container resize fires a camera event carrying an unchanged viewport.
+    // A new object there would write the store on every layout pass, and the
+    // map re-renders on each write.
+    const framed: SearchAreaState = { anchor: BARCELONA_VIEW, pending: null };
+    expect(
+      reduceMapMovement(framed, {
+        bounds: shift(BARCELONA_VIEW, 0.0002),
+        isFinal: true,
+        source: 'programmatic',
+      }),
+    ).toBe(framed);
+  });
+
+  it('the SOURCE is what decides it, not the geometry', () => {
+    // The sharpest statement of the rule: identical bounds, opposite answers.
+    // Anything that infers the source from the numbers gets one of these wrong.
+    const state: SearchAreaState = { anchor: BARCELONA_VIEW, pending: null };
+    const byApp = reduceMapMovement(state, {
+      bounds: MADRID_VIEW,
+      isFinal: true,
+      source: 'programmatic',
+    });
+    const byPerson = reduceMapMovement(state, {
+      bounds: MADRID_VIEW,
+      isFinal: true,
+      source: 'user',
+    });
+
+    expect(byApp.pending).toBeNull();
+    expect(byPerson.pending).toEqual(MADRID_VIEW);
+  });
+});
+
+describe('committedScopeBounds', () => {
+  it('reads a confirmed viewport back out', () => {
+    expect(
+      committedScopeBounds({
+        kind: 'map_bounds',
+        bounds: MADRID_VIEW,
+        center: { longitude: -3.7, latitude: 40.415 },
+        label: { primary: 'search.summary.mapArea', kind: 'generated' },
+        precision: 'area',
+      }),
+    ).toEqual(MADRID_VIEW);
+  });
+
+  it('gives a place its declared extent, and null when it declares none', () => {
+    const withBounds = committedScopeBounds({
+      kind: 'place',
+      source: { kind: 'homiio', entity: 'city', id: 'city-1' },
+      placeType: 'city',
+      label: { primary: 'Barcelona', kind: 'place' },
+      admin: { countryCode: 'ES' },
+      center: { longitude: 2.17, latitude: 41.38 },
+      bounds: BARCELONA_VIEW,
+      precision: 'centroid',
+    });
+    const withoutBounds = committedScopeBounds({
+      kind: 'place',
+      source: { kind: 'homiio', entity: 'city', id: 'city-1' },
+      placeType: 'city',
+      label: { primary: 'Barcelona', kind: 'place' },
+      admin: { countryCode: 'ES' },
+      center: { longitude: 2.17, latitude: 41.38 },
+      precision: 'centroid',
+    });
+
+    expect(withBounds).toEqual(BARCELONA_VIEW);
+    // A place with no extent has no area to return to — the caller renders no
+    // action rather than framing an invented rectangle.
+    expect(withoutBounds).toBeNull();
+  });
+
+  it('has no answer for "everywhere"', () => {
+    expect(committedScopeBounds(null)).toBeNull();
+  });
+});

--- a/packages/frontend/__tests__/searchMarkers.test.ts
+++ b/packages/frontend/__tests__/searchMarkers.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Markers come from the SAME set as the cards, and never from a different one.
+ *
+ * #354's mandatory case "marker without a matching card, card without
+ * coordinates" is really two claims, and only one of them is a bug:
+ *
+ *  - **A marker with no card is incoherent.** The pins and the rows must be the
+ *    same result set, or clicking a pin selects nothing and the map is showing
+ *    homes the list denies exist. `toMarkers` is a projection of the loaded
+ *    properties, so this is true by construction — and asserted here, because
+ *    "by construction" stops being true the moment somebody fetches markers
+ *    from a second endpoint.
+ *  - **A card with no marker is legitimate and must be VISIBLE.** A listing
+ *    whose address has no coordinates is a real home; dropping it from the list
+ *    would hide it, and dropping it from the map silently makes the map look
+ *    like it is still loading. It is kept in the list, left off the map, and
+ *    counted, so the screen can say why the two differ.
+ */
+import { OfferingType, type Property } from '@homiio/shared-types';
+
+import { toMarkers } from '@/components/search/searchMarkers';
+import type { Formatting } from '@/utils/format';
+
+const formatting = { locale: 'en-GB' } as Formatting;
+
+/** A listing, with or without coordinates on its address. */
+function listing(id: string, coordinates?: [number, number]): Property {
+  return {
+    id,
+    longTermRent: { monthlyAmount: 1200, currency: 'EUR' },
+    offerings: [OfferingType.LONG_TERM_RENT],
+    ...(coordinates
+      ? { address: { coordinates: { type: 'Point', coordinates } } }
+      : { address: { street: 'Carrer Gran' } }),
+  } as unknown as Property;
+}
+
+describe('toMarkers', () => {
+  it('draws every listing that has coordinates', () => {
+    const markers = toMarkers(
+      [listing('a', [2.17, 41.38]), listing('b', [-3.7, 40.41])],
+      OfferingType.LONG_TERM_RENT,
+      formatting,
+    );
+
+    expect(markers.map((marker) => marker.id)).toEqual(['a', 'b']);
+    expect(markers[0].coordinates).toEqual([2.17, 41.38]);
+  });
+
+  it('emits NO marker that has no card', () => {
+    // The incoherent direction. Every marker id must exist in the property set
+    // it was built from — a pin selecting nothing is a map describing a
+    // different query.
+    const properties = [listing('a', [2.17, 41.38]), listing('b')];
+    const ids = new Set(properties.map((property) => property.id));
+
+    for (const marker of toMarkers(properties, OfferingType.LONG_TERM_RENT, formatting)) {
+      expect(ids.has(marker.id)).toBe(true);
+    }
+  });
+
+  it('leaves a listing with no coordinates OFF the map and countable', () => {
+    const properties = [listing('a', [2.17, 41.38]), listing('b'), listing('c')];
+    const markers = toMarkers(properties, OfferingType.LONG_TERM_RENT, formatting);
+
+    expect(markers.map((marker) => marker.id)).toEqual(['a']);
+    // The difference the results header renders. Two homes are in the list and
+    // not on the map, and the screen says so rather than leaving the reader to
+    // notice a map that looks unfinished.
+    expect(properties.length - markers.length).toBe(2);
+  });
+
+  it('refuses a coordinate pair that is not a pair of numbers', () => {
+    // Ingested data is not trusted to be well formed. A `[null, null]` reaching
+    // MapLibre throws inside the map rather than in this function, which is the
+    // hardest place to attribute it from.
+    const malformed = { id: 'x', address: { coordinates: { coordinates: ['2.17', null] } } };
+    expect(
+      toMarkers([malformed as unknown as Property], OfferingType.LONG_TERM_RENT, formatting),
+    ).toEqual([]);
+  });
+});

--- a/packages/frontend/__tests__/searchQueryIdentity.test.ts
+++ b/packages/frontend/__tests__/searchQueryIdentity.test.ts
@@ -1,0 +1,233 @@
+/**
+ * One search, one identity — the string the map, the list, the heading, the
+ * count, the cache key and the server's echo all quote.
+ *
+ * The defect it exists for renders perfectly: the header says "Barcelona", the
+ * map frames Barcelona, and the list is answering a request that still carries
+ * Madrid's bounds. Nothing throws and no type is violated. The only way to see
+ * it is to ask each surface which query it is showing and compare the answers,
+ * which is impossible unless the answer is a single deterministic value derived
+ * from the EFFECTIVE query rather than from whatever object each surface holds.
+ *
+ * Two properties are load-bearing, and they pull in opposite directions:
+ *
+ *  - **Total.** Any change that changes the results must change the id.
+ *    Missing one merges two searches into a single cache entry and a single
+ *    heading, silently.
+ *  - **Coarse where it must be.** The device's own position never reaches it,
+ *    for the same reason it never reaches `locationKey`, a URL or a log.
+ */
+import {
+  OfferingType,
+  PropertyType,
+  isOpaqueId,
+  type LocationSelection,
+} from '@homiio/shared-types';
+import {
+  buildSearchParams,
+  searchQueryDescriptor,
+  searchQueryId,
+} from '@/hooks/usePropertySearch';
+import type { SearchQuery } from '@/components/search/types';
+
+function baseQuery(overrides: Partial<SearchQuery> = {}): SearchQuery {
+  return {
+    offering: OfferingType.LONG_TERM_RENT,
+    location: null,
+    queryText: null,
+    propertyTypes: [],
+    amenities: [],
+    sortBy: 'relevance',
+    sortOrder: 'desc',
+    ...overrides,
+  };
+}
+
+const BARCELONA_CITY_ID = '01H8XQ7C2R9V6WQ2N4M0KJ3ZTA';
+
+const barcelona: LocationSelection = {
+  kind: 'place',
+  source: { kind: 'homiio', entity: 'city', id: BARCELONA_CITY_ID },
+  placeType: 'city',
+  label: { primary: 'Barcelona', secondary: 'Catalonia, Spain', kind: 'place' },
+  admin: { countryCode: 'ES', regionName: 'Catalonia', cityName: 'Barcelona' },
+  center: { longitude: 2.1734035, latitude: 41.3850639 },
+  bounds: { west: 2.05, south: 41.32, east: 2.23, north: 41.47 },
+  precision: 'centroid',
+};
+
+const madridViewport: LocationSelection = {
+  kind: 'map_bounds',
+  bounds: { west: -3.75, south: 40.38, east: -3.65, north: 40.45 },
+  center: { longitude: -3.7, latitude: 40.415 },
+  label: { primary: 'search.summary.mapArea', kind: 'generated' },
+  precision: 'area',
+};
+
+const deviceFix: LocationSelection = {
+  kind: 'current_location',
+  center: { longitude: 2.1734035, latitude: 41.3850639 },
+  radiusMeters: 25_000,
+  precision: 'exact',
+};
+
+describe('searchQueryId', () => {
+  it('is the one shape the observability contract accepts for an opaque id', () => {
+    // Not cosmetic: the backend validates the echo with `isOpaqueId` before
+    // writing it into a response body, and the analytics events in
+    // `observability/schema` declare `queryId` with the same field kind. An id
+    // in another shape would be dropped by the server and rejected by the
+    // emitter, and both silently.
+    expect(isOpaqueId(searchQueryId(baseQuery()))).toBe(true);
+    expect(isOpaqueId(searchQueryId(baseQuery({ location: barcelona })))).toBe(true);
+  });
+
+  it('is stable for the same query', () => {
+    expect(searchQueryId(baseQuery({ bedrooms: 2 }))).toBe(searchQueryId(baseQuery({ bedrooms: 2 })));
+  });
+
+  it('changes when the geographic scope is replaced', () => {
+    // The Barcelona → Madrid case, at the identity layer: confirming a map
+    // viewport must produce a DIFFERENT search, or the previous city's results
+    // are served from cache under the new area's heading.
+    expect(searchQueryId(baseQuery({ location: barcelona }))).not.toBe(
+      searchQueryId(baseQuery({ location: madridViewport })),
+    );
+  });
+
+  it('separates two cities that share a name', () => {
+    // Identity comes from the canonical id, never the label — the two
+    // Barcelonas differ nowhere else.
+    const venezuelan: LocationSelection = {
+      ...barcelona,
+      source: { kind: 'homiio', entity: 'city', id: 'A_DIFFERENT_CITY_ID' },
+      admin: { countryCode: 'VE', regionName: 'Anzoátegui', cityName: 'Barcelona' },
+    };
+    expect(searchQueryId(baseQuery({ location: barcelona }))).not.toBe(
+      searchQueryId(baseQuery({ location: venezuelan })),
+    );
+  });
+
+  it('separates free text from a place with the same spelling', () => {
+    // "Barcelona" typed and Barcelona picked are different questions (ADR 0002
+    // §4.1), so they are different searches and must not share a cache entry.
+    expect(searchQueryId(baseQuery({ queryText: 'Barcelona' }))).not.toBe(
+      searchQueryId(baseQuery({ location: barcelona })),
+    );
+  });
+
+  describe('every dimension that changes the results changes the id', () => {
+    // Each case is a query that differs from the base in exactly one respect.
+    // A dimension missing from the descriptor would show up here as two
+    // different searches sharing one id — which in production is one heading
+    // and one count over the other query's rows.
+    const cases: [string, Partial<SearchQuery>][] = [
+      ['offering', { offering: OfferingType.SHORT_TERM_RENT }],
+      ['free text', { queryText: 'loft with a terrace' }],
+      ['property type', { propertyTypes: [PropertyType.APARTMENT] }],
+      ['minimum price', { priceMin: 800 }],
+      ['maximum price', { priceMax: 1400 }],
+      ['bedrooms', { bedrooms: 2 }],
+      ['bathrooms', { bathrooms: 2 }],
+      ['amenities', { amenities: ['balcony'] }],
+      ['guests', { guests: 3 }],
+      ['dates', { dates: { start: '2026-06-01', end: '2026-06-08' } }],
+      ['sort field', { sortBy: 'price' }],
+      ['sort direction', { sortOrder: 'asc' }],
+      ['fair price', { fairPrice: true }],
+      ['instant book', { instantBook: true }],
+      ['pet friendly', { petFriendly: true }],
+      ['location', { location: barcelona }],
+    ];
+
+    const baseId = searchQueryId(baseQuery());
+
+    it.each(cases)('%s', (_label, overrides) => {
+      expect(searchQueryId(baseQuery(overrides))).not.toBe(baseId);
+    });
+
+    it('covers every param the request can carry', () => {
+      // The floor that stops the list above from rotting into a subset. A
+      // filter added to `buildSearchParams` and forgotten here would leave two
+      // searches sharing an id and nothing would say so — so the params of a
+      // fully-populated query are compared against what the cases produce,
+      // and an unlisted one fails.
+      const populated = baseQuery(
+        cases.reduce<Partial<SearchQuery>>((acc, [, overrides]) => ({ ...acc, ...overrides }), {}),
+      );
+      const emitted = Object.keys(buildSearchParams(populated));
+      // Paging is the infinite query's business and the geographic params are
+      // the location dimension, which the `location` case covers.
+      const accountedFor = new Set([
+        'page',
+        'limit',
+        'offering',
+        'sortBy',
+        'sortOrder',
+        'q',
+        'propertyType',
+        'priceMin',
+        'priceMax',
+        'minSalePrice',
+        'maxSalePrice',
+        'bedrooms',
+        'bathrooms',
+        'amenities',
+        'guests',
+        'checkIn',
+        'checkOut',
+        'fairPrice',
+        'instantBook',
+        'petFriendly',
+        'exchangeMode',
+        'city',
+        'state',
+        'neighborhood',
+        'lat',
+        'lng',
+        'radius',
+        'swLat',
+        'swLng',
+        'neLat',
+        'neLng',
+      ]);
+      expect(emitted.filter((key) => !accountedFor.has(key))).toEqual([]);
+      // …and the list really did populate the request, so the assertion above
+      // is not passing over an almost-empty params object.
+      expect(emitted.length).toBeGreaterThanOrEqual(18);
+    });
+  });
+
+  describe('no coordinate of a person ever reaches it', () => {
+    it('keys a device search by its RADIUS and nothing else', () => {
+      const descriptor = searchQueryDescriptor(baseQuery({ location: deviceFix }));
+
+      // The fix goes in the REQUEST — that is the one place it legitimately
+      // goes — and nowhere near the identity.
+      expect(buildSearchParams(baseQuery({ location: deviceFix }))).toMatchObject({
+        lat: 41.3850639,
+        lng: 2.1734035,
+      });
+      expect(JSON.stringify(descriptor)).not.toContain('41.3850639');
+      expect(JSON.stringify(descriptor)).not.toContain('2.1734035');
+      expect(descriptor.center).toBeUndefined();
+      expect(descriptor.radiusKm).toBe(25);
+      expect(descriptor.locationKind).toBe('radius');
+    });
+
+    it('keys a place by its id, not by its centre', () => {
+      const descriptor = searchQueryDescriptor(baseQuery({ location: barcelona }));
+      expect(descriptor.placeKey).toBe(`homiio:city:${BARCELONA_CITY_ID}`);
+      expect(descriptor.center).toBeUndefined();
+    });
+
+    it('does carry a map viewport, which is not anybody position', () => {
+      // The deliberate exception, stated so nobody "fixes" it: a confirmed
+      // viewport IS the query, and an identity that dropped it could not tell
+      // one area from another.
+      const descriptor = searchQueryDescriptor(baseQuery({ location: madridViewport }));
+      expect(descriptor.bounds).toEqual({ west: -3.75, south: 40.38, east: -3.65, north: 40.45 });
+      expect(descriptor.locationKind).toBe('bbox');
+    });
+  });
+});

--- a/packages/frontend/__tests__/searchStaleResponse.test.tsx
+++ b/packages/frontend/__tests__/searchStaleResponse.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * A slow answer to an old question can never overwrite the new one.
+ *
+ * #354 invariant 5, and the reason it needs its own file: the failure is a
+ * RACE, and a test that hopes to reproduce a race proves nothing when it
+ * passes. Every ordering here is forced — each request's promise is held open
+ * and resolved by hand, in the order the test names — so "the older response
+ * arrived second" is a fact of the test rather than something it waited for.
+ *
+ * Two mechanisms are checked, and they fail in different directions:
+ *
+ *  - **Keying.** Barcelona and Madrid are different searches with different
+ *    ids, so the late Barcelona page lands in Barcelona's cache entry and is
+ *    invisible to a surface showing Madrid. This is the one that holds in the
+ *    ordinary case.
+ *  - **The echo.** A page whose id is stamped by the SERVER as belonging to
+ *    another query is refused outright. Keying cannot catch that one — the
+ *    response arrives on the right key carrying the wrong answer, which is what
+ *    a proxy, a shared cache or a mis-served request produces — and rendering
+ *    it would put one search's rows under another's heading and count.
+ */
+import React, { type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { OfferingType, type LocationSelection } from '@homiio/shared-types';
+
+import { api } from '@/utils/api';
+import { searchQueryId, usePropertySearch } from '@/hooks/usePropertySearch';
+import type { SearchQuery } from '@/components/search/types';
+
+jest.mock('@/utils/api', () => ({
+  api: { get: jest.fn() },
+}));
+
+const apiGet = api.get as jest.MockedFunction<typeof api.get>;
+
+function baseQuery(overrides: Partial<SearchQuery> = {}): SearchQuery {
+  return {
+    offering: OfferingType.LONG_TERM_RENT,
+    location: null,
+    queryText: null,
+    propertyTypes: [],
+    amenities: [],
+    sortBy: 'relevance',
+    sortOrder: 'desc',
+    ...overrides,
+  };
+}
+
+const barcelona: LocationSelection = {
+  kind: 'place',
+  source: { kind: 'homiio', entity: 'city', id: '01H8XQ7C2R9V6WQ2N4M0KJ3ZTA' },
+  placeType: 'city',
+  label: { primary: 'Barcelona', secondary: 'Catalonia, Spain', kind: 'place' },
+  admin: { countryCode: 'ES' },
+  center: { longitude: 2.1734, latitude: 41.3851 },
+  precision: 'centroid',
+};
+
+const madridViewport: LocationSelection = {
+  kind: 'map_bounds',
+  bounds: { west: -3.75, south: 40.38, east: -3.65, north: 40.45 },
+  center: { longitude: -3.7, latitude: 40.415 },
+  label: { primary: 'search.summary.mapArea', kind: 'generated' },
+  precision: 'area',
+};
+
+const BARCELONA_QUERY = baseQuery({ location: barcelona });
+const MADRID_QUERY = baseQuery({ location: madridViewport });
+
+/** A search response body, stamped with whichever identity the test wants. */
+function page(id: string, propertyId: string, total: number): { data: unknown } {
+  return {
+    data: {
+      success: true,
+      data: [{ id: propertyId }],
+      total,
+      page: 1,
+      limit: 24,
+      totalPages: 1,
+      hasMore: false,
+      queryId: id,
+      location: { status: 'resolved', appliedLocationKind: 'city' },
+    },
+  };
+}
+
+/** A promise plus the handle that settles it, so ordering is the test's to decide. */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * ONE client per test, created outside the wrapper component.
+ *
+ * Constructing it inside the wrapper looks tidier and hangs the suite: the
+ * wrapper is a component, so every render would build a new client, every
+ * consumer would resubscribe to a new context value, and the render loop never
+ * settles. There is no error and no failing assertion — jest simply never
+ * finishes.
+ */
+let client: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }): React.JSX.Element {
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  apiGet.mockReset();
+  client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+});
+
+afterEach(() => {
+  client.clear();
+});
+
+describe('two requests resolved in reverse order', () => {
+  it('shows the newer search, and the late answer to the older one changes nothing', async () => {
+    const barcelonaId = searchQueryId(BARCELONA_QUERY);
+    const madridId = searchQueryId(MADRID_QUERY);
+    // The premise of the whole test. If these ever collided, both responses
+    // would land on one cache entry and the ordering below would decide the
+    // result — which is the bug, not the test.
+    expect(barcelonaId).not.toBe(madridId);
+
+    const first = deferred<{ data: unknown }>();
+    const second = deferred<{ data: unknown }>();
+    apiGet.mockImplementationOnce(() => first.promise as never);
+    apiGet.mockImplementationOnce(() => second.promise as never);
+
+    const view = renderHook((query: SearchQuery) => usePropertySearch(query), {
+      wrapper,
+      initialProps: BARCELONA_QUERY,
+    });
+
+    // The user moves the map and confirms before Barcelona has answered.
+    view.rerender(MADRID_QUERY);
+
+    // Madrid answers first…
+    second.resolve(page(madridId, 'madrid-listing', 7));
+    await waitFor(() => expect(view.result.current.properties).toHaveLength(1));
+    expect(view.result.current.properties[0].id).toBe('madrid-listing');
+    expect(view.result.current.total).toBe(7);
+    expect(view.result.current.queryId).toBe(madridId);
+
+    // …and Barcelona answers afterwards. This is the moment the defect
+    // produced: a list of Barcelona homes appearing under a map of Madrid,
+    // with no error anywhere.
+    first.resolve(page(barcelonaId, 'barcelona-listing', 812));
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(2));
+
+    expect(view.result.current.properties.map((p) => p.id)).toEqual(['madrid-listing']);
+    expect(view.result.current.total).toBe(7);
+    expect(view.result.current.queryId).toBe(madridId);
+  });
+});
+
+describe('a response stamped with another query', () => {
+  it('is refused rather than rendered', async () => {
+    apiGet.mockResolvedValueOnce(
+      page(searchQueryId(BARCELONA_QUERY), 'barcelona-listing', 812) as never,
+    );
+
+    const view = renderHook(() => usePropertySearch(MADRID_QUERY), { wrapper });
+
+    await waitFor(() => expect(view.result.current.isError).toBe(true));
+    // The rows are NOT shown. An implementation that logged the mismatch and
+    // rendered anyway would satisfy "it noticed" and still put Barcelona's
+    // listings under Madrid's heading.
+    expect(view.result.current.properties).toEqual([]);
+    expect(view.result.current.total).toBe(0);
+    expect(view.result.current.error?.name).toBe('StaleSearchResponseError');
+  });
+
+  it('accepts a response that carries the matching identity', async () => {
+    // The positive control for the case above. Without it, a hook that refused
+    // EVERY response would pass that test and show nothing, ever.
+    apiGet.mockResolvedValueOnce(
+      page(searchQueryId(MADRID_QUERY), 'madrid-listing', 7) as never,
+    );
+
+    const view = renderHook(() => usePropertySearch(MADRID_QUERY), { wrapper });
+
+    await waitFor(() => expect(view.result.current.properties).toHaveLength(1));
+    expect(view.result.current.isError).toBe(false);
+    expect(view.result.current.appliedLocation).toEqual({
+      status: 'resolved',
+      appliedLocationKind: 'city',
+    });
+  });
+
+  it('accepts a server that stamps nothing at all', async () => {
+    // An older deployment echoes no id. Treating silence as a mismatch would
+    // black out the results surface for a shape that is merely older.
+    apiGet.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: [{ id: 'madrid-listing' }],
+        total: 7,
+        page: 1,
+        limit: 24,
+        totalPages: 1,
+        hasMore: false,
+      },
+    } as never);
+
+    const view = renderHook(() => usePropertySearch(MADRID_QUERY), { wrapper });
+
+    await waitFor(() => expect(view.result.current.properties).toHaveLength(1));
+    expect(view.result.current.isError).toBe(false);
+    expect(view.result.current.appliedLocation).toBeNull();
+  });
+});
+
+describe('the identity the request carries', () => {
+  it('is sent to the server, so the answer can be stamped with it', async () => {
+    apiGet.mockResolvedValueOnce(page(searchQueryId(MADRID_QUERY), 'madrid-listing', 7) as never);
+
+    const view = renderHook(() => usePropertySearch(MADRID_QUERY), { wrapper });
+    await waitFor(() => expect(view.result.current.properties).toHaveLength(1));
+
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/properties/search',
+      expect.objectContaining({
+        params: expect.objectContaining({ queryId: searchQueryId(MADRID_QUERY) }),
+      }),
+    );
+  });
+});

--- a/packages/frontend/__tests__/searchThisAreaContract.test.ts
+++ b/packages/frontend/__tests__/searchThisAreaContract.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Barcelona → pan to Madrid → confirm, end to end.
+ *
+ * The discriminating fixture #354 requires, run through the REAL store and the
+ * REAL request builder rather than either one alone. Both halves already have
+ * their own suites — `searchQueryStoreAtomicity` asserts the resulting
+ * selection, `buildSearchParams` asserts the emitted params — and neither can
+ * see the join, which is where the defect lived: a selection that was replaced
+ * correctly, and a request that carried the previous place's name anyway.
+ *
+ * Every assertion is on the REQUEST or on the STORE, never on a result count.
+ * That is the design of the file: the broken behaviour returns ZERO listings,
+ * which is a plausible-looking answer, and reads in the UI as "this area is
+ * empty" rather than as a bug.
+ */
+import { OfferingType, locationKey, type LocationSelection } from '@homiio/shared-types';
+
+import {
+  DEFAULT_SEARCH_QUERY,
+  mapBoundsSelection,
+  useSearchQueryStore,
+} from '@/store/searchQueryStore';
+import { buildSearchParams, searchQueryId } from '@/hooks/usePropertySearch';
+import { reduceMapMovement, type SearchAreaState } from '@/components/search/searchArea';
+
+const BARCELONA_CITY_ID = '01H8XQ7C2R9V6WQ2N4M0KJ3ZTA';
+
+const barcelona: LocationSelection = {
+  kind: 'place',
+  source: { kind: 'homiio', entity: 'city', id: BARCELONA_CITY_ID },
+  placeType: 'city',
+  label: { primary: 'Barcelona', secondary: 'Catalonia, Spain', kind: 'place' },
+  admin: { countryCode: 'ES', regionName: 'Catalonia', cityName: 'Barcelona' },
+  center: { longitude: 2.1734035, latitude: 41.3850639 },
+  bounds: { west: 2.05, south: 41.32, east: 2.23, north: 41.47 },
+  precision: 'centroid',
+};
+
+/** The viewport the map reports once the user has dragged to Madrid. */
+const MADRID_VIEW = { west: -3.75, south: 40.38, east: -3.65, north: 40.45 };
+/** What the map reports when it frames Barcelona on open — padding included. */
+const BARCELONA_FRAMED = { west: 2.03, south: 41.3, east: 2.25, north: 41.49 };
+
+/** Everything about Barcelona that must not survive into a Madrid request. */
+const BARCELONA_TRACES = [BARCELONA_CITY_ID, 'Barcelona', 'Catalonia', '2.1734035', '2.05'];
+
+beforeEach(() => {
+  useSearchQueryStore.setState({ query: DEFAULT_SEARCH_QUERY, pendingViewport: null });
+});
+
+/** Drive the map exactly as the results view does, and return the new state. */
+function move(
+  state: SearchAreaState,
+  bounds: typeof MADRID_VIEW,
+  source: 'user' | 'programmatic',
+): SearchAreaState {
+  const next = reduceMapMovement(state, { bounds, isFinal: true, source });
+  useSearchQueryStore.getState().setPendingViewport(next.pending);
+  return next;
+}
+
+describe('Barcelona, panned to Madrid, confirmed', () => {
+  it('sends the new box and NOTHING of the old place', () => {
+    const store = useSearchQueryStore.getState();
+    store.commitLocation(barcelona);
+
+    // The search opens: the app frames the city, which must not arm anything.
+    let camera = move({ anchor: null, pending: null }, BARCELONA_FRAMED, 'programmatic');
+    expect(useSearchQueryStore.getState().pendingViewport).toBeNull();
+
+    // The user drags to Madrid and confirms.
+    camera = move(camera, MADRID_VIEW, 'user');
+    const pending = useSearchQueryStore.getState().pendingViewport;
+    expect(pending).toEqual(MADRID_VIEW);
+    if (!pending) throw new Error('unreachable');
+    useSearchQueryStore.getState().commitLocation(mapBoundsSelection(pending));
+
+    const params = buildSearchParams(useSearchQueryStore.getState().query);
+
+    // The box went out…
+    expect(params).toMatchObject({
+      swLat: 40.38,
+      swLng: -3.75,
+      neLat: 40.45,
+      neLng: -3.65,
+    });
+    // …and every route Barcelona could have come back on is closed. Asserting
+    // on the SERIALISED params rather than field by field is deliberate: a
+    // remnant that reappeared under another key, or one level deeper, would
+    // slip past a per-field check.
+    expect(params).not.toHaveProperty('q');
+    expect(params).not.toHaveProperty('city');
+    const serialised = JSON.stringify(params);
+    for (const trace of BARCELONA_TRACES) {
+      expect(serialised).not.toContain(trace);
+    }
+  });
+
+  it('re-keys the search, so the previous city cannot be served from cache', () => {
+    useSearchQueryStore.getState().commitLocation(barcelona);
+    const before = searchQueryId(useSearchQueryStore.getState().query);
+
+    useSearchQueryStore.getState().commitLocation(mapBoundsSelection(MADRID_VIEW));
+    const after = searchQueryId(useSearchQueryStore.getState().query);
+
+    expect(after).not.toBe(before);
+    expect(locationKey(useSearchQueryStore.getState().query.location)).toBe(
+      'bbox:-3.75,40.38,-3.65,40.45',
+    );
+  });
+
+  it('keeps free text the user actually typed', () => {
+    // "loft with a terrace" is a description of a home, not of a city, so
+    // moving the map does not retract it. This is the case that makes the
+    // previous test meaningful: `q` is absent there because nothing was typed,
+    // not because `q` is never sent.
+    useSearchQueryStore.getState().setQueryText('loft with a terrace');
+    useSearchQueryStore.getState().commitLocation(barcelona);
+    useSearchQueryStore.getState().commitLocation(mapBoundsSelection(MADRID_VIEW));
+
+    const params = buildSearchParams(useSearchQueryStore.getState().query);
+    expect(params.q).toBe('loft with a terrace');
+    expect(params).toMatchObject({ swLng: -3.75 });
+  });
+
+  it('keeps free text that HAPPENS to spell a city, because provenance is what counts', () => {
+    // The sharp case. "Barcelona" typed into the text box survives a map-area
+    // commit; "Barcelona" as the previous selection's NAME does not. The two
+    // are the same string and different facts, and a rule written on the VALUE
+    // would have to get one of them wrong.
+    useSearchQueryStore.getState().setQueryText('Barcelona');
+    useSearchQueryStore.getState().commitLocation(mapBoundsSelection(MADRID_VIEW));
+
+    expect(buildSearchParams(useSearchQueryStore.getState().query).q).toBe('Barcelona');
+  });
+});
+
+describe('panning without confirming', () => {
+  it('changes neither the committed query nor the request', () => {
+    useSearchQueryStore.getState().commitLocation(barcelona);
+    const before = useSearchQueryStore.getState().query;
+    const paramsBefore = buildSearchParams(before);
+
+    move({ anchor: BARCELONA_FRAMED, pending: null }, MADRID_VIEW, 'user');
+
+    expect(useSearchQueryStore.getState().query).toBe(before);
+    expect(buildSearchParams(useSearchQueryStore.getState().query)).toEqual(paramsBefore);
+    // The viewport is remembered — it is what the button would confirm — and
+    // it is not part of the query.
+    expect(useSearchQueryStore.getState().pendingViewport).toEqual(MADRID_VIEW);
+  });
+
+  it('discards the pending box when the user picks a place instead', () => {
+    // Otherwise pressing "Search this area" after choosing a city would apply
+    // a viewport from the map the user has visibly left.
+    move({ anchor: null, pending: null }, MADRID_VIEW, 'user');
+    useSearchQueryStore.getState().commitLocation(barcelona);
+
+    expect(useSearchQueryStore.getState().pendingViewport).toBeNull();
+  });
+});
+
+describe('an empty answer keeps the scope it was asked about', () => {
+  it('leaves the committed area exactly as it was', () => {
+    // Invariant 8. Nothing here reacts to a result COUNT, and that is the
+    // property: a fallback would live in the store or the params, so the test
+    // asserts the request is byte-identical before and after a query returns
+    // nothing. Widening on zero results is how a search for a quiet
+    // neighbourhood silently becomes a search for the planet.
+    useSearchQueryStore.getState().commitLocation(mapBoundsSelection(MADRID_VIEW));
+    const params = buildSearchParams(useSearchQueryStore.getState().query);
+    const id = searchQueryId(useSearchQueryStore.getState().query);
+
+    // A zero-result response changes no store state at all — there is no
+    // action for it to call.
+    expect(buildSearchParams(useSearchQueryStore.getState().query)).toEqual(params);
+    expect(searchQueryId(useSearchQueryStore.getState().query)).toBe(id);
+    expect(useSearchQueryStore.getState().query.location).not.toBeNull();
+    expect(params.swLng).toBe(-3.75);
+  });
+});
+
+describe('pagination while the map is moving', () => {
+  it('pages the committed query, not the viewport under the cursor', () => {
+    // Paging asks for the next page OF THE COMMITTED SEARCH. A pending
+    // viewport must not leak into the request, or page 2 answers a different
+    // question from page 1 and the list grows rows from two places.
+    useSearchQueryStore.getState().commitLocation(barcelona);
+    move({ anchor: BARCELONA_FRAMED, pending: null }, MADRID_VIEW, 'user');
+
+    const params = buildSearchParams(useSearchQueryStore.getState().query);
+    expect(params.city).toBe(BARCELONA_CITY_ID);
+    expect(params).not.toHaveProperty('swLat');
+    // Same identity as before the pan, so every page shares one cache entry.
+    expect(searchQueryId(useSearchQueryStore.getState().query)).toBe(
+      searchQueryId({ ...DEFAULT_SEARCH_QUERY, location: barcelona }),
+    );
+  });
+});
+
+describe('offering', () => {
+  it('survives a map-area commit, because it is not geographic', () => {
+    useSearchQueryStore.getState().setOffering(OfferingType.SHORT_TERM_RENT);
+    useSearchQueryStore.getState().commitLocation(mapBoundsSelection(MADRID_VIEW));
+
+    expect(buildSearchParams(useSearchQueryStore.getState().query).offering).toBe(
+      OfferingType.SHORT_TERM_RENT,
+    );
+  });
+});

--- a/packages/frontend/components/Map.tsx
+++ b/packages/frontend/components/Map.tsx
@@ -17,6 +17,7 @@ import type {
   LonLat,
   MapApi,
   MapEvent,
+  MapMoveSource,
   MarkerInput,
   MarkerStyle,
   OutboundMapMessage,
@@ -57,7 +58,7 @@ export interface MapProps {
   onAddressSelect?: (address: GeocodedAddress, coordinates: LonLat) => void;
   onAddressLookupStart?: () => void;
   onAddressLookupEnd?: () => void;
-  onRegionChange?: (e: { center: LonLat; zoom: number; bearing: number; pitch: number; bounds: { west: number; south: number; east: number; north: number }; isFinal?: boolean }) => void;
+  onRegionChange?: (e: { center: LonLat; zoom: number; bearing: number; pitch: number; bounds: { west: number; south: number; east: number; north: number }; isFinal?: boolean; source: MapMoveSource }) => void;
   onMarkerPress?: (e: { id: string; lngLat: LonLat }) => void;
   onClusterPress?: (e: { leaves: ClusterLeaf[] }) => void;
 }
@@ -415,7 +416,13 @@ const MapComponent = React.forwardRef<MapApi, MapProps>(function Map(props, ref)
             bounds: msg.bounds,
           });
         }
-        onRegionChange?.(msg);
+        // The document is the ONLY producer of this message and it always
+        // stamps a source (`buildMapDocument`, pinned by
+        // `__tests__/mapMoveSource.test.ts`). Normalising anyway means a
+        // payload this host cannot read is treated as "the app moved the
+        // camera" — the reading that changes nothing — rather than arming a
+        // button off a message that arrived malformed.
+        onRegionChange?.({ ...msg, source: msg.source === 'user' ? 'user' : 'programmatic' });
       }
     } catch {
       // Silently handle message parsing errors

--- a/packages/frontend/components/Map.web.tsx
+++ b/packages/frontend/components/Map.web.tsx
@@ -50,12 +50,14 @@ import {
   installMissingImageFallback,
 } from './mapStyle';
 import { colors } from '@/styles/colors';
+import { PROGRAMMATIC_MOVE, moveSourceOf } from './mapTypes';
 import type {
   GeocodedAddress,
   ClusterLeaf,
   ClusterOptions,
   LonLat,
   MapApi,
+  MapMoveSource,
   MarkerInput,
   MarkerStyle,
 } from './mapTypes';
@@ -95,7 +97,7 @@ export interface MapProps {
   onAddressSelect?: (address: GeocodedAddress, coordinates: LonLat) => void;
   onAddressLookupStart?: () => void;
   onAddressLookupEnd?: () => void;
-  onRegionChange?: (e: { center: LonLat; zoom: number; bearing: number; pitch: number; bounds: { west: number; south: number; east: number; north: number }; isFinal?: boolean }) => void;
+  onRegionChange?: (e: { center: LonLat; zoom: number; bearing: number; pitch: number; bounds: { west: number; south: number; east: number; north: number }; isFinal?: boolean; source: MapMoveSource }) => void;
   onMarkerPress?: (e: { id: string; lngLat: LonLat }) => void;
   onClusterPress?: (e: { leaves: ClusterLeaf[] }) => void;
 }
@@ -333,7 +335,11 @@ const MapComponent = React.forwardRef<MapApi, MapProps>(function Map(props, ref)
   }, [renderPillMarkers]);
 
   // Emit a region change, throttling the streaming (non-final) updates.
-  const emitRegion = useCallback((isFinal: boolean) => {
+  //
+  // `event` is the MapLibre event that caused the move, taken as `unknown`
+  // because the only thing read off it is the marker every camera command in
+  // this file attaches — see `PROGRAMMATIC_MOVE`.
+  const emitRegion = useCallback((isFinal: boolean, event?: unknown) => {
     const map = mapRef.current;
     if (!map) return;
     const now = Date.now();
@@ -365,6 +371,7 @@ const MapComponent = React.forwardRef<MapApi, MapProps>(function Map(props, ref)
       pitch: map.getPitch(),
       bounds: boundsPayload,
       isFinal,
+      source: moveSourceOf(event),
     });
   }, []);
 
@@ -464,7 +471,9 @@ const MapComponent = React.forwardRef<MapApi, MapProps>(function Map(props, ref)
             source.getClusterExpansionZoom(clusterId).then((zoom) => {
               const geometry = feature.geometry;
               if (geometry.type === 'Point') {
-                map.easeTo({ center: toLonLat(geometry.coordinates), zoom });
+                // Expanding a cluster is a click on a cluster, not a statement
+                // about which area to search — so it must not arm the button.
+                map.easeTo({ center: toLonLat(geometry.coordinates), zoom }, PROGRAMMATIC_MOVE);
               }
             }).catch(() => {
               // Cluster expansion is best-effort; ignore lookup failures.
@@ -523,15 +532,20 @@ const MapComponent = React.forwardRef<MapApi, MapProps>(function Map(props, ref)
         }
       });
 
-      const onMove = () => emitRegion(false);
-      const onMoveEnd = () => emitRegion(true);
+      const onMove = (event: unknown) => emitRegion(false, event);
+      const onMoveEnd = (event: unknown) => emitRegion(true, event);
       (['move', 'zoom', 'rotate', 'pitch'] as const).forEach((ev) => map.on(ev, onMove));
       (['moveend', 'zoomend', 'rotateend', 'pitchend'] as const).forEach((ev) => map.on(ev, onMoveEnd));
 
       // Recompute size when the flex/grid parent resolves or resizes — the GL
       // canvas needs an explicit pixel size and the container starts at 0×0 until
       // RN-Web layout settles.
-      resizeObserver = new ResizeObserver(() => map.resize());
+      //
+      // `resize` FIRES `movestart`/`move`/`moveend`, so it must be marked like
+      // any other camera command: the first one lands as the split layout
+      // settles, which is exactly the "a programmatic initial move must not show
+      // the button" case.
+      resizeObserver = new ResizeObserver(() => map.resize(PROGRAMMATIC_MOVE));
       resizeObserver.observe(container);
     };
 
@@ -613,10 +627,10 @@ const MapComponent = React.forwardRef<MapApi, MapProps>(function Map(props, ref)
         const zoom = accuracy && accuracy > COARSE_ACCURACY_M
           ? Math.max(initialZoom, COARSE_ZOOM)
           : Math.max(initialZoom, FINE_ZOOM);
-        map.easeTo({
-          center: [loc.coords.longitude, loc.coords.latitude],
-          zoom,
-        });
+        map.easeTo(
+          { center: [loc.coords.longitude, loc.coords.latitude], zoom },
+          PROGRAMMATIC_MOVE,
+        );
         hasCenteredOnce.current = true;
       } catch {
         // Location is best-effort; the map keeps its initial camera.
@@ -631,7 +645,7 @@ const MapComponent = React.forwardRef<MapApi, MapProps>(function Map(props, ref)
   // Expose the imperative MapApi — identical to the native component.
   useImperativeHandle(ref, () => ({
     navigateToLocation: (center: LonLat, zoom: number = 15) => {
-      mapRef.current?.easeTo({ center, zoom, duration: NAVIGATE_DURATION_MS });
+      mapRef.current?.easeTo({ center, zoom, duration: NAVIGATE_DURATION_MS }, PROGRAMMATIC_MOVE);
     },
     fitBounds: (bounds, options) => {
       const map = mapRef.current;
@@ -640,17 +654,24 @@ const MapComponent = React.forwardRef<MapApi, MapProps>(function Map(props, ref)
       // the two platforms cannot drift on either the wrap or the degenerate box.
       if (isDegenerateBounds(bounds)) {
         const centre = boundsCenter(bounds);
-        map.easeTo({
-          center: [centre.longitude, centre.latitude],
-          zoom: DEGENERATE_BOUNDS_ZOOM,
-          duration: options?.duration ?? NAVIGATE_DURATION_MS,
-        });
+        map.easeTo(
+          {
+            center: [centre.longitude, centre.latitude],
+            zoom: DEGENERATE_BOUNDS_ZOOM,
+            duration: options?.duration ?? NAVIGATE_DURATION_MS,
+          },
+          PROGRAMMATIC_MOVE,
+        );
         return;
       }
-      map.fitBounds(toCameraBounds(bounds), {
-        padding: options?.padding ?? FIT_BOUNDS_PADDING,
-        duration: options?.duration ?? NAVIGATE_DURATION_MS,
-      });
+      map.fitBounds(
+        toCameraBounds(bounds),
+        {
+          padding: options?.padding ?? FIT_BOUNDS_PADDING,
+          duration: options?.duration ?? NAVIGATE_DURATION_MS,
+        },
+        PROGRAMMATIC_MOVE,
+      );
     },
     highlightMarker: (id: string | null) => {
       const pillMarkers = pillMarkersRef.current;

--- a/packages/frontend/components/mapDocument.ts
+++ b/packages/frontend/components/mapDocument.ts
@@ -120,6 +120,8 @@ const buildScript = (options: MapDocumentOptions): string => {
   }))});
 
   const srcId='markers';
+  // Mirrors mapTypes.PROGRAMMATIC_MOVE. See the note in emit() below.
+  const PROGRAMMATIC_MOVE = { homiioProgrammatic: true };
   const cluster=${String(cluster.enabled)}, cRad=${cluster.radius}, cMax=${cluster.maxZoom};
   const cColor=${JSON.stringify(cluster.color)}, cText=${JSON.stringify(cluster.textColor)};
   let highlightedFeatureId = null;
@@ -197,7 +199,7 @@ const buildScript = (options: MapDocumentOptions): string => {
       const features = map.queryRenderedFeatures(e.point, { layers: ['clusters'] });
       if (!features.length) return;
       const clusterId = features[0].properties.cluster_id;
-      map.getSource(srcId).getClusterExpansionZoom(clusterId).then((z)=>{ map.easeTo({center: features[0].geometry.coordinates, zoom:z}); }).catch(()=>{});
+      map.getSource(srcId).getClusterExpansionZoom(clusterId).then((z)=>{ map.easeTo({center: features[0].geometry.coordinates, zoom:z}, PROGRAMMATIC_MOVE); }).catch(()=>{});
     });
 
     map.on('mouseenter', 'clusters', () => { map.getCanvas().style.cursor = 'pointer'; });
@@ -225,27 +227,33 @@ const buildScript = (options: MapDocumentOptions): string => {
   });
 
   let last = 0;
-  const emit = (force=false) => {
+  const emit = (force, ev) => {
     const now = Date.now();
     if (!force && now - last < 100) return;
     last = now;
     const c = map.getCenter();
     const b = map.getBounds();
     const boundsPayload = { west: b.getWest(), south: b.getSouth(), east: b.getEast(), north: b.getNorth() };
-    post({ type:'region', center:[c.lng,c.lat], zoom: map.getZoom(), bearing: map.getBearing(), pitch: map.getPitch(), bounds: boundsPayload, isFinal: force });
+    // Every camera command this document issues carries PROGRAMMATIC_MOVE, and
+    // maplibre merges that object into the events it fires for the command. So
+    // an unmarked event is a gesture. The key must stay identical to
+    // mapTypes.PROGRAMMATIC_MOVE - the host cannot import into this template
+    // literal, so the agreement is pinned by a test that reads this string.
+    const source = (ev && ev.homiioProgrammatic === true) ? 'programmatic' : 'user';
+    post({ type:'region', center:[c.lng,c.lat], zoom: map.getZoom(), bearing: map.getBearing(), pitch: map.getPitch(), bounds: boundsPayload, isFinal: force, source: source });
   };
 
-  ['move','zoom','rotate','pitch'].forEach(ev => map.on(ev, () => { emit(false); }));
-  ['moveend','zoomend','rotateend','pitchend'].forEach(ev => map.on(ev, () => { emit(true); }));
+  ['move','zoom','rotate','pitch'].forEach(ev => map.on(ev, (e) => { emit(false, e); }));
+  ['moveend','zoomend','rotateend','pitchend'].forEach(ev => map.on(ev, (e) => { emit(true, e); }));
 
   const handle=(raw)=>{ try{
     const m = JSON.parse(raw.data || raw);
     if(!m || typeof m !== 'object') return;
     if(m.type==='setView'){
       if (m.duration === 0) {
-        map.jumpTo({ center: m.center, zoom: m.zoom });
+        map.jumpTo({ center: m.center, zoom: m.zoom }, PROGRAMMATIC_MOVE);
       } else {
-        map.easeTo({ center: m.center, zoom: m.zoom, duration: m.duration || 500 });
+        map.easeTo({ center: m.center, zoom: m.zoom, duration: m.duration || 500 }, PROGRAMMATIC_MOVE);
       }
     }
     if(m.type==='fitBounds'){
@@ -257,7 +265,7 @@ const buildScript = (options: MapDocumentOptions): string => {
       map.fitBounds(m.bounds, {
         padding: typeof m.padding === 'number' ? m.padding : 48,
         duration: typeof m.duration === 'number' ? m.duration : 500,
-      });
+      }, PROGRAMMATIC_MOVE);
     }
     if(m.type==='setData'){
       const s = map.getSource(srcId);

--- a/packages/frontend/components/mapTypes.ts
+++ b/packages/frontend/components/mapTypes.ts
@@ -24,6 +24,35 @@ export type LonLat = [number, number];
  */
 export type { GeocodedAddress } from '@homiio/shared-types';
 
+/**
+ * Who moved the camera.
+ *
+ * The distinction has to travel WITH the event because nothing downstream can
+ * recover it: a viewport that arrived because the app framed a city and one the
+ * user dragged there are the same four numbers. Without it, opening a search
+ * arms "Search this area" against the area the search is already showing — the
+ * button appears, unprompted, over results that already answer it.
+ */
+export type MapMoveSource = 'user' | 'programmatic';
+
+/**
+ * The marker every camera COMMAND carries, merged into the events MapLibre
+ * fires for it (`easeTo`/`fitBounds`/`jumpTo`/`resize` all take `eventData`).
+ *
+ * Marking the commands rather than sniffing for a DOM `originalEvent` is the
+ * safer direction of failure: an unmarked command reads as a user gesture, so a
+ * camera call somebody forgets to mark shows a button that need not be there,
+ * while the alternative — treating anything unrecognised as programmatic —
+ * hides the button for good and looks like the feature was never built.
+ */
+export const PROGRAMMATIC_MOVE = { homiioProgrammatic: true } as const;
+
+/** Read {@link PROGRAMMATIC_MOVE} back off an event of unknown shape. */
+export function moveSourceOf(event: unknown): MapMoveSource {
+  const marked = event as { homiioProgrammatic?: unknown } | null | undefined;
+  return marked?.homiioProgrammatic === true ? 'programmatic' : 'user';
+}
+
 /** A clustered marker leaf as emitted by the document (GeoJSON-style feature). */
 export interface ClusterLeaf {
   geometry?: { type: 'Point'; coordinates: LonLat };
@@ -52,6 +81,11 @@ export type MapEvent =
       pitch: number;
       bounds: { west: number; south: number; east: number; north: number };
       isFinal?: boolean; // true when a move/zoom gesture ends
+      /**
+       * Whether a person moved the camera or the app did. Required, so a new
+       * map adapter cannot omit it and leave every consumer guessing.
+       */
+      source: MapMoveSource;
     };
 
 /** Commands the host sends down into the embedded document. */

--- a/packages/frontend/components/search/SearchResultsView.tsx
+++ b/packages/frontend/components/search/SearchResultsView.tsx
@@ -49,17 +49,22 @@ import { useIsScreenNotMobile } from '@/hooks/useOptimizedMediaQuery';
 import { usePropertySearch } from '@/hooks/usePropertySearch';
 import { colors } from '@/styles/colors';
 import { cardShadow, hairline, radius, spacing } from '@/constants/styles';
-import { OfferingType, PropertyType, boundsCenter, formatMoney } from '@homiio/shared-types';
+import { PropertyType, boundsCenter } from '@homiio/shared-types';
 import type { GeoBounds, LocationSelection, Property } from '@homiio/shared-types';
-import { resolvePrimaryOffering, toPriceDescriptor } from '@/utils/propertyUtils';
-import { useFormatting, type Formatting } from '@/utils/format';
-import { browseModeFromOffering, savedSearchName } from './types';
+import { useFormatting } from '@/utils/format';
+import { locationDisplayLabel, savedSearchName } from './types';
 
 import { SearchActionPill } from './SearchActionPill';
 import { SearchSummaryBar } from './SearchSummaryBar';
 import { resolveSortLabel, SortControl } from './SortControl';
+import { committedScopeBounds, reduceMapMovement, type MapMovement } from './searchArea';
+import { toMarkers } from './searchMarkers';
 import type { SearchQuery, SearchSortBy, SearchSortOrder } from './types';
-import { mapBoundsSelection, type SearchFilterPatch } from '@/store/searchQueryStore';
+import {
+  mapBoundsSelection,
+  useSearchQueryStore,
+  type SearchFilterPatch,
+} from '@/store/searchQueryStore';
 
 /** Default zoom applied when no location bbox is known. */
 const DEFAULT_MAP_ZOOM = 12;
@@ -70,54 +75,6 @@ const SKELETON_COUNT = 6;
  * the first-load count since it's just a hint that more rows are arriving.
  */
 const NEXT_PAGE_SKELETON_COUNT = 2;
-
-/**
- * Build map markers ([lng, lat] pins) from a property list.
- *
- * The pin label used to be `€${Math.round(amount).toLocaleString()}` — a euro
- * sign on every marker in the catalogue, whatever the listing was priced in, and
- * grouped in the DEVICE's locale rather than the reader's. It now goes through
- * the shared formatter, so a Polish listing shows złoty and a Romanian one lei.
- *
- * Markers stay whole-unit (`maximumFractionDigits: 0`): a pin is a few
- * characters wide and `1.234,56 €` does not fit in one.
- */
-function toMarkers(
-  properties: readonly Property[],
-  offering: OfferingType,
-  formatting: Formatting,
-): { id: string; coordinates: [number, number]; priceLabel: string }[] {
-  const browseMode = browseModeFromOffering(offering);
-  return properties
-    .map((p) => {
-      const coords = p.address?.coordinates?.coordinates ?? p.location?.coordinates;
-      if (
-        !coords ||
-        coords.length !== 2 ||
-        typeof coords[0] !== 'number' ||
-        typeof coords[1] !== 'number'
-      ) {
-        return null;
-      }
-      // Price the pin off the ACTIVE offering's block (monthly / nightly / sale).
-      const primary = resolvePrimaryOffering(p, browseMode);
-      const price = toPriceDescriptor(primary);
-      const priceLabel = price
-        ? formatMoney(price.amount, price.currency, formatting.locale, {
-            maximumFractionDigits: 0,
-          })
-        : primary.label;
-      return {
-        id: p.id,
-        coordinates: [coords[0], coords[1]] as [number, number],
-        priceLabel,
-      };
-    })
-    .filter(
-      (m): m is { id: string; coordinates: [number, number]; priceLabel: string } =>
-        m !== null,
-    );
-}
 
 /**
  * The centre of a declared box, as the map's `[lng, lat]` pair.
@@ -207,12 +164,54 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
 
   const mapRef = useRef<MapApi>(null);
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
-  const [pendingBounds, setPendingBounds] = useState<GeoBounds | null>(null);
   const [showMobileMap, setShowMobileMap] = useState(false);
 
+  /**
+   * The pending viewport lives in the STORE, not in this component.
+   *
+   * That is what makes "a box over a map the user has since navigated away
+   * from can never be committed" structural: every action that changes the
+   * committed selection — a place picked in the panel, a saved search applied,
+   * a URL arriving with a different `loc` — clears it in the same `set` call.
+   * Held here instead, it would survive all three and could be confirmed
+   * afterwards, applying a viewport from a search the user has left.
+   *
+   * Committing still goes through {@link SearchResultsViewProps.onCommitLocation}
+   * rather than the store's own `commitPendingViewport`, because the URL is the
+   * authority and only the route screen writes it (ADR 0002 §6.1).
+   */
+  const pendingViewport = useSearchQueryStore((s) => s.pendingViewport);
+  /**
+   * The viewport the app itself last framed.
+   *
+   * STATE rather than a ref, and the difference is not stylistic: the "back to
+   * the searched area" action is only offered when there is somewhere to go
+   * back TO, so the answer is read during render, and a ref read during render
+   * does not re-render when it changes — the action would appear one render
+   * late, or not at all.
+   *
+   * It changes only on a finished PROGRAMMATIC movement (an opening frame, a
+   * return, a re-frame after a new area is confirmed), so the re-render is
+   * rare. It also cannot reload the map: the WebView document and the MapLibre
+   * instance are both built once and fed through refs, so a re-render of this
+   * component reaches neither.
+   */
+  const [anchor, setAnchor] = useState<GeoBounds | null>(null);
+
   const search = usePropertySearch(query);
-  const { properties, total, isLoading, isError, error, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
-    search;
+  const {
+    properties,
+    total,
+    isLoading,
+    isError,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+    queryId,
+    appliedLocation,
+  } = search;
 
   const { searchExists } = useSavedSearches();
 
@@ -344,13 +343,67 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
     mapRef.current?.highlightMarker(highlightedId);
   }, [highlightedId]);
 
+  /**
+   * Fold a map movement into the camera state.
+   *
+   * The decision itself is in `searchArea.reduceMapMovement`, which is pure and
+   * shared by both map adapters. This callback only routes the two halves of
+   * the result to where each belongs.
+   *
+   * The pending viewport is read through `getState()` rather than from the
+   * subscribed value, so this callback's identity does not change on every pan
+   * — `onRegionChange` is compared by the map's memo, and a new function on
+   * each pan would re-render it constantly.
+   */
   const handleRegionChange = useCallback(
-    ({ bounds, isFinal }: { bounds: GeoBounds; isFinal?: boolean }) => {
-      if (!bounds || !isFinal) return;
-      setPendingBounds(bounds);
+    (movement: MapMovement) => {
+      const previous = { anchor, pending: useSearchQueryStore.getState().pendingViewport };
+      const next = reduceMapMovement(previous, movement);
+      if (next === previous) return;
+      setAnchor(next.anchor);
+      if (next.pending !== previous.pending) {
+        useSearchQueryStore.getState().setPendingViewport(next.pending);
+      }
+    },
+    [anchor],
+  );
+
+  /**
+   * Leaving the screen discards the pending viewport.
+   *
+   * The store outlives this component, so without this a box the user drifted
+   * to, walked away from and never confirmed is still pending when they come
+   * back — and "Search this area" is offered on arrival, over an area they have
+   * no memory of choosing. #354 lists abandoning the screen as a discard
+   * trigger for exactly that reason.
+   *
+   * An effect is right here: it updates an EXTERNAL store on unmount, which is
+   * the case effects are for, and the empty dependency list is accurate — the
+   * cleanup reads the store through `getState()` rather than closing over it.
+   */
+  useEffect(
+    () => () => {
+      useSearchQueryStore.getState().setPendingViewport(null);
     },
     [],
   );
+
+  /**
+   * Take the map back to the area the results actually describe.
+   *
+   * The anchor is preferred over the selection's own box because it is the
+   * viewport the app really framed — padding and zoom snapping included — so
+   * returning to it lands exactly where the search opened. On a cold load
+   * nothing has been framed yet and the selection's declared extent is the
+   * honest fallback. The resulting camera move is programmatic, so the reducer
+   * clears the pending viewport when it arrives; clearing it here as well would
+   * make the button flicker back if the frame is refused.
+   */
+  const returnBounds = anchor ?? committedScopeBounds(query.location);
+  const handleReturnToSearchedArea = useCallback(() => {
+    if (!returnBounds) return;
+    mapRef.current?.fitBounds(returnBounds);
+  }, [returnBounds]);
 
   /**
    * "Search this area" — ONE state transition, replacing the geographic scope
@@ -371,10 +424,9 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
    * retract what they typed.
    */
   const handleSearchThisArea = useCallback(() => {
-    if (!pendingBounds) return;
-    onCommitLocation(mapBoundsSelection(pendingBounds));
-    setPendingBounds(null);
-  }, [pendingBounds, onCommitLocation]);
+    if (!pendingViewport) return;
+    onCommitLocation(mapBoundsSelection(pendingViewport));
+  }, [pendingViewport, onCommitLocation]);
 
   const handleSortPress = useCallback(() => {
     bottomSheet.openBottomSheet(
@@ -510,9 +562,27 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
     enabled: hasNextPage,
   });
 
+  /**
+   * The heading describes the COMMITTED query, never the pending viewport.
+   *
+   * It reads `total`, which comes from the same page as `properties` and the
+   * markers, so the count cannot belong to a different search than the rows
+   * beneath it — and a page stamped with another query's id never arrives at
+   * all (`StaleSearchResponseError`).
+   *
+   * The `unresolved` branch is the one that costs nothing and matters most:
+   * "we could not find that place" and "there are no homes here" are the same
+   * empty list on the wire, and only the server's echo separates them.
+   */
   const resultsHeading = useMemo(() => {
     if (isLoading) {
       return t('search.header.loading', 'Searching properties...') || 'Searching properties...';
+    }
+    if (appliedLocation?.status === 'unresolved') {
+      return (
+        t('search.header.unresolvedLocation', 'We could not find that place') ||
+        'We could not find that place'
+      );
     }
     if (total === 0) {
       return t('search.header.noResults', 'No properties match this search') ||
@@ -521,7 +591,34 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
     // Pass `count` as interpolation options so i18next selects the pluralized
     // `search.header.count_one`/`_other` variant and fills `{{count}}`.
     return t('search.header.count', { count: total }) || `${total} properties`;
-  }, [t, isLoading, total]);
+  }, [t, isLoading, total, appliedLocation?.status]);
+
+  /**
+   * What the map is showing that the results are not.
+   *
+   * Shown only while a viewport is pending, and it names the scope the results
+   * DO describe — "Still showing results for Barcelona" as the user drifts over
+   * Madrid. Without it the two disagree in silence, which is the whole defect
+   * this screen exists to close.
+   */
+  const stillShowingLabel = useMemo(
+    () =>
+      t('search.area.stillShowing', {
+        place: locationDisplayLabel(query.location, t),
+        defaultValue: 'Still showing results for {{place}}',
+      }) || 'Still showing these results',
+    [t, query.location],
+  );
+
+  /**
+   * How many loaded results the map cannot draw.
+   *
+   * Said out loud rather than left as a discrepancy. Without it the map shows
+   * fewer homes than the heading counts and the gap reads as a map that has not
+   * finished loading — the same "looks like it is still working" failure as a
+   * place with no geometry framing nothing.
+   */
+  const unmappableCount = properties.length - markers.length;
 
   // --- shared sub-renders ---
   // The route wraps this screen in a plain View (no SafeAreaView) and the
@@ -640,14 +737,33 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
 
   const listScroll = (
     <ScrollView
+      // The list and the map below carry the SAME query id, which is what makes
+      // "these two surfaces are showing one search" observable in the rendered
+      // tree rather than merely asserted in a comment. Both come from one
+      // `usePropertySearch` call, so they cannot drift — the ids are how a
+      // browser-level check, or a person with the inspector open, can see that.
+      nativeID={`search-list-${queryId}`}
       style={styles.listScroll}
       contentContainerStyle={styles.listScrollContent}
       onScroll={handleListScroll}
       scrollEventThrottle={16}
       showsVerticalScrollIndicator={false}
     >
-      <View style={styles.resultsHeader}>
+      {/* `accessibilityLiveRegion` is what announces a result set changing
+          under a screen reader: committing a new area replaces the heading and
+          the count in place, with no navigation and nothing focused, so
+          without it the change is silent. RN-Web maps it to `aria-live`. */}
+      <View
+        style={styles.resultsHeader}
+        accessibilityLiveRegion="polite"
+        accessibilityRole="header"
+      >
         <BloomText style={styles.resultsTitle}>{resultsHeading}</BloomText>
+        {unmappableCount > 0 ? (
+          <BloomText style={styles.resultsNote}>
+            {t('search.header.withoutMapLocation', { count: unmappableCount })}
+          </BloomText>
+        ) : null}
       </View>
       {listBody()}
       {isFetchingNextPage ? (
@@ -661,7 +777,7 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
   );
 
   const mapPanel = (
-    <View style={styles.mapPanel}>
+    <View style={styles.mapPanel} nativeID={`search-map-${queryId}`}>
       <MapView
         ref={mapRef}
         style={styles.mapFill}
@@ -673,9 +789,13 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
         onRegionChange={handleRegionChange}
         onMarkerPress={handleMarkerPress}
       />
-      {pendingBounds ? (
+      {pendingViewport ? (
+        // `pointerEvents: 'none'` on the strip and `'auto'` on each control is
+        // the sanctioned split: `box-none` in a STYLE is silently dropped by
+        // RN-Web, leaving a transparent full-width overlay that swallows every
+        // drag and hover on the map beneath it.
         <View style={styles.searchAreaWrap}>
-          <View style={[styles.searchAreaButton, cardShadow.md]}>
+          <View style={[styles.searchAreaButton, cardShadow.md, styles.interactive]}>
             <Button
               onPress={handleSearchThisArea}
               variant="primary"
@@ -688,6 +808,26 @@ export const SearchResultsView: React.FC<SearchResultsViewProps> = ({
             >
               {t('search.actions.searchArea', 'Search this area') || 'Search this area'}
             </Button>
+          </View>
+          <View
+            style={[styles.pendingNotice, cardShadow.md, styles.interactive]}
+            accessibilityLiveRegion="polite"
+          >
+            <BloomText style={styles.pendingNoticeText}>{stillShowingLabel}</BloomText>
+            {returnBounds ? (
+              <Button
+                onPress={handleReturnToSearchedArea}
+                variant="secondary"
+                size="small"
+                accessibilityLabel={
+                  t('search.actions.backToSearchedArea', 'Back to searched area') ||
+                  'Back to searched area'
+                }
+              >
+                {t('search.actions.backToSearchedArea', 'Back to searched area') ||
+                  'Back to searched area'}
+              </Button>
+            ) : null}
           </View>
         </View>
       ) : null}
@@ -885,6 +1025,11 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: colors.COLOR_BLACK,
   },
+  resultsNote: {
+    marginTop: spacing.xs,
+    fontSize: 13,
+    color: colors.COLOR_BLACK_LIGHT_4,
+  },
   // Grid gutter aligned to the header gutter and every other property-grid
   // screen (`spacing.lg`) for a clean, consistent left edge across the app.
   gridPadding: {
@@ -904,11 +1049,33 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     alignItems: 'center',
+    gap: spacing.sm,
+    // Valid CSS, unlike `box-none`. The children below re-enable themselves.
+    pointerEvents: 'none',
   },
   searchAreaButton: {
     backgroundColor: colors.surfaceElevated,
     borderRadius: radius.pill,
     overflow: 'hidden',
+  },
+  /** A child `auto` inside a parent `none` IS hittable — that is the split. */
+  interactive: {
+    pointerEvents: 'auto',
+  },
+  pendingNotice: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    maxWidth: 420,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    backgroundColor: colors.surfaceElevated,
+    borderRadius: radius.pill,
+  },
+  pendingNoticeText: {
+    flexShrink: 1,
+    fontSize: 13,
+    color: colors.COLOR_BLACK,
   },
   popoverWrap: {
     position: 'absolute',

--- a/packages/frontend/components/search/searchArea.ts
+++ b/packages/frontend/components/search/searchArea.ts
@@ -1,0 +1,202 @@
+/**
+ * "Search this area" — when the button is armed, and by whom.
+ *
+ * ## Why this is a pure reducer and not four lines inside the results view
+ *
+ * The rule has to hold on two map adapters (a MapLibre instance on web, a
+ * WebView document on native) and it is decided from data neither of them can
+ * be asked about afterwards: a viewport that arrived because the app framed a
+ * city and one the user dragged there are the same four numbers. The decision
+ * is therefore taken once, here, from the movement's own {@link MapMoveSource},
+ * and both adapters feed it the same event shape.
+ *
+ * It is also the only place the three failure modes below are prevented, and
+ * none of them announces itself:
+ *
+ *  - **Opening a search arms the button.** The map frames the committed
+ *    selection on mount, that framing emits a region change, and a naive
+ *    handler records it as pending — so "Search this area" appears, unprompted,
+ *    over results that already answer it. Pressing it re-searches the same
+ *    place under a GENERATED label, silently replacing "Barcelona" with "Map
+ *    area" and losing the city id.
+ *  - **Panning back does not disarm it.** The user explores, returns to where
+ *    they started, and is still offered a button that would do nothing except
+ *    swap the place for a rectangle.
+ *  - **Sub-pixel jitter arms it.** An inertial pan settles a few metres off and
+ *    the button flickers into existence.
+ *
+ * ## The anchor is a MEASUREMENT, not the committed bounds
+ *
+ * The obvious comparison — "is the viewport the committed selection's box?" —
+ * does not work, and the reason is worth writing down because it looks like it
+ * should. `fitBounds` applies padding and snaps to a continuous zoom, so the
+ * viewport it produces is reliably LARGER than the box it was given and has the
+ * map's aspect ratio rather than the box's. Comparing against the request would
+ * therefore be false immediately after a successful frame.
+ *
+ * So the anchor is whatever viewport the app's OWN camera command actually
+ * produced, recorded from the programmatic event that reports it. "Back at the
+ * searched area" then means "back where the app put us", which is exact.
+ */
+
+import {
+  boundsSpanDegrees,
+  normalizeLongitude,
+  type GeoBounds,
+  type LocationSelection,
+} from '@homiio/shared-types';
+
+import type { MapMoveSource } from '@/components/mapTypes';
+
+/**
+ * How far a viewport may drift from the anchor and still count as the same
+ * area, as a fraction of the anchor's own span.
+ *
+ * Relative rather than absolute because a degree means something different at
+ * every zoom: 0.01° is a third of a city viewport and nothing at all on a map
+ * of Europe. Two per cent is below what a person can see and comfortably above
+ * the settle of an inertial pan.
+ */
+export const VIEWPORT_MATCH_TOLERANCE_RATIO = 0.02;
+
+/** A finalised map movement, as both adapters report it. */
+export interface MapMovement {
+  readonly bounds: GeoBounds;
+  /** Only a FINISHED gesture is a statement of intent; a stream of frames is not. */
+  readonly isFinal?: boolean;
+  readonly source: MapMoveSource;
+}
+
+/**
+ * What the results surface remembers about the camera.
+ *
+ * `anchor` is the viewport the app last framed on purpose. `pending` is a
+ * viewport the user has moved to and not confirmed — NOT part of the query, and
+ * never sent anywhere.
+ */
+export interface SearchAreaState {
+  readonly anchor: GeoBounds | null;
+  readonly pending: GeoBounds | null;
+}
+
+export const INITIAL_SEARCH_AREA_STATE: SearchAreaState = { anchor: null, pending: null };
+
+/**
+ * The shortest angular distance between two longitudes, in degrees.
+ *
+ * `Math.abs(a - b)` is wrong across the antimeridian: 179.99 and -179.99 are
+ * 0.02° apart and subtract to 359.98, so a viewport that drifted by metres
+ * would read as having moved most of the way round the planet — and the button
+ * would arm on a map nobody touched. {@link normalizeLongitude} wraps the
+ * difference into [-180, 180), which is exactly this quantity.
+ */
+function longitudeDistance(a: number, b: number): number {
+  return Math.abs(normalizeLongitude(a - b));
+}
+
+/**
+ * Whether two viewports describe the same area.
+ *
+ * All four edges must agree, each within the tolerance scaled by the REFERENCE
+ * box's span in that axis. Comparing edges rather than centres is deliberate: a
+ * pure zoom keeps the centre exactly and changes the area, which is a different
+ * question the user is entitled to ask.
+ */
+export function viewportsMatch(
+  reference: GeoBounds,
+  candidate: GeoBounds,
+  toleranceRatio: number = VIEWPORT_MATCH_TOLERANCE_RATIO,
+): boolean {
+  const span = boundsSpanDegrees(reference);
+  const lngTolerance = Math.abs(span.longitude) * toleranceRatio;
+  const latTolerance = Math.abs(span.latitude) * toleranceRatio;
+
+  // The WIDTH is checked as well as the edges, and it is not redundant with
+  // them: two boxes can have west and east edges a whisker apart and describe
+  // wildly different areas, because `west > east` means the box wraps. `west
+  // 170 → east 169.9999` is very nearly the whole planet and `west 170 → east
+  // 170.0001` is very nearly nothing. Height needs no such check — latitude
+  // does not wrap, so south and north settle it.
+  //
+  // Comparing the wrap FLAGS instead would be the intuitive guard and is wrong
+  // in the other direction: it refuses a box nudged a few metres ACROSS the
+  // antimeridian, which is the same area by any honest reading and one a user
+  // reaches by dragging.
+  if (Math.abs(span.longitude - boundsSpanDegrees(candidate).longitude) > lngTolerance) {
+    return false;
+  }
+
+  return (
+    longitudeDistance(reference.west, candidate.west) <= lngTolerance &&
+    longitudeDistance(reference.east, candidate.east) <= lngTolerance &&
+    Math.abs(reference.south - candidate.south) <= latTolerance &&
+    Math.abs(reference.north - candidate.north) <= latTolerance
+  );
+}
+
+/**
+ * Fold a map movement into the camera state.
+ *
+ * Four rules, in the order they are decided:
+ *
+ * 1. **A movement that is not final changes nothing.** Streaming frames while a
+ *    finger is down are not a statement about where to search.
+ * 2. **A programmatic movement becomes the anchor and clears any pending
+ *    viewport.** The app just framed something on purpose — an opening frame, a
+ *    "back to the searched area", a camera restored on return from a detail
+ *    screen — and whatever the user had wandered to before that is gone.
+ * 3. **A user movement that lands back on the anchor clears the pending
+ *    viewport.** Returning to where you started is not a new area to search.
+ * 4. **Any other user movement becomes the pending viewport.** Which changes no
+ *    results, no request and no URL until it is confirmed.
+ */
+export function reduceMapMovement(
+  state: SearchAreaState,
+  movement: MapMovement,
+): SearchAreaState {
+  if (!movement.isFinal) return state;
+
+  if (movement.source === 'programmatic') {
+    if (state.anchor && state.pending === null && viewportsMatch(state.anchor, movement.bounds)) {
+      // Identical anchor, nothing pending: return the SAME object so a caller
+      // writing this into React or Zustand state does not re-render on a resize
+      // that moved nothing.
+      return state;
+    }
+    return { anchor: movement.bounds, pending: null };
+  }
+
+  // No anchor yet means the app has never framed anything — a map that opened
+  // on its own default. A user gesture there is still a real intent to search
+  // somewhere else, so it arms.
+  if (state.anchor && viewportsMatch(state.anchor, movement.bounds)) {
+    return state.pending === null ? state : { ...state, pending: null };
+  }
+  return { ...state, pending: movement.bounds };
+}
+
+/**
+ * The box the committed selection frames, or `null` when it declares none.
+ *
+ * Used for "take me back to the area I searched" when the app has no anchor yet
+ * — on a cold load the committed box is the best available answer, and it is
+ * the same value the opening frame would have used.
+ */
+export function committedScopeBounds(selection: LocationSelection | null): GeoBounds | null {
+  if (!selection) return null;
+  switch (selection.kind) {
+    case 'map_bounds':
+    case 'polygon':
+      return selection.bounds;
+    case 'place':
+    case 'address_candidate':
+      return selection.bounds ?? null;
+    case 'current_location':
+    case 'multi_area':
+      return null;
+    default: {
+      const exhaustive: never = selection;
+      return exhaustive;
+    }
+  }
+}

--- a/packages/frontend/components/search/searchMarkers.ts
+++ b/packages/frontend/components/search/searchMarkers.ts
@@ -1,0 +1,75 @@
+/**
+ * Map pins for a result set — the projection, and nothing else.
+ *
+ * Its own module rather than a helper inside `SearchResultsView` for two
+ * reasons, and the second is the one that matters: the results view imports the
+ * map component, which imports `react-native-webview`, which needs a native
+ * module no test environment has. A pure rule that cannot be unit-tested is a
+ * pure rule nobody checks.
+ */
+import { formatMoney, type OfferingType, type Property } from '@homiio/shared-types';
+
+import { resolvePrimaryOffering, toPriceDescriptor } from '@/utils/propertyUtils';
+import type { Formatting } from '@/utils/format';
+import { browseModeFromOffering } from './types';
+
+/** A price pin: where it goes, and what it says. */
+export interface MapMarker {
+  id: string;
+  coordinates: [number, number];
+  priceLabel: string;
+}
+
+/**
+ * Build map markers ([lng, lat] pins) from a property list.
+ *
+ * The pin label used to be `€${Math.round(amount).toLocaleString()}` — a euro
+ * sign on every marker in the catalogue, whatever the listing was priced in, and
+ * grouped in the DEVICE's locale rather than the reader's. It now goes through
+ * the shared formatter, so a Polish listing shows złoty and a Romanian one lei.
+ *
+ * Markers stay whole-unit (`maximumFractionDigits: 0`): a pin is a few
+ * characters wide and `1.234,56 €` does not fit in one.
+ *
+ * ## The marker set is a SUBSET of the card set, and the screen says so
+ *
+ * A listing whose address carries no coordinates cannot be drawn, so it is
+ * dropped here and kept in the list — the right call, because it is a real
+ * home somebody can rent. What is NOT acceptable is doing it silently: the map
+ * then shows fewer homes than the heading counts, which reads as a map that has
+ * not finished loading. The caller renders the difference (see
+ * `unmappableCount`). Exported so the subset property has a test of its own.
+ */
+export function toMarkers(
+  properties: readonly Property[],
+  offering: OfferingType,
+  formatting: Formatting,
+): MapMarker[] {
+  const browseMode = browseModeFromOffering(offering);
+  return properties
+    .map((p) => {
+      const coords = p.address?.coordinates?.coordinates ?? p.location?.coordinates;
+      if (
+        !coords ||
+        coords.length !== 2 ||
+        typeof coords[0] !== 'number' ||
+        typeof coords[1] !== 'number'
+      ) {
+        return null;
+      }
+      // Price the pin off the ACTIVE offering's block (monthly / nightly / sale).
+      const primary = resolvePrimaryOffering(p, browseMode);
+      const price = toPriceDescriptor(primary);
+      const priceLabel = price
+        ? formatMoney(price.amount, price.currency, formatting.locale, {
+            maximumFractionDigits: 0,
+          })
+        : primary.label;
+      return {
+        id: p.id,
+        coordinates: [coords[0], coords[1]] as [number, number],
+        priceLabel,
+      };
+    })
+    .filter((marker): marker is MapMarker => marker !== null);
+}

--- a/packages/frontend/hooks/usePropertySearch.ts
+++ b/packages/frontend/hooks/usePropertySearch.ts
@@ -22,11 +22,14 @@ import { type InfiniteData, type UseInfiniteQueryResult } from '@tanstack/react-
 import { useMemo } from 'react';
 import {
   OfferingType,
+  deriveQueryId,
   locationKey,
   type GeoBounds,
   type GeoPoint,
+  type LocationKind,
   type LocationSelection,
   type Property,
+  type QueryDescriptor,
   type SingleLocationSelection,
 } from '@homiio/shared-types';
 import type { SearchQuery } from '@/components/search/types';
@@ -37,6 +40,25 @@ import {
 
 /** Endpoint path for the public property search. */
 const SEARCH_ENDPOINT = '/api/properties/search';
+
+/**
+ * What the server says it actually applied (ADR 0002 §6.3).
+ *
+ * Read rather than re-derived: the client's belief about the request it sent is
+ * the one thing that cannot arbitrate "map in Madrid, list from Barcelona".
+ */
+export interface SearchLocationEcho {
+  status: 'resolved' | 'unresolved' | 'none';
+  /** The coarse scope the query really ran under. Absent on an older server. */
+  appliedLocationKind?: LocationKind;
+  cityId?: string;
+  regionId?: string;
+  neighborhoodId?: string;
+  bounds?: GeoBounds;
+  center?: GeoPoint;
+  radiusMeters?: number;
+  requested?: { param: string; value: string };
+}
 
 /**
  * Raw search response envelope. The backend returns both the nested
@@ -50,6 +72,9 @@ interface SearchResponse {
   limit: number;
   totalPages: number;
   hasMore: boolean;
+  /** The `queryId` this request carried, echoed verbatim. */
+  queryId?: string;
+  location?: SearchLocationEcho;
 }
 
 /** One page of results plus paging metadata used by `getNextPageParam`. */
@@ -59,6 +84,29 @@ export interface PropertySearchPage {
   totalPages: number;
   total: number;
   hasMore: boolean;
+  /** The identity this page belongs to, as the SERVER echoed it. */
+  queryId: string | null;
+  /** The scope the server applied for this page, or `null` when it said nothing. */
+  location: SearchLocationEcho | null;
+}
+
+/**
+ * A page that came back stamped with a different query's identity.
+ *
+ * Thrown rather than rendered, which is the whole point: the alternative is
+ * showing one query's rows under another query's heading and count, and that
+ * failure looks exactly like a correct result. React Query turns it into the
+ * error state, which already carries a retry and keeps the previous map and
+ * filters (ADR 0002 §6.3, invariant 5 of #354).
+ */
+export class StaleSearchResponseError extends Error {
+  constructor(
+    readonly expected: string,
+    readonly received: string,
+  ) {
+    super(`Search response belongs to query ${received}, not ${expected}`);
+    this.name = 'StaleSearchResponseError';
+  }
 }
 
 /**
@@ -339,6 +387,126 @@ export function isUnscopeableLocation(location: SearchQuery['location']): boolea
 }
 
 /**
+ * The COARSE scope label a query id is stamped with.
+ *
+ * Coarse is the right word and the reason it is safe: identity comes from
+ * `placeKey`, which is `locationKey` and therefore carries the canonical id, so
+ * two places that share a label here still produce different ids. A `district`
+ * and a `postcode` both reporting `neighborhood` merges nothing; it only means
+ * the vocabulary the observability schema publishes (`LOCATION_KINDS`) has no
+ * finer word, and inventing one here would put a second vocabulary in the repo.
+ */
+function descriptorLocationKind(selection: LocationSelection | null): LocationKind {
+  if (!selection) return 'none';
+  switch (selection.kind) {
+    case 'current_location':
+      return 'radius';
+    case 'map_bounds':
+    case 'polygon':
+      return 'bbox';
+    // A multi-area selection goes out as the box that COVERS its areas (see
+    // `locationParams`), so `bbox` is what the request actually applied rather
+    // than a compromise.
+    case 'multi_area':
+      return 'bbox';
+    case 'address_candidate':
+      return 'neighborhood';
+    case 'place':
+      switch (selection.placeType) {
+        case 'country':
+          return 'country';
+        case 'region':
+          return 'region';
+        case 'city':
+          return 'city';
+        case 'district':
+        case 'neighborhood':
+        case 'postcode':
+          return 'neighborhood';
+        default: {
+          const exhaustive: never = selection.placeType;
+          return exhaustive;
+        }
+      }
+    default: {
+      const exhaustive: never = selection;
+      return exhaustive;
+    }
+  }
+}
+
+/** Read a numeric param back out of the built params, or `undefined`. */
+function numericParam(
+  params: Record<string, string | number>,
+  key: string,
+): number | undefined {
+  const value = params[key];
+  return typeof value === 'number' ? value : undefined;
+}
+
+/**
+ * The descriptor a query's id is the digest of.
+ *
+ * ## It is built FROM the request params, not beside them
+ *
+ * `filters` is the same `rest` object the cache key uses — everything
+ * `buildSearchParams` emitted minus paging and the geographic dimension — so a
+ * new filter cannot be added to the request and forgotten here. A descriptor
+ * assembled field-by-field would need editing every time a filter lands, and
+ * the failure of forgetting is silent: two different searches would share one
+ * id, one cache entry and one heading.
+ *
+ * ## NO COORDINATE EVER ENTERS IT
+ *
+ * `bounds` is a map viewport, which is not anybody's position. Everything else
+ * geographic reaches the descriptor as `placeKey` (a canonical id) or as
+ * `radiusKm` (a distance). In particular `current_location` contributes its
+ * RADIUS and nothing else, exactly as `locationKey` does — the device fix goes
+ * in the request and reaches no key, no id, no URL and no log (ADR 0002 §8.2).
+ *
+ * The inherited consequence, stated because it is real: two device searches at
+ * the same radius from positions 50 km apart produce one id and therefore one
+ * cache entry. That is `locationKey`'s existing behaviour, decided by the ADR
+ * rather than by this function.
+ */
+export function searchQueryDescriptor(query: SearchQuery): QueryDescriptor {
+  const params = buildSearchParams(query);
+  const west = numericParam(params, 'swLng');
+  const south = numericParam(params, 'swLat');
+  const east = numericParam(params, 'neLng');
+  const north = numericParam(params, 'neLat');
+  const bounds =
+    west !== undefined && south !== undefined && east !== undefined && north !== undefined
+      ? { west, south, east, north }
+      : undefined;
+  const radiusMeters = numericParam(params, 'radius');
+
+  return {
+    locationKind: descriptorLocationKind(query.location),
+    placeKey: locationKey(query.location),
+    ...(bounds ? { bounds } : {}),
+    ...(radiusMeters === undefined ? {} : { radiusKm: radiusMeters / 1000 }),
+    ...(query.queryText ? { freeText: query.queryText } : {}),
+    sort: `${query.sortBy}:${query.sortOrder}`,
+    filters: identifyingParams(params),
+  };
+}
+
+/**
+ * The ONE identity the map, the list, the heading, the count, the cache key and
+ * the server's echo all quote.
+ *
+ * It is `deriveQueryId` from the observability contract rather than a second
+ * hash of this module's own, because the analytics events #350 defines already
+ * carry a `queryId` on exactly this shape (`schema.ts`, `opaqueId`). Two
+ * derivations would guarantee that a divergence report and the UI disagree
+ * about which search they are describing.
+ */
+export function searchQueryId(query: SearchQuery): string {
+  return deriveQueryId(searchQueryDescriptor(query));
+}
+
+/**
  * Stable query key for the active search.
  *
  * Excludes `page`/`limit` (the infinite query owns paging) so all pages of one
@@ -360,15 +528,22 @@ export function isUnscopeableLocation(location: SearchQuery['location']): boolea
  * `locationKey` gives distinct ids distinct keys and grids a box to 3 dp.
  */
 export function searchQueryKey(query: SearchQuery): readonly unknown[] {
-  return buildSearchQueryKey(buildSearchParams(query), query.location);
+  return buildSearchQueryKey(buildSearchParams(query), query.location, searchQueryId(query));
 }
 
-/** Shared by {@link searchQueryKey} and the hook, so the two cannot drift. */
-function buildSearchQueryKey(
+/**
+ * Everything a request carries that is neither paging nor geography.
+ *
+ * Shared by the cache key and {@link searchQueryDescriptor} so the identity and
+ * the key cannot disagree about which dimensions matter, and so a filter added
+ * to `buildSearchParams` reaches both without being named twice.
+ */
+function identifyingParams(
   params: Record<string, string | number>,
-  location: SearchQuery['location'],
-): readonly unknown[] {
+): Record<string, string | number> {
   const {
+    // Paging is the infinite query's own business: all pages of one search
+    // share a cache entry.
     page: _page,
     limit: _limit,
     // Every geographic param is replaced by `locationKey`. Dropping them here
@@ -383,9 +558,31 @@ function buildSearchQueryKey(
     neLng: _neLng,
     city: _city,
     state: _state,
+    // `neighborhood` is a canonical id rather than a coordinate, so it leaks
+    // nothing — but it IS the geographic dimension, and `locationKey` already
+    // carries it as `homiio:neighborhood:<id>`. Leaving it here would make the
+    // comment above false for one param, which is how the next person removing
+    // a leak misses one.
+    neighborhood: _neighborhood,
     ...rest
   } = params;
-  return ['propertySearch', locationKey(location), rest];
+  return rest;
+}
+
+/** Shared by {@link searchQueryKey} and the hook, so the two cannot drift. */
+function buildSearchQueryKey(
+  params: Record<string, string | number>,
+  location: SearchQuery['location'],
+  queryId: string,
+): readonly unknown[] {
+  // `queryId` leads, because it is the identity every other surface quotes and
+  // "the list, the map and the heading share a query id" has to be true of the
+  // cache too. It is REDUNDANT with the two elements after it, by construction:
+  // the descriptor it digests is built from this same params object and this
+  // same `locationKey`. They stay because a hash cannot be read — the leak test
+  // in `__tests__/buildSearchParams.test.ts` inspects the key for a coordinate,
+  // and against a key that was only a digest that assertion could never fail.
+  return ['propertySearch', queryId, locationKey(location), identifyingParams(params)];
 }
 
 /**
@@ -406,6 +603,20 @@ export type PropertySearchResult = UseInfiniteQueryResult<
   properties: Property[];
   /** Total match count reported by the server. */
   total: number;
+  /**
+   * The identity of the query this result describes.
+   *
+   * Every surface that renders any part of it — the heading, the count, the
+   * markers, the map camera — is showing THIS query and can say so.
+   */
+  queryId: string;
+  /**
+   * The scope the SERVER applied, or `null` until a page has arrived.
+   *
+   * ADR 0002 §6.3: the map frames itself from this rather than from the
+   * client's belief about the request it sent.
+   */
+  appliedLocation: SearchLocationEcho | null;
 };
 
 export function usePropertySearch(
@@ -418,27 +629,54 @@ export function usePropertySearch(
   // under that place's name — the failure ADR 0002 §4.3 forbids, arrived at
   // from the params side rather than the resolution side.
   const unscopeable = isUnscopeableLocation(query.location);
-  const baseParams = useMemo(() => buildSearchParams(query), [query]);
-  // Built from the already-constructed `baseParams` so the params object is not
-  // built twice per query, through the SAME helper `searchQueryKey` uses so the
-  // two cannot drift — a hook keyed differently from the exported key function
-  // is a cache that misses in one direction and collides in the other.
+  const searchParams = useMemo(() => buildSearchParams(query), [query]);
+  const queryId = useMemo(() => searchQueryId(query), [query]);
+  // Sent so the server can stamp its answer with the identity it was asked
+  // under. It is an echo, never an input: nothing server-side reads it as a
+  // filter, and a response carrying somebody else's stamp is refused below.
+  const baseParams = useMemo(
+    () => ({ ...searchParams, queryId }),
+    [searchParams, queryId],
+  );
+  // Built from the already-constructed params so the object is not built twice
+  // per query, through the SAME helper `searchQueryKey` uses so the two cannot
+  // drift — a hook keyed differently from the exported key function is a cache
+  // that misses in one direction and collides in the other.
   const queryKey = useMemo(
-    () => buildSearchQueryKey(baseParams, query.location),
-    [baseParams, query.location],
+    () => buildSearchQueryKey(searchParams, query.location, queryId),
+    [searchParams, query.location, queryId],
   );
 
-  return useInfinitePropertyList<SearchResponse, PropertySearchPage>({
+  const result = useInfinitePropertyList<SearchResponse, PropertySearchPage>({
     queryKey,
     endpoint: SEARCH_ENDPOINT,
     baseParams,
     enabled: enabled && !unscopeable,
-    mapResponse: (data, pageParam) => ({
-      properties: data.data ?? [],
-      page: data.page ?? pageParam,
-      totalPages: data.totalPages ?? 1,
-      total: data.total ?? (data.data?.length ?? 0),
-      hasMore: data.hasMore ?? false,
-    }),
+    mapResponse: (data, pageParam) => {
+      // A server that says NOTHING is not a mismatch — an older deployment
+      // echoes no id, and refusing its answers would black out the results
+      // surface for a shape that is merely older, not wrong. A server that
+      // names a DIFFERENT query is refused, because rendering it would put one
+      // search's rows under another's heading and count, which is precisely the
+      // failure that cannot be seen by looking at the screen.
+      if (typeof data.queryId === 'string' && data.queryId.length > 0 && data.queryId !== queryId) {
+        throw new StaleSearchResponseError(queryId, data.queryId);
+      }
+      return {
+        properties: data.data ?? [],
+        page: data.page ?? pageParam,
+        totalPages: data.totalPages ?? 1,
+        total: data.total ?? (data.data?.length ?? 0),
+        hasMore: data.hasMore ?? false,
+        queryId: data.queryId ?? null,
+        location: data.location ?? null,
+      };
+    },
   });
+
+  return {
+    ...result,
+    queryId,
+    appliedLocation: result.data?.pages[0]?.location ?? null,
+  };
 }

--- a/packages/frontend/locales/ar.json
+++ b/packages/frontend/locales/ar.json
@@ -674,7 +674,8 @@
       "filters": "Filters",
       "saved": "Saved",
       "decreaseGuests": "Decrease guests",
-      "increaseGuests": "Increase guests"
+      "increaseGuests": "Increase guests",
+      "backToSearchedArea": "العودة إلى المنطقة التي بحثت عنها"
     },
     "summary": {
       "edit": "Edit search",
@@ -724,7 +725,10 @@
       "noResults": "No properties match this search",
       "loading": "Searching properties...",
       "count_one": "{{count}} property",
-      "count_other": "{{count}} properties"
+      "count_other": "{{count}} properties",
+      "unresolvedLocation": "لم نتمكن من العثور على هذا المكان",
+      "withoutMapLocation_one": "{{count}} منها بدون موقع على الخريطة",
+      "withoutMapLocation_other": "{{count}} منها بدون موقع على الخريطة"
     },
     "recent": {
       "title": "Recent searches"
@@ -758,12 +762,15 @@
       "enableNotifications": "Enable notifications"
     },
     "where": {
-      "noResults": "No places match that search.",
-      "offline": "Can't reach Homiio. Check your connection and try again.",
-      "rateLimited": "Too many searches just now. Try again in a moment.",
-      "providerUnavailable": "Place search is temporarily unavailable. Try again shortly.",
-      "failed": "Couldn't search for places right now.",
-      "degraded": "Showing results from a backup source; some places may be missing."
+      "noResults": "لا توجد أماكن تطابق هذا البحث.",
+      "offline": "تعذّر الاتصال بـ Homiio. تحقّق من اتصالك وحاول مرة أخرى.",
+      "rateLimited": "عمليات بحث كثيرة جدًا الآن. حاول مرة أخرى بعد قليل.",
+      "providerUnavailable": "البحث عن الأماكن غير متاح مؤقتًا. حاول مرة أخرى قريبًا.",
+      "failed": "تعذّر البحث عن الأماكن الآن.",
+      "degraded": "نعرض نتائج من مصدر احتياطي؛ قد تنقص بعض الأماكن."
+    },
+    "area": {
+      "stillShowing": "ما زلنا نعرض نتائج {{place}}"
     }
   },
   "profile": {

--- a/packages/frontend/locales/bn-BD.json
+++ b/packages/frontend/locales/bn-BD.json
@@ -674,7 +674,8 @@
       "filters": "Filters",
       "saved": "Saved",
       "decreaseGuests": "Decrease guests",
-      "increaseGuests": "Increase guests"
+      "increaseGuests": "Increase guests",
+      "backToSearchedArea": "অনুসন্ধান করা এলাকায় ফিরে যান"
     },
     "summary": {
       "edit": "Edit search",
@@ -724,7 +725,10 @@
       "noResults": "No properties match this search",
       "loading": "Searching properties...",
       "count_one": "{{count}} property",
-      "count_other": "{{count}} properties"
+      "count_other": "{{count}} properties",
+      "unresolvedLocation": "আমরা সেই জায়গাটি খুঁজে পাইনি",
+      "withoutMapLocation_one": "এর মধ্যে {{count}}টির মানচিত্রে অবস্থান নেই",
+      "withoutMapLocation_other": "এর মধ্যে {{count}}টির মানচিত্রে অবস্থান নেই"
     },
     "recent": {
       "title": "Recent searches"
@@ -758,12 +762,15 @@
       "enableNotifications": "Enable notifications"
     },
     "where": {
-      "noResults": "No places match that search.",
-      "offline": "Can't reach Homiio. Check your connection and try again.",
-      "rateLimited": "Too many searches just now. Try again in a moment.",
-      "providerUnavailable": "Place search is temporarily unavailable. Try again shortly.",
-      "failed": "Couldn't search for places right now.",
-      "degraded": "Showing results from a backup source; some places may be missing."
+      "noResults": "সেই অনুসন্ধানের সঙ্গে কোনো জায়গা মেলেনি।",
+      "offline": "Homiio-তে সংযোগ করা যাচ্ছে না। আপনার সংযোগ পরীক্ষা করে আবার চেষ্টা করুন।",
+      "rateLimited": "এই মুহূর্তে অনেক বেশি অনুসন্ধান হচ্ছে। কিছুক্ষণ পরে আবার চেষ্টা করুন।",
+      "providerUnavailable": "জায়গা অনুসন্ধান সাময়িকভাবে বন্ধ আছে। একটু পরে আবার চেষ্টা করুন।",
+      "failed": "এখন জায়গা খোঁজা যায়নি।",
+      "degraded": "বিকল্প উৎস থেকে ফলাফল দেখানো হচ্ছে; কিছু জায়গা বাদ পড়তে পারে।"
+    },
+    "area": {
+      "stillShowing": "এখনও {{place}}-এর ফলাফল দেখানো হচ্ছে"
     }
   },
   "profile": {

--- a/packages/frontend/locales/ca-ES.json
+++ b/packages/frontend/locales/ca-ES.json
@@ -671,7 +671,8 @@
       "filters": "Filters",
       "saved": "Saved",
       "decreaseGuests": "Redueix hostes",
-      "increaseGuests": "Augmenta hostes"
+      "increaseGuests": "Augmenta hostes",
+      "backToSearchedArea": "Torna a la zona cercada"
     },
     "summary": {
       "edit": "Edita la cerca",
@@ -721,7 +722,10 @@
       "noResults": "Cap propietat coincideix amb aquesta cerca",
       "loading": "Cercant propietats...",
       "count_one": "{{count}} propietat",
-      "count_other": "{{count}} propietats"
+      "count_other": "{{count}} propietats",
+      "unresolvedLocation": "No hem trobat aquest lloc",
+      "withoutMapLocation_one": "{{count}} d'aquests no té ubicació al mapa",
+      "withoutMapLocation_other": "{{count}} d'aquests no tenen ubicació al mapa"
     },
     "recent": {
       "title": "Recent searches"
@@ -761,6 +765,9 @@
       "providerUnavailable": "La cerca de llocs no està disponible temporalment. Torna-ho a provar aviat.",
       "failed": "Ara mateix no s’han pogut cercar llocs.",
       "degraded": "Es mostren resultats d’una font alternativa; poden faltar llocs."
+    },
+    "area": {
+      "stillShowing": "Encara mostrem resultats de {{place}}"
     }
   },
   "profile": {

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -674,7 +674,8 @@
       "filters": "Filters",
       "saved": "Saved",
       "decreaseGuests": "Decrease guests",
-      "increaseGuests": "Increase guests"
+      "increaseGuests": "Increase guests",
+      "backToSearchedArea": "Back to searched area"
     },
     "summary": {
       "edit": "Edit search",
@@ -724,7 +725,10 @@
       "noResults": "No properties match this search",
       "loading": "Searching properties...",
       "count_one": "{{count}} property",
-      "count_other": "{{count}} properties"
+      "count_other": "{{count}} properties",
+      "unresolvedLocation": "We could not find that place",
+      "withoutMapLocation_one": "{{count}} of these has no map location",
+      "withoutMapLocation_other": "{{count}} of these have no map location"
     },
     "recent": {
       "title": "Recent searches"
@@ -764,6 +768,9 @@
       "providerUnavailable": "Place search is temporarily unavailable. Try again shortly.",
       "failed": "Couldn't search for places right now.",
       "degraded": "Showing results from a backup source; some places may be missing."
+    },
+    "area": {
+      "stillShowing": "Still showing results for {{place}}"
     }
   },
   "profile": {

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -650,7 +650,8 @@
       "filters": "Filters",
       "saved": "Saved",
       "decreaseGuests": "Reducir huéspedes",
-      "increaseGuests": "Aumentar huéspedes"
+      "increaseGuests": "Aumentar huéspedes",
+      "backToSearchedArea": "Volver a la zona buscada"
     },
     "summary": {
       "edit": "Editar búsqueda",
@@ -700,7 +701,10 @@
       "noResults": "Ninguna propiedad coincide con esta búsqueda",
       "loading": "Buscando propiedades...",
       "count_one": "{{count}} propiedad",
-      "count_other": "{{count}} propiedades"
+      "count_other": "{{count}} propiedades",
+      "unresolvedLocation": "No hemos encontrado ese lugar",
+      "withoutMapLocation_one": "{{count}} de estos no tiene ubicación en el mapa",
+      "withoutMapLocation_other": "{{count}} de estos no tienen ubicación en el mapa"
     },
     "recent": {
       "title": "Recent searches"
@@ -740,6 +744,9 @@
       "providerUnavailable": "La búsqueda de lugares no está disponible temporalmente. Inténtalo en breve.",
       "failed": "No se han podido buscar lugares ahora mismo.",
       "degraded": "Mostrando resultados de una fuente alternativa; puede que falten lugares."
+    },
+    "area": {
+      "stillShowing": "Seguimos mostrando resultados de {{place}}"
     }
   },
   "profile": {

--- a/packages/frontend/locales/fr-FR.json
+++ b/packages/frontend/locales/fr-FR.json
@@ -674,7 +674,8 @@
       "filters": "Filters",
       "saved": "Saved",
       "decreaseGuests": "Decrease guests",
-      "increaseGuests": "Increase guests"
+      "increaseGuests": "Increase guests",
+      "backToSearchedArea": "Revenir à la zone recherchée"
     },
     "summary": {
       "edit": "Edit search",
@@ -724,7 +725,10 @@
       "noResults": "No properties match this search",
       "loading": "Searching properties...",
       "count_one": "{{count}} property",
-      "count_other": "{{count}} properties"
+      "count_other": "{{count}} properties",
+      "unresolvedLocation": "Nous n'avons pas trouvé ce lieu",
+      "withoutMapLocation_one": "{{count}} d'entre eux n'a pas de position sur la carte",
+      "withoutMapLocation_other": "{{count}} d'entre eux n'ont pas de position sur la carte"
     },
     "recent": {
       "title": "Recent searches"
@@ -758,12 +762,15 @@
       "enableNotifications": "Enable notifications"
     },
     "where": {
-      "noResults": "No places match that search.",
-      "offline": "Can't reach Homiio. Check your connection and try again.",
-      "rateLimited": "Too many searches just now. Try again in a moment.",
-      "providerUnavailable": "Place search is temporarily unavailable. Try again shortly.",
-      "failed": "Couldn't search for places right now.",
-      "degraded": "Showing results from a backup source; some places may be missing."
+      "noResults": "Aucun lieu ne correspond à cette recherche.",
+      "offline": "Impossible de joindre Homiio. Vérifiez votre connexion et réessayez.",
+      "rateLimited": "Trop de recherches à la fois. Réessayez dans un instant.",
+      "providerUnavailable": "La recherche de lieux est temporairement indisponible. Réessayez sous peu.",
+      "failed": "Impossible de rechercher des lieux pour le moment.",
+      "degraded": "Résultats issus d'une source de secours ; certains lieux peuvent manquer."
+    },
+    "area": {
+      "stillShowing": "Résultats toujours affichés pour {{place}}"
     }
   },
   "profile": {

--- a/packages/frontend/locales/hi-IN.json
+++ b/packages/frontend/locales/hi-IN.json
@@ -674,7 +674,8 @@
       "filters": "Filters",
       "saved": "Saved",
       "decreaseGuests": "Decrease guests",
-      "increaseGuests": "Increase guests"
+      "increaseGuests": "Increase guests",
+      "backToSearchedArea": "खोजे गए क्षेत्र पर लौटें"
     },
     "summary": {
       "edit": "Edit search",
@@ -724,7 +725,10 @@
       "noResults": "No properties match this search",
       "loading": "Searching properties...",
       "count_one": "{{count}} property",
-      "count_other": "{{count}} properties"
+      "count_other": "{{count}} properties",
+      "unresolvedLocation": "हमें वह जगह नहीं मिली",
+      "withoutMapLocation_one": "इनमें से {{count}} का मानचित्र पर स्थान नहीं है",
+      "withoutMapLocation_other": "इनमें से {{count}} का मानचित्र पर स्थान नहीं है"
     },
     "recent": {
       "title": "Recent searches"
@@ -758,12 +762,15 @@
       "enableNotifications": "Enable notifications"
     },
     "where": {
-      "noResults": "No places match that search.",
-      "offline": "Can't reach Homiio. Check your connection and try again.",
-      "rateLimited": "Too many searches just now. Try again in a moment.",
-      "providerUnavailable": "Place search is temporarily unavailable. Try again shortly.",
-      "failed": "Couldn't search for places right now.",
-      "degraded": "Showing results from a backup source; some places may be missing."
+      "noResults": "उस खोज से कोई जगह मेल नहीं खाती।",
+      "offline": "Homiio से संपर्क नहीं हो पा रहा। अपना कनेक्शन जाँचें और फिर कोशिश करें।",
+      "rateLimited": "अभी बहुत अधिक खोजें हो रही हैं। थोड़ी देर बाद कोशिश करें।",
+      "providerUnavailable": "जगह खोज अस्थायी रूप से उपलब्ध नहीं है। थोड़ी देर बाद कोशिश करें।",
+      "failed": "अभी जगहें नहीं खोजी जा सकीं।",
+      "degraded": "वैकल्पिक स्रोत से परिणाम दिखाए जा रहे हैं; कुछ जगहें छूट सकती हैं।"
+    },
+    "area": {
+      "stillShowing": "अब भी {{place}} के परिणाम दिखाए जा रहे हैं"
     }
   },
   "profile": {

--- a/packages/frontend/locales/id-ID.json
+++ b/packages/frontend/locales/id-ID.json
@@ -674,7 +674,8 @@
       "filters": "Filters",
       "saved": "Saved",
       "decreaseGuests": "Decrease guests",
-      "increaseGuests": "Increase guests"
+      "increaseGuests": "Increase guests",
+      "backToSearchedArea": "Kembali ke area yang dicari"
     },
     "summary": {
       "edit": "Edit search",
@@ -724,7 +725,10 @@
       "noResults": "No properties match this search",
       "loading": "Searching properties...",
       "count_one": "{{count}} property",
-      "count_other": "{{count}} properties"
+      "count_other": "{{count}} properties",
+      "unresolvedLocation": "Kami tidak menemukan tempat itu",
+      "withoutMapLocation_one": "{{count}} di antaranya tidak memiliki lokasi di peta",
+      "withoutMapLocation_other": "{{count}} di antaranya tidak memiliki lokasi di peta"
     },
     "recent": {
       "title": "Recent searches"
@@ -758,12 +762,15 @@
       "enableNotifications": "Enable notifications"
     },
     "where": {
-      "noResults": "No places match that search.",
-      "offline": "Can't reach Homiio. Check your connection and try again.",
-      "rateLimited": "Too many searches just now. Try again in a moment.",
-      "providerUnavailable": "Place search is temporarily unavailable. Try again shortly.",
-      "failed": "Couldn't search for places right now.",
-      "degraded": "Showing results from a backup source; some places may be missing."
+      "noResults": "Tidak ada tempat yang cocok dengan pencarian itu.",
+      "offline": "Tidak dapat menghubungi Homiio. Periksa koneksi Anda lalu coba lagi.",
+      "rateLimited": "Terlalu banyak pencarian saat ini. Coba lagi sebentar lagi.",
+      "providerUnavailable": "Pencarian tempat sementara tidak tersedia. Coba lagi nanti.",
+      "failed": "Tidak dapat mencari tempat saat ini.",
+      "degraded": "Menampilkan hasil dari sumber cadangan; beberapa tempat mungkin tidak ada."
+    },
+    "area": {
+      "stillShowing": "Masih menampilkan hasil untuk {{place}}"
     }
   },
   "profile": {

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -818,7 +818,8 @@
       "filters": "Filters",
       "saved": "Saved",
       "decreaseGuests": "Riduci ospiti",
-      "increaseGuests": "Aumenta ospiti"
+      "increaseGuests": "Aumenta ospiti",
+      "backToSearchedArea": "Torna all'area cercata"
     },
     "summary": {
       "edit": "Modifica ricerca",
@@ -868,7 +869,10 @@
       "noResults": "Nessun immobile corrisponde a questa ricerca",
       "loading": "Ricerca immobili...",
       "count_one": "{{count}} immobile",
-      "count_other": "{{count}} immobili"
+      "count_other": "{{count}} immobili",
+      "unresolvedLocation": "Non abbiamo trovato quel luogo",
+      "withoutMapLocation_one": "{{count}} di questi non ha una posizione sulla mappa",
+      "withoutMapLocation_other": "{{count}} di questi non hanno una posizione sulla mappa"
     },
     "recent": {
       "title": "Recent searches"
@@ -908,6 +912,9 @@
       "providerUnavailable": "La ricerca dei luoghi non è momentaneamente disponibile. Riprova a breve.",
       "failed": "Non è stato possibile cercare luoghi in questo momento.",
       "degraded": "Risultati da una fonte alternativa; alcuni luoghi potrebbero mancare."
+    },
+    "area": {
+      "stillShowing": "Stiamo ancora mostrando i risultati di {{place}}"
     }
   },
   "profile": {

--- a/packages/frontend/locales/pt-BR.json
+++ b/packages/frontend/locales/pt-BR.json
@@ -674,7 +674,8 @@
       "filters": "Filters",
       "saved": "Saved",
       "decreaseGuests": "Decrease guests",
-      "increaseGuests": "Increase guests"
+      "increaseGuests": "Increase guests",
+      "backToSearchedArea": "Voltar à área pesquisada"
     },
     "summary": {
       "edit": "Edit search",
@@ -724,7 +725,10 @@
       "noResults": "No properties match this search",
       "loading": "Searching properties...",
       "count_one": "{{count}} property",
-      "count_other": "{{count}} properties"
+      "count_other": "{{count}} properties",
+      "unresolvedLocation": "Não encontramos esse lugar",
+      "withoutMapLocation_one": "{{count}} destes não tem localização no mapa",
+      "withoutMapLocation_other": "{{count}} destes não têm localização no mapa"
     },
     "recent": {
       "title": "Recent searches"
@@ -758,12 +762,15 @@
       "enableNotifications": "Enable notifications"
     },
     "where": {
-      "noResults": "No places match that search.",
-      "offline": "Can't reach Homiio. Check your connection and try again.",
-      "rateLimited": "Too many searches just now. Try again in a moment.",
-      "providerUnavailable": "Place search is temporarily unavailable. Try again shortly.",
-      "failed": "Couldn't search for places right now.",
-      "degraded": "Showing results from a backup source; some places may be missing."
+      "noResults": "Nenhum lugar corresponde a essa busca.",
+      "offline": "Não foi possível conectar ao Homiio. Verifique sua conexão e tente de novo.",
+      "rateLimited": "Buscas demais agora. Tente de novo em instantes.",
+      "providerUnavailable": "A busca de lugares está temporariamente indisponível. Tente em breve.",
+      "failed": "Não foi possível buscar lugares agora.",
+      "degraded": "Mostrando resultados de uma fonte alternativa; alguns lugares podem faltar."
+    },
+    "area": {
+      "stillShowing": "Ainda mostrando resultados de {{place}}"
     }
   },
   "profile": {

--- a/packages/frontend/locales/ru-RU.json
+++ b/packages/frontend/locales/ru-RU.json
@@ -674,7 +674,8 @@
       "filters": "Filters",
       "saved": "Saved",
       "decreaseGuests": "Decrease guests",
-      "increaseGuests": "Increase guests"
+      "increaseGuests": "Increase guests",
+      "backToSearchedArea": "Вернуться к искомой области"
     },
     "summary": {
       "edit": "Edit search",
@@ -724,7 +725,10 @@
       "noResults": "No properties match this search",
       "loading": "Searching properties...",
       "count_one": "{{count}} property",
-      "count_other": "{{count}} properties"
+      "count_other": "{{count}} properties",
+      "unresolvedLocation": "Не удалось найти это место",
+      "withoutMapLocation_one": "{{count}} из них не имеет положения на карте",
+      "withoutMapLocation_other": "{{count}} из них не имеют положения на карте"
     },
     "recent": {
       "title": "Recent searches"
@@ -758,12 +762,15 @@
       "enableNotifications": "Enable notifications"
     },
     "where": {
-      "noResults": "No places match that search.",
-      "offline": "Can't reach Homiio. Check your connection and try again.",
-      "rateLimited": "Too many searches just now. Try again in a moment.",
-      "providerUnavailable": "Place search is temporarily unavailable. Try again shortly.",
-      "failed": "Couldn't search for places right now.",
-      "degraded": "Showing results from a backup source; some places may be missing."
+      "noResults": "Ни одно место не соответствует этому запросу.",
+      "offline": "Нет связи с Homiio. Проверьте подключение и повторите попытку.",
+      "rateLimited": "Слишком много запросов. Повторите попытку через мгновение.",
+      "providerUnavailable": "Поиск мест временно недоступен. Повторите попытку позже.",
+      "failed": "Сейчас не удалось найти места.",
+      "degraded": "Показаны результаты из резервного источника; некоторых мест может не быть."
+    },
+    "area": {
+      "stillShowing": "Показаны результаты для {{place}}"
     }
   },
   "profile": {

--- a/packages/frontend/locales/zh-CN.json
+++ b/packages/frontend/locales/zh-CN.json
@@ -674,7 +674,8 @@
       "filters": "Filters",
       "saved": "Saved",
       "decreaseGuests": "Decrease guests",
-      "increaseGuests": "Increase guests"
+      "increaseGuests": "Increase guests",
+      "backToSearchedArea": "返回已搜索区域"
     },
     "summary": {
       "edit": "Edit search",
@@ -724,7 +725,10 @@
       "noResults": "No properties match this search",
       "loading": "Searching properties...",
       "count_one": "{{count}} property",
-      "count_other": "{{count}} properties"
+      "count_other": "{{count}} properties",
+      "unresolvedLocation": "未能找到该地点",
+      "withoutMapLocation_one": "其中 {{count}} 个没有地图位置",
+      "withoutMapLocation_other": "其中 {{count}} 个没有地图位置"
     },
     "recent": {
       "title": "Recent searches"
@@ -758,12 +762,15 @@
       "enableNotifications": "Enable notifications"
     },
     "where": {
-      "noResults": "No places match that search.",
-      "offline": "Can't reach Homiio. Check your connection and try again.",
-      "rateLimited": "Too many searches just now. Try again in a moment.",
-      "providerUnavailable": "Place search is temporarily unavailable. Try again shortly.",
-      "failed": "Couldn't search for places right now.",
-      "degraded": "Showing results from a backup source; some places may be missing."
+      "noResults": "没有符合该搜索的地点。",
+      "offline": "无法连接 Homiio。请检查网络连接后重试。",
+      "rateLimited": "搜索过于频繁，请稍后再试。",
+      "providerUnavailable": "地点搜索暂时不可用，请稍后再试。",
+      "failed": "目前无法搜索地点。",
+      "degraded": "正在显示备用来源的结果，部分地点可能缺失。"
+    },
+    "area": {
+      "stillShowing": "仍在显示{{place}}的搜索结果"
     }
   },
   "profile": {

--- a/packages/shared-types/src/location.ts
+++ b/packages/shared-types/src/location.ts
@@ -517,10 +517,30 @@ export function crossesAntimeridian(bounds: GeoBounds): boolean {
  * naive form for `2.05→2.23`, `-3.75→-3.65` and `-10→40` — which is what makes
  * adopting it everywhere safe rather than a behaviour change.
  */
+/**
+ * How wide and how tall a box is, in degrees, measured the way the box means.
+ *
+ * The longitude term is the reason this is a function rather than a
+ * subtraction: for a box that wraps the antimeridian, `east - west` is the
+ * NEGATIVE of nothing useful (`-170 - 170 = -340`), and the span it describes
+ * is the 20 degrees the other way. Extracted so {@link boundsCenter} and every
+ * caller that needs a size read one implementation — the header above records
+ * that four production sites each derived this arithmetic naively, and a second
+ * copy is how a fifth happens.
+ */
+export function boundsSpanDegrees(bounds: GeoBounds): { longitude: number; latitude: number } {
+  return {
+    longitude: crossesAntimeridian(bounds)
+      ? 360 - bounds.west + bounds.east
+      : bounds.east - bounds.west,
+    // Latitude never wraps: `south > north` is an ERROR rather than a
+    // convention, so the plain difference is correct and always was.
+    latitude: bounds.north - bounds.south,
+  };
+}
+
 export function boundsCenter(bounds: GeoBounds): GeoPoint {
-  const eastwardSpan = crossesAntimeridian(bounds)
-    ? 360 - bounds.west + bounds.east
-    : bounds.east - bounds.west;
+  const eastwardSpan = boundsSpanDegrees(bounds).longitude;
   return {
     longitude: normalizeLongitude(bounds.west + eastwardSpan / 2),
     // Latitude never wraps: `south > north` is an ERROR rather than a


### PR DESCRIPTION
Closes #354. Depends on #352 (landed), builds on ADR 0002.

**Rebased onto `d10ac39b` (#353).** The conflicts were the twelve locale files
and nothing else; the key sets #353 and #354 add are disjoint (verified — zero
overlap), so the resolution is additive. All twelve were rebuilt from main's
content with #354's keys re-applied, uniformly, so none carries a merge artefact
nobody inspected. One deliberate override, called out below: #353 filled
`search.where.*` in eight locales with the ENGLISH strings as a parity filler and
this branch had translated them; the translations win, on an identical key set.
Every check below was re-run after the rebase, the mandatory mutation included.

## The bug, precisely

`SearchResultsView` kept a pending viewport while the user panned. Confirming
"Search this area" could keep the previous location's label while replacing the
bounds; `buildSearchParams` then sent both the bbox and `q`, and the backend
ANDed them. Map in Madrid, `q` still "Barcelona", zero results, no exception
anywhere. Separately there was no explicit query identity, so nothing could tell
which search a given payload, heading or count belonged to.

## The 8 invariants, and the test that pins each

| # | Invariant | Pinned by |
|---|---|---|
| 1 | Map and list show the same `queryId` | `frontend/__tests__/searchQueryIdentity.test.ts` (totality: every request dimension changes the id, with a floor asserting the case list covers every param `buildSearchParams` emits) + `buildSearchParams.test.ts` "drops page/limit…" (the cache key's first discriminator IS `searchQueryId(query)`) + both surfaces carry `search-list-<id>` / `search-map-<id>` from one `usePropertySearch` call |
| 2 | Panning changes nothing until confirmed | `searchArea.test.ts` "ignores a movement that is still in progress", "does NOT arm on the app framing the committed selection"; `searchThisAreaContract.test.ts` "changes neither the committed query nor the request" |
| 3 | Confirming bounds REPLACES the previous scope | `searchThisAreaContract.test.ts` "sends the new box and NOTHING of the old place" (asserts on the serialised params against every Barcelona trace: id, name, region, centre, west edge) + `searchQueryStoreAtomicity.test.ts` (already landed) |
| 4 | Free text survives only if it is genuinely free text | `searchThisAreaContract.test.ts` "keeps free text that HAPPENS to spell a city, because provenance is what counts" + the source gate `noLabelAsFreeText.test.ts` |
| 5 | A stale response cannot overwrite current state | `searchStaleResponse.test.tsx` — two requests resolved in a FORCED reverse order, plus `StaleSearchResponseError` for a payload the server stamped with another query |
| 6 | The header describes the committed query, not the pending viewport | `resultsHeading` reads `query`/`total` only; the pending viewport renders a separate banner naming the scope the results still describe. The spread that could reintroduce an old label on the committed selection is refused by `noLabelAsFreeText.test.ts` |
| 7 | The count belongs to the same query as the items and markers | `total`, `properties` and the markers all come from one hook call and one page; a page stamped with a different id is refused. Server side, `searchLocationContract.test.ts` "counts only what the scope matched, however small the page" |
| 8 | Zero results does NOT trigger a global fallback | `searchThisAreaContract.test.ts` "an empty answer keeps the scope it was asked about"; `searchLocationContract.test.ts` "never widens an unresolvable place into a global feed" |

## Acceptance criteria

- [x] Barcelona → Madrid → confirm sends no Barcelona geographic filter — `searchThisAreaContract.test.ts`
- [x] Moving the map without confirming does not change the list
- [x] An initial programmatic movement does not show the button — `searchArea.test.ts`, and `mapMoveSource.test.ts` proves both adapters mark their camera commands (`resize` included, since it fires move/moveend as the layout settles)
- [x] Header, URL, query key, count, list and map share one query id
- [x] A late response for the previous query does not overwrite the new one
- [x] Zero results keeps the queried scope
- [x] Returning from detail restores query and viewport — the query comes from the URL (#352's one-writer loop), the viewport from the existing per-screen `MapStateContext`, which seeds the map constructor on web and posts a `setView` on native. That `setView` is now marked programmatic, so restoring does not arm the button.
- [x] Mobile list/map toggle does not rebuild the query — the toggle is local state; both branches render the same `mapPanel`/`listScroll` from one hook
- [x] Errors allow retry without losing filters — the error state replaces the list body only; map, query and filters are untouched
- [x] Tests cover web and native map adapters — see `mapMoveSource.test.ts`

## Mandatory tests

Barcelona/Madrid discriminating fixture; programmatic vs user; two requests in reverse order; real query text inside map bounds; old city label removed; return from detail; marker without a card and card without coordinates (`searchMarkers.test.ts`); pagination while the map moves; 0 results; error and retry; **and the old-label mutation must fail**.

## Mutation evidence

Each mutation was applied, confirmed present in the file, run, then restored from a pristine copy (never `git checkout`), and a marker from my own edit re-asserted afterwards. **Both old-label mutations were re-run after the rebase** and are still RED, named at `usePropertySearch.ts:327` and `SearchResultsView.tsx:429`.

| Mutation | Result |
|---|---|
| **`params.q = query.location.label.primary` when no free text** (the mandatory old-label mutation) | **RED — 5 tests across 3 suites.** The gate named it: `packages/frontend/hooks/usePropertySearch.ts:327 [a place label sent as the q request param] params.q = query.location.label.primary;` |
| **`onCommitLocation({ ...mapBoundsSelection(pending), label: query.location.label })`** — the old label kept on the SELECTION, which changes no request param and only corrupts the heading | **RED —** `SearchResultsView.tsx:444 [a map-area selection assembled by spreading, which can keep the old label]` |
| Drop `PROGRAMMATIC_MOVE` from one web camera command | RED — `mapMoveSource.test.ts` reported `resize at index 20838` |
| `reduceMapMovement` ignores the move source | RED — 6 tests across `searchArea` and `searchThisAreaContract` |
| Backend: always expand `q` into a place | RED — 2 tests |
| Backend: remove the shape+place refusal | RED — 4 tests |
| Backend: `countProperties(undefined)` (count and page on different `where`) | RED — expected 1, received 3 |

## Verification

Baseline on the untouched branch point (`bebc76b4`) first: frontend `78 passed / 4 suites`, backend search suites `20 passed / 2 suites`. The numbers below are POST-REBASE and include #353's suites.

```
bunx jest --ci                       (packages/frontend)  31 suites, 464 tests   exit 0
bunx jest <10 suites, incl. homeSections + the source-text and mongo gates>
                                     (packages/backend)   10 suites, 108 tests   exit 0
bunx tsc --noEmit                    frontend / backend / shared-types           exit 0
bunx expo lint                       1 error, and it is pre-existing
                                     (SindiExplanationBottomSheet:136, recorded
                                     as deliberately deferred in AGENTS.md)
bun scripts/check-locale-parity.ts   exit 0   (was FAILING on main — see below)
bun run check:docs                   exit 0
bun run check:lockfile               exit 0
bun run --cwd packages/frontend build && check:cold-start / /explore /properties
                                     PASS ×3, zero console errors, exit 0
```

Backend tests ran against the shared dev Postgres on `127.0.0.1:5434` with a
throwaway migrated database per worker.

## Breaking / shared-shape changes

Additive except where noted; call out to #353 and #358 if you rebase.

- **`GET /api/properties/search` now 400s on a SHAPE + NAMED PLACE combination**
  (`swLat…`/`lat,lng` together with `city`/`state`/`neighborhood`),
  `error: 'INVALID_LOCATION'`. This is the one behaviour change a caller can
  trip on. No caller in this repo sends both — `locationParams` emits exactly
  one shape per selection — and place ids that nest (`city` + `neighborhood`)
  still work.
- **`q` is no longer expanded into a place when a geographic scope is present.**
  A scoped request that previously matched via the city-id branch now matches on
  text alone, which is narrower.
- **The response envelope gains `queryId` (echo, absent when none was sent) and
  `location.appliedLocationKind`.** `location` was previously asserted with
  `toEqual` in `searchLocationContract.test.ts`; those assertions are updated.
- **The React Query key for the property search gained a leading element**
  (`['propertySearch', queryId, locationKey, rest]`). Cache-only; nothing
  persists it.
- `buildSearchParams` output is UNCHANGED. `queryId` is added to the request by
  the hook, not by the builder, so `buildSearchParams.test.ts`'s exact-shape
  assertion still holds.
- `toMarkers` moved from `SearchResultsView` to `components/search/searchMarkers.ts`
  — it could not be unit-tested where it was, because importing the results view
  pulls `react-native-webview` and a native module no test environment has.
- `shared-types` gains `boundsSpanDegrees`; `boundsCenter` now uses it.

## What I did NOT do, and why

- **`addressId` is still ignored by the search endpoint.** `app/addresses/[id].tsx`
  sends `?addressId=…&limit=50` and gets an UNFILTERED feed — the ADR §4.3
  "requested and lost becomes a global feed" failure, live today, found while
  working here. I left it: fixing it means echoing an `appliedLocationKind` for
  an address, and `LOCATION_KINDS` (published by #350's schema) has no such
  value. Inventing one here would put a second vocabulary in the repo for a
  screen outside this issue. It wants its own issue plus a schema decision.
- **No component-render test of `SearchResultsView`.** It imports the map, hence
  `react-native-webview`; the rules it owns were extracted into pure modules
  (`searchArea`, `searchMarkers`) and tested there instead, and the boot path is
  covered by `check:cold-start` on `/explore`.
- **No live browser verification of the button appearing and disappearing.** The
  arming rule is tested at the reducer and the marking at the source of both
  adapters; a real MapLibre gesture is not reproducible under jsdom. Worth a
  manual pass before release.
- **Server-side clustering is untouched** (out of scope per the issue), so the
  markers are the loaded page's, and the screen now states the difference
  between the list and the map rather than hiding it.
- **`search.where.*` in eight locales.** Those six keys (from #406) had no
  entry at all when this branch started, so `check:i18n` was RED on `main` and
  this branch translated them. #353 has since landed the same keys carrying the
  ENGLISH strings, which fixes parity on its own. The rebase keeps the
  translations — same keys, better words, no behaviour change. Say so if you
  would rather ship main's fillers and translate separately.
- **#353's own `home.*` and `location.scope.*` strings are English in all eleven
  non-English locales.** Left alone: they are outside this issue, `check:i18n`
  compares KEYS and passes either way, and quietly rewriting another PR's copy
  inside a rebase is not a change anybody asked for. Worth its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
