### PR TITLE
ci(deploy): actually apply the migrations, on both sides of the rollout

### DIFF
--- a/.github/scripts/deploy-ecs-image.sh
+++ b/.github/scripts/deploy-ecs-image.sh
@@ -91,8 +91,11 @@ fi
 # then the worker through this same script. Left unset, `RUN_MIGRATIONS=true`
 # would therefore run the migrator TWICE per release — wasted at best, and at
 # worst a race: `db/migrate.ts` takes no cross-process advisory lock, and neither
-# does drizzle (recorded as a precondition carried out of Lote 0). Nothing can
-# run two migrators concurrently today; the deploy is the first thing that could.
+# does drizzle. That was recorded as a precondition carried out of Lote 0 on the
+# reasoning that nothing could run two migrators concurrently; `deploy-aws.yml`
+# now sets `RUN_MIGRATIONS: 'true'`, so this variable is what keeps that true
+# WITHIN a release, and the workflow's `concurrency` group is what keeps it true
+# ACROSS releases. See `packages/backend/db/migrate.ts` for what remains open.
 #
 # Naming the owning SERVICE, rather than trusting each lane to set the flag
 # correctly, is what makes a job-level `RUN_MIGRATIONS: true` safe: the worker
@@ -120,21 +123,32 @@ MIGRATION_SERVICE="${MIGRATION_SERVICE:-}"
 #
 # This replaces a hardcoded `["bun","packages/backend/dist/scripts/migrate.js"]`
 # that was wrong on both counts and named a file that has never existed in this
-# repository — `RUN_MIGRATIONS=true` has therefore never once worked here.
+# repository — so `RUN_MIGRATIONS=true` could never once have worked here. It
+# was also never set: nothing turned it on until 2026-08-10, by which point
+# production was four migrations behind and answering 500 on two routes.
 #
-# `--phase=pre` is the side of the cutover this runs on; the `post` phase runs
-# AFTER the rollout, as a separate invocation, and is not part of this table.
+# `--phase=pre` is the only side this table runs. The `post` phase runs AFTER
+# the rollout, through `POST_DEPLOY_TASK_COMMAND_JSON` below, and `deploy-aws.yml`
+# sets it on the WORKER lane — the last service to roll, and therefore the first
+# moment no old image is serving. A `post` migration drops or narrows something,
+# so running it from this table would break the image still running.
 #
-# THE POPULATION FLOOR IS THE ENTRY THAT IS NOT HERE YET. `db/assertPostgresPopulated.ts`
-# ships in this batch but is deliberately NOT wired in, because it asserts that
-# Postgres is AUTHORITATIVE — false before the cutover, and false again the
-# moment we exercise the planned rollback to Mongo. Landing it live now would
-# block every deploy from here to the window, and landing it live and forgetting
-# it would block every deploy after a rollback, for a reason nothing about that
-# rollback would lead anyone to look for. It has no env flag on purpose: a flag
-# is a second thing to remember, and the guard's lifetime should equal the
-# lifetime of the claim it makes. The cutover commit (Lote 13) appends this entry
-# verbatim, and reverting that commit removes it again:
+# THE POPULATION FLOOR IS STILL THE ENTRY THAT IS NOT HERE, AND THE REASON HAS
+# CHANGED. `db/assertPostgresPopulated.ts` asserts that Postgres is AUTHORITATIVE.
+# That was false before the cutover and would have been false again after the
+# planned rollback to Mongo, which is why this comment used to say the cutover
+# commit would append the entry and a revert would remove it.
+#
+# The cutover has happened and there is no rollback target: `AGENTS.md`'s data
+# storage section records that `models/`, `db/backfill/` and mongoose are deleted,
+# `MONGODB_URI` is off both task definitions and out of SSM, and the only copy of
+# the old data is an offline dump. So the ORIGINAL objection is gone.
+#
+# What replaces it is narrower and has to be measured rather than reasoned about:
+# the five floors are numbers taken from a Mongo census on 2026-08-06, and no one
+# has counted the rows Postgres holds today. Wiring a floor that production does
+# not clear blocks every deploy, which is the failure this guard exists to avoid
+# causing. Count first, then append this entry verbatim:
 #
 #   ,
 #   {
@@ -724,10 +738,14 @@ if [[ -n "$POST_DEPLOY_SMOKE_SCRIPT" ]]; then
 fi
 
 if [[ -n "$POST_DEPLOY_TASK_COMMAND_JSON" ]]; then
+  # Labelled for what the hook IS rather than for one thing a caller might put
+  # in it. Homiio's worker lane puts the `post` migration phase here, and a line
+  # reading "Post-deploy reconciliation failed" for a failed migration is the
+  # kind of operator-facing string that misleads at the worst possible moment.
   if ! run_one_shot_command \
-    "Post-deploy reconciliation" \
+    "Post-deploy task" \
     "$POST_DEPLOY_TASK_COMMAND_JSON"; then
-    echo "::error::Post-deploy reconciliation failed."
+    echo "::error::The post-deploy task failed."
     if ! rollback_service; then
       echo "::error::Reconciliation and rollback both failed; manual intervention is required."
     fi

--- a/.github/scripts/test-deploy-ecs-image.sh
+++ b/.github/scripts/test-deploy-ecs-image.sh
@@ -36,7 +36,7 @@ export DEPLOY_TEST_TASK_LAST_STATUS=STOPPED
 # full green run -- and every guarantee below would read as verified while never
 # having executed. Incremented by run_release, checked at the very end.
 cases_run=0
-MINIMUM_CASES=22
+MINIMUM_CASES=24
 
 aws() {
   local service_json='{
@@ -304,6 +304,18 @@ run_release() {
   local output_file="$case_directory/output.log"
   local smoke_script="$case_directory/smoke.sh"
 
+  # What this case hands the post-deploy hook. An env override rather than a
+  # tenth positional, which nobody could read at a call site. `none` means the
+  # lane sets NO post-deploy task — the real API lane's shape, and distinct from
+  # "unset", which keeps the historical `reconcile` fixture every older case
+  # below expects.
+  local post_deploy_command
+  case "${DEPLOY_TEST_POST_DEPLOY_TASK_COMMAND_JSON:-}" in
+    '') post_deploy_command='["reconcile"]' ;;
+    none) post_deploy_command='' ;;
+    *) post_deploy_command="$DEPLOY_TEST_POST_DEPLOY_TASK_COMMAND_JSON" ;;
+  esac
+
   cases_run=$((cases_run + 1))
   mkdir -p "$case_directory"
   DEPLOY_TEST_LOG="$case_directory/aws.log"
@@ -345,7 +357,7 @@ run_release() {
     POLL_INTERVAL=1
     RUN_MIGRATIONS="$run_migrations"
     POST_DEPLOY_SMOKE_SCRIPT="$smoke_script"
-    POST_DEPLOY_TASK_COMMAND_JSON='["reconcile"]'
+    POST_DEPLOY_TASK_COMMAND_JSON="$post_deploy_command"
   )
   if [[ "$inject_internal_metrics" == "true" ]]; then
     release_environment+=(
@@ -601,6 +613,141 @@ printf '%s\n' \
 diff -u \
   "$test_directory/owning-lane-runs-migration/expected.log" \
   "$test_directory/owning-lane-runs-migration/aws.log"
+
+# ── THE WIRING ITSELF, READ OUT OF deploy-aws.yml ───────────────────────────
+#
+# Every case above proves the SCRIPT behaves correctly when it is handed
+# `RUN_MIGRATIONS=true`. None of them proves anything hands it that, and for
+# months nothing did: the flag defaulted to `false`, no workflow set it, and this
+# suite was green throughout. Production ran four migrations behind while
+# `check-migration-phases.mjs` verified that every one of them DECLARED a phase —
+# a passing gate about a pipeline that did nothing with the declaration.
+#
+# So these two cases take the values out of the workflow file and drive the
+# script with them. They fail if `RUN_MIGRATIONS` stops being `true`, if
+# `MIGRATION_SERVICE` stops naming the API lane, or if the post-deploy migration
+# command is removed or moved — which is the whole point, because none of those
+# edits breaks anything else in this repository.
+#
+# WHICH LANE declares the post-deploy command is not observable from here; this
+# suite only sees that exactly one lane does. `deployMigrationWiring.test.ts`
+# owns the lane attribution, and reads the same file.
+
+workflow_file="$repository_root/.github/workflows/deploy-aws.yml"
+
+# A WORKFLOW-LEVEL `env:` value, matched at exactly two spaces of indent.
+#
+# The indent is the assertion, not decoration: a step-level `env:` binding sits
+# at ten, so a pattern that ignored leading space would happily read a value
+# scoped to one step and report it as the job-wide default. Exactly one match is
+# required — zero means the key was renamed, more than one means two scopes
+# disagree and this helper cannot say which one the deploy reads.
+workflow_env_value() {
+  local key="$1" matches value
+  matches="$(grep -cE "^  ${key}:" "$workflow_file" || true)"
+  if [[ "$matches" != "1" ]]; then
+    echo "ASSERTION FAILED: expected exactly one workflow-level \`${key}:\` in $workflow_file, found $matches." >&2
+    exit 1
+  fi
+  value="$(grep -E "^  ${key}:" "$workflow_file" | head -1)"
+  value="${value#*: }"
+  value="${value%\'}"
+  value="${value#\'}"
+  value="${value%\"}"
+  value="${value#\"}"
+  printf '%s' "$value"
+}
+
+workflow_run_migrations="$(workflow_env_value RUN_MIGRATIONS)"
+workflow_migration_service="$(workflow_env_value MIGRATION_SERVICE)"
+# The API lane's own service name, read from `APP` rather than from
+# MIGRATION_SERVICE.
+#
+# THAT DISTINCTION IS THE WHOLE CASE, and it was measured: deriving the lane from
+# MIGRATION_SERVICE made both cases below pass with MIGRATION_SERVICE mutated to
+# `homiio-worker`, because the API-lane case then WAS the worker and happily ran
+# the migrator there. A check that names its subject after the value it is
+# checking cannot fail — the same shape as a table map derived from a collection
+# name. Read from APP, the same mutation turns both cases red.
+workflow_app="$(workflow_env_value APP)"
+
+# THE GATE, stated before it is used, so a failure names the value rather than
+# surfacing as a confusing diff twenty lines later.
+if [[ "$workflow_run_migrations" != "true" ]]; then
+  echo "ASSERTION FAILED: deploy-aws.yml sets RUN_MIGRATIONS to '$workflow_run_migrations', not 'true'." >&2
+  echo "The deploy would push an image and roll it out without applying a single migration," >&2
+  echo "and every job in this repository would still be green — which is exactly what" >&2
+  echo "happened until 2026-08-10." >&2
+  exit 1
+fi
+if [[ -z "$workflow_migration_service" ]]; then
+  echo "ASSERTION FAILED: deploy-aws.yml declares no MIGRATION_SERVICE." >&2
+  echo "Without it BOTH lanes run the migrator on one release, and the migrator holds" >&2
+  echo "no cross-process lock." >&2
+  exit 1
+fi
+if [[ -z "$workflow_app" ]]; then
+  echo "ASSERTION FAILED: deploy-aws.yml declares no APP, so neither lane below has a name." >&2
+  exit 1
+fi
+
+# Exactly one lane may declare a post-deploy task. Two would run the post
+# migration twice per release; none would never run it at all, and an unapplied
+# `post` migration is silent until the NEXT release's `pre` run blocks behind it.
+workflow_post_command_matches="$(grep -cE "^ {10}POST_DEPLOY_TASK_COMMAND_JSON:" "$workflow_file" || true)"
+if [[ "$workflow_post_command_matches" != "1" ]]; then
+  echo "ASSERTION FAILED: expected exactly one lane in $workflow_file to set POST_DEPLOY_TASK_COMMAND_JSON, found $workflow_post_command_matches." >&2
+  exit 1
+fi
+workflow_post_command="$(grep -E "^ {10}POST_DEPLOY_TASK_COMMAND_JSON:" "$workflow_file" | head -1)"
+workflow_post_command="${workflow_post_command#*: }"
+workflow_post_command="${workflow_post_command%\'}"
+workflow_post_command="${workflow_post_command#\'}"
+if ! jq -e 'type == "array" and length > 0' <<<"$workflow_post_command" >/dev/null; then
+  echo "ASSERTION FAILED: the post-deploy command in $workflow_file is not a non-empty JSON array: $workflow_post_command" >&2
+  exit 1
+fi
+workflow_post_command_line="task:$(jq -r 'join(" ")' <<<"$workflow_post_command")"
+
+# The API lane, with the workflow's own values. It runs the `pre` migrator before
+# `update-service` and declares NO post-deploy task, which is why this case sets
+# `none` rather than inheriting the harness's `reconcile` fixture.
+DEPLOY_TEST_APP="$workflow_app" \
+DEPLOY_TEST_MIGRATION_SERVICE="$workflow_migration_service" \
+DEPLOY_TEST_POST_DEPLOY_TASK_COMMAND_JSON=none \
+  run_release workflow-api-lane-migrates true "$workflow_run_migrations" false 0
+printf '%s\n' \
+  'task:node packages/backend/dist/db/migrate.js --target-database=homiio --phase=pre' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=1' \
+  smoke \
+  >"$test_directory/workflow-api-lane-migrates/expected.log"
+diff -u \
+  "$test_directory/workflow-api-lane-migrates/expected.log" \
+  "$test_directory/workflow-api-lane-migrates/aws.log"
+assert_aws_log_lacks workflow-api-lane-migrates "--phase=post" "The API lane ran the post migration. It rolls FIRST, so the worker would still be serving the previous image when a DROP landed."
+
+# The worker lane, same workflow values. It declines the `pre` migrator because
+# MIGRATION_SERVICE names the API, and it runs the `post` phase AFTER its own
+# rollout — the first moment no old image is serving, since both services share
+# one image and this one rolls last.
+DEPLOY_TEST_APP="${workflow_app}-worker" \
+DEPLOY_TEST_MIGRATION_SERVICE="$workflow_migration_service" \
+DEPLOY_TEST_POST_DEPLOY_TASK_COMMAND_JSON="$workflow_post_command" \
+  run_release workflow-worker-lane-migrates-post true "$workflow_run_migrations" false 0
+printf '%s\n' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=1' \
+  smoke \
+  "$workflow_post_command_line" \
+  >"$test_directory/workflow-worker-lane-migrates-post/expected.log"
+diff -u \
+  "$test_directory/workflow-worker-lane-migrates-post/expected.log" \
+  "$test_directory/workflow-worker-lane-migrates-post/aws.log"
+assert_aws_log_lacks workflow-worker-lane-migrates-post "--phase=pre" "The worker lane ran the pre migrator. Both services share one image and the migrator holds no cross-process lock, so it must run exactly once per release."
+assert_output_contains workflow-worker-lane-migrates-post "Skipping migrations for ${workflow_app}-worker"
+# The ORDER is the assertion, and a whole-log diff is what sees it: a `post`
+# migration recorded before `update-service` would be a DROP applied while the
+# previous image was still serving.
+assert_output_contains workflow-worker-lane-migrates-post "ECS rollout reached a healthy steady state"
 
 # A migration one-shot that never STOPS is the case that reaches the EXIT trap's
 # unfinished-task warning -- the only signal that a migration may still be

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,29 @@ on:
 # the `_id` -> `id` incident), and it produces no red job anywhere.
 #
 # So cancellation is now scoped to the refs that do not deploy. Pull requests
-# keep the fast-cancel behaviour; pushes to main QUEUE behind each other, which
-# is what "serialize production rollouts" has meant in deploy-aws.yml all along.
-# The cost is real and deliberate: on a busy morning main's deploys run one after
-# another instead of the newest winning. That is the trade the rollout guarantee
-# is worth.
+# keep the fast-cancel behaviour; a run on main that has STARTED is never
+# cancelled, which is what "serialize production rollouts" has meant in
+# deploy-aws.yml all along.
+#
+# WHAT THIS DOES NOT DO, MEASURED, because the previous version of this comment
+# claimed the opposite and a safety argument now leans on it. It said pushes to
+# main "QUEUE behind each other" and that "main's deploys run one after another
+# instead of the newest winning". They do not. `cancel-in-progress` governs the
+# IN-PROGRESS run only; a run still PENDING in the group is evicted by the next
+# push, and at most one pending run is ever retained. On 2026-08-10 runs
+# `31376441022` (a3213af2, 09:50:10Z) and `31376457516` (873c3e25, 09:50:23Z)
+# were both `cancelled` while `31376855242` (ff4f04c3, 09:55:41Z) went on to
+# run. Both cancelled runs report ZERO jobs — they never started one. So the
+# newest DOES win; what is guaranteed is only that a run already executing is
+# left alone.
+#
+# For a rollout that is the property that matters: a run that never started
+# never called `update-service` and never started a migrator, so nothing is left
+# half-done. The cost lands elsewhere and is worth knowing — an intermediate
+# commit's deploy can be dropped entirely, and `deployment-scope.sh` reads a
+# single commit (`<sha>^1..<sha>`), so if the run that wins is documentation-only
+# it deploys nothing at all and the skipped commit's changes wait for the next
+# code merge.
 concurrency:
   group: ci-${{ github.ref }}
   # An EXPRESSION, and a mistyped one degrades silently to falsy — which would

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -55,17 +55,40 @@ env:
   APP: homiio
   CLUSTER: oxy-cluster
   DOCKERFILE: packages/backend/Dockerfile
-  # Which of the two lanes below owns the one-shot migrations. Both roll the SAME
-  # image through deploy-ecs-image.sh, and the migrator holds no cross-process
-  # advisory lock, so it must run exactly once per release. Naming the service
-  # here rather than setting RUN_MIGRATIONS per step means a future job-level
-  # `RUN_MIGRATIONS: true` still cannot reach the worker: the worker lane sets
-  # APP to `homiio-worker`, which does not match, and it declines with a notice.
-  #
-  # RUN_MIGRATIONS itself stays at its default of `false` until the cutover
-  # (issue #281, Lote 13). Turning it on before `/oxy/homiio/DATABASE_URL` exists
-  # in SSM would fail the one-shot and therefore the whole release.
+  # Which of the two lanes below owns the one-shot `pre` migrations. Both roll
+  # the SAME image through deploy-ecs-image.sh, and the migrator holds no
+  # cross-process advisory lock, so it must run exactly once per release. Naming
+  # the service here rather than setting RUN_MIGRATIONS per step is what makes
+  # the workflow-level `RUN_MIGRATIONS` below safe: the worker lane sets APP to
+  # `homiio-worker`, which does not match, and it declines with a notice.
   MIGRATION_SERVICE: homiio
+  # THE DEPLOY APPLIES MIGRATIONS. It did not until this line existed, and the
+  # gap was invisible: `RUN_MIGRATIONS` defaults to `false` in
+  # deploy-ecs-image.sh, nothing set it, and every deploy was green.
+  #
+  # What that cost, on 2026-08-10: production was four migrations behind (0008,
+  # 0009, 0010, 0011) and `/api/cities` and `/api/home/sections` both answered
+  # 500 until the one-shot was run BY HAND. The migrations had merged with green
+  # CI, green deploys, and a passing `check-migration-phases.mjs` gate — which
+  # verifies every migration DECLARES a phase, while nothing consumed the
+  # declaration. A green gate about a pipeline that does nothing.
+  #
+  # Two preconditions the old comment here named, and where each stands:
+  #
+  #   - `/oxy/homiio/DATABASE_URL` must exist in SSM, or the one-shot fails and
+  #     takes the release with it. It exists; it is the only database secret
+  #     either task definition carries, and the sync step below maintains it.
+  #   - Two migrators must not run concurrently. `db/migrate.ts` records this as
+  #     a PRECONDITION of turning this on, because drizzle reads the ledger's
+  #     high-water mark outside its transaction. The interlock is the
+  #     `concurrency` block above plus `ci.yml`'s non-cancelling group on main,
+  #     pinned by `deployRolloutConcurrency.test.ts` — see `db/migrate.ts` for
+  #     what is left uncovered and what it would cost.
+  #
+  # Quoted so the value reaching the script is the string `true`. The script
+  # rejects anything that is neither `true` nor `false` rather than treating an
+  # unparseable value as off.
+  RUN_MIGRATIONS: 'true'
   # The commit CI judged. When called from ci.yml this IS that commit, because a
   # called workflow runs inside the caller's run — there is no window in which
   # main moves on underneath. Under workflow_dispatch it is the dispatched ref.
@@ -276,6 +299,36 @@ jobs:
           fi
           bash .github/scripts/deploy-ecs-image.sh
 
+      # THE `post` MIGRATION PHASE RUNS HERE, AND THE LANE IS THE ASSERTION.
+      #
+      # `pre` is additive and correct against both images, so it runs before the
+      # API rollout. `post` takes something away — a DROP, a RENAME, a narrowed
+      # CHECK — so it is only safe once NO old image is serving. Both services
+      # run the SAME image, and the worker rolls last, so "no old image is
+      # serving" is first true at the end of THIS step and not the API one.
+      # Putting it on the API lane would drop a column out from under a worker
+      # still running the previous image for the length of its own rollout.
+      #
+      # `POST_DEPLOY_TASK_COMMAND_JSON` is the hook deploy-ecs-image.sh already
+      # provides for exactly this position: after `update-service`, after the
+      # rollout reaches a healthy steady state, and after any smoke checks. A
+      # non-zero exit fails the job and rolls this service back.
+      #
+      # IT IS UNCONDITIONAL, WHICH IS THE POINT. Sibling repos grep the release
+      # for a post-phase marker and skip this task when it finds none, to save a
+      # Fargate task. Homiio does not, for two reasons. A wrong grep reads as "no
+      # post migration in this release" and silently skips the drop — the same
+      # silent-skip shape as the defect this whole change repairs — whereas a
+      # wrong COMMAND fails loudly on the first release that needs it. And an
+      # ungated task runs the post path on every deploy, so it cannot rot between
+      # the day it is written and the day it first matters. With nothing pending
+      # the migrator logs `No migrations to apply (phase=post, journal
+      # entries=N)` and exits 0.
+      #
+      # It cannot block a normal release either: `--phase=post` refuses only when
+      # a `pre` migration is still pending after the rollout, and the `pre` run
+      # in the API lane above would already have failed the job before this step
+      # was reached (see @oxyhq/db's `phases.ts`, `planMigrationRun`).
       - name: Register immutable task definition and deploy (listing worker)
         env:
           # Still oxy/homiio: APP names the ECS SERVICE, and the worker shares
@@ -284,13 +337,19 @@ jobs:
           # workflow's value or one a sibling key just set.
           IMAGE_URI: ${{ env.ECR_REGISTRY }}/oxy/${{ env.APP }}@${{ steps.build.outputs.digest }}
           DEPLOY_SHA: ''
+          POST_DEPLOY_TASK_COMMAND_JSON: '["node","packages/backend/dist/db/migrate.js","--target-database=homiio","--phase=post"]'
         run: |
           export APP="${APP}-worker"
           # CONTAINER_NAME is left to default to APP, which is what the
           # oxy-homiio-worker family actually calls its container.
           STATUS=$(aws ecs describe-services --cluster "$CLUSTER" --services "$APP" --query 'services[0].status' --output text 2>/dev/null || echo NONE)
           if [ "$STATUS" != "ACTIVE" ]; then
-            echo "ECS service $APP not created yet - image is in ECR, skipping $APP"
+            # Not silent, because this branch now skips the post migration too.
+            # It self-corrects loudly rather than quietly: the next release's
+            # `pre` run BLOCKS on a `pre` migration queued behind the unapplied
+            # `post` one and names both files.
+            echo "::warning::ECS service $APP does not exist, so the post-deploy migration phase did not run either. Any post-rollout migration in this release is unapplied."
+            echo "image is in ECR, skipping $APP"
             exit 0
           fi
           bash .github/scripts/deploy-ecs-image.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,9 +176,23 @@ HISTORY plus durable rules; this section is the current state.**
   file-count figures this section used to carry moved every week and were the
   single most misleading thing in this document.
 - **Migrations:** `bun run db:migrate` (`db/migrate.ts --phase=all` for a
-  developer database), applied in production as a one-shot ECS task running the
-  compiled `dist/db/migrate.js` — same `pre`/`post` deploy-phase convention as
-  the rest of Oxy. Never `drizzle-kit migrate`.
+  developer database). Never `drizzle-kit migrate`.
+
+  In production `deploy-aws.yml` applies them as one-shot ECS tasks running the
+  compiled `dist/db/migrate.js`, on both sides of the rollout: `--phase=pre` in
+  the API lane before `update-service`, `--phase=post` in the WORKER lane after
+  its rollout, because the worker rolls last and `post` is only safe once no old
+  image is serving. Both are unconditional and pinned by
+  `.github/scripts/test-deploy-ecs-image.sh` and
+  `__tests__/unit/deployMigrationWiring.test.ts`.
+
+  **This paragraph described an intention until 2026-08-10.** `RUN_MIGRATIONS`
+  defaulted to `false` and nothing set it, so no deploy had ever applied a
+  migration; production ran four behind and answered 500 on `/api/cities` and
+  `/api/home/sections`. The durable lesson is the shape, not the date: the CI
+  gate that checks every migration DECLARES a phase passed the whole time,
+  because nothing consumed the declaration. Before trusting any gate here, ask
+  what reads its output.
 - **Tests:** `docker-compose.postgres.yml` runs `postgis/postgis:17-3.5` on
   `127.0.0.1:5434` (5432 and 5433 are already taken by oxy-api's and Mention's
   own compose files on the same machine). `bun run --cwd packages/backend test`

--- a/packages/backend/__tests__/unit/deployMigrationWiring.test.ts
+++ b/packages/backend/__tests__/unit/deployMigrationWiring.test.ts
@@ -1,0 +1,213 @@
+/**
+ * The deploy applies migrations, on both sides of the rollout, from the right
+ * lane — three facts that live only in workflow YAML and a shell script, and
+ * that nothing else in this repository can observe.
+ *
+ * ## The defect this exists for
+ *
+ * `deploy-ecs-image.sh` defaults `RUN_MIGRATIONS` to `false`, and until
+ * 2026-08-10 nothing set it to anything. Every deploy pushed an image, rolled it
+ * out, and applied no migration at all. Nothing was red: CI passed, the deploy
+ * passed, and `.github/scripts/check-migration-phases.mjs` — a real gate —
+ * verified that every migration DECLARED which side of a deploy it belonged on,
+ * while nothing consumed the declaration. Production ended four migrations
+ * behind (0008 through 0011) and answered 500 on `/api/cities` and
+ * `/api/home/sections` until a one-shot was run by hand.
+ *
+ * The lesson generalises past migrations: a gate on an input is not a gate on
+ * the pipeline that reads it, and the two look identical from a green run.
+ *
+ * ## What this file owns, and what it does not
+ *
+ * `.github/scripts/test-deploy-ecs-image.sh` drives the real script with the
+ * values read out of this same workflow and asserts the resulting AWS calls, so
+ * it covers "does `RUN_MIGRATIONS=true` reach the API lane and not the worker".
+ * What it cannot see is WHICH lane declares the post-deploy command, because by
+ * the time the script runs it has been handed one value with no lane attached.
+ *
+ * That attribution is the whole safety argument for the `post` phase, so it is
+ * asserted here: both services roll the SAME image, the worker rolls LAST, and a
+ * `post` migration drops or narrows something. Declared on the API lane it would
+ * run while the worker was still serving the previous image for the length of
+ * its own rollout. Declared on the worker lane it runs once nothing old is left.
+ *
+ * These assertions are exact rather than semantic. Deciding "is this YAML
+ * equivalent to that YAML" in general means reimplementing a parser and being
+ * approximately right; requiring a deliberate edit here means a rewrite gets
+ * read by a person first.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** The repository root — four levels above `packages/backend/__tests__/unit`. */
+const REPOSITORY_ROOT = join(__dirname, '..', '..', '..', '..');
+const workflow = readFileSync(
+  join(REPOSITORY_ROOT, '.github', 'workflows', 'deploy-aws.yml'),
+  'utf8',
+);
+const deployScript = readFileSync(
+  join(REPOSITORY_ROOT, '.github', 'scripts', 'deploy-ecs-image.sh'),
+  'utf8',
+);
+
+/** The name of each lane's step, in the order the job runs them. */
+const API_STEP = 'Register immutable task definition and deploy (API)';
+const WORKER_STEP = 'Register immutable task definition and deploy (listing worker)';
+
+/**
+ * A step's body: from its `- name:` line to the next step at the same
+ * indentation, or the end of the file, with whole-line `#` comments removed.
+ *
+ * Scoping is the point. Both lanes bind `IMAGE_URI` and `DEPLOY_SHA`, so an
+ * assertion that read the whole file would pass on the other lane's bindings —
+ * which is precisely the mistake that would put the `post` migration on the API
+ * lane and still look verified.
+ *
+ * The comments go because a step's slice runs up to the NEXT step's `- name:`,
+ * which means it swallows the comment block explaining that next step. This
+ * repository has already been bitten by the line-based version of that: a
+ * component's own doc comment quoting a forbidden form made a grep report a
+ * violation, and a gate that cries wolf gets switched off by whoever hits it
+ * next. Here it would fail in the other direction — a lane could look like it
+ * declared a binding that is only being DESCRIBED above the lane below it.
+ */
+const stepBody = (name: string): string => {
+  const start = workflow.indexOf(`      - name: ${name}`);
+  if (start === -1) return '';
+  const rest = workflow.slice(start + 1);
+  const end = rest.search(/^ {6}- name: /m);
+  const body = end === -1 ? rest : rest.slice(0, end);
+  return body
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+};
+
+const apiStep = stepBody(API_STEP);
+const workerStep = stepBody(WORKER_STEP);
+
+/**
+ * A workflow-LEVEL `env:` value, matched at exactly two spaces of indent.
+ *
+ * The indent carries the assertion: a step-level binding sits at ten, so an
+ * unanchored match would read a value scoped to one step and report it as the
+ * job-wide default. Returns null when absent, so "not declared" and "declared
+ * empty" stay distinguishable.
+ */
+const workflowEnv = (key: string): string | null => {
+  const matches = [...workflow.matchAll(new RegExp(`^ {2}${key}: (.*)$`, 'gm'))];
+  if (matches.length !== 1) return null;
+  return matches[0][1].trim().replace(/^'(.*)'$/, '$1').replace(/^"(.*)"$/, '$1');
+};
+
+/**
+ * Every `["node", …]` command the deploy script or workflow runs the migrator
+ * with.
+ *
+ * The character class excludes newlines as well as brackets, and that is not
+ * tidiness: both files are full of `[[ … ]]` shell tests and YAML flow
+ * sequences, so a class that could cross a line would happily match from one
+ * unrelated bracket to another and hand `JSON.parse` a page of shell.
+ */
+const migratorCommands = (source: string): string[][] =>
+  [...source.matchAll(/\[[^[\]\n]*dist\/db\/migrate\.js[^[\]\n]*\]/g)].map((match) =>
+    (JSON.parse(match[0]) as string[]).map((argument) => argument.trim()),
+  );
+
+describe('the deploy applies migrations', () => {
+  it('reads both lanes and the script at all', () => {
+    // Vacuity floor. Every assertion below reads one of these; an empty string
+    // would make several of them pass for the wrong reason, which is how a gate
+    // stops gating without going red.
+    expect(apiStep).not.toBe('');
+    expect(workerStep).not.toBe('');
+    expect(apiStep).toContain('bash .github/scripts/deploy-ecs-image.sh');
+    expect(workerStep).toContain('bash .github/scripts/deploy-ecs-image.sh');
+    expect(deployScript).toContain('MIGRATION_TASK_COMMANDS_JSON=');
+  });
+
+  it('turns migrations on, job-wide and unambiguously', () => {
+    // The one-word edit that recreates the incident. `false`, absent, or a
+    // spelling the script rejects all mean an image rolls out against whatever
+    // schema production happens to have.
+    expect(workflowEnv('RUN_MIGRATIONS')).toBe('true');
+    // And the script must keep REFUSING anything else rather than treating an
+    // unparseable value as off — a typo'd `True` silently skipping every
+    // migration is the same failure with a different cause.
+    expect(deployScript).toContain(
+      "if [[ \"$RUN_MIGRATIONS\" != \"true\" && \"$RUN_MIGRATIONS\" != \"false\" ]]; then",
+    );
+  });
+
+  it('gives the pre migrations to exactly one lane, the API one', () => {
+    // Both services roll the same image through the same script, and the
+    // migrator holds no cross-process lock, so a job-wide `RUN_MIGRATIONS`
+    // is only safe because MIGRATION_SERVICE names one lane. The worker lane
+    // derives its own APP by suffixing, which is why this compares against the
+    // workflow's APP rather than a literal.
+    expect(workflowEnv('MIGRATION_SERVICE')).toBe(workflowEnv('APP'));
+    expect(workerStep).toContain('export APP="${APP}-worker"');
+    // Neither lane may override the flag or the owner locally: a step-level
+    // binding would silently win over the job-wide values asserted above.
+    expect(apiStep).not.toContain('RUN_MIGRATIONS:');
+    expect(workerStep).not.toContain('RUN_MIGRATIONS:');
+    expect(apiStep).not.toContain('MIGRATION_SERVICE:');
+    expect(workerStep).not.toContain('MIGRATION_SERVICE:');
+  });
+
+  it('runs the post phase on the WORKER lane, which rolls last', () => {
+    // THE LANE IS THE SAFETY ARGUMENT. `post` drops and narrows, so it is only
+    // correct once no old image is serving; the worker rolls after the API, so
+    // that moment arrives at the end of the worker's rollout and not the API's.
+    expect(workerStep).toContain('POST_DEPLOY_TASK_COMMAND_JSON:');
+    expect(apiStep).not.toContain('POST_DEPLOY_TASK_COMMAND_JSON:');
+    // Ordering, read off the file rather than assumed from the two assertions
+    // above: swapping the steps would leave both of them true and the guarantee
+    // false.
+    expect(workflow.indexOf(`- name: ${API_STEP}`)).toBeLessThan(
+      workflow.indexOf(`- name: ${WORKER_STEP}`),
+    );
+  });
+
+  it('runs pre before the rollout and post after it, against one database', () => {
+    const pre = migratorCommands(deployScript);
+    const post = migratorCommands(workerStep);
+    expect(pre).toHaveLength(1);
+    expect(post).toHaveLength(1);
+    expect(pre[0]).toContain('--phase=pre');
+    expect(post[0]).toContain('--phase=post');
+
+    // `node`, not `bun`: the runtime image installs production dependencies
+    // only and its CMD is node. The path this replaced named a file that has
+    // never existed here, which is why `RUN_MIGRATIONS=true` could not have
+    // worked even had something set it.
+    for (const command of [pre[0], post[0]]) {
+      expect(command[0]).toBe('node');
+      expect(command[1]).toBe('packages/backend/dist/db/migrate.js');
+    }
+
+    // Both phases must name the SAME database, and name one at all. The
+    // migrator requires `--target-database` because a run pointed at the wrong
+    // database fails SUCCESS-SHAPED: it finds an empty ledger, applies the whole
+    // journal, and logs `Applied N migration(s)`.
+    const target = (command: string[]): string =>
+      command.find((argument) => argument.startsWith('--target-database=')) ?? '';
+    expect(target(pre[0])).toBe('--target-database=homiio');
+    expect(target(post[0])).toBe(target(pre[0]));
+  });
+
+  it('keeps the post phase unconditional, so it cannot rot until it matters', () => {
+    // Sibling repos gate the post task on grepping the release for a post-phase
+    // marker, to save a Fargate task on a release that has none. A wrong grep
+    // there reads as "no post migration in this release" and skips the drop
+    // silently — the same shape as the defect this file exists for — while a
+    // wrong COMMAND fails loudly on the first release that needs one.
+    //
+    // So the invariant is that the worker lane carries no step-level condition.
+    // Asserted as the absence of an `if:` key rather than as the absence of the
+    // marker TEXT: the marker is a legitimate thing for a comment here to
+    // mention, and a gate that reds on its own documentation gets switched off.
+    expect(workerStep).not.toMatch(/^ {8}if:/m);
+  });
+});

--- a/packages/backend/db/MIGRATION-CONTRACT.md
+++ b/packages/backend/db/MIGRATION-CONTRACT.md
@@ -311,9 +311,17 @@ the reasoning is worth keeping rather than the old sentence:
 - The interlock a GitHub deploy actually needs is a workflow-level `concurrency`
   group with `cancel-in-progress: false`, and `deploy-aws.yml` has carried one
   (`deploy-homiio-backend`) throughout. It is a CALLED workflow, so it runs
-  inside `ci.yml`'s run, whose group also does not cancel on `refs/heads/main` —
-  two merges to main queue rather than overlap. Both halves are pinned by
-  `__tests__/unit/deployRolloutConcurrency.test.ts`.
+  inside `ci.yml`'s run, whose group also does not cancel on `refs/heads/main`.
+  Both halves are pinned by `__tests__/unit/deployRolloutConcurrency.test.ts`.
+- **Be precise about what that group guarantees**, because the natural reading is
+  wrong: `cancel-in-progress: false` protects a run that has STARTED, and does
+  not queue the rest. A run still PENDING in the group is evicted by the next
+  push — measured 2026-08-10, runs `31376441022` and `31376457516` were both
+  cancelled with ZERO jobs each while `31376855242` proceeded. For the migrator
+  that is sufficient and not accidental: a run that never started never ran
+  `migrate.js`. What it costs is that an intermediate commit's deploy can be
+  dropped, so its migrations wait for the next one — which applies everything
+  pending.
 - What that leaves open is a `workflow_dispatch` of `deploy-aws.yml` landing
   while a push-triggered deploy is mid-flight: different runs, and the old
   parenthetical about "two concurrency groups that cannot see each other" is

--- a/packages/backend/db/MIGRATION-CONTRACT.md
+++ b/packages/backend/db/MIGRATION-CONTRACT.md
@@ -296,22 +296,39 @@ cutover: an image built before a migration existed prints `No migrations to
 apply`, exits 0, and is otherwise byte-identical to the correct case. Compare it
 against `meta/_journal.json` at the pinned SHA and refuse if they differ.
 
-## Open — required before the deploy runs migrations (batch 12)
+## Open — the deploy runs migrations, and the interlock is the workflow's
 
-**There is no cross-process advisory lock**, and one is needed before
-`deploy-aws.yml` gains a migration step. drizzle's migrator takes no lock of any
-kind: it reads the ledger's high-water mark OUTSIDE its transaction, then opens
-one and replays everything newer. Two concurrent runs therefore both read the
-same mark and both replay the same DDL, and the loser fails on an already-applied
-statement after the winner has committed — leaving a duplicate ledger row behind.
+**There is still no cross-process advisory lock.** drizzle's migrator takes no
+lock of any kind: it reads the ledger's high-water mark OUTSIDE its transaction,
+then opens one and replays everything newer. Two concurrent runs therefore both
+read the same mark and both replay the same DDL, and the loser fails on an
+already-applied statement after the winner has committed.
 
-Homiio has no path that can run two migrators today, because nothing runs
-migrations automatically at all. Wiring the deploy to migrate is exactly what
-creates the race (a deploy's own step against a manual dispatch, in two GitHub
-concurrency groups that cannot see each other). oxy-api's `db/migrate.ts` has the
-reference implementation: a session-scoped `pg_try_advisory_lock` held on its own
-connection for the caller's lifetime, not on the short-lived one `runMigrations`
-opens internally.
+**This section used to say the lock was required BEFORE `deploy-aws.yml` gained
+a migration step. That step landed on 2026-08-10 without it, deliberately**, and
+the reasoning is worth keeping rather than the old sentence:
+
+- The interlock a GitHub deploy actually needs is a workflow-level `concurrency`
+  group with `cancel-in-progress: false`, and `deploy-aws.yml` has carried one
+  (`deploy-homiio-backend`) throughout. It is a CALLED workflow, so it runs
+  inside `ci.yml`'s run, whose group also does not cancel on `refs/heads/main` —
+  two merges to main queue rather than overlap. Both halves are pinned by
+  `__tests__/unit/deployRolloutConcurrency.test.ts`.
+- What that leaves open is a `workflow_dispatch` of `deploy-aws.yml` landing
+  while a push-triggered deploy is mid-flight: different runs, and the old
+  parenthetical about "two concurrency groups that cannot see each other" is
+  right about exactly that case and no other.
+- The cost there is a red deploy rather than a damaged database — the loser
+  exits non-zero on an already-applied statement. **The old claim that it leaves
+  "a duplicate ledger row behind" is not something this repository has measured,
+  and the ecosystem measurement of the same drizzle replay rule says the ledger
+  ends correct with one row.** Do not repeat the duplicate-row claim without
+  measuring it here.
+
+oxy-api's `db/migrate.ts` still has the reference implementation if the lock is
+wanted: a session-scoped `pg_try_advisory_lock` held on its own connection for
+the caller's lifetime, not on the short-lived one `runMigrations` opens
+internally.
 
 ## Batch 0 scope, and what it deliberately leaves for later
 

--- a/packages/backend/db/assertPostgresPopulated.ts
+++ b/packages/backend/db/assertPostgresPopulated.ts
@@ -29,23 +29,28 @@
  * about in its own comments. Anything this file did to the data could therefore
  * still be happening after the deploy gave up. It counts, and it exits.
  *
- * ## ITS LIFETIME IS THE CUTOVER'S — it is NOT wired in by this commit
+ * ## STILL NOT WIRED IN, and the reason has changed — read this before wiring it
  *
- * This asserts that Postgres is AUTHORITATIVE. That is true from the cutover
- * onward, false before it, and false again the moment we exercise the planned
- * rollback: Mongo is the rollback target, and reverting to it makes an empty
- * Postgres correct again. A floor that outlived the cutover would then block
- * every subsequent deploy for a reason nothing about a Mongo rollback would lead
- * anyone to look for.
+ * This asserts that Postgres is AUTHORITATIVE. That was false before the
+ * cutover, and would have been false again after the planned rollback to Mongo,
+ * so the original plan was for the cutover commit to append this file's entry to
+ * `MIGRATION_TASK_COMMANDS_JSON` in `deploy-ecs-image.sh` and for a revert to
+ * remove it — the guard's lifetime tied to the lifetime of the claim it makes,
+ * with no env flag, because a flag is a second thing to remember at the moment
+ * nobody has attention to spare. That is also why this stays out of `/health`: a
+ * permanent claim about the app becomes a trap for whoever first boots on a
+ * fresh database.
  *
- * So `MIGRATION_TASK_COMMANDS_JSON` in `deploy-ecs-image.sh` carries the entry
- * for this file as a comment, and the cutover commit (issue #281, Lote 13)
- * appends it verbatim — reverting the cutover reverts the guard with it. There
- * is no env flag on purpose: a flag is a second thing to remember at the exact
- * moment nobody has attention to spare, and it would let the guard's lifetime
- * drift away from the lifetime of the claim it makes. That is the same objection
- * that keeps this out of `/health`: a permanent claim about the app becomes a
- * trap for whoever first boots on a fresh database.
+ * The cutover happened, and there is no rollback target left (see `AGENTS.md`).
+ * The entry was never appended, and the objection that kept it out is gone.
+ *
+ * WHAT REPLACES IT IS A MEASUREMENT, NOT AN ARGUMENT. Every floor below is a
+ * number from the Mongo census of 2026-08-06, and nobody has counted what
+ * Postgres holds now. A floor production does not clear blocks every deploy —
+ * the exact failure this guard exists to prevent, caused by the guard. So:
+ * count the five tables against production first, adjust or justify each floor
+ * against what you measured, and only then append the entry. Wiring it on the
+ * strength of this paragraph is not the same as wiring it on a count.
  *
  * ## It needs no "we are mid-migration" escape hatch
  *

--- a/packages/backend/db/migrate.ts
+++ b/packages/backend/db/migrate.ts
@@ -52,18 +52,33 @@
  * lock here: `deploy-aws.yml` carries `concurrency: deploy-homiio-backend` with
  * `cancel-in-progress: false`, and because it is a CALLED workflow the run it
  * lives in is `ci.yml`'s, whose group does not cancel on `refs/heads/main`
- * either. Two merges to main therefore queue rather than overlap. Both halves
- * are pinned by `__tests__/unit/deployRolloutConcurrency.test.ts`, which fails
- * the build if either moves.
+ * either. Both halves are pinned by
+ * `__tests__/unit/deployRolloutConcurrency.test.ts`, which fails the build if
+ * either moves.
  *
- * What that does NOT cover is a `workflow_dispatch` of `deploy-aws.yml` landing
- * while a push-triggered deploy is mid-flight, since the two are different runs.
- * The cost if it happens is bounded and worth stating rather than implying: the
- * loser exits non-zero on an already-applied statement and its deploy goes red,
- * while the ledger stays correct — this is a property of drizzle's replay rule,
- * not a Homiio measurement. A red deploy, not a damaged database. A
- * session-scoped advisory lock taken on a connection held for this process's
- * lifetime is the mechanism that would close it; see `db/MIGRATION-CONTRACT.md`.
+ * STATE WHAT THAT GROUP ACTUALLY GUARANTEES, because the obvious reading is
+ * wrong and this is the load-bearing sentence. `cancel-in-progress: false` does
+ * NOT make merges to main queue up and run one after another. It governs the
+ * IN-PROGRESS run only: a run still PENDING in the group is EVICTED by the next
+ * push. Measured 2026-08-10 — runs `31376441022` and `31376457516` were both
+ * cancelled while `31376855242` proceeded, and the two cancelled ones report
+ * ZERO jobs, so neither ever started one.
+ *
+ * That is exactly the guarantee a migrator needs, and no more: a run that never
+ * started never ran `migrate.js`, so two migrators cannot overlap through this
+ * path. What it does not give is that every commit deploys — an evicted run's
+ * commit is simply skipped, and its migrations wait for the next deploy, which
+ * applies everything pending.
+ *
+ * What is NOT covered at all is a `workflow_dispatch` of `deploy-aws.yml`
+ * landing while a push-triggered deploy is mid-flight, since the two are
+ * different runs. The cost if it happens is bounded and worth stating rather
+ * than implying: the loser exits non-zero on an already-applied statement and
+ * its deploy goes red, while the ledger stays correct — this is a property of
+ * drizzle's replay rule, not a Homiio measurement. A red deploy, not a damaged
+ * database. A session-scoped advisory lock taken on a connection held for this
+ * process's lifetime is the mechanism that would close it; see
+ * `db/MIGRATION-CONTRACT.md`.
  *
  * ## Why not `drizzle-kit migrate`
  *

--- a/packages/backend/db/migrate.ts
+++ b/packages/backend/db/migrate.ts
@@ -3,9 +3,10 @@
  *
  * This is the ONE migration mechanism for the Postgres side of this package.
  * `bun run db:migrate` runs it, the jest harness (`db/testDatabase.ts`) calls
- * the same function in-process, CI runs the same script, and production will run
- * its COMPILED form (`dist/db/migrate.js`) as a one-shot ECS task. Nothing
- * applies a migration by any other route.
+ * the same function in-process, CI runs the same script, and production runs its
+ * COMPILED form (`dist/db/migrate.js`) as a one-shot ECS task on every deploy —
+ * `--phase=pre` before the API rollout, `--phase=post` after the worker's.
+ * Nothing applies a migration by any other route.
  *
  * The actual apply — journal read, phase-marker read, ledger read, extension
  * setup, `migrate()`, the post-apply re-check — is `runMigrations` from
@@ -35,16 +36,34 @@
  * and a manual dispatch have no previous image to protect; a production one-shot
  * task states its own phase explicitly on the command line.
  *
- * ## What is deliberately NOT here yet
+ * ## The interlock is the WORKFLOW's, and there is still no advisory lock
  *
- * No cross-process advisory lock. drizzle's migrator takes no lock of its own —
- * it reads the ledger's high-water mark OUTSIDE its transaction, then replays
- * everything newer inside one — so two concurrent runs both replay the same DDL
- * and the loser fails on an already-applied statement. Homiio has no path that
- * can run two migrators today (nothing in `deploy-aws.yml` runs migrations at
- * all yet). Wiring the deploy to migrate is what makes a deploy race a manual
- * dispatch, so the lock is a PRECONDITION of that change, not of this one. See
- * `db/MIGRATION-CONTRACT.md`.
+ * drizzle's migrator takes no lock of its own — it reads the ledger's
+ * high-water mark OUTSIDE its transaction, then replays everything newer inside
+ * one — so two concurrent runs both replay the same DDL and the loser fails on
+ * an already-applied statement. `@oxyhq/db/migrate`'s runner says the same in
+ * its own header and assigns the interlock to the caller, naming this exact
+ * case: a deploy's own migration step racing a manually dispatched one.
+ *
+ * An earlier revision of this comment said Homiio had no path that could run
+ * two migrators, because nothing in `deploy-aws.yml` ran migrations at all, and
+ * called the lock a precondition of turning them on. Turning them on is done
+ * (2026-08-10), and the precondition is met by the WORKFLOW rather than by a
+ * lock here: `deploy-aws.yml` carries `concurrency: deploy-homiio-backend` with
+ * `cancel-in-progress: false`, and because it is a CALLED workflow the run it
+ * lives in is `ci.yml`'s, whose group does not cancel on `refs/heads/main`
+ * either. Two merges to main therefore queue rather than overlap. Both halves
+ * are pinned by `__tests__/unit/deployRolloutConcurrency.test.ts`, which fails
+ * the build if either moves.
+ *
+ * What that does NOT cover is a `workflow_dispatch` of `deploy-aws.yml` landing
+ * while a push-triggered deploy is mid-flight, since the two are different runs.
+ * The cost if it happens is bounded and worth stating rather than implying: the
+ * loser exits non-zero on an already-applied statement and its deploy goes red,
+ * while the ledger stays correct — this is a property of drizzle's replay rule,
+ * not a Homiio measurement. A red deploy, not a damaged database. A
+ * session-scoped advisory lock taken on a connection held for this process's
+ * lifetime is the mechanism that would close it; see `db/MIGRATION-CONTRACT.md`.
  *
  * ## Why not `drizzle-kit migrate`
  *


### PR DESCRIPTION
## The defect

`.github/scripts/deploy-ecs-image.sh` defaults `RUN_MIGRATIONS` to `false`, and
nothing in this repository ever set it. **No Homiio deploy has ever applied a
database migration in production.**

Nothing was red about that. CI passed, the deploy passed, and
`.github/scripts/check-migration-phases.mjs` — a real gate with its own mutation
test — verified that every migration DECLARED which side of a deploy it belonged
on, the whole time nothing consumed the declaration. A green gate about a
pipeline that did nothing.

Measured on 2026-08-10: a `DRY_RUN=true` one-off reported **four migrations
unapplied — 0008, 0009, 0010, 0011**. Applying them by hand took `/api/cities`
and `/api/home/sections` from 500 to 200. That manual repair is already done;
this PR is the pipeline only, so it does not touch production by itself.

The general shape is worth more than the instance: **a gate on an input is not a
gate on the pipeline that reads it, and the two are indistinguishable from a
green run.**

## What changed

**1. `RUN_MIGRATIONS: 'true'`**, at workflow `env` scope beside the
`MIGRATION_SERVICE: homiio` that makes it safe. Verified against the script
rather than against its comment: `migrations_run_in_this_lane` is set to `false`
when `MIGRATION_SERVICE` is non-empty and differs from `APP`
(`deploy-ecs-image.sh:188-193`), and the worker lane sets `APP` to
`homiio-worker` in its own shell. It skips with a notice rather than refusing,
which is the right direction — the API lane has already applied the schema by
then, and exiting 1 would strand the worker on the old image.

Quoted, so the value reaching the script is the string `true`; the script
rejects anything that is neither `true` nor `false` instead of reading an
unparseable value as off.

**2. The `post` phase now runs, on the WORKER lane.** It was the same defect one
phase over. All 13 migrations on `main` declare `pre` today, so `post` is empty —
but nothing invoked it, so the first `post` migration would have been deferred
silently by the `pre` run (`Leaving 1 migration(s) for a later phase`, exit 0,
green deploy) and the next `pre` migration behind it would then have **BLOCKED
every deploy**, because the ledger records a high-water mark and cannot express a
hole (`@oxyhq/db`'s `phases.ts`, `planMigrationRun`).

It runs through `POST_DEPLOY_TASK_COMMAND_JSON`, the hook the script already
provides for that position: after `update-service`, after the rollout reaches a
healthy steady state, after smoke. **The lane is the safety argument** — both
services run the same image and the worker rolls last, so "no old image is
serving" is first true at the end of the worker's rollout. On the API lane a
`post` DROP would land while the worker was still running the previous image for
the length of its own rollout.

It is **unconditional**, unlike the sibling repos that grep the release for a
post-phase marker first. A wrong grep reads as "no post migration in this
release" and skips the DROP silently — the same silent-skip shape as the defect
this PR repairs — whereas a wrong command fails loudly on the first release that
needs one. And an ungated task exercises the post path on every deploy, so it
cannot rot between the day it is written and the day it first matters. With
nothing pending the migrator logs `No migrations to apply (phase=post, journal
entries=N)` and exits 0; it cannot block a normal release, because `--phase=post`
refuses only when a `pre` migration is still pending, and the `pre` run in the
API lane would already have failed the job.

**3. Two gates, both mutation-tested** (evidence below).

- `.github/scripts/test-deploy-ecs-image.sh` reads `RUN_MIGRATIONS`,
  `MIGRATION_SERVICE` and `APP` out of `deploy-aws.yml` and drives the real
  script with them — two new cases, floor raised 22 → 24.
- `packages/backend/__tests__/unit/deployMigrationWiring.test.ts` owns what the
  bash suite structurally cannot see: which LANE declares the post command, and
  that the API step precedes the worker step.

**4. Comments this makes false, corrected in the same change.** `db/migrate.ts`
said "nothing in `deploy-aws.yml` runs migrations at all yet" and called a
cross-process advisory lock a PRECONDITION of turning them on;
`MIGRATION-CONTRACT.md` said the same; `AGENTS.md` described the production
one-shot as though it already happened — **that claim was aspirational until
this PR, and this PR is what makes it true.**

## The advisory-lock precondition, and what the concurrency group really does

`db/migrate.ts` named the lock explicitly, so it is answered rather than skipped.
The interlock a GitHub deploy needs is a workflow-level `concurrency` group with
`cancel-in-progress: false`, and `deploy-aws.yml` has carried one
(`deploy-homiio-backend`) throughout; because it is a CALLED workflow it runs
inside `ci.yml`'s run, whose group also does not cancel on `refs/heads/main`.
Both halves are already pinned by `deployRolloutConcurrency.test.ts`.

**But `ci.yml`'s own comment claimed something false, and this argument was
leaning on it.** It said pushes to main "QUEUE behind each other" and that
"main's deploys run one after another instead of the newest winning". They do
not. `cancel-in-progress` governs the IN-PROGRESS run only; a run still PENDING
in the group is evicted by the next push, and at most one pending run is
retained. Measured on main today:

| run | commit | createdAt | conclusion | jobs |
|---|---|---|---|---|
| `31376441022` | `a3213af2` | 09:50:10Z | cancelled | **0** |
| `31376457516` | `873c3e25` | 09:50:23Z | cancelled | **0** |
| `31376855242` | `ff4f04c3` | 09:55:41Z | ran | — |

Zero jobs on both cancelled runs — neither ever started one. So the newest DOES
win; what is guaranteed is only that a run already executing is left alone.

**That is still exactly the guarantee this change needs, and no more.** A run
that never started never called `migrate.js`, so two migrators cannot overlap
through this path. Saying it precisely matters because the wrong version of the
sentence would invite someone to "fix" the eviction later and remove the thing
the argument actually rests on.

Two honest costs, neither introduced here:

- **An intermediate commit's deploy can be dropped entirely.** Combined with
  `deployment-scope.sh` reading a single commit (`<sha>^1..<sha>`), a
  documentation-only commit winning the race deploys nothing at all, and the
  skipped commit's migrations wait for the next code merge — which applies
  everything pending, so it self-heals, silently and on no fixed schedule.
- **A `workflow_dispatch` of `deploy-aws.yml` racing a push deploy is not
  covered**, since the two are different runs. The cost is a red deploy, not a
  damaged database: the loser exits non-zero on an already-applied statement.
  That is a property of drizzle's replay rule, **not a Homiio measurement**, and
  `db/migrate.ts` now says so in those words. The `MIGRATION-CONTRACT.md` claim
  that it leaves "a duplicate ledger row behind" is unverified here and is
  marked as such rather than repeated.

Corrected in all three places that stated it: `ci.yml`, `db/migrate.ts`,
`db/MIGRATION-CONTRACT.md`.

## Rebased onto `ff4f04c3`, and 0013 is a live example of the split

The first CI run was based on `873c3e25` and predated #358. Rebased onto
`ff4f04c3` and re-verified; the journal now holds **14** entries, and both new
migrations declare `pre` (`0012_housing_watches_and_alerts`,
`0013_evictions_local_privacy`), so `post` is still empty and the unconditional
post task no-ops as designed.

**The rebase did surface one thing, and it was a stale artifact rather than an
interaction.** `tsc` reported 88 errors, all `TS2305`/`TS2724` from
`@homiio/shared-types` — the referenced project's `dist/` predating #356/#358
while jest read `src/`. Rebuilding `shared-types` (after deleting its
`tsbuildinfo`, which survives a `dist` delete and makes the next build a silent
no-op) and `listing-providers` takes it to **exit 0**. CI installs with scripts
enabled so the root postinstall builds `shared-types`, so this never reached it.

Neither gate enumerates or counts migrations — they read workflow and script
TEXT — and the population floor counts rows in five tables 0013 does not touch,
so nothing in this PR takes the journal as input. That is now measured rather
than reasoned: mutations 1 and 3 were re-run on the rebased tree and both still
discriminate.

**`0013` is worth reading against this change.** Its header records that it
REPLACES the `location_precision` and eviction-reason vocabularies, so during a
rolling deploy exactly one image writes values the CHECKs refuse — and it chose
`pre` so that image is the OUTGOING one, whose failure ends when the rollout
does, rather than the incoming one, whose failure persists if the migration task
is delayed. That reasoning assumes the `pre` migration is applied BEFORE
`update-service`, which is precisely the ordering this PR makes automatic. Until
now it would not have been applied at all.

## `assertPostgresPopulated.ts` — still unwired, new reason

The cutover it was waiting for **has happened**, with evidence: `AGENTS.md`'s
data-storage section records `models/`, `db/backfill/`, mongoose and
`mongodb-memory-server` deleted; `MONGODB_URI` is off both task definitions and
deleted from SSM; and there is no rollback target, the only copy of the old data
being an offline dump. So the original objection — that it would block every
deploy after a rollback to Mongo — is gone.

It is **still not wired**, for a narrower reason that has to be measured rather
than argued: its five floors (`properties` ≥ 5,000, `images` ≥ 50,000,
`addresses` ≥ 3,000, `cities` ≥ 500, `agencies` ≥ 800) are numbers from a Mongo
census dated 2026-08-06, and nobody has counted what Postgres holds now. Wiring a
floor production does not clear blocks every deploy — the exact failure the guard
exists to prevent, caused by the guard. I was asked not to run anything against
production, so I did not count. Both the guard's own doc comment and the script's
comment now say this, and it is filed as an issue.

## Mutation evidence

Every mutation was asserted to have LANDED before the run, and the workflow was
restored from a namespaced pristine copy afterwards and re-verified against four
markers from my own edit plus one pre-existing landmark, with a negative control
(`RUN_MIGRATIONS: 'false'` must be absent) that also returned 0.

| # | Mutation | `test-deploy-ecs-image.sh` | `deployMigrationWiring.test.ts` |
|---|---|---|---|
| 1 | `RUN_MIGRATIONS: 'true'` → `'false'` | **RED** — `deploy-aws.yml sets RUN_MIGRATIONS to 'false', not 'true'` | **RED** — `Expected: "true" / Received: "false"` |
| 2 | `MIGRATION_SERVICE: homiio` → `homiio-worker` | **RED** — diff shows the `--phase=pre` task missing from the API lane | **RED** — `Expected: "homiio" / Received: "homiio-worker"` |
| 3 | move the post command from the worker lane to the API lane | green (cannot see lanes — by construction) | **RED** — 2 tests, `Expected substring: "POST_DEPLOY_TASK_COMMAND_JSON:"` |
| 4 | delete the post command entirely | **RED** — `expected exactly one lane … found 0` | **RED** — 2 tests |
| 5 | `--phase=pre` → `--phase=all` in the script | **RED** — whole-log diff names both strings | (n/a to this gate's own scope; also covered) |

**Mutation 3 is why both gates exist**, and mutation 2 is the finding worth
recording: the bash cases initially derived the API lane's `APP` from
`MIGRATION_SERVICE`, so mutating `MIGRATION_SERVICE` to `homiio-worker` renamed
the case's own subject and **the suite stayed green** — a check that names its
subject after the value it is checking cannot fail. Reading `APP` instead makes
the same mutation red. Fixed before this PR was opened.

## What I did not do

- Nothing was run against production. The manual repair was already done.
- Not merged.
- No unrelated changes. Two pre-existing lint errors (`server.ts:5`,
  `__tests__/db/placePoiCache.test.ts:28`) are untouched; `lint` is skipped in CI
  by design.

## Local verification

All re-run on the rebased tree at `ff4f04c3`:

- `bash .github/scripts/test-deploy-ecs-image.sh` — 24 release cases, exit 0.
- `bun run --cwd packages/backend test` — **152 suites, 2,115 tests**, all
  passing.
- `bunx tsc --noEmit -p packages/backend/tsconfig.json` — exit 0 after
  rebuilding `shared-types` and `listing-providers` (see above).
- `bun .github/scripts/check-migration-phases.mjs packages/backend/drizzle` —
  14 migrations, all declaring a phase, exit 0.
- `bun run check:docs`, `bun run check:lockfile`, `bash -n .github/scripts/*.sh`
  — all exit 0.
- `eslint` on every file this PR touches — exit 0.
- The workflow parses, and its resolved values are
  `APP=homiio`, `MIGRATION_SERVICE=homiio`, `RUN_MIGRATIONS='true'`, with
  `POST_DEPLOY_TASK_COMMAND_JSON` present on the worker step and absent from the
  API step.