### PR TITLE
fix(evictions): make an unhandled location kind a compile error, not a silent refusal

### DIFF
--- a/packages/frontend/__tests__/evictionScope.test.ts
+++ b/packages/frontend/__tests__/evictionScope.test.ts
@@ -1,0 +1,184 @@
+/**
+ * `selectionToBoardScope` — every selection kind is DECIDED, and no kind can
+ * mis-scope the eviction board.
+ *
+ * ## Two different guarantees, and only one of them is a runtime test
+ *
+ * **A new kind must fail to compile.** That is the `never` guard inside
+ * `selectionToBoardScope` plus `LOCATION_SELECTION_KINDS`' `satisfies`, and no
+ * runtime assertion can express it — a TypeScript union does not exist at run
+ * time. It was verified by MUTATION: before the guard, deleting the
+ * `multi_area` arm produced no `tsc` error at all, because the function returns
+ * `… | undefined` and an unhandled kind simply falls off the end.
+ *
+ * **Every kind must resolve to a scope or to NOTHING — never to the wrong
+ * place.** That is what this file asserts, over one fixture per kind.
+ *
+ * The distinction matters because the failure being guarded against is not a
+ * crash. An unhandled kind returned `undefined`, the board disabled its query
+ * and showed the picker: safe, and completely silent. The same defect class in
+ * the home-sections controller (three of six place types handled) looked like a
+ * working feature until somebody picked the fourth.
+ */
+
+import {
+  LOCATION_SELECTION_KINDS,
+  selectionToBoardScope,
+} from '@/components/evictions/evictionScope';
+import type { LocationSelection } from '@homiio/shared-types';
+
+const BOUNDS = { west: 2.05, south: 41.32, east: 2.23, north: 41.47 } as const;
+const CENTRE = { longitude: 2.1686, latitude: 41.3874 } as const;
+
+/** One fixture per kind, keyed so a missing entry is a compile error. */
+const FIXTURES: Record<keyof typeof LOCATION_SELECTION_KINDS, LocationSelection> = {
+  current_location: {
+    kind: 'current_location',
+    center: CENTRE,
+    radiusMeters: 5_000,
+    precision: 'approximate',
+  },
+  place: {
+    kind: 'place',
+    source: { kind: 'homiio', entity: 'city', id: 'city-1' },
+    placeType: 'city',
+    label: { primary: 'Barcelona', kind: 'place' },
+    admin: { countryCode: 'ES', cityName: 'Barcelona' },
+    precision: 'centroid',
+    center: CENTRE,
+  },
+  address_candidate: {
+    kind: 'address_candidate',
+    source: { kind: 'external', provider: 'osm', ref: 'way/1' },
+    label: { primary: 'Carrer de Sants', kind: 'place' },
+    admin: { countryCode: 'ES' },
+    precision: 'exact',
+    center: CENTRE,
+  },
+  map_bounds: {
+    kind: 'map_bounds',
+    bounds: BOUNDS,
+    center: CENTRE,
+    label: { primary: 'Map area', kind: 'generated' },
+    precision: 'area',
+  },
+  polygon: {
+    kind: 'polygon',
+    polygon: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [2.05, 41.32],
+          [2.23, 41.32],
+          [2.23, 41.47],
+          [2.05, 41.47],
+          [2.05, 41.32],
+        ],
+      ],
+    },
+    bounds: BOUNDS,
+    label: { primary: 'Drawn area', kind: 'generated' },
+    precision: 'area',
+  },
+  multi_area: {
+    kind: 'multi_area',
+    areas: [],
+    label: { primary: 'Several areas', kind: 'generated' },
+  },
+};
+
+describe('selectionToBoardScope', () => {
+  it('covers every declared selection kind', () => {
+    // Vacuity floor. `Object.keys` over an empty or truncated fixture set would
+    // make every loop below iterate nothing, which reads exactly like a clean
+    // pass — the shape this whole file exists to prevent.
+    const kinds = Object.keys(FIXTURES);
+    expect(kinds.sort()).toEqual(Object.keys(LOCATION_SELECTION_KINDS).sort());
+    expect(kinds.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('resolves a scope, or nothing — never a scope of a different shape', () => {
+    for (const [kind, selection] of Object.entries(FIXTURES)) {
+      const scope = selectionToBoardScope(selection);
+      if (scope === undefined) continue;
+      // The board's own contract: one shape per scope, and never a geometric
+      // shape AND a named place together.
+      expect(['global', 'city', 'bbox', 'radius', 'following', 'attending']).toContain(scope.kind);
+      if (scope.kind === 'bbox') {
+        expect(scope.swLat).toBeLessThanOrEqual(scope.neLat);
+        expect(Object.keys(scope).sort()).toEqual(['kind', 'neLat', 'neLng', 'swLat', 'swLng']);
+      }
+      if (scope.kind === 'radius') {
+        expect(scope.radiusMeters).toBeGreaterThan(0);
+        expect(Object.keys(scope).sort()).toEqual(['kind', 'lat', 'lng', 'radiusMeters']);
+      }
+      if (scope.kind === 'city') {
+        expect(Object.keys(scope).sort()).toEqual(['city', 'kind']);
+        expect(scope.city).not.toBe('');
+      }
+      expect(kind).toBeTruthy();
+    }
+  });
+
+  it('maps the kinds that carry geometry to the shape that matches it', () => {
+    expect(selectionToBoardScope(FIXTURES.current_location)).toEqual({
+      kind: 'radius',
+      lat: CENTRE.latitude,
+      lng: CENTRE.longitude,
+      radiusMeters: 5_000,
+    });
+    expect(selectionToBoardScope(FIXTURES.map_bounds)).toEqual({
+      kind: 'bbox',
+      swLat: BOUNDS.south,
+      swLng: BOUNDS.west,
+      neLat: BOUNDS.north,
+      neLng: BOUNDS.east,
+    });
+    expect(selectionToBoardScope(FIXTURES.polygon)).toEqual({
+      kind: 'bbox',
+      swLat: BOUNDS.south,
+      swLng: BOUNDS.west,
+      neLat: BOUNDS.north,
+      neLng: BOUNDS.east,
+    });
+  });
+
+  it('answers NOTHING rather than a guess for a selection it cannot query', () => {
+    // `null` is not "everywhere": a caller with no selection has not asked for
+    // the world, it has not asked anything.
+    expect(selectionToBoardScope(null)).toBeUndefined();
+    // Several areas at once is deliberately unsupported rather than
+    // approximated by the first one — showing one of three neighbourhoods
+    // somebody picked, silently, is the failure that looks like it worked.
+    expect(selectionToBoardScope(FIXTURES.multi_area)).toBeUndefined();
+    // A named place with no geometry at all is a legitimate disambiguation
+    // candidate (ADR 0002) and still not something this board can query.
+    const unframable: LocationSelection = {
+      kind: 'place',
+      source: { kind: 'homiio', entity: 'region', id: 'region-1' },
+      placeType: 'region',
+      label: { primary: 'Somewhere', kind: 'place' },
+      admin: { countryCode: 'ES' },
+      precision: 'area',
+    };
+    expect(selectionToBoardScope(unframable)).toBeUndefined();
+  });
+
+  it('falls back to the CITY scope for a named city with no geometry', () => {
+    // The board matches `location_city` by name, so a city Homiio knows but has
+    // no coordinates for is still answerable — which is the case ADR 0002 keeps
+    // selectable precisely so a homonym stays reachable.
+    const cityWithoutGeometry: LocationSelection = {
+      kind: 'place',
+      source: { kind: 'homiio', entity: 'city', id: 'city-2' },
+      placeType: 'city',
+      label: { primary: 'Riverside', kind: 'place' },
+      admin: { countryCode: 'ES', cityName: 'Riverside' },
+      precision: 'area',
+    };
+    expect(selectionToBoardScope(cityWithoutGeometry)).toEqual({
+      kind: 'city',
+      city: 'Riverside',
+    });
+  });
+});

--- a/packages/frontend/components/evictions/evictionScope.ts
+++ b/packages/frontend/components/evictions/evictionScope.ts
@@ -19,6 +19,26 @@
 import type { EvictionBoardScope, LocationSelection } from '@homiio/shared-types';
 
 /**
+ * Every `LocationSelection` kind, DERIVED from the union rather than listed.
+ *
+ * `satisfies Record<LocationSelection['kind'], true>` is what makes it derived:
+ * adding a kind to the contract fails to compile HERE until somebody decides
+ * what the board does with it. A hand-written array would accept the new kind
+ * silently and the test below would keep passing over a set that had quietly
+ * stopped being complete.
+ *
+ * Exported for `__tests__/evictionScope.test.ts`, which is the only consumer.
+ */
+export const LOCATION_SELECTION_KINDS = {
+  current_location: true,
+  place: true,
+  address_candidate: true,
+  map_bounds: true,
+  polygon: true,
+  multi_area: true,
+} as const satisfies Record<LocationSelection['kind'], true>;
+
+/**
  * The board scope a selection implies, or `undefined` when it implies none.
  *
  * A `multi_area` selection is deliberately unsupported rather than approximated
@@ -75,7 +95,35 @@ export function selectionToBoardScope(
     }
     case 'multi_area':
       return undefined;
+    default:
+      return unsupportedSelection(selection);
   }
+}
+
+/**
+ * The exhaustiveness guard.
+ *
+ * Without it this switch is not checked by the type system at all: the function
+ * returns `EvictionBoardScope | undefined`, so a kind with no arm simply falls
+ * off the end as `undefined` and `tsc` is satisfied. Verified by MUTATION —
+ * deleting the `multi_area` arm produced no error before this existed.
+ *
+ * The behaviour that fallthrough produced was already the SAFE one: no scope
+ * means the board disables its query and shows the picker, so a kind nobody
+ * handled could never mis-scope a request, only refuse it. What was missing is
+ * that nobody was TOLD. `never` turns a new kind into a compile error at the
+ * one place that has to make a decision about it, which is the same defect
+ * class as the home-sections controller handling three of six place types
+ * (fixed in `a3213af2`) — there it refused places the picker could produce, and
+ * the refusal looked like a working feature.
+ *
+ * Returns `undefined` at runtime rather than throwing: a board that shows the
+ * picker is a better answer to an unknown selection than a crash, and this
+ * function is on a render path.
+ */
+function unsupportedSelection(selection: never): undefined {
+  void selection;
+  return undefined;
 }
 
 /** The radius a point-shaped place is queried with, in metres. */


### PR DESCRIPTION
Follow-up to #410 (#358). Found by probing my own merged code for the defect class `a3213af2` fixed on the Home surface.

## What was wrong

`selectionToBoardScope` switches over every `LocationSelection` kind, and **nothing checked that it was exhaustive**. The function returns `EvictionBoardScope | undefined`, so a kind with no arm falls off the end as `undefined` and `tsc` is satisfied.

Verified by mutation before writing the fix — deleting the `multi_area` arm produced **no error**:

```
$ bunx tsc --noEmit      # before this PR, with the arm deleted
TSC_EXIT=0
```

## Why it was not a live bug, and still worth closing

The fallthrough produced the SAFE outcome. `undefined` means no scope, the board disables its query (`enabled: scope.canQuery && Boolean(boardScope)`) and shows the picker — so an unhandled kind could never mis-scope a request, only refuse it. That is ADR 0002's rule working.

What was missing is that **nobody was told**. A kind added to `LocationSelection` would quietly become unsupported on this board with no failing build and no failing test — the same shape as the home-sections controller handling three of six `PlaceType` values, where the refusal looked like a working feature until somebody picked the fourth.

## The fix: two mechanisms, neither sufficient alone

**Union-derived, not hand-listed.** `LOCATION_SELECTION_KINDS` uses `as const satisfies Record<LocationSelection['kind'], true>`, so adding a kind to the contract fails to compile here until somebody decides what the board does with it. A hand-written array would accept the new kind silently and the test would keep passing over a set that had quietly stopped being complete.

**A `never` guard in the switch**, so a missing arm is a compile error at the one place that has to make the decision. It returns `undefined` at runtime rather than throwing: this is on a render path, and a board showing the picker is a better answer to an unknown selection than a crash.

## Mutation evidence

**A — delete a switch arm.** Now a compile error naming the unhandled kind:

```
components/evictions/evictionScope.ts(97,35): error TS2345:
  Argument of type '{ readonly kind: "multi_area"; … }' is not assignable to parameter of type 'never'.
TSC_EXIT=2
```

**B — mis-scope a bbox** (swap `north`/`south` into `swLat`/`neLat`). The runtime test bites, because the type system cannot see this one at all:

```
● resolves a scope, or nothing — never a scope of a different shape
    Expected: <= 41.32
    Received:    41.47
● maps the kinds that carry geometry to the shape that matches it
Tests: 2 failed, 3 passed, 5 total
```

Both restored from a pristine copy kept outside the repository (never `git checkout`), verified byte-identical afterwards **and** re-checked against markers from my own edit — a checksum against the pristine copy proves the restore was faithful, not what it was faithful to.

## The test

Five cases in `packages/frontend/__tests__/evictionScope.test.ts`, one fixture per kind, keyed so a missing fixture is a compile error. It asserts what the type system cannot: every kind resolves to a scope of the right **shape** or to nothing, and never to a scope of a different shape — including that a `bbox` carries exactly its four corners and a `city` exactly its name, so the "geometric shape AND named place together" combination that `GET /api/properties/search` now refuses cannot be constructed here either.

It carries a vacuity floor: `Object.keys` over a truncated fixture set iterates nothing and reads exactly like a clean pass, so the kind set is asserted complete and non-trivially sized before anything loops over it.

## Verification

| Check | Result |
|---|---|
| `bunx tsc --noEmit` (frontend) | exit 0 |
| `bun run test` (frontend) | **497 / 497**, 36 suites, exit 0 |
| `bun run lint` | 0 errors in the changed files |

Behaviour is unchanged for every kind that exists today; this only makes the next one a compile error instead of a silent refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
