### PR TITLE
ci(lint): arm the lint job, which has never once run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,38 +345,36 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
           NODE_ENV: production
 
-  # ─────────────────────────────────────────────────────────────────────────
-  # `lint` is still OFF BY DEFAULT. A job that is red on every pull request from
-  # the day it lands is not a gate — it is a thing the next person disables — so
-  # it stays behind a repository variable until `bun run lint` exits 0, and the
-  # debt stays visible in the place the gate will live.
-  #
-  # `frontend-typecheck` was the other one and is now ARMED, below: it exits 0,
-  # so its switch was removed rather than left set to `ready`. A switch that
-  # nobody needs is a switch someone can flip the wrong way.
-  #
-  # To turn `lint` on: fix the errors it reports, then delete its `if:` — not
-  # set the variable. Same reasoning.
-  # ─────────────────────────────────────────────────────────────────────────
-
   lint:
-    # Set HOMIIO_LINT_GATE=ready once `bun run lint` exits 0.
+    # ARMED. `bun run lint` exits 0 across all four packages.
     #
-    # Today it does not: backend 344 errors, listing-providers 15, frontend 14;
-    # shared-types is clean. #249 removed the noise that made this unreadable
-    # (jest globals, 3555 false `no-undef`s), so what remains is real: 272
-    # `no-require-imports` in a package that is deliberately "type":"commonjs",
-    # 57 unused-vars, and 10 genuine `no-undef`s. listing-providers' 15 include 6
-    # `no-undef` on DOM/undici types (RequestInit), which is the case #249's fix
-    # does not cover — its config still needs typescript-eslint's
-    # `eslint-recommended` to stop the base rule reporting TypeScript types.
+    # It was gated on `vars.HOMIIO_LINT_GATE == 'ready'` from #254 until this
+    # commit, and that variable was never set — at the repository or the org —
+    # so the job was SKIPPED on every run it ever appeared in. A skipped job is
+    # not a neutral outcome on a pull request: `gh pr checks` prints it as
+    # `skipping` in the same list as the passes, the run concludes `success`,
+    # and any check that counts failures rather than naming the jobs it expects
+    # reads the whole thing as green. The presence of a job says nothing about
+    # what it ran.
     #
-    # NOTHING IS BUILT IN THIS JOB, ON PURPOSE. `eslint .` in the backend has no
-    # `ignores`, and eslint 9's flat config does not skip `dist/` by default, so
-    # a build step before this would lint generated `.d.ts` output and add 214
-    # phantom errors. That is why `bun run lint` gives 344 on a clean checkout
-    # and 558 after `bun run build` — measured, both ways, on the same commit.
-    if: vars.HOMIIO_LINT_GATE == 'ready'
+    # The debt the switch was waiting on is gone, and not because a rule was
+    # relaxed: no severity in any of the four eslint configs has changed since
+    # #254. `require(` in backend `.ts` went 268 -> 15 while the package GREW
+    # from 302 to 449 files, which is the Postgres port paying off the 272
+    # `no-require-imports` that made up most of the original 344.
+    #
+    # Measured on this commit, `bun run lint`: backend 0 errors / 102 warnings,
+    # frontend 0 / 23, listing-providers and shared-types clean. Warnings do not
+    # fail the job. That is deliberate for now and it is a REAL gap — nothing
+    # here stops the warning count growing — but 101 of the 102 backend warnings
+    # are `@typescript-eslint/no-explicit-any`, and pinning a ceiling before
+    # those are typed would only teach the next person to raise the ceiling.
+    #
+    # NOTHING IS BUILT IN THIS JOB, ON PURPOSE — eslint does not typecheck, so a
+    # build buys nothing and costs minutes. The generated output that used to
+    # make this dangerous (`bun run lint` reporting 344 on a clean tree and 558
+    # after `bun run build`) is now excluded by `ignores: ['dist/**']` in the
+    # backend and frontend configs rather than by hoping nobody builds first.
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/packages/backend/__tests__/db/placePoiCache.test.ts
+++ b/packages/backend/__tests__/db/placePoiCache.test.ts
@@ -25,7 +25,6 @@
  * that only wrote once could not tell any of those apart.
  */
 
-import { eq } from 'drizzle-orm';
 import type { NearbyServiceCategory } from '@homiio/shared-types';
 
 import { getDb } from '../../db/postgres';

--- a/packages/backend/controllers/billingController.ts
+++ b/packages/backend/controllers/billingController.ts
@@ -68,11 +68,13 @@ async function applySubscriptionState(oxyUserId: string, columns: SubscriptionSt
   return readEntitlements(oxyUserId);
 }
 
-// Lazy require Stripe to avoid hard crash if not configured
+// Construct the client lazily, so an unconfigured deployment answers 501
+// rather than throwing. Nothing here is required lazily — `stripe` is a static
+// import at the top of this file and loads with the module either way; it is
+// `new Stripe(key)` that must not run without a key.
 function getStripe() {
   const key = config.stripe?.secretKey;
   if (!key) return null;
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   return new Stripe(key, { apiVersion: '2024-06-20' });
 }
 

--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -2,7 +2,7 @@
 import 'dotenv/config';
 
 import express from "express";
-import type { Request, Response, NextFunction } from 'express';
+import type { Request, Response } from 'express';
 import cors, { type CorsOptions } from 'cors';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';

--- a/packages/frontend/app/(tabs)/saved/watches/[watchId].tsx
+++ b/packages/frontend/app/(tabs)/saved/watches/[watchId].tsx
@@ -20,7 +20,7 @@
  * second before flipping the first and finding out nothing happens.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet, View } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { useTranslation } from 'react-i18next';

--- a/packages/frontend/components/SindiExplanationBottomSheet.tsx
+++ b/packages/frontend/components/SindiExplanationBottomSheet.tsx
@@ -80,9 +80,20 @@ export function SindiExplanationBottomSheet({ onClose }: SindiExplanationBottomS
   const onLayout = useCallback(
     (e: LayoutChangeEvent) => {
       const w = e.nativeEvent.layout.width;
-      if (w && Math.abs(w - layoutWidth) > 1) setLayoutWidth(w);
+      if (!w || Math.abs(w - layoutWidth) <= 1) return;
+      setLayoutWidth(w);
+      // Per-step heights were measured at the OLD width, so a width change
+      // (orientation, split view) makes every one of them stale. This resets
+      // them where the width changes rather than in an effect keyed on
+      // `layoutWidth`: this handler is the only caller of `setLayoutWidth`, so
+      // no other path could have fired that effect, and keeping both state
+      // updates in one event lets React batch them into a single render instead
+      // of the extra pass an effect-driven reset costs.
+      heights.value = Array(TOTAL_STEPS).fill(0);
+      setContainerHeight(0);
+      heightAnim.value = 0;
     },
-    [layoutWidth],
+    [layoutWidth, heights, heightAnim],
   );
 
   const handleStepChange = useCallback((nearest: number) => {
@@ -129,13 +140,6 @@ export function SindiExplanationBottomSheet({ onClose }: SindiExplanationBottomS
       easing: Easing.out(Easing.quad),
     });
   }, [containerHeight, heightAnim]);
-
-  // Reset cached heights when width changes (e.g., orientation)
-  useEffect(() => {
-    heights.value = Array(TOTAL_STEPS).fill(0);
-    setContainerHeight(0);
-    heightAnim.value = 0;
-  }, [layoutWidth, heightAnim, heights]);
 
   const handleScrollEnd = useCallback(
     (e: NativeSyntheticEvent<NativeScrollEvent>) => {


### PR DESCRIPTION
## The finding

`lint` has carried `if: vars.HOMIIO_LINT_GATE == 'ready'` since #254. **That variable has never existed.**

```
$ gh api repos/:owner/:repo/actions/variables
COPILOT_AGENT_FIREWALL_ENABLED, EXPO_PUBLIC_OXY_CLIENT_ID     (total_count: 2)
$ gh api orgs/OxyHQ/actions/variables
total_count: 0
```

Checked at both levels deliberately: on the free org plan an org variable scoped to "Public repositories" reaches a private repo as an empty string with no error. There is no such variable at either level, so the condition has been false in every run since #254 and the linter has never executed against this repository.

**The control, read off a real run rather than the YAML** — run [31445190129](https://github.com/OxyHQ/Homiio/actions/runs/31445190129) (PR #422, `fix/featured-widget-scope`):

| job | status | conclusion |
|---|---|---|
| lockfile, backend, frontend, frontend-bundle, frontend-typecheck | completed | **success** |
| **lint** | completed | **skipped** |

and the **run** concludes `success`. `gh pr checks` prints it as `skipping  0s` in the same list as eleven passes.

One correction to how this was filed: the gate is on the **job**, not on a step, so the pair is a skipped JOB inside a success RUN rather than a skipped step inside a success job. The hazard is the same and arguably worse at that level — nothing is red, branch protection is untroubled, and any check that counts failures instead of naming the jobs it requires reads the whole thing as green.

## The debt was already paid, and not by relaxing a rule

#254 recorded backend 344 errors, listing-providers 15, frontend 14. Measured on `13d0849d`, `bun run lint` reports **0 errors in all four packages**.

That needed a control, because "someone downgraded the rules" produces the same number. It wasn't that:

- **No severity in any of the four eslint configs has changed since #254.** The only edits to `packages/backend/eslint.config.mjs` are an added `ignores: ['dist/**']` and `flat/eslint-recommended`; the `rules` block is untouched.
- `require(` in backend `.ts` went **268 → 15** while the package **grew 302 → 449 files**. That is the Postgres port retiring the 272 `no-require-imports` that made up most of the 344 — real code change, not bookkeeping.

## Histogram

Measured with the command CI runs (`bun run lint`). The frontend numbers are from `expo lint`, not a bare `eslint .` — those disagree (5/121 vs 2/23) because `expo lint` scopes differently, and the wrong one would have been a fiction.

| package | before | after |
|---|---|---|
| backend | 2 errors, 102 warnings | **0 errors**, 101 warnings |
| frontend | 2 errors, 23 warnings | **0 errors**, 23 warnings |
| listing-providers | clean | clean |
| shared-types | clean | clean |

By rule, before:

| n | sev | rule | package |
|---|---|---|---|
| 101 | warning | `@typescript-eslint/no-explicit-any` | backend |
| 2 | **error** | `@typescript-eslint/no-unused-vars` | backend |
| 1 | warning | unused `eslint-disable` directive | backend |
| 12 | warning | `react-hooks/exhaustive-deps` | frontend |
| 8 | warning | `unused-imports/no-unused-vars` | frontend |
| 3 | warning | `import/no-named-as-default-member` | frontend |
| 1 | **error** | `react-hooks/set-state-in-effect` | frontend |
| 1 | **error** | `unused-imports/no-unused-imports` | frontend |

No rule was disabled and no `eslint-disable` was added to reach zero. One was **removed**.

## The four errors

1. **Three unused imports** — `NextFunction` (server.ts), `eq` (placePoiCache.test.ts), `useState` (saved watch screen). Each named exactly once in its file, on the import line; confirmed per file by grep, not by the linter alone.
2. **`billingController.ts:75`** — an `eslint-disable-next-line @typescript-eslint/no-var-requires` that excused nothing, above a comment claiming "Lazy require Stripe". There is no require: `stripe` is a static import at line 15 and loads with the module either way; what is deferred is `new Stripe(key)`. Directive and comment go together, since both were halves of the same wrong statement. (The rule it named no longer exists in typescript-eslint v8 — nothing had reported the directive as unused because nothing ran the linter.)
3. **`SindiExplanationBottomSheet.tsx:136`** — `react-hooks/set-state-in-effect`. The width-change reset moves out of the effect keyed on `layoutWidth` and into `onLayout`, which is the **only** caller of `setLayoutWidth` (one call site, checked), so the effect could not fire for any other reason. Both state updates now sit in one event and React batches them into a single render. The effect's mount run was already a no-op and stays one — it assigned each of the three values what the component had just initialised it to. This is the event-handler-instead-of-`useEffect` form `~/AGENTS.md` asks for, and it does not touch the `react-hooks/immutability` exemption this file carries from #269, which is about Reanimated shared-value writes and is argued on its own premise.

## Verification

- `bun run lint` → **exit 0**, all four packages.
- **Mutation test, because exit 0 is also what a lint that scanned nothing reports.** Appending `const __lintMutationProbe: number = 1;` to server.ts took backend from 0 errors to 1 and `bun run lint` to exit 1. Confirmed the mutation applied (`git diff --stat` plus a grep for the probe) before running, then restored from a pristine copy — not `git checkout` — and asserted a marker from my own edit survived the restore.
- `bun x tsc --noEmit -p packages/backend/tsconfig.json` → 0 errors, and `packages/frontend` typecheck → 0. Worth recording: run without `bun run --filter @homiio/listing-providers build` first, the backend reports **194** errors. That is the missing build, not this branch — CI builds listing-providers before typechecking and so must any local check.
- All 8 CI gate self-tests pass, plus `check:docs` and `check-version-pins.sh`.

## What this does NOT change

`deploy-backend` needs `[backend, frontend, frontend-typecheck, lockfile, frontend-bundle]` — `lint` is deliberately absent and stays absent. Arming lint gates pull requests, not deploys. Whether a lint failure should block a production rollout is a separate policy call and not this PR's to make.

## The gap left open, stated rather than hidden

**124 warnings remain and do not fail the job.** Nothing here stops that number growing, which is a real weakness in the gate and is recorded as such in the job's own comment.

I did not pin a ceiling with `--max-warnings`. 101 of the 124 are `@typescript-eslint/no-explicit-any` in backend controllers; typing them is a separate piece of work, and a ceiling set before that lands would go red on unrelated PRs whose cheapest green is to raise the ceiling — the gate switching itself off one defensible line at a time. It is also a poor moment: a dozen worktrees are mid-Postgres-port on this repo right now. Better as a follow-up that lands with the typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)