### PR TITLE
test(geo): assert what the predicate can reach, not what the planner happens to prefer (#354)

### DIFF
--- a/packages/backend/__tests__/integration/searchGeoIndexes.test.ts
+++ b/packages/backend/__tests__/integration/searchGeoIndexes.test.ts
@@ -4,25 +4,80 @@
  *
  * #354 asks for the PostGIS indexes for bbox and radius to be verified. The
  * schema declaring `index('addresses_geo_gist').using('gist', table.geo)` is
- * not that verification: a `geography` cast dropped from a predicate, a
- * `ST_Distance(...) < r` written into a WHERE clause, or a functional index on
- * a column the query no longer reads all leave that line untouched and turn
- * every geo search into a sequential scan over every address on the planet.
- * Only a plan can tell you.
+ * not that verification: a `ST_Distance(...) < r` written into a WHERE clause,
+ * or an index on a column the query no longer reads, leave that line untouched
+ * and turn every geo search into a sequential scan over every address on the
+ * planet. Only a plan can tell you.
  *
- * ## Why `enable_seqscan = off`, and why that is not cheating
+ * ## Why `enable_seqscan = off` is the ONLY plan assertion here
  *
- * The test tables hold a handful of rows, so the planner correctly prefers a
- * sequential scan — on eight rows an index is slower, and a test asserting
- * "the plan uses the index" against a small table would be asserting something
- * false about a healthy database. Turning the sequential scan off asks the
- * question that actually matters and that scale does not change: **CAN this
- * predicate use the index at all?** A predicate that cannot is invisible until
- * production, where the table is large enough for the answer to hurt.
+ * An earlier version of this file also asserted the DEFAULT plan — that the
+ * planner reaches for the index unprompted — on the strength of a measurement
+ * on three rows. That assertion was **flaky and blocked a sibling PR**: CI ran
+ * it against a worker database holding ONE row, where `Seq Scan` is the correct
+ * plan and the test went red on code nobody had touched.
  *
- * Both halves are needed, and each catches what the other cannot: the
- * catalogue check sees an index that was never created, the plan check sees an
- * index that exists and cannot be used.
+ * The measurement had been real. Generalising it was the mistake: **the default
+ * plan is a property of the table's statistics, not of the predicate**, so a
+ * test asserting it is testing the environment. Re-measured properly
+ * (`postgis/postgis:17-3.5`, 2026-08-10), across row count, `ANALYZE` state and
+ * fixture spread — `default` is the plan with `enable_seqscan` left alone,
+ * `forced` is with it off:
+ *
+ * ```
+ *  rows  ANALYZE  spread   bbox default  radius default   both forced
+ *     1    no      —          INDEX          INDEX            INDEX
+ *     1    yes     —          SEQ            SEQ              INDEX
+ *     3    no      —          SEQ            SEQ              INDEX
+ *     3    yes     tight      INDEX          SEQ              INDEX
+ *    10 … 20000    tight      INDEX          SEQ              INDEX
+ *   200 … 20000    wide       INDEX          INDEX            INDEX
+ * ```
+ *
+ * Three separate things move the default plan and none of them is this
+ * codebase: the row count, whether statistics have been gathered, and the
+ * fixture's SELECTIVITY. That last one is worth spelling out because it looked
+ * like a PostGIS finding and was not: in the `tight` rows every seeded point
+ * sits INSIDE the 25 km circle, so `ST_DWithin` matches everything and a
+ * sequential scan is genuinely the right plan. Scatter the same 20,000 rows
+ * across Europe (`wide`, 0 of them in the circle) and the default plan uses the
+ * index for both predicates. "Radius never uses the index" would have been a
+ * false statement about PostGIS derived from a badly-shaped fixture.
+ *
+ * Forcing the sequential scan off asks the question that survives all three:
+ * **CAN this predicate reach the index at all?** That is a property of the SQL
+ * this repo emits — `INDEX` in 20 of 20 measured combinations — and rewriting
+ * `withinCircle` as `ST_Distance(geo, p) < r`, the mistake `propertyGeo.ts`'s
+ * own header warns about, turns it RED (mutation-tested).
+ *
+ * ## One mutation it does NOT catch, measured rather than assumed
+ *
+ * Deleting the explicit `::geography` from `withinBoundingBox`'s envelope leaves
+ * every check here green — and that is CORRECT, not a hole. PostGIS defines an
+ * implicit geometry→geography cast, so `ST_Intersects(geography, geometry)`
+ * resolves to the geography overload and the semantics are unchanged: probed on
+ * a real server, a Fijian point inside the antimeridian strip `170 → -170` is
+ * `true` with the cast and `true` without it.
+ *
+ * The complement bug `propertyGeo.ts` warns about needs the COLUMN to become
+ * planar — `geo::geometry` on both sides makes that same point `false`. It is a
+ * SEMANTIC failure, so the guard for it is
+ * `__tests__/integration/antimeridianBoundingBox.test.ts`, which asserts which
+ * rows come back, not which plan produced them. Worth writing down because the
+ * obvious mutation for THIS file is the one that proves nothing.
+ *
+ * ## What this file therefore does NOT cover, stated so nobody assumes it does
+ *
+ * That the planner PREFERS the index at production scale. It cannot be asserted
+ * here without pinning cost constants and seeding a realistic distribution on
+ * every run, and its failures would read as "the environment changed" rather
+ * than "the code broke". If that guarantee is wanted it belongs in an EXPLAIN
+ * check against production-shaped data, not in this suite.
+ *
+ * The three checks that remain each catch what the others cannot: the catalogue
+ * check sees an index that was never created, the forced-plan checks see an
+ * index that exists and cannot be reached, and the negative control sees an
+ * assertion that has stopped discriminating.
  */
 
 import { sql } from 'drizzle-orm';
@@ -65,7 +120,9 @@ describe('the geo predicates the search actually ships', () => {
       countryCode: 'ES-IDX',
     });
     // A handful of rows, so the plan is about a table that exists rather than
-    // an empty one the planner may shortcut entirely.
+    // an empty one the planner may shortcut entirely. The COUNT does not matter
+    // to what is asserted below — that was the flaw in the version this
+    // replaces — but the table not being empty does.
     for (const [index, street] of ['Carrer Gran', 'Carrer Petit', 'Passeig'].entries()) {
       await seedAddress({
         chain,
@@ -74,6 +131,10 @@ describe('the geo predicates the search actually ships', () => {
         latitude: 41.3874 + index / 1000,
       });
     }
+    // Pin the statistics rather than racing autovacuum. Nothing below depends
+    // on them, and that is the point: gathering them makes the starting state
+    // the same on every run, so a future failure here means the SQL changed.
+    await getDb().execute(sql`analyze addresses`);
   });
 
   it('has a GiST index on the generated geography column', async () => {
@@ -98,22 +159,6 @@ describe('the geo predicates the search actually ships', () => {
     expect(plan).toContain('addresses');
     expect(plan).toContain(GEO_INDEX);
     expect(plan).toContain('Index Scan');
-  });
-
-  it.each([
-    ['a bounding box', withinBoundingBox(BARCELONA_BOX)],
-    ['a centre and radius', withinCircle(BARCELONA_CIRCLE)],
-  ])('and CHOOSES it unprompted for %s', async (_label, predicate) => {
-    // Measured rather than assumed, and it surprised the author: on a table of
-    // three rows the planner still prefers the GiST index (cost 20.65 against a
-    // sequential scan), so the `enable_seqscan = off` above is a robustness
-    // belt rather than the only way to see the index at all. Asserting the
-    // DEFAULT plan is the stronger statement — it is the plan production runs —
-    // and keeping both means a change that makes the predicate merely
-    // index-ABLE, rather than index-PREFERRED, still shows up as one failure
-    // instead of none.
-    const plan = await planFor(predicate, 'on');
-    expect(plan).toContain(GEO_INDEX);
   });
 
   it('does NOT name the geo index for a predicate that cannot use it', async () => {


### PR DESCRIPTION
Follow-up to #354. Fixes a **flaky test I introduced there**, which turned #409 red on code nobody had touched.

## What was wrong

`searchGeoIndexes.test.ts` asserted that the planner reaches for the GiST index **unprompted**:

```
Expected substring: "addresses_geo_gist"
Received:  Aggregate  (cost=13.51..13.52 rows=1 width=8)
             ->  Seq Scan on addresses  (cost=0.00..13.51 rows=1 width=0)
```

CI ran it against a worker database holding **one row**, where `Seq Scan` is the correct plan. It passed on my run and on #411's, which is worse than a straight failure: a single green run cannot tell a correct test from a lucky one.

The measurement behind the assertion was real. **Generalising it was the mistake** — the default plan is a property of the table's statistics, not of the predicate, so the test was asserting something about the environment.

## Re-measured, properly

`postgis/postgis:17-3.5`, 2026-08-10, across row count, `ANALYZE` state and fixture spread. `default` = `enable_seqscan` left alone; `forced` = off.

```
 rows  ANALYZE  spread   bbox default  radius default   both forced
    1    no      —          INDEX          INDEX            INDEX
    1    yes     —          SEQ            SEQ              INDEX
    3    no      —          SEQ            SEQ              INDEX
    3    yes     tight      INDEX          SEQ              INDEX
   10 … 20000    tight      INDEX          SEQ              INDEX
  200 … 20000    wide       INDEX          INDEX            INDEX
```

Three things move the default plan and none of them is this codebase: row count, whether statistics exist, and the fixture's **selectivity**.

**That third one nearly became a false finding in a comment.** In the `tight` rows every seeded point sits *inside* the 25 km circle, so `ST_DWithin` matches everything and a sequential scan is genuinely right — which reads as "radius never uses the index". Scatter the same 20,000 rows across Europe (`wide`, 0 in the circle) and the default plan uses the index for **both** predicates. It was the fixture's shape, not PostGIS. Had I written the naive reading down, it would have sat in the file misleading people indefinitely.

## What this PR does

Takes **option 2**: the statistical assertion is **deleted**, not loosened — loosening it produces a check that cannot fail. What remains is deterministic and is a property of the SQL this repo emits:

- the index exists (catalogue check);
- with `enable_seqscan = off`, **both** predicates reach it — `INDEX` in 20 of 20 measured combinations;
- a predicate that cannot use it does not name it (negative control).

The header now states plainly that **"the planner prefers it at production scale" is NOT covered here**, and where that guarantee would belong (an EXPLAIN check against production-shaped data, not this suite). Both vacuity floors and the negative control are untouched, as asked. `ANALYZE` is added to the fixture so the starting state is pinned rather than racing autovacuum — nothing asserted depends on it, which is the point.

## Verification

| run | result |
|---|---|
| 5 consecutive, shipped 3-row fixture | 5 × green |
| 3 consecutive, **1-row** table (the exact CI condition) | 3 × green |
| 3 consecutive, **20,000-row** table | 3 × green |
| 5 consecutive, with `antimeridianBoundingBox` + `searchLocationContract` | 5 × `41 passed` |

**Mutation:** rewriting `withinCircle` as `ST_Distance(geo, p) < r` — the mistake `propertyGeo.ts`'s own header warns about — turns it **RED**, naming the radius case. Restored from a pristine copy; markers re-asserted.

## One thing I got wrong and corrected mid-flight

My first draft of the new header claimed this file catches a dropped `::geography` cast. **It does not, and that is correct rather than a hole** — I measured it instead of assuming. PostGIS defines an implicit geometry→geography cast, so `ST_Intersects(geography, geometry)` resolves to the geography overload and the semantics are unchanged: on a real server, a Fijian point inside the antimeridian strip `170 → -170` is `true` with the cast and `true` without.

The complement bug `propertyGeo.ts` warns about needs the **column** to go planar — `geo::geometry` on both sides makes that same point `false`. That is a semantic failure, so its guard is `antimeridianBoundingBox.test.ts`, which asserts which rows come back rather than which plan produced them. Both facts are now in the file, because the obvious mutation for this file is the one that proves nothing.

No production code changes. Test and comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
