### PR TITLE
fix(deploy): desiredCount 0 is a state, so release the image and skip only the rollout

### DIFF
--- a/.github/scripts/deploy-ecs-image.sh
+++ b/.github/scripts/deploy-ecs-image.sh
@@ -21,70 +21,6 @@ AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID:-}"
 AWS_PARTITION="${AWS_PARTITION:-aws}"
 POST_DEPLOY_SMOKE_SCRIPT="${POST_DEPLOY_SMOKE_SCRIPT:-}"
 POST_DEPLOY_TASK_COMMAND_JSON="${POST_DEPLOY_TASK_COMMAND_JSON:-}"
-# Deploy a service that is deliberately scaled to ZERO — and say which one.
-#
-# Every ordinary deploy must refuse a zero-count service: it means capacity was
-# lost, and rolling a new image onto nothing produces a green deploy and an
-# outage. That guard stays, and this does not weaken it.
-#
-# The exception it exists for is the Mongo->Postgres cutover (issue #281). Both
-# Homiio services are stopped at desiredCount 0 for the whole window ON PURPOSE,
-# because the running image is Mongo-backed: bringing either up after the copy
-# has finished would let real user writes land in the store being abandoned, and
-# the copy is not incremental, so nothing recovers them. The worker is the one
-# that WRITES, which is why it is stopped first and why an authorisation for one
-# service must not silently cover the other. Downtime is acceptable there;
-# losing writes is not.
-#
-# It names the SERVICE rather than being a boolean because a bare `true` left in
-# a workflow file or pasted out of a runbook authorises a zero-count deploy of
-# ANYTHING, and the value that would be wrong is exactly the value that is
-# easiest to copy. Homiio has TWO services (`homiio`, `homiio-worker`), so that
-# distinction is load-bearing here in a way it was not for a single-service repo.
-ALLOW_ZERO_DESIRED_COUNT="${ALLOW_ZERO_DESIRED_COUNT:-}"
-
-# Whether THIS run may proceed against a zero-count service.
-#
-# The value is `<service>:<YYYY-MM-DD>` and BOTH halves must hold: the service
-# must be this one, and the date must not have passed. Every other shape refuses.
-#
-# The expiry is what keeps this from being a permanent reduction in protection.
-# Without it, a variable set for one window and never removed silently disarms
-# the zero-count guard forever, and the failure only shows up the day somebody
-# scales to zero for an unrelated reason and a deploy reports green onto no
-# capacity. With it, a forgotten variable disarms ITSELF the day after.
-#
-# It fails toward REFUSING, which is the direction that matters: if the window
-# slips past the expiry the deploy refuses loudly, mid-window, and is fixed in
-# thirty seconds by updating the variable. It can never fail toward permitting.
-zero_desired_count_allowed=false
-zero_optin_expiry=""
-if [[ -n "$ALLOW_ZERO_DESIRED_COUNT" ]]; then
-  if [[ ! "$ALLOW_ZERO_DESIRED_COUNT" =~ ^[A-Za-z0-9_-]+:[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
-    echo "::error::ALLOW_ZERO_DESIRED_COUNT is set but malformed: expected <service>:<YYYY-MM-DD>, e.g. $APP:$(date -u -d '+2 days' +%F). Refusing to treat an unparseable authorisation as permission."
-    exit 1
-  fi
-  zero_optin_service="${ALLOW_ZERO_DESIRED_COUNT%%:*}"
-  zero_optin_expiry="${ALLOW_ZERO_DESIRED_COUNT#*:}"
-  # A regex-valid but NONEXISTENT date (2026-13-45) would sort after every real
-  # date and therefore never expire — fail-open, the one direction this must not
-  # have. Round-tripping it through `date` rejects that.
-  if ! zero_optin_parsed="$(date -u -d "$zero_optin_expiry" +%F 2>/dev/null)" ||
-     [[ "$zero_optin_parsed" != "$zero_optin_expiry" ]]; then
-    echo "::error::ALLOW_ZERO_DESIRED_COUNT carries an invalid date: $zero_optin_expiry. Refusing."
-    exit 1
-  fi
-  zero_optin_today="$(date -u +%F)"
-  # ISO dates compare correctly as strings; the expiry day itself is still valid.
-  if [[ "$zero_optin_expiry" < "$zero_optin_today" ]]; then
-    echo "::error::ALLOW_ZERO_DESIRED_COUNT expired on $zero_optin_expiry (today is $zero_optin_today). If this window is still running, update the variable; do not delete the expiry."
-    exit 1
-  fi
-  if [[ "$zero_optin_service" == "$APP" ]]; then
-    zero_desired_count_allowed=true
-  fi
-fi
-
 # Which ECS service's deploy lane runs the one-shot migrations.
 #
 # Homiio's two services share ONE image, and `deploy-aws.yml` rolls the API and
@@ -270,12 +206,28 @@ if ! [[ "$service_desired_count" =~ ^[0-9]+$ ]]; then
   echo "::error::ECS service $APP reported a non-numeric desiredCount (${service_desired_count:-missing}); refusing to deploy."
   exit 1
 fi
-if (( service_desired_count < 1 )) && [[ "$zero_desired_count_allowed" != true ]]; then
-  echo "::error::ECS service $APP must have a positive desiredCount before deployment (current: ${service_desired_count:-missing}). Scale the service up explicitly before retrying, or set ALLOW_ZERO_DESIRED_COUNT=$APP:<YYYY-MM-DD> if this is a deliberate zero-capacity deploy."
-  exit 1
-fi
+# desiredCount 0 is a STATE, not an error, and it needs no authorisation to be
+# recognised as one. Both Homiio services are parked at zero for the whole of a
+# store cutover on purpose, and refusing the deploy there is self-sealing: the
+# image that would make the service bootable again is the image the refusal
+# blocks, so the parked state can never be left.
+#
+# What this must NOT become is a green deploy that reports a release nobody got.
+# So the release still does everything that is real at zero capacity — it runs
+# the migrations, registers the revision, and POINTS THE SERVICE AT IT — and then
+# stops at the one step that is not real, the rollout, and says so loudly.
+#
+# Pointing the service is the half that is easy to leave out and expensive to
+# skip. `register-task-definition` alone does not repoint anything: ECS launches
+# whatever revision the SERVICE is configured with, so a later `desiredCount`
+# bump would start the OLD image, and this script derives its next render from
+# `services[0].taskDefinition` (see `current_task_definition` above), so every
+# subsequent deploy would keep building on the stale revision too. Homiio has TWO
+# services and each carries its own revision, so each has to be repointed by its
+# own lane.
+zero_capacity_deploy=false
 if (( service_desired_count < 1 )); then
-  echo "::warning::Deploying $APP at desiredCount=0, authorised by ALLOW_ZERO_DESIRED_COUNT=$ALLOW_ZERO_DESIRED_COUNT (expires $zero_optin_expiry). The rollout will complete with zero running tasks and the service will serve NOTHING until it is scaled up."
+  zero_capacity_deploy=true
 fi
 
 task_definition_file="$(mktemp)"
@@ -367,22 +319,19 @@ wait_for_service_rollout() {
               "$desired" =~ ^[0-9]+$ &&
               "$service_desired" =~ ^[0-9]+$ ]]; then
         echo "::warning::ECS returned non-numeric task counts for the $label rollout; retrying."
-      elif (( service_desired < 1 )) && [[ "$zero_desired_count_allowed" != true ]]; then
+      # These two refusals are UNCONDITIONAL, and they are the protection that
+      # survives the zero-capacity path above. A service that STARTED this deploy
+      # with capacity and reached zero part-way through has lost it — that is a
+      # real regression, not a parked service, and it must stay red. A release
+      # that begins at zero never enters this loop at all: it exits before the
+      # rollout, so there is nothing here for it to be exempted from.
+      elif (( service_desired < 1 )); then
         echo "::error::ECS service $APP reached desiredCount=0 during the $label rollout."
         return 1
       elif [[ "$rollout_state" == "COMPLETED" ]]; then
-        # All THREE zero-checks need the same exemption. Under an authorised
-        # zero-count deploy the steady state genuinely IS zero tasks, so a bypass
-        # applied only to the pre-check would let the release start and then kill
-        # it mid-rollout — later, and harder to read, than refusing up front, and
-        # with the cutover window already burning.
-        if (( desired < 1 )) && [[ "$zero_desired_count_allowed" != true ]]; then
+        if (( desired < 1 )); then
           echo "::error::ECS $label rollout for $APP completed at desiredCount=0; refusing to accept a zero-task steady state."
           return 1
-        fi
-        if (( desired < 1 )); then
-          echo "$label rollout for $APP completed at desiredCount=0, as authorised."
-          return 0
         fi
         if [[ "$running" == "$desired" ]]; then
           return 0
@@ -699,10 +648,31 @@ if ! aws ecs update-service \
   }' \
   >/dev/null; then
   echo "::error::ECS rejected the service update; restoring the previous task definition defensively."
+  # At zero capacity there is nothing to restore TO: no task is running, so the
+  # "previous image" is not serving either, and rollback_service would sit in
+  # wait_for_service_rollout until MAX_WAIT_SECS waiting for a steady state that
+  # cannot arrive. Say that instead of spending twenty minutes proving it.
+  if [[ "$zero_capacity_deploy" == "true" ]]; then
+    echo "::error::$APP is at desiredCount=0, so no rollback was attempted: nothing is running to roll back from, and the service is still pointed at $current_task_definition."
+    exit 1
+  fi
   if ! rollback_service; then
     echo "::error::The defensive rollback also failed; manual intervention is required."
   fi
   exit 1
+fi
+
+# Everything real at zero capacity is now done: the migrations ran, the revision
+# is registered, and the service points at it. The rollout is the part that would
+# be a lie, so it is skipped rather than waited on — a rollout at desiredCount 0
+# reaches "COMPLETED" with zero running tasks, which is exactly the
+# plausible-looking green this estate keeps getting caught by.
+if [[ "$zero_capacity_deploy" == "true" ]]; then
+  echo "::warning::NO ROLLOUT PERFORMED: ECS service $APP is at desiredCount=0 and is running ZERO tasks."
+  echo "::warning::NO ROLLOUT PERFORMED: the task definition WAS registered and the service now points at it: $new_task_definition"
+  echo "::warning::NO ROLLOUT PERFORMED: image $IMAGE_URI is NOT live and $APP is serving NOTHING. This deploy released nothing to users."
+  echo "::warning::NO ROLLOUT PERFORMED: to run this image, raise desired_count in oxy-infra terraform and deploy again."
+  exit 0
 fi
 
 echo "Deploying immutable image $IMAGE_URI with task definition $new_task_definition"

--- a/.github/scripts/test-deploy-ecs-image.sh
+++ b/.github/scripts/test-deploy-ecs-image.sh
@@ -36,7 +36,11 @@ export DEPLOY_TEST_TASK_LAST_STATUS=STOPPED
 # full green run -- and every guarantee below would read as verified while never
 # having executed. Incremented by run_release, checked at the very end.
 cases_run=0
-MINIMUM_CASES=24
+# 24 -> 18: the six ALLOW_ZERO_DESIRED_COUNT cases and the standalone zero-count
+# REFUSAL case went with the opt-in they tested, replaced by one `zero-desired-count`
+# case asserting the release lands. Lower this ONLY alongside a deletion you can
+# name; a floor quietly reduced to match whatever ran is not a floor.
+MINIMUM_CASES=18
 
 aws() {
   local service_json='{
@@ -350,7 +354,6 @@ run_release() {
     # `deploy-test` to keep matching the container in the mocked task definition.
     APP="${DEPLOY_TEST_APP:-deploy-test}"
     CONTAINER_NAME=deploy-test
-    ALLOW_ZERO_DESIRED_COUNT="${DEPLOY_TEST_ALLOW_ZERO_DESIRED_COUNT:-}"
     MIGRATION_SERVICE="${DEPLOY_TEST_MIGRATION_SERVICE:-}"
     IMAGE_URI="example.invalid/deploy-test@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     MAX_WAIT_SECS=5
@@ -426,6 +429,21 @@ assert_output_lacks() {
 
 # The recorded AWS calls must not mention a string. Used to prove a refusal
 # happened BEFORE anything mutating, and that a lane ran no migrator.
+assert_aws_log_contains() {
+  local case_name="$1" needle="$2" why="$3"
+  if ! grep -qF -- "$needle" "$test_directory/$case_name/aws.log"; then
+    {
+      echo "ASSERTION FAILED in case '$case_name'"
+      echo "  the recorded AWS calls must contain: $needle"
+      echo "  why: $why"
+      echo "  ---- recorded AWS calls ----"
+      cat "$test_directory/$case_name/aws.log"
+      echo "  ---- end ----"
+    } >&2
+    return 1
+  fi
+}
+
 assert_aws_log_lacks() {
   local case_name="$1" needle="$2" why="$3"
   if grep -qF -- "$needle" "$test_directory/$case_name/aws.log"; then
@@ -778,10 +796,6 @@ if ! grep -qF \
   exit 1
 fi
 
-run_release zero-desired-count false false false 0 false 0
-assert_output_contains zero-desired-count "must have a positive desiredCount before deployment (current: 0)"
-assert_no_aws_calls zero-desired-count "Zero-capacity service reached a mutating AWS call."
-
 run_release transient-zero-deployment true false false 0 false 1 transient-zero-deployment
 printf '%s\n' \
   'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=1' \
@@ -843,88 +857,51 @@ assert_aws_log_lacks smoke-no-rollback-failure 'service:arn:aws:ecs:test:task-de
 assert_output_contains smoke-no-rollback-failure "stays on arn:aws:ecs:test:task-definition/deploy-test:2"
 assert_output_contains smoke-no-rollback-failure "Nothing was rolled back; this release needs a human."
 
-# ALLOW_ZERO_DESIRED_COUNT, in the five states that matter.
+# A service parked at desiredCount 0 -- the state the cutover leaves both Homiio
+# services in -- must still land its image, because the release that would make
+# the service bootable again is the one a refusal blocks.
 #
-# The cutover (issue #281) deploys `homiio` and `homiio-worker` while both are
-# deliberately scaled to zero, because the running image is Mongo-backed and
-# bringing either up after the copy would let real writes land in the store being
-# abandoned. Every OTHER deploy must still refuse a zero-count service, and the
-# exemption must not outlive the window.
+# This REPLACES the ALLOW_ZERO_DESIRED_COUNT opt-in, which refused by default and
+# permitted only with a dated `<service>:<YYYY-MM-DD>` variable. That mechanism
+# was never reachable in production: the script read the variable and
+# `deploy-aws.yml` never passed it, so the six cases that tested it exercised an
+# env var no deploy could set. It is deleted rather than left inert.
 #
-# The value is `<service>:<YYYY-MM-DD>`. Two cases carry the design:
-#   - WRONG SERVICE proves the value is compared against APP rather than read as
-#     a boolean. A boolean passes every other case here. Homiio has TWO services,
-#     so an authorisation for one really must not cover the other.
-#   - EXPIRED proves a forgotten variable disarms itself. Without it the
-#     exemption is a permanent reduction in protection bought for one window.
+# The exact log is the whole assertion, and what it does NOT contain matters more
+# than what it does. Compare `migration-order` above, the same release at
+# desired=1: there, `service:` is followed by `smoke` and `task:reconcile`. Here
+# the log must STOP at `service:`, because neither is real when nothing is
+# running -- a smoke check against a service with zero tasks is the plausible
+# green this case exists to refuse. `diff -u` fails if either appears.
+run_release zero-desired-count true true false 0 false 0
+printf '%s\n' \
+  'task:node packages/backend/dist/db/migrate.js --target-database=homiio --phase=pre' \
+  'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=0' \
+  >"$test_directory/zero-desired-count/expected.log"
+diff -u \
+  "$test_directory/zero-desired-count/expected.log" \
+  "$test_directory/zero-desired-count/aws.log"
+# `service:...deploy-test:2:...` is the REPOINT, and it is the half that is easy
+# to drop: registering a revision does not point the service at it, so without
+# this line a later scale-up would launch the OLD image and every subsequent
+# deploy would render from the stale revision. Homiio has TWO services, each
+# carrying its own revision, so each lane has to repoint its own.
+assert_aws_log_contains zero-desired-count 'service:arn:aws:ecs:test:task-definition/deploy-test:2:desired=0' "A zero-capacity release did not repoint the service, so a later scale-up would launch the OLD image."
+assert_output_contains zero-desired-count "NO ROLLOUT PERFORMED: ECS service deploy-test is at desiredCount=0"
+assert_output_contains zero-desired-count "NO ROLLOUT PERFORMED: the task definition WAS registered and the service now points at it: arn:aws:ecs:test:task-definition/deploy-test:2"
+assert_output_contains zero-desired-count "NO ROLLOUT PERFORMED: image example.invalid"
+# The success line of an ordinary release. If it ever appears here, a reader of
+# the workflow log six weeks from now cannot tell this run apart from one that
+# actually shipped, which is the failure this whole case exists to prevent.
+assert_output_lacks zero-desired-count "ECS rollout reached a healthy steady state" "A zero-capacity release claimed a healthy rollout it never performed."
 
-zero_optin_future="$(date -u -d '+2 days' +%F)"
-zero_optin_past="$(date -u -d '-1 day' +%F)"
-
-# 1. Absent -> refuses. (This is `zero-desired-count` above, restated against the
-#    opt-in so the group reads as a set.)
-DEPLOY_TEST_ALLOW_ZERO_DESIRED_COUNT="" \
-  run_release zero-count-optin-absent false false false 0 false 0
-assert_output_contains zero-count-optin-absent "must have a positive desiredCount before deployment (current: 0)"
-assert_no_aws_calls zero-count-optin-absent "Zero-count deploy with no opt-in reached a mutating AWS call."
-
-# 2. MALFORMED (no expiry at all -- the shape somebody reaches for first) ->
-#    refuses. An unparseable authorisation is not permission.
-DEPLOY_TEST_ALLOW_ZERO_DESIRED_COUNT="true" \
-  run_release zero-count-optin-malformed false false false 0 false 0
-assert_output_contains zero-count-optin-malformed "ALLOW_ZERO_DESIRED_COUNT is set but malformed"
-assert_no_aws_calls zero-count-optin-malformed "A malformed zero-count opt-in reached a mutating AWS call."
-
-# 3. WRONG service, valid date -> refuses. A boolean cannot tell this from case 6.
-#    Spelled as the sibling service, which is the value that would really be
-#    pasted: authorising `homiio` must not authorise `homiio-worker`.
-DEPLOY_TEST_ALLOW_ZERO_DESIRED_COUNT="deploy-test-worker:$zero_optin_future" \
-  run_release zero-count-optin-wrong-service false false false 0 false 0
-assert_output_contains zero-count-optin-wrong-service "must have a positive desiredCount before deployment (current: 0)"
-assert_no_aws_calls zero-count-optin-wrong-service "Zero-count deploy authorised by the WRONG service name reached a mutating AWS call. The opt-in is being read as a boolean rather than compared against APP."
-
-# 4. Right service, EXPIRED -> refuses, and says so by name rather than falling
-#    through to the generic desiredCount message.
-DEPLOY_TEST_ALLOW_ZERO_DESIRED_COUNT="deploy-test:$zero_optin_past" \
-  run_release zero-count-optin-expired false false false 0 false 0
-assert_output_contains zero-count-optin-expired "ALLOW_ZERO_DESIRED_COUNT expired on $zero_optin_past"
-assert_no_aws_calls zero-count-optin-expired "An EXPIRED zero-count opt-in reached a mutating AWS call."
-
-# 5. A regex-valid but nonexistent date must refuse rather than sort after every
-#    real date and never expire -- the one fail-OPEN this could have had.
-DEPLOY_TEST_ALLOW_ZERO_DESIRED_COUNT="deploy-test:2026-13-45" \
-  run_release zero-count-optin-impossible-date false false false 0 false 0
-assert_output_contains zero-count-optin-impossible-date "carries an invalid date: 2026-13-45"
-
-# 6. Right service, valid date -> proceeds, and SAYS what it costs.
-#
-#    ONE case covers all THREE refusals, and that is a measured claim rather than
-#    a hopeful one: it runs with the service at desiredCount 0 against the
-#    `completed-zero-deployment` scenario, so it traverses the pre-deploy gate,
-#    then the mid-rollout `service_desired < 1` gate on the first poll, then the
-#    COMPLETED steady-state gate — and mutating any ONE of the three in isolation
-#    turns this case red. A fourth case driving `zero-service-during-deploy` was
-#    written and removed: it reproduces the identical state, so it could never
-#    fail independently, and a case that cannot fail alone reads to the next
-#    person as coverage that is not there.
-#
-#    The three assertions below map one-to-one onto the three gates: the
-#    authorisation warning (gate 1), the absence of the mid-rollout refusal
-#    (gate 2), and the "as authorised" steady state (gate 3).
-DEPLOY_TEST_ALLOW_ZERO_DESIRED_COUNT="deploy-test:$zero_optin_future" \
-  run_release zero-count-optin-correct true false false 0 false 0 completed-zero-deployment
-assert_output_contains zero-count-optin-correct "authorised by ALLOW_ZERO_DESIRED_COUNT=deploy-test:$zero_optin_future (expires $zero_optin_future)"
-assert_output_contains zero-count-optin-correct "serve NOTHING until it is scaled up"
-assert_output_contains zero-count-optin-correct "completed at desiredCount=0, as authorised"
-assert_output_lacks zero-count-optin-correct "reached desiredCount=0 during the deployment rollout" "An authorised zero-count deploy was killed by the MID-ROLLOUT guard (gate 2). All three zero-count refusals must honour ALLOW_ZERO_DESIRED_COUNT."
-assert_output_lacks zero-count-optin-correct "refusing to accept a zero-task steady state" "An authorised zero-count deploy was killed by the STEADY-STATE guard (gate 3). The exemption was applied to the pre-check only; all three zero-checks need it."
-
-# A non-numeric desiredCount is NOT covered by any authorisation: it is ECS
-# saying it does not know the answer, which no date and no service name can make
-# safe. Without this, folding the numeric check into the zero check would let a
-# valid opt-in wave through a service whose count could not be read at all.
-DEPLOY_TEST_ALLOW_ZERO_DESIRED_COUNT="deploy-test:$zero_optin_future" \
-  run_release non-numeric-desired-count false false false 0 false '"unknown"'
+# A non-numeric desiredCount still REFUSES, and is deliberately split from the
+# zero case above: ECS declining to say what the count is, is not the same fact
+# as a zero it reports confidently. Without this, folding the numeric check into
+# the zero check would wave through a service whose count could not be read at
+# all -- and it is the negative control for the case above, since deleting the
+# numeric check outright would otherwise leave the suite green.
+run_release non-numeric-desired-count false false false 0 false '"unknown"'
 assert_output_contains non-numeric-desired-count "reported a non-numeric desiredCount"
 assert_no_aws_calls non-numeric-desired-count "A service with an unreadable desiredCount reached a mutating AWS call."
 


### PR DESCRIPTION
> **Read this first: this PR DELETES a tested guard.** The `ALLOW_ZERO_DESIRED_COUNT` opt-in goes, along with six harness cases. My reasoning is below; if you would rather keep it and just wire the variable through, that is a one-line alternative and I will swap it — say the word. Nothing here is urgent: `homiio` is `desired=2 running=2` and not blocked.

## What I found

The opt-in **was never reachable in production.** `deploy-ecs-image.sh` read `ALLOW_ZERO_DESIRED_COUNT`; `deploy-aws.yml` never passed it (zero occurrences in the file); no repo variable of that name exists (`gh api repos/OxyHQ/Homiio/actions/variables`). So the script always took the refusing branch and an operator had **no way to authorise anything**.

Six harness cases tested it — by injecting `DEPLOY_TEST_ALLOW_ZERO_DESIRED_COUNT` straight into the script's environment, bypassing the workflow that was supposed to supply it. Tested, green, and dead.

That is the same shape as #417's `RUN_MIGRATIONS` (machinery present, nothing setting it, everything green), in the same file, found the same way, this week.

## Why delete rather than wire

Wiring the variable restores a **refusal**, and the refusal is the bug. `desiredCount 0` is a *state* — both Homiio services sit there for the whole of a store cutover on purpose — and refusing the deploy there is self-sealing: the image that would make the service bootable again is the image the refusal blocks. Keeping a dated opt-in also means an operator must set and babysit an expiring variable in each repo mid-cutover; the same guard is failing `crowdsource`'s `main` right now (run `31378523910`) and blocking `alia`.

## The change

At zero capacity the release does everything that is real — runs the migrations, registers the revision, and **points the service at it** — then stops at the rollout and says so:

```
::warning::NO ROLLOUT PERFORMED: ECS service homiio is at desiredCount=0 and is running ZERO tasks.
::warning::NO ROLLOUT PERFORMED: the task definition WAS registered and the service now points at it: <arn>
::warning::NO ROLLOUT PERFORMED: image <uri> is NOT live and homiio is serving NOTHING. This deploy released nothing to users.
::warning::NO ROLLOUT PERFORMED: to run this image, raise desired_count in oxy-infra terraform and deploy again.
```

Homiio has two services, each carrying its own revision, so each lane repoints its own.

**The protection that mattered survives, and gets stronger.** The two mid-rollout zero refusals become **unconditional** again — under the opt-in they were exempted. A service that started this deploy with capacity and reached zero part-way through has lost it: a real regression, and it stays red. A release that *begins* at zero exits before the rollout and never enters that loop, so it needs no exemption. The pre-existing `zero-service-during-deploy` and `completed-zero-deployment` cases pin both, unchanged.

A non-numeric `desiredCount` still refuses — that split was already right here and is kept.

## Verification

Baseline green on `3baa2b1c` (24 cases) before any edit. Mutation-tested, each mutation confirmed **applied and semantically live** before its result was trusted:

| mutation | result |
|---|---|
| remove the skip (rollout, smoke and reconcile run at zero) | **RED** |
| skip the rollout *without* repointing the service | **RED** |
| weaken the `NO ROLLOUT PERFORMED` message | **RED** |
| treat an unreadable `desiredCount` as zero | **RED** |

Script restored to the ship-intended bytes after each (`md5 3f581ef91235`), suite green on the restored file (18 cases), `shellcheck` clean.

`MINIMUM_CASES` 24 → 18. The floor **caught this change** when I first ran it — it refused a green at 18 cases, which is exactly what it is for. Lowered deliberately and named against the deletions, not quietly fitted to whatever ran.

## Scope

Re-derived against this repo's own script rather than ported — the four affected repos turned out to have four different migration architectures, and Homiio was the only one carrying this opt-in at all. Sibling PRs: CrowdSource #97, Alia #116, Allo #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)