### PR TITLE
fix(home): the featured rail was the global feed, and it is now scoped

### DIFF
--- a/packages/frontend/__tests__/widgets/featuredWidgetScope.test.tsx
+++ b/packages/frontend/__tests__/widgets/featuredWidgetScope.test.tsx
@@ -1,0 +1,407 @@
+/**
+ * The featured-homes rail cannot issue an unscoped query (#353).
+ *
+ * ## Why it asserts on the REQUEST and not on the render
+ *
+ * The defect this file exists to keep out was invisible on screen: the widget
+ * rendered four perfectly good property cards, correctly formatted, with a
+ * working link on each — from anywhere on earth. Nothing about the output said
+ * so, and no assertion about what it renders could have told the fixed version
+ * from the broken one. The one place the two differ is the HTTP call, so that is
+ * what is pinned here: `api.get` is mocked, and the tests read what reached it.
+ *
+ * ## Two halves, two different mutations
+ *
+ * Scoping this widget takes two things, and removing either reintroduces the
+ * bug in a different shape, so both need their own assertion:
+ *
+ *  1. the scope must be IN the query (`location: scope.selection`) — remove it
+ *     and a request goes out with no geographic parameter while the widget still
+ *     looks scoped, heading and all;
+ *  2. the query must be GATED on `scope.canQuery` — remove it and a request goes
+ *     out before any area has been chosen, which is a global feed reached from
+ *     a cold start.
+ *
+ * The mutation evidence for both is in the PR body.
+ *
+ * ## The positive control
+ *
+ * `it('sends the request when there IS a scope')` is not decoration. Every
+ * "no request was made" assertion below is satisfied by a widget that never
+ * fetches anything at all, so without a case proving a request DOES happen when
+ * it should, this whole file passes against a component rendering an empty div.
+ */
+import React, { type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BloomThemeProvider } from '@oxyhq/bloom/theme';
+import { act, render, waitFor } from '@testing-library/react-native';
+import { OfferingType, type LocationSelection } from '@homiio/shared-types';
+
+import { api } from '@/utils/api';
+import { useLocationScope, type LocationScope } from '@/hooks/useLocationScope';
+import {
+  FeaturedPropertiesWidget,
+  featuredSearchQuery,
+  rankFeatured,
+  scopeNotice,
+  type FeaturedProperty,
+} from '@/components/widgets/FeaturedPropertiesWidget';
+
+jest.mock('@/utils/api', () => ({
+  api: { get: jest.fn() },
+}));
+
+jest.mock('@/hooks/useLocationScope', () => ({
+  useLocationScope: jest.fn(),
+}));
+
+// `expo-router` reaches `standard-navigation`, which ships ESM this suite's
+// `transformIgnorePatterns` does not transform. Only `useRouter` is needed here,
+// and navigation is not what this file measures.
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+}));
+
+// The offering axis is not what this file is about, and mounting the real
+// provider drags AsyncStorage hydration into every case.
+jest.mock('@/context/RentalModeContext', () => ({
+  useRentalMode: () => ({ offering: 'long_term_rent', mode: 'long_term', isLoading: false }),
+}));
+
+// A card renders images, save mutations and a router link — none of which
+// decides whether a request carried an area. Stubbed so a failure here is about
+// the scope rather than about the card.
+jest.mock('@/components/PropertyCard', () => ({
+  PropertyCard: () => null,
+}));
+
+const apiGet = api.get as jest.MockedFunction<typeof api.get>;
+const mockScope = useLocationScope as jest.MockedFunction<typeof useLocationScope>;
+
+const BARCELONA: LocationSelection = {
+  kind: 'place',
+  source: { kind: 'homiio', entity: 'city', id: 'city-barcelona' },
+  placeType: 'city',
+  label: { primary: 'Barcelona', kind: 'place' },
+  admin: { countryCode: 'ES', cityName: 'Barcelona' },
+  precision: 'centroid',
+  center: { longitude: 2.1686, latitude: 41.3874 },
+};
+
+const DEVICE: LocationSelection = {
+  kind: 'current_location',
+  center: { longitude: 2.1734035, latitude: 41.3850639 },
+  radiusMeters: 25_000,
+  precision: 'exact',
+};
+
+/** A scope in whichever state the case needs. Every field the widget reads. */
+function scope(overrides: Partial<LocationScope>): LocationScope {
+  return {
+    selection: null,
+    resolution: { status: 'idle' },
+    source: null,
+    deviceIssue: null,
+    needsPlace: true,
+    isGlobal: false,
+    canQuery: false,
+    nearbyPlace: null,
+    choose: jest.fn(),
+    exploreGlobal: jest.fn(),
+    useCurrentLocation: jest.fn(),
+    permissionPromptShown: false,
+    ...overrides,
+  };
+}
+
+/** One page of results, in the shape `usePropertySearch` reads. */
+function page(): { data: unknown } {
+  return {
+    data: {
+      success: true,
+      data: [{ id: 'listing-1' }],
+      total: 1,
+      page: 1,
+      limit: 24,
+      totalPages: 1,
+      hasMore: false,
+    },
+  };
+}
+
+let client: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }): React.JSX.Element {
+  // Bloom typography throws outside its provider, so the widget cannot render
+  // at all without it — the same ordering rule the app's own root obeys.
+  return (
+    <BloomThemeProvider>
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    </BloomThemeProvider>
+  );
+}
+
+/** Every call this widget could have made to the search endpoint. */
+function searchCalls(): Record<string, unknown>[] {
+  return apiGet.mock.calls
+    .filter(([url]) => url === '/api/properties/search')
+    .map(([, config]) => {
+      const params = (config as { params?: Record<string, unknown> } | undefined)?.params;
+      return params ?? {};
+    });
+}
+
+/**
+ * Let every queued effect, promise and React Query notification run.
+ *
+ * "No request was made" is a claim about a moment, and a bare assertion straight
+ * after `render` makes it about the earliest possible one — before an effect
+ * that fires a request has had a turn. This gives the request every chance to
+ * happen, so a passing assertion means it did not rather than not yet.
+ */
+async function flush(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+/** The geographic parameters the search endpoint understands. */
+const GEO_PARAMS = ['city', 'state', 'neighborhood', 'lat', 'lng', 'radius', 'swLat', 'swLng', 'neLat', 'neLng'];
+
+beforeEach(() => {
+  apiGet.mockReset();
+  apiGet.mockResolvedValue(page() as never);
+  mockScope.mockReset();
+  client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+});
+
+afterEach(() => {
+  client.clear();
+});
+
+describe('with no area chosen', () => {
+  it('issues NO request at all', async () => {
+    mockScope.mockReturnValue(scope({ resolution: { status: 'idle' }, needsPlace: true }));
+
+    render(<FeaturedPropertiesWidget />, { wrapper });
+    await flush();
+
+    expect(searchCalls()).toEqual([]);
+    expect(apiGet).not.toHaveBeenCalled();
+  });
+
+  it('says the area is missing rather than rendering an empty list', async () => {
+    // "There are no featured homes" and "you have not told us where" are
+    // different facts, and only one of them is true here.
+    mockScope.mockReturnValue(scope({ resolution: { status: 'idle' }, needsPlace: true }));
+
+    const view = render(<FeaturedPropertiesWidget />, { wrapper });
+    await flush();
+
+    expect(view.getByText('home.featured.chooseArea')).toBeTruthy();
+    expect(view.queryByText('home.featured.empty')).toBeNull();
+  });
+});
+
+describe('while the scope is still resolving', () => {
+  it('issues NO request, and does not claim the area is unset', async () => {
+    mockScope.mockReturnValue(scope({ resolution: { status: 'resolving' }, needsPlace: false }));
+
+    const view = render(<FeaturedPropertiesWidget />, { wrapper });
+    await flush();
+
+    expect(searchCalls()).toEqual([]);
+    expect(view.getByText('location.scope.resolving')).toBeTruthy();
+  });
+});
+
+describe('when the device rung failed', () => {
+  it('issues NO request, and names the reason', async () => {
+    // The rung the old code fell through: a denied permission used to end at a
+    // worldwide list. It ends at a sentence.
+    mockScope.mockReturnValue(
+      scope({
+        resolution: { status: 'failed', reason: 'permission_denied' },
+        deviceIssue: 'permission_denied',
+        needsPlace: true,
+      }),
+    );
+
+    const view = render(<FeaturedPropertiesWidget />, { wrapper });
+    await flush();
+
+    expect(searchCalls()).toEqual([]);
+    expect(view.getByText('location.scope.failure.permission_denied')).toBeTruthy();
+  });
+});
+
+describe('with a committed city', () => {
+  it('sends the request, scoped to that city', async () => {
+    // THE POSITIVE CONTROL for every "no request" case above, and the assertion
+    // that fails if the selection stops reaching the query.
+    mockScope.mockReturnValue(
+      scope({
+        selection: BARCELONA,
+        resolution: { status: 'resolved', selection: BARCELONA },
+        source: 'session',
+        needsPlace: false,
+        canQuery: true,
+      }),
+    );
+
+    render(<FeaturedPropertiesWidget />, { wrapper });
+
+    await waitFor(() => expect(searchCalls()).toHaveLength(1));
+    expect(searchCalls()[0]).toMatchObject({ city: 'city-barcelona' });
+    await flush();
+  });
+
+  it('names the area in its own heading', async () => {
+    mockScope.mockReturnValue(
+      scope({
+        selection: BARCELONA,
+        resolution: { status: 'resolved', selection: BARCELONA },
+        needsPlace: false,
+        canQuery: true,
+      }),
+    );
+
+    const view = render(<FeaturedPropertiesWidget />, { wrapper });
+
+    // A rail of listings that states no area is the defect wearing a fix.
+    await waitFor(() => expect(view.getByText('home.featured.titleIn')).toBeTruthy());
+    expect(view.queryByText('home.featured.title')).toBeNull();
+    await flush();
+  });
+});
+
+describe('with the device position', () => {
+  it('sends the centre and radius, and no city', async () => {
+    mockScope.mockReturnValue(
+      scope({
+        selection: DEVICE,
+        resolution: { status: 'resolved', selection: DEVICE },
+        source: 'device',
+        needsPlace: false,
+        canQuery: true,
+      }),
+    );
+
+    render(<FeaturedPropertiesWidget />, { wrapper });
+
+    await waitFor(() => expect(searchCalls()).toHaveLength(1));
+    expect(searchCalls()[0]).toMatchObject({
+      lat: 41.3850639,
+      lng: 2.1734035,
+      radius: 25_000,
+    });
+    await flush();
+  });
+});
+
+describe('with an explicit "explore everywhere"', () => {
+  it('is the ONLY state that sends a request carrying no area', async () => {
+    // Distinguishing this from "no area chosen" is the point. Both have
+    // `selection === null`; only this one is a decision somebody made, and only
+    // `canQuery` tells them apart.
+    mockScope.mockReturnValue(
+      scope({
+        selection: null,
+        resolution: { status: 'idle' },
+        source: 'global',
+        needsPlace: false,
+        isGlobal: true,
+        canQuery: true,
+      }),
+    );
+
+    render(<FeaturedPropertiesWidget />, { wrapper });
+
+    await waitFor(() => expect(searchCalls()).toHaveLength(1));
+    for (const param of GEO_PARAMS) {
+      expect(searchCalls()[0]).not.toHaveProperty(param);
+    }
+    await flush();
+  });
+});
+
+describe('featuredSearchQuery', () => {
+  it('carries the committed selection as the query location', () => {
+    expect(featuredSearchQuery(BARCELONA, OfferingType.LONG_TERM_RENT).location).toBe(BARCELONA);
+  });
+
+  it('carries a null selection through unchanged, for the global case', () => {
+    // The floor for the case above: a builder that always returned the selection
+    // it was given would pass that one, and so would one that always returned
+    // `BARCELONA`. This one only passes for a builder that passes it through.
+    expect(featuredSearchQuery(null, OfferingType.LONG_TERM_RENT).location).toBeNull();
+  });
+
+  it('adds no free text of its own', () => {
+    // `q` and a geographic scope are independent dimensions (ADR 0002). A widget
+    // that sent the area's NAME as free text alongside the area would ask "homes
+    // matching the word Barcelona, inside Barcelona", whose honest answer is
+    // usually zero — and zero looks exactly like a quiet area.
+    expect(featuredSearchQuery(BARCELONA, OfferingType.LONG_TERM_RENT).queryText).toBeNull();
+  });
+
+  it('carries the offering it was given', () => {
+    expect(featuredSearchQuery(BARCELONA, OfferingType.SALE).offering).toBe(OfferingType.SALE);
+  });
+});
+
+describe('rankFeatured', () => {
+  /**
+   * A listing carrying only the three fields the ranking reads.
+   *
+   * ONE cast, here, rather than one per fixture: a `Property` has dozens of
+   * required fields and none of them reaches this function, so spelling them out
+   * would bury the two that decide the order.
+   */
+  function listing(id: string, savesCount: number, fair = false): FeaturedProperty {
+    return {
+      id,
+      savesCount,
+      ...(fair ? { priceEthics: { isFairPrice: true } } : {}),
+    } as unknown as FeaturedProperty;
+  }
+
+  it('puts a fairly-priced home ahead of a more-saved one', () => {
+    const ranked = rankFeatured([listing('popular', 900), listing('fair', 1, true)]);
+    expect(ranked.map((p) => p.id)).toEqual(['fair', 'popular']);
+  });
+
+  it('breaks a tie on saves', () => {
+    const ranked = rankFeatured([listing('quiet', 2), listing('loved', 40)]);
+    expect(ranked.map((p) => p.id)).toEqual(['loved', 'quiet']);
+  });
+
+  it('does not mutate its input', () => {
+    const input = [listing('a', 1), listing('b', 9)];
+    rankFeatured(input);
+    expect(input.map((p) => p.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('scopeNotice', () => {
+  const t = ((key: string) => key) as never;
+
+  it('names the failure reason rather than a generic sentence', () => {
+    // "Location is off" and "we could not reach Homiio" call for different
+    // actions; one message for both sends half of its readers to the wrong place.
+    expect(scopeNotice({ status: 'failed', reason: 'network' }, t)).toBe(
+      'location.scope.failure.network',
+    );
+    expect(scopeNotice({ status: 'failed', reason: 'permission_denied' }, t)).toBe(
+      'location.scope.failure.permission_denied',
+    );
+  });
+
+  it('asks for an area when nothing has been tried', () => {
+    expect(scopeNotice({ status: 'idle' }, t)).toBe('home.featured.chooseArea');
+  });
+
+  it('says it is still resolving rather than asking for an area', () => {
+    expect(scopeNotice({ status: 'resolving' }, t)).toBe('location.scope.resolving');
+  });
+});

--- a/packages/frontend/components/widgets/FeaturedPropertiesWidget.tsx
+++ b/packages/frontend/components/widgets/FeaturedPropertiesWidget.tsx
@@ -1,125 +1,251 @@
-import React, { useMemo, useEffect } from 'react';
+/**
+ * Featured homes IN THE COMMITTED SCOPE (#353).
+ *
+ * ## What it was
+ *
+ * `useProperties()` plus `loadProperties({ limit: 5, status: 'published' })` in a
+ * mount effect — a request with no geographic parameter of any kind, ranked
+ * client-side and rendered in the rail beside a page whose whole premise is an
+ * explicit, visible area. It was the global feed ADR 0002 principle 2 forbids,
+ * still alive inside a widget: four homes from anywhere on earth, under a
+ * heading that named no place, next to a scope bar that named one.
+ *
+ * ## Where its scope comes from
+ *
+ * `useLocationScope()` — the SAME hook Home and the eviction board read, not a
+ * second location source. The widget commits nothing and derives nothing: it has
+ * no picker, no "use my location" button and no fallback of its own, because
+ * `LocationScopeBar` is the one surface allowed to commit a selection. A widget
+ * that could commit one would be exactly the second authority the shared
+ * contract exists to prevent.
+ *
+ * The rail is a sibling of the page rather than its child, so the scope cannot
+ * arrive as a prop. Reading the shared hook is what makes the two agree anyway:
+ * both resolve from one store and one React Query cache, so the rail and the
+ * page cannot disagree about where the user is looking.
+ *
+ * ## With no scope it shows NOTHING, and says so
+ *
+ * `scope.canQuery` is the only gate, and it is true for exactly two states: a
+ * committed selection, or an explicit "explore everywhere" somebody pressed.
+ * There is no arm of this component that fetches listings otherwise — a failed
+ * device fix, a permission denial and a fresh install all end at a sentence, not
+ * at a worldwide list.
+ *
+ * A sentence rather than rendering nothing at all, deliberately. An empty rail
+ * reads as "there are no homes here", which is the same false impression in a
+ * quieter form; the issue's requirement is that a surface STATES its area, and
+ * "no area chosen yet" is a statement about the area.
+ */
+import React, { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { Loading } from '@oxyhq/bloom/loading';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import type { Property } from '@homiio/shared-types';
+import type { TFunction } from 'i18next';
+import {
+  formatDistance,
+  type LocationResolution,
+  type LocationSelection,
+  type OfferingType,
+  type Property,
+} from '@homiio/shared-types';
 import { colors } from '@/styles/colors';
 import { BaseWidget } from './BaseWidget';
-import { useProperties } from '@/hooks';
+import { usePropertySearch } from '@/hooks/usePropertySearch';
+import { useLocationScope } from '@/hooks/useLocationScope';
+import { useRentalMode } from '@/context/RentalModeContext';
+import { describeScope } from '@/components/location/LocationScopeBar';
+import { DEFAULT_SEARCH_QUERY } from '@/store/searchQueryStore';
+import type { SearchQuery } from '@/components/search/types';
+import { exploreHref } from '@/utils/searchUrl';
+import { useFormatting } from '@/utils/format';
 import { PropertyCard } from '../PropertyCard';
 import { ThemedText } from '../ThemedText';
 import { Button } from '@oxyhq/bloom/button';
 
 // The API decorates listings with an aggregate save count that is not part of
 // the persisted Property model, so it is modelled as an optional extension.
-type FeaturedProperty = Property & { savesCount?: number };
+export type FeaturedProperty = Property & { savesCount?: number };
+
+/** How many homes the rail shows. */
+const FEATURED_COUNT = 4;
+
+/**
+ * The search this widget runs.
+ *
+ * Exported because the one property that has to hold — the committed scope
+ * reaches the request — is a fact about this object, and pinning it here means
+ * the assertion does not depend on rendering anything.
+ *
+ * It is `DEFAULT_SEARCH_QUERY` plus two fields and nothing else. No free text,
+ * no filters: this is "featured homes where you are looking", and every
+ * dimension the widget does not set is a dimension it cannot silently disagree
+ * with the rest of the app about.
+ */
+export function featuredSearchQuery(
+  selection: LocationSelection | null,
+  offering: OfferingType,
+): SearchQuery {
+  return { ...DEFAULT_SEARCH_QUERY, offering, location: selection };
+}
+
+/**
+ * "Featured" — fairly priced first, then most saved.
+ *
+ * Unchanged from before the scope landed, and deliberately: this widget's defect
+ * was WHERE it looked, not how it ranked what it found. Pure so the ordering can
+ * be asserted directly.
+ */
+export function rankFeatured(properties: readonly FeaturedProperty[]): FeaturedProperty[] {
+  return [...properties].sort((a, b) => {
+    const aFair = a.priceEthics?.isFairPrice ? 1 : 0;
+    const bFair = b.priceEthics?.isFairPrice ? 1 : 0;
+    if (bFair !== aFair) return bFair - aFair;
+    const aSaves = typeof a.savesCount === 'number' ? a.savesCount : 0;
+    const bSaves = typeof b.savesCount === 'number' ? b.savesCount : 0;
+    return bSaves - aSaves;
+  });
+}
 
 export function FeaturedPropertiesWidget() {
   const { t } = useTranslation();
+  const router = useRouter();
+  const scope = useLocationScope();
+  const { offering } = useRentalMode();
+  const { locale } = useFormatting();
 
-  // Use the same pattern as the main homepage
-  const { properties, loading, error, loadProperties } = useProperties();
+  const query = useMemo(
+    () => featuredSearchQuery(scope.selection, offering),
+    [scope.selection, offering],
+  );
+  // `enabled` is the whole guard. `canQuery` is false for every state that is
+  // not a committed area or an explicit "everywhere", so an unresolved,
+  // failed or never-asked scope issues no request at all.
+  const search = usePropertySearch(query, { enabled: scope.canQuery });
 
-  // Load properties on mount if not already loaded
-  useEffect(() => {
-    if (!properties || properties.length === 0) {
-      loadProperties({
-        limit: 5,
-        status: 'published',
-      });
-    }
-  }, [loadProperties, properties]);
+  const featured = useMemo(
+    () => rankFeatured(search.properties).slice(0, FEATURED_COUNT),
+    [search.properties],
+  );
 
-  const featured = useMemo(() => {
-    return properties || [];
-  }, [properties]);
+  /**
+   * The area, in the same words the scope bar uses.
+   *
+   * `describeScope` rather than a local formatter: two surfaces naming one area
+   * differently is the confusion the shared bar was built to remove, and a
+   * second describer here would drift the first time one of them learned about a
+   * new selection kind.
+   *
+   * An explicit "everywhere" has `selection === null`, so it falls to the plain
+   * title — "Featured in Everywhere" is not a sentence, and the user who pressed
+   * that button already knows what they pressed.
+   */
+  const title = scope.selection
+    ? t('home.featured.titleIn', {
+        area: describeScope({
+          selection: scope.selection,
+          nearbyPlace: scope.nearbyPlace,
+          t,
+          formatDistanceValue: (metres) => formatDistance(metres, locale),
+        }),
+      })
+    : t('home.featured.title');
 
-  if (error) {
-    console.error('FeaturedPropertiesWidget Error:', error);
+  /**
+   * "View all", carrying the scope.
+   *
+   * `null` when the selection cannot be written as a URL token, and the button
+   * is then not rendered — a CTA that dropped the area would put the global feed
+   * one tap from a widget that exists to keep it out of reach, which is the
+   * whole bug arriving through a link instead of a request.
+   */
+  const seeAllHref = useMemo(() => exploreHref(query), [query]);
+
+  if (!scope.canQuery) {
     return (
-      <BaseWidget title={t('home.featured.title')}>
+      <BaseWidget title={title}>
+        <View style={styles.emptyContainer}>
+          <ThemedText style={styles.emptyText}>{scopeNotice(scope.resolution, t)}</ThemedText>
+        </View>
+      </BaseWidget>
+    );
+  }
+
+  if (search.isError) {
+    return (
+      <BaseWidget title={title}>
         <View style={styles.errorContainer}>
-          <ThemedText style={styles.errorText}>
-            Failed to load properties
-          </ThemedText>
+          <ThemedText style={styles.errorText}>{t('home.featured.loadFailed')}</ThemedText>
         </View>
       </BaseWidget>
     );
   }
 
   return (
-    <BaseWidget title={t('home.featured.title')}>
+    <BaseWidget title={title}>
       <View>
-        {loading ? (
+        {search.isLoading ? (
           <View style={styles.loadingContainer}>
             <Loading iconSize={16} showText={false} />
             <ThemedText style={styles.loadingText}>{t('state.loading')}</ThemedText>
           </View>
+        ) : featured.length === 0 ? (
+          <View style={styles.emptyContainer}>
+            <ThemedText style={styles.emptyText}>{t('home.featured.empty')}</ThemedText>
+          </View>
         ) : (
-          <FeaturedProperties properties={featured} />
+          <>
+            {featured.map((property) => (
+              <PropertyCard
+                key={property.id}
+                property={property}
+                variant="compact"
+                orientation="horizontal"
+                showSaveButton={true}
+                showVerifiedBadge={true}
+                showTypeIcon={false}
+                showFeatures={true}
+                showPrice={true}
+                showLocation={true}
+                showRating={false}
+                showSaveCount={true}
+                saveCountDisplayMode="inline"
+                style={styles.propertyCard}
+                onPress={() => router.push(`/properties/${property.id}`)}
+              />
+            ))}
+            {seeAllHref ? (
+              <Button onPress={() => router.push(seeAllHref)}>{t('home.viewAll')}</Button>
+            ) : null}
+          </>
         )}
       </View>
     </BaseWidget>
   );
 }
 
-function FeaturedProperties({ properties }: { properties: FeaturedProperty[] }) {
-  const router = useRouter();
-  const { t } = useTranslation();
-
-  // Order most saved to less saved, then limit to 4
-  const sorted = Array.isArray(properties)
-    ? [...properties].sort((a, b) => {
-      const aFair = a.priceEthics?.isFairPrice ? 1 : 0;
-      const bFair = b.priceEthics?.isFairPrice ? 1 : 0;
-      if (bFair !== aFair) return bFair - aFair;
-      const aSaves = typeof a.savesCount === 'number' ? a.savesCount : 0;
-      const bSaves = typeof b.savesCount === 'number' ? b.savesCount : 0;
-      return bSaves - aSaves;
-    })
-    : [];
-  const limited = sorted.slice(0, 4);
-
-  // Show message if no properties available
-  if (limited.length === 0) {
-    return (
-      <View style={styles.emptyContainer}>
-        <ThemedText style={styles.emptyText}>
-          {t('home.featured.empty')}
-        </ThemedText>
-      </View>
-    );
+/**
+ * What to say when there is nothing to query.
+ *
+ * The failure REASON when there is one — "location is off" and "we could not
+ * reach Homiio" call for different actions, and a single generic sentence sends
+ * half of the people who read it to the wrong setting. Same keys the scope bar
+ * uses, so the rail and the bar cannot describe one failure two ways.
+ */
+export function scopeNotice(resolution: LocationResolution, t: TFunction): string {
+  switch (resolution.status) {
+    case 'resolving':
+      return t('location.scope.resolving');
+    case 'failed':
+      return t(`location.scope.failure.${resolution.reason}`);
+    // `resolved` cannot reach here — a resolved scope can be queried — but it is
+    // spelled out rather than folded into a default so that adding a fifth
+    // status is a compile error instead of a silently generic sentence.
+    case 'idle':
+    case 'resolved':
+      return t('home.featured.chooseArea');
   }
-
-  return (
-    <>
-      {limited.map((property) => (
-        <PropertyCard
-          key={property.id}
-          property={property}
-          variant="compact"
-          orientation="horizontal"
-          showSaveButton={true}
-          showVerifiedBadge={true}
-          showTypeIcon={false}
-          showFeatures={true}
-          showPrice={true}
-          showLocation={true}
-          showRating={false}
-          showSaveCount={true}
-          saveCountDisplayMode="inline"
-          style={styles.propertyCard}
-          onPress={() => router.push(`/properties/${property.id}`)}
-        />
-      ))}
-      <Button
-        onPress={() => router.push('/properties')}
-      >
-        {t('home.viewAll')}
-      </Button>
-    </>
-  );
 }
 
 const styles = StyleSheet.create({

--- a/packages/frontend/locales/ar.json
+++ b/packages/frontend/locales/ar.json
@@ -181,7 +181,10 @@
       "gridLongTerm": "Studios in {{place}}",
       "gridVacation": "Beach apartments in {{place}}",
       "gridBuy": "Homes for sale in {{place}}",
-      "gridExchange": "Home exchanges in {{place}}"
+      "gridExchange": "Home exchanges in {{place}}",
+      "titleIn": "Featured in {{area}}",
+      "chooseArea": "Choose an area to see featured homes.",
+      "loadFailed": "Could not load featured homes for this area."
     },
     "viewAll": "View All",
     "recentlyViewed": {

--- a/packages/frontend/locales/bn-BD.json
+++ b/packages/frontend/locales/bn-BD.json
@@ -181,7 +181,10 @@
       "gridLongTerm": "Studios in {{place}}",
       "gridVacation": "Beach apartments in {{place}}",
       "gridBuy": "Homes for sale in {{place}}",
-      "gridExchange": "Home exchanges in {{place}}"
+      "gridExchange": "Home exchanges in {{place}}",
+      "titleIn": "Featured in {{area}}",
+      "chooseArea": "Choose an area to see featured homes.",
+      "loadFailed": "Could not load featured homes for this area."
     },
     "viewAll": "View All",
     "recentlyViewed": {

--- a/packages/frontend/locales/ca-ES.json
+++ b/packages/frontend/locales/ca-ES.json
@@ -144,7 +144,10 @@
       "gridLongTerm": "Estudis a {{place}}",
       "gridVacation": "Apartaments de platja a {{place}}",
       "gridBuy": "Habitatges en venda a {{place}}",
-      "gridExchange": "Intercanvis de casa a {{place}}"
+      "gridExchange": "Intercanvis de casa a {{place}}",
+      "titleIn": "Featured in {{area}}",
+      "chooseArea": "Choose an area to see featured homes.",
+      "loadFailed": "Could not load featured homes for this area."
     },
     "viewAll": "Veure Tot",
     "recentlyViewed": {

--- a/packages/frontend/locales/en.json
+++ b/packages/frontend/locales/en.json
@@ -177,11 +177,14 @@
     },
     "featured": {
       "title": "Featured Properties",
+      "titleIn": "Featured in {{area}}",
       "empty": "No featured properties available at the moment",
       "gridLongTerm": "Studios in {{place}}",
       "gridVacation": "Beach apartments in {{place}}",
       "gridBuy": "Homes for sale in {{place}}",
-      "gridExchange": "Home exchanges in {{place}}"
+      "gridExchange": "Home exchanges in {{place}}",
+      "chooseArea": "Choose an area to see featured homes.",
+      "loadFailed": "Could not load featured homes for this area."
     },
     "viewAll": "View All",
     "recentlyViewed": {

--- a/packages/frontend/locales/es.json
+++ b/packages/frontend/locales/es.json
@@ -147,7 +147,10 @@
       "gridLongTerm": "Estudios en {{place}}",
       "gridVacation": "Apartamentos de playa en {{place}}",
       "gridBuy": "Viviendas en venta en {{place}}",
-      "gridExchange": "Intercambios de casa en {{place}}"
+      "gridExchange": "Intercambios de casa en {{place}}",
+      "titleIn": "Featured in {{area}}",
+      "chooseArea": "Choose an area to see featured homes.",
+      "loadFailed": "Could not load featured homes for this area."
     },
     "viewAll": "Ver Todo",
     "recentlyViewed": {

--- a/packages/frontend/locales/fr-FR.json
+++ b/packages/frontend/locales/fr-FR.json
@@ -181,7 +181,10 @@
       "gridLongTerm": "Studios in {{place}}",
       "gridVacation": "Beach apartments in {{place}}",
       "gridBuy": "Homes for sale in {{place}}",
-      "gridExchange": "Home exchanges in {{place}}"
+      "gridExchange": "Home exchanges in {{place}}",
+      "titleIn": "Featured in {{area}}",
+      "chooseArea": "Choose an area to see featured homes.",
+      "loadFailed": "Could not load featured homes for this area."
     },
     "viewAll": "View All",
     "recentlyViewed": {

--- a/packages/frontend/locales/hi-IN.json
+++ b/packages/frontend/locales/hi-IN.json
@@ -181,7 +181,10 @@
       "gridLongTerm": "Studios in {{place}}",
       "gridVacation": "Beach apartments in {{place}}",
       "gridBuy": "Homes for sale in {{place}}",
-      "gridExchange": "Home exchanges in {{place}}"
+      "gridExchange": "Home exchanges in {{place}}",
+      "titleIn": "Featured in {{area}}",
+      "chooseArea": "Choose an area to see featured homes.",
+      "loadFailed": "Could not load featured homes for this area."
     },
     "viewAll": "View All",
     "recentlyViewed": {

--- a/packages/frontend/locales/id-ID.json
+++ b/packages/frontend/locales/id-ID.json
@@ -181,7 +181,10 @@
       "gridLongTerm": "Studios in {{place}}",
       "gridVacation": "Beach apartments in {{place}}",
       "gridBuy": "Homes for sale in {{place}}",
-      "gridExchange": "Home exchanges in {{place}}"
+      "gridExchange": "Home exchanges in {{place}}",
+      "titleIn": "Featured in {{area}}",
+      "chooseArea": "Choose an area to see featured homes.",
+      "loadFailed": "Could not load featured homes for this area."
     },
     "viewAll": "View All",
     "recentlyViewed": {

--- a/packages/frontend/locales/it.json
+++ b/packages/frontend/locales/it.json
@@ -301,7 +301,10 @@
       "gridVacation": "Appartamenti al mare a {{place}}",
       "gridBuy": "Case in vendita a {{place}}",
       "gridExchange": "Scambi di casa in {{place}}",
-      "empty": "No featured properties available at the moment"
+      "empty": "No featured properties available at the moment",
+      "titleIn": "Featured in {{area}}",
+      "chooseArea": "Choose an area to see featured homes.",
+      "loadFailed": "Could not load featured homes for this area."
     },
     "recentlyViewed": {
       "title": "Visualizzate di Recente",

--- a/packages/frontend/locales/pt-BR.json
+++ b/packages/frontend/locales/pt-BR.json
@@ -181,7 +181,10 @@
       "gridLongTerm": "Studios in {{place}}",
       "gridVacation": "Beach apartments in {{place}}",
       "gridBuy": "Homes for sale in {{place}}",
-      "gridExchange": "Home exchanges in {{place}}"
+      "gridExchange": "Home exchanges in {{place}}",
+      "titleIn": "Featured in {{area}}",
+      "chooseArea": "Choose an area to see featured homes.",
+      "loadFailed": "Could not load featured homes for this area."
     },
     "viewAll": "View All",
     "recentlyViewed": {

--- a/packages/frontend/locales/ru-RU.json
+++ b/packages/frontend/locales/ru-RU.json
@@ -181,7 +181,10 @@
       "gridLongTerm": "Studios in {{place}}",
       "gridVacation": "Beach apartments in {{place}}",
       "gridBuy": "Homes for sale in {{place}}",
-      "gridExchange": "Home exchanges in {{place}}"
+      "gridExchange": "Home exchanges in {{place}}",
+      "titleIn": "Featured in {{area}}",
+      "chooseArea": "Choose an area to see featured homes.",
+      "loadFailed": "Could not load featured homes for this area."
     },
     "viewAll": "View All",
     "recentlyViewed": {

--- a/packages/frontend/locales/zh-CN.json
+++ b/packages/frontend/locales/zh-CN.json
@@ -181,7 +181,10 @@
       "gridLongTerm": "Studios in {{place}}",
       "gridVacation": "Beach apartments in {{place}}",
       "gridBuy": "Homes for sale in {{place}}",
-      "gridExchange": "Home exchanges in {{place}}"
+      "gridExchange": "Home exchanges in {{place}}",
+      "titleIn": "Featured in {{area}}",
+      "chooseArea": "Choose an area to see featured homes.",
+      "loadFailed": "Could not load featured homes for this area."
     },
     "viewAll": "View All",
     "recentlyViewed": {


### PR DESCRIPTION
## The bug

`FeaturedPropertiesWidget` fetched with `useProperties()` +
`loadProperties({ limit: 5, status: 'published' })` inside a mount effect. That
request carries **no geographic parameter of any kind**, so the widget rendered
four listings from anywhere on earth — in the right rail, beside a page whose
whole premise since #353 is an explicit, visible area. It is the global feed ADR
0002 principle 2 forbids, still alive inside a widget.

It was invisible on screen: four correctly-formatted property cards, each with a
working link. Nothing about the output said where they were from.

**It is worse than "on Home".** `RightBar`'s `screenId` falls through to `'home'`
for **any unmatched pathname** (`components/RightBar.tsx:35`), so the home widget
set — this one included — also renders on `/roommates`, `/reviews`, `/saved`,
`/viewings`, `/tips` and every other route the switch does not name. Reported,
not changed here: it is a routing decision, not this bug.

## The census

Every file under `packages/frontend/components/widgets/` (14 tracked files), by
what it fetches rather than by name.

**Positive control:** the search had to find the widget already known to be
broken. `git grep -nE "useProperties\(|usePropertySearch\(|useHomeSections\(|useInfinitePropertyList\(|usePropertiesByCity\(|useInfiniteCityProperties\(|propertyService\.|loadProperties\("`
over that directory returned exactly `FeaturedPropertiesWidget.tsx:22` and `:27`
— the two lines the defect lives on — and nothing else.

**Residual**, because a fixed list of hook names only finds what it was told to
look for: every `use*` identifier appearing at a call site in that directory,
classified individually. The first version of that sweep was wrong and worth
recording — `\buse[A-Z][A-Za-z]*\(` missed `useQuery<Profile | null>({` because
the type argument breaks the pattern before the paren, and a missing entry reads
exactly like an absent one. The corrected sweep also surfaced
`useSearchQueryStore`, which the first had likewise dropped.

| Widget | What it fetches | Geographic? | Verdict |
|---|---|---|---|
| **FeaturedPropertiesWidget** | `useProperties()` → unscoped property list | **no scope at all** | **DEFECT — fixed here** |
| RecentlyViewedWidget | `useRecentlyViewed()` — this user's own view history, by id | not a geographic query; yours wherever you are | OK |
| PropertyBookingWidget | `useProperty(propertyId)` + landlord profile by id | scoped by id | OK |
| NeighborhoodRatingWidget | `useNeighborhood({propertyId \| name+city+state})`, `enabled: byProperty \|\| byName` | scoped by explicit props, renders nothing unresolved; also flag-gated off | OK |
| PropertyPreviewWidget | the create-property form store | issues no request | OK |
| SavedSearchesWidget | `useSavedSearches()` — this user's own watches | not geographic | OK |
| QuickFiltersWidget | `useSearchQueryStore().patchFilters` → `/explore` | `patchFilters` **cannot reach** `location` or `queryText`; the scope stays whatever `/explore` holds | OK by construction |
| PropertyAlertWidget | `useSavedSearches().saveSearch` — write, not a listing query | see below | OK, checked |
| DonationWidget, EcoCertificationWidget, HorizonInitiativeWidget, BaseWidget, WidgetManager | static / composition | no request | OK |

`PropertyAlertWidget` deserves the extra line because it looks like a second
location source and is not one. It takes a **free-text** `location` string and
stores it on a saved search. Free text and geographic scope are independent
dimensions (ADR 0002), and #356's primary-area rung already refuses to scope
anything by a watch whose location never resolved — `primaryAreaOf` skips a
label-only watch rather than re-geocoding the label, which is the homonym bug.
So a watch created here can never become somebody's Home scope by accident.
Nothing to fix.

**One defect, and it is the one that was reported.**

## The fix

`FeaturedPropertiesWidget` now reads `useLocationScope()` — the **same** hook
Home and the eviction board read, not a second location source — and queries
through `usePropertySearch`, so the selection reaches the request via
`locationParams` and the cache key leads with the query id and `locationKey`
(no coordinate ever enters a key).

The rail is a **sibling** of the page rather than its child, so the scope cannot
arrive as a prop. Reading the shared hook is what makes the two agree anyway:
one store, one React Query cache, so the rail and the page cannot disagree about
where the user is looking. The widget **commits** nothing — no picker, no "use my
location" button, no fallback of its own — because `LocationScopeBar` is the one
surface allowed to commit a selection, and a widget that could commit one would
be exactly the second authority the shared contract exists to prevent.

Two smaller consequences that are part of the same rule:

- **The heading names the area**, via `describeScope` from `LocationScopeBar` —
  the shared describer, not a second one. A rail of listings that states no area
  is the defect wearing a fix.
- **"View all" carries the scope** through `exploreHref`, and is **not rendered
  at all** when the selection cannot be written as a URL token. A CTA that
  dropped the area would put the global feed one tap from the widget that exists
  to keep it out of reach — the whole bug arriving through a link instead of a
  request.

The `useEffect` + `loadProperties()` is gone; the data path is React Query only.

## What it shows with no scope, and why

**`scope.canQuery` is the only gate.** It is true for exactly two states: a
committed selection, or an explicit "explore everywhere" somebody pressed. There
is no arm of the component that fetches listings otherwise.

- **Never a global list.** A failed device fix, a denied permission, a fresh
  install and a still-resolving ladder all end at a sentence.
- **A sentence, not an empty rail.** Rendering nothing was the other candidate
  and is worse: an empty rail reads as *"there are no homes here"*, which is the
  same false impression more quietly. #353's requirement is that a surface
  STATES its area, and "no area chosen yet" is a statement about the area.
- **The reason, when there is one.** `scopeNotice` reuses the scope bar's own
  `location.scope.failure.*` keys, so the rail and the bar cannot describe one
  failure two ways. "Location is off" and "we could not reach Homiio" call for
  different actions; one generic sentence sends half its readers to the wrong
  setting.
- **Explicit global IS honoured**, and that is not a loophole. It has
  `selection === null` exactly like "nothing chosen", and only `canQuery` tells
  them apart — which is precisely the distinction `resolveLocationScope` exists
  to make. Home behaves identically.

## Tests

`packages/frontend/__tests__/widgets/featuredWidgetScope.test.tsx`, 18 cases.
They assert on the **request** (`api.get` mocked, params read) rather than on the
render, because no assertion about what this widget renders could have told the
fixed version from the broken one.

The positive control is load-bearing: every "no request was made" case is
satisfied by a widget that never fetches anything, so without
`sends the request, scoped to that city` the whole file would pass against a
component returning `null`.

### Mutation evidence

Both halves of the fix were mutated separately, each confirmed to have landed
before the run (the file diffed and md5'd), each restored afterwards from a
namespaced pristine copy — never `git checkout` — and the restore verified by
markers from the edit itself plus an md5 match.

**M1 — drop the scope from the query** (`{ ...DEFAULT_SEARCH_QUERY, offering, location: selection }`
→ `{ ...DEFAULT_SEARCH_QUERY, offering }`). Landed check: `location: selection`
count 0, md5 changed. Result: **exit 1, 3 failed / 15 passed**

```
✕ sends the request, scoped to that city
✕ sends the centre and radius, and no city
✕ carries the committed selection as the query location
```

Worth noting what stayed green: `names the area in its own heading` passed,
because the title reads `scope.selection` directly. Under M1 the widget renders
a heading naming Barcelona while querying the world — the failure looks *more*
convincing than the original bug, and only the request assertions see it.

**M2 — drop the gate** (`usePropertySearch(query, { enabled: scope.canQuery })`
→ `usePropertySearch(query)`; the hook defaults `enabled` to true). Landed check:
`enabled: scope.canQuery` count 0, md5 changed. Result: **exit 1, 3 failed / 15
passed**, and a *different* three:

```
✕ with no area chosen › issues NO request at all
✕ while the scope is still resolving › issues NO request
✕ when the device rung failed › issues NO request, and names the reason
```

Neither mutation kills the other's tests, which is the point of running both.

## Verification

Every command's full output and exit code was read, never grepped for a pass.

| Check | Result |
|---|---|
| `bun run --cwd packages/frontend typecheck` | exit **0** |
| `bun run --cwd packages/frontend test` | exit **0** — 37 suites, **515 tests**, all passed (`noFunctionFormStyle` gate included) |
| `bun run --cwd packages/frontend build` | exit **0** |
| `bun run --cwd packages/frontend check:cold-start / /properties` | exit **0** — both routes `visibility=visible`, `consoleErrors: []`, `pageErrors: []` |
| `bun run check:lockfile` | exit **0** (no dependency change) |
| `bun scripts/check-locale-parity.ts` | exit **0** after `sync-locale-keys.ts` propagated 3 keys to 11 locales |
| `bun run --cwd packages/frontend lint` | exit 1 — **2 errors, both pre-existing** in files not touched here (`app/(tabs)/saved/watches/[watchId].tsx`, `SindiExplanationBottomSheet.tsx:136`, the latter documented as deliberately deferred in `AGENTS.md`). My files produce **zero** lint output; CI's `lint` job is `HOMIIO_LINT_GATE`-gated off by design. |

**Real browser, real width.** The cold-start check runs at 1280×900, which is
above `RightBar`'s 990px breakpoint, so it did exercise this widget — but it
samples only 120 characters, which is not enough to read a rail. A second CDP
run at 1600×1000 against the same `dist/` printed the full rendered text:

```
Featured Properties

Location is off, so we cannot search near you. Pick a place instead — location is optional.
```

`consoleErrors: []`. Headless Chrome denies geolocation, so the device rung
fails — and the widget lands on the named-reason branch, showing no listings and
issuing no request, with the scope bar above it saying the same thing. That is
the state that used to render four homes from anywhere.

## Not changed

- **`RightBar`'s `screenId` default.** Reported above; it is a routing decision.
- **The "featured" ranking.** Still fair-price first, then most-saved, over the
  page the search returns. This widget's defect was *where* it looked, not how it
  ranked what it found, and changing both at once would make the diff impossible
  to reason about.
- **`@react-navigation`-style broad refactors.** The `expo-router` and
  `PropertyCard` mocks in the test exist because the former ships untransformed
  ESM under this suite's `transformIgnorePatterns` and the latter decides nothing
  about scope. Neither is a production change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
