### PR TITLE
fix(home): scope by the city the picker actually hands over, and say so when it fails (#353)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -816,7 +816,15 @@ const [pressed, setPressed] = useState(false);
   function-form `Pressable` lives in a list.
 - Canonical template:
   `packages/frontend/components/search/SearchSummaryBar.tsx`.
-- Audit: `grep -rn "style={({" app components --include=*.tsx` must return ZERO.
+- **Audit: `packages/frontend/__tests__/noFunctionFormStyle.test.ts`**, which runs
+  in the ordinary suite. It replaced `grep -rn "style={({" app components`,
+  and the reason is worth keeping: a grep is LINE-based, so it cannot tell code
+  from prose, and it started reporting a violation the moment a component's own
+  doc comment quoted the forbidden form in order to warn about it. A gate that
+  cries wolf gets switched off by whoever hits it next. The test strips comments
+  first — through `@homiio/shared-types/testing/stripComments`, the one stripper
+  this repo has — and carries a positive control, a negative control (that very
+  comment), and a floor on files scanned.
 
 ## `pointerEvents: 'box-none'` / `'box-only'` in a STYLE is BROKEN on web
 

--- a/packages/backend/__tests__/integration/homeSections.test.ts
+++ b/packages/backend/__tests__/integration/homeSections.test.ts
@@ -32,7 +32,13 @@ import { OfferingType, PropertyStatus, PropertyType } from '@homiio/shared-types
 import { getHomeSections } from '../../controllers/home/homeSectionsController';
 import { errorHandler } from '../../middlewares/errorHandler';
 import { serializeWireIds } from '../../middlewares/wireIds';
+import { getDb } from '../../db/postgres';
+import { cities, countries, regions } from '../../db/schema';
+import { resetGeoCache } from '../../services/geocoding/cache';
+import { registerProvider, resetProviderRegistry } from '../../services/geocoding/registry';
+import { GeocodingProviderError, type ProviderPlace } from '../../services/geocoding/types';
 import {
+  objectIdHex,
   resetGeoTables,
   seedAddress,
   seedGeoChain,
@@ -51,7 +57,7 @@ interface SectionPayload {
   source: string;
   generatedAt: string;
   location: { status: string; key?: string };
-  items: { id: string; address?: { cityName?: string } }[];
+  items: { id: string; title?: string; address?: { cityName?: string } }[];
 }
 
 interface HomePayload {
@@ -446,6 +452,315 @@ describe('GET /home/sections', () => {
       // the rent response DOES have sections — the rule simply does not apply.
       expect(rentIds.length).toBeGreaterThan(0);
       expect(rentIds).not.toContain('price_reduced');
+    });
+  });
+
+  /**
+   * The defect that reached production, and the shape of its repair.
+   *
+   * `GET /api/home/sections?loc=city.osm.R347950` answered **400
+   * UNSUPPORTED_LOCATION** on the live service. That token is not exotic input:
+   * it is the ORDINARY output of picking a city, because the place picker
+   * resolves through the #351 geo gateway and every gateway candidate is
+   * external (`source: { kind: 'external', provider, ref }`, pinned by
+   * `geoGateway.test.ts`). So the location ladder handed Home a scope Home
+   * refused — the same class of failure #353 exists to prevent, arrived at from
+   * the other side.
+   *
+   * ## Each RUNG is distinguished, not just the outcome
+   *
+   * The repair has three rungs — a canonical Homiio city, the place's own
+   * bounds, then `unresolved` — and the first two both answer "Barcelona
+   * listings" for a Barcelona pick. A fixture that only asserts "Barcelona came
+   * back" therefore cannot tell which rung ran, and the first version of this
+   * file could not: every country code was unique per chain (`ES-Barcelona`), so
+   * `lookupCityPlaces({ countryCode: 'ES' })` matched no country at all, and
+   * every "resolved by Homiio city" assertion was in fact passing through the
+   * BOUNDS fallback. It was mutation-testing that exposed it — capping the
+   * lookup at one row changed nothing, because the lookup was never reached.
+   *
+   * So each rung now has a fixture only IT can satisfy: a second Homiio city
+   * inside the same bounding box, whose listing the city rung excludes and the
+   * bounds rung includes.
+   *
+   * The provider is a registered FAKE rather than a mocked module, the same seam
+   * `geoGateway.test.ts` uses: the request goes through the real registry, cache
+   * and normaliser, so a repair that only works against a mock fails here.
+   */
+  describe('an external (geocoder) place ref', () => {
+    const PROVIDER_ID = 'fakeosm';
+    const EXTERNAL_REF = 'R347950';
+    /** The bbox the fake geocoder returns for "Barcelona". Contains BARCELONA and NEARBY. */
+    const PICKED_BOUNDS = { west: 2.0, south: 41.3, east: 2.3, north: 41.5 };
+    /** A second point inside `PICKED_BOUNDS`, in a DIFFERENT Homiio city. */
+    const NEARBY = { longitude: 2.1, latitude: 41.36 };
+
+    function providerPlace(overrides: Partial<ProviderPlace> = {}): ProviderPlace {
+      return {
+        providerId: PROVIDER_ID,
+        ref: EXTERNAL_REF,
+        name: 'Barcelona',
+        displayName: 'Barcelona, Catalunya, España',
+        address: { city: 'Barcelona', region: 'Catalunya', country: 'España', countryCode: 'ES' },
+        center: { longitude: 2.1774322, latitude: 41.3828939 },
+        bounds: PICKED_BOUNDS,
+        rawAddressType: 'city',
+        ...overrides,
+      };
+    }
+
+    function installFake(resolve?: (ref: string) => Promise<ProviderPlace | null>): void {
+      registerProvider({
+        id: PROVIDER_ID,
+        attribution: { text: '© Fake contributors', url: 'https://example.invalid/copyright' },
+        autocomplete: async () => [providerPlace()],
+        resolve: async (input) => (resolve ? resolve(input.ref) : providerPlace()),
+        reverse: async () => providerPlace(),
+        health: async () => ({ providerId: PROVIDER_ID, healthy: true }),
+      });
+    }
+
+    /**
+     * ONE country whose code is really `ES`.
+     *
+     * The lookup filters HARD on the country code the geocoder reported, so a
+     * fixture country coded `ES-Barcelona` makes every Homiio-city rung
+     * unreachable — which is exactly how the first version of these tests
+     * passed while measuring the wrong rung.
+     */
+    async function seedSpain(): Promise<string> {
+      const [country] = await getDb()
+        .insert(countries)
+        .values({ id: objectIdHex(), code: 'ES', name: 'Spain' })
+        .returning({ id: countries.id });
+      return country.id;
+    }
+
+    /** A city (and its region) under an EXISTING country, with a listing on it. */
+    async function seedCityWithListing(options: {
+      countryId: string;
+      cityName: string;
+      regionName: string;
+      longitude: number;
+      latitude: number;
+      title: string;
+    }): Promise<{ cityId: string; propertyId: string }> {
+      const db = getDb();
+      const [region] = await db
+        .insert(regions)
+        .values({ id: objectIdHex(), countryId: options.countryId, name: options.regionName })
+        .returning({ id: regions.id });
+      const [city] = await db
+        .insert(cities)
+        .values({
+          id: objectIdHex(),
+          countryId: options.countryId,
+          regionId: region.id,
+          name: options.cityName,
+          latitude: options.latitude,
+          longitude: options.longitude,
+        })
+        .returning({ id: cities.id });
+
+      const addressId = await seedAddress({
+        chain: { countryId: options.countryId, regionId: region.id, cityId: city.id },
+        street: `${options.title} street`,
+        longitude: options.longitude,
+        latitude: options.latitude,
+      });
+      const propertyId = await seedProperty({
+        addressId,
+        overrides: {
+          title: options.title,
+          type: PropertyType.APARTMENT,
+          status: PropertyStatus.PUBLISHED,
+          availabilityIsAvailable: true,
+          offerings: [OfferingType.LONG_TERM_RENT],
+          longTermRentMonthlyAmount: 1200,
+        },
+      });
+      return { cityId: city.id, propertyId };
+    }
+
+    const externalQuery = {
+      loc: `city.${PROVIDER_ID}.${EXTERNAL_REF}`,
+      offering: OfferingType.LONG_TERM_RENT,
+    };
+
+    beforeEach(() => {
+      resetProviderRegistry();
+      resetGeoCache();
+      installFake();
+    });
+
+    afterEach(() => {
+      resetProviderRegistry();
+      resetGeoCache();
+    });
+
+    it('scopes by the matching Homiio CITY, not merely by the picked box', async () => {
+      // The discriminator: `Hospitalet` sits INSIDE the geocoder's bounding box
+      // but is a different Homiio city. The city rung excludes its listing; the
+      // bounds rung would include it. Asserting only "Barcelona came back" would
+      // pass under either.
+      const countryId = await seedSpain();
+      await seedCityWithListing({
+        countryId,
+        cityName: 'Barcelona',
+        regionName: 'Catalonia',
+        ...BARCELONA,
+        title: 'In Barcelona',
+      });
+      await seedCityWithListing({
+        countryId,
+        cityName: 'Hospitalet',
+        regionName: 'Catalonia South',
+        ...NEARBY,
+        title: 'In the box but another city',
+      });
+
+      const response = await request(app).get('/home/sections').query(externalQuery).expect(200);
+      const payload = response.body.data as HomePayload;
+      const titles = allItems(payload).map((item) => item.title);
+
+      expect(payload.location.status).toBe('resolved');
+      expect(titles).toContain('In Barcelona');
+      expect(titles).not.toContain('In the box but another city');
+    });
+
+    it('keeps the REQUESTED ref as the echoed key, so the client can match it', async () => {
+      // The client compares this against its own `locationKey(selection)`, which
+      // is built from what it asked for. Echoing the Homiio id it resolved TO
+      // would read as "the server applied a different scope".
+      const countryId = await seedSpain();
+      await seedCityWithListing({
+        countryId,
+        cityName: 'Barcelona',
+        regionName: 'Catalonia',
+        ...BARCELONA,
+        title: 'In Barcelona',
+      });
+
+      const response = await request(app).get('/home/sections').query(externalQuery).expect(200);
+
+      expect((response.body.data as HomePayload).location.key).toBe(
+        `ext:${PROVIDER_ID}:${EXTERNAL_REF}`,
+      );
+    });
+
+    it('falls back to the place’s OWN bounds when Homiio knows no such city', async () => {
+      // The city the geocoder found is real; Homiio simply has no row for it. A
+      // dead end here would send the user back to the picker to choose the same
+      // place again, forever. The bounds ARE the area they picked, and they are
+      // what `/api/properties/search` already scopes an external place by.
+      const countryId = await seedSpain();
+      await seedCityWithListing({
+        countryId,
+        cityName: 'Sant Adrià',
+        regionName: 'Catalonia',
+        ...NEARBY,
+        title: 'Inside the picked box',
+      });
+      // Far outside the box, so "scoped by the box" is distinguishable from
+      // "answered globally".
+      await seedListingAt({ city: 'Madrid', ...MADRID });
+
+      const response = await request(app).get('/home/sections').query(externalQuery).expect(200);
+      const payload = response.body.data as HomePayload;
+      const titles = allItems(payload).map((item) => item.title);
+
+      expect(payload.location.status).toBe('resolved');
+      expect(titles).toContain('Inside the picked box');
+      expect(titles.some((title) => title === 'Madrid home')).toBe(false);
+    });
+
+    it('does NOT pick between two Homiio cities of the same name — it uses the box', async () => {
+      // The homonym guard, and the reason `lookupCityPlaces` is called with NO
+      // `limit`: capping a lookup that can match several rows turns a genuinely
+      // ambiguous answer into a confident wrong one (#295). Both cities are
+      // called Barcelona and both sit inside the picked box, so the correct
+      // behaviour — fall through to the bounds — returns BOTH listings, while a
+      // capped lookup would silently scope to whichever row sorted first.
+      const countryId = await seedSpain();
+      await seedCityWithListing({
+        countryId,
+        cityName: 'Barcelona',
+        regionName: 'Catalonia',
+        ...BARCELONA,
+        title: 'The first Barcelona',
+      });
+      await seedCityWithListing({
+        countryId,
+        cityName: 'Barcelona',
+        regionName: 'Anzoátegui',
+        ...NEARBY,
+        title: 'The second Barcelona',
+      });
+
+      const response = await request(app).get('/home/sections').query(externalQuery).expect(200);
+      const titles = allItems(response.body.data as HomePayload).map((item) => item.title);
+
+      expect(titles).toContain('The first Barcelona');
+      expect(titles).toContain('The second Barcelona');
+    });
+
+    it('answers UNRESOLVED, not 400 and not globally, when the geocoder knows the ref no longer', async () => {
+      installFake(async () => null);
+      await seedListingAt({ city: 'Barcelona', ...BARCELONA });
+      await seedListingAt({ city: 'Madrid', ...MADRID });
+
+      const response = await request(app).get('/home/sections').query(externalQuery).expect(200);
+      const payload = response.body.data as HomePayload;
+
+      expect(payload.location.status).toBe('unresolved');
+      // The whole point: a lost location must not widen. Both cities are seeded,
+      // so a global answer would be visibly non-empty here.
+      expect(payload.sections).toHaveLength(0);
+    });
+
+    it('answers 503, NOT 400, when the geocoder itself cannot answer', async () => {
+      // A gateway outage is about the moment, not about the request, so it is
+      // the one failure here a client may retry — and the client's retry
+      // predicate reads exactly this status. Reporting it as `unresolved` would
+      // tell somebody their city does not exist because a provider was down.
+      installFake(async () => {
+        throw new GeocodingProviderError('provider_unavailable', PROVIDER_ID);
+      });
+      await seedListingAt({ city: 'Barcelona', ...BARCELONA });
+
+      const response = await request(app).get('/home/sections').query(externalQuery).expect(503);
+
+      expect(response.body.error).toBe('GEOCODER_UNAVAILABLE');
+    });
+
+    it('still 400s for a ref shape Home genuinely cannot scope', async () => {
+      // The check is narrowed, not removed. A multi-area scope would need the
+      // covering box, which is a SUPERSET of what the user asked for.
+      await seedListingAt({ city: 'Barcelona', ...BARCELONA });
+
+      const response = await request(app)
+        .get('/home/sections')
+        .query({
+          loc: `multi.city.${PROVIDER_ID}.${EXTERNAL_REF}+here.25000`,
+          offering: OfferingType.LONG_TERM_RENT,
+        })
+        .expect(400);
+
+      expect(response.body.error).toBe('UNSUPPORTED_LOCATION');
+    });
+
+    it('still 400s for an external ref of a type Home cannot scope', async () => {
+      // A `country.` or `postcode.` scope has no predicate to hang on, whichever
+      // source it came from. Narrowing the external check must not have widened
+      // the type check.
+      await seedListingAt({ city: 'Barcelona', ...BARCELONA });
+
+      const response = await request(app)
+        .get('/home/sections')
+        .query({ loc: `country.${PROVIDER_ID}.${EXTERNAL_REF}`, offering: OfferingType.LONG_TERM_RENT })
+        .expect(400);
+
+      expect(response.body.error).toBe('UNSUPPORTED_LOCATION');
     });
   });
 });

--- a/packages/backend/controllers/home/homeSectionsController.ts
+++ b/packages/backend/controllers/home/homeSectionsController.ts
@@ -38,12 +38,16 @@ import {
   OfferingType,
   locationKeyOfRef,
   parseLocationToken,
+  type GeoPlace,
   type HomeLocationSummary,
   type HomeSectionsResponse,
   type LocationRef,
 } from '@homiio/shared-types';
 
 import { logger } from '../../middlewares/logging';
+import { lookupCityPlaces } from '../../db/geo/placeLookup';
+import { resolvePlace } from '../../services/geocoding/gateway';
+import { parseLanguage } from '../../services/geocoding/validation';
 import {
   resolveCityId,
   resolveNeighborhoodId,
@@ -100,15 +104,161 @@ interface ResolvedScope {
   location: HomeLocationSummary;
 }
 
-/** A 400 the caller must render, with a machine-readable code. */
+/**
+ * A scope this endpoint cannot serve, with a machine-readable code.
+ *
+ * `status` distinguishes the two kinds, and the distinction is what the client's
+ * retry predicate reads: a **400** means "this scope is not acceptable", which no
+ * amount of retrying will change, and a **503** means "the gateway could not
+ * answer just now", which is exactly what a retry is for. Collapsing them is how
+ * a browser fires the same doomed request four times.
+ */
 class HomeScopeError extends Error {
   readonly code: string;
+  readonly status: number;
 
-  constructor(code: string, message: string) {
+  constructor(code: string, message: string, status = 400) {
     super(message);
     this.name = 'HomeScopeError';
     this.code = code;
+    this.status = status;
   }
+}
+
+/** The radius applied when an external place has a centre but no extent. */
+const EXTERNAL_POINT_RADIUS_METERS = 25_000;
+
+/**
+ * The place types Homiio can narrow a listing query by.
+ *
+ * `country` and `postcode` are absent because there is no predicate for them:
+ * `addresses` carries a city, a region and a neighborhood id and nothing else a
+ * scope can hang on. Refusing them is right — dropping one instead is how a
+ * named scope becomes a global page under that name's heading, which ADR §1.3(d)
+ * records this home screen shipping for months.
+ */
+const SCOPEABLE_PLACE_TYPES: ReadonlySet<string> = new Set(['city', 'region', 'neighborhood']);
+
+/** The reader's language, for the geocoder's own labels. Same shape as `geoController`. */
+function languageOf(req: Request): string {
+  const header = req.headers['accept-language'];
+  return parseLanguage(undefined, typeof header === 'string' ? header : undefined);
+}
+
+/**
+ * Scope by an EXTERNAL place ref — the ordinary output of picking a city.
+ *
+ * ## The defect this repairs, which reached production
+ *
+ * This branch used to throw `UNSUPPORTED_LOCATION`, so
+ * `GET /api/home/sections?loc=city.osm.R347950` answered **400**. That token is
+ * not exotic input: the place picker resolves through the #351 geo gateway, and
+ * every gateway candidate is external (`{ kind: 'external', provider, ref }`).
+ * The location ladder therefore handed Home a scope Home refused — the failure
+ * #353 exists to prevent, arrived at from the other side, and the user saw four
+ * silent failures.
+ *
+ * ## Three rungs, and the order is the point
+ *
+ *  1. **The canonical Homiio place.** An id survives a provider swap where a
+ *     provider ref is only as stable as the provider, so a Homiio city is always
+ *     the better scope when one matches. The gateway's own bbox is passed as a
+ *     HARD filter, which is what stops "Barcelona, Catalonia" resolving to
+ *     "Barcelona, Anzoátegui": the candidate has to sit inside the box the
+ *     geocoder returned. An AMBIGUOUS result deliberately falls through rather
+ *     than picking one — auto-picking a homonym is the bug ADR 0002 §7 names.
+ *  2. **The place's own geometry.** `cities` is seeded from Homiio's own data
+ *     and does not cover the world, so a real place the geocoder found perfectly
+ *     well may have no row here. Refusing at that point sends the user back to
+ *     the picker to choose the same place again, forever. Its bounds ARE the
+ *     area they picked, and they are what `/api/properties/search` already
+ *     scopes an external place by (`usePropertySearch.locationParams` →
+ *     `geometryParams`) — two surfaces disagreeing about one selection is the
+ *     bug class this epic removes.
+ *  3. **`unresolved`.** Only when the gateway cannot name the place at all, or
+ *     names one with no geometry and no Homiio match. Never a 400 and never a
+ *     widening: the client renders the picker, as it already does.
+ */
+async function resolveExternalPlace(
+  ref: Extract<LocationRef, { kind: 'place' }>,
+  token: string,
+  language: string,
+): Promise<ResolvedScope> {
+  // The REQUESTED identity, echoed unchanged. The client compares this against
+  // its own `locationKey(selection)`, which is built from what it asked for;
+  // echoing the Homiio id we resolved TO would read as "the server applied a
+  // different scope".
+  const key = locationKeyOfRef(ref);
+  const unresolved: ResolvedScope = {
+    scope: {},
+    location: { status: 'unresolved', requested: { param: 'city', value: ref.id } },
+  };
+
+  let place: GeoPlace | null;
+  try {
+    const result = await resolvePlace(token, language);
+    place = result.place ?? null;
+  } catch (error) {
+    // A gateway that cannot answer is NOT "no such place". Reporting it as
+    // `unresolved` would tell somebody their city does not exist because a
+    // provider was rate-limited, and would make a retryable failure look final.
+    logger.warn('home.sections.geocoder_unavailable', {
+      locationKey: key,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+    throw new HomeScopeError(
+      'GEOCODER_UNAVAILABLE',
+      'That place could not be looked up just now. Try again.',
+      503,
+    );
+  }
+
+  if (!place) return unresolved;
+
+  // 1. The canonical Homiio place.
+  const lookup = await lookupCityPlaces({
+    token: place.label.primary,
+    countryCode: place.admin.countryCode,
+    // NO `limit: 1`. Capping a lookup that can match several rows turns a
+    // genuinely ambiguous answer into a confident wrong one — the #295 bug, and
+    // `placeLookup` says so at the one `.limit()` it has.
+    ...(place.bounds ? { bounds: place.bounds } : {}),
+    ...(place.precision === 'area' ? {} : { near: place.center }),
+  });
+  if (lookup.status === 'resolved') {
+    return { scope: { cityId: lookup.place.id }, location: { status: 'resolved', key } };
+  }
+
+  // 2. The place's own geometry.
+  if (place.bounds) {
+    return {
+      scope: {
+        boundingBox: {
+          swLat: place.bounds.south,
+          swLng: place.bounds.west,
+          neLat: place.bounds.north,
+          neLng: place.bounds.east,
+        },
+      },
+      location: { status: 'resolved', key, bounds: place.bounds },
+    };
+  }
+  if (place.precision !== 'area') {
+    return {
+      scope: {
+        centerRadius: {
+          lat: place.center.latitude,
+          lng: place.center.longitude,
+          radiusMeters: EXTERNAL_POINT_RADIUS_METERS,
+        },
+      },
+      location: { status: 'resolved', key, radiusMeters: EXTERNAL_POINT_RADIUS_METERS },
+    };
+  }
+
+  // 3. Named, but unframeable and unmatched. There is genuinely nothing to
+  //    scope by, and answering anyway would answer globally.
+  return unresolved;
 }
 
 /**
@@ -121,6 +271,8 @@ class HomeScopeError extends Error {
  */
 async function resolveScope(
   ref: LocationRef,
+  token: string,
+  language: string,
   query: Record<string, RawQueryValue>,
 ): Promise<ResolvedScope> {
   const key = locationKeyOfRef(ref);
@@ -164,11 +316,17 @@ async function resolveScope(
     }
 
     case 'place': {
-      if (ref.source.kind !== 'homiio') {
+      // The three placeTypes Homiio can narrow by, checked BEFORE the source so
+      // an unsupported type is refused identically whether it came from Homiio
+      // or a geocoder.
+      if (!SCOPEABLE_PLACE_TYPES.has(ref.placeType)) {
         throw new HomeScopeError(
           'UNSUPPORTED_LOCATION',
-          'An external place ref cannot scope Home yet. Resolve it to a Homiio place first.',
+          `Home cannot scope by ${ref.placeType}. Supported: city, region, neighborhood, bbox, here.`,
         );
+      }
+      if (ref.source.kind !== 'homiio') {
+        return resolveExternalPlace(ref, token, language);
       }
       if (ref.placeType === 'city') {
         const cityId = await resolveCityId(ref.id);
@@ -200,6 +358,9 @@ async function resolveScope(
         }
         return { scope: { neighborhoodId }, location: { status: 'resolved', key } };
       }
+      // Unreachable: `SCOPEABLE_PLACE_TYPES` is checked above and holds exactly
+      // the three branches returned from. Kept as an exhaustiveness guard rather
+      // than deleted, so adding a fourth scopeable type fails loudly here.
       throw new HomeScopeError(
         'UNSUPPORTED_LOCATION',
         `Home cannot scope by ${ref.placeType}. Supported: city, region, neighborhood, bbox, here.`,
@@ -242,12 +403,13 @@ export async function getHomeSections(req: Request, res: Response): Promise<void
       return;
     }
     try {
-      const resolved = await resolveScope(parsed.value, query);
+      const resolved = await resolveScope(parsed.value, loc, languageOf(req), query);
       scope = resolved.scope;
       location = resolved.location;
     } catch (error) {
       if (error instanceof HomeScopeError) {
-        res.status(400).json({ success: false, message: error.message, error: error.code });
+        // `status` decides whether the client may retry — see the class comment.
+        res.status(error.status).json({ success: false, message: error.message, error: error.code });
         return;
       }
       throw error;

--- a/packages/frontend/__tests__/home/homeFailureSurfacing.test.ts
+++ b/packages/frontend/__tests__/home/homeFailureSurfacing.test.ts
@@ -1,0 +1,153 @@
+/**
+ * A Home request that fails must SAY so — the user's actual complaint (#353).
+ *
+ * ## What happened in production
+ *
+ * The browser fired `GET /api/home/sections?loc=city.osm.R347950` **four times**,
+ * every one answered **400**, and the surface showed nothing that named a
+ * failure. Two separate defects wearing one symptom, and this file pins both
+ * halves of the repair:
+ *
+ *  1. **A 400 was retried.** "This scope is not acceptable" cannot become
+ *     acceptable by asking again, so three of those four requests could never
+ *     have succeeded — and each one bought more time during which the surface
+ *     merely looked slow.
+ *  2. **A failure could render as an absence.** "We could not load this area"
+ *     and "there is nothing in this area" are different claims about the world,
+ *     and showing the second for the first tells somebody their city is empty
+ *     when Homiio could not answer.
+ */
+
+import {
+  homeSectionsFailureMessage,
+  homeSurfaceState,
+  isRetryableHomeSectionsError,
+} from '@/hooks/useHomeSections';
+import { ApiError } from '@/utils/api';
+
+describe('what may be retried', () => {
+  it('does NOT retry the 400 that caused the incident', () => {
+    // The exact production failure: `UNSUPPORTED_LOCATION` on a scope the
+    // endpoint refused. Retrying it is asking the same question again.
+    expect(isRetryableHomeSectionsError(new ApiError('UNSUPPORTED_LOCATION', 400))).toBe(false);
+  });
+
+  it('does not retry any other 4xx either', () => {
+    // The floor for the case above: a predicate special-casing 400 alone would
+    // pass it while still hammering a 404 or a 422.
+    for (const status of [401, 403, 404, 409, 422, 429, 499]) {
+      expect(isRetryableHomeSectionsError(new ApiError('nope', status))).toBe(false);
+    }
+  });
+
+  it('DOES retry a 5xx, which is about the moment rather than the request', () => {
+    for (const status of [500, 502, 503, 504]) {
+      expect(isRetryableHomeSectionsError(new ApiError('later', status))).toBe(true);
+    }
+  });
+
+  it('DOES retry the geocoder-unavailable 503 the repair introduces', () => {
+    // The server now distinguishes "this scope is not acceptable" (400) from
+    // "the gateway could not answer just now" (503). If the client did not read
+    // that distinction, the split would buy nothing.
+    expect(isRetryableHomeSectionsError(new ApiError('GEOCODER_UNAVAILABLE', 503))).toBe(true);
+  });
+
+  it('DOES retry a failure that never reached a status', () => {
+    // Offline, DNS, a dropped socket. The request never reached the server, so
+    // nothing has been said about whether the scope is acceptable.
+    expect(isRetryableHomeSectionsError(new ApiError('Network Error'))).toBe(true);
+    expect(isRetryableHomeSectionsError(new Error('boom'))).toBe(true);
+  });
+});
+
+describe('the surface never renders a failure as an absence', () => {
+  const base = {
+    needsPlace: false,
+    canQuery: true,
+    isLoading: false,
+    hasError: false,
+    sectionCount: 0,
+  };
+
+  it('reports FAILED, not empty, when the request failed with nothing to show', () => {
+    // The assertion this file exists for.
+    expect(homeSurfaceState({ ...base, hasError: true })).toBe('failed');
+  });
+
+  it('reports EMPTY only when the request succeeded and matched nothing', () => {
+    // The floor: without it, a function returning 'failed' for everything would
+    // satisfy the case above.
+    expect(homeSurfaceState(base)).toBe('empty');
+  });
+
+  it('keeps showing sections when a BACKGROUND refresh fails', () => {
+    // The data is real and still on screen; blanking the page would destroy
+    // something correct. The toast and the stale banner carry the failure.
+    expect(homeSurfaceState({ ...base, hasError: true, sectionCount: 3 })).toBe('sections');
+  });
+
+  it('asks for a place before it reports anything else', () => {
+    // With no scope there is nothing to have failed at, so the picker outranks
+    // even an error left over from a previous scope.
+    expect(homeSurfaceState({ ...base, needsPlace: true, hasError: true })).toBe('needs_place');
+    expect(homeSurfaceState({ ...base, canQuery: false, hasError: true })).toBe('needs_place');
+  });
+
+  it('reports LOADING only while there is nothing to show and nothing has failed', () => {
+    expect(homeSurfaceState({ ...base, isLoading: true })).toBe('loading');
+    // A failure outranks a stale `isLoading`, so a settled error is never
+    // rendered as a spinner that will never resolve.
+    expect(homeSurfaceState({ ...base, isLoading: true, hasError: true })).toBe('loading');
+  });
+
+  it('returns exactly one state for every input combination', () => {
+    // Exhaustive rather than illustrative: the states are exclusive by
+    // construction and a sweep is what proves it, with a vacuity floor so a
+    // broken generator cannot pass by never looping.
+    const flags = [false, true];
+    const allowed = new Set(['needs_place', 'loading', 'failed', 'empty', 'sections']);
+    let checked = 0;
+
+    for (const needsPlace of flags) {
+      for (const canQuery of flags) {
+        for (const isLoading of flags) {
+          for (const hasError of flags) {
+            for (const sectionCount of [0, 3]) {
+              const state = homeSurfaceState({
+                needsPlace,
+                canQuery,
+                isLoading,
+                hasError,
+                sectionCount,
+              });
+              expect(allowed.has(state)).toBe(true);
+              // The rule that matters, asserted over every combination: a
+              // failure with nothing to show is NEVER reported as empty.
+              if (hasError && sectionCount === 0 && canQuery && !needsPlace && !isLoading) {
+                expect(state).toBe('failed');
+              }
+              checked += 1;
+            }
+          }
+        }
+      }
+    }
+
+    expect(checked).toBe(2 ** 4 * 2);
+    expect(checked).toBe(32);
+  });
+});
+
+describe('the failure message always has words in it', () => {
+  it('never returns an empty string, even with i18n uninitialised', () => {
+    // MEASURED in this environment: an i18next that has not been `init`ed
+    // returns `undefined` from `t()`, and does so even when a `defaultValue` is
+    // supplied. `toast.error(undefined)` is a toast with no words — the silent
+    // failure this change removes, reintroduced on the boot path.
+    const message = homeSectionsFailureMessage();
+
+    expect(typeof message).toBe('string');
+    expect(message.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/packages/frontend/__tests__/home/homeFailureToast.test.tsx
+++ b/packages/frontend/__tests__/home/homeFailureToast.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * A failed Home request produces EXACTLY ONE message (#353).
+ *
+ * The production incident was four failed requests and nothing said. The render
+ * path is pinned by `homeFailureSurfacing.test.ts`; this file pins the other
+ * half — that a message is actually emitted, and that it is emitted ONCE rather
+ * than once per retry, per re-render, or per anything else that happens more
+ * often than a person fails to load a page.
+ *
+ * The toast module is mocked because it is the EXTERNAL SYSTEM under test here:
+ * what matters is how many times the hook calls it and with what, not what
+ * Bloom draws. Bloom's own rendering is Bloom's to test.
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { ApiError } from '@/utils/api';
+import { homeSectionsFailureMessage, useHomeSections } from '@/hooks/useHomeSections';
+import { OfferingType, type LocationSelection } from '@homiio/shared-types';
+
+// `mock`-prefixed, because a `jest.mock` factory is hoisted above every other
+// statement in the file and may only reach variables named that way — the one
+// naming convention jest enforces rather than suggests.
+const mockToastError = jest.fn();
+jest.mock('@oxyhq/bloom/toast', () => ({
+  toast: { error: (...args: unknown[]) => mockToastError(...args), success: jest.fn() },
+}));
+
+const mockFetchHomeSections = jest.fn();
+jest.mock('@/services/homeSectionsService', () => ({
+  fetchHomeSections: (...args: unknown[]) => mockFetchHomeSections(...args),
+  UnscopableLocationError: class extends Error {},
+}));
+
+const BARCELONA: LocationSelection = {
+  kind: 'place',
+  source: { kind: 'homiio', entity: 'city', id: 'city-barcelona' },
+  placeType: 'city',
+  label: { primary: 'Barcelona', kind: 'place' },
+  admin: { countryCode: 'ES', cityName: 'Barcelona' },
+  precision: 'centroid',
+  center: { longitude: 2.1686, latitude: 41.3874 },
+};
+
+function Probe({ selection }: { selection: LocationSelection | null }): React.ReactElement {
+  const home = useHomeSections(selection, OfferingType.LONG_TERM_RENT, { enabled: true });
+  return <Text>{home.error ? 'failed' : 'ok'}</Text>;
+}
+
+function renderProbe(selection: LocationSelection | null = BARCELONA) {
+  // `retry: false` here is a DEFAULT, and the hook overrides it with its own
+  // predicate — so these tests exercise that predicate rather than bypassing it.
+  // That is not incidental: mutating the predicate to retry a 4xx turns this
+  // file red as well as `homeFailureSurfacing.test.ts`, because the doomed
+  // request is then attempted three times before the message appears. Measured,
+  // not assumed — the first version of this comment claimed retries were off.
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <Probe selection={selection} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockToastError.mockClear();
+  mockFetchHomeSections.mockReset();
+});
+
+describe('a failed Home request is never silent', () => {
+  it('emits a message when the request fails', async () => {
+    mockFetchHomeSections.mockRejectedValue(new ApiError('UNSUPPORTED_LOCATION', 400));
+
+    const { findByText } = renderProbe();
+    await findByText('failed');
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledTimes(1));
+
+    // The message is TRANSLATED, so asserting an English sentence would pass
+    // while shipping an untranslated string. What must hold is that the hook
+    // asked i18n for THIS key and that whatever came back has words in it —
+    // `t()` on an uninitialised i18next returns `undefined`, and a toast with no
+    // text is the silent failure this file exists to prevent.
+    const [message] = mockToastError.mock.calls[0] as [unknown];
+    expect(typeof message).toBe('string');
+    expect((message as string).trim().length).toBeGreaterThan(0);
+    expect(message).toBe(homeSectionsFailureMessage());
+  });
+
+  it('emits exactly ONE message however often the surface re-renders', async () => {
+    // The incident fired four requests. Whatever the retry count, a person
+    // failing to load a page once should be told once.
+    mockFetchHomeSections.mockRejectedValue(new ApiError('UNSUPPORTED_LOCATION', 400));
+
+    const { findByText, rerender } = renderProbe();
+    await findByText('failed');
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+    rerender(
+      <QueryClientProvider client={client}>
+        <Probe selection={BARCELONA} />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledTimes(1));
+  });
+
+  it('says NOTHING when the request succeeds', async () => {
+    // The floor. Without it, a hook that toasted unconditionally would satisfy
+    // both assertions above.
+    mockFetchHomeSections.mockResolvedValue({
+      location: { status: 'resolved', key: 'homiio:city:city-barcelona' },
+      generatedAt: new Date().toISOString(),
+      sections: [],
+    });
+
+    const { findByText } = renderProbe();
+    await findByText('ok');
+
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/__tests__/noFunctionFormStyle.test.ts
+++ b/packages/frontend/__tests__/noFunctionFormStyle.test.ts
@@ -1,0 +1,194 @@
+/**
+ * No JSX element carries React Native's FUNCTION-FORM `style` prop.
+ *
+ * ## The bug it guards
+ *
+ * NativeWind's css-interop (v4 `react-native-css-interop`, and the v5 preview
+ * this app runs) rewrites the `style` prop of every JSX element to merge
+ * `className` styles, and it does NOT support `style={({ pressed }) => [...]}`.
+ * The function is swallowed and the element renders with **no style at all** —
+ * silently, with children still rendering their own styles, which is what makes
+ * it look like a spacing bug rather than a dropped prop. `AGENTS.md` carries the
+ * rule and the replacement (a static style array plus `onPressIn`/`onPressOut`
+ * state); `components/search/SearchSummaryBar.tsx` is the canonical template.
+ *
+ * ## Why this file exists rather than the documented grep
+ *
+ * The rule shipped as a command in `AGENTS.md` —
+ * `grep -rn "style={({" app components --include=*.tsx` must return ZERO — and a
+ * grep is LINE-based, so it cannot tell code from prose. It began returning `1`
+ * the moment a component's own doc comment quoted the forbidden form in order to
+ * warn about it (`components/location/LocationScopeBar.tsx`). A gate that cries
+ * wolf gets switched off by whoever hits it next, and an off gate is worse than
+ * the hole it was covering.
+ *
+ * So the scan strips comments first, through the ONE comment stripper this
+ * repository has (`@homiio/shared-types/testing/stripComments`) — `AGENTS.md`
+ * records that having two is itself a defect, and the currency and geocoder
+ * gates already use this one.
+ *
+ * ## The anti-vacuity defences, which every scan of this shape needs
+ *
+ *  - **`git ls-files`, not a directory walk** — build output is excluded for
+ *    free rather than by an ignore list that rots, and the file set cannot
+ *    disagree with what git tracks. Consequence for anyone mutation-testing
+ *    this: an UNSTAGED probe is not in the index and therefore not scanned, so
+ *    a planted file must be `git add -f`ed or the mutation measures nothing.
+ *  - **A directory pathspec**, never a doubled-star glob ending in an extension:
+ *    that form matches only files in a SUBdirectory and silently drops every
+ *    top-level one, which reads exactly like a clean result.
+ *  - **A vacuity floor** on files scanned. `expect([]).toEqual([])` is what a
+ *    broken traversal produces and is indistinguishable from a clean tree.
+ *  - **A pinned predicate**, positive AND negative: the positive case fails if
+ *    the scan stops matching anything at all, and the negative case is the
+ *    comment that caused this file to be written.
+ *  - **A tracked-but-unreadable file is a FAILURE, not a skip.** An unread file
+ *    is exactly where a reintroduction would hide.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { stripComments } from '@homiio/shared-types/testing/stripComments';
+
+/** Repository root — two levels up from `packages/frontend`. */
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+
+/** Directory pathspecs, never a doubled-star glob. See the header. */
+const SCANNED_PATHSPECS = ['packages/frontend/app', 'packages/frontend/components'];
+
+/**
+ * Extensions that must be clean. Affirmative on purpose: a file type arriving
+ * tomorrow is not silently exempt, it is simply not yet covered, and adding it
+ * here is a visible decision.
+ */
+const SCANNED_EXTENSIONS = ['.tsx', '.jsx'];
+
+/**
+ * The forbidden shape: a `style` prop opening with a function.
+ *
+ * Whitespace-tolerant between `{` and `(`, because `style={ ({ pressed }) =>`
+ * is the same bug written by a different formatter. Deliberately NOT anchored to
+ * `pressed`: `({ hovered })`, `({ focused })` and a bare `() =>` are the same
+ * swallowed prop, and a pattern naming one of them would pass the others.
+ */
+const FUNCTION_FORM_STYLE = /style=\{\s*\(/;
+
+/**
+ * Sized against the tree at the time of writing (291 files under these two
+ * pathspecs) with room to shrink. A number this far below the real count cannot
+ * be tripped by ordinary deletion, and a traversal that broke entirely returns
+ * zero.
+ */
+const MINIMUM_SCANNED_FILES = 150;
+
+interface Finding {
+  file: string;
+  line: number;
+  text: string;
+}
+
+/** Every CODE line of `source` carrying the function form. Prose cannot match. */
+function scanSource(file: string, source: string): Finding[] {
+  const findings: Finding[] = [];
+  stripComments(source)
+    .split('\n')
+    .forEach((text, index) => {
+      if (FUNCTION_FORM_STYLE.test(text)) {
+        findings.push({ file, line: index + 1, text: text.trim() });
+      }
+    });
+  return findings;
+}
+
+/** Tracked source files under the scanned pathspecs, by repo-relative path. */
+function trackedSourceFiles(): string[] {
+  const output = execFileSync('git', ['ls-files', '--', ...SCANNED_PATHSPECS], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return output
+    .split('\n')
+    .filter(Boolean)
+    .filter((file) => SCANNED_EXTENSIONS.some((extension) => file.endsWith(extension)));
+}
+
+const describeFinding = (finding: Finding): string => `${finding.file}:${finding.line}  ${finding.text}`;
+
+describe('the predicate can tell code from prose', () => {
+  it('matches a real function-form style prop', () => {
+    // The POSITIVE control. Without it, a scan that stopped matching anything at
+    // all would report a clean tree forever.
+    expect(scanSource('probe.tsx', '<Pressable style={({ pressed }) => [styles.x]} />')).toHaveLength(1);
+  });
+
+  it('matches the other function forms, not just `pressed`', () => {
+    // A pattern naming one destructured flag would pass the rest, and every one
+    // of these is the same swallowed prop.
+    for (const source of [
+      '<Pressable style={({ hovered }) => styles.x} />',
+      '<Pressable style={({ focused }) => styles.x} />',
+      '<Pressable style={() => styles.x} />',
+      '<Pressable style={ ({ pressed }) => styles.x } />',
+    ]) {
+      expect(scanSource('probe.tsx', source)).toHaveLength(1);
+    }
+  });
+
+  it('does NOT match a doc comment quoting the forbidden form', () => {
+    // The NEGATIVE control, and the reason this file replaced a grep: a
+    // component warning about the rule in its own header is not a violation of
+    // it. This is the exact text at `components/location/LocationScopeBar.tsx`.
+    const comment = [
+      '/**',
+      " * `style={({ pressed }) => [...]}` — the css-interop swallows the function",
+      ' * form and the element renders with no style at all.',
+      ' */',
+      'const x = 1;',
+    ].join('\n');
+
+    expect(scanSource('probe.tsx', comment)).toEqual([]);
+  });
+
+  it('does NOT match a line comment or a static style array', () => {
+    expect(scanSource('probe.tsx', '// style={({ pressed }) => …} is forbidden')).toEqual([]);
+    // The SANCTIONED replacement must not be flagged, or the gate would forbid
+    // its own fix.
+    expect(
+      scanSource('probe.tsx', '<Pressable style={[styles.x, pressed && styles.xPressed]} />'),
+    ).toEqual([]);
+  });
+});
+
+describe('no component uses the function-form style prop', () => {
+  const files = trackedSourceFiles();
+
+  it('scans enough files that a broken traversal cannot pass as clean', () => {
+    expect(files.length).toBeGreaterThanOrEqual(MINIMUM_SCANNED_FILES);
+  });
+
+  it('finds no violation, and can read every file it was given', () => {
+    const findings: Finding[] = [];
+    const unreadable: string[] = [];
+
+    for (const file of files) {
+      let source: string;
+      try {
+        source = readFileSync(join(REPO_ROOT, file), 'utf8');
+      } catch {
+        // A tracked file the tree does not have is a FAILURE, never a skip: an
+        // unread file is exactly where a reintroduction would hide.
+        unreadable.push(file);
+        continue;
+      }
+      findings.push(...scanSource(file, source));
+    }
+
+    expect(unreadable).toEqual([]);
+    // Reported with file, line and the offending text, so whoever hits this gate
+    // does not have to go looking for it.
+    expect(findings.map(describeFinding)).toEqual([]);
+  });
+});

--- a/packages/frontend/app/(tabs)/index.tsx
+++ b/packages/frontend/app/(tabs)/index.tsx
@@ -47,7 +47,7 @@ import { H1, P } from '@oxyhq/bloom/typography';
 import { serializeLocationToken, type LocationSelection, type Property } from '@homiio/shared-types';
 
 import { useLocationScope } from '@/hooks/useLocationScope';
-import { useHomeSections } from '@/hooks/useHomeSections';
+import { homeSurfaceState, useHomeSections } from '@/hooks/useHomeSections';
 import { LocationScopeBar } from '@/components/location/LocationScopeBar';
 import { HomeSectionBand } from '@/components/home/HomeSectionBand';
 import { PropertyResultsGridSkeleton } from '@/components/ui/PropertyResultsGridSkeleton';
@@ -95,6 +95,16 @@ export default function HomePage() {
 
   const scope = useLocationScope();
   const home = useHomeSections(scope.selection, browseOffering, { enabled: scope.canQuery });
+
+  // ONE exclusive answer, so "we could not load this" can never be rendered as
+  // "there is nothing here" — see `homeSurfaceState`.
+  const surface = homeSurfaceState({
+    needsPlace: scope.needsPlace,
+    canQuery: scope.canQuery,
+    isLoading: home.isLoading,
+    hasError: home.error !== null,
+    sectionCount: home.sections.length,
+  });
 
   const { properties: recentlyViewedProperties, refetch: refetchRecentlyViewed } = useRecentlyViewed();
   const { savedProperties, isLoading: savedLoading, loadSavedProperties } = useSavedPropertiesContext();
@@ -268,7 +278,7 @@ export default function HomePage() {
         <View className="gap-6 md:gap-8 pb-14 pt-6">
           {/* The mandatory picker. NOT a global list: when nothing has been
               chosen and the device cannot answer, Home asks rather than guesses. */}
-          {scope.needsPlace ? (
+          {surface === 'needs_place' ? (
             <View className={`gap-2 ${PAGE_GUTTER_CLASS}`}>
               <SectionEyebrow>{t('home.scopePrompt.eyebrow')}</SectionEyebrow>
               <H1 className="text-[24px] font-bold leading-7 tracking-tight text-foreground">
@@ -280,14 +290,14 @@ export default function HomePage() {
 
           {/* Skeletons that PRESERVE the layout, so nothing jumps when the
               sections land. */}
-          {home.isLoading ? (
+          {surface === 'loading' ? (
             <View className={`gap-6 ${PAGE_GUTTER_CLASS}`}>
               <PropertyResultsGridSkeleton count={SKELETON_CARDS} />
               <PropertyResultsGridSkeleton count={SKELETON_CARDS} />
             </View>
           ) : null}
 
-          {home.error ? (
+          {surface === 'failed' ? (
             <View className={`gap-2 ${PAGE_GUTTER_CLASS}`}>
               <P className="text-sm text-muted-foreground">{t('home.sections.error')}</P>
               <Button variant="secondary" size="medium" onPress={onRefresh} accessibilityLabel={t('common.retry')}>
@@ -304,7 +314,7 @@ export default function HomePage() {
 
           {/* A USEFUL empty state: what to do, not an apology. Only shown once the
               surface has actually answered, so it never flashes during a load. */}
-          {scope.canQuery && !home.isLoading && !home.error && home.sections.length === 0 ? (
+          {surface === 'empty' ? (
             <View className={`gap-3 ${PAGE_GUTTER_CLASS}`}>
               <H1 className="text-[22px] font-bold leading-7 tracking-tight text-foreground">
                 {t('home.empty.title')}

--- a/packages/frontend/hooks/useHomeSections.ts
+++ b/packages/frontend/hooks/useHomeSections.ts
@@ -31,10 +31,13 @@
  * precisely the "no presentarla como actualizada" the issue forbids.
  */
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useQuery, type QueryKey } from '@tanstack/react-query';
+import i18next from 'i18next';
+import { toast } from '@oxyhq/bloom/toast';
 import { locationKey, type HomeSection, type LocationSelection, type Property } from '@homiio/shared-types';
 
+import { ApiError } from '@/utils/api';
 import { fetchHomeSections } from '@/services/homeSectionsService';
 import {
   readHomeSnapshot,
@@ -47,6 +50,66 @@ export const STALE_AFTER_MS = 1000 * 60 * 30;
 
 /** How long a fetched surface is served without a background refetch. */
 const HOME_SECTIONS_STALE_TIME_MS = 1000 * 60 * 2;
+
+/**
+ * Attempts after the first, for a failure that retrying can actually fix.
+ *
+ * Two, not four. The production incident fired the SAME doomed request four
+ * times against a 400 and showed the user nothing — four attempts at an answer
+ * that could not change, and four chances for the surface to look merely slow.
+ */
+const HOME_SECTIONS_MAX_RETRIES = 2;
+
+/**
+ * The words shown when i18n has not loaded yet.
+ *
+ * Deliberately the same sentence as `home.sections.loadFailedToast` in
+ * `en.json`; the key is the copy, and this is the guarantee that SOMETHING is
+ * said even when the key cannot be resolved.
+ */
+const HOME_SECTIONS_FAILED_FALLBACK =
+  'Could not load homes for this area. Nothing is hidden — the request failed.';
+
+/**
+ * The failure message, guaranteed to have words in it.
+ *
+ * MEASURED, in this repo's own jest environment: an i18next that has not been
+ * `init`ed returns `undefined` from `t()` — and it does so **even when a
+ * `defaultValue` is supplied**, because the pre-init `t` is a stub that never
+ * looks at its options. So `defaultValue` is not the guard it appears to be, and
+ * the floor has to be applied here.
+ *
+ * It matters because `toast.error(undefined)` is a toast with no words in it:
+ * the silent failure this whole change exists to remove, reintroduced one layer
+ * down and only on the boot path, where nobody would look for it.
+ */
+export function homeSectionsFailureMessage(): string {
+  const translated = i18next.t('home.sections.loadFailedToast');
+  return typeof translated === 'string' && translated.trim().length > 0
+    ? translated
+    : HOME_SECTIONS_FAILED_FALLBACK;
+}
+
+/**
+ * Whether retrying could plausibly succeed.
+ *
+ * A **4xx is a statement about the REQUEST** — this scope is not acceptable —
+ * and no number of identical retries will make it acceptable. A 5xx, or a
+ * failure with no status at all (the transport never reached one), is about the
+ * moment, and that is exactly what a retry is for.
+ *
+ * Exported because it is the whole of the fix and belongs in a test that can
+ * name a status, rather than inside an options object nothing can reach.
+ */
+export function isRetryableHomeSectionsError(error: unknown): boolean {
+  const status = error instanceof ApiError ? error.status : undefined;
+  // No status: the request never reached the server. Retrying on reconnect is
+  // the correct behaviour, and it is the one case where an immediate retry is
+  // also cheap.
+  if (typeof status !== 'number') return true;
+  if (status >= 400 && status < 500) return false;
+  return true;
+}
 
 export type HomeDataFreshness = 'live' | 'cached' | 'stale';
 
@@ -122,7 +185,8 @@ export function useHomeSections(
     },
     enabled: options.enabled,
     staleTime: HOME_SECTIONS_STALE_TIME_MS,
-    retry: 1,
+    retry: (failureCount, error) =>
+      failureCount < HOME_SECTIONS_MAX_RETRIES && isRetryableHomeSectionsError(error),
   });
 
   const restored: HomeSnapshot | null = useMemo(
@@ -137,6 +201,31 @@ export function useHomeSections(
     failed: query.isError,
     ageMs: generatedAt ? Date.now() - new Date(generatedAt).getTime() : null,
   });
+
+  /**
+   * ONE message per distinct failure, and never one per retry.
+   *
+   * The signature is a STRING built from the scope, the offering and the
+   * message, so React Query's own retries — which do not change any of the
+   * three — cannot re-fire it, and switching city after a failure legitimately
+   * can. A ref-based "have I toasted yet" flag would have to be reset on every
+   * scope change by hand, and the hand is what gets forgotten.
+   *
+   * An effect is the right tool here rather than a smell: a toast is an external
+   * system, and updating an external system from React state is the one thing
+   * effects are for.
+   */
+  const failureSignature = query.isError
+    ? `${scopeKey}|${offering}|${query.error instanceof Error ? query.error.message : 'unknown'}`
+    : null;
+
+  useEffect(() => {
+    if (failureSignature === null) return;
+    // `i18next.t` rather than `useTranslation`'s `t`: the latter changes
+    // identity on a language switch, which would re-toast an old failure the
+    // moment somebody changed language.
+    toast.error(homeSectionsFailureMessage());
+  }, [failureSignature]);
 
   const refresh = useCallback(async () => {
     // Refetches the SAME key. The location ladder is untouched, so the scope
@@ -158,4 +247,42 @@ export function useHomeSections(
     error: query.error instanceof Error ? query.error : null,
     refresh,
   };
+}
+
+/**
+ * What the Home surface must render, as ONE exclusive answer.
+ *
+ * ## Why this is a function and not four booleans in the screen
+ *
+ * The production incident was a silent failure: four requests failed and the
+ * user saw nothing that named a failure. The states are mutually exclusive and
+ * the dangerous pair is `failed` and `empty` — "we could not load this area" and
+ * "there is nothing in this area" are different claims about the world, and
+ * rendering the second for the first tells somebody their city is empty when
+ * Homiio simply could not answer.
+ *
+ * Expressed as four conditions in JSX, that distinction is one `&&` away from
+ * being lost and cannot be tested without mounting the screen. Expressed here,
+ * it is an ordinary assertion, and `failed` is ordered ABOVE `empty` so the
+ * misleading claim is unreachable rather than merely discouraged.
+ */
+export type HomeSurfaceState = 'needs_place' | 'loading' | 'failed' | 'empty' | 'sections';
+
+export function homeSurfaceState(input: {
+  readonly needsPlace: boolean;
+  readonly canQuery: boolean;
+  readonly isLoading: boolean;
+  readonly hasError: boolean;
+  readonly sectionCount: number;
+}): HomeSurfaceState {
+  // The picker comes first: with no scope there is nothing to have failed at.
+  if (input.needsPlace || !input.canQuery) return 'needs_place';
+  // Then anything already fetched, so a failed BACKGROUND refresh over data we
+  // still hold does not blank the page — the data is real, and the toast plus
+  // the stale banner carry the failure.
+  if (input.sectionCount > 0) return 'sections';
+  if (input.isLoading) return 'loading';
+  // BEFORE `empty`, and that order is the fix.
+  if (input.hasError) return 'failed';
+  return 'empty';
 }

--- a/packages/frontend/locales/ar.json
+++ b/packages/frontend/locales/ar.json
@@ -327,7 +327,8 @@
         "eyebrow": "Public",
         "title": "Public housing",
         "reason": "Listed as public housing. Homiio has no cooperative or community housing field yet, so those are not included"
-      }
+      },
+      "loadFailedToast": "Could not load homes for this area. Nothing is hidden — the request failed."
     },
     "scopePrompt": {
       "eyebrow": "One step first",

--- a/packages/frontend/locales/bn-BD.json
+++ b/packages/frontend/locales/bn-BD.json
@@ -327,7 +327,8 @@
         "eyebrow": "Public",
         "title": "Public housing",
         "reason": "Listed as public housing. Homiio has no cooperative or community housing field yet, so those are not included"
-      }
+      },
+      "loadFailedToast": "Could not load homes for this area. Nothing is hidden — the request failed."
     },
     "scopePrompt": {
       "eyebrow": "One step first",

--- a/packages/frontend/locales/ca-ES.json
+++ b/packages/frontend/locales/ca-ES.json
@@ -336,7 +336,8 @@
         "eyebrow": "Public",
         "title": "Public housing",
         "reason": "Listed as public housing. Homiio has no cooperative or community housing field yet, so those are not included"
-      }
+      },
+      "loadFailedToast": "Could not load homes for this area. Nothing is hidden — the request failed."
     },
     "scopePrompt": {
       "eyebrow": "One step first",

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -327,7 +327,8 @@
         "eyebrow": "Public",
         "title": "Public housing",
         "reason": "Listed as public housing. Homiio has no cooperative or community housing field yet, so those are not included"
-      }
+      },
+      "loadFailedToast": "Could not load homes for this area. Nothing is hidden — the request failed."
     },
     "scopePrompt": {
       "eyebrow": "One step first",

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -315,7 +315,8 @@
         "eyebrow": "Public",
         "title": "Public housing",
         "reason": "Listed as public housing. Homiio has no cooperative or community housing field yet, so those are not included"
-      }
+      },
+      "loadFailedToast": "Could not load homes for this area. Nothing is hidden — the request failed."
     },
     "scopePrompt": {
       "eyebrow": "One step first",

--- a/packages/frontend/locales/fr-FR.json
+++ b/packages/frontend/locales/fr-FR.json
@@ -327,7 +327,8 @@
         "eyebrow": "Public",
         "title": "Public housing",
         "reason": "Listed as public housing. Homiio has no cooperative or community housing field yet, so those are not included"
-      }
+      },
+      "loadFailedToast": "Could not load homes for this area. Nothing is hidden — the request failed."
     },
     "scopePrompt": {
       "eyebrow": "One step first",

--- a/packages/frontend/locales/hi-IN.json
+++ b/packages/frontend/locales/hi-IN.json
@@ -327,7 +327,8 @@
         "eyebrow": "Public",
         "title": "Public housing",
         "reason": "Listed as public housing. Homiio has no cooperative or community housing field yet, so those are not included"
-      }
+      },
+      "loadFailedToast": "Could not load homes for this area. Nothing is hidden — the request failed."
     },
     "scopePrompt": {
       "eyebrow": "One step first",

--- a/packages/frontend/locales/id-ID.json
+++ b/packages/frontend/locales/id-ID.json
@@ -327,7 +327,8 @@
         "eyebrow": "Public",
         "title": "Public housing",
         "reason": "Listed as public housing. Homiio has no cooperative or community housing field yet, so those are not included"
-      }
+      },
+      "loadFailedToast": "Could not load homes for this area. Nothing is hidden — the request failed."
     },
     "scopePrompt": {
       "eyebrow": "One step first",

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -471,7 +471,8 @@
         "eyebrow": "Public",
         "title": "Public housing",
         "reason": "Listed as public housing. Homiio has no cooperative or community housing field yet, so those are not included"
-      }
+      },
+      "loadFailedToast": "Could not load homes for this area. Nothing is hidden — the request failed."
     },
     "scopePrompt": {
       "eyebrow": "One step first",

--- a/packages/frontend/locales/pt-BR.json
+++ b/packages/frontend/locales/pt-BR.json
@@ -327,7 +327,8 @@
         "eyebrow": "Public",
         "title": "Public housing",
         "reason": "Listed as public housing. Homiio has no cooperative or community housing field yet, so those are not included"
-      }
+      },
+      "loadFailedToast": "Could not load homes for this area. Nothing is hidden — the request failed."
     },
     "scopePrompt": {
       "eyebrow": "One step first",

--- a/packages/frontend/locales/ru-RU.json
+++ b/packages/frontend/locales/ru-RU.json
@@ -327,7 +327,8 @@
         "eyebrow": "Public",
         "title": "Public housing",
         "reason": "Listed as public housing. Homiio has no cooperative or community housing field yet, so those are not included"
-      }
+      },
+      "loadFailedToast": "Could not load homes for this area. Nothing is hidden — the request failed."
     },
     "scopePrompt": {
       "eyebrow": "One step first",

--- a/packages/frontend/locales/zh-CN.json
+++ b/packages/frontend/locales/zh-CN.json
@@ -327,7 +327,8 @@
         "eyebrow": "Public",
         "title": "Public housing",
         "reason": "Listed as public housing. Homiio has no cooperative or community housing field yet, so those are not included"
-      }
+      },
+      "loadFailedToast": "Could not load homes for this area. Nothing is hidden — the request failed."
     },
     "scopePrompt": {
       "eyebrow": "One step first",


### PR DESCRIPTION
Repairs a defect from #353 (PR #407) that **reached production**. #407 is merged and stays merged.

**Rebased onto `6f0450e2`** — current `main`, which includes #354. The earlier push was based on `d10ac39b`, so its CI had tested this code merged with the *old* main; #354 touched `packages/shared-types/src/location.ts`, which this change's scope resolution consumes directly. That diff is **purely additive** (`boundsSpanDegrees` extracted, `boundsCenter` delegating to it) and moves nothing this branch uses, but a textual clean-merge is not a semantic one, so the whole gate set was re-run on the rebased tree with `shared-types` and `listing-providers` rebuilt first — `tsc` reads `dist`, `jest` reads `src`, and believing a typecheck across that gap is how a stale build passes for the wrong reason. The only file overlap with #354 was the 12 locale files, and both key sets survive (asserted, not assumed).

## Root cause

`GET https://api.homiio.com/api/home/sections?loc=city.osm.R347950` answered **400 `UNSUPPORTED_LOCATION`**. The browser fired it four times and the user was shown nothing.

That token is **not exotic input — it is the ordinary output of picking a city.** The place picker resolves through the #351 geo gateway, and every gateway candidate is external (`source: { kind: 'external', provider, ref }`, pinned by `geoGateway.test.ts`). `homeSectionsController.ts` refused any `place` ref whose source was not `homiio`, so `useLocationScope` handed Home a scope Home rejected. It is the same class of failure #353 exists to prevent, arrived at from the other side: **the two halves of one contract disagreed about what a location is.**

Verified before fixing, in this order: the URL the client sends (above), the route serving it (`routes/public.ts` → `getHomeSections`), and the handler's behaviour against a **real Postgres plus the real geocoding registry** — a reproducing test was written first and went red on exactly the four cases below.

## The graceful path vs the genuine 400

The check is **narrowed, not removed**. An external ref now resolves through three rungs, and only a ref that is genuinely unscopable still 400s.

| Situation | Before | Now |
|---|---|---|
| OSM ref, Homiio knows the city | **400** | Scoped by the canonical **Homiio city id** — an id survives a provider swap; a provider ref does not |
| OSM ref, Homiio has no such city | **400** | Scoped by **the place's own bounds** — the area the user actually picked |
| OSM ref, two Homiio cities share the name | **400** | **Never auto-picked.** Ambiguity falls through to the bounds (ADR 0002 §7) |
| Geocoder no longer knows the ref | **400** | `200` + `location.status: "unresolved"`, **no sections** — renders the picker |
| Geocoder itself is down | **400** | **503 `GEOCODER_UNAVAILABLE`** — retryable, and not a claim that the city does not exist |
| `multi.` scope | 400 | **400** (a covering box is a superset of what was asked for) |
| `country.` / `postcode.` | 400 | **400** (no predicate exists to scope by) |

Two details that are load-bearing:

- **The echoed `location.key` stays the REQUESTED ref** (`ext:osm:R347950`), not the Homiio id it resolved to. The client compares it against its own `locationKey(selection)`; echoing something else would read as "the server applied a different scope".
- **The Homiio lookup passes the geocoder's bbox as a HARD filter and no `limit`.** The bbox is what stops "Barcelona, Catalonia" resolving to "Barcelona, Anzoátegui"; the absent `limit` is what keeps an ambiguous answer ambiguous (#295 — capping a multi-row lookup turns ambiguity into a confident wrong answer).

### The bounds rung — proposed as a deviation, reviewed and APPROVED

The brief specified two outcomes: resolves to a Homiio place → scope by id; otherwise → the graceful `unresolved`. I added **the bounds rung between them** and flagged it for review; it was approved on the reasoning below and stays.

`cities` is seeded from Homiio's own data and does not cover the world, so without this rung a user in a city the geocoder knows and Homiio does not is sent back to the picker to choose the same place again, forever — a dead end rather than a scope. The bounds are an explicit, local, user-chosen area, which is exactly what #353 requires, and never a global widening. That `/api/properties/search` already scopes the same selection by bounds (`usePropertySearch.locationParams` → `geometryParams`) settles it: refusing here would have made Home the only surface unable to honour a place the rest of the app can.

## Defect 2 — the silence, which is the user's actual complaint

- **A 400 is no longer retried.** `isRetryableHomeSectionsError` refuses every 4xx (the scope is not acceptable; asking again cannot change that) and retries 5xx and status-less transport failures. Three of the incident's four requests could never have succeeded.
- **One toast per failed query, deduped** on `(scope, offering, message)` — retries and re-renders cannot multiply it, and changing city after a failure legitimately can. Bloom's `toast`, not a second implementation.
- **A failure can no longer render as an absence.** `homeSurfaceState` returns one exclusive answer with `failed` ordered **above** `empty`, so "we could not load this area" is never drawn as "there is nothing in this area". The retry affordance sits in the section area, as before.
- **i18n:** `home.sections.loadFailedToast` added to `en.json`, synced across all 12 locales, parity green.

**Measured while testing, and it changed the code:** an i18next that has not been `init`ed returns `undefined` from `t()` — **even when a `defaultValue` is supplied**, because the pre-init `t` never reads its options. `toast.error(undefined)` is a toast with no words in it, which is the silent failure being fixed, reintroduced on the boot path. `homeSectionsFailureMessage()` therefore applies its own floor.

## Also in this branch: the function-form `style` audit no longer cries wolf

`grep -rn "style={({" app components --include=*.tsx` was the documented audit for the NativeWind rule, and it began reporting a violation the moment a component's own doc comment quoted the forbidden form **in order to warn about it** (`components/location/LocationScopeBar.tsx:35`, added by #353). A grep is line-based and cannot tell code from prose. A gate that cries wolf gets switched off by whoever hits it next, and an off gate is worse than the hole it covered.

It is now `packages/frontend/__tests__/noFunctionFormStyle.test.ts`, running in the ordinary suite and stripping comments first through the ONE stripper this repo has (`@homiio/shared-types/testing/stripComments`; a second implementation is itself a defect). `git ls-files` rather than a directory walk, directory pathspecs rather than a doubled-star glob, a floor of 150 files against a real 291, a positive control, and a negative control that is the very comment which caused it to exist. The pattern is deliberately not anchored to `pressed` — `({ hovered })`, `({ focused })` and a bare `() =>` are the same swallowed prop.

**Mutation-tested both ways:** a real `style={({ pressed }) => …}` planted in a scanned component turns it **RED** and names the file and line — planted `git add -f`, because the scan reads the INDEX and an unstaged probe would have measured nothing — and the doc comment stays **green**, in the tree, where it still is. `AGENTS.md`'s audit line now points at the test.

## What mutation testing found — the honest part

**The first mutation SURVIVED, and it was right to.** Capping the city lookup at one row changed nothing, because every fixture country was coded `ES-Barcelona` rather than `ES` — so `lookupCityPlaces({ countryCode: 'ES' })` matched no country at all and **every "resolved by Homiio city" assertion was in fact passing through the bounds fallback.** The rung under test was never reached.

The fixtures now give each rung a case only it can satisfy: a second Homiio city (`Hospitalet`) **inside the same bounding box**, whose listing the city rung excludes and the bounds rung includes. Two new tests came out of it — the rung discriminator and a two-cities-called-Barcelona homonym guard.

| Mutation | Result |
|---|---|
| External branch throws `UNSUPPORTED_LOCATION` again (the production defect) | **4 RED** |
| `limit: 1` on the city lookup (ambiguity → a silent pick) | **SURVIVED** first, then **1 RED** after the fixtures were repaired |
| Skip the canonical Homiio rung, always use the box | **1 RED** — proves the new discriminator works |
| Retry predicate returns `true` for 4xx | **4 RED** |
| `homeSurfaceState` reports `empty` where it should report `failed` | **2 RED** |
| Remove the toast entirely (the silence, restored) | **2 RED** |

Every mutation was confirmed to have landed (grep for the marker) before the run, restored from a namespaced pristine copy — never `git checkout` — and each restore re-asserted markers from my own edit. Restored tree: **49 passed, 0 failed**.

## Commands run

All re-run on the rebased tree (`1bbe6c79`), with `shared-types` and `listing-providers` rebuilt from scratch first.

| Command | Exit |
|---|---|
| `shared-types` build (after `rm tsconfig.tsbuildinfo`) | 0 |
| `listing-providers` build | 0 |
| backend `bunx tsc --noEmit` | 0 |
| backend home + geo + **#354's** `searchLocationContract` and `searchGeoIndexes` + `cityPlaceLookup` + `wireIdContract` | 0 — 7 suites / **149 tests** |
| frontend `typecheck` | 0 |
| frontend `test` | 0 — **34 suites / 485 tests** |
| frontend `check:i18n` | 0 (12 locales, both key sets) |
| frontend `build` | 0 |
| `check:cold-start / /properties /explore` | **0** — all PASS, `consoleErrors: []` |
| `node scripts/check-docs.mjs` | 0 |
| frontend `lint` | 1 — **pre-existing only**: the single error is `SindiExplanationBottomSheet:136`, recorded in `AGENTS.md` as deliberately deferred. Positive control confirms the scan ran and **zero** of this branch's files appear |

**CI on the rebased head**, checked by JOB NAME rather than by tally: `backend`, `frontend`, `frontend-typecheck`, `frontend-bundle` and `lockfile` are all present and `success`; failed 0, pending 0. Runs started `09:09Z`, after `6f0450e2` landed at `09:01:45Z`. `lint` reports `skipped`, and that is repo-wide rather than a property of this branch — it is gated behind `HOMIIO_LINT_GATE` and is `skipped` on `6f0450e2` and `d10ac39b` too.

## Not done

- **No production verification of the fix itself.** I reproduced the defect and the repair against a real Postgres and the real geocoding registry with a fake provider; the live path through the actual OSM provider can only be confirmed after deploy. `curl 'https://api.homiio.com/api/home/sections?loc=city.osm.R347950'` should return `200` with `location.key = "ext:osm:R347950"`.
- **The toast was not observed in a browser.** The cold-start check runs logged out and cannot reach a failing scoped request; the message is asserted through the hook with the toast module mocked.
- `R347950` was never resolved to a specific place — the repair does not depend on which city it is, and the tests cover the case where Homiio knows it and the case where it does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
