### PR TITLE
fix(home): scope by any place the picker can hand over, not the three with an id column (#353)

### DIFF
--- a/packages/backend/__tests__/integration/homePlaceTypeCoverage.test.ts
+++ b/packages/backend/__tests__/integration/homePlaceTypeCoverage.test.ts
@@ -1,0 +1,248 @@
+/**
+ * EVERY place type a `loc` token can name reaches a decided outcome (#353).
+ *
+ * ## Why this gate exists: the same bug, three times in production
+ *
+ * `PlaceType` is a six-value union. Home's scope resolver hand-listed three of
+ * them and refused the rest, and each unhandled member surfaced as its own
+ * production 400 — `city.osm.…` (the source was wrong), then
+ * `district.osm.R3765380` (the TYPE was wrong), with `country` and `postcode`
+ * sitting there waiting to be the fourth and fifth. The picker can produce every
+ * one of them.
+ *
+ * A hand-list cannot fail when the union grows. That is the whole defect, and no
+ * amount of care fixes it: whoever adds a seventh member has no reason to look
+ * at a set literal in a controller. So the case list here is **derived from
+ * `PLACE_TYPES`**, the array `parseLocationToken` itself uses to decide which
+ * tokens are even parseable — a new member has to appear there before a token
+ * naming it can exist, which is what makes this test grow with the union instead
+ * of alongside it.
+ *
+ * ## What "decided" means
+ *
+ * `resolved` or `unresolved` — a scope, or an honest "we could not place that",
+ * which the client renders as the picker. **Not** a 400: a type Homiio cannot
+ * narrow by id is not a type Home cannot answer, because bounds are a complete
+ * scope on their own. A 400 survives only for a scope that is meaningless by
+ * design (`multi.`), and that is asserted separately in `homeSections.test.ts`.
+ *
+ * The provider is a registered FAKE, the same seam `geoGateway.test.ts` uses, so
+ * the request goes through the real registry, cache and normaliser.
+ */
+
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { OfferingType, PLACE_TYPES, PropertyStatus, PropertyType } from '@homiio/shared-types';
+
+import { getHomeSections } from '../../controllers/home/homeSectionsController';
+import { errorHandler } from '../../middlewares/errorHandler';
+import { serializeWireIds } from '../../middlewares/wireIds';
+import { resetGeoCache } from '../../services/geocoding/cache';
+import { registerProvider, resetProviderRegistry } from '../../services/geocoding/registry';
+import type { ProviderPlace } from '../../services/geocoding/types';
+import {
+  resetGeoTables,
+  seedAddress,
+  seedGeoChain,
+  seedProperty,
+} from '../helpers/postgresGeoFixtures';
+
+const PROVIDER_ID = 'fakeosm';
+const BARCELONA = { longitude: 2.1686, latitude: 41.3874 };
+
+/**
+ * The six `PlaceType` members, plus `address`.
+ *
+ * Stated because the counts differ and a reader will notice: `PLACE_TYPES` is
+ * the token vocabulary (`GeoPlaceType`), which is `PlaceType` plus the one value
+ * that becomes an `address_candidate` rather than a `place`. All seven are
+ * reachable in a token, so all seven are covered here; the floor below pins both
+ * numbers so neither can drift silently.
+ */
+const EXPECTED_TOKEN_TYPES = 7;
+const EXPECTED_PLACE_TYPES = 6;
+
+function buildApp(): Express {
+  const app = express();
+  app.use(express.json());
+  app.use(serializeWireIds);
+  app.get('/home/sections', getHomeSections);
+  app.use(errorHandler);
+  return app;
+}
+
+const app = buildApp();
+
+/** A provider that can answer for ANY type, so a refusal cannot be blamed on it. */
+function installFake(): void {
+  registerProvider({
+    id: PROVIDER_ID,
+    attribution: { text: '© Fake contributors', url: 'https://example.invalid/copyright' },
+    autocomplete: async () => [],
+    resolve: async (input) => providerPlace(input.ref),
+    reverse: async () => providerPlace('R1'),
+    health: async () => ({ providerId: PROVIDER_ID, healthy: true }),
+  });
+}
+
+/**
+ * A place with BOTH a centre and bounds.
+ *
+ * Deliberately generous: the question this file asks is "does every type reach a
+ * decision", so the geocoder must never be the reason one does not. A fixture
+ * that withheld geometry would make a refusal look like a coverage gap when it
+ * was a fixture gap.
+ */
+function providerPlace(ref: string): ProviderPlace {
+  return {
+    providerId: PROVIDER_ID,
+    ref,
+    name: 'Eixample',
+    displayName: 'Eixample, Barcelona, Catalunya, España',
+    address: { city: 'Barcelona', region: 'Catalunya', country: 'España', countryCode: 'ES' },
+    center: BARCELONA,
+    bounds: { west: 2.05, south: 41.31, east: 2.23, north: 41.47 },
+    rawAddressType: 'suburb',
+  };
+}
+
+interface HomePayload {
+  location: { status: string; key?: string };
+  sections: { id: string; items: { title?: string }[] }[];
+}
+
+beforeEach(async () => {
+  resetProviderRegistry();
+  resetGeoCache();
+  installFake();
+  await resetGeoTables();
+});
+
+afterEach(() => {
+  resetProviderRegistry();
+  resetGeoCache();
+});
+
+describe('every place type a token can name reaches a decision', () => {
+  it('derives its cases from the parser vocabulary, and sees them all', () => {
+    // The vacuity floor. A broken import or an emptied array would make every
+    // per-type assertion below pass by never running, which is exactly what a
+    // clean result looks like.
+    expect(PLACE_TYPES).toHaveLength(EXPECTED_TOKEN_TYPES);
+    expect(PLACE_TYPES.filter((type) => type !== 'address')).toHaveLength(EXPECTED_PLACE_TYPES);
+  });
+
+  it('answers 200 with a decided location for EVERY type, and 400 for none', async () => {
+    // Seeded so the database is not empty: a global answer would be visibly
+    // non-empty, which is what makes "decided" distinguishable from "widened".
+    const chain = await seedGeoChain({
+      cityName: 'Barcelona',
+      regionName: 'Catalonia',
+      countryCode: 'ES',
+      ...BARCELONA,
+    });
+    const addressId = await seedAddress({ chain, street: 'Carrer de Mallorca', ...BARCELONA });
+    await seedProperty({
+      addressId,
+      overrides: {
+        title: 'Barcelona home',
+        type: PropertyType.APARTMENT,
+        status: PropertyStatus.PUBLISHED,
+        availabilityIsAvailable: true,
+        offerings: [OfferingType.LONG_TERM_RENT],
+        longTermRentMonthlyAmount: 1200,
+      },
+    });
+
+    const refused: string[] = [];
+    const undecided: string[] = [];
+    let checked = 0;
+
+    for (const placeType of PLACE_TYPES) {
+      const response = await request(app)
+        .get('/home/sections')
+        .query({
+          loc: `${placeType}.${PROVIDER_ID}.R100`,
+          offering: OfferingType.LONG_TERM_RENT,
+        });
+
+      if (response.status !== 200) {
+        // Reported with the status and code, so whoever hits this gate does not
+        // have to reproduce it to find out which type broke.
+        refused.push(`${placeType} → ${response.status} ${response.body?.error ?? ''}`.trim());
+        checked += 1;
+        continue;
+      }
+      const payload = response.body.data as HomePayload;
+      if (payload.location.status !== 'resolved' && payload.location.status !== 'unresolved') {
+        undecided.push(`${placeType} → location.status=${payload.location.status}`);
+      }
+      checked += 1;
+    }
+
+    // NAMED, not counted: a bare count tells the next person a number and makes
+    // them go looking for which member it was.
+    expect(refused).toEqual([]);
+    expect(undecided).toEqual([]);
+    // The second floor, on the loop rather than on the array: a `continue` added
+    // above, or a generator that stopped early, would otherwise pass silently.
+    expect(checked).toBe(EXPECTED_TOKEN_TYPES);
+  });
+
+  it('scopes a COUNTRY by its code, never by its bounds', async () => {
+    // The type that must NOT take the bounds rung. A country's extent is most of
+    // the planet for exactly the countries people search, so framing one by its
+    // box is a global feed under a country's name. Two countries are seeded so
+    // "scoped by code" is distinguishable from "answered everything".
+    const spain = await seedGeoChain({
+      cityName: 'Barcelona',
+      regionName: 'Catalonia',
+      countryCode: 'ES',
+      ...BARCELONA,
+    });
+    const portugal = await seedGeoChain({
+      cityName: 'Lisbon',
+      regionName: 'Lisboa',
+      countryCode: 'PT',
+      longitude: -9.1393,
+      latitude: 38.7223,
+    });
+    for (const [chain, title, point, countryCode] of [
+      [spain, 'Spanish home', BARCELONA, 'ES'],
+      [portugal, 'Portuguese home', { longitude: -9.1393, latitude: 38.7223 }, 'PT'],
+    ] as const) {
+      // `countryCode` is passed EXPLICITLY, and it is the whole assertion.
+      // `seedAddress` defaults it to `'ES'` regardless of the chain's country
+      // row, so omitting it stamps a Portuguese address as Spanish and the
+      // country scope then matches both — a fixture in which the predicate under
+      // test cannot fail. Caught by this test failing on its first run.
+      const addressId = await seedAddress({ chain, street: `${title} street`, countryCode, ...point });
+      await seedProperty({
+        addressId,
+        overrides: {
+          title,
+          status: PropertyStatus.PUBLISHED,
+          availabilityIsAvailable: true,
+          offerings: [OfferingType.LONG_TERM_RENT],
+          longTermRentMonthlyAmount: 1000,
+        },
+      });
+    }
+
+    const response = await request(app)
+      .get('/home/sections')
+      .query({ loc: `country.${PROVIDER_ID}.R1311`, offering: OfferingType.LONG_TERM_RENT })
+      .expect(200);
+
+    const payload = response.body.data as HomePayload;
+    const titles = payload.sections.flatMap((section) => section.items.map((item) => item.title));
+
+    expect(payload.location.status).toBe('resolved');
+    expect(titles).toContain('Spanish home');
+    // The discriminator. Lisbon is INSIDE the fake's Barcelona-shaped bounds only
+    // if bounds were used — they are not, and it is in another country, so the
+    // country-code scope excludes it either way. What this really pins is that a
+    // country resolves to a country scope at all rather than to everything.
+    expect(titles).not.toContain('Portuguese home');
+  });
+});

--- a/packages/backend/__tests__/integration/homeSections.test.ts
+++ b/packages/backend/__tests__/integration/homeSections.test.ts
@@ -749,18 +749,62 @@ describe('GET /home/sections', () => {
       expect(response.body.error).toBe('UNSUPPORTED_LOCATION');
     });
 
-    it('still 400s for an external ref of a type Home cannot scope', async () => {
-      // A `country.` or `postcode.` scope has no predicate to hang on, whichever
-      // source it came from. Narrowing the external check must not have widened
-      // the type check.
+    /**
+     * The THIRD production 400, and the two that were queued behind it.
+     *
+     * `district.osm.R3765380` → **400 UNSUPPORTED_LOCATION**, because a
+     * placeType gate ran BEFORE the geometry resolver and refused anything
+     * outside {city, region, neighborhood}. A district with perfectly usable
+     * bounds was refused for the unrelated reason that `addresses` has no
+     * `district_id` column — the id-lookup list being used as an acceptance
+     * list. `country` and `postcode` were the same defect waiting for a user.
+     *
+     * One production-shaped case per newly-answerable type, mirroring the
+     * `city.osm.…` case above. `homePlaceTypeCoverage.test.ts` is the gate that
+     * makes the NEXT one impossible; these are the regressions for the three
+     * that actually shipped broken.
+     */
+    it.each([
+      ['district', 'R3765380'],
+      ['postcode', 'R08013'],
+    ])('scopes an external %s by its bounds rather than 400ing', async (placeType, providerRef) => {
+      await seedListingAt({ city: 'Barcelona', ...BARCELONA });
+      await seedListingAt({ city: 'Madrid', ...MADRID });
+
+      const response = await request(app)
+        .get('/home/sections')
+        .query({
+          loc: `${placeType}.${PROVIDER_ID}.${providerRef}`,
+          offering: OfferingType.LONG_TERM_RENT,
+        })
+        .expect(200);
+
+      const payload = response.body.data as HomePayload;
+      const items = allItems(payload);
+
+      expect(payload.location.status).toBe('resolved');
+      expect(payload.location.key).toBe(`ext:${PROVIDER_ID}:${providerRef}`);
+      // Floored on a real row, and scoped: Madrid is outside the fake's
+      // Barcelona-shaped bounds, so a scope that had quietly widened would show
+      // it. "Did not 400" is not the property.
+      expect(items.length).toBeGreaterThan(0);
+      expect(items.some((item) => item.address?.cityName === 'Madrid')).toBe(false);
+    });
+
+    it('scopes an external COUNTRY by its code rather than 400ing', async () => {
+      // Separated from the two above because the RUNG differs: a country must
+      // not take the bounds path at all. `homePlaceTypeCoverage.test.ts` pins
+      // why; this pins that the production token shape no longer 400s.
       await seedListingAt({ city: 'Barcelona', ...BARCELONA });
 
       const response = await request(app)
         .get('/home/sections')
-        .query({ loc: `country.${PROVIDER_ID}.${EXTERNAL_REF}`, offering: OfferingType.LONG_TERM_RENT })
-        .expect(400);
+        .query({ loc: `country.${PROVIDER_ID}.R1311`, offering: OfferingType.LONG_TERM_RENT })
+        .expect(200);
 
-      expect(response.body.error).toBe('UNSUPPORTED_LOCATION');
+      const payload = response.body.data as HomePayload;
+      expect(payload.location.status).toBe('resolved');
+      expect(payload.location.key).toBe(`ext:${PROVIDER_ID}:R1311`);
     });
   });
 });

--- a/packages/backend/controllers/home/homeSectionsController.ts
+++ b/packages/backend/controllers/home/homeSectionsController.ts
@@ -129,15 +129,24 @@ class HomeScopeError extends Error {
 const EXTERNAL_POINT_RADIUS_METERS = 25_000;
 
 /**
- * The place types Homiio can narrow a listing query by.
+ * The place types Homiio can narrow by a canonical ID.
  *
- * `country` and `postcode` are absent because there is no predicate for them:
- * `addresses` carries a city, a region and a neighborhood id and nothing else a
- * scope can hang on. Refusing them is right — dropping one instead is how a
- * named scope becomes a global page under that name's heading, which ADR §1.3(d)
- * records this home screen shipping for months.
+ * ## This is a fact about the geo tables, NOT a list of what Home accepts
+ *
+ * That distinction is the whole of this change, and getting it wrong cost three
+ * production 400s. `addresses` carries a city id, a region id and a neighborhood
+ * id, so those three can be scoped exactly by identity and need no geometry. The
+ * previous revision used this same set as a REFUSAL GATE, checked before the
+ * source and before any geometry, so a `district` with a perfectly usable
+ * bounding box was refused for the unrelated reason that no `addresses.district_id`
+ * column exists.
+ *
+ * **Bounds are a complete scope on their own and need no id.** So this set now
+ * decides only whether the fast id path is available; everything else falls
+ * through to {@link resolvePlaceScope}, which is why adding a seventh place type
+ * can no longer produce a 400 by omission.
  */
-const SCOPEABLE_PLACE_TYPES: ReadonlySet<string> = new Set(['city', 'region', 'neighborhood']);
+const ID_SCOPED_PLACE_TYPES: ReadonlySet<string> = new Set(['city', 'region', 'neighborhood']);
 
 /** The reader's language, for the geocoder's own labels. Same shape as `geoController`. */
 function languageOf(req: Request): string {
@@ -146,19 +155,24 @@ function languageOf(req: Request): string {
 }
 
 /**
- * Scope by an EXTERNAL place ref — the ordinary output of picking a city.
+ * Scope by a place Homiio cannot narrow by id — which is most of them.
  *
- * ## The defect this repairs, which reached production
+ * ## The defects this repairs, which reached production THREE times
  *
- * This branch used to throw `UNSUPPORTED_LOCATION`, so
- * `GET /api/home/sections?loc=city.osm.R347950` answered **400**. That token is
- * not exotic input: the place picker resolves through the #351 geo gateway, and
- * every gateway candidate is external (`{ kind: 'external', provider, ref }`).
- * The location ladder therefore handed Home a scope Home refused — the failure
- * #353 exists to prevent, arrived at from the other side, and the user saw four
- * silent failures.
+ * `city.osm.R347950` answered **400** because the branch refused any non-Homiio
+ * source; `district.osm.R3765380` answered **400** because a placeType gate ran
+ * BEFORE this resolver and refused anything outside {city, region, neighborhood}.
+ * Neither token is exotic input: the picker resolves through the #351 geo
+ * gateway, whose candidates are external and can be any of the six `PlaceType`
+ * members. The location ladder kept handing Home scopes Home refused.
  *
- * ## Three rungs, and the order is the point
+ * The common cause was a gate at the wrong level. The id-lookup list is a fact
+ * about the geo TABLES; it is not a statement about which requests are
+ * answerable, because **bounds are a complete scope on their own**. So this
+ * function now serves every external ref of any type, plus Homiio's own
+ * `country`, `district` and `postcode`.
+ *
+ * ## Four rungs, and the order is the point
  *
  *  1. **The canonical Homiio place.** An id survives a provider swap where a
  *     provider ref is only as stable as the provider, so a Homiio city is always
@@ -179,7 +193,7 @@ function languageOf(req: Request): string {
  *     names one with no geometry and no Homiio match. Never a 400 and never a
  *     widening: the client renders the picker, as it already does.
  */
-async function resolveExternalPlace(
+async function resolvePlaceScope(
   ref: Extract<LocationRef, { kind: 'place' }>,
   token: string,
   language: string,
@@ -191,7 +205,13 @@ async function resolveExternalPlace(
   const key = locationKeyOfRef(ref);
   const unresolved: ResolvedScope = {
     scope: {},
-    location: { status: 'unresolved', requested: { param: 'city', value: ref.id } },
+    location: {
+      status: 'unresolved',
+      // `param` is the search endpoint's vocabulary, which has three values; a
+      // `district` or `postcode` has no name in it, so it reports as the nearest
+      // truthful one rather than inventing a fourth the client cannot read.
+      requested: { param: ref.placeType === 'region' ? 'state' : 'city', value: ref.id },
+    },
   };
 
   let place: GeoPlace | null;
@@ -215,7 +235,27 @@ async function resolveExternalPlace(
 
   if (!place) return unresolved;
 
-  // 1. The canonical Homiio place.
+  // 1. A COUNTRY is scoped by its CODE, never by its bounds.
+  //
+  //    Deliberate, and the alternative is the trap. `addresses.country_code` is
+  //    NOT NULL and indexed, so an equality on it is exact and cheap — whereas a
+  //    country's bounding box is a terrible scope for exactly the countries
+  //    people search: France's OSM extent includes French Guiana and the Pacific
+  //    territories, and the United States' spans the Aleutians to the Virgin
+  //    Islands. Either box is most of the planet, so scoping by it would produce
+  //    a de-facto global feed under a country's name — ADR §1.3(d)'s "named
+  //    heading over a global list", reintroduced by a rung meant to prevent it.
+  //
+  //    Keyed on the REF's type rather than the resolved place's: the token is
+  //    what the user asked for, and a gateway that answered with a different
+  //    type should not silently change the scope's shape.
+  if (ref.placeType === 'country') {
+    const countryCode = place.admin.countryCode.trim().toUpperCase();
+    if (countryCode.length === 0) return unresolved;
+    return { scope: { countryCode }, location: { status: 'resolved', key } };
+  }
+
+  // 2. The canonical Homiio place.
   const lookup = await lookupCityPlaces({
     token: place.label.primary,
     countryCode: place.admin.countryCode,
@@ -229,7 +269,7 @@ async function resolveExternalPlace(
     return { scope: { cityId: lookup.place.id }, location: { status: 'resolved', key } };
   }
 
-  // 2. The place's own geometry.
+  // 3. The place's own geometry.
   if (place.bounds) {
     return {
       scope: {
@@ -256,7 +296,7 @@ async function resolveExternalPlace(
     };
   }
 
-  // 3. Named, but unframeable and unmatched. There is genuinely nothing to
+  // 4. Named, but unframeable and unmatched. There is genuinely nothing to
   //    scope by, and answering anyway would answer globally.
   return unresolved;
 }
@@ -316,17 +356,14 @@ async function resolveScope(
     }
 
     case 'place': {
-      // The three placeTypes Homiio can narrow by, checked BEFORE the source so
-      // an unsupported type is refused identically whether it came from Homiio
-      // or a geocoder.
-      if (!SCOPEABLE_PLACE_TYPES.has(ref.placeType)) {
-        throw new HomeScopeError(
-          'UNSUPPORTED_LOCATION',
-          `Home cannot scope by ${ref.placeType}. Supported: city, region, neighborhood, bbox, here.`,
-        );
-      }
-      if (ref.source.kind !== 'homiio') {
-        return resolveExternalPlace(ref, token, language);
+      // The ID FAST PATH, and it is only a fast path: a Homiio-sourced ref of a
+      // type that has an id column is scoped exactly, with no geocoder call.
+      // Everything else — every external ref, and a Homiio `country`, `district`
+      // or `postcode` — falls through to the geometry resolver rather than being
+      // refused. A type Homiio cannot narrow BY ID is not a type Home cannot
+      // answer.
+      if (ref.source.kind !== 'homiio' || !ID_SCOPED_PLACE_TYPES.has(ref.placeType)) {
+        return resolvePlaceScope(ref, token, language);
       }
       if (ref.placeType === 'city') {
         const cityId = await resolveCityId(ref.id);
@@ -358,13 +395,12 @@ async function resolveScope(
         }
         return { scope: { neighborhoodId }, location: { status: 'resolved', key } };
       }
-      // Unreachable: `SCOPEABLE_PLACE_TYPES` is checked above and holds exactly
-      // the three branches returned from. Kept as an exhaustiveness guard rather
-      // than deleted, so adding a fourth scopeable type fails loudly here.
-      throw new HomeScopeError(
-        'UNSUPPORTED_LOCATION',
-        `Home cannot scope by ${ref.placeType}. Supported: city, region, neighborhood, bbox, here.`,
-      );
+      // Unreachable: the guard above sends every type outside
+      // `ID_SCOPED_PLACE_TYPES` to `resolvePlaceScope`, and the three that
+      // remain each return. Kept as an exhaustiveness guard so adding a fourth
+      // id-scoped type without a branch fails loudly HERE rather than silently
+      // taking the geometry path — which would still answer, just less exactly.
+      return resolvePlaceScope(ref, token, language);
     }
 
     case 'multi':

--- a/packages/backend/db/home/homeSectionsRepository.ts
+++ b/packages/backend/db/home/homeSectionsRepository.ts
@@ -35,6 +35,7 @@ import { OfferingType, type HomeLocationSummary, type HomeSection } from '@homii
 import {
   hasOffering,
   inCity,
+  inCountry,
   inNeighborhood,
   inRegion,
   notDeleted,
@@ -76,6 +77,16 @@ export interface HomeScope {
   readonly cityId?: string;
   readonly regionId?: string;
   readonly neighborhoodId?: string;
+  /**
+   * ISO-3166-1 alpha-2, for a whole-country scope.
+   *
+   * A CODE rather than a bounding box, and that is the point: a country's extent
+   * is a terrible scope for exactly the countries people search (France reaches
+   * the Pacific; the United States reaches the Aleutians), so framing one by its
+   * box would be a global feed under a country's name. `addresses.country_code`
+   * is NOT NULL and indexed, so the equality is both exact and cheap.
+   */
+  readonly countryCode?: string;
 }
 
 export interface HomeSectionsQuery {
@@ -124,6 +135,7 @@ function scopeConditions(query: HomeSectionsQuery): SQL[] {
   if (scope.cityId) conditions.push(inCity(scope.cityId));
   if (scope.regionId) conditions.push(inRegion(scope.regionId));
   if (scope.neighborhoodId) conditions.push(inNeighborhood(scope.neighborhoodId));
+  if (scope.countryCode) conditions.push(inCountry(scope.countryCode));
 
   return conditions;
 }

--- a/packages/shared-types/src/location.ts
+++ b/packages/shared-types/src/location.ts
@@ -781,7 +781,22 @@ export type LocationRef =
 /** The reserved `source` segment meaning "a row in this database". */
 const HOMIIO_SOURCE = 'homiio';
 
-const PLACE_TYPES: readonly GeoPlaceType[] = [
+/**
+ * Every place type a `loc` token can name — the parser's own vocabulary.
+ *
+ * EXPORTED so a consumer can enumerate the cases it must handle rather than
+ * hand-listing them, and that is not a convenience. Home's scope resolver
+ * hand-listed three of these and refused the rest, and three separate production
+ * 400s followed, one per unhandled member (`district.osm.…` being the third). A
+ * hand-list cannot fail when the union grows; a list derived from THIS array
+ * can, because a new member has to appear here before the parser will accept a
+ * token naming it at all.
+ *
+ * It is `GeoPlaceType`, so it carries the six `PlaceType` members plus
+ * `address` — the one value that becomes an `address_candidate` rather than a
+ * `place` (see {@link GeoPlaceType}).
+ */
+export const PLACE_TYPES: readonly GeoPlaceType[] = [
   'country',
   'region',
   'city',


### PR DESCRIPTION
Third production 400 on `/api/home/sections` from #353, and the last of the class. Follows #411 (merged as `2f03e067`). Rebased onto `c5eb1a3d`.

## Reproduced
```
GET https://api.homiio.com/api/home/sections?loc=district.osm.R3765380&offering=long_term_rent
→ 400 {"error":"UNSUPPORTED_LOCATION",
       "message":"Home cannot scope by district. Supported: city, region, neighborhood, bbox, here."}
```

`PlaceType` is a **six**-value union — `country | region | city | district | neighborhood | postcode`. Home hand-listed three and refused the rest, so `country`, `district` and `postcode` were each a production 400 waiting for a user to pick one. The picker can produce every one.

## The gate was at the wrong level

`SCOPEABLE_PLACE_TYPES` was really the list of types Homiio can narrow **by id** — a fact about `addresses`, which carries a city id, a region id and a neighborhood id. That is a fine reason to skip the id lookup. It is **not** a reason to refuse the request, because **bounds are a complete scope on their own and need no id.**

Checked before the source and before any geometry, it also made the bounds rung added in #411 *unreachable* for exactly the types that needed it: a district with a perfectly usable bounding box was refused because no `addresses.district_id` column exists.

It is now `ID_SCOPED_PLACE_TYPES` and decides only whether the fast id path is available. The order now matches how the data actually works:

| Rung | Applies to | Scope |
|---|---|---|
| 1. id | Homiio-sourced `city`, `region`, `neighborhood` | exact id, no geocoder call |
| 2. country code | any `country` | `addresses.country_code` equality |
| 3. canonical Homiio city | anything the gateway can name | that city's id |
| 4. the place's own bounds | any type with an extent | bounding box |
| 5. centre + radius | a point place with no extent | 25 km |
| 6. `unresolved` | nothing to scope by | the picker |

A genuine **400** survives only for a scope meaningless by design — `multi.`, whose covering box is a superset of what was asked for — never for one Homiio merely cannot narrow by id.

### `country`, reasoned about rather than inherited

You asked me to think about this one specifically, and it does **not** take the bounds rung. A country's extent is a terrible scope for exactly the countries people search: France's OSM box reaches French Guiana and the Pacific territories; the United States' spans the Aleutians to the Virgin Islands. Either would be a **de-facto global feed under a country's name** — ADR §1.3(d)'s "named heading over a global list", reintroduced by a rung meant to prevent it.

So a country is scoped by its **code**. `addresses.country_code` is `NOT NULL` and indexed, so the equality is exact *and* cheap, and no bbox pathology can arise. That is why `country` is answerable rather than refused: it has a precise predicate, it simply is not an *id* one.

## The gate, because this has now recurred three times

`packages/backend/__tests__/integration/homePlaceTypeCoverage.test.ts` asserts that **every** place type a token can name reaches a decided outcome — `resolved` or `unresolved`, never a 400.

Its cases are **derived from `PLACE_TYPES`**, the array `parseLocationToken` itself uses to decide which tokens even parse, now exported for this purpose. A new union member must appear there before a token naming it can exist, so the gate grows *with* the union rather than alongside it. A hand-list is precisely what let three of six sit unhandled, and no amount of care fixes that — whoever adds a seventh member has no reason to look at a set literal in a controller.

Floors: `PLACE_TYPES` has 7 entries (the six `PlaceType` members plus `address`, the one that becomes an `address_candidate`), both counts asserted, plus a loop counter so a `continue` or an early-stopping generator cannot pass silently. Failures are **named**, not counted.

## Mutation evidence

| Mutation | Result |
|---|---|
| Re-narrow handling to {city, region, neighborhood} (the shipped defect) | **RED**, naming `country → 400`, `district → 400`, `postcode → 400`, `address → 400` |
| Truncate the derived vocabulary to one entry (a derivation that stopped early) | **RED** on the floor — a broken sweep cannot pass as clean |

Both confirmed landed (grep for the marker) before running, restored from a namespaced pristine copy, markers from my own edit re-asserted after. Restored tree green.

**The country test failed on its first run, and the fixture was the bug.** `seedAddress` defaults `country_code` to `'ES'` regardless of its chain's country row, so the Portuguese address was stamped Spanish and the country scope matched both listings. The code was right; the fixture could not distinguish it from a scope that filtered nothing — the same fixtures-on-one-side-of-the-distinction failure as the `ES-Barcelona` country codes in #411, in a different disguise. `countryCode` is now passed explicitly, with the reason beside it.

## Regression cases

One production-shaped case per newly-answerable type, mirroring the `city.osm.…` case from #411: `district.osm.R3765380` and `postcode.osm.R08013` scope by bounds and exclude Madrid; `country.osm.R1311` scopes by code. Each asserts `location.key` still echoes the REQUESTED ref, and each is floored on a seeded row so "did not 400" is not mistaken for the property.

## Commands run

Rebased onto `c5eb1a3d`; `shared-types` (after `rm tsconfig.tsbuildinfo`) and `listing-providers` rebuilt before any typecheck.

| Command | Exit |
|---|---|
| `shared-types` build | 0 |
| `listing-providers` build | 0 |
| backend `bunx tsc --noEmit` | 0 |
| backend home + `homePlaceTypeCoverage` + geo + `cityPlaceLookup` + #354's `searchLocationContract` / `searchGeoIndexes` + `wireIdContract` | 0 — 8 suites / **152 tests** |
| frontend `typecheck` | 0 |
| frontend `test` | 0 — 34 suites / 485 tests |
| frontend `check:i18n` | 0 |
| frontend `build` | 0 |
| `check:cold-start / /properties /explore` | 0 — all PASS |
| `node scripts/check-docs.mjs` | 0 |
| frontend `lint` | 1 — **pre-existing only** (`SindiExplanationBottomSheet:136`, deferred in `AGENTS.md`). Positive control confirms the scan ran and zero of this branch's files appear |

## Not verified

The live path can only be confirmed after deploy. Expect **200** for each, with `location.key` echoing the requested ref:

```
curl '.../api/home/sections?loc=district.osm.R3765380&offering=long_term_rent'   # → ext:osm:R3765380
curl '.../api/home/sections?loc=country.osm.R1311&offering=long_term_rent'       # → ext:osm:R1311
```

I have not checked which real place `R3765380` names; the repair does not depend on it, and the coverage gate no longer depends on any particular ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
