### PR TITLE
fix(layout): give every route a rail decision, so none inherits Home's

### DIFF
--- a/packages/frontend/__tests__/widgets/rightBarRail.test.tsx
+++ b/packages/frontend/__tests__/widgets/rightBarRail.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * `RightBar` renders the map's answer, and nothing of its own (#423).
+ *
+ * ## Why this exists beside the totality test
+ *
+ * `routeRailTotality.test.ts` proves the MAP is total and that the resolver
+ * agrees with it. Neither fact reaches the screen on its own: the acceptance
+ * criterion is about what an unmatched route RENDERS, and the component is the
+ * only place that is observable. A map that says `null` and a component that
+ * renders Home anyway would satisfy every assertion in that file.
+ *
+ * So this one renders `RightBar` at real pathnames and reads what
+ * `WidgetManager` was handed — including the case where it must be handed
+ * nothing at all, because "renders no rail" cannot be asserted by inspecting
+ * props that were never passed.
+ *
+ * The rail's own visibility rules (>=990px, the Sindi panel) are forced ON, so a
+ * failure here is about the ROUTE and never about a breakpoint.
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { RightBar } from '@/components/RightBar';
+
+// `mock`-prefixed because jest hoists `jest.mock` factories above the file and
+// refuses any other out-of-scope reference from inside one.
+const mockUsePathname = jest.fn<string, []>();
+
+jest.mock('expo-router', () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+// The rail is desktop-only; this file is not about the breakpoint.
+jest.mock('@/hooks/useOptimizedMediaQuery', () => ({
+  useIsRightBarVisible: () => true,
+  useIsLargeDesktop: () => true,
+}));
+
+jest.mock('@/store/uiStore', () => ({
+  useUIStore: (selector: (state: { sindiPanelOpen: boolean }) => unknown) =>
+    selector({ sindiPanelOpen: false }),
+}));
+
+/**
+ * A spy in place of the real widget set.
+ *
+ * The question here is which rail was REQUESTED, not what it looks like —
+ * and mounting the real widgets would drag every data hook in the app into a
+ * test about routing.
+ */
+const mockWidgetManager = jest.fn();
+jest.mock('@/components/widgets', () => ({
+  WidgetManager: (props: Record<string, unknown>) => {
+    mockWidgetManager(props);
+    return null;
+  },
+}));
+
+/** The props `WidgetManager` was mounted with, or `null` if it never was. */
+function railProps(): Record<string, unknown> | null {
+  return mockWidgetManager.mock.calls.length > 0 ? mockWidgetManager.mock.calls[0][0] : null;
+}
+
+function renderAt(pathname: string): ReturnType<typeof render> {
+  mockUsePathname.mockReturnValue(pathname);
+  return render(<RightBar />);
+}
+
+beforeEach(() => {
+  mockWidgetManager.mockClear();
+  mockUsePathname.mockReset();
+});
+
+describe('a route with no rail renders nothing', () => {
+  it('mounts no widget set at all on a page that only ever inherited Home', () => {
+    // `/reviews` rendered Home's rail — recently viewed, featured properties,
+    // donation, horizon, eco — beside a page about tenancy history. Not a
+    // considered layout; the absence of one.
+    const view = renderAt('/reviews');
+
+    expect(railProps()).toBeNull();
+    expect(view.toJSON()).toBeNull();
+  });
+
+  it('mounts nothing for a pathname that is not a route at all', () => {
+    // The residual. Restoring the `'home'` default fails right here.
+    const view = renderAt('/definitely-not-a-route');
+
+    expect(railProps()).toBeNull();
+    expect(view.toJSON()).toBeNull();
+  });
+});
+
+describe('a route with a rail gets exactly that rail', () => {
+  it('gives Home its own widget set', () => {
+    // The POSITIVE control for both cases above: a component that rendered
+    // `null` unconditionally would pass them and delete the rail from the app.
+    renderAt('/');
+
+    expect(railProps()).toMatchObject({ screenId: 'home' });
+  });
+
+  it('passes the property id from the segment that holds it', () => {
+    renderAt('/properties/68a1f0c2b9/apply');
+
+    expect(railProps()).toMatchObject({
+      screenId: 'property-details',
+      propertyId: '68a1f0c2b9',
+    });
+  });
+
+  it('passes the city on the city listing route, and no property id', () => {
+    renderAt('/properties/city/barcelona');
+
+    expect(railProps()).toMatchObject({ screenId: 'properties', city: 'barcelona' });
+    expect(railProps()?.propertyId).toBeUndefined();
+  });
+
+  it('never hands a non-id path segment over as a property id', () => {
+    // `/properties/drafts` used to mount `PropertyBookingWidget` with
+    // `propertyId="drafts"`, which fetched `GET /api/properties/drafts`. It has
+    // no rail now, so there is nothing to hand anything to.
+    const view = renderAt('/properties/drafts');
+
+    expect(railProps()).toBeNull();
+    expect(view.toJSON()).toBeNull();
+  });
+});

--- a/packages/frontend/__tests__/widgets/routeRailTotality.test.ts
+++ b/packages/frontend/__tests__/widgets/routeRailTotality.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Every route in `app/` has a rail decided for it, and none inherits one (#423).
+ *
+ * ## Why the route list is DERIVED and not written here
+ *
+ * A hand-written list of routes is the same instrument as the hand-written list
+ * of path segments this change deleted from `RightBar` (`my`, `saved`, `eco`,
+ * `type`, `city` — the segments that are not property ids), and it failed the
+ * same way: it had to name every case, and it did not, so `/properties/drafts`
+ * became a property id. `homeSectionsController`'s place types failed this way
+ * in #416 too — three of six values unhandled, 400ing in production.
+ *
+ * So the routes come from the `app/` TREE, and this file's job is to make a
+ * route that is absent from `ROUTE_RAIL` a failing test rather than a silent
+ * default. Adding a screen now forces a rail decision. That is the whole point.
+ *
+ * ## Why a filesystem walk rather than `git ls-files`
+ *
+ * The repository's other scans use `git ls-files`, correctly: they ask "is this
+ * pattern anywhere in the tracked source", where git's index is the authority
+ * and build output is excluded for free. This asks a different question — "what
+ * routes does the ROUTER serve" — and expo-router resolves routes from the
+ * filesystem. An untracked file under `app/` is a live route in development, and
+ * a scan that could not see it would report a total map while the router had a
+ * route the map does not know. `app/` holds no build output, so the usual reason
+ * to prefer the index does not apply here.
+ *
+ * ## The anti-vacuity defences
+ *
+ *  - `routeFromFile` is pinned with POSITIVE cases (a group segment, an index, a
+ *    dynamic segment, a nested dynamic segment) and NEGATIVE ones (`_layout`,
+ *    `+html`, `+not-found`, a platform-suffixed layout). A derivation that
+ *    stopped producing routes would otherwise report an empty tree as clean.
+ *  - A FLOOR on routes discovered. `expect([]).toEqual([])` is exactly what a
+ *    broken walk produces.
+ *  - The check runs in BOTH directions — no route missing from the map, and no
+ *    map entry that is not a route — because a one-way check lets the map rot
+ *    into a list of paths that no longer exist.
+ *  - Every `ScreenId` must be reached by some route, so a widget set cannot go
+ *    on existing after the route that displayed it is gone. That is how
+ *    `saved-properties` survived pointing at a path that never existed.
+ */
+
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { SCREEN_IDS, type ScreenId } from '@/components/widgets/screenIds';
+import { ROUTE_RAIL, railForPathname } from '@/components/widgets/routeRail';
+
+/** The router's directory. */
+const APP_DIR = join(__dirname, '..', '..', 'app');
+
+/**
+ * Filenames that are NOT routes.
+ *
+ * `_layout` wraps routes, `+html` is the web document shell, and `+not-found` is
+ * the fallback screen — it has no pathname of its own, which is precisely why
+ * `railForPathname`'s unmatched residual exists.
+ */
+const NON_ROUTE_BASENAMES = new Set(['_layout', '+html', '+not-found']);
+
+/** A platform variant resolves to the SAME route as its base file. */
+const PLATFORM_SUFFIX = /\.(web|native|ios|android)$/;
+
+const SOURCE_EXTENSION = /\.(tsx|ts|jsx|js)$/;
+
+/**
+ * The route a file under `app/` serves, or `null` when it serves none.
+ *
+ * Three expo-router rules, and all three are places a hand-transcribed list gets
+ * it wrong: a `(group)` segment is transparent, `index` IS its directory, and a
+ * `.web`/`.native` suffix is the same route twice.
+ *
+ * Exported implicitly through the tests below rather than from the app bundle:
+ * this is test-only machinery, and `node:fs` must never reach a React Native
+ * bundle.
+ */
+export function routeFromFile(relativePath: string): string | null {
+  if (!SOURCE_EXTENSION.test(relativePath)) return null;
+
+  const withoutExtension = relativePath.replace(SOURCE_EXTENSION, '');
+  const parts = withoutExtension.split('/');
+  const basename = parts[parts.length - 1].replace(PLATFORM_SUFFIX, '');
+  if (NON_ROUTE_BASENAMES.has(basename)) return null;
+
+  const segments = [...parts.slice(0, -1), basename].filter(
+    (segment) => !(segment.startsWith('(') && segment.endsWith(')')),
+  );
+  if (segments[segments.length - 1] === 'index') segments.pop();
+
+  return segments.length === 0 ? '/' : `/${segments.join('/')}`;
+}
+
+/** Every file under `app/`, as a path relative to it. */
+function filesUnder(dir: string, prefix: string[] = []): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      found.push(...filesUnder(join(dir, entry.name), [...prefix, entry.name]));
+    } else {
+      found.push([...prefix, entry.name].join('/'));
+    }
+  }
+  return found;
+}
+
+/** Every route the router serves, deduplicated across platform variants. */
+function appRoutes(): string[] {
+  const routes = new Set<string>();
+  for (const file of filesUnder(APP_DIR)) {
+    const route = routeFromFile(file);
+    if (route !== null) routes.add(route);
+  }
+  return [...routes].sort();
+}
+
+/**
+ * Sized against the tree at the time of writing (69 routes) with room to
+ * shrink. A walk that broke entirely returns zero, and no ordinary deletion
+ * takes the app below this.
+ */
+const MINIMUM_ROUTES = 45;
+
+/** A pathname for a pattern: each `[param]` becomes a plausible value. */
+function concrete(pattern: string): string {
+  return pattern.replace(/\[([^\]]+)\]/g, (_match, name: string) => `a-real-${name}`);
+}
+
+const ROUTES = appRoutes();
+const MAPPED = Object.keys(ROUTE_RAIL).sort();
+
+describe('routeFromFile follows expo-router, not a guess', () => {
+  it('treats a (group) segment as transparent and index as its directory', () => {
+    expect(routeFromFile('(tabs)/index.tsx')).toBe('/');
+    expect(routeFromFile('(tabs)/saved/index.tsx')).toBe('/saved');
+    expect(routeFromFile('settings/index.tsx')).toBe('/settings');
+  });
+
+  it('keeps dynamic segments verbatim, at any depth', () => {
+    expect(routeFromFile('explore/[query].tsx')).toBe('/explore/[query]');
+    expect(routeFromFile('(tabs)/saved/[folderId]/edit.tsx')).toBe('/saved/[folderId]/edit');
+    expect(routeFromFile('properties/[id]/book-viewing.tsx')).toBe(
+      '/properties/[id]/book-viewing',
+    );
+  });
+
+  it('resolves a platform variant to the same route as its base file', () => {
+    // Otherwise `_layout.web.tsx` reads as a route called `/_layout.web`, and a
+    // real screen's `.web` variant would demand a second map entry.
+    expect(routeFromFile('(tabs)/_layout.web.tsx')).toBeNull();
+    expect(routeFromFile('explore/index.web.tsx')).toBe('/explore');
+  });
+
+  it('rejects the files that are not routes', () => {
+    // The NEGATIVE control. A derivation that returned a route for these would
+    // make the map permanently, unfixably incomplete.
+    expect(routeFromFile('_layout.tsx')).toBeNull();
+    expect(routeFromFile('(tabs)/_layout.tsx')).toBeNull();
+    expect(routeFromFile('+html.tsx')).toBeNull();
+    expect(routeFromFile('+not-found.tsx')).toBeNull();
+    expect(routeFromFile('styles/colors.css')).toBeNull();
+  });
+});
+
+describe('the route→rail map is TOTAL', () => {
+  it('walks enough of app/ that a broken traversal cannot pass as clean', () => {
+    expect(ROUTES.length).toBeGreaterThanOrEqual(MINIMUM_ROUTES);
+  });
+
+  it('finds a rail decision for every route the router serves', () => {
+    // THE GATE. A route absent from `ROUTE_RAIL` used to inherit Home's widgets
+    // by falling through `RightBar`'s ladder; now it fails here, by name.
+    const undecided = ROUTES.filter((route) => !(route in ROUTE_RAIL));
+    expect(undecided).toEqual([]);
+  });
+
+  it('has no entry for a route that does not exist', () => {
+    // The other direction, and not symmetry for its own sake: `saved-properties`
+    // pointed at `/properties/saved` for the whole life of this repository, a
+    // path no file has ever served, and nothing said so.
+    const orphans = MAPPED.filter((pattern) => !ROUTES.includes(pattern));
+    expect(orphans).toEqual([]);
+  });
+
+  it('reaches every rail layout from at least one route', () => {
+    // A widget set nothing can display is dead code that reads as a feature.
+    const reached = new Set<ScreenId | null>(
+      Object.values(ROUTE_RAIL).map((assignment) => assignment.rail),
+    );
+    const unreachable = SCREEN_IDS.filter((id) => !reached.has(id));
+    expect(unreachable).toEqual([]);
+  });
+
+  it('has no two patterns that could match the same pathname', () => {
+    // Two patterns differing only in a param NAME would both match, and which
+    // one wins would depend on object key order. Nothing in the matcher would
+    // report it.
+    const shapes = MAPPED.map((pattern) => pattern.replace(/\[[^\]]+\]/g, '[*]'));
+    expect(shapes.length - new Set(shapes).size).toBe(0);
+  });
+});
+
+describe('railForPathname agrees with the map for every real route', () => {
+  it('matches each route to its own pattern', () => {
+    // The map being total is worth nothing if the MATCHER cannot find the entry.
+    // Checked over every route rather than a sample, because the cases that go
+    // wrong are the ones nobody thinks to sample.
+    const mismatched = ROUTES.filter(
+      (route) => railForPathname(concrete(route)).pattern !== route,
+    );
+    expect(mismatched).toEqual([]);
+  });
+
+  it('returns the rail the map declares, for every route', () => {
+    // `?.` deliberately: an entry MISSING from the map is the case above's to
+    // report, and reading `.rail` off `undefined` here would replace that
+    // named-route failure with a TypeError pointing at this line. `undefined`
+    // never equals the resolver's `null`, so a missing route still lands in
+    // `disagreeing` — it is named twice rather than crashing once.
+    const disagreeing = ROUTES.filter(
+      (route) => railForPathname(concrete(route)).screenId !== ROUTE_RAIL[route]?.rail,
+    );
+    expect(disagreeing).toEqual([]);
+  });
+
+  it('prefers a static segment over a dynamic one', () => {
+    // `/properties/create` and `/properties/[id]` both match `/properties/create`.
+    // The replaced code needed an ordered ladder to get this right; here it is a
+    // property of the matcher, so map order cannot break it.
+    expect(railForPathname('/properties/create').pattern).toBe('/properties/create');
+    expect(railForPathname('/properties/create').screenId).toBe('create-property');
+  });
+
+  it('ignores a query string and a trailing slash', () => {
+    expect(railForPathname('/explore?q=barcelona').screenId).toBe('explore');
+    expect(railForPathname('/properties/').pattern).toBe('/properties');
+  });
+});
+
+describe('an unrecognised pathname gets NO rail', () => {
+  it('renders nothing rather than Home', () => {
+    // The one residual in the system. It used to be `return 'home'`, which is
+    // why forty-nine routes wore Home's rail; the mutation that restores it
+    // fails here.
+    for (const pathname of ['/definitely-not-a-route', '/properties/[id]/nope', '/a/b/c/d/e']) {
+      expect(railForPathname(pathname)).toEqual({ screenId: null, pattern: null });
+    }
+  });
+});
+
+describe('the defects the ladder was hiding', () => {
+  it('does not treat a non-id path segment as a property id', () => {
+    // Measured before the change: `/properties/drafts` mounted
+    // `PropertyBookingWidget` with `propertyId="drafts"`, whose `useProperty`
+    // is `enabled: Boolean(id)` — so each of these issued a doomed
+    // `GET /api/properties/<segment>`.
+    for (const pathname of [
+      '/properties/drafts',
+      '/properties/recently-viewed',
+      '/properties/address-detail',
+      '/properties/my',
+    ]) {
+      expect(railForPathname(pathname).propertyId).toBeUndefined();
+    }
+  });
+
+  it('still reads the property id on a real detail route', () => {
+    // The positive control for the case above: a resolver that returned
+    // `undefined` for everything would pass it and break every detail page.
+    expect(railForPathname('/properties/68a1f0c2b9').propertyId).toBe('68a1f0c2b9');
+    expect(railForPathname('/properties/68a1f0c2b9/apply').propertyId).toBe('68a1f0c2b9');
+    expect(railForPathname('/properties/68a1f0c2b9').screenId).toBe('property-details');
+  });
+
+  it('gives a filtered LIST the list rail, not the detail rail', () => {
+    expect(railForPathname('/properties/city/barcelona').screenId).toBe('properties');
+    expect(railForPathname('/properties/city/barcelona').city).toBe('barcelona');
+    expect(railForPathname('/properties/city/barcelona').propertyId).toBeUndefined();
+    expect(railForPathname('/properties/type/apartment').screenId).toBe('properties');
+  });
+
+  it('gives the pages that only ever inherited Home no rail at all', () => {
+    // A sample of the forty-nine. Each of these rendered Home's widgets —
+    // including, until #422, a globally unscoped property feed.
+    for (const pathname of [
+      '/saved',
+      '/reviews',
+      '/roommates',
+      '/viewings',
+      '/tips',
+      '/settings',
+      '/evictions',
+      '/inbox',
+      '/contracts',
+    ]) {
+      expect(railForPathname(pathname).screenId).toBeNull();
+    }
+  });
+
+  it('leaves the routes that CHOSE a rail with the one they chose', () => {
+    // The floor for the case above: assigning `null` to everything would satisfy
+    // it and delete the rail from the app.
+    expect(railForPathname('/').screenId).toBe('home');
+    expect(railForPathname('/properties').screenId).toBe('properties');
+    expect(railForPathname('/explore').screenId).toBe('explore');
+    expect(railForPathname('/explore/barcelona').screenId).toBe('explore-results');
+    expect(railForPathname('/profile').screenId).toBe('profile');
+    expect(railForPathname('/profile/edit').screenId).toBe('profile');
+  });
+});

--- a/packages/frontend/components/RightBar.tsx
+++ b/packages/frontend/components/RightBar.tsx
@@ -1,7 +1,21 @@
+/**
+ * The right rail.
+ *
+ * It decides NOTHING about which widgets a route gets — `routeRail.ts` owns
+ * that, as a total map from every route in `app/` to a widget set or to `null`.
+ * This component asks it and renders the answer.
+ *
+ * The ladder that used to live here (`pathname ===` / `startsWith`, ending in
+ * `return 'home'`) sent 49 of 69 routes to Home's rail by fall-through, and
+ * re-derived a property id by counting slashes — guarded by a hand-maintained
+ * list of path segments that are not ids, which is exactly the kind of list
+ * that goes stale. Read `routeRail.ts`'s header for the full measurement.
+ */
 import React, { useMemo } from 'react';
 import { View, Platform, type ViewStyle } from 'react-native';
 import { usePathname } from 'expo-router';
 import { WidgetManager } from './widgets';
+import { railForPathname } from './widgets/routeRail';
 import {
   useIsRightBarVisible,
   useIsLargeDesktop,
@@ -14,67 +28,17 @@ export const RightBar = React.memo(function RightBar() {
   const sindiPanelOpen = useUIStore((s) => s.sindiPanelOpen);
   const pathname = usePathname() || '/';
 
-  // Memoize screen ID calculation
-  const screenId = useMemo(() => {
-    if (pathname === '/') return 'home';
-    if (pathname === '/properties') return 'properties';
-    if (pathname === '/properties/create') return 'create-property';
-    if (
-      pathname.startsWith('/properties/') &&
-      pathname !== '/properties/my' &&
-      pathname !== '/properties/saved'
-    )
-      return 'property-details';
-    if (pathname === '/properties/saved') return 'saved-properties';
-    if (pathname === '/profile' || pathname.startsWith('/profile/')) return 'profile';
-    if (pathname === '/contracts' || pathname.startsWith('/contracts/')) return 'contracts';
-    if (pathname === '/payments' || pathname.startsWith('/payments/')) return 'payments';
-    if (pathname === '/messages' || pathname.startsWith('/messages/')) return 'messages';
-    if (pathname === '/explore') return 'explore';
-    if (pathname.startsWith('/explore/')) return 'explore-results';
-    return 'home'; // Default to home
-  }, [pathname]);
-
-  // Memoize property information extraction
-  const propertyInfo = useMemo<{ propertyId?: string; city?: string }>(() => {
-    // Extract property ID from property details page
-    if (
-      pathname.startsWith('/properties/') &&
-      pathname !== '/properties/my' &&
-      pathname !== '/properties/saved'
-    ) {
-      const pathParts = pathname.split('/');
-      const propertyId = pathParts[2]; // /properties/[id]
-
-      if (
-        propertyId &&
-        propertyId !== 'my' &&
-        propertyId !== 'saved' &&
-        propertyId !== 'eco' &&
-        propertyId !== 'type' &&
-        propertyId !== 'city'
-      ) {
-        return { propertyId };
-      }
-    }
-
-    // Extract city information from city properties page
-    if (pathname.startsWith('/properties/city/')) {
-      const pathParts = pathname.split('/');
-      const cityId = pathParts[3]; // /properties/city/[id]
-
-      if (cityId) {
-        // Only the city identifier is available from the route. State and
-        // neighborhood are intentionally omitted so downstream widgets fall
-        // back to their own data sources rather than rendering placeholders.
-        return { city: cityId };
-      }
-    }
-
-    return {};
-  }, [pathname]);
+  // One lookup: the rail AND the params it needs, both read off the pattern
+  // that matched. Only the city identifier is ever available from a route —
+  // state and neighborhood are deliberately absent so downstream widgets fall
+  // back to their own data sources rather than rendering placeholders.
+  const rail = useMemo(() => railForPathname(pathname), [pathname]);
 
   if (!isRightBarVisible) return null;
+  // No rail for this route. A route reaches this either because its entry in
+  // `ROUTE_RAIL` says so, or because the pathname is not a route at all — and
+  // for both, rendering somebody else's widgets is the thing #423 removed.
+  if (rail.screenId === null) return null;
   // Drop the 4th column while the Sindi panel is docked, unless the screen is
   // large-desktop (>= 1440) where all four columns fit.
   if (sindiPanelOpen && !isLargeDesktop) return null;
@@ -95,9 +59,9 @@ export const RightBar = React.memo(function RightBar() {
   return (
     <View className="w-[350px] flex-col px-4 pt-4 gap-4" style={stickyStyle}>
       <WidgetManager
-        screenId={screenId}
-        propertyId={propertyInfo.propertyId}
-        city={propertyInfo.city}
+        screenId={rail.screenId}
+        propertyId={rail.propertyId}
+        city={rail.city}
       />
     </View>
   );

--- a/packages/frontend/components/widgets/WidgetManager.tsx
+++ b/packages/frontend/components/widgets/WidgetManager.tsx
@@ -11,26 +11,13 @@ import { QuickFiltersWidget } from './QuickFiltersWidget';
 import { PropertyPreviewWidget } from './PropertyPreviewWidget';
 import { PropertyBookingWidget } from './PropertyBookingWidget';
 import { DonationWidget } from './DonationWidget';
+import type { ScreenId } from './screenIds';
 
 // Feature flag: controls whether the Neighborhood widget is rendered.
 // Off by default — the widget only renders real, Homiio-derived metrics, so it
 // stays gated until neighborhood data coverage is broad enough to be useful.
 const NEIGHBORHOOD_WIDGET_ENABLED =
   (process.env.EXPO_PUBLIC_NEIGHBORHOOD_WIDGET_ENABLED || '').toLowerCase() === 'true';
-
-// Define screen IDs
-export type ScreenId =
-  | 'home'
-  | 'properties'
-  | 'property-details'
-  | 'saved-properties'
-  | 'profile'
-  | 'contracts'
-  | 'payments'
-  | 'messages'
-  | 'explore'
-  | 'explore-results'
-  | 'create-property';
 
 interface WidgetManagerProps {
   screenId: ScreenId;
@@ -86,21 +73,9 @@ export const WidgetManager = React.memo(function WidgetManager({
         <RecentlyViewedWidget key="recently-viewed" />,
         <EcoCertificationWidget key="eco-cert" />,
       ],
-      'saved-properties': [
-        <PropertyAlertWidget key="property-alert" />,
-        <NeighborhoodRatingWidget
-          key="neighborhood"
-          neighborhoodName={neighborhoodName}
-          city={city}
-          state={state}
-        />,
-      ],
       profile: [
         <DonationWidget key="donation" />,
       ],
-      contracts: [],
-      payments: [],
-      messages: [],
       explore: [
         <QuickFiltersWidget key="quick-filters" />,
         <SavedSearchesWidget key="saved-searches" />,

--- a/packages/frontend/components/widgets/index.ts
+++ b/packages/frontend/components/widgets/index.ts
@@ -3,6 +3,7 @@ export * from './FeaturedPropertiesWidget';
 export * from './EcoCertificationWidget';
 export * from './HorizonInitiativeWidget';
 export * from './DonationWidget';
+export * from './screenIds';
 export * from './WidgetManager';
 export * from './SavedSearchesWidget';
 export * from './PropertyAlertWidget';

--- a/packages/frontend/components/widgets/routeRail.ts
+++ b/packages/frontend/components/widgets/routeRail.ts
@@ -1,0 +1,305 @@
+/**
+ * Which right-rail widget set each route gets — TOTALLY, with no fall-through
+ * (#423).
+ *
+ * ## What this replaced, and what it was costing
+ *
+ * `RightBar` used to resolve the rail with a ladder of `pathname ===` and
+ * `pathname.startsWith(...)` tests ending in `return 'home'`. Measured against
+ * the real `app/` tree on 2026-08-11, that ladder resolved **49 of 69 routes**
+ * to Home's rail by FALL-THROUGH — `/reviews`, `/roommates`, `/saved`,
+ * `/viewings`, `/tips`, `/settings`, `/evictions`, `/inbox` and forty more.
+ *
+ * A default meaning "home" cannot tell *"this route wants the home rail"* from
+ * *"nobody has decided what this route's rail is"*. Those are different facts
+ * and only one of them is a decision. It is also the multiplier on the class of
+ * bug #353 exists to remove: until #422 the featured widget issued a globally
+ * unscoped query, and this fall-through is why it did so on forty-nine routes
+ * rather than one.
+ *
+ * Three more defects the ladder was hiding, all found by enumerating rather
+ * than by reading:
+ *
+ *  - **Three `ScreenId` values no route could ever reach.** `saved-properties`
+ *    named `/properties/saved`, which has never existed in this repository's
+ *    history; `payments` and `messages` named routes that do not exist either.
+ *  - **Three routes fetching a property that cannot exist.** The
+ *    `startsWith('/properties/')` arm treated `/properties/drafts`,
+ *    `/properties/recently-viewed` and `/properties/address-detail` as detail
+ *    pages and handed the path segment to `PropertyBookingWidget` as a property
+ *    id — so each mounted `useProperty('drafts')` and issued a doomed
+ *    `GET /api/properties/drafts`. The guard list beside it excluded `my`,
+ *    `saved`, `eco`, `type` and `city`, which is a hand-maintained list of
+ *    exceptions: it had to name every non-id segment, and it did not.
+ *  - **A rail chosen for a page that is not that page.** `/properties/city/[id]`
+ *    and `/properties/type/[type]` are LISTS and were getting the property
+ *    DETAIL rail, booking widget included.
+ *
+ * ## The rule this map follows
+ *
+ * **A route keeps the rail the previous code demonstrably CHOSE for it. Every
+ * route that only ever received Home's rail by fall-through gets `null`.**
+ *
+ * `null` is not "unknown" — it is the decision "no rail here", which is the
+ * issue's safest default: the absence of a decision must produce the absence of
+ * UI, never somebody else's UI. Upgrading any of them to a real rail is a
+ * product call, and it is now a one-line, visible, reviewable change instead of
+ * something a route acquires by existing.
+ *
+ * ## Adding a route
+ *
+ * Add it here. `__tests__/widgets/routeRailTotality.test.ts` walks the real
+ * `app/` tree and FAILS on any route absent from this map, so a new screen
+ * cannot be silently absorbed by a default — it has to be given one. The same
+ * test fails on an entry that is not a real route, and on a `ScreenId` no route
+ * reaches, so the map cannot rot in either direction.
+ */
+
+import type { ScreenId } from './screenIds';
+
+/**
+ * The rail a route gets, plus which of its dynamic segments the widgets need.
+ *
+ * The param NAMES live here rather than in `RightBar` because they are a fact
+ * about the route, and the previous version's habit of re-deriving them from
+ * `pathname.split('/')[2]` is what produced a property id of `"drafts"`.
+ */
+export interface RailAssignment {
+  /** The widget set, or `null` for the deliberate decision "no rail here". */
+  readonly rail: ScreenId | null;
+  /** The dynamic segment carrying a property id, for a rail that shows one. */
+  readonly propertyIdParam?: string;
+  /** The dynamic segment carrying a city id, for a rail that shows one. */
+  readonly cityParam?: string;
+}
+
+/** The decision "this route has no rail". Shared because it is one decision. */
+const NO_RAIL: RailAssignment = { rail: null };
+
+/**
+ * Every route in `app/`, and the rail it gets.
+ *
+ * Keys are expo-router route PATTERNS: `(group)` segments are transparent and
+ * `index` is its directory, exactly as the router resolves them, so a key here
+ * is comparable to a real pathname without anyone transcribing it.
+ */
+export const ROUTE_RAIL: Readonly<Record<string, RailAssignment>> = {
+  // ---- Home -------------------------------------------------------------
+  '/': { rail: 'home' },
+
+  // ---- Property discovery: the renter-facing LISTS -----------------------
+  // One surface, one rail. `/properties` already had it; the two filtered
+  // views of the same list were getting the DETAIL rail because they happen to
+  // sit under the same path prefix.
+  '/properties': { rail: 'properties' },
+  '/properties/type/[type]': { rail: 'properties' },
+  // The only route that ever wanted a city: the replaced code carried a branch
+  // extracting it, for `NeighborhoodRatingWidget`, so this is the previous
+  // intent preserved rather than a new decision.
+  '/properties/city/[id]': { rail: 'properties', cityParam: 'id' },
+
+  // ---- A property, and the flows that hang off one ----------------------
+  // `propertyIdParam` is declared, so the id comes from the MATCHED segment
+  // rather than from counting slashes.
+  '/properties/[id]': { rail: 'property-details', propertyIdParam: 'id' },
+  '/properties/[id]/apply': { rail: 'property-details', propertyIdParam: 'id' },
+  '/properties/[id]/book-viewing': { rail: 'property-details', propertyIdParam: 'id' },
+  '/properties/[id]/report': { rail: 'property-details', propertyIdParam: 'id' },
+
+  // ---- Creating a listing ------------------------------------------------
+  '/properties/create': { rail: 'create-property' },
+
+  // ---- Owner-side property surfaces --------------------------------------
+  // Lists, but of YOUR listings, not of homes to rent. The renter rail's saved
+  // searches and price alerts answer a question nobody is asking here, and
+  // nobody ever chose it for them — they fell through to Home.
+  '/properties/my': NO_RAIL,
+  '/properties/drafts': NO_RAIL,
+  '/properties/recently-viewed': NO_RAIL,
+  '/properties/address-detail': NO_RAIL,
+
+  // ---- Explore -----------------------------------------------------------
+  '/explore': { rail: 'explore' },
+  '/explore/[query]': { rail: 'explore-results' },
+  // `/search` is a two-line `<Redirect>` to `/explore` and renders nothing of
+  // its own, so it gets no rail: the rail that matters is the one `/explore`
+  // resolves once the redirect lands.
+  '/search': NO_RAIL,
+  '/search/[query]': NO_RAIL,
+
+  // ---- Profile -----------------------------------------------------------
+  '/profile': { rail: 'profile' },
+  '/profile/edit': { rail: 'profile' },
+  '/profile/subscriptions': { rail: 'profile' },
+
+  // ---- Tenancy: contracts, applications, viewings, reservations ----------
+  // `/contracts*` already rendered NO rail — its widget list was empty, and an
+  // empty list makes `WidgetManager` return null — so `null` here is the same
+  // behaviour said out loud. The rest fell through to Home.
+  '/contracts': NO_RAIL,
+  '/contracts/[id]': NO_RAIL,
+  '/contracts/new': NO_RAIL,
+  '/applications': NO_RAIL,
+  '/applications/[id]': NO_RAIL,
+  '/landlord/applications': NO_RAIL,
+  '/landlord/applications/[id]': NO_RAIL,
+  '/viewings': NO_RAIL,
+  '/reservations/[id]': NO_RAIL,
+  '/stays': NO_RAIL,
+  '/exchange/[id]': NO_RAIL,
+  '/exchange/requests': NO_RAIL,
+
+  // ---- Hosting -----------------------------------------------------------
+  '/host/calendar': NO_RAIL,
+  '/host/reservations': NO_RAIL,
+  '/agent': NO_RAIL,
+  '/agency/[slug]': NO_RAIL,
+
+  // ---- Research: reviews, evictions, insights, addresses -----------------
+  // These answer a geographic question of their own and state their own scope
+  // (#353). A rail of unrelated listings beside them is the "not a considered
+  // layout, the absence of one" case the issue names.
+  '/reviews': NO_RAIL,
+  '/reviews/write': NO_RAIL,
+  '/reviews/city/[cityId]': NO_RAIL,
+  '/reviews/neighborhood/[neighborhoodId]': NO_RAIL,
+  '/evictions': NO_RAIL,
+  '/evictions/new': NO_RAIL,
+  '/evictions/[id]': NO_RAIL,
+  '/insights': NO_RAIL,
+  '/addresses/[id]': NO_RAIL,
+
+  // ---- Roommates ---------------------------------------------------------
+  '/roommates': NO_RAIL,
+  '/roommates/[id]': NO_RAIL,
+  '/roommates/preferences': NO_RAIL,
+
+  // ---- Saved: folders, notes, alerts, watches -----------------------------
+  // `ScreenId` used to carry a `saved-properties` value for these, pointing at
+  // `/properties/saved` — a path that has never existed in this repository, so
+  // that rail has never rendered. It is deleted rather than re-pointed here:
+  // choosing a rail for the saved pages is a product decision nobody has made,
+  // and inventing one from a dead constant would be guessing at intent.
+  '/saved': NO_RAIL,
+  '/saved/notes': NO_RAIL,
+  '/saved/[folderId]': NO_RAIL,
+  '/saved/[folderId]/edit': NO_RAIL,
+  '/saved/alerts': NO_RAIL,
+  '/saved/alerts/[alertId]': NO_RAIL,
+  '/saved/watches/[watchId]': NO_RAIL,
+
+  // ---- Sindi, inbox, notifications ---------------------------------------
+  // Conversation surfaces own their full width.
+  '/sindi': NO_RAIL,
+  '/sindi/[conversationId]': NO_RAIL,
+  '/sindi/shared/[token]': NO_RAIL,
+  '/inbox': NO_RAIL,
+  '/notifications': NO_RAIL,
+
+  // ---- Settings and standalone pages -------------------------------------
+  '/settings': NO_RAIL,
+  '/settings/currency': NO_RAIL,
+  '/settings/language': NO_RAIL,
+  '/settings/notifications': NO_RAIL,
+  '/settings/sindi': NO_RAIL,
+  '/tips': NO_RAIL,
+  '/tips/[slug]': NO_RAIL,
+  '/donate': NO_RAIL,
+  '/horizon': NO_RAIL,
+};
+
+/** What a pathname resolves to. `pattern` is `null` when nothing matched. */
+export interface ResolvedRail {
+  /** The widget set to render, or `null` for no rail. */
+  readonly screenId: ScreenId | null;
+  /** The route pattern that matched, or `null` for an unrecognised pathname. */
+  readonly pattern: string | null;
+  readonly propertyId?: string;
+  readonly city?: string;
+}
+
+/** No pattern matched: render no rail. See {@link railForPathname}. */
+const UNMATCHED: ResolvedRail = { screenId: null, pattern: null };
+
+function segmentsOf(path: string): string[] {
+  return path.split('/').filter((segment) => segment.length > 0);
+}
+
+function isDynamic(segment: string): boolean {
+  return segment.startsWith('[') && segment.endsWith(']');
+}
+
+/**
+ * The route patterns, pre-split. Built once at module load: the map is a
+ * literal, so re-splitting 69 patterns on every navigation would be work with
+ * no possible different answer.
+ */
+const PATTERNS: readonly { pattern: string; segments: string[] }[] = Object.keys(ROUTE_RAIL).map(
+  (pattern) => ({ pattern, segments: segmentsOf(pattern) }),
+);
+
+/**
+ * Resolve a pathname to its rail.
+ *
+ * **An unrecognised pathname gets NO rail**, which is the one residual left in
+ * the system and is deliberate rather than a fall-through: nothing can reach it
+ * except a pathname that is not a route at all (`+not-found`, a deep link to a
+ * deleted screen, a typo), and rendering Home's widgets over a 404 was never a
+ * decision anybody made. The totality test proves no REAL route reaches it.
+ *
+ * A static segment beats a dynamic one at the same position, so
+ * `/properties/create` resolves to `/properties/create` and not to
+ * `/properties/[id]` — the previous code needed an ordered ladder plus a list
+ * of excluded words to achieve that, and the list is what went stale.
+ */
+export function railForPathname(pathname: string): ResolvedRail {
+  // Defensive: `usePathname` does not include a query or hash, but a caller
+  // passing `router`-shaped input should not silently miss every pattern.
+  const path = pathname.split(/[?#]/)[0];
+  const segments = segmentsOf(path);
+
+  let bestPattern: string | null = null;
+  let bestParams: Record<string, string> = {};
+  let bestStatics = -1;
+
+  for (const candidate of PATTERNS) {
+    if (candidate.segments.length !== segments.length) continue;
+
+    let statics = 0;
+    const params: Record<string, string> = {};
+    let matched = true;
+
+    for (let i = 0; i < segments.length; i += 1) {
+      const expected = candidate.segments[i];
+      if (isDynamic(expected)) {
+        params[expected.slice(1, -1)] = segments[i];
+      } else if (expected === segments[i]) {
+        statics += 1;
+      } else {
+        matched = false;
+        break;
+      }
+    }
+
+    if (matched && statics > bestStatics) {
+      bestPattern = candidate.pattern;
+      bestParams = params;
+      bestStatics = statics;
+    }
+  }
+
+  if (bestPattern === null) return UNMATCHED;
+
+  const assignment = ROUTE_RAIL[bestPattern];
+  const propertyId = assignment.propertyIdParam
+    ? bestParams[assignment.propertyIdParam]
+    : undefined;
+  const city = assignment.cityParam ? bestParams[assignment.cityParam] : undefined;
+
+  return {
+    screenId: assignment.rail,
+    pattern: bestPattern,
+    ...(propertyId ? { propertyId } : {}),
+    ...(city ? { city } : {}),
+  };
+}

--- a/packages/frontend/components/widgets/screenIds.ts
+++ b/packages/frontend/components/widgets/screenIds.ts
@@ -1,0 +1,33 @@
+/**
+ * The rail layouts this app has — the vocabulary, with no React attached.
+ *
+ * Its own module rather than a constant inside `WidgetManager.tsx` for one
+ * concrete reason: `routeRail.ts` and its totality test need to ENUMERATE these,
+ * and importing them from the component pulls in every widget and, through
+ * those, `expo-router` — which ships ESM this jest suite does not transform. A
+ * vocabulary is data; a component that renders it is not, and a pure map should
+ * not have to load a React tree to name its own values.
+ *
+ * An ARRAY with the union derived from it, because a TypeScript union does not
+ * exist at runtime and `__tests__/widgets/routeRailTotality.test.ts` proves
+ * every value here is REACHED by a route.
+ *
+ * Four values used to fail that and are gone. `saved-properties` named
+ * `/properties/saved`, a path that has never existed in this repository's
+ * history; `payments` and `messages` named routes that do not exist either — so
+ * none of the three had ever rendered. `contracts` WAS reachable, but its widget
+ * list was empty and an empty list makes `WidgetManager` return `null`, which
+ * made it a second spelling of "no rail". "No rail" now has exactly one
+ * spelling, and it lives in `routeRail.ts` as `null`.
+ */
+export const SCREEN_IDS = [
+  'home',
+  'properties',
+  'property-details',
+  'profile',
+  'explore',
+  'explore-results',
+  'create-property',
+] as const;
+
+export type ScreenId = (typeof SCREEN_IDS)[number];


### PR DESCRIPTION
Closes #423.

## What the ladder was doing

`RightBar` resolved the right-rail widget set with a ladder of `pathname ===`
and `startsWith(...)` tests ending in `return 'home'`. I transcribed that ladder
verbatim and ran it against every route derived from the real `app/` tree
(2026-08-11, at base `13d0849d`):

| resolved to | routes |
|---|---|
| **`home`, by FALL-THROUGH** | **49** |
| `property-details` | 9 |
| `contracts` | 3 |
| `profile` | 3 |
| `home` (chosen) | 1 |
| `properties` | 1 |
| `explore` | 1 |
| `explore-results` | 1 |
| `create-property` | 1 |
| | **69 total** |

**Forty-nine of sixty-nine routes wore Home's rail because nobody had written a
case for them** — `/reviews`, `/roommates`, `/saved`, `/viewings`, `/tips`,
`/settings`, `/evictions`, `/inbox`, `/insights`, `/agent`, `/donate`,
`/applications`, `/host/*`, `/notifications`, `/stays`, `/sindi/*` and the rest.

A default meaning "home" cannot tell *"this route wants the home rail"* from
*"nobody has decided what this route's rail is"*. It is also the multiplier on
the class of bug #353 exists to remove: until #422 `FeaturedPropertiesWidget`
issued a globally unscoped property query, and this fall-through is why it did so
on forty-nine routes rather than one.

## Three more defects the same enumeration surfaced

None of these was in the issue. They were invisible to reading and obvious to
counting.

**1. Three `ScreenId` values no route could reach.** `saved-properties` named
`/properties/saved` — and `git log --all --diff-filter=A` shows **no file has
ever existed at that path in this repository's history**, so that widget set has
never rendered, not once. `payments` and `messages` named routes that do not
exist either. `contracts` *was* reachable, but its widget list was `[]` and an
empty list makes `WidgetManager` return `null`, so it was a second spelling of
"no rail". All four are deleted; "no rail" now has exactly one spelling.

**2. Three routes issuing a request for a property that cannot exist.** The
`startsWith('/properties/')` arm treated anything under that prefix as a detail
page and read the id with `pathname.split('/')[2]`:

| route | `propertyId` handed to `PropertyBookingWidget` |
|---|---|
| `/properties/drafts` | `"drafts"` |
| `/properties/recently-viewed` | `"recently-viewed"` |
| `/properties/address-detail` | `"address-detail"` |

`useProperty` is `enabled: Boolean(id)`, so each of those mounted a real
`GET /api/properties/drafts`. The guard beside it was a hand-maintained list of
segments that are not ids (`my`, `saved`, `eco`, `type`, `city`) — it had to name
every one, and it did not. **That is the same instrument that left three of six
`PlaceType` values unhandled in #416.**

**3. A rail chosen for a page that is not that page.** `/properties/city/[id]`
and `/properties/type/[type]` are LISTS and were getting the property DETAIL
rail, booking widget included.

## The fix — option 3, the total map

`packages/frontend/components/widgets/routeRail.ts` maps **every one of the 69
route patterns** to a widget set or to `null`. Params are declared per route
(`propertyIdParam`, `cityParam`) and read off the **matched pattern**, so nothing
counts slashes and no list of not-an-id words is needed. A static segment beats a
dynamic one, so `/properties/create` resolves to itself rather than to
`/properties/[id]` — a property of the matcher now, not of ladder order.

`RightBar` decides nothing: it asks the map and renders the answer, or `null`.

**The rule I applied, stated in the module so the next reader inherits it rather
than guessing:** *a route keeps the rail the previous code demonstrably CHOSE for
it; every route that only ever received Home's by fall-through gets `null`.*
`null` is not "unknown" — it is the decision "no rail here", the issue's safest
default. Upgrading any of them to a real rail is a product call, and it is now a
one-line reviewable change instead of something a route acquires by existing.

Two places I did NOT apply that mechanically, both stated because they are the
judgement calls in this PR:

- `/properties/city/[id]` → the LIST rail with its `city` param, because the
  replaced code carried a branch extracting that city specifically for
  `NeighborhoodRatingWidget`. That is preserved intent, not a new decision.
  `/properties/type/[type]` follows it as the same surface.
- `/saved*` → `null` rather than re-pointing the orphaned `saved-properties`
  rail at it. Choosing a rail for the saved pages is a product decision nobody
  has made, and reviving it from a constant that has never rendered would be
  guessing at intent. Say the word and it is one line.

## Is a total map practical? Yes — measured, not assumed

69 routes, of which 20 carry dynamic segments, no catch-alls, max depth 3. The
map is a literal; the matcher handles the segments. Costs one entry per new
screen, and the test tells you exactly which entry is missing, by name. I did not
need to fall back to options 1 or 2.

## The test derives the route list from the tree

`__tests__/widgets/routeRailTotality.test.ts` (19 cases) walks the real `app/`
directory with expo-router's own rules — `(group)` transparent, `index` is its
directory, `.web`/`.native` collapse to one route — and asserts:

- **every route the router serves has an entry** (the gate);
- **no entry names a route that does not exist** (the direction that caught
  `saved-properties`);
- **every `ScreenId` is reached by some route** (so a widget set cannot outlive
  its page);
- **no two patterns could match the same pathname**;
- **the RESOLVER agrees with the map for all 69**, not for a sample.

`SCREEN_IDS` moved to its own `screenIds.ts` for this: enumerating them at
runtime from `WidgetManager.tsx` drags in every widget and, through them,
`expo-router`, which ships ESM this jest config does not transform. A vocabulary
is data.

**Anti-vacuity:** `routeFromFile` carries positive controls (group, index,
dynamic, nested dynamic, platform variant) and negative ones (`_layout`,
`+html`, `+not-found`, a non-source file); the walk has a floor of 45 routes
against 69 real ones, because `expect([]).toEqual([])` is exactly what a broken
traversal produces.

**A filesystem walk, not `git ls-files`, and the reason is not carelessness.**
The repo's other scans ask "is this pattern anywhere in the tracked source",
where git's index is the authority. This asks "what routes does the ROUTER
serve", and expo-router resolves from the filesystem — an untracked file under
`app/` is a live route in development, and a scan that could not see it would
report a total map while the router had a route the map does not know. `app/`
holds no build output, so the usual reason to prefer the index does not apply.

`__tests__/widgets/rightBarRail.test.tsx` (6 cases) is the second file, and
mutation 3 below is why it exists: the map being total is not the same as the
screen rendering it.

## Mutation evidence

Each confirmed landed before running (file diffed and md5'd), each restored from
a namespaced pristine copy — never `git checkout` — and each restore verified by
md5 plus markers from my own edit.

**M1 — delete a route's entry** (`'/reviews': NO_RAIL,` removed). → exit 1,
**3 red of 19**, and `/reviews` is NAMED three times in the output:

```
✕ finds a rail decision for every route the router serves
✕ matches each route to its own pattern
✕ returns the rail the map declares, for every route
```

The first attempt of this mutation exposed a flaw in my own test — the third
assertion crashed with `TypeError: Cannot read properties of undefined (reading
'rail')` instead of naming the route. Fixed with `?.` (a missing entry yields
`undefined`, which never equals the resolver's `null`, so the route is still
reported), re-run, and the TypeError count is now **0** with the route named 3×.

**M2 — restore the `'home'` fall-through** (`UNMATCHED` → `{ screenId: 'home' }`).
→ exit 1, **2 red across BOTH new files**:

```
✕ an unrecognised pathname gets NO rail › renders nothing rather than Home
✕ a route with no rail renders nothing › mounts nothing for a pathname that is not a route at all
```

**M3 — make `RightBar` ignore the map** (drop the `null` guard, pass
`rail.screenId ?? 'home'`). → exit 1, and this is the one that justifies the
second test file: `routeRailTotality` and `featuredWidgetScope` **stayed GREEN**,
and only the render test went red, 3 cases. A perfect map plus a component that
renders Home anyway is a state the map tests cannot see.

## Verification

Full output and exit code read for every command; no check was judged by whether
a grep matched.

| Check | Result |
|---|---|
| `typecheck` | exit **0** |
| `test` (frontend) | exit **0** — **39 suites, 540 tests**, all passed |
| `build` | exit **0** |
| `check:cold-start / /properties /reviews /saved /explore` | exit **0** — all five `visibility=visible`, `consoleErrors: []`, `pageErrors: []` |
| `node scripts/check-docs.mjs` | exit **0** — 25 pages, 20 routers, 24 frontend segments, no drift |
| `bun run check:lockfile` | not re-run — no dependency change in this PR |
| `lint` | exit 1 on the **same 25 problems / 2 errors** as the pre-change baseline, in files this PR does not touch. My files produce **zero** output (positive control: `SindiExplanationBottomSheet` appears 2×; negative control: 0). One warning I *did* introduce (`ReadonlyArray<T>` → `readonly T[]`) is fixed. |

**Real browser, 1600×1000, against the built `dist`** — the cold-start check runs
at 1280 (above `RightBar`'s 990 breakpoint) but samples 120 characters, too few
to see a rail:

- `/` — rail intact: Featured Properties, Support Our Mission, Horizon
  Initiative, Eco-Certified Properties. `consoleErrors: []`.
- `/reviews` — **no rail at all**; the content panel takes the full width and the
  page ends at "Cities with reviews". `consoleErrors: []`. Before this change it
  carried Recently viewed + Featured Properties + Donation + Horizon + Eco-Cert.

**One thing I will not hide:** the first full-suite run after wiring this up died
with `SIGSEGV` in the jest runner — no test failure, no summary. It did not
reproduce: three consecutive runs immediately after were **534/534 green**, and
the final run at 540/540. I could not attribute it to anything in this change and
am reporting it rather than omitting it.

## Follow-ups, not done here

- **`AGENTS.md` has no line saying "a new route needs a `ROUTE_RAIL` entry".**
  The module header and the failing test message both say it, and the test is
  self-enforcing, so nothing is silently lost — but it is a docs-keeper-shaped
  edit if you want it there.
- Upgrading any `null` route to a real rail (`/saved`, `/properties/my`,
  `/properties/drafts`) is a product decision, deliberately left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
