### PR TITLE
feat(addresses): one chokepoint that turns a candidate into a canonical place (#360)

### DIFF
--- a/packages/backend/__tests__/db/expiry.test.ts
+++ b/packages/backend/__tests__/db/expiry.test.ts
@@ -93,7 +93,7 @@ describe('expiry sweep registry', () => {
     expect(violations).toEqual([]);
   });
 
-  it('registers exactly the five columns that mean "delete this row"', async () => {
+  it('registers exactly the six columns that mean "delete this row"', async () => {
     // A vacuity floor with teeth: `findUnsupportedExpiryColumns` over an EMPTY
     // registry returns `[]` and passes the assertion above while checking
     // nothing at all. Naming the entries is what makes that assertion mean
@@ -106,16 +106,24 @@ describe('expiry sweep registry', () => {
     // source, four here, one refused" a checked statement rather than an
     // arithmetic claim in a comment.
     //
-    // `housing_domain_events.expires_at` (#356) is the FIFTH entry and has no
-    // Mongo ancestor at all — it was registered when the table was created
-    // rather than found by that census. That is the shape this registry wants
-    // every future table to arrive in, and it is why the count in this test's
-    // NAME is now the registry's size rather than the census's: the two stopped
-    // being the same number the moment a table was born on Postgres.
+    // `housing_domain_events.expires_at` (#356) and `address_candidates.expires_at`
+    // (#360) are the fifth and sixth entries and have no Mongo ancestor at all —
+    // both were registered when the table was created rather than found by that
+    // census. That is the shape this registry wants every future table to arrive
+    // in, and it is why the count in this test's NAME is the registry's size
+    // rather than the census's: the two stopped being the same number the moment
+    // a table was born on Postgres.
     const registered = EXPIRY_SWEEP_TARGETS.map(
       (target) => `${getTableName(target.table)}.${sqlColumnName(target.column)}`,
     ).sort();
     expect(registered).toEqual([
+      // #360's candidate table is the SIXTH entry and, like
+      // `housing_domain_events` below, has no Mongo ancestor: it was registered
+      // when the table was created rather than found by that census. A candidate
+      // is an OBSERVATION whose every audit-relevant fact is copied by value
+      // onto `address_materializations` at materialization time, so the sweep
+      // costs a materialized place nothing.
+      'address_candidates.expires_at',
       'housing_domain_events.expires_at',
       'moderation_events.expires_at',
       'moderation_outbox.expires_at',

--- a/packages/backend/__tests__/db/housingMaterialization.test.ts
+++ b/packages/backend/__tests__/db/housingMaterialization.test.ts
@@ -1,0 +1,738 @@
+/**
+ * `materializeHousingCandidate`, against a REAL Postgres server.
+ *
+ * A real server is not optional for any of this. `addresses.address_level` is a
+ * GENERATED column, the identity and idempotency indexes are PARTIAL (so an
+ * `ON CONFLICT` naming one either infers the right arbiter or fails at RUNTIME
+ * with `42P10`, never at compile time), the SQLSTATE of a CHECK violation lives
+ * on drizzle's `cause` rather than on the error it throws, and a failed
+ * statement inside a transaction aborts the whole thing with `25P02`. None of
+ * the four is observable against a mock: a mocked insert that rejects leaves no
+ * aborted transaction behind, so a recovery path passes in the test and fails in
+ * production.
+ *
+ * ## The fixtures are built to make the DISTINCTIONS visible
+ *
+ * Several assertions here would pass against a broken implementation if the
+ * fixtures were tidier, and each is called out where it sits:
+ *
+ *  - the ambiguity zone needs a genuine near-duplicate (`42` versus
+ *    `42, entrance A`) AND a control that must NOT be ambiguous (`43`), because
+ *    a fixture set with no near-duplicate cannot tell "returned ambiguity
+ *    correctly" from "found nothing";
+ *  - the two-units-in-one-building case needs TWO units, because one unit's
+ *    parent is the same row whether the hierarchy works or collapses;
+ *  - the idempotency index needs an explicit-NULL fixture, because a suite whose
+ *    calls all pass a key cannot tell a partial unique index from a total one;
+ *  - the level derivation needs a row carrying `''`, which the writer can never
+ *    produce, so it is inserted by raw SQL.
+ */
+
+import { eq, sql } from 'drizzle-orm';
+import { constraintNameOf, uuidv7 } from '@oxyhq/db';
+
+import { closePostgres, connectPostgres, type Database } from '../../db/postgres';
+import {
+  addressCandidates,
+  addressExternalRefs,
+  addressMaterializations,
+  addresses,
+  cities,
+} from '../../db/schema';
+import { findOrCreateCanonicalAddress } from '../../services/addressService';
+import { deriveAddressLevel } from '../../services/addressIdentity';
+import {
+  materializeHousingCandidate,
+  type HousingCandidateDraft,
+  type MaterializationResult,
+} from '../../services/housingMaterialization';
+
+let db: Database;
+
+/**
+ * One city per RUN, and one per CASE.
+ *
+ * `city_id` is a hard equality filter in every lookup this module makes, so a
+ * per-case city isolates each case completely — from a rerun, from a sibling
+ * jest worker, and from the other cases in this file.
+ *
+ * That last one is not hypothetical. The first draft of this file put the run
+ * token in the STREET names instead, so every street here shared a
+ * 12-character substring; `pg_trgm` similarity between unrelated fixtures ran
+ * 0.61-0.74, and three cases reported an ambiguity that had nothing to do with
+ * what they were testing. Street names are therefore realistic and the isolation
+ * lives in the city.
+ */
+const SUITE = uuidv7().slice(-12);
+let caseIndex = 0;
+function nextCity(): string {
+  caseIndex += 1;
+  return `Materializeville ${SUITE} ${caseIndex}`;
+}
+
+/** Barcelona-ish, so distances between fixtures are metres rather than degrees. */
+const BASE_POINT = { longitude: 2.17, latitude: 41.39 };
+
+beforeAll(async () => {
+  db = await connectPostgres();
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+/**
+ * A candidate with every geo NAME the geocoder would otherwise be asked for.
+ *
+ * `city`, `state` and `countryCode` together make `resolveGeoNames`
+ * short-circuit, so nothing in this file makes a network call — the same
+ * arrangement `reviewAddressHierarchy.test.ts` relies on.
+ */
+function draft(city: string, overrides: Partial<HousingCandidateDraft> = {}): HousingCandidateDraft {
+  return {
+    provider: 'osm',
+    rawText: 'Carrer de Provença 42, Barcelona',
+    origin: 'geocoder',
+    precision: 'exact',
+    longitude: BASE_POINT.longitude,
+    latitude: BASE_POINT.latitude,
+    proposedCity: city,
+    proposedRegion: 'Catalonia',
+    proposedCountry: 'Spain',
+    proposedCountryCode: 'ES',
+    proposedStreet: 'Carrer de Provença',
+    proposedPostalCode: '08013',
+    ...overrides,
+  };
+}
+
+/** Materialize under a listing upsert, the ordinary durable action. */
+function materialize(
+  candidate: HousingCandidateDraft,
+  extra: { idempotencyKey?: string; confirmedAddressId?: string } = {},
+): Promise<MaterializationResult> {
+  return materializeHousingCandidate(
+    { candidate, confirmedAddressId: extra.confirmedAddressId },
+    {
+      action: 'listing_upsert',
+      actorOxyUserId: `oxy-${SUITE}`,
+      idempotencyKey: extra.idempotencyKey,
+    },
+  );
+}
+
+/** Narrow to the success branch, failing loudly with the actual status. */
+function expectMaterialized(result: MaterializationResult) {
+  if (result.status !== 'materialized') {
+    throw new Error(
+      `expected a materialized result, got ${result.status}: ${JSON.stringify(result)}`,
+    );
+  }
+  return result;
+}
+
+async function addressRow(id: string) {
+  const [row] = await db.select().from(addresses).where(eq(addresses.id, id)).limit(1);
+  return row;
+}
+
+/** Every address in one CITY, at any level. Scoped, so no other case leaks in. */
+async function addressCountInCity(city: string): Promise<number> {
+  const rows = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(addresses)
+    .innerJoin(cities, eq(addresses.cityId, cities.id))
+    .where(eq(cities.name, city));
+  return Number(rows[0]?.count ?? 0);
+}
+
+/** Every address in one city carrying `entrance`, for the "wrote nothing" checks. */
+async function addressesWithEntranceInCity(city: string, entrance: string) {
+  return db
+    .select({ id: addresses.id })
+    .from(addresses)
+    .innerJoin(cities, eq(addresses.cityId, cities.id))
+    .where(sql`${cities.name} = ${city} and ${addresses.entrance} = ${entrance}`);
+}
+
+describe('the candidate → canonical boundary', () => {
+  it('creates the street → building → unit chain in order, with stored parents', async () => {
+    const city = nextCity();
+    const result = expectMaterialized(
+      await materialize(
+        draft(city, {
+          proposedStreet: 'Carrer de Provença',
+          proposedNumber: '42',
+          proposedFloor: '3r',
+          proposedUnit: '1a',
+        }),
+      ),
+    );
+
+    expect(result.addressLevel).toBe('UNIT');
+    expect(result.unitAddressId).toBe(result.addressId);
+    expect(result.buildingAddressId).not.toBeNull();
+    expect(result.streetAddressId).not.toBe(result.buildingAddressId);
+    expect(result.match.matchKind).toBe('created');
+
+    const unit = await addressRow(result.addressId);
+    const building = await addressRow(result.buildingAddressId ?? '');
+    const streetRow = await addressRow(result.streetAddressId);
+
+    // The LEVELS are what the database computed, not what this code asserted.
+    expect(unit.addressLevel).toBe('UNIT');
+    expect(building.addressLevel).toBe('BUILDING');
+    expect(streetRow.addressLevel).toBe('STREET');
+
+    // The hierarchy is STORED, which is the whole point of `parent_address_id`.
+    expect(unit.parentAddressId).toBe(building.id);
+    expect(building.parentAddressId).toBe(streetRow.id);
+    expect(streetRow.parentAddressId).toBeNull();
+
+    // Only the identifying fields for each level are carried down.
+    expect(building.floor).toBeNull();
+    expect(streetRow.number).toBeNull();
+
+    // The provenance record exists and names the action that authorised it.
+    const [provenance] = await db
+      .select()
+      .from(addressMaterializations)
+      .where(eq(addressMaterializations.id, result.materializationId));
+    expect(provenance.durableAction).toBe('listing_upsert');
+    expect(provenance.candidateId).toBe(result.candidateId);
+    expect(provenance.addressId).toBe(result.addressId);
+    // Copied BY VALUE, so the audit survives the candidate's expiry sweep.
+    expect(provenance.rawText).toBe('Carrer de Provença 42, Barcelona');
+    expect(provenance.normalizationVersion).toBeGreaterThan(0);
+  });
+
+  it('gives two units of one building two identities and one shared parent', async () => {
+    // THE discriminating fixture for ADR 0001 §1.3. Under the v1 key these two
+    // are ONE row, because `floor` decides the level and is absent from that
+    // key — and one unit alone cannot show it, since its parent is the same row
+    // whether the hierarchy works or collapses.
+    const city = nextCity();
+    const first = expectMaterialized(
+      await materialize(
+        draft(city, { proposedStreet: 'Carrer de Provença', proposedNumber: '42', proposedFloor: '3r' }),
+      ),
+    );
+    const second = expectMaterialized(
+      await materialize(
+        draft(city, { proposedStreet: 'Carrer de Provença', proposedNumber: '42', proposedFloor: '4t' }),
+      ),
+    );
+
+    expect(second.addressId).not.toBe(first.addressId);
+    expect(second.buildingAddressId).toBe(first.buildingAddressId);
+    expect(second.streetAddressId).toBe(first.streetAddressId);
+
+    const rows = await db
+      .select({ id: addresses.id, level: addresses.addressLevel, floor: addresses.floor })
+      .from(addresses)
+      .where(eq(addresses.parentAddressId, first.buildingAddressId ?? ''));
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.floor).sort()).toEqual(['3r', '4t']);
+    expect(rows.every((row) => row.level === 'UNIT')).toBe(true);
+  });
+
+  it('gives two entrances of one address two buildings under one street', async () => {
+    // The other half of the same defect: `entrance` decides the level and is
+    // absent from the v1 key, so `100 Esc. A` and `100 Esc. B` are one row today.
+    const city = nextCity();
+    const a = expectMaterialized(
+      await materialize(
+        draft(city, { proposedStreet: 'Avinguda del Mar', proposedNumber: '100', proposedEntrance: 'A' }),
+      ),
+    );
+    const b = expectMaterialized(
+      await materialize(
+        draft(city, { proposedStreet: 'Avinguda del Mar', proposedNumber: '100', proposedEntrance: 'B' }),
+      ),
+    );
+
+    expect(b.addressId).not.toBe(a.addressId);
+    expect(b.streetAddressId).toBe(a.streetAddressId);
+    expect((await addressRow(a.addressId)).addressLevel).toBe('BUILDING');
+    expect((await addressRow(b.addressId)).addressLevel).toBe('BUILDING');
+  });
+
+  it('folds a doubled space, a trailing space, case and an accent onto one identity', async () => {
+    // ADR 0001 §10.10. The v1 key already folds case and a trailing space and
+    // SPLITS on an internal double space, so the fourth spelling is the one that
+    // discriminates v2 from v1 — a fixture set without it would pass either way.
+    const city = nextCity();
+    const ids = new Set<string>();
+    for (const buildingName of ['Torre Mapfre', 'torre mapfre', 'Torre Mapfre ', 'Torré  Mapfre']) {
+      const result = expectMaterialized(
+        await materialize(
+          draft(city, { proposedStreet: 'Avinguda del Port', proposedBuildingName: buildingName }),
+        ),
+      );
+      ids.add(result.addressId);
+    }
+    expect(ids.size).toBe(1);
+  });
+
+  it('keeps a roman-numeral pair apart', async () => {
+    // The control for the case above, and the reason normalization stops where
+    // it does: `Torre Mapfre I` and `Torre Mapfre II` are two real buildings in
+    // one development, so a normalizer aggressive enough to merge them would
+    // trade a split for a much worse merge.
+    const city = nextCity();
+    const one = expectMaterialized(
+      await materialize(
+        draft(city, { proposedStreet: 'Avinguda dels Romans', proposedBuildingName: 'Torre Mapfre I' }),
+      ),
+    );
+    const two = await materialize(
+      draft(city, { proposedStreet: 'Avinguda dels Romans', proposedBuildingName: 'Torre Mapfre II' }),
+    );
+    // `Torre Mapfre I` and `Torre Mapfre II` are COMPATIBLE only if one side is
+    // absent, and both name a building — so this is not even an ambiguity.
+    expect(two.status).toBe('materialized');
+    if (two.status !== 'materialized') throw new Error('unreachable');
+    expect(two.addressId).not.toBe(one.addressId);
+  });
+});
+
+describe('idempotency and concurrency', () => {
+  it('returns the same entity for the same candidate confirmed twice', async () => {
+    const city = nextCity();
+    const first = expectMaterialized(
+      await materialize(draft(city, { proposedStreet: 'Carrer de Balmes', proposedNumber: '7' })),
+    );
+    const second = expectMaterialized(
+      await materialize(draft(city, { proposedStreet: 'Carrer de Balmes', proposedNumber: '7' })),
+    );
+
+    expect(second.addressId).toBe(first.addressId);
+    expect(second.match.matchKind).toBe('exact_identity_key');
+    // Two candidates — a candidate is an EVENT and is deliberately not deduped
+    // globally (ADR 0001 §2.2) — and one place, plus its street.
+    expect(second.candidateId).not.toBe(first.candidateId);
+    expect(await addressCountInCity(city)).toBe(2);
+  });
+
+  it('collapses two calls carrying one idempotency key onto one materialization', async () => {
+    const city = nextCity();
+    const key = `idem-${SUITE}`;
+    const first = expectMaterialized(
+      await materialize(draft(city, { proposedStreet: 'Carrer de Muntaner', proposedNumber: '9' }), {
+        idempotencyKey: key,
+      }),
+    );
+    // A DIFFERENT address in the second call, so the replay is demonstrably keyed
+    // on the idempotency key rather than on the two candidates being identical.
+    const second = expectMaterialized(
+      await materialize(draft(city, { proposedStreet: 'Carrer de Muntaner', proposedNumber: '11' }), {
+        idempotencyKey: key,
+      }),
+    );
+
+    expect(second.addressId).toBe(first.addressId);
+    expect(second.materializationId).toBe(first.materializationId);
+
+    const rows = await db
+      .select({ id: addressMaterializations.id })
+      .from(addressMaterializations)
+      .where(eq(addressMaterializations.idempotencyKey, key));
+    expect(rows).toHaveLength(1);
+  });
+
+  it('permits any number of materializations with NO idempotency key', async () => {
+    // The explicit-NULL fixture. `address_materializations_idempotency_key` is
+    // PARTIAL, so NULLs coexist; a TOTAL unique index would satisfy every
+    // "rejects a duplicate key" assertion above and fail exactly here — which is
+    // the direction `CONVENTIONS.md` records as the one a suite usually cannot
+    // see.
+    const city = nextCity();
+    const ids: string[] = [];
+    for (const number of ['1', '2', '3']) {
+      const result = expectMaterialized(
+        await materialize(draft(city, { proposedStreet: 'Carrer de Girona', proposedNumber: number })),
+      );
+      ids.push(result.materializationId);
+    }
+    const rows = await db
+      .select({ id: addressMaterializations.id, key: addressMaterializations.idempotencyKey })
+      .from(addressMaterializations)
+      .where(sql`${addressMaterializations.id} in ${ids}`);
+    expect(rows).toHaveLength(3);
+    expect(rows.every((row) => row.key === null)).toBe(true);
+  });
+
+  it('converges when two requests for one dwelling race', async () => {
+    const city = nextCity();
+    const candidate = { proposedStreet: 'Carrer de la Cursa', proposedNumber: '5' };
+    const [a, b] = await Promise.all([
+      materialize(draft(city, candidate)),
+      materialize(draft(city, candidate)),
+    ]);
+    const first = expectMaterialized(a);
+    const second = expectMaterialized(b);
+    expect(second.addressId).toBe(first.addressId);
+    expect(await addressCountInCity(city)).toBe(2);
+  });
+});
+
+describe('ambiguity is returned, never guessed', () => {
+  it('refuses to decide between a building and the same building with an entrance', async () => {
+    const city = nextCity();
+    const existing = expectMaterialized(
+      await materialize(draft(city, { proposedStreet: 'Carrer del Rosselló', proposedNumber: '42' })),
+    );
+
+    // The genuine near-duplicate: every identifying field is COMPATIBLE (the
+    // stored row names no entrance), so nothing contradicts the claim that these
+    // are one place — and nothing establishes it either.
+    const ambiguous = await materialize(
+      draft(city, {
+        proposedStreet: 'Carrer del Rosselló',
+        proposedNumber: '42',
+        proposedEntrance: 'A',
+      }),
+    );
+
+    expect(ambiguous.status).toBe('ambiguous');
+    if (ambiguous.status !== 'ambiguous') throw new Error('unreachable');
+    expect(ambiguous.candidates.map((c) => c.addressId)).toContain(existing.addressId);
+    // Refusing to decide must not leave a row behind.
+    expect(await addressesWithEntranceInCity(city, 'a')).toHaveLength(0);
+  });
+
+  it('does NOT call two different numbers on one street ambiguous', async () => {
+    // The control, and the reason the ambiguity zone is usable at all: without
+    // the compatibility rule EVERY address on a street would be ambiguous, and
+    // the assertion above would pass for entirely the wrong reason.
+    const city = nextCity();
+    const first = expectMaterialized(
+      await materialize(draft(city, { proposedStreet: 'Carrer del Rosselló', proposedNumber: '42' })),
+    );
+    const second = await materialize(
+      draft(city, { proposedStreet: 'Carrer del Rosselló', proposedNumber: '43' }),
+    );
+
+    expect(second.status).toBe('materialized');
+    if (second.status !== 'materialized') throw new Error('unreachable');
+    expect(second.addressId).not.toBe(first.addressId);
+    expect(second.streetAddressId).toBe(first.streetAddressId);
+  });
+
+  it('accepts a confirmation and creates no rival row beside it', async () => {
+    const city = nextCity();
+    const existing = expectMaterialized(
+      await materialize(draft(city, { proposedStreet: 'Carrer de Casanova', proposedNumber: '42' })),
+    );
+    const before = await addressCountInCity(city);
+
+    const confirmed = expectMaterialized(
+      await materialize(
+        draft(city, {
+          proposedStreet: 'Carrer de Casanova',
+          proposedNumber: '42',
+          proposedEntrance: 'A',
+        }),
+        { confirmedAddressId: existing.addressId },
+      ),
+    );
+
+    expect(confirmed.addressId).toBe(existing.addressId);
+    expect(confirmed.match.matchKind).toBe('confirmed_probable');
+    // The confirmed row's OWN fields are authoritative, so `entrance A` did not
+    // acquire a building of its own. Without that rule this count would be one
+    // higher and the assertion above would still pass.
+    expect(await addressCountInCity(city)).toBe(before);
+    expect(await addressesWithEntranceInCity(city, 'a')).toHaveLength(0);
+  });
+});
+
+describe('conflicts are refused, never overwritten', () => {
+  it('refuses to move a provider ref that already names another place', async () => {
+    const city = nextCity();
+    const ref = `ref-${SUITE}`;
+    const first = expectMaterialized(
+      await materialize(
+        draft(city, { proposedStreet: 'Carrer de Balmes', proposedNumber: '1', providerRef: ref }),
+      ),
+    );
+
+    // A different street AND a different number, so the ref'd row is not even a
+    // probable match: the portal is claiming one id for two distinct places.
+    const conflict = await materialize(
+      draft(city, { proposedStreet: 'Avinguda Diagonal', proposedNumber: '2', providerRef: ref }),
+    );
+
+    expect(conflict.status).toBe('conflict');
+    if (conflict.status !== 'conflict') throw new Error('unreachable');
+    expect(conflict.conflicts[0].kind).toBe('provider_ref_bound_elsewhere');
+    expect(conflict.conflicts[0].existingAddressId).toBe(first.addressId);
+
+    // The ref still names the FIRST place — a silent move is the failure this
+    // refusal exists to prevent — and the second place was never created, since
+    // the conflict is decided before anything is written.
+    const [refRow] = await db
+      .select()
+      .from(addressExternalRefs)
+      .where(eq(addressExternalRefs.externalId, ref));
+    expect(refRow.addressId).toBe(first.addressId);
+    const diagonal = await db
+      .select({ id: addresses.id })
+      .from(addresses)
+      .innerJoin(cities, eq(addresses.cityId, cities.id))
+      .where(sql`${cities.name} = ${city} and ${addresses.street} = 'avinguda diagonal'`);
+    expect(diagonal).toHaveLength(0);
+  });
+
+  it('lets a provider ref survive the portal relabelling the same place', async () => {
+    const city = nextCity();
+    const ref = `stable-${SUITE}`;
+    const first = expectMaterialized(
+      await materialize(
+        draft(city, { proposedStreet: 'Carrer de Provença', proposedNumber: '3', providerRef: ref }),
+      ),
+    );
+
+    // Same ref, same number, same point — the portal has started spelling the
+    // street with a `z`. Identity by text no longer matches; the ref does, and
+    // the row it names is still a probable match, so the ref wins.
+    const again = expectMaterialized(
+      await materialize(
+        draft(city, { proposedStreet: 'Carrer de Provenza', proposedNumber: '3', providerRef: ref }),
+      ),
+    );
+    expect(again.addressId).toBe(first.addressId);
+    expect(again.match.matchKind).toBe('exact_external_ref');
+
+    const [refRow] = await db
+      .select()
+      .from(addressExternalRefs)
+      .where(eq(addressExternalRefs.externalId, ref));
+    // `first_seen_at` records when Homiio FIRST saw the identifier and must not
+    // be re-stamped; `last_seen_at` moves.
+    expect(refRow.lastSeenAt.getTime()).toBeGreaterThanOrEqual(refRow.firstSeenAt.getTime());
+  });
+});
+
+describe('validation refuses a permanent identity it cannot justify', () => {
+  it('refuses to materialize a building from a city centroid, and keeps the candidate', async () => {
+    // ADR 0001 §10.6: materializing from a centroid collapses every listing in
+    // one city onto a fabricated building that then accumulates reviews about
+    // unrelated flats. 94-100% of habitaclia and fotocasa listings carry one.
+    const city = nextCity();
+    const result = await materialize(
+      draft(city, { proposedStreet: 'Carrer del Centroide', proposedNumber: '8', precision: 'centroid' }),
+    );
+
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') throw new Error('unreachable');
+    expect(result.reason).toBe('imprecise_location');
+
+    // The candidate SURVIVES — that is what lets the listing be ingested and
+    // shown at city scope rather than dropped.
+    const [candidate] = await db
+      .select()
+      .from(addressCandidates)
+      .where(eq(addressCandidates.id, result.candidateId));
+    expect(candidate.materializedAddressId).toBeNull();
+    expect(candidate.rawText).toBe('Carrer de Provença 42, Barcelona');
+    expect(await addressCountInCity(city)).toBe(0);
+  });
+
+  it('refuses a candidate with no street', async () => {
+    const result = await materialize(draft(nextCity(), { proposedStreet: '   ' }));
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') throw new Error('unreachable');
+    expect(result.reason).toBe('missing_street');
+  });
+
+  it('refuses a candidate with no coordinates', async () => {
+    const result = await materialize(
+      draft(nextCity(), { proposedStreet: 'Carrer Sense Punt', longitude: null, latitude: null }),
+    );
+    expect(result.status).toBe('rejected');
+    if (result.status !== 'rejected') throw new Error('unreachable');
+    expect(result.reason).toBe('missing_coordinates');
+  });
+
+  it('lets the CHECK refuse an out-of-range coordinate, naming the constraint', async () => {
+    // Barcelona TRANSPOSED is a perfectly valid point in Turkey, which no range
+    // check can catch — so the fixture uses a pair that transposition makes out
+    // of range, which is the case the constraint exists for. PostGIS coerces
+    // latitude 200 into range with a NOTICE and SUCCEEDS, turning a bad
+    // coordinate into a different, entirely plausible place.
+    //
+    // The SQLSTATE is read through `constraintNameOf`, never off `error.code`:
+    // drizzle WRAPS the driver error, so the code lives on `cause` and a check
+    // written against the driver's own shape answers `undefined` for every real
+    // violation.
+    let caught: unknown;
+    try {
+      await materialize(
+        draft(nextCity(), {
+          proposedStreet: 'Carrer Transposat',
+          longitude: 41.39,
+          latitude: 200,
+        }),
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    expect(constraintNameOf(caught)).toBe('address_candidates_coordinates_check');
+  });
+});
+
+describe('living beside the v1 key', () => {
+  it('adopts a pre-v2 row rather than creating a rival beside it', async () => {
+    // A row written the way every existing caller writes one: a v1
+    // `normalized_key` and no `identity_key`, exactly like the 11,734 rows in
+    // production.
+    const city = nextCity();
+    const legacy = await findOrCreateCanonicalAddress({
+      // ACCENTED, which is the case that matters: v1 lowercases and trims but
+      // does NOT strip diacritics, so this row's `normalized_key` hashes
+      // `carrer de provença` while the v2 normalization of the same candidate
+      // hashes `carrer de provenca`. Looking up only the stripped form would
+      // adopt nothing and create a rival row beside every accented street in the
+      // corpus — measured, on this exact case, before `legacyKeyCandidates`
+      // existed.
+      street: 'Carrer de Provença',
+      number: '21',
+      postal_code: '08013',
+      city,
+      state: 'Catalonia',
+      country: 'Spain',
+      countryCode: 'ES',
+      coordinates: { type: 'Point', coordinates: [BASE_POINT.longitude, BASE_POINT.latitude] },
+    });
+    expect(legacy.identityKey).toBeNull();
+
+    const result = expectMaterialized(
+      await materialize(draft(city, { proposedStreet: 'Carrer de Provença', proposedNumber: '21' })),
+    );
+    expect(result.addressId).toBe(legacy.id);
+    expect(result.match.matchKind).toBe('adopted_v1_key');
+
+    const adopted = await addressRow(legacy.id);
+    expect(adopted.identityKey).not.toBeNull();
+    // The v1 key is untouched, so every existing caller still resolves to it.
+    expect(adopted.normalizedKey).toBe(legacy.normalizedKey);
+  });
+
+  it('creates a row with a NULL v1 key when v1 cannot tell two places apart', async () => {
+    // The collapse case. A building and a floor-only flat hash to ONE v1 key,
+    // and `addresses_normalized_key_key` is unique — so the second row cannot
+    // carry one. NULL is the honest answer, and it is what lets the two exist.
+    const city = nextCity();
+    const building = expectMaterialized(
+      await materialize(draft(city, { proposedStreet: 'Carrer de Sardenya', proposedNumber: '33' })),
+    );
+    const flat = expectMaterialized(
+      await materialize(
+        draft(city, { proposedStreet: 'Carrer de Sardenya', proposedNumber: '33', proposedFloor: '2n' }),
+      ),
+    );
+
+    expect(flat.addressId).not.toBe(building.addressId);
+    const flatRow = await addressRow(flat.addressId);
+    const buildingRow = await addressRow(building.addressId);
+    expect(buildingRow.normalizedKey).not.toBeNull();
+    expect(flatRow.normalizedKey).toBeNull();
+    expect(flatRow.identityKey).not.toBeNull();
+    expect(flatRow.addressLevel).toBe('UNIT');
+  });
+});
+
+describe('the merge redirect is honoured before it is ever written', () => {
+  it('returns the survivor when a matched row has been merged away', async () => {
+    const city = nextCity();
+    const loser = expectMaterialized(
+      await materialize(draft(city, { proposedStreet: 'Carrer de Aribau', proposedNumber: '61' })),
+    );
+    const survivor = expectMaterialized(
+      await materialize(draft(city, { proposedStreet: 'Carrer de Aribau', proposedNumber: '62' })),
+    );
+
+    // Nothing performs a merge yet, so the pointer is written directly — which
+    // is the point of the case: the matcher must already follow it, or the day
+    // merge lands it starts handing callers a row the merge retired.
+    await db
+      .update(addresses)
+      .set({ mergedIntoAddressId: survivor.addressId })
+      .where(eq(addresses.id, loser.addressId));
+
+    const again = expectMaterialized(
+      await materialize(draft(city, { proposedStreet: 'Carrer de Aribau', proposedNumber: '61' })),
+    );
+    expect(again.addressId).toBe(survivor.addressId);
+  });
+});
+
+describe('the TypeScript level derivation agrees with the generated column', () => {
+  it('answers identically for every discriminating shape, including an empty string', async () => {
+    // `deriveAddressLevel` is a TypeScript copy of a `GENERATED ALWAYS`
+    // predicate, and a copy can drift silently. The `''` rows are the cases the
+    // service can never produce (`identityValueOrNull` writes NULL), so they are
+    // inserted by raw SQL — and they are exactly where `is not null` and
+    // `coalesce(x, '') <> ''` disagree.
+    const city = nextCity();
+    const anchor = await materialize(
+      draft(city, { proposedStreet: 'Carrer Derivació', proposedNumber: '1' }),
+    );
+    const anchorRow = await addressRow(expectMaterialized(anchor).addressId);
+
+    const shapes = [
+      { label: 'street only', number: null, floor: null },
+      { label: 'number', number: '5', floor: null },
+      { label: 'floor', number: '5', floor: '3r' },
+      { label: 'empty-string floor', number: '5', floor: '' },
+      { label: 'empty-string number', number: '', floor: null },
+    ];
+
+    const observed: string[][] = [];
+    const expected: string[][] = [];
+    for (const shape of shapes) {
+      const id = uuidv7();
+      await db.execute(sql`
+        insert into addresses (
+          id, country_id, region_id, city_id, country_code, street, postal_code,
+          number, floor, longitude, latitude
+        ) values (
+          ${id}, ${anchorRow.countryId}, ${anchorRow.regionId}, ${anchorRow.cityId},
+          ${anchorRow.countryCode}, 'carrer derivacio', '08013',
+          ${shape.number}, ${shape.floor}, ${BASE_POINT.longitude}, ${BASE_POINT.latitude}
+        )
+      `);
+      const [row] = await db
+        .select({ level: addresses.addressLevel })
+        .from(addresses)
+        .where(eq(addresses.id, id));
+      observed.push([shape.label, row.level ?? 'null']);
+      expected.push([
+        shape.label,
+        deriveAddressLevel({
+          street: 'carrer derivacio',
+          postalCode: '08013',
+          cityId: anchorRow.cityId,
+          countryCode: anchorRow.countryCode,
+          number: shape.number,
+          floor: shape.floor,
+        }),
+      ]);
+    }
+
+    // Compared as whole lists, so a failure names WHICH shape disagreed rather
+    // than merely that one did.
+    expect(expected).toEqual(observed);
+    // Vacuity floor: an empty loop would satisfy the assertion above.
+    expect(observed).toHaveLength(5);
+    expect(observed.map((row) => row[1])).toEqual([
+      'STREET',
+      'BUILDING',
+      'UNIT',
+      'BUILDING',
+      'STREET',
+    ]);
+  });
+});

--- a/packages/backend/__tests__/db/materializationReadPaths.test.ts
+++ b/packages/backend/__tests__/db/materializationReadPaths.test.ts
@@ -1,0 +1,294 @@
+/**
+ * **An autocomplete query must never create a permanent row.**
+ *
+ * This is the rule #360 exists to make true, and it is the one that cannot be
+ * stated as a type: a read path does not fail to compile if it starts writing,
+ * it just quietly starts minting identities for every keystroke a user types.
+ * So it is asserted two ways, and the two fail in different directions on
+ * purpose.
+ *
+ * ## 1. Behavioural — the read paths are RUN and measured
+ *
+ * The address typeahead, the nearby-address lookup and the city place lookup are
+ * exercised against a real database, and `addresses`, `address_candidates` and
+ * `address_materializations` are counted before and after.
+ *
+ * A "nothing was created" assertion is exactly the shape that passes when the
+ * check is broken, so it carries both defences the ecosystem's own rules ask
+ * for:
+ *
+ *  - a **POSITIVE CONTROL across time**: the same counters are measured around a
+ *    real materialization in the same test, and must MOVE. Without it, a census
+ *    that counted the wrong table, or a read path that threw and was swallowed,
+ *    would report a clean pass.
+ *  - a **vacuity floor**: each read path must actually return rows. A typeahead
+ *    that matched nothing writes nothing, and would satisfy the assertion while
+ *    measuring nothing at all.
+ *
+ * ## 2. Structural — the database refuses an action that names a read
+ *
+ * `address_materializations.durable_action` is NOT NULL with a CHECK over the
+ * six durable actions #360 lists, and there is deliberately no member meaning
+ * "a search", "a preview" or "an autocomplete". That is asserted against the
+ * REAL constraint rather than against the TypeScript tuple it was generated
+ * from: the tuple is a value a future edit could widen in one line, while the
+ * CHECK is in migration `0014` and applies to every writer of that table,
+ * including raw SQL and anything that bypasses this repository entirely.
+ */
+
+import { eq, sql } from 'drizzle-orm';
+import { constraintNameOf, uuidv7 } from '@oxyhq/db';
+
+import { closePostgres, connectPostgres, type Database } from '../../db/postgres';
+import {
+  addressCandidates,
+  addressMaterializations,
+  addresses,
+  cities,
+} from '../../db/schema';
+import {
+  nearestAddressesQuery,
+  selectAddressWithGeoNames,
+} from '../../services/addressService';
+import { lookupCityPlaces } from '../../db/geo/placeLookup';
+import { escapeLikePattern } from '../../db/likePattern';
+import { materializeHousingCandidate } from '../../services/housingMaterialization';
+
+let db: Database;
+
+const SUITE = uuidv7().slice(-12);
+const CITY = `Readpathville ${SUITE}`;
+const STREET = 'Carrer de la Lectura';
+const BASE_POINT = { longitude: 2.17, latitude: 41.39 };
+
+beforeAll(async () => {
+  db = await connectPostgres();
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+interface Counts {
+  readonly addresses: number;
+  readonly candidates: number;
+  readonly materializations: number;
+}
+
+/**
+ * The three tables a materialization touches.
+ *
+ * Counted WHOLE rather than scoped to this suite's city, because the question is
+ * "did a read path create anything at all", and scoping it would hide a read
+ * path that created a row somewhere unexpected — which is precisely the shape of
+ * the bug.
+ */
+async function counts(): Promise<Counts> {
+  const [row] = await db.execute<{ a: string; c: string; m: string }>(sql`
+    select
+      (select count(*) from addresses) as a,
+      (select count(*) from address_candidates) as c,
+      (select count(*) from address_materializations) as m
+  `);
+  // postgres.js decodes `count(*)` (a bigint) as a STRING, and drizzle types it
+  // as whatever the annotation says — so `a + 1` would be string concatenation.
+  // Coerced explicitly at the boundary.
+  return {
+    addresses: Number(row.a),
+    candidates: Number(row.c),
+    materializations: Number(row.m),
+  };
+}
+
+/** Seed one real place, so every read path below has something to find. */
+async function seedPlace(): Promise<string> {
+  const result = await materializeHousingCandidate(
+    {
+      candidate: {
+        provider: 'osm',
+        rawText: `${STREET} 1`,
+        origin: 'geocoder',
+        precision: 'exact',
+        longitude: BASE_POINT.longitude,
+        latitude: BASE_POINT.latitude,
+        proposedCity: CITY,
+        proposedRegion: 'Catalonia',
+        proposedCountry: 'Spain',
+        proposedCountryCode: 'ES',
+        proposedStreet: STREET,
+        proposedPostalCode: '08013',
+        proposedNumber: '1',
+      },
+    },
+    { action: 'listing_upsert', actorOxyUserId: `oxy-${SUITE}` },
+  );
+  if (result.status !== 'materialized') {
+    throw new Error(`seed failed: ${result.status} ${JSON.stringify(result)}`);
+  }
+  return result.addressId;
+}
+
+describe('a read path cannot create a permanent row', () => {
+  it('leaves every materialization table untouched, while a real write moves them', async () => {
+    await seedPlace();
+
+    const before = await counts();
+
+    // ── The address typeahead: `addressController.searchAddresses`'s query. ──
+    const typeahead = await selectAddressWithGeoNames({
+      where: sql`${addresses.street} ilike ${`%${escapeLikePattern('lectura')}%`}`,
+      limit: 10,
+    });
+
+    // ── The nearby lookup: `addressController.getNearbyAddresses`. ──
+    const near = nearestAddressesQuery({
+      longitude: BASE_POINT.longitude,
+      latitude: BASE_POINT.latitude,
+      radiusMeters: 5000,
+    });
+    const nearby = await selectAddressWithGeoNames({
+      where: near.where,
+      orderBy: near.orderBy,
+      limit: 10,
+    });
+
+    // ── The place lookup behind city autocomplete. ──
+    const places = await lookupCityPlaces({ token: CITY, countryCode: 'ES' });
+
+    const after = await counts();
+
+    // The assertion this file exists for.
+    expect(after).toEqual(before);
+
+    // VACUITY FLOOR. A read that matched nothing writes nothing, and would
+    // satisfy the assertion above while measuring nothing at all.
+    expect(typeahead.length).toBeGreaterThan(0);
+    expect(nearby.length).toBeGreaterThan(0);
+    expect(places.status).not.toBe('not_found');
+
+    // POSITIVE CONTROL, measured across the change rather than beside it: the
+    // same counters, around a real durable action, must MOVE. Without this a
+    // census counting the wrong tables would report a clean pass forever.
+    const control = await materializeHousingCandidate(
+      {
+        candidate: {
+          provider: 'osm',
+          rawText: `${STREET} 2`,
+          origin: 'geocoder',
+          precision: 'exact',
+          longitude: BASE_POINT.longitude,
+          latitude: BASE_POINT.latitude,
+          proposedCity: CITY,
+          proposedRegion: 'Catalonia',
+          proposedCountry: 'Spain',
+          proposedCountryCode: 'ES',
+          proposedStreet: STREET,
+          proposedPostalCode: '08013',
+          proposedNumber: '2',
+        },
+      },
+      { action: 'review', actorOxyUserId: `oxy-${SUITE}` },
+    );
+    expect(control.status).toBe('materialized');
+
+    const afterWrite = await counts();
+    expect(afterWrite.addresses).toBeGreaterThan(after.addresses);
+    expect(afterWrite.candidates).toBeGreaterThan(after.candidates);
+    expect(afterWrite.materializations).toBeGreaterThan(after.materializations);
+  });
+
+  it('records a candidate for a rejected materialization without creating an address', async () => {
+    // The one thing a read-ish path IS allowed to do: record a candidate. This
+    // pins the boundary from the other side — a candidate is cheap, internal and
+    // expiring, and recording one must not mint an identity.
+    const before = await counts();
+    const rejected = await materializeHousingCandidate(
+      {
+        candidate: {
+          provider: 'osm',
+          rawText: 'somewhere in this city',
+          origin: 'autocomplete_selection',
+          // A city centroid, which is what 94-100% of habitaclia and fotocasa
+          // listings carry.
+          precision: 'centroid',
+          longitude: BASE_POINT.longitude,
+          latitude: BASE_POINT.latitude,
+          proposedCity: CITY,
+          proposedRegion: 'Catalonia',
+          proposedCountry: 'Spain',
+          proposedCountryCode: 'ES',
+          proposedStreet: STREET,
+          proposedNumber: '99',
+        },
+      },
+      { action: 'listing_upsert' },
+    );
+    expect(rejected.status).toBe('rejected');
+
+    const after = await counts();
+    expect(after.candidates).toBe(before.candidates + 1);
+    expect(after.addresses).toBe(before.addresses);
+    expect(after.materializations).toBe(before.materializations);
+  });
+});
+
+describe('the database itself refuses an action that names a read', () => {
+  it('rejects `autocomplete` as a durable action, naming the constraint', async () => {
+    // Asserted against the REAL CHECK from migration 0014, not against the
+    // TypeScript tuple it was generated from: the tuple is a value one edit
+    // could widen, while the constraint binds every writer of the table,
+    // including raw SQL and anything bypassing this repository.
+    const [address] = await db
+      .select({ id: addresses.id })
+      .from(addresses)
+      .innerJoin(cities, eq(addresses.cityId, cities.id))
+      .where(eq(cities.name, CITY))
+      .limit(1);
+    expect(address).toBeDefined();
+
+    let caught: unknown;
+    try {
+      await db.execute(sql`
+        insert into address_materializations (
+          id, address_id, candidate_id, provider, raw_text, raw_text_hash,
+          normalization_version, match_kind, durable_action
+        ) values (
+          ${uuidv7()}, ${address.id}, ${uuidv7()}, 'osm', 'typed', 'hash',
+          2, 'created', 'autocomplete'
+        )
+      `);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeDefined();
+    // Through `constraintNameOf`, never `error.code`: drizzle WRAPS the driver
+    // error, so the SQLSTATE lives on `cause` and a check written against the
+    // driver's own documented shape answers `undefined` for every real
+    // violation.
+    expect(constraintNameOf(caught)).toBe('address_materializations_durable_action_check');
+
+    // NEGATIVE CONTROL for the assertion above: a value that IS in the closed
+    // set inserts cleanly, so "the constraint refused it" is distinguishable
+    // from "this insert was malformed for some unrelated reason".
+    const [candidate] = await db
+      .select({ id: addressCandidates.id })
+      .from(addressCandidates)
+      .limit(1);
+    const okId = uuidv7();
+    await db.execute(sql`
+      insert into address_materializations (
+        id, address_id, candidate_id, provider, raw_text, raw_text_hash,
+        normalization_version, match_kind, durable_action
+      ) values (
+        ${okId}, ${address.id}, ${candidate.id}, 'osm', 'typed', 'hash',
+        2, 'created', 'follow_dwelling'
+      )
+    `);
+    const [written] = await db
+      .select({ action: addressMaterializations.durableAction })
+      .from(addressMaterializations)
+      .where(eq(addressMaterializations.id, okId));
+    expect(written.action).toBe('follow_dwelling');
+  });
+});

--- a/packages/backend/__tests__/db/partialUniques.test.ts
+++ b/packages/backend/__tests__/db/partialUniques.test.ts
@@ -384,6 +384,12 @@ describe('the partial indexes really are partial', () => {
     // here deliberately, which is the point — it is the list a reviewer checks
     // against the Mongo `partialFilterExpression`s.
     expect(named).toEqual([
+      // #360's two, both for the same reason `addresses_normalized_key_key`
+      // below is partial: the column is NULL on every row written by any other
+      // path, and an `ON CONFLICT` naming either has to repeat the predicate or
+      // fail at RUNTIME with `42P10` while `tsc` stays clean.
+      'address_materializations_idempotency_key',
+      'addresses_identity_key_key',
       'addresses_normalized_key_key',
       'billing_plus_stripe_subscription_id_key',
       'conversations_share_token_key',

--- a/packages/backend/__tests__/db/propertyImages.test.ts
+++ b/packages/backend/__tests__/db/propertyImages.test.ts
@@ -14,7 +14,7 @@
  * there are none.
  */
 
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 import { UNIQUE_VIOLATION, constraintNameOf, sqlStateOf, uuidv7 } from '@oxyhq/db';
 import { closePostgres, connectPostgres, type Database } from '../../db/postgres';
 import { findHasImagesDisagreements, syncAllHasImages, syncHasImages } from '../../db/hasImages';
@@ -180,6 +180,17 @@ describe('one primary photo per listing', () => {
   it('lets TWO DIFFERENT listings each have their own primary', async () => {
     // Vacuity floor on the constraint itself: an index on `is_primary` alone,
     // without `property_id`, would pass every assertion above and reject this.
+    //
+    // What makes it a floor is that the SECOND `attachPhoto` succeeds — under
+    // the wrong index it raises `23505` and this test dies there. The read below
+    // is the confirmation, and it is SCOPED to the two listings this case
+    // created: an unscoped `where is_primary` reads every row in the worker's
+    // database, so it also fails whenever a sibling FILE in the same worker
+    // leaves a primary photo behind — a Postgres database outlives the file that
+    // wrote to it, unlike the in-memory Mongo this replaced. That made the
+    // assertion depend on how jest happened to distribute files across workers,
+    // which is a property of the schedule and not of the index. Scoping loses
+    // nothing, because the floor was never the unscoped read.
     const first = await createProperty();
     const second = await createProperty();
     await attachPhoto(first, { isPrimary: true });
@@ -188,7 +199,7 @@ describe('one primary photo per listing', () => {
     const rows = await db
       .select({ propertyId: propertyImages.propertyId })
       .from(propertyImages)
-      .where(eq(propertyImages.isPrimary, true));
+      .where(and(eq(propertyImages.isPrimary, true), inArray(propertyImages.propertyId, [first, second])));
     expect(rows.map((row) => row.propertyId).sort()).toEqual([first, second].sort());
   });
 });

--- a/packages/backend/__tests__/helpers/postgresGeoFixtures.ts
+++ b/packages/backend/__tests__/helpers/postgresGeoFixtures.ts
@@ -55,6 +55,8 @@ import { randomBytes } from 'node:crypto';
 import { getDb } from '../../db/postgres';
 import { syncHasImages } from '../../db/hasImages';
 import {
+  addressCandidates,
+  addressMaterializations,
   addresses,
   agencies,
   commissions,
@@ -144,6 +146,20 @@ export async function resetGeoTables(): Promise<void> {
   // and appears in CI at low ones, purely by how jest distributes files.
   await db.delete(reviews);
   await db.delete(agencies);
+  // The candidate → canonical tables (#360), before addresses and in this order.
+  // `address_materializations.address_id` and
+  // `address_candidates.materialized_address_id` are both ON DELETE **RESTRICT**
+  // — the provenance record is what makes a merge reversible, and NULL on the
+  // candidate's pointer already means "not materialized", so SET NULL would give
+  // that value a second meaning. The materialization goes first because it also
+  // names the candidate (by value, with no constraint, so the order is for
+  // legibility rather than for the database).
+  //
+  // `address_external_refs` is deliberately absent: it CASCADEs from
+  // `addresses`, so the delete below takes it. Listing it here would suggest the
+  // other two could have been solved the same way, and they could not.
+  await db.delete(addressMaterializations);
+  await db.delete(addressCandidates);
   await db.delete(addresses);
   await db.delete(neighborhoods);
   // `cities.cover_image_id` / `regions.cover_image_id` are ON DELETE SET NULL,

--- a/packages/backend/__tests__/unit/migrationSnapshotChain.test.ts
+++ b/packages/backend/__tests__/unit/migrationSnapshotChain.test.ts
@@ -1,0 +1,197 @@
+/**
+ * The drizzle-kit SNAPSHOT chain, asserted as a chain.
+ *
+ * ## The failure this exists to catch, measured on `main`
+ *
+ * Two branches generate a migration off the same parent and are merged in
+ * sequence. Nothing recomputes a snapshot, so both end up naming the SAME
+ * `prevId` and the chain forks. Measured on `main` at `0a9a53f6`: `#356`
+ * (watches → 0012) and `#358` (evictions → 0013) were both generated off 0011,
+ * and `0013_snapshot.json` carried `prevId = c209c091…`, which is **0011's** id.
+ *
+ * The visible symptom is that `drizzle-kit generate` refuses to run at all:
+ *
+ *     Error: [drizzle/meta/0012_snapshot.json, drizzle/meta/0013_snapshot.json]
+ *     are pointing to a parent snapshot: … which is a collision.
+ *
+ * **The dangerous half is the one that is not visible.** The later snapshot is a
+ * full picture of the schema, and it was taken on a tree that never had the
+ * earlier migration's objects — so `0013_snapshot.json` described 69 tables and
+ * was missing all three of 0012's (`housing_alerts`, `housing_domain_events`,
+ * `housing_watch_rules`) plus 0012's nine `saved_searches` columns. Once the
+ * pointer is repaired but the CONTENT is not, the next generated migration
+ * re-emits those objects, and since the deploy applies migrations
+ * (`430f8ff2`) that is a release that fails at apply time with "relation already
+ * exists" — not a confusing local error.
+ *
+ * ## Why a test rather than a convention
+ *
+ * Nothing recomputes a snapshot. The break sat on `main` from the moment #358
+ * merged until somebody needed a 0014, and no test, no build and no deploy could
+ * have noticed: a FRESH database applies every migration in order and never
+ * reads a snapshot's contents, so CI and the per-worker throwaway databases pass
+ * either way. The disagreement exists only against a database that already has
+ * the migrations applied — which is production, and only production.
+ *
+ * This file reads the files themselves and needs no database, which is why it is
+ * a unit test: it is checking a property of the repository, not of a server.
+ *
+ * ## One thing this deliberately does NOT check, and how that was established
+ *
+ * A first draft also asserted that every migration declares an
+ * `oxy:deploy-phase` marker. Mutation-testing it — stripping the marker from
+ * `0014` — killed the run, but **not through that assertion**: `@oxyhq/db`'s
+ * migrator refuses an unmarked migration, and the jest harness migrates a
+ * throwaway database in `globalSetup`, so the run dies before any test executes.
+ * The assertion could therefore never be the thing that failed.
+ *
+ * It was removed rather than kept as a restatement. The migrator's check is
+ * strictly stronger — it runs at APPLY time, in production, not only where the
+ * harness happens to migrate — and an assertion that cannot fire is worse than
+ * no assertion, because a reader takes it for a gate.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import * as schema from '../../db/schema';
+import { getTableName } from 'drizzle-orm';
+import type { PgTable } from 'drizzle-orm/pg-core';
+
+const MIGRATIONS_DIR = path.join(__dirname, '..', '..', 'drizzle');
+const META_DIR = path.join(MIGRATIONS_DIR, 'meta');
+
+/**
+ * Floors, so a broken traversal cannot pass over nothing.
+ *
+ * `expect([]).toEqual([])` on an empty file list is exactly what a wrong path or
+ * a changed filename produces, and it is indistinguishable from a clean chain.
+ * Both numbers are MINIMUMS: adding a migration needs no edit here, removing one
+ * does.
+ */
+const MINIMUM_SNAPSHOTS = 15;
+const MINIMUM_TABLES = 72;
+
+interface Snapshot {
+  readonly file: string;
+  readonly index: number;
+  readonly id: string;
+  readonly prevId: string;
+  readonly tables: ReadonlySet<string>;
+}
+
+function readSnapshots(): Snapshot[] {
+  return fs
+    .readdirSync(META_DIR)
+    .filter((file) => /^\d{4}_snapshot\.json$/.test(file))
+    .sort()
+    .map((file) => {
+      const parsed = JSON.parse(fs.readFileSync(path.join(META_DIR, file), 'utf8')) as {
+        id: string;
+        prevId: string;
+        tables: Record<string, unknown>;
+      };
+      return {
+        file,
+        index: Number(file.slice(0, 4)),
+        id: parsed.id,
+        prevId: parsed.prevId,
+        // Keys are `public.<name>`; the qualifier is dropped so this compares
+        // against the schema barrel's own names.
+        tables: new Set(Object.keys(parsed.tables).map((key) => key.split('.').pop() ?? key)),
+      };
+    });
+}
+
+/** Every table the barrel exports — the same enumeration the db gates use. */
+function declaredTableNames(): Set<string> {
+  const exported: unknown[] = Object.values(schema);
+  const tables = exported.filter(
+    (value): value is PgTable =>
+      typeof value === 'object' && value !== null && Symbol.for('drizzle:Name') in value,
+  );
+  return new Set(tables.map(getTableName));
+}
+
+describe('the drizzle snapshot chain', () => {
+  it('finds every snapshot on disk', () => {
+    // The floor. A wrong directory or a changed filename pattern yields an empty
+    // list, over which every assertion below passes silently.
+    const snapshots = readSnapshots();
+    expect(snapshots.length).toBeGreaterThanOrEqual(MINIMUM_SNAPSHOTS);
+    expect(snapshots.map((snapshot) => snapshot.index)).toEqual(
+      snapshots.map((_, position) => position),
+    );
+  });
+
+  it('gives every snapshot exactly one predecessor, and no two the same parent', () => {
+    // THE assertion. Two branches generated off one parent and merged in
+    // sequence leave two snapshots naming the same `prevId`; nothing recomputes
+    // a snapshot, so it sits there until somebody needs the next migration.
+    const snapshots = readSnapshots();
+
+    const wrongParent = snapshots
+      .slice(1)
+      .filter((snapshot, position) => snapshot.prevId !== snapshots[position].id)
+      .map((snapshot) => `${snapshot.file} names prevId ${snapshot.prevId}`);
+    expect(wrongParent).toEqual([]);
+
+    // Stated separately rather than folded into the check above, because it is
+    // the condition drizzle-kit itself reports and the wording a reader will be
+    // searching for when they hit "are pointing to a parent snapshot … which is
+    // a collision".
+    const parents = snapshots.slice(1).map((snapshot) => snapshot.prevId);
+    const shared = parents.filter((parent, position) => parents.indexOf(parent) !== position);
+    expect(shared).toEqual([]);
+
+    // Ids must be distinct too: two snapshots sharing an id would satisfy the
+    // chain above while making "which one is the parent" unanswerable.
+    const ids = snapshots.map((snapshot) => snapshot.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('leaves the head snapshot describing exactly the tables the schema declares', () => {
+    // The CONSEQUENCE, caught independently of the cause. A forked chain is
+    // repaired by fixing a pointer, and a pointer fix alone leaves the head
+    // snapshot still missing the other branch's objects — which is the half that
+    // reaches production. This compares the head against the schema barrel,
+    // which is what the migrations are supposed to have built.
+    const snapshots = readSnapshots();
+    const head = snapshots[snapshots.length - 1];
+    const declared = declaredTableNames();
+
+    // Floors on both sides, for the same reason as above.
+    expect(declared.size).toBeGreaterThanOrEqual(MINIMUM_TABLES);
+    expect(head.tables.size).toBeGreaterThanOrEqual(MINIMUM_TABLES);
+
+    const missingFromSnapshot = [...declared].filter((name) => !head.tables.has(name)).sort();
+    const missingFromSchema = [...head.tables].filter((name) => !declared.has(name)).sort();
+    expect({ missingFromSnapshot, missingFromSchema }).toEqual({
+      missingFromSnapshot: [],
+      missingFromSchema: [],
+    });
+  });
+
+  it('has a journal entry for every migration file, and a file for every entry', () => {
+    // Not the snapshot chain, but the same class of drift and free to check
+    // here: the journal is what the MIGRATOR reads, and a `.sql` file absent
+    // from it is never applied while an entry with no file fails the run.
+    const journal = JSON.parse(
+      fs.readFileSync(path.join(META_DIR, '_journal.json'), 'utf8'),
+    ) as { entries: Array<{ idx: number; tag: string }> };
+    const tags = journal.entries.map((entry) => entry.tag);
+    expect(tags.length).toBeGreaterThanOrEqual(MINIMUM_SNAPSHOTS);
+
+    const files = fs
+      .readdirSync(MIGRATIONS_DIR)
+      .filter((file) => file.endsWith('.sql'))
+      .map((file) => file.replace(/\.sql$/, ''))
+      .sort();
+    expect(tags.slice().sort()).toEqual(files);
+    // The journal's own order must be its index order, since that is the order
+    // the migrator applies in.
+    expect(journal.entries.map((entry) => entry.idx)).toEqual(
+      journal.entries.map((_, position) => position),
+    );
+  });
+});

--- a/packages/backend/db/MIGRATION-CONTRACT.md
+++ b/packages/backend/db/MIGRATION-CONTRACT.md
@@ -296,6 +296,96 @@ cutover: an image built before a migration existed prints `No migrations to
 apply`, exits 0, and is otherwise byte-identical to the correct case. Compare it
 against `meta/_journal.json` at the pinned SHA and refuse if they differ.
 
+## Two branches generating a migration off one parent fork the SNAPSHOT chain
+
+**Measured on `main` at `0a9a53f6` (2026-08-11).** `drizzle-kit generate` could
+not run at all:
+
+```
+Error: [drizzle/meta/0012_snapshot.json, drizzle/meta/0013_snapshot.json] are
+pointing to a parent snapshot: … which is a collision.
+```
+
+`#356` (watches → 0012) and `#358` (evictions → 0013) were each generated off
+0011 and merged back to back. **Nothing recomputes a snapshot**, so
+`0013_snapshot.json` kept `prevId = c209c091…` — 0011's id, the same parent 0012
+names — and the chain forked. It sat there from the moment #358 merged until
+somebody needed a 0014.
+
+### The refused `generate` is the harmless half
+
+A snapshot is a FULL picture of the schema, taken on the tree that generated it.
+`0013_snapshot.json` was taken on a tree that never had 0012, so it described 69
+tables and was **missing all three of 0012's** (`housing_alerts`,
+`housing_domain_events`, `housing_watch_rules`) plus 0012's nine `saved_searches`
+columns.
+
+Repair the POINTER and leave the CONTENT, and the next generated migration
+re-emits those objects — `CREATE TABLE housing_alerts …` in a 0014. Since the
+deploy applies migrations, that is a release that fails at apply time with
+"relation already exists", not a confusing local error.
+
+### Nothing that runs today could have caught it
+
+A FRESH database applies every migration in order and never reads a snapshot's
+contents. So CI, the per-worker throwaway databases and a developer's local
+reset all pass **either way** — the disagreement exists only against a database
+that already has the migrations applied, which is production and only
+production. It is the same shape as every other trap in this file: green
+everywhere the check runs, wrong where it matters.
+
+### The check, and it is cheap
+
+`__tests__/unit/migrationSnapshotChain.test.ts` reads the files and needs no
+database. Two assertions, and **both are needed because they catch opposite
+halves**:
+
+1. **Every snapshot's `prevId` names its immediate predecessor, and no two share
+   a parent.** This is the CAUSE, caught at the moment the second branch merges.
+2. **The head snapshot describes exactly the tables the schema barrel declares.**
+   This is the CONSEQUENCE, caught independently — a pointer-only repair leaves
+   the head still missing the other branch's objects, and that is the half that
+   reaches production.
+
+Mutation-tested three ways: reintroducing the real `prevId` (only assertion 1
+reds), deleting one table from the head snapshot with the chain left intact (only
+assertion 2 reds), and dropping a migration from `_journal.json` (only the
+journal assertion reds). A fourth assertion — "every migration declares a deploy
+phase" — was WRITTEN AND THEN REMOVED: stripping the marker killed the run, but
+through `@oxyhq/db`'s migrator in `globalSetup` rather than through the
+assertion, which therefore could never fire. The migrator's check is strictly
+stronger because it also runs at apply time in production.
+
+### How to repair one, and how to prove the repair
+
+Do NOT hand-edit the snapshot's contents. Fix `prevId`, then run the generator on
+an **unmodified** tree and adopt its output as the repaired snapshot, keeping the
+old snapshot's own `id` so nothing downstream sees an identity change.
+
+**Two measurements make a repair verified rather than plausible**, and "generate
+works now" is neither:
+
+- **The set difference BOTH ways.** Here: the regenerated snapshot had 72 tables
+  against 69, the difference was exactly 0012's three, and the difference in the
+  other direction was EMPTY. One direction alone cannot tell a repair from a
+  replacement.
+- **Apply the chain to a database that ALREADY HAS the previous migration**, not
+  only to a fresh one — a fresh run cannot distinguish the two cases, which is
+  the whole problem. Bring a probe database to the production state (hide the new
+  `.sql` and its journal entry, migrate, seed rows into the affected tables),
+  then restore and migrate again: exactly one migration must apply. Verified for
+  0014 on 2026-08-11 — `Applying 1 migration(s)`, exit 0, over a seeded
+  `addresses` — and the resulting catalogue was **byte-identical to a
+  fresh-database build across 1,722 rows** of columns, constraints and index
+  definitions. Give that comparison a negative control (add a column to one side
+  and confirm the diff sees it): a broken catalogue query returns two empty
+  files, and `diff` reports them identical. That happened on the first attempt
+  here — an ambiguous `oid` — and only the line-count floor exposed it.
+
+**The cause is structural, not carelessness.** Any two branches that both
+generate a migration will do this, and neither author can see it from their own
+branch. The check is what makes it visible at merge time.
+
 ## Open — the deploy runs migrations, and the interlock is the workflow's
 
 **There is still no cross-process advisory lock.** drizzle's migrator takes no

--- a/packages/backend/db/expiry.ts
+++ b/packages/backend/db/expiry.ts
@@ -71,6 +71,7 @@
 
 import type { PgColumn, PgTable } from 'drizzle-orm/pg-core';
 import type { ExpirySweepTarget } from '@oxyhq/db/expiry';
+import { addressCandidates } from './schema/addressMaterialization';
 import { conversations } from './schema/conversations';
 import { evictionCases } from './schema/evictions';
 import { moderationEvents, moderationOutbox } from './schema/moderation';
@@ -175,6 +176,25 @@ export const EXPIRY_SWEEP_TARGETS: readonly ExpirySweepTarget[] = [
       'ported, because a table that grows with every listing change in the ' +
       'catalogue is exactly the shape this registry exists to catch, and the ' +
       'only reason the others needed catching is that nobody was there to ' +
+      'register them at birth.',
+  },
+  {
+    table: addressCandidates,
+    column: addressCandidates.expiresAt,
+    retentionSeconds: 0,
+    reason:
+      'The caducidad on an address CANDIDATE (#360). INTENT CHECKED, and the ' +
+      'check is the whole reason this is safe: a candidate is an OBSERVATION — ' +
+      'what somebody typed or a geocoder answered — and every fact an audit ' +
+      'needs is copied BY VALUE onto `address_materializations` at the moment ' +
+      'it produces a canonical row (provider, ref, raw text, its hash, the ' +
+      'normalization version), which is also why `candidate_id` there carries ' +
+      'no foreign key. So this sweep costs a materialized place nothing and ' +
+      'costs an unmaterialized guess exactly what it is worth. It is the second ' +
+      'entry here with NO Mongo ancestor, registered at BIRTH for the same ' +
+      'reason as the one above: a table that grows with every keystroke in an ' +
+      'autocomplete is the shape this registry exists to catch, and the only ' +
+      'reason the ported entries needed catching is that nobody was there to ' +
       'register them at birth.',
   },
 ];

--- a/packages/backend/db/schema/addressMaterialization.ts
+++ b/packages/backend/db/schema/addressMaterialization.ts
@@ -1,0 +1,607 @@
+/**
+ * The candidate → canonical boundary — issue #360, ADR 0001 §2.2 and §5.3.
+ *
+ * Three tables, and the reason they are one file is that they are one sentence:
+ * a {@link addressCandidates | candidate} is what somebody typed or a geocoder
+ * returned, an {@link addressMaterializations | materialization} is the durable
+ * act of turning one into a canonical `addresses` row, and an
+ * {@link addressExternalRefs | external ref} is the provider identifier that act
+ * attached to the place.
+ *
+ * They are a SEPARATE file from `addresses.ts` for the reason `watches.ts` is
+ * separate from `saved.ts`: the lifetimes differ. A candidate EXPIRES — it is a
+ * transient observation and carries its own deadline and its own sweep entry. An
+ * address is permanent. A materialization is an audit record and outlives both.
+ *
+ * ## The rule these tables exist to make structural
+ *
+ * **An autocomplete query must never create a permanent row.** A candidate is
+ * cheap, internal and disposable, so a preview can record one freely; only
+ * {@link addressMaterializations} names a DURABLE ACTION, and only the
+ * materialization service writes an `addresses` row. Nothing here can be reached
+ * by a read path, and `__tests__/db/addressMaterialization.test.ts` fails if the
+ * read paths acquire the ability.
+ *
+ * ## Visibility
+ *
+ * All three are INTERNAL (ADR 0001 §2.2). No public DTO carries a candidate, a
+ * materialization or an external ref; a candidate holds the free text a person
+ * typed, and the whole purpose of the boundary is to keep that out of identity
+ * and off the wire.
+ */
+
+import { check, doublePrecision, index, integer, jsonb, pgTable, text, uniqueIndex } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { createdAt, generatedId, inList, timestamptz, updatedAt } from '@oxyhq/db';
+import { addresses } from './addresses';
+
+/**
+ * How precise the SOURCE of a candidate's coordinates was.
+ *
+ * The four values of ADR 0002's `LocationPrecision`, restated as a tuple so the
+ * column type and the CHECK derive from one list. Kept in the same spelling as
+ * the shared type on purpose — a candidate arriving from
+ * `GET /api/geo/search` carries exactly this value, and a second vocabulary
+ * would need a translation table whose only job would be to go wrong.
+ *
+ * It is NOT ADR 0003's publication ladder (`exact | building | street |
+ * neighborhood | city | approximate_radius | hidden`). That one is the ceiling a
+ * READER may be served; this one is a fact about the observation. They are
+ * different questions and conflating them is how a row ends up stored at the
+ * precision it was published at, which ADR 0001 §2.1.5 forbids.
+ */
+export const CANDIDATE_PRECISIONS = ['exact', 'approximate', 'centroid', 'area'] as const;
+
+export type CandidatePrecision = (typeof CANDIDATE_PRECISIONS)[number];
+
+/**
+ * How the candidate came to exist — the "evidencia/origen de la selección" the
+ * issue requires, as a closed set rather than free text.
+ *
+ * It is what a later audit reads to answer "why does Homiio believe this place
+ * is here", and it is also the input to the precision rules in
+ * `materializeHousingCandidate`: a `map_pin` a person dropped is evidence about
+ * a point, while a `listing_ingest` centroid is evidence about a city.
+ */
+export const CANDIDATE_ORIGINS = [
+  /** Free text a person typed, with no provider behind it. */
+  'user_typed',
+  /** A row the person picked out of an autocomplete list. */
+  'autocomplete_selection',
+  /** A point a person placed on a map. */
+  'map_pin',
+  /** A geocoder's answer to a forward or reverse lookup. */
+  'geocoder',
+  /** A portal listing's address block, arriving through ingestion. */
+  'listing_ingest',
+  /** An official or open dataset (cadastre, INE, OSM extract). */
+  'public_dataset',
+  /** A correction somebody proposed and the community approved. */
+  'approved_correction',
+] as const;
+
+export type CandidateOrigin = (typeof CANDIDATE_ORIGINS)[number];
+
+/**
+ * The durable actions that MAY materialize an address — issue #360's list,
+ * closed, and the single most load-bearing value set in this file.
+ *
+ * Materialization is permitted only as a side effect of one of these. There is
+ * no `preview`, no `search` and no `autocomplete` member, and their absence is
+ * the enforcement: {@link addressMaterializations.durableAction} is NOT NULL
+ * with a CHECK, so a read path that reached the service would have to invent an
+ * action value the database refuses. A rule stated only in a service is a rule
+ * one refactor away from being untrue.
+ */
+export const DURABLE_MATERIALIZATION_ACTIONS = [
+  /** Creating or updating a listing. */
+  'listing_upsert',
+  /** Writing a review. */
+  'review',
+  /** Following a dwelling. */
+  'follow_dwelling',
+  /** Linking a public dataset record to a place. */
+  'public_data_link',
+  /** Creating an event that needs a canonical identity (an eviction notice). */
+  'canonical_event',
+  /** An approved community correction. */
+  'approved_correction',
+] as const;
+
+export type DurableMaterializationAction = (typeof DURABLE_MATERIALIZATION_ACTIONS)[number];
+
+/**
+ * How the canonical row was arrived at — the "explicación de match" the service
+ * returns, stored so the explanation survives the request that produced it.
+ *
+ * `adopted_v1_key` is the member that will read as odd in a year, so: an
+ * address written before this service existed carries a v1 `normalized_key` and
+ * no `identity_key`. When a candidate resolves to such a row AND the row's level
+ * and identity fields agree with the candidate's, the service ADOPTS it —
+ * stamping the v2 key onto the existing row rather than creating a second one.
+ * That is a different fact from `exact_identity_key` (which matched a row this
+ * service itself wrote) and from `created`, and a merge audit needs to tell them
+ * apart.
+ */
+export const MATERIALIZATION_MATCH_KINDS = [
+  /** No match; the row was created by this materialization. */
+  'created',
+  /** An existing row carried the same v2 identity key. */
+  'exact_identity_key',
+  /** An existing row was found through `(source, external_id)`. */
+  'exact_external_ref',
+  /** A pre-v2 row matched on the v1 key and was stamped with a v2 identity. */
+  'adopted_v1_key',
+  /** A probable match a caller explicitly confirmed. */
+  'confirmed_probable',
+] as const;
+
+export type MaterializationMatchKind = (typeof MATERIALIZATION_MATCH_KINDS)[number];
+
+/**
+ * What somebody typed, or a geocoder returned, before anybody decided it is a
+ * place — ADR 0001 §5.3.
+ *
+ * ## Deliberately NOT deduped globally
+ *
+ * ADR 0001 §2.2 gives this table the natural key
+ * `(submitted_by, raw_text_hash, created_at)` and states in the same breath that
+ * it is not deduped globally, because **two people typing the same wrong thing
+ * is two events**. That is a description of what identifies a row, not a
+ * constraint to enforce, and enforcing it would be actively wrong twice over:
+ * `created_at` is truncated to milliseconds (`CONVENTIONS.md`), so a retried
+ * submit inside one millisecond would be refused as a duplicate; and a unique
+ * violation on a candidate would abort the enclosing transaction of whatever
+ * durable action was being attempted. There is therefore a plain index on
+ * `(submitted_by_oxy_user_id, raw_text_hash)` for the "show me my own
+ * candidates" read and no unique index anywhere on this table.
+ *
+ * ## Free text lives HERE, and only here
+ *
+ * ADR 0001 invariant 6 forbids copying administrative geo as text. The
+ * `proposed_*` columns below are exactly that — free text — and they do not
+ * violate the invariant, they are what makes it keepable: a candidate is the
+ * quarantine that keeps free text OUT of `addresses`, whose geo is referenced by
+ * id and resolved at materialization. A proposed name is a claim awaiting
+ * resolution; a resolved id is identity. Reading one of these columns to
+ * populate anything but a resolution attempt is the mistake this docblock exists
+ * to name.
+ *
+ * ## Expiry
+ *
+ * `expires_at` is the issue's "caducidad" and is registered in `db/expiry.ts`.
+ * A candidate is evidence for a decision that has already been taken, never the
+ * decision itself: {@link addressMaterializations} copies everything an audit
+ * needs off the candidate at materialization time, which is why the sweep costs
+ * the audit trail nothing. Registered at BIRTH rather than ported, for the
+ * reason `housing_domain_events` was — a table that grows with every keystroke
+ * in an autocomplete is precisely the shape the registry exists to catch.
+ */
+export const addressCandidates = pgTable(
+  'address_candidates',
+  {
+    id: generatedId(),
+
+    /**
+     * The Oxy account that submitted it, or NULL for the ingestion worker.
+     *
+     * No foreign key: Oxy owns identity and Homiio reaches it over HTTP
+     * (`deferredForeignKeys.ts`). NULL means "no human submitted this", which is
+     * the ingest case and is a genuinely different fact from any account id —
+     * so the column carries no sentinel.
+     */
+    submittedByOxyUserId: text(),
+
+    // ── Provider ──
+    //
+    // Free `text`, with NO check constraint, and that is a decision rather than
+    // an omission. The set spans three open registries at once: the listing
+    // providers in `PROVIDER_IDS`, the geocoding providers registered by
+    // configuration (`GEOCODING_PROVIDER_ORDER`, so the set is not knowable at
+    // schema time at all), and Homiio's own `user` for free text with nobody
+    // behind it. `properties.source` can afford a CHECK because it is exactly
+    // one of those registries; this column cannot, and a CHECK built from
+    // today's union would reject the first provider anybody registers — the
+    // same failure `PROPERTY_SOURCES` documents from the other direction.
+    provider: text().notNull(),
+    /**
+     * The provider's own ref for this RESULT.
+     *
+     * Note the difference from {@link addressExternalRefs.externalId}, which is
+     * the provider's ref for an ENTITY: a geocoder's result ref identifies one
+     * answer to one query and is not a stable name for a building, so it is
+     * never treated as identity. Nullable, because free text has no ref.
+     */
+    providerRef: text(),
+
+    /** What was typed or received, verbatim. Never normalized in place. */
+    rawText: text().notNull(),
+    /**
+     * sha256 over the NORMALIZED raw text — part of ADR 0001's natural key.
+     *
+     * Hashed rather than indexed directly because the raw text is unbounded and
+     * this column exists to answer "has this person already submitted this
+     * string", never to be read back.
+     */
+    rawTextHash: text().notNull(),
+
+    /**
+     * The provider's normalized payload.
+     *
+     * `jsonb`, and it earns it by `CONVENTIONS.md`'s own test: the shape is
+     * whatever the provider sent, which is the same argument that makes
+     * `addresses.extras` the one jsonb column in that table. Flattening it would
+     * mean a migration per provider.
+     */
+    normalizedPayload: jsonb().notNull().default({}),
+    /**
+     * Which normalization produced {@link normalizedPayload} and the
+     * `proposed_*` columns.
+     *
+     * The issue asks for a "versión de normalización" and this is why it
+     * matters: the normalization rules decide the identity key, so a candidate
+     * normalized by an older version may resolve differently from an identical
+     * one normalized today. Recording the version is what lets a later audit
+     * tell a genuine disagreement from a rules change.
+     */
+    normalizationVersion: integer().notNull(),
+
+    // ── Coordinates and precision ──
+    //
+    // BOTH NULLABLE, unlike `addresses`: a candidate may be pure free text with
+    // no location at all, and that is the ordinary state of a half-typed
+    // autocomplete query. The all-or-none CHECK below is what stops a half of a
+    // pair being stored, which is the shape that produces a point at
+    // (0, latitude).
+    longitude: doublePrecision(),
+    latitude: doublePrecision(),
+    /**
+     * How precise the observation was — see {@link CANDIDATE_PRECISIONS}.
+     *
+     * The service refuses to materialize a BUILDING or a UNIT from a `centroid`
+     * or `area` candidate. That rule is not a CHECK because it constrains the
+     * relationship between this row and the LEVEL of the row being created,
+     * which lives elsewhere; it is enforced in `materializeHousingCandidate` and
+     * pinned by a test that supplies a centroid candidate with a street number.
+     */
+    precision: text({ enum: CANDIDATE_PRECISIONS }).notNull(),
+
+    // ── Proposed administrative geo, as NAMES ──
+    proposedCountryCode: text(),
+    proposedCountry: text(),
+    proposedRegion: text(),
+    proposedCity: text(),
+    proposedNeighborhood: text(),
+
+    // ── Proposed address, as free text ──
+    proposedStreet: text(),
+    /**
+     * NULL when the source supplied none — never `''` and never `'00000'`.
+     *
+     * ADR 0001 §3.2 decision 6, and the reason is that both of those are VALUES:
+     * they enter the identity hash and make two unpostcoded places look like one
+     * postcoded place. `IngestionService` substitutes `'00000'` today, which is
+     * exactly the fabrication this column refuses to accept.
+     */
+    proposedPostalCode: text(),
+    proposedNumber: text(),
+    proposedBuildingName: text(),
+    proposedBlock: text(),
+    proposedEntrance: text(),
+    proposedFloor: text(),
+    proposedUnit: text(),
+    proposedSubunit: text(),
+
+    // ── Evidence ──
+    origin: text({ enum: CANDIDATE_ORIGINS }).notNull(),
+    /** Where the observation can be seen, when the provider exposes a URL. */
+    sourceUrl: text(),
+    /**
+     * The provider's own confidence, 0..1, when it reports one.
+     *
+     * Nullable and NOT defaulted: `0` is a provider saying "I am certain this is
+     * wrong" and absence is a provider saying nothing, and a default would erase
+     * the difference. The service treats absence as absence, never as zero.
+     */
+    confidence: doublePrecision(),
+
+    /**
+     * When this observation stops being worth keeping. Swept by `db/expiry.ts`.
+     */
+    expiresAt: timestamptz().notNull(),
+
+    /**
+     * The canonical row this candidate produced, once it produced one.
+     *
+     * RESTRICT, NOT `SET NULL`, and this is the case `CONVENTIONS.md` warns
+     * about: NULL here ALREADY means "not materialized", so `SET NULL` would
+     * give the value a second meaning and turn "this address was deleted out
+     * from under its candidate" into "this candidate was never materialized" —
+     * silently, and in the direction that hides the loss. Nothing deletes an
+     * address, and a merge sets `addresses.merged_into_address_id` rather than
+     * deleting the loser, so RESTRICT refuses only the operation that would
+     * destroy the link.
+     */
+    materializedAddressId: text().references(() => addresses.id, { onDelete: 'restrict' }),
+    materializedAt: timestamptz(),
+
+    createdAt: createdAt(),
+    updatedAt: updatedAt(),
+  },
+  (table) => [
+    // ADR 0001's natural key, minus `created_at`, and NOT unique — see the
+    // docblock. It serves "my own candidates" and the duplicate-submission
+    // diagnostics, both of which want the whole group rather than one row.
+    index('address_candidates_submitter_raw_text_idx').on(
+      table.submittedByOxyUserId,
+      table.rawTextHash,
+    ),
+    // Non-unique BY DESIGN. One geocoder result ref legitimately appears on many
+    // candidates — the same building typed by ten people resolves to one OSM
+    // ref — and making this unique would refuse nine of them. Uniqueness of a
+    // provider ref is a property of the ENTITY, and it is enforced exactly once,
+    // on `address_external_refs`.
+    index('address_candidates_provider_ref_idx').on(table.provider, table.providerRef),
+    // Required by the expiry registry: the sweep's predicate is a range scan.
+    index('address_candidates_expires_at_idx').on(table.expiresAt),
+    index('address_candidates_materialized_address_id_idx').on(table.materializedAddressId),
+
+    check(
+      'address_candidates_precision_check',
+      sql`${table.precision} in (${sql.raw(inList(CANDIDATE_PRECISIONS))})`,
+    ),
+    check(
+      'address_candidates_origin_check',
+      sql`${table.origin} in (${sql.raw(inList(CANDIDATE_ORIGINS))})`,
+    ),
+
+    // All-or-none, with the range folded in. Written with `is not null` spelled
+    // out on BOTH columns of the positive branch rather than as
+    // `(lng is null and lat is null) or (lng between … and lat between …)`,
+    // because a CHECK rejects only an explicit FALSE: with one side NULL the
+    // first branch is false, the comparison is NULL, and `false or NULL` is
+    // NULL — so the tidier spelling ADMITS exactly the half-a-pair it exists to
+    // refuse. `CONVENTIONS.md` records the same trap shipping once already in
+    // `exchange_requests_offered_window_check`.
+    check(
+      'address_candidates_coordinates_check',
+      sql`(${table.longitude} is null and ${table.latitude} is null)
+          or (${table.longitude} is not null and ${table.latitude} is not null
+              and ${table.longitude} between -180 and 180
+              and ${table.latitude} between -90 and 90)`,
+    ),
+
+    // A materialized candidate names both the row and the instant, or neither.
+    // Same `is not null` discipline, same reason.
+    check(
+      'address_candidates_materialized_coherence_check',
+      sql`(${table.materializedAddressId} is null and ${table.materializedAt} is null)
+          or (${table.materializedAddressId} is not null and ${table.materializedAt} is not null)`,
+    ),
+  ],
+);
+
+/**
+ * A provider's identifier for a PLACE — ADR 0001 §3.4.
+ *
+ * ## An external identifier is an attribute, never identity
+ *
+ * The place's identity is its `addresses.id` and its `identity_key`. A portal's
+ * building id is a second name for it, held so that the next listing carrying
+ * that id resolves to the same place without re-deriving anything from text —
+ * "un match exacto por provider id" in the issue's matching table. If the portal
+ * disappears, the place is unaffected, which is the property that makes this a
+ * separate table rather than a column.
+ *
+ * ## Shape, reconciled between the ADR and the issue
+ *
+ * ADR 0001 §3.4 specifies `(address_id, source, external_id, first_seen_at,
+ * last_seen_at)` unique on `(source, external_id)`; issue #360 sketches a
+ * `HousingEntitySourceRef` with `entityType: 'street' | 'building' | 'unit'`,
+ * `entityId`, `provider`, `providerEntityId`, `sourceUrl`, `confidence` and
+ * `rawLabel`. The ADR is the authority and it is closed, so the ADR's names and
+ * key are used; the issue's three extra ATTRIBUTES are carried because the ADR
+ * does not exclude them and the issue requires them.
+ *
+ * **`entityType` is deliberately absent.** Street, building and unit are three
+ * LEVELS of `addresses` (ADR 0001 invariant 2), so the level is
+ * `addresses.address_level` — a `GENERATED ALWAYS` column. Copying it here would
+ * create a denormalized second copy that can disagree with the generated one,
+ * and the disagreement would be invisible: nothing recomputes a copy. One FK,
+ * and the level is read from the row it names.
+ *
+ * ## The unique key is what makes a conflict a CONFLICT
+ *
+ * `(source, external_id)` unique is the issue's "provider ref unique por
+ * provider/id", and it is the mechanism behind "provider ref ya vinculado a otra
+ * entidad" being a refusal rather than a silent rewrite: the second address
+ * claiming a ref cannot take it, so the service reports the conflict instead of
+ * moving the pointer. Both columns are NOT NULL, so `NULLS DISTINCT` never
+ * arises and the index is total rather than partial.
+ */
+export const addressExternalRefs = pgTable(
+  'address_external_refs',
+  {
+    id: generatedId(),
+
+    /**
+     * The place this identifier names.
+     *
+     * CASCADE, and it is the one CASCADE in this file. An external ref is a
+     * second NAME for a row and has no meaning without it — the same reasoning
+     * every `*_id` on a child table in this schema follows. It is safe in a way
+     * the candidate's pointer is not, because nothing else references an
+     * external ref, so cascading it loses no relation and no audit: the
+     * materialization log records the ref it attached, by value.
+     */
+    addressId: text()
+      .notNull()
+      .references(() => addresses.id, { onDelete: 'cascade' }),
+
+    /** The provider registry id — `idealista`, `osm`, `catastro`. */
+    source: text().notNull(),
+    /** That provider's own stable id for the place. */
+    externalId: text().notNull(),
+
+    /** Where the identifier was seen, when the provider exposes a URL. */
+    sourceUrl: text(),
+    /** The label the provider used, kept for audit rather than for matching. */
+    rawLabel: text(),
+    /** The provider's own confidence, 0..1, when it reports one. */
+    confidence: doublePrecision(),
+
+    firstSeenAt: timestamptz().notNull(),
+    lastSeenAt: timestamptz().notNull(),
+
+    createdAt: createdAt(),
+    updatedAt: updatedAt(),
+  },
+  (table) => [
+    uniqueIndex('address_external_refs_source_external_id_key').on(table.source, table.externalId),
+    index('address_external_refs_address_id_idx').on(table.addressId),
+    check(
+      'address_external_refs_confidence_range_check',
+      sql`${table.confidence} between 0 and 1`,
+    ),
+    check(
+      'address_external_refs_seen_order_check',
+      sql`${table.lastSeenAt} >= ${table.firstSeenAt}`,
+    ),
+  ],
+);
+
+/**
+ * One row per act of materialization — the provenance record, and the audit
+ * trail a merge or a split will read.
+ *
+ * ## Why it is an event log and not a set of columns on `addresses`
+ *
+ * ADR 0001 §2.1.7: *a duplicate is recorded, never discarded.* One place is
+ * routinely materialized many times — three portals advertising one flat, a
+ * review written years after the listing that first created the building — and
+ * every one of those is a separate fact about how Homiio came to believe what it
+ * believes. Columns on `addresses` would keep the last one and silently discard
+ * the rest, which is the shape of loss the invariant forbids.
+ *
+ * ## It copies what it needs off the candidate, because the candidate expires
+ *
+ * `candidate_id` carries **no foreign key**, and the reason is the one
+ * `moderation_outbox.event_id` already records in this schema: the two rows are
+ * under independent expiry regimes, so CASCADE would let the candidate sweep
+ * delete the audit trail and RESTRICT would make the candidate sweep fail. The
+ * classification is registered in `ID_COLUMNS_WITHOUT_FOREIGN_KEY` with that
+ * reason. Everything an audit needs — the provider, the ref, the raw text, its
+ * hash, the normalization version — is therefore copied here BY VALUE at
+ * materialization time, so the record is complete once the candidate is gone.
+ *
+ * ## Idempotency
+ *
+ * `idempotency_key` carries a PARTIAL unique index (`where … is not null`),
+ * which is what makes "el mismo candidato confirmado dos veces devuelve la misma
+ * entidad" structural rather than a read-then-write with a window. Two concurrent
+ * requests carrying one key converge: the loser's `ON CONFLICT DO NOTHING`
+ * returns nothing and it reads the winner's row back.
+ *
+ * **A partial index is not inferable from its columns**, so every `ON CONFLICT`
+ * naming it must repeat the predicate verbatim (`onConflictDoNothing({ target,
+ * where })`) or Postgres answers `42P10 there is no unique or exclusion
+ * constraint matching the ON CONFLICT specification` — at runtime, with a clean
+ * `tsc`. The service does; `__tests__/db/addressMaterialization.test.ts`
+ * mutation-tests it by dropping the predicate and asserting the SQLSTATE.
+ */
+export const addressMaterializations = pgTable(
+  'address_materializations',
+  {
+    id: generatedId(),
+
+    /**
+     * The canonical row this act produced or resolved to.
+     *
+     * RESTRICT: the audit trail is the thing that makes a merge reversible, so
+     * an address may not be deleted while a record says it was materialized.
+     */
+    addressId: text()
+      .notNull()
+      .references(() => addresses.id, { onDelete: 'restrict' }),
+
+    /** The `address_candidates` row. NO foreign key — see the docblock. */
+    candidateId: text().notNull(),
+
+    // ── Copied off the candidate, so the record survives its expiry ──
+    provider: text().notNull(),
+    providerRef: text(),
+    rawText: text().notNull(),
+    rawTextHash: text().notNull(),
+    normalizationVersion: integer().notNull(),
+
+    // ── The explanation of the match ──
+    matchKind: text({ enum: MATERIALIZATION_MATCH_KINDS }).notNull(),
+    /**
+     * One line naming what actually matched — which key, which ref, which row.
+     *
+     * Free text on purpose: it is read by a human auditing a merge, never
+     * parsed. A structured version would have to enumerate the reasons in
+     * advance, and the reasons are exactly what a correction workflow is trying
+     * to learn.
+     */
+    matchDetail: text(),
+    /**
+     * The v2 identity key this act resolved to.
+     *
+     * Copied rather than joined because a merge REWRITES which row a key belongs
+     * to, and the audit has to record the key as it was at the time. Nullable
+     * only for the paths that resolve without one (an external-ref hit on a
+     * pre-v2 row).
+     */
+    identityKey: text(),
+
+    // ── The durable action that authorised it ──
+    /**
+     * NOT NULL with a CHECK, and this pair is the enforcement of "autocomplete
+     * does not materialize": there is no action value for a read.
+     */
+    durableAction: text({ enum: DURABLE_MATERIALIZATION_ACTIONS }).notNull(),
+    /**
+     * The id of the thing the action produced — a listing, a review, a case.
+     *
+     * Polymorphic across several nouns, so it carries no foreign key, following
+     * `images.entity_id` and `housing_domain_events.subject_id`. Nullable
+     * because the action frequently produces its row AFTER the address it needs
+     * (a listing insert must name an `address_id`), so the reference is
+     * back-filled by the caller when it can be and honestly absent when it
+     * cannot.
+     */
+    durableActionRef: text(),
+    /** The Oxy account that performed it, or NULL for the ingestion worker. */
+    actorOxyUserId: text(),
+    /**
+     * The caller's idempotency key for this durable action, when it has one.
+     *
+     * NULLABLE and that is load-bearing rather than lax: Postgres unique
+     * indexes are `NULLS DISTINCT`, so any number of rows may hold NULL, which
+     * is exactly what a caller with no key needs. A sentinel value would collapse
+     * every keyless materialization onto one row — the opposite of what absence
+     * means. `__tests__/db` carries the explicit-NULL fixture, because a suite
+     * whose cases all supply a key cannot tell this index from a total one.
+     */
+    idempotencyKey: text(),
+
+    createdAt: createdAt(),
+  },
+  (table) => [
+    uniqueIndex('address_materializations_idempotency_key')
+      .on(table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} is not null`),
+    index('address_materializations_address_id_idx').on(table.addressId),
+    index('address_materializations_candidate_id_idx').on(table.candidateId),
+
+    check(
+      'address_materializations_match_kind_check',
+      sql`${table.matchKind} in (${sql.raw(inList(MATERIALIZATION_MATCH_KINDS))})`,
+    ),
+    check(
+      'address_materializations_durable_action_check',
+      sql`${table.durableAction} in (${sql.raw(inList(DURABLE_MATERIALIZATION_ACTIONS))})`,
+    ),
+  ],
+);

--- a/packages/backend/db/schema/addresses.ts
+++ b/packages/backend/db/schema/addresses.ts
@@ -15,7 +15,16 @@
  * See `CONVENTIONS.md` for the rules every other decision follows.
  */
 
-import { check, doublePrecision, index, jsonb, pgTable, text, uniqueIndex } from 'drizzle-orm/pg-core';
+import {
+  check,
+  doublePrecision,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  uniqueIndex,
+  type AnyPgColumn,
+} from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 import { createdAt, generatedId, geography, inList, updatedAt } from '@oxyhq/db';
 import { cities, countries, neighborhoods, regions } from './geo';
@@ -179,6 +188,79 @@ export const addresses = pgTable(
      */
     normalizedKey: text(),
 
+    /**
+     * The LEVEL-AWARE identity key — ADR 0001 §5.1, written only by
+     * `materializeHousingCandidate`.
+     *
+     * It exists BESIDE {@link normalizedKey} and never replaces it, because the
+     * v1 key is copied verbatim from the source and re-keying it would re-create
+     * 11,734 existing buildings on their next ingest. Both columns are live; a
+     * row may carry one, the other, or both.
+     *
+     * ## Why a second key was unavoidable
+     *
+     * The v1 key hashes `street|number|unit|building_name|block|postal_code|
+     * city_id|country_code` while {@link addressLevel} derives from `floor`,
+     * `unit`, `subunit`, `number`, `building_name`, `block` and `entrance`.
+     * `floor`, `entrance` and `subunit` therefore DECIDE the level and are
+     * ABSENT from the key, so a building and the flat on its third floor hash
+     * identically and — under the partial unique index above — become one row
+     * whose level depends on which advertisement was ingested first (ADR 0001
+     * §1.3, measured). Nothing that dedupes on the v1 key can create the
+     * street → building → unit chain this column exists to serve.
+     *
+     * v2 hashes the level itself plus every field that discriminates it, with
+     * internal whitespace collapsed and diacritics stripped
+     * (`computeAddressIdentityKey`).
+     *
+     * **NULL on every row written by any other path**, which is the honest state
+     * rather than an omission: the ADR's plan is forward-only, and back-filling
+     * this column for existing rows is phase 2, gated on a census that has not
+     * run. A NULL here means "no v2 identity has been computed for this row",
+     * never "this row has no identity".
+     */
+    identityKey: text(),
+
+    /**
+     * The row one level up: a UNIT's building, a BUILDING's street.
+     *
+     * NULL for a STREET row, and NULL on every row that predates
+     * `materializeHousingCandidate` — the hierarchy is a projection
+     * `resolveAddressHierarchy` recomputes per review today, and this column
+     * stores it once so every other domain can read it. Populating it for
+     * existing rows is ADR 0001 phase 2.
+     *
+     * RESTRICT rather than CASCADE or SET NULL. CASCADE would delete every flat
+     * in a block along with the block; SET NULL would silently promote a unit to
+     * a street-level orphan, and NULL already means "this is a STREET row", so
+     * the action would introduce a second meaning for the value — the test
+     * `CONVENTIONS.md` sets for `ON DELETE SET NULL`, failed. Nothing in Homiio
+     * deletes an address; anything that ever does must re-parent first.
+     */
+    parentAddressId: text().references((): AnyPgColumn => addresses.id, { onDelete: 'restrict' }),
+
+    /**
+     * The survivor of a merge, when this row lost one — ADR 0001 §8.1.
+     *
+     * A merge NEVER deletes the losing row: reviews, leases and occupancies
+     * point at it, and a wrong merge publishes one household's reviews under
+     * another's address. Setting a pointer instead is what makes the operation
+     * reversible, and reversibility is the requirement rather than a nicety.
+     *
+     * Nothing performs a merge yet — that workflow is the second half of #360.
+     * The column and its FK land here because the MATCHER has to honour it from
+     * its first line: `materializeHousingCandidate` follows this pointer before
+     * returning any match, so a redirect that lands later cannot silently start
+     * handing callers a row the merge retired. A matcher written without it
+     * would have to be re-audited path by path when merge arrives, which is
+     * exactly the "bolt it on later" this column exists to avoid.
+     *
+     * RESTRICT: a survivor may not be deleted while something redirects to it.
+     */
+    mergedIntoAddressId: text().references((): AnyPgColumn => addresses.id, {
+      onDelete: 'restrict',
+    }),
+
     createdAt: createdAt(),
     updatedAt: updatedAt(),
   },
@@ -191,6 +273,25 @@ export const addresses = pgTable(
     uniqueIndex('addresses_normalized_key_key')
       .on(table.normalizedKey)
       .where(sql`${table.normalizedKey} is not null`),
+
+    // The v2 key's own partial unique index — the same shape and the same
+    // reason, on a column that is NULL for every row written before
+    // `materializeHousingCandidate` existed. Partial is REQUIRED here rather
+    // than merely tidy: a total unique index over a column that is NULL on
+    // 11,734 rows would be correct in Postgres (NULLs are distinct) and would
+    // still index all of them, and the predicate is what any `ON CONFLICT`
+    // against it must repeat verbatim to name this index as its arbiter.
+    uniqueIndex('addresses_identity_key_key')
+      .on(table.identityKey)
+      .where(sql`${table.identityKey} is not null`),
+
+    // "Every child of this row", the read the hierarchy exists for.
+    index('addresses_parent_address_id_idx').on(table.parentAddressId),
+    // Partial: a merged-away row is the rare case by construction, so indexing
+    // only the rows that carry a redirect keeps this the size of the real set.
+    index('addresses_merged_into_address_id_idx')
+      .on(table.mergedIntoAddressId)
+      .where(sql`${table.mergedIntoAddressId} is not null`),
 
     // The spatial index. Every `$near` / `$geoWithin` / `$centerSphere` property
     // search resolves through this table, so this is the index the whole search
@@ -243,5 +344,17 @@ export const addresses = pgTable(
       'addresses_coordinates_range_check',
       sql`${table.longitude} between -180 and 180 and ${table.latitude} between -90 and 90`,
     ),
+
+    // No row is its own parent and no row is its own merge survivor. Both are
+    // one-row cycles a self-referencing foreign key cannot see: the constraint
+    // is satisfied by `id` existing, and `id` always exists on the row being
+    // written. Longer cycles are not expressible as a CHECK and are refused by
+    // the writer instead.
+    //
+    // Both admit NULL, deliberately: a NULL parent is a STREET row and a NULL
+    // survivor is a row nobody merged, which are the ordinary states rather than
+    // the ones being forbidden.
+    check('addresses_parent_not_self_check', sql`${table.parentAddressId} <> ${table.id}`),
+    check('addresses_merge_not_self_check', sql`${table.mergedIntoAddressId} <> ${table.id}`),
   ],
 );

--- a/packages/backend/db/schema/deferredForeignKeys.ts
+++ b/packages/backend/db/schema/deferredForeignKeys.ts
@@ -37,6 +37,7 @@
 import { getTableColumns, getTableName } from 'drizzle-orm';
 import type { PgColumn, PgTable, UpdateDeleteAction } from 'drizzle-orm/pg-core';
 import { sqlColumnName } from '../casing';
+import { addressExternalRefs, addressMaterializations } from './addressMaterialization';
 import { billing, billingProcessedSessions } from './billing';
 import { housingAlerts, housingDomainEvents } from './watches';
 import { images } from './images';
@@ -171,6 +172,10 @@ export const OXY_ACCOUNT_COLUMN_NAMES: ReadonlySet<string> = new Set([
   'granted_by_oxy_user_id',
   'voucher_oxy_user_id',
   'vouched_oxy_user_id',
+  // `address_candidates` records WHO observed a place (#360). Nullable, because
+  // the ingestion worker submits candidates with no human behind them, and that
+  // absence is a different fact from any account id rather than a missing one.
+  'submitted_by_oxy_user_id',
 ]);
 
 /**
@@ -370,6 +375,43 @@ export const ID_COLUMNS_WITHOUT_FOREIGN_KEY: readonly IdColumnWithoutForeignKey[
       '`event_id` would become a history entry saying "something changed" the ' +
       'day the sweep ran. It is also what the cooldown unique index is keyed ' +
       'on, which a nullable reference through another table could not be.',
+  },
+  {
+    table: addressExternalRefs,
+    column: addressExternalRefs.externalId,
+    reason:
+      'A PROVIDER\'s own id for a place — a portal\'s building id, an OSM ref, ' +
+      'a cadastral value — so there is nothing in this schema for it to ' +
+      'reference, the same class as `properties.source_id`. It is half of this ' +
+      'table\'s unique key rather than a pointer: the row exists to say "that ' +
+      'provider calls this place X", and ADR 0001 §3.4 is explicit that an ' +
+      'external identifier is an ATTRIBUTE and never identity, so a constraint ' +
+      'here would be asserting the opposite of the decision.',
+  },
+  {
+    table: addressMaterializations,
+    column: addressMaterializations.candidateId,
+    reason:
+      'The `address_candidates` row this materialization consumed, referenced ' +
+      'by value because the two are under INDEPENDENT expiry regimes and two ' +
+      'sweeps have no ordering between them — the same refusal, for the same ' +
+      'reason, as `moderation_outbox.event_id`. CASCADE would let the candidate ' +
+      'sweep delete the audit trail a merge depends on; RESTRICT would make the ' +
+      'candidate sweep fail against every materialized candidate, i.e. all the ' +
+      'successful ones. Nothing is lost by the absence: every fact an audit ' +
+      'reads is copied onto this row by value at materialization time.',
+  },
+  {
+    table: addressMaterializations,
+    column: addressMaterializations.durableActionRef,
+    reason:
+      'Polymorphic by `durable_action` across a listing, a review, an eviction ' +
+      'case and a correction, so one column cannot reference it — the ' +
+      'permanent case `images.entity_id` and `housing_domain_events.subject_id` ' +
+      'already carry. It must also OUTLIVE its subject: a listing is ' +
+      'hard-deleted by the expiry sweep, and the record that materializing a ' +
+      'place was authorised by that listing is exactly what a later merge audit ' +
+      'needs after the advertisement is gone.',
   },
 ];
 

--- a/packages/backend/db/schema/index.ts
+++ b/packages/backend/db/schema/index.ts
@@ -26,6 +26,11 @@
  */
 
 export { addresses } from './addresses';
+export {
+  addressCandidates,
+  addressExternalRefs,
+  addressMaterializations,
+} from './addressMaterialization';
 export { agencies } from './agencies';
 export {
   tenantApplicationDocuments,

--- a/packages/backend/drizzle/0014_housing_candidate_materialization.sql
+++ b/packages/backend/drizzle/0014_housing_candidate_materialization.sql
@@ -1,0 +1,139 @@
+-- oxy:deploy-phase=pre
+--
+-- #360 — the candidate → canonical boundary: address candidates, provider refs
+-- and the materialization audit trail, plus the three additive columns on
+-- `addresses` that the materialization chokepoint cannot be built without.
+--
+-- `pre`, and it is the easy kind of `pre` rather than the traded kind that
+-- `0013` had to argue for: every statement below is ADDITIVE and every new
+-- column on an existing table is NULLABLE with no default. The outgoing image
+-- does not name one of them, so its INSERTs stay legal for the whole rollout
+-- window; the incoming image needs them from its first request. Nothing here
+-- rewrites a value, drops a column, or narrows a vocabulary, so there is no
+-- window in which either image is writing something the other refuses.
+--
+-- The three columns on `addresses` are ADR 0001 phase 1 (§9), landed here
+-- because `materializeHousingCandidate` is the first thing that can write them:
+--
+--   `identity_key`        the LEVEL-AWARE dedup key. The v1 `normalized_key`
+--                         hashes neither `floor` nor `entrance` nor `subunit`
+--                         while `address_level` derives FROM them, so a
+--                         building and its third-floor flat collapse onto one
+--                         row today (ADR 0001 §1.3, measured). Both columns
+--                         stay live; `normalized_key` is untouched and is still
+--                         what `findOrCreateCanonicalAddress` dedupes on.
+--   `parent_address_id`   the street → building → unit chain, stored instead of
+--                         re-projected per review.
+--   `merged_into_address_id`  the merge redirect. Nothing performs a merge yet;
+--                         the matcher honours the pointer from its first line so
+--                         that a redirect landing later cannot start handing
+--                         callers a row a merge retired.
+--
+-- No backfill. Every existing row keeps `identity_key`, `parent_address_id` and
+-- `merged_into_address_id` NULL, which is the honest state: the ADR's plan is
+-- forward-only and populating them is phase 2, gated on a census that has not
+-- run.
+--
+CREATE TABLE "address_candidates" (
+	"id" text PRIMARY KEY NOT NULL,
+	"submitted_by_oxy_user_id" text,
+	"provider" text NOT NULL,
+	"provider_ref" text,
+	"raw_text" text NOT NULL,
+	"raw_text_hash" text NOT NULL,
+	"normalized_payload" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"normalization_version" integer NOT NULL,
+	"longitude" double precision,
+	"latitude" double precision,
+	"precision" text NOT NULL,
+	"proposed_country_code" text,
+	"proposed_country" text,
+	"proposed_region" text,
+	"proposed_city" text,
+	"proposed_neighborhood" text,
+	"proposed_street" text,
+	"proposed_postal_code" text,
+	"proposed_number" text,
+	"proposed_building_name" text,
+	"proposed_block" text,
+	"proposed_entrance" text,
+	"proposed_floor" text,
+	"proposed_unit" text,
+	"proposed_subunit" text,
+	"origin" text NOT NULL,
+	"source_url" text,
+	"confidence" double precision,
+	"expires_at" timestamp with time zone NOT NULL,
+	"materialized_address_id" text,
+	"materialized_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT date_trunc('milliseconds', now()) NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT date_trunc('milliseconds', now()) NOT NULL,
+	CONSTRAINT "address_candidates_precision_check" CHECK ("address_candidates"."precision" in ('exact', 'approximate', 'centroid', 'area')),
+	CONSTRAINT "address_candidates_origin_check" CHECK ("address_candidates"."origin" in ('user_typed', 'autocomplete_selection', 'map_pin', 'geocoder', 'listing_ingest', 'public_dataset', 'approved_correction')),
+	CONSTRAINT "address_candidates_coordinates_check" CHECK (("address_candidates"."longitude" is null and "address_candidates"."latitude" is null)
+          or ("address_candidates"."longitude" is not null and "address_candidates"."latitude" is not null
+              and "address_candidates"."longitude" between -180 and 180
+              and "address_candidates"."latitude" between -90 and 90)),
+	CONSTRAINT "address_candidates_materialized_coherence_check" CHECK (("address_candidates"."materialized_address_id" is null and "address_candidates"."materialized_at" is null)
+          or ("address_candidates"."materialized_address_id" is not null and "address_candidates"."materialized_at" is not null))
+);
+--> statement-breakpoint
+CREATE TABLE "address_external_refs" (
+	"id" text PRIMARY KEY NOT NULL,
+	"address_id" text NOT NULL,
+	"source" text NOT NULL,
+	"external_id" text NOT NULL,
+	"source_url" text,
+	"raw_label" text,
+	"confidence" double precision,
+	"first_seen_at" timestamp with time zone NOT NULL,
+	"last_seen_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT date_trunc('milliseconds', now()) NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT date_trunc('milliseconds', now()) NOT NULL,
+	CONSTRAINT "address_external_refs_confidence_range_check" CHECK ("address_external_refs"."confidence" between 0 and 1),
+	CONSTRAINT "address_external_refs_seen_order_check" CHECK ("address_external_refs"."last_seen_at" >= "address_external_refs"."first_seen_at")
+);
+--> statement-breakpoint
+CREATE TABLE "address_materializations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"address_id" text NOT NULL,
+	"candidate_id" text NOT NULL,
+	"provider" text NOT NULL,
+	"provider_ref" text,
+	"raw_text" text NOT NULL,
+	"raw_text_hash" text NOT NULL,
+	"normalization_version" integer NOT NULL,
+	"match_kind" text NOT NULL,
+	"match_detail" text,
+	"identity_key" text,
+	"durable_action" text NOT NULL,
+	"durable_action_ref" text,
+	"actor_oxy_user_id" text,
+	"idempotency_key" text,
+	"created_at" timestamp with time zone DEFAULT date_trunc('milliseconds', now()) NOT NULL,
+	CONSTRAINT "address_materializations_match_kind_check" CHECK ("address_materializations"."match_kind" in ('created', 'exact_identity_key', 'exact_external_ref', 'adopted_v1_key', 'confirmed_probable')),
+	CONSTRAINT "address_materializations_durable_action_check" CHECK ("address_materializations"."durable_action" in ('listing_upsert', 'review', 'follow_dwelling', 'public_data_link', 'canonical_event', 'approved_correction'))
+);
+--> statement-breakpoint
+ALTER TABLE "addresses" ADD COLUMN "identity_key" text;--> statement-breakpoint
+ALTER TABLE "addresses" ADD COLUMN "parent_address_id" text;--> statement-breakpoint
+ALTER TABLE "addresses" ADD COLUMN "merged_into_address_id" text;--> statement-breakpoint
+ALTER TABLE "address_candidates" ADD CONSTRAINT "address_candidates_materialized_address_id_addresses_id_fk" FOREIGN KEY ("materialized_address_id") REFERENCES "public"."addresses"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "address_external_refs" ADD CONSTRAINT "address_external_refs_address_id_addresses_id_fk" FOREIGN KEY ("address_id") REFERENCES "public"."addresses"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "address_materializations" ADD CONSTRAINT "address_materializations_address_id_addresses_id_fk" FOREIGN KEY ("address_id") REFERENCES "public"."addresses"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "address_candidates_submitter_raw_text_idx" ON "address_candidates" USING btree ("submitted_by_oxy_user_id","raw_text_hash");--> statement-breakpoint
+CREATE INDEX "address_candidates_provider_ref_idx" ON "address_candidates" USING btree ("provider","provider_ref");--> statement-breakpoint
+CREATE INDEX "address_candidates_expires_at_idx" ON "address_candidates" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX "address_candidates_materialized_address_id_idx" ON "address_candidates" USING btree ("materialized_address_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "address_external_refs_source_external_id_key" ON "address_external_refs" USING btree ("source","external_id");--> statement-breakpoint
+CREATE INDEX "address_external_refs_address_id_idx" ON "address_external_refs" USING btree ("address_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "address_materializations_idempotency_key" ON "address_materializations" USING btree ("idempotency_key") WHERE "address_materializations"."idempotency_key" is not null;--> statement-breakpoint
+CREATE INDEX "address_materializations_address_id_idx" ON "address_materializations" USING btree ("address_id");--> statement-breakpoint
+CREATE INDEX "address_materializations_candidate_id_idx" ON "address_materializations" USING btree ("candidate_id");--> statement-breakpoint
+ALTER TABLE "addresses" ADD CONSTRAINT "addresses_parent_address_id_addresses_id_fk" FOREIGN KEY ("parent_address_id") REFERENCES "public"."addresses"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "addresses" ADD CONSTRAINT "addresses_merged_into_address_id_addresses_id_fk" FOREIGN KEY ("merged_into_address_id") REFERENCES "public"."addresses"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "addresses_identity_key_key" ON "addresses" USING btree ("identity_key") WHERE "addresses"."identity_key" is not null;--> statement-breakpoint
+CREATE INDEX "addresses_parent_address_id_idx" ON "addresses" USING btree ("parent_address_id");--> statement-breakpoint
+CREATE INDEX "addresses_merged_into_address_id_idx" ON "addresses" USING btree ("merged_into_address_id") WHERE "addresses"."merged_into_address_id" is not null;--> statement-breakpoint
+ALTER TABLE "addresses" ADD CONSTRAINT "addresses_parent_not_self_check" CHECK ("addresses"."parent_address_id" <> "addresses"."id");--> statement-breakpoint
+ALTER TABLE "addresses" ADD CONSTRAINT "addresses_merge_not_self_check" CHECK ("addresses"."merged_into_address_id" <> "addresses"."id");

--- a/packages/backend/drizzle/meta/0013_snapshot.json
+++ b/packages/backend/drizzle/meta/0013_snapshot.json
@@ -1,6 +1,6 @@
 {
   "id": "a14c476c-2c42-49cb-b088-32fa0fa221b9",
-  "prevId": "c209c091-5586-4b37-872b-25fa62a31999",
+  "prevId": "62814704-d6f6-46e5-ad56-20d872a84f85",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -744,7 +744,7 @@
           "primaryKey": false,
           "notNull": true,
           "generated": {
-            "as": "regexp_replace(\n    regexp_replace(\n      translate(replace(replace(replace(replace(replace(regexp_replace(lower(name), '[\\u0300-\\u036F]', '', 'g'), 'ß', 'ss'), 'æ', 'ae'), 'œ', 'oe'), 'þ', 'th'), 'ĳ', 'ij'), 'àáâãäåāăąçćčĉċďđðèéêëēĕėęěĝğġģĥħìíîïĩīĭįıĵķĺļľłñńņňòóôõöøōŏőŕŗřśŝşšșţťŧțùúûüũūŭůűųŵýÿŷźżž', 'aaaaaaaaacccccdddeeeeeeeeegggghhiiiiiiiiijkllllnnnnooooooooorrrsssssttttuuuuuuuuuuwyyyzzz'),\n      '[^a-z0-9]+', '-', 'g'\n    ),\n    '^-+|-+$', '', 'g'\n  )",
+            "as": "regexp_replace(\n    regexp_replace(\n      translate(replace(replace(replace(replace(replace(regexp_replace(lower(name), '[\\u0300-\\u036F]', '', 'g'), '\u00df', 'ss'), '\u00e6', 'ae'), '\u0153', 'oe'), '\u00fe', 'th'), '\u0133', 'ij'), '\u00e0\u00e1\u00e2\u00e3\u00e4\u00e5\u0101\u0103\u0105\u00e7\u0107\u010d\u0109\u010b\u010f\u0111\u00f0\u00e8\u00e9\u00ea\u00eb\u0113\u0115\u0117\u0119\u011b\u011d\u011f\u0121\u0123\u0125\u0127\u00ec\u00ed\u00ee\u00ef\u0129\u012b\u012d\u012f\u0131\u0135\u0137\u013a\u013c\u013e\u0142\u00f1\u0144\u0146\u0148\u00f2\u00f3\u00f4\u00f5\u00f6\u00f8\u014d\u014f\u0151\u0155\u0157\u0159\u015b\u015d\u015f\u0161\u0219\u0163\u0165\u0167\u021b\u00f9\u00fa\u00fb\u00fc\u0169\u016b\u016d\u016f\u0171\u0173\u0175\u00fd\u00ff\u0177\u017a\u017c\u017e', 'aaaaaaaaacccccdddeeeeeeeeegggghhiiiiiiiiijkllllnnnnooooooooorrrsssssttttuuuuuuuuuuwyyyzzz'),\n      '[^a-z0-9]+', '-', 'g'\n    ),\n    '^-+|-+$', '', 'g'\n  )",
             "type": "stored"
           }
         },
@@ -3731,6 +3731,633 @@
         "exchange_reviews_distinct_parties_check": {
           "name": "exchange_reviews_distinct_parties_check",
           "value": "\"exchange_reviews\".\"reviewer_oxy_user_id\" <> \"exchange_reviews\".\"subject_oxy_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.housing_alerts": {
+      "name": "housing_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watch_id": {
+          "name": "watch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_type": {
+          "name": "rule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cooldown_bucket": {
+          "name": "cooldown_bucket",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_state": {
+          "name": "delivery_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "suppression_reason": {
+          "name": "suppression_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_channels": {
+          "name": "delivered_channels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "housing_alerts_idempotency_key": {
+          "name": "housing_alerts_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_alerts_cooldown_key": {
+          "name": "housing_alerts_cooldown_key",
+          "columns": [
+            {
+              "expression": "watch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cooldown_bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_alerts_owner_created_idx": {
+          "name": "housing_alerts_owner_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_alerts_watch_created_idx": {
+          "name": "housing_alerts_watch_created_idx",
+          "columns": [
+            {
+              "expression": "watch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_alerts_pending_idx": {
+          "name": "housing_alerts_pending_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_alerts\".\"delivery_state\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "housing_alerts_watch_id_saved_searches_id_fk": {
+          "name": "housing_alerts_watch_id_saved_searches_id_fk",
+          "tableFrom": "housing_alerts",
+          "tableTo": "saved_searches",
+          "columnsFrom": [
+            "watch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "housing_alerts_event_id_housing_domain_events_id_fk": {
+          "name": "housing_alerts_event_id_housing_domain_events_id_fk",
+          "tableFrom": "housing_alerts",
+          "tableTo": "housing_domain_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "housing_alerts_notification_id_notifications_id_fk": {
+          "name": "housing_alerts_notification_id_notifications_id_fk",
+          "tableFrom": "housing_alerts",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "housing_alerts_rule_type_check": {
+          "name": "housing_alerts_rule_type_check",
+          "value": "\"housing_alerts\".\"rule_type\" in ('new_listing', 'price_decrease', 'price_increase', 'cost_terms_changed', 'listing_removed', 'listing_reappeared', 'new_review', 'eviction_nearby', 'source_conflict')"
+        },
+        "housing_alerts_subject_type_check": {
+          "name": "housing_alerts_subject_type_check",
+          "value": "\"housing_alerts\".\"subject_type\" in ('property', 'address', 'eviction', 'review')"
+        },
+        "housing_alerts_delivery_state_check": {
+          "name": "housing_alerts_delivery_state_check",
+          "value": "\"housing_alerts\".\"delivery_state\" in ('pending', 'delivered', 'suppressed', 'failed')"
+        },
+        "housing_alerts_suppression_reason_check": {
+          "name": "housing_alerts_suppression_reason_check",
+          "value": "\"housing_alerts\".\"suppression_reason\" is null or \"housing_alerts\".\"suppression_reason\" in ('muted', 'cadence_off', 'channel_unavailable', 'rate_limited')"
+        },
+        "housing_alerts_suppression_coherence_check": {
+          "name": "housing_alerts_suppression_coherence_check",
+          "value": "(\"housing_alerts\".\"delivery_state\" = 'suppressed') = (\"housing_alerts\".\"suppression_reason\" is not null)"
+        },
+        "housing_alerts_delivered_channels_check": {
+          "name": "housing_alerts_delivered_channels_check",
+          "value": "\"housing_alerts\".\"delivery_state\" <> 'delivered' or cardinality(\"housing_alerts\".\"delivered_channels\") >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.housing_domain_events": {
+      "name": "housing_domain_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition": {
+          "name": "transition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "case when longitude is null or latitude is null then null\n          else ST_MakePoint(longitude, latitude)::geography end",
+            "type": "stored"
+          }
+        },
+        "is_backfill": {
+          "name": "is_backfill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "housing_domain_events_unprocessed_idx": {
+          "name": "housing_domain_events_unprocessed_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_domain_events\".\"processed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_domain_events_geo_gist": {
+          "name": "housing_domain_events_geo_gist",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_domain_events\".\"geo\" is not null",
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "housing_domain_events_subject_idx": {
+          "name": "housing_domain_events_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_domain_events_expires_at_idx": {
+          "name": "housing_domain_events_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_domain_events\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "housing_domain_events_type_check": {
+          "name": "housing_domain_events_type_check",
+          "value": "\"housing_domain_events\".\"type\" in ('new_listing', 'price_decrease', 'price_increase', 'cost_terms_changed', 'listing_removed', 'listing_reappeared', 'new_review', 'eviction_nearby', 'source_conflict')"
+        },
+        "housing_domain_events_subject_type_check": {
+          "name": "housing_domain_events_subject_type_check",
+          "value": "\"housing_domain_events\".\"subject_type\" in ('property', 'address', 'eviction', 'review')"
+        },
+        "housing_domain_events_coordinate_pair_check": {
+          "name": "housing_domain_events_coordinate_pair_check",
+          "value": "(\"housing_domain_events\".\"longitude\" is null) = (\"housing_domain_events\".\"latitude\" is null)"
+        },
+        "housing_domain_events_coordinate_range_check": {
+          "name": "housing_domain_events_coordinate_range_check",
+          "value": "\"housing_domain_events\".\"longitude\" is null or (\n        \"housing_domain_events\".\"longitude\" between -180 and 180 and \"housing_domain_events\".\"latitude\" between -90 and 90\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.housing_watch_rules": {
+      "name": "housing_watch_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watch_id": {
+          "name": "watch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "housing_watch_rules_watch_type_key": {
+          "name": "housing_watch_rules_watch_type_key",
+          "columns": [
+            {
+              "expression": "watch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_watch_rules_type_enabled_idx": {
+          "name": "housing_watch_rules_type_enabled_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_watch_rules\".\"enabled\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "housing_watch_rules_watch_id_saved_searches_id_fk": {
+          "name": "housing_watch_rules_watch_id_saved_searches_id_fk",
+          "tableFrom": "housing_watch_rules",
+          "tableTo": "saved_searches",
+          "columnsFrom": [
+            "watch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "housing_watch_rules_type_check": {
+          "name": "housing_watch_rules_type_check",
+          "value": "\"housing_watch_rules\".\"type\" in ('new_listing', 'price_decrease', 'price_increase', 'cost_terms_changed', 'listing_removed', 'listing_reappeared', 'new_review', 'eviction_nearby', 'source_conflict')"
+        },
+        "housing_watch_rules_threshold_check": {
+          "name": "housing_watch_rules_threshold_check",
+          "value": "threshold is null or (threshold >= 0 and threshold <= 1000)"
         }
       },
       "isRLSEnabled": false
@@ -11569,6 +12196,70 @@
           "notNull": true,
           "default": false
         },
+        "query_version": {
+          "name": "query_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "is_primary_area": {
+          "name": "is_primary_area",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cadence": {
+          "name": "cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "channels": {
+          "name": "channels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{in_app}'::text[]"
+        },
+        "muted_until": {
+          "name": "muted_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alerts_active_from": {
+          "name": "alerts_active_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "push_privacy_mode": {
+          "name": "push_privacy_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'discreet'"
+        },
+        "area": {
+          "name": "area",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_geo": {
+          "name": "area_geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "case when area is null then null else ST_GeomFromGeoJSON(area)::geography end",
+            "type": "stored"
+          }
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -11642,13 +12333,62 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "saved_searches_primary_area_key": {
+          "name": "saved_searches_primary_area_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"saved_searches\".\"is_primary_area\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_searches_area_geo_gist": {
+          "name": "saved_searches_area_geo_gist",
+          "columns": [
+            {
+              "expression": "area_geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"saved_searches\".\"area_geo\" is not null",
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
         }
       },
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "saved_searches_cadence_check": {
+          "name": "saved_searches_cadence_check",
+          "value": "\"saved_searches\".\"cadence\" in ('instant', 'daily', 'weekly', 'off')"
+        },
+        "saved_searches_push_privacy_mode_check": {
+          "name": "saved_searches_push_privacy_mode_check",
+          "value": "\"saved_searches\".\"push_privacy_mode\" in ('discreet', 'detailed')"
+        },
+        "saved_searches_channels_check": {
+          "name": "saved_searches_channels_check",
+          "value": "\"saved_searches\".\"channels\" <@ ARRAY['in_app', 'push', 'email']::text[]\n        and cardinality(\"saved_searches\".\"channels\") >= 1\n        and 'in_app' = any(\"saved_searches\".\"channels\")"
+        },
+        "saved_searches_query_version_check": {
+          "name": "saved_searches_query_version_check",
+          "value": "query_version >= 1"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.tenant_application_documents": {

--- a/packages/backend/drizzle/meta/0014_snapshot.json
+++ b/packages/backend/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,13676 @@
+{
+  "id": "7008d5c0-e162-4320-a172-c96ccc1801fa",
+  "prevId": "a14c476c-2c42-49cb-b088-32fa0fa221b9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.address_candidates": {
+      "name": "address_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submitted_by_oxy_user_id": {
+          "name": "submitted_by_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_text_hash": {
+          "name": "raw_text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_payload": {
+          "name": "normalized_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "normalization_version": {
+          "name": "normalization_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "precision": {
+          "name": "precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_country_code": {
+          "name": "proposed_country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_country": {
+          "name": "proposed_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_region": {
+          "name": "proposed_region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_city": {
+          "name": "proposed_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_neighborhood": {
+          "name": "proposed_neighborhood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_street": {
+          "name": "proposed_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_postal_code": {
+          "name": "proposed_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_number": {
+          "name": "proposed_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_building_name": {
+          "name": "proposed_building_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_block": {
+          "name": "proposed_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_entrance": {
+          "name": "proposed_entrance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_floor": {
+          "name": "proposed_floor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_unit": {
+          "name": "proposed_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_subunit": {
+          "name": "proposed_subunit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "materialized_address_id": {
+          "name": "materialized_address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "materialized_at": {
+          "name": "materialized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "address_candidates_submitter_raw_text_idx": {
+          "name": "address_candidates_submitter_raw_text_idx",
+          "columns": [
+            {
+              "expression": "submitted_by_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raw_text_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_candidates_provider_ref_idx": {
+          "name": "address_candidates_provider_ref_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_candidates_expires_at_idx": {
+          "name": "address_candidates_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_candidates_materialized_address_id_idx": {
+          "name": "address_candidates_materialized_address_id_idx",
+          "columns": [
+            {
+              "expression": "materialized_address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "address_candidates_materialized_address_id_addresses_id_fk": {
+          "name": "address_candidates_materialized_address_id_addresses_id_fk",
+          "tableFrom": "address_candidates",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "materialized_address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "address_candidates_precision_check": {
+          "name": "address_candidates_precision_check",
+          "value": "\"address_candidates\".\"precision\" in ('exact', 'approximate', 'centroid', 'area')"
+        },
+        "address_candidates_origin_check": {
+          "name": "address_candidates_origin_check",
+          "value": "\"address_candidates\".\"origin\" in ('user_typed', 'autocomplete_selection', 'map_pin', 'geocoder', 'listing_ingest', 'public_dataset', 'approved_correction')"
+        },
+        "address_candidates_coordinates_check": {
+          "name": "address_candidates_coordinates_check",
+          "value": "(\"address_candidates\".\"longitude\" is null and \"address_candidates\".\"latitude\" is null)\n          or (\"address_candidates\".\"longitude\" is not null and \"address_candidates\".\"latitude\" is not null\n              and \"address_candidates\".\"longitude\" between -180 and 180\n              and \"address_candidates\".\"latitude\" between -90 and 90)"
+        },
+        "address_candidates_materialized_coherence_check": {
+          "name": "address_candidates_materialized_coherence_check",
+          "value": "(\"address_candidates\".\"materialized_address_id\" is null and \"address_candidates\".\"materialized_at\" is null)\n          or (\"address_candidates\".\"materialized_address_id\" is not null and \"address_candidates\".\"materialized_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.address_external_refs": {
+      "name": "address_external_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_label": {
+          "name": "raw_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "address_external_refs_source_external_id_key": {
+          "name": "address_external_refs_source_external_id_key",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_external_refs_address_id_idx": {
+          "name": "address_external_refs_address_id_idx",
+          "columns": [
+            {
+              "expression": "address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "address_external_refs_address_id_addresses_id_fk": {
+          "name": "address_external_refs_address_id_addresses_id_fk",
+          "tableFrom": "address_external_refs",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "address_external_refs_confidence_range_check": {
+          "name": "address_external_refs_confidence_range_check",
+          "value": "\"address_external_refs\".\"confidence\" between 0 and 1"
+        },
+        "address_external_refs_seen_order_check": {
+          "name": "address_external_refs_seen_order_check",
+          "value": "\"address_external_refs\".\"last_seen_at\" >= \"address_external_refs\".\"first_seen_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.address_materializations": {
+      "name": "address_materializations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_text_hash": {
+          "name": "raw_text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalization_version": {
+          "name": "normalization_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_kind": {
+          "name": "match_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_detail": {
+          "name": "match_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_key": {
+          "name": "identity_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durable_action": {
+          "name": "durable_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_action_ref": {
+          "name": "durable_action_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_oxy_user_id": {
+          "name": "actor_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "address_materializations_idempotency_key": {
+          "name": "address_materializations_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"address_materializations\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_materializations_address_id_idx": {
+          "name": "address_materializations_address_id_idx",
+          "columns": [
+            {
+              "expression": "address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_materializations_candidate_id_idx": {
+          "name": "address_materializations_candidate_id_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "address_materializations_address_id_addresses_id_fk": {
+          "name": "address_materializations_address_id_addresses_id_fk",
+          "tableFrom": "address_materializations",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "address_materializations_match_kind_check": {
+          "name": "address_materializations_match_kind_check",
+          "value": "\"address_materializations\".\"match_kind\" in ('created', 'exact_identity_key', 'exact_external_ref', 'adopted_v1_key', 'confirmed_probable')"
+        },
+        "address_materializations_durable_action_check": {
+          "name": "address_materializations_durable_action_check",
+          "value": "\"address_materializations\".\"durable_action\" in ('listing_upsert', 'review', 'follow_dwelling', 'public_data_link', 'canonical_event', 'approved_correction')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.addresses": {
+      "name": "addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "neighborhood_id": {
+          "name": "neighborhood_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "building_name": {
+          "name": "building_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrance": {
+          "name": "entrance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "floor": {
+          "name": "floor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subunit": {
+          "name": "subunit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district": {
+          "name": "district",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_lines": {
+          "name": "address_lines",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "po_box": {
+          "name": "po_box",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_plot_block": {
+          "name": "land_plot_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_plot_lot": {
+          "name": "land_plot_lot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_plot_parcel": {
+          "name": "land_plot_parcel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extras": {
+          "name": "extras",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "ST_MakePoint(longitude, latitude)::geography",
+            "type": "stored"
+          }
+        },
+        "address_level": {
+          "name": "address_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "\n      case\n        when coalesce(floor, '') <> '' or coalesce(unit, '') <> ''\n          or coalesce(subunit, '') <> '' then 'UNIT'\n        when coalesce(number, '') <> '' or coalesce(building_name, '') <> ''\n          or coalesce(block, '') <> '' or coalesce(entrance, '') <> '' then 'BUILDING'\n        else 'STREET'\n      end\n    ",
+            "type": "stored"
+          }
+        },
+        "normalized_key": {
+          "name": "normalized_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_key": {
+          "name": "identity_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_address_id": {
+          "name": "parent_address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_into_address_id": {
+          "name": "merged_into_address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "addresses_normalized_key_key": {
+          "name": "addresses_normalized_key_key",
+          "columns": [
+            {
+              "expression": "normalized_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"addresses\".\"normalized_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_identity_key_key": {
+          "name": "addresses_identity_key_key",
+          "columns": [
+            {
+              "expression": "identity_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"addresses\".\"identity_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_parent_address_id_idx": {
+          "name": "addresses_parent_address_id_idx",
+          "columns": [
+            {
+              "expression": "parent_address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_merged_into_address_id_idx": {
+          "name": "addresses_merged_into_address_id_idx",
+          "columns": [
+            {
+              "expression": "merged_into_address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"addresses\".\"merged_into_address_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_geo_gist": {
+          "name": "addresses_geo_gist",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "addresses_city_id_idx": {
+          "name": "addresses_city_id_idx",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_region_id_idx": {
+          "name": "addresses_region_id_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_country_id_idx": {
+          "name": "addresses_country_id_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_neighborhood_id_idx": {
+          "name": "addresses_neighborhood_id_idx",
+          "columns": [
+            {
+              "expression": "neighborhood_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_postal_code_country_idx": {
+          "name": "addresses_postal_code_country_idx",
+          "columns": [
+            {
+              "expression": "postal_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "country_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_street_trgm_idx": {
+          "name": "addresses_street_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"street\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "addresses_country_id_countries_id_fk": {
+          "name": "addresses_country_id_countries_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "addresses_region_id_regions_id_fk": {
+          "name": "addresses_region_id_regions_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "addresses_city_id_cities_id_fk": {
+          "name": "addresses_city_id_cities_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "addresses_neighborhood_id_neighborhoods_id_fk": {
+          "name": "addresses_neighborhood_id_neighborhoods_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "neighborhoods",
+          "columnsFrom": [
+            "neighborhood_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "addresses_parent_address_id_addresses_id_fk": {
+          "name": "addresses_parent_address_id_addresses_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "parent_address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "addresses_merged_into_address_id_addresses_id_fk": {
+          "name": "addresses_merged_into_address_id_addresses_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "merged_into_address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "addresses_address_level_check": {
+          "name": "addresses_address_level_check",
+          "value": "\"addresses\".\"address_level\" in ('STREET', 'BUILDING', 'UNIT')"
+        },
+        "addresses_coordinates_range_check": {
+          "name": "addresses_coordinates_range_check",
+          "value": "\"addresses\".\"longitude\" between -180 and 180 and \"addresses\".\"latitude\" between -90 and 90"
+        },
+        "addresses_parent_not_self_check": {
+          "name": "addresses_parent_not_self_check",
+          "value": "\"addresses\".\"parent_address_id\" <> \"addresses\".\"id\""
+        },
+        "addresses_merge_not_self_check": {
+          "name": "addresses_merge_not_self_check",
+          "value": "\"addresses\".\"merged_into_address_id\" <> \"addresses\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agencies": {
+      "name": "agencies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "agencies_normalized_name_key": {
+          "name": "agencies_normalized_name_key",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agencies_slug_key": {
+          "name": "agencies_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agencies_name_trgm_idx": {
+          "name": "agencies_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agencies_normalized_name_not_empty_check": {
+          "name": "agencies_normalized_name_not_empty_check",
+          "value": "length(\"agencies\".\"normalized_name\") > 0"
+        },
+        "agencies_slug_not_empty_check": {
+          "name": "agencies_slug_not_empty_check",
+          "value": "length(\"agencies\".\"slug\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing": {
+      "name": "billing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plus_active": {
+          "name": "plus_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "plus_since": {
+          "name": "plus_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plus_canceled_at": {
+          "name": "plus_canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plus_stripe_subscription_id": {
+          "name": "plus_stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_credits": {
+          "name": "file_credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_payment_at": {
+          "name": "last_payment_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founder_supporter": {
+          "name": "founder_supporter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "founder_since": {
+          "name": "founder_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "billing_oxy_user_id_key": {
+          "name": "billing_oxy_user_id_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_plus_active_idx": {
+          "name": "billing_plus_active_idx",
+          "columns": [
+            {
+              "expression": "plus_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"billing\".\"plus_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_plus_stripe_subscription_id_key": {
+          "name": "billing_plus_stripe_subscription_id_key",
+          "columns": [
+            {
+              "expression": "plus_stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"billing\".\"plus_stripe_subscription_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_file_credits_non_negative_check": {
+          "name": "billing_file_credits_non_negative_check",
+          "value": "\"billing\".\"file_credits\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_processed_sessions": {
+      "name": "billing_processed_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_id": {
+          "name": "billing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "billing_processed_sessions_key": {
+          "name": "billing_processed_sessions_key",
+          "columns": [
+            {
+              "expression": "billing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_processed_sessions_billing_id_billing_id_fk": {
+          "name": "billing_processed_sessions_billing_id_billing_id_fk",
+          "tableFrom": "billing_processed_sessions",
+          "tableTo": "billing",
+          "columnsFrom": [
+            "billing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cities": {
+      "name": "cities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "regexp_replace(\n    regexp_replace(\n      translate(replace(replace(replace(replace(replace(regexp_replace(lower(name), '[\\u0300-\\u036F]', '', 'g'), 'ß', 'ss'), 'æ', 'ae'), 'œ', 'oe'), 'þ', 'th'), 'ĳ', 'ij'), 'àáâãäåāăąçćčĉċďđðèéêëēĕėęěĝğġģĥħìíîïĩīĭįıĵķĺļľłñńņňòóôõöøōŏőŕŗřśŝşšșţťŧțùúûüũūŭůűųŵýÿŷźżž', 'aaaaaaaaacccccdddeeeeeeeeegggghhiiiiiiiiijkllllnnnnooooooooorrrsssssttttuuuuuuuuuuwyyyzzz'),\n      '[^a-z0-9]+', '-', 'g'\n    ),\n    '^-+|-+$', '', 'g'\n  )",
+            "type": "stored"
+          }
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_west": {
+          "name": "bbox_west",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_south": {
+          "name": "bbox_south",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_east": {
+          "name": "bbox_east",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_north": {
+          "name": "bbox_north",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "population": {
+          "name": "population",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_rent": {
+          "name": "average_rent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "properties_count": {
+          "name": "properties_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "cities_region_name_key": {
+          "name": "cities_region_name_key",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_country_id_idx": {
+          "name": "cities_country_id_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_active_popularity_idx": {
+          "name": "cities_active_popularity_idx",
+          "columns": [
+            {
+              "expression": "\"properties_count\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"cities\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_name_lower_idx": {
+          "name": "cities_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_region_name_lower_idx": {
+          "name": "cities_region_name_lower_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_name_trgm_idx": {
+          "name": "cities_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "cities_slug_idx": {
+          "name": "cities_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cities_country_id_countries_id_fk": {
+          "name": "cities_country_id_countries_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cities_region_id_regions_id_fk": {
+          "name": "cities_region_id_regions_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cities_cover_image_id_images_id_fk": {
+          "name": "cities_cover_image_id_images_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "images",
+          "columnsFrom": [
+            "cover_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cities_currency_check": {
+          "name": "cities_currency_check",
+          "value": "\"cities\".\"currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        },
+        "cities_bbox_complete_check": {
+          "name": "cities_bbox_complete_check",
+          "value": "(\n        \"cities\".\"bbox_west\" is null and \"cities\".\"bbox_south\" is null\n        and \"cities\".\"bbox_east\" is null and \"cities\".\"bbox_north\" is null\n      ) or (\n        \"cities\".\"bbox_west\" is not null and \"cities\".\"bbox_south\" is not null\n        and \"cities\".\"bbox_east\" is not null and \"cities\".\"bbox_north\" is not null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.commissions": {
+      "name": "commissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "partner_id": {
+          "name": "partner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "basis_offering": {
+          "name": "basis_offering",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "basis_deal_value": {
+          "name": "basis_deal_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "basis_kind": {
+          "name": "basis_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "basis_rate": {
+          "name": "basis_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basis_flat": {
+          "name": "basis_flat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "commissions_property_id_key": {
+          "name": "commissions_property_id_key",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commissions_partner_created_idx": {
+          "name": "commissions_partner_created_idx",
+          "columns": [
+            {
+              "expression": "partner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commissions_status_idx": {
+          "name": "commissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commissions_partner_id_partners_id_fk": {
+          "name": "commissions_partner_id_partners_id_fk",
+          "tableFrom": "commissions",
+          "tableTo": "partners",
+          "columnsFrom": [
+            "partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "commissions_property_id_properties_id_fk": {
+          "name": "commissions_property_id_properties_id_fk",
+          "tableFrom": "commissions",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "commissions_status_check": {
+          "name": "commissions_status_check",
+          "value": "\"commissions\".\"status\" in ('pending', 'approved', 'paid', 'cancelled')"
+        },
+        "commissions_basis_offering_check": {
+          "name": "commissions_basis_offering_check",
+          "value": "\"commissions\".\"basis_offering\" in ('rent', 'sale', 'exchange')"
+        },
+        "commissions_basis_kind_check": {
+          "name": "commissions_basis_kind_check",
+          "value": "\"commissions\".\"basis_kind\" in ('percentOfMonthlyRent', 'flat')"
+        },
+        "commissions_basis_components_check": {
+          "name": "commissions_basis_components_check",
+          "value": "(\n        \"commissions\".\"basis_kind\" = 'percentOfMonthlyRent'\n          and \"commissions\".\"basis_rate\" is not null and \"commissions\".\"basis_flat\" is null\n      ) or (\n        \"commissions\".\"basis_kind\" = 'flat'\n          and \"commissions\".\"basis_flat\" is not null and \"commissions\".\"basis_rate\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_message_attachments": {
+      "name": "conversation_message_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_message_attachments_message_id_idx": {
+          "name": "conversation_message_attachments_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_message_attachments_message_id_conversation_messages_id_fk": {
+          "name": "conversation_message_attachments_message_id_conversation_messages_id_fk",
+          "tableFrom": "conversation_message_attachments",
+          "tableTo": "conversation_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_message_attachments_type_check": {
+          "name": "conversation_message_attachments_type_check",
+          "value": "\"conversation_message_attachments\".\"type\" in ('file', 'image', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_messages": {
+      "name": "conversation_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversation_messages_conversation_position_key": {
+          "name": "conversation_messages_conversation_position_key",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_messages_conversation_id_conversations_id_fk": {
+          "name": "conversation_messages_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_messages_role_check": {
+          "name": "conversation_messages_role_check",
+          "value": "\"conversation_messages\".\"role\" in ('user', 'assistant', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "metadata_initial_message": {
+          "name": "metadata_initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "metadata_language": {
+          "name": "metadata_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "metadata_tags": {
+          "name": "metadata_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "sharing_is_shared": {
+          "name": "sharing_is_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharing_share_token": {
+          "name": "sharing_share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharing_shared_at": {
+          "name": "sharing_shared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharing_expires_at": {
+          "name": "sharing_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analytics_last_activity": {
+          "name": "analytics_last_activity",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analytics_total_tokens": {
+          "name": "analytics_total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "conversations_oxy_user_created_idx": {
+          "name": "conversations_oxy_user_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_oxy_user_status_updated_idx": {
+          "name": "conversations_oxy_user_status_updated_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_share_token_key": {
+          "name": "conversations_share_token_key",
+          "columns": [
+            {
+              "expression": "sharing_share_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversations\".\"sharing_share_token\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_sharing_expires_at_idx": {
+          "name": "conversations_sharing_expires_at_idx",
+          "columns": [
+            {
+              "expression": "sharing_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations\".\"sharing_expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_status_check": {
+          "name": "conversations_status_check",
+          "value": "\"conversations\".\"status\" in ('active', 'archived', 'deleted')"
+        },
+        "conversations_topic_check": {
+          "name": "conversations_topic_check",
+          "value": "\"conversations\".\"topic\" in ('rent', 'repairs', 'lease', 'rights', 'general')"
+        },
+        "conversations_metadata_source_check": {
+          "name": "conversations_metadata_source_check",
+          "value": "\"conversations\".\"metadata_source\" in ('quick_action', 'example', 'manual', 'url_share')"
+        },
+        "conversations_sharing_coherent_check": {
+          "name": "conversations_sharing_coherent_check",
+          "value": "(\n        \"conversations\".\"sharing_is_shared\"\n          and \"conversations\".\"sharing_share_token\" is not null\n          and \"conversations\".\"sharing_shared_at\" is not null\n          and \"conversations\".\"sharing_expires_at\" is not null\n      ) or (\n        not \"conversations\".\"sharing_is_shared\"\n          and \"conversations\".\"sharing_share_token\" is null\n          and \"conversations\".\"sharing_shared_at\" is null\n          and \"conversations\".\"sharing_expires_at\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.countries": {
+      "name": "countries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "flag": {
+          "name": "flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_locale": {
+          "name": "default_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "countries_code_key": {
+          "name": "countries_code_key",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "countries_name_lower_idx": {
+          "name": "countries_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "countries_currency_check": {
+          "name": "countries_currency_check",
+          "value": "\"countries\".\"currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_attendees": {
+      "name": "eviction_case_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rsvped_at": {
+          "name": "rsvped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_basis": {
+          "name": "confirmation_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "eviction_case_attendees_case_user_key": {
+          "name": "eviction_case_attendees_case_user_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_attendees_case_id_eviction_cases_id_fk": {
+          "name": "eviction_case_attendees_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_case_attendees",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_case_attendees_confirmation_check": {
+          "name": "eviction_case_attendees_confirmation_check",
+          "value": "(\"eviction_case_attendees\".\"confirmed_at\" is null) = (\"eviction_case_attendees\".\"confirmation_basis\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_followers": {
+      "name": "eviction_case_followers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_case_followers_case_user_key": {
+          "name": "eviction_case_followers_case_user_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_case_followers_user_idx": {
+          "name": "eviction_case_followers_user_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_followers_case_id_eviction_cases_id_fk": {
+          "name": "eviction_case_followers_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_case_followers",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_help_needs": {
+      "name": "eviction_case_help_needs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "need_type": {
+          "name": "need_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_case_help_needs_key": {
+          "name": "eviction_case_help_needs_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "need_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_case_help_needs_type_idx": {
+          "name": "eviction_case_help_needs_type_idx",
+          "columns": [
+            {
+              "expression": "need_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_help_needs_case_id_eviction_cases_id_fk": {
+          "name": "eviction_case_help_needs_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_case_help_needs",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_case_help_needs_type_check": {
+          "name": "eviction_case_help_needs_type_check",
+          "value": "\"eviction_case_help_needs\".\"need_type\" in ('presence', 'legal_support', 'translation', 'transport', 'temporary_housing', 'outreach', 'organization_contact')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_updates": {
+      "name": "eviction_case_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'note'"
+        },
+        "actor_oxy_user_id": {
+          "name": "actor_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_scheduled_at": {
+          "name": "new_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_case_updates_case_position_idx": {
+          "name": "eviction_case_updates_case_position_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"position\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_case_updates_case_position_key": {
+          "name": "eviction_case_updates_case_position_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_updates_case_id_eviction_cases_id_fk": {
+          "name": "eviction_case_updates_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_case_updates",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_case_updates_new_status_check": {
+          "name": "eviction_case_updates_new_status_check",
+          "value": "\"eviction_case_updates\".\"new_status\" in ('upcoming', 'stopped', 'postponed', 'executed', 'cancelled')"
+        },
+        "eviction_case_updates_event_type_check": {
+          "name": "eviction_case_updates_event_type_check",
+          "value": "\"eviction_case_updates\".\"event_type\" in ('case_created', 'date_changed', 'location_precision_changed', 'instructions_updated', 'postponed', 'stopped', 'executed', 'cancelled', 'legal_resource_added', 'organization_verified', 'correction_published', 'precautionary_hold_applied', 'note')"
+        },
+        "eviction_case_updates_position_check": {
+          "name": "eviction_case_updates_position_check",
+          "value": "\"eviction_case_updates\".\"position\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_cases": {
+      "name": "eviction_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_label": {
+          "name": "location_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_longitude": {
+          "name": "location_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_latitude": {
+          "name": "location_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_radius_meters": {
+          "name": "location_radius_meters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2500
+        },
+        "location_geo": {
+          "name": "location_geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "ST_MakePoint(location_longitude, location_latitude)::geography",
+            "type": "stored"
+          }
+        },
+        "location_precision": {
+          "name": "location_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approximate_radius'"
+        },
+        "location_city": {
+          "name": "location_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_country_code": {
+          "name": "location_country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_exact_longitude": {
+          "name": "location_exact_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_exact_latitude": {
+          "name": "location_exact_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_exact_address": {
+          "name": "location_exact_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_household_authorized_at": {
+          "name": "location_household_authorized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        },
+        "precautionary_hold_at": {
+          "name": "precautionary_hold_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disputed_at": {
+          "name": "disputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agency_id": {
+          "name": "agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_telegram": {
+          "name": "contact_telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_whatsapp": {
+          "name": "contact_whatsapp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_instructions": {
+          "name": "contact_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_unlock_min_tenure_days": {
+          "name": "contact_unlock_min_tenure_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_reminder_sent_at": {
+          "name": "outcome_reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_cases_status_scheduled_idx": {
+          "name": "eviction_cases_status_scheduled_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_cases_oxy_user_created_idx": {
+          "name": "eviction_cases_oxy_user_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_cases_location_geo_gist": {
+          "name": "eviction_cases_location_geo_gist",
+          "columns": [
+            {
+              "expression": "location_geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "eviction_cases_updated_idx": {
+          "name": "eviction_cases_updated_idx",
+          "columns": [
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_cases_agency_id_idx": {
+          "name": "eviction_cases_agency_id_idx",
+          "columns": [
+            {
+              "expression": "agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"eviction_cases\".\"agency_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_cases_organization_id_idx": {
+          "name": "eviction_cases_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"eviction_cases\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_cases_agency_id_agencies_id_fk": {
+          "name": "eviction_cases_agency_id_agencies_id_fk",
+          "tableFrom": "eviction_cases",
+          "tableTo": "agencies",
+          "columnsFrom": [
+            "agency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "eviction_cases_organization_id_eviction_organizations_id_fk": {
+          "name": "eviction_cases_organization_id_eviction_organizations_id_fk",
+          "tableFrom": "eviction_cases",
+          "tableTo": "eviction_organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "eviction_cases_cover_image_id_images_id_fk": {
+          "name": "eviction_cases_cover_image_id_images_id_fk",
+          "tableFrom": "eviction_cases",
+          "tableTo": "images",
+          "columnsFrom": [
+            "cover_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_cases_status_check": {
+          "name": "eviction_cases_status_check",
+          "value": "\"eviction_cases\".\"status\" in ('upcoming', 'stopped', 'postponed', 'executed', 'cancelled')"
+        },
+        "eviction_cases_location_precision_check": {
+          "name": "eviction_cases_location_precision_check",
+          "value": "\"eviction_cases\".\"location_precision\" in ('street', 'neighborhood', 'approximate_radius')"
+        },
+        "eviction_cases_coordinates_range_check": {
+          "name": "eviction_cases_coordinates_range_check",
+          "value": "\"eviction_cases\".\"location_longitude\" between -180 and 180\n        and \"eviction_cases\".\"location_latitude\" between -90 and 90"
+        },
+        "eviction_cases_exact_coordinates_range_check": {
+          "name": "eviction_cases_exact_coordinates_range_check",
+          "value": "(\"eviction_cases\".\"location_exact_longitude\" is null\n            or \"eviction_cases\".\"location_exact_longitude\" between -180 and 180)\n        and (\"eviction_cases\".\"location_exact_latitude\" is null\n            or \"eviction_cases\".\"location_exact_latitude\" between -90 and 90)"
+        },
+        "eviction_cases_exact_location_authorized_check": {
+          "name": "eviction_cases_exact_location_authorized_check",
+          "value": "(\"eviction_cases\".\"location_exact_longitude\" is null) = (\"eviction_cases\".\"location_exact_latitude\" is null)\n        and (\n          \"eviction_cases\".\"location_household_authorized_at\" is not null\n          or (\"eviction_cases\".\"location_exact_longitude\" is null\n              and \"eviction_cases\".\"location_exact_address\" is null)\n        )"
+        },
+        "eviction_cases_radius_positive_check": {
+          "name": "eviction_cases_radius_positive_check",
+          "value": "\"eviction_cases\".\"location_radius_meters\" > 0"
+        },
+        "eviction_cases_contact_tenure_check": {
+          "name": "eviction_cases_contact_tenure_check",
+          "value": "\"eviction_cases\".\"contact_unlock_min_tenure_days\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_comments": {
+      "name": "eviction_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_comments_case_created_idx": {
+          "name": "eviction_comments_case_created_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_comments_oxy_user_id_idx": {
+          "name": "eviction_comments_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_comments_case_id_eviction_cases_id_fk": {
+          "name": "eviction_comments_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_comments",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_location_access_audit": {
+      "name": "eviction_location_access_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_oxy_user_id": {
+          "name": "actor_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denial_reason": {
+          "name": "denial_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_location_access_audit_case_created_idx": {
+          "name": "eviction_location_access_audit_case_created_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_location_access_audit_case_id_eviction_cases_id_fk": {
+          "name": "eviction_location_access_audit_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_location_access_audit",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_location_access_audit_action_check": {
+          "name": "eviction_location_access_audit_action_check",
+          "value": "\"eviction_location_access_audit\".\"action\" in ('granted', 'revoked', 'read', 'denied')"
+        },
+        "eviction_location_access_audit_denial_check": {
+          "name": "eviction_location_access_audit_denial_check",
+          "value": "(\"eviction_location_access_audit\".\"action\" = 'denied') = (\"eviction_location_access_audit\".\"denial_reason\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_location_grants": {
+      "name": "eviction_location_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_oxy_user_id": {
+          "name": "grantee_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_oxy_user_id": {
+          "name": "granted_by_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "eviction_location_grants_live_key": {
+          "name": "eviction_location_grants_live_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grantee_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"eviction_location_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_location_grants_case_idx": {
+          "name": "eviction_location_grants_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_location_grants_case_id_eviction_cases_id_fk": {
+          "name": "eviction_location_grants_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_location_grants",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_location_grants_purpose_check": {
+          "name": "eviction_location_grants_purpose_check",
+          "value": "\"eviction_location_grants\".\"purpose\" in ('legal_representation', 'accompaniment', 'emergency_housing')"
+        },
+        "eviction_location_grants_window_check": {
+          "name": "eviction_location_grants_window_check",
+          "value": "\"eviction_location_grants\".\"expires_at\" > \"eviction_location_grants\".\"granted_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_organizations": {
+      "name": "eviction_organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_channels": {
+          "name": "public_channels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_source": {
+          "name": "verification_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_organizations_normalized_name_key": {
+          "name": "eviction_organizations_normalized_name_key",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_organizations_verified_source_check": {
+          "name": "eviction_organizations_verified_source_check",
+          "value": "\"eviction_organizations\".\"verified_at\" is null or \"eviction_organizations\".\"verification_source\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_reports": {
+      "name": "eviction_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_oxy_user_id": {
+          "name": "reporter_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_reports_status_created_idx": {
+          "name": "eviction_reports_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_reports_case_status_idx": {
+          "name": "eviction_reports_case_status_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_reports_open_reporter_key": {
+          "name": "eviction_reports_open_reporter_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"eviction_reports\".\"status\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_reports_case_id_eviction_cases_id_fk": {
+          "name": "eviction_reports_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_reports",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_reports_reason_check": {
+          "name": "eviction_reports_reason_check",
+          "value": "\"eviction_reports\".\"reason\" in ('false_information', 'personal_data_exposed', 'location_too_precise', 'outdated', 'harassment', 'spam', 'dangerous_contact')"
+        },
+        "eviction_reports_status_check": {
+          "name": "eviction_reports_status_check",
+          "value": "\"eviction_reports\".\"status\" in ('open', 'reviewing', 'resolved', 'dismissed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_supporter_vouches": {
+      "name": "eviction_supporter_vouches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voucher_oxy_user_id": {
+          "name": "voucher_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vouched_oxy_user_id": {
+          "name": "vouched_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_supporter_vouches_key": {
+          "name": "eviction_supporter_vouches_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "voucher_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vouched_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_supporter_vouches_vouched_idx": {
+          "name": "eviction_supporter_vouches_vouched_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vouched_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_supporter_vouches_case_id_eviction_cases_id_fk": {
+          "name": "eviction_supporter_vouches_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_supporter_vouches",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_supporter_vouches_distinct_check": {
+          "name": "eviction_supporter_vouches_distinct_check",
+          "value": "\"eviction_supporter_vouches\".\"voucher_oxy_user_id\" <> \"eviction_supporter_vouches\".\"vouched_oxy_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_update_notifications": {
+      "name": "eviction_update_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "update_id": {
+          "name": "update_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_oxy_user_id": {
+          "name": "recipient_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_update_notifications_key": {
+          "name": "eviction_update_notifications_key",
+          "columns": [
+            {
+              "expression": "update_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_update_notifications_update_id_eviction_case_updates_id_fk": {
+          "name": "eviction_update_notifications_update_id_eviction_case_updates_id_fk",
+          "tableFrom": "eviction_update_notifications",
+          "tableTo": "eviction_case_updates",
+          "columnsFrom": [
+            "update_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exchange_requests": {
+      "name": "exchange_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_oxy_user_id": {
+          "name": "requester_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_oxy_user_id": {
+          "name": "host_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offered_property_id": {
+          "name": "offered_property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_window_start": {
+          "name": "requested_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_window_end": {
+          "name": "requested_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offered_window_start": {
+          "name": "offered_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offered_window_end": {
+          "name": "offered_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "exchange_requests_requested_window_gist": {
+          "name": "exchange_requests_requested_window_gist",
+          "columns": [
+            {
+              "expression": "tstzrange(\"requested_window_start\", \"requested_window_end\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "exchange_requests_property_status_idx": {
+          "name": "exchange_requests_property_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exchange_requests_requester_status_created_idx": {
+          "name": "exchange_requests_requester_status_created_idx",
+          "columns": [
+            {
+              "expression": "requester_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exchange_requests_host_status_created_idx": {
+          "name": "exchange_requests_host_status_created_idx",
+          "columns": [
+            {
+              "expression": "host_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_requests_property_id_properties_id_fk": {
+          "name": "exchange_requests_property_id_properties_id_fk",
+          "tableFrom": "exchange_requests",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "exchange_requests_offered_property_id_properties_id_fk": {
+          "name": "exchange_requests_offered_property_id_properties_id_fk",
+          "tableFrom": "exchange_requests",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "offered_property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exchange_requests_mode_check": {
+          "name": "exchange_requests_mode_check",
+          "value": "\"exchange_requests\".\"mode\" in ('swap', 'host', 'both')"
+        },
+        "exchange_requests_status_check": {
+          "name": "exchange_requests_status_check",
+          "value": "\"exchange_requests\".\"status\" in ('pending', 'confirmed', 'declined', 'cancelled', 'completed')"
+        },
+        "exchange_requests_requested_window_order_check": {
+          "name": "exchange_requests_requested_window_order_check",
+          "value": "\"exchange_requests\".\"requested_window_end\" > \"exchange_requests\".\"requested_window_start\""
+        },
+        "exchange_requests_offered_window_check": {
+          "name": "exchange_requests_offered_window_check",
+          "value": "(\n        \"exchange_requests\".\"offered_window_start\" is null and \"exchange_requests\".\"offered_window_end\" is null\n      ) or (\n        \"exchange_requests\".\"offered_window_start\" is not null and \"exchange_requests\".\"offered_window_end\" is not null\n          and \"exchange_requests\".\"offered_window_end\" > \"exchange_requests\".\"offered_window_start\"\n      )"
+        },
+        "exchange_requests_host_mode_offers_nothing_check": {
+          "name": "exchange_requests_host_mode_offers_nothing_check",
+          "value": "\"exchange_requests\".\"mode\" <> 'host' or (\n        \"exchange_requests\".\"offered_property_id\" is null\n        and \"exchange_requests\".\"offered_window_start\" is null\n        and \"exchange_requests\".\"offered_window_end\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.exchange_reviews": {
+      "name": "exchange_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "exchange_request_id": {
+          "name": "exchange_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_oxy_user_id": {
+          "name": "reviewer_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_oxy_user_id": {
+          "name": "subject_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories_communication": {
+          "name": "categories_communication",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories_cleanliness": {
+          "name": "categories_cleanliness",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories_accuracy": {
+          "name": "categories_accuracy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories_hospitality": {
+          "name": "categories_hospitality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "exchange_reviews_request_reviewer_key": {
+          "name": "exchange_reviews_request_reviewer_key",
+          "columns": [
+            {
+              "expression": "exchange_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reviewer_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exchange_reviews_subject_created_idx": {
+          "name": "exchange_reviews_subject_created_idx",
+          "columns": [
+            {
+              "expression": "subject_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_reviews_exchange_request_id_exchange_requests_id_fk": {
+          "name": "exchange_reviews_exchange_request_id_exchange_requests_id_fk",
+          "tableFrom": "exchange_reviews",
+          "tableTo": "exchange_requests",
+          "columnsFrom": [
+            "exchange_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exchange_reviews_rating_check": {
+          "name": "exchange_reviews_rating_check",
+          "value": "\"exchange_reviews\".\"rating\" between 1 and 5"
+        },
+        "exchange_reviews_categories_range_check": {
+          "name": "exchange_reviews_categories_range_check",
+          "value": "(\"exchange_reviews\".\"categories_communication\" is null or \"exchange_reviews\".\"categories_communication\" between 1 and 5)\n        and (\"exchange_reviews\".\"categories_cleanliness\" is null or \"exchange_reviews\".\"categories_cleanliness\" between 1 and 5)\n        and (\"exchange_reviews\".\"categories_accuracy\" is null or \"exchange_reviews\".\"categories_accuracy\" between 1 and 5)\n        and (\"exchange_reviews\".\"categories_hospitality\" is null or \"exchange_reviews\".\"categories_hospitality\" between 1 and 5)"
+        },
+        "exchange_reviews_distinct_parties_check": {
+          "name": "exchange_reviews_distinct_parties_check",
+          "value": "\"exchange_reviews\".\"reviewer_oxy_user_id\" <> \"exchange_reviews\".\"subject_oxy_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.housing_alerts": {
+      "name": "housing_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watch_id": {
+          "name": "watch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_type": {
+          "name": "rule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cooldown_bucket": {
+          "name": "cooldown_bucket",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_state": {
+          "name": "delivery_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "suppression_reason": {
+          "name": "suppression_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_channels": {
+          "name": "delivered_channels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "housing_alerts_idempotency_key": {
+          "name": "housing_alerts_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_alerts_cooldown_key": {
+          "name": "housing_alerts_cooldown_key",
+          "columns": [
+            {
+              "expression": "watch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cooldown_bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_alerts_owner_created_idx": {
+          "name": "housing_alerts_owner_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_alerts_watch_created_idx": {
+          "name": "housing_alerts_watch_created_idx",
+          "columns": [
+            {
+              "expression": "watch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_alerts_pending_idx": {
+          "name": "housing_alerts_pending_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_alerts\".\"delivery_state\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "housing_alerts_watch_id_saved_searches_id_fk": {
+          "name": "housing_alerts_watch_id_saved_searches_id_fk",
+          "tableFrom": "housing_alerts",
+          "tableTo": "saved_searches",
+          "columnsFrom": [
+            "watch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "housing_alerts_event_id_housing_domain_events_id_fk": {
+          "name": "housing_alerts_event_id_housing_domain_events_id_fk",
+          "tableFrom": "housing_alerts",
+          "tableTo": "housing_domain_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "housing_alerts_notification_id_notifications_id_fk": {
+          "name": "housing_alerts_notification_id_notifications_id_fk",
+          "tableFrom": "housing_alerts",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "housing_alerts_rule_type_check": {
+          "name": "housing_alerts_rule_type_check",
+          "value": "\"housing_alerts\".\"rule_type\" in ('new_listing', 'price_decrease', 'price_increase', 'cost_terms_changed', 'listing_removed', 'listing_reappeared', 'new_review', 'eviction_nearby', 'source_conflict')"
+        },
+        "housing_alerts_subject_type_check": {
+          "name": "housing_alerts_subject_type_check",
+          "value": "\"housing_alerts\".\"subject_type\" in ('property', 'address', 'eviction', 'review')"
+        },
+        "housing_alerts_delivery_state_check": {
+          "name": "housing_alerts_delivery_state_check",
+          "value": "\"housing_alerts\".\"delivery_state\" in ('pending', 'delivered', 'suppressed', 'failed')"
+        },
+        "housing_alerts_suppression_reason_check": {
+          "name": "housing_alerts_suppression_reason_check",
+          "value": "\"housing_alerts\".\"suppression_reason\" is null or \"housing_alerts\".\"suppression_reason\" in ('muted', 'cadence_off', 'channel_unavailable', 'rate_limited')"
+        },
+        "housing_alerts_suppression_coherence_check": {
+          "name": "housing_alerts_suppression_coherence_check",
+          "value": "(\"housing_alerts\".\"delivery_state\" = 'suppressed') = (\"housing_alerts\".\"suppression_reason\" is not null)"
+        },
+        "housing_alerts_delivered_channels_check": {
+          "name": "housing_alerts_delivered_channels_check",
+          "value": "\"housing_alerts\".\"delivery_state\" <> 'delivered' or cardinality(\"housing_alerts\".\"delivered_channels\") >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.housing_domain_events": {
+      "name": "housing_domain_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition": {
+          "name": "transition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "case when longitude is null or latitude is null then null\n          else ST_MakePoint(longitude, latitude)::geography end",
+            "type": "stored"
+          }
+        },
+        "is_backfill": {
+          "name": "is_backfill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "housing_domain_events_unprocessed_idx": {
+          "name": "housing_domain_events_unprocessed_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_domain_events\".\"processed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_domain_events_geo_gist": {
+          "name": "housing_domain_events_geo_gist",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_domain_events\".\"geo\" is not null",
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "housing_domain_events_subject_idx": {
+          "name": "housing_domain_events_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_domain_events_expires_at_idx": {
+          "name": "housing_domain_events_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_domain_events\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "housing_domain_events_type_check": {
+          "name": "housing_domain_events_type_check",
+          "value": "\"housing_domain_events\".\"type\" in ('new_listing', 'price_decrease', 'price_increase', 'cost_terms_changed', 'listing_removed', 'listing_reappeared', 'new_review', 'eviction_nearby', 'source_conflict')"
+        },
+        "housing_domain_events_subject_type_check": {
+          "name": "housing_domain_events_subject_type_check",
+          "value": "\"housing_domain_events\".\"subject_type\" in ('property', 'address', 'eviction', 'review')"
+        },
+        "housing_domain_events_coordinate_pair_check": {
+          "name": "housing_domain_events_coordinate_pair_check",
+          "value": "(\"housing_domain_events\".\"longitude\" is null) = (\"housing_domain_events\".\"latitude\" is null)"
+        },
+        "housing_domain_events_coordinate_range_check": {
+          "name": "housing_domain_events_coordinate_range_check",
+          "value": "\"housing_domain_events\".\"longitude\" is null or (\n        \"housing_domain_events\".\"longitude\" between -180 and 180 and \"housing_domain_events\".\"latitude\" between -90 and 90\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.housing_watch_rules": {
+      "name": "housing_watch_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watch_id": {
+          "name": "watch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "housing_watch_rules_watch_type_key": {
+          "name": "housing_watch_rules_watch_type_key",
+          "columns": [
+            {
+              "expression": "watch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_watch_rules_type_enabled_idx": {
+          "name": "housing_watch_rules_type_enabled_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_watch_rules\".\"enabled\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "housing_watch_rules_watch_id_saved_searches_id_fk": {
+          "name": "housing_watch_rules_watch_id_saved_searches_id_fk",
+          "tableFrom": "housing_watch_rules",
+          "tableTo": "saved_searches",
+          "columnsFrom": [
+            "watch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "housing_watch_rules_type_check": {
+          "name": "housing_watch_rules_type_check",
+          "value": "\"housing_watch_rules\".\"type\" in ('new_listing', 'price_decrease', 'price_increase', 'cost_terms_changed', 'listing_removed', 'listing_reappeared', 'new_review', 'eviction_nearby', 'source_conflict')"
+        },
+        "housing_watch_rules_threshold_check": {
+          "name": "housing_watch_rules_threshold_check",
+          "value": "threshold is null or (threshold >= 0 and threshold <= 1000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keys_original": {
+          "name": "keys_original",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keys_small": {
+          "name": "keys_small",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keys_medium": {
+          "name": "keys_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keys_large": {
+          "name": "keys_large",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urls_original": {
+          "name": "urls_original",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urls_small": {
+          "name": "urls_small",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urls_medium": {
+          "name": "urls_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urls_large": {
+          "name": "urls_large",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "images_entity_order_idx": {
+          "name": "images_entity_order_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "images_entity_type_check": {
+          "name": "images_entity_type_check",
+          "value": "\"images\".\"entity_type\" in ('property', 'city', 'region', 'country', 'profile')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.jurisdiction_resources": {
+      "name": "jurisdiction_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "jurisdiction_resources_country_type_idx": {
+          "name": "jurisdiction_resources_country_type_idx",
+          "columns": [
+            {
+              "expression": "country_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jurisdiction_resources_region_idx": {
+          "name": "jurisdiction_resources_region_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jurisdiction_resources\".\"region_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jurisdiction_resources_country_url_key": {
+          "name": "jurisdiction_resources_country_url_key",
+          "columns": [
+            {
+              "expression": "country_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jurisdiction_resources_region_id_regions_id_fk": {
+          "name": "jurisdiction_resources_region_id_regions_id_fk",
+          "tableFrom": "jurisdiction_resources",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "jurisdiction_resources_type_check": {
+          "name": "jurisdiction_resources_type_check",
+          "value": "\"jurisdiction_resources\".\"resource_type\" in ('legal_aid', 'tenant_union', 'emergency_housing', 'official_info')"
+        },
+        "jurisdiction_resources_languages_check": {
+          "name": "jurisdiction_resources_languages_check",
+          "value": "cardinality(\"jurisdiction_resources\".\"languages\") >= 1"
+        },
+        "jurisdiction_resources_validity_check": {
+          "name": "jurisdiction_resources_validity_check",
+          "value": "\"jurisdiction_resources\".\"valid_until\" is null or \"jurisdiction_resources\".\"valid_until\" > \"jurisdiction_resources\".\"verified_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_co_tenants": {
+      "name": "lease_co_tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'secondary'"
+        },
+        "signed_date": {
+          "name": "signed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "lease_co_tenants_lease_id_idx": {
+          "name": "lease_co_tenants_lease_id_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_co_tenants_lease_id_leases_id_fk": {
+          "name": "lease_co_tenants_lease_id_leases_id_fk",
+          "tableFrom": "lease_co_tenants",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_co_tenants_role_check": {
+          "name": "lease_co_tenants_role_check",
+          "value": "\"lease_co_tenants\".\"role\" in ('primary', 'secondary', 'guarantor')"
+        },
+        "lease_co_tenants_status_check": {
+          "name": "lease_co_tenants_status_check",
+          "value": "\"lease_co_tenants\".\"status\" in ('pending', 'signed', 'declined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_documents": {
+      "name": "lease_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "uploaded_by_oxy_user_id": {
+          "name": "uploaded_by_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_date": {
+          "name": "uploaded_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lease_documents_lease_id_idx": {
+          "name": "lease_documents_lease_id_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_documents_lease_id_leases_id_fk": {
+          "name": "lease_documents_lease_id_leases_id_fk",
+          "tableFrom": "lease_documents",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_documents_type_check": {
+          "name": "lease_documents_type_check",
+          "value": "\"lease_documents\".\"type\" in ('lease_agreement', 'addendum', 'inspection_report', 'insurance', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_inspection_findings": {
+      "name": "lease_inspection_findings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area": {
+          "name": "area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        }
+      },
+      "indexes": {
+        "lease_inspection_findings_inspection_id_idx": {
+          "name": "lease_inspection_findings_inspection_id_idx",
+          "columns": [
+            {
+              "expression": "inspection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_inspection_findings_inspection_id_lease_inspections_id_fk": {
+          "name": "lease_inspection_findings_inspection_id_lease_inspections_id_fk",
+          "tableFrom": "lease_inspection_findings",
+          "tableTo": "lease_inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_inspection_findings_condition_check": {
+          "name": "lease_inspection_findings_condition_check",
+          "value": "\"lease_inspection_findings\".\"condition\" in ('excellent', 'good', 'fair', 'poor', 'needs_repair')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_inspections": {
+      "name": "lease_inspections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inspector": {
+          "name": "inspector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_by_tenant": {
+          "name": "signed_by_tenant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signed_by_landlord": {
+          "name": "signed_by_landlord",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "lease_inspections_lease_id_idx": {
+          "name": "lease_inspections_lease_id_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_inspections_lease_id_leases_id_fk": {
+          "name": "lease_inspections_lease_id_leases_id_fk",
+          "tableFrom": "lease_inspections",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_inspections_type_check": {
+          "name": "lease_inspections_type_check",
+          "value": "\"lease_inspections\".\"type\" in ('move_in', 'move_out', 'periodic', 'maintenance')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_payment_schedule": {
+      "name": "lease_payment_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "paid_date": {
+          "name": "paid_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lease_payment_schedule_lease_due_idx": {
+          "name": "lease_payment_schedule_lease_due_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lease_payment_schedule_due_status_idx": {
+          "name": "lease_payment_schedule_due_status_idx",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_payment_schedule_lease_id_leases_id_fk": {
+          "name": "lease_payment_schedule_lease_id_leases_id_fk",
+          "tableFrom": "lease_payment_schedule",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_payment_schedule_type_check": {
+          "name": "lease_payment_schedule_type_check",
+          "value": "\"lease_payment_schedule\".\"type\" in ('rent', 'deposit', 'fee', 'utility')"
+        },
+        "lease_payment_schedule_status_check": {
+          "name": "lease_payment_schedule_status_check",
+          "value": "\"lease_payment_schedule\".\"status\" in ('pending', 'paid', 'overdue', 'cancelled')"
+        },
+        "lease_payment_schedule_method_check": {
+          "name": "lease_payment_schedule_method_check",
+          "value": "\"lease_payment_schedule\".\"payment_method\" in ('cash', 'check', 'bank_transfer', 'credit_card', 'debit_card', 'digital_wallet')"
+        },
+        "lease_payment_schedule_paid_evidence_check": {
+          "name": "lease_payment_schedule_paid_evidence_check",
+          "value": "(\n        \"lease_payment_schedule\".\"status\" = 'paid'\n          and \"lease_payment_schedule\".\"paid_date\" is not null and \"lease_payment_schedule\".\"paid_amount\" is not null\n      ) or (\n        \"lease_payment_schedule\".\"status\" <> 'paid'\n          and \"lease_payment_schedule\".\"paid_date\" is null and \"lease_payment_schedule\".\"paid_amount\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_shared_utility_costs": {
+      "name": "lease_shared_utility_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility": {
+          "name": "utility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_percentage": {
+          "name": "split_percentage",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lease_shared_utility_costs_lease_id_idx": {
+          "name": "lease_shared_utility_costs_lease_id_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_shared_utility_costs_lease_id_leases_id_fk": {
+          "name": "lease_shared_utility_costs_lease_id_leases_id_fk",
+          "tableFrom": "lease_shared_utility_costs",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_shared_utility_costs_utility_check": {
+          "name": "lease_shared_utility_costs_utility_check",
+          "value": "\"lease_shared_utility_costs\".\"utility\" in ('electricity', 'gas', 'water', 'trash', 'internet', 'cable', 'heat', 'air_conditioning')"
+        },
+        "lease_shared_utility_costs_split_check": {
+          "name": "lease_shared_utility_costs_split_check",
+          "value": "\"lease_shared_utility_costs\".\"split_percentage\" between 0 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.leases": {
+      "name": "leases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landlord_oxy_user_id": {
+          "name": "landlord_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_oxy_user_id": {
+          "name": "tenant_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_terms_start_date": {
+          "name": "lease_terms_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_terms_end_date": {
+          "name": "lease_terms_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_terms_renewal_options": {
+          "name": "lease_terms_renewal_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "lease_terms_renewal_notice_required": {
+          "name": "lease_terms_renewal_notice_required",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "lease_terms_termination_notice_required": {
+          "name": "lease_terms_termination_notice_required",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "rent_details_monthly_rent": {
+          "name": "rent_details_monthly_rent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rent_details_currency": {
+          "name": "rent_details_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "rent_details_due_date": {
+          "name": "rent_details_due_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "rent_details_late_fee_amount": {
+          "name": "rent_details_late_fee_amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rent_details_late_fee_grace_period": {
+          "name": "rent_details_late_fee_grace_period",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "rent_details_security_deposit": {
+          "name": "rent_details_security_deposit",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rent_details_pet_deposit": {
+          "name": "rent_details_pet_deposit",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "utilities_included": {
+          "name": "utilities_included",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "utilities_tenant_responsible": {
+          "name": "utilities_tenant_responsible",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rules_pets_allowed": {
+          "name": "rules_pets_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_pets_types": {
+          "name": "rules_pets_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rules_pets_max_number": {
+          "name": "rules_pets_max_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rules_pets_restrictions": {
+          "name": "rules_pets_restrictions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rules_smoking": {
+          "name": "rules_smoking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_guests_overnight_allowed": {
+          "name": "rules_guests_overnight_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rules_guests_overnight_max_consecutive_days": {
+          "name": "rules_guests_overnight_max_consecutive_days",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "rules_guests_overnight_max_days_per_month": {
+          "name": "rules_guests_overnight_max_days_per_month",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "rules_guests_parties": {
+          "name": "rules_guests_parties",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_subletting": {
+          "name": "rules_subletting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_alterations": {
+          "name": "rules_alterations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signatures_landlord_signed": {
+          "name": "signatures_landlord_signed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signatures_landlord_signed_date": {
+          "name": "signatures_landlord_signed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatures_landlord_digital_signature": {
+          "name": "signatures_landlord_digital_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatures_tenant_signed": {
+          "name": "signatures_tenant_signed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signatures_tenant_signed_date": {
+          "name": "signatures_tenant_signed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatures_tenant_digital_signature": {
+          "name": "signatures_tenant_digital_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_given_by_oxy_user_id": {
+          "name": "termination_notice_given_by_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_given_date": {
+          "name": "termination_notice_given_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_effective_date": {
+          "name": "termination_notice_effective_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_reason": {
+          "name": "termination_notice_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_acknowledged": {
+          "name": "termination_notice_acknowledged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "termination_notice_acknowledged_date": {
+          "name": "termination_notice_acknowledged_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "leases_property_status_idx": {
+          "name": "leases_property_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "leases_landlord_status_idx": {
+          "name": "leases_landlord_status_idx",
+          "columns": [
+            {
+              "expression": "landlord_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "leases_tenant_status_idx": {
+          "name": "leases_tenant_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "leases_term_range_gist": {
+          "name": "leases_term_range_gist",
+          "columns": [
+            {
+              "expression": "tstzrange(\"lease_terms_start_date\", \"lease_terms_end_date\", '[]')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "leases_active_end_date_idx": {
+          "name": "leases_active_end_date_idx",
+          "columns": [
+            {
+              "expression": "lease_terms_end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"leases\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "leases_property_id_properties_id_fk": {
+          "name": "leases_property_id_properties_id_fk",
+          "tableFrom": "leases",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "leases_room_id_properties_id_fk": {
+          "name": "leases_room_id_properties_id_fk",
+          "tableFrom": "leases",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "leases_status_check": {
+          "name": "leases_status_check",
+          "value": "\"leases\".\"status\" in ('draft', 'pending_signatures', 'active', 'expired', 'terminated', 'cancelled')"
+        },
+        "leases_renewal_options_check": {
+          "name": "leases_renewal_options_check",
+          "value": "\"leases\".\"lease_terms_renewal_options\" in ('none', 'automatic', 'optional')"
+        },
+        "leases_rent_currency_check": {
+          "name": "leases_rent_currency_check",
+          "value": "\"leases\".\"rent_details_currency\" in ('USD', 'EUR', 'GBP', 'CAD')"
+        },
+        "leases_utilities_included_check": {
+          "name": "leases_utilities_included_check",
+          "value": "\"leases\".\"utilities_included\" <@ array['electricity', 'gas', 'water', 'trash', 'internet', 'cable', 'heat', 'air_conditioning']::text[]"
+        },
+        "leases_utilities_tenant_responsible_check": {
+          "name": "leases_utilities_tenant_responsible_check",
+          "value": "\"leases\".\"utilities_tenant_responsible\" <@ array['electricity', 'gas', 'water', 'trash', 'internet', 'cable', 'heat', 'air_conditioning']::text[]"
+        },
+        "leases_rules_pets_types_check": {
+          "name": "leases_rules_pets_types_check",
+          "value": "\"leases\".\"rules_pets_types\" <@ array['dog', 'cat', 'bird', 'fish', 'reptile', 'other']::text[]"
+        },
+        "leases_rent_due_date_check": {
+          "name": "leases_rent_due_date_check",
+          "value": "\"leases\".\"rent_details_due_date\" between 1 and 31"
+        },
+        "leases_term_order_check": {
+          "name": "leases_term_order_check",
+          "value": "\"leases\".\"lease_terms_end_date\" > \"leases\".\"lease_terms_start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.listing_reports": {
+      "name": "listing_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_oxy_user_id": {
+          "name": "reporter_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "listing_reports_status_created_idx": {
+          "name": "listing_reports_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listing_reports_property_status_idx": {
+          "name": "listing_reports_property_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listing_reports_open_reporter_key": {
+          "name": "listing_reports_open_reporter_key",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"listing_reports\".\"status\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listing_reports_property_id_properties_id_fk": {
+          "name": "listing_reports_property_id_properties_id_fk",
+          "tableFrom": "listing_reports",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "listing_reports_reason_check": {
+          "name": "listing_reports_reason_check",
+          "value": "\"listing_reports\".\"reason\" in ('inaccurate', 'scam', 'inappropriate', 'unavailable', 'privacy', 'unsafe', 'other')"
+        },
+        "listing_reports_status_check": {
+          "name": "listing_reports_status_check",
+          "value": "\"listing_reports\".\"status\" in ('open', 'reviewing', 'resolved', 'dismissed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_enforcements": {
+      "name": "moderation_enforcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_action": {
+          "name": "recommended_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_reason": {
+          "name": "skipped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state_property_moderation_restricted": {
+          "name": "previous_state_property_moderation_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state_review_moderation_status": {
+          "name": "previous_state_review_moderation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_enforcements_decision_action_key": {
+          "name": "moderation_enforcements_decision_action_key",
+          "columns": [
+            {
+              "expression": "decision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_enforcements_subject_created_idx": {
+          "name": "moderation_enforcements_subject_created_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_enforcements_case_id_idx": {
+          "name": "moderation_enforcements_case_id_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_enforcements_action_check": {
+          "name": "moderation_enforcements_action_check",
+          "value": "\"moderation_enforcements\".\"action\" in ('none', 'restrict', 'restore', 'flag_for_review', 'unflag', 'manual_review')"
+        },
+        "moderation_enforcements_mode_check": {
+          "name": "moderation_enforcements_mode_check",
+          "value": "\"moderation_enforcements\".\"mode\" in ('observe', 'manual', 'automatic')"
+        },
+        "moderation_enforcements_previous_review_status_check": {
+          "name": "moderation_enforcements_previous_review_status_check",
+          "value": "\"moderation_enforcements\".\"previous_state_review_moderation_status\" in ('active', 'under_review', 'removed')"
+        },
+        "moderation_enforcements_decision_revision_check": {
+          "name": "moderation_enforcements_decision_revision_check",
+          "value": "\"moderation_enforcements\".\"decision_revision\" >= 1"
+        },
+        "moderation_enforcements_applied_at_check": {
+          "name": "moderation_enforcements_applied_at_check",
+          "value": "\"moderation_enforcements\".\"applied\" = (\"moderation_enforcements\".\"applied_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_events": {
+      "name": "moderation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claimed'"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_events_case_id_idx": {
+          "name": "moderation_events_case_id_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"moderation_events\".\"case_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_events_expires_at_idx": {
+          "name": "moderation_events_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_events_state_received_idx": {
+          "name": "moderation_events_state_received_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_events_state_check": {
+          "name": "moderation_events_state_check",
+          "value": "\"moderation_events\".\"state\" in ('claimed', 'queued', 'ignored')"
+        },
+        "moderation_events_queued_at_check": {
+          "name": "moderation_events_queued_at_check",
+          "value": "(\"moderation_events\".\"state\" = 'queued') = (\"moderation_events\".\"queued_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_outbox": {
+      "name": "moderation_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_outbox_due_idx": {
+          "name": "moderation_outbox_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_outbox_lease_idx": {
+          "name": "moderation_outbox_lease_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_outbox_expires_at_idx": {
+          "name": "moderation_outbox_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_outbox_report_id_moderation_reports_id_fk": {
+          "name": "moderation_outbox_report_id_moderation_reports_id_fk",
+          "tableFrom": "moderation_outbox",
+          "tableTo": "moderation_reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_outbox_kind_check": {
+          "name": "moderation_outbox_kind_check",
+          "value": "\"moderation_outbox\".\"kind\" in ('report.submit', 'decision.apply')"
+        },
+        "moderation_outbox_status_check": {
+          "name": "moderation_outbox_status_check",
+          "value": "\"moderation_outbox\".\"status\" in ('pending', 'processing', 'processed', 'dead_letter')"
+        },
+        "moderation_outbox_attempts_check": {
+          "name": "moderation_outbox_attempts_check",
+          "value": "\"moderation_outbox\".\"attempts\" >= 0"
+        },
+        "moderation_outbox_lease_pair_check": {
+          "name": "moderation_outbox_lease_pair_check",
+          "value": "(\"moderation_outbox\".\"lease_owner\" is null) = (\"moderation_outbox\".\"lease_until\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_reports": {
+      "name": "moderation_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reported_type": {
+          "name": "reported_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_id": {
+          "name": "reported_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_oxy_user_id": {
+          "name": "reporter_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_status": {
+          "name": "local_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "local_status_reason": {
+          "name": "local_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_report_id": {
+          "name": "crowd_source_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_case_id": {
+          "name": "crowd_source_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_merged": {
+          "name": "crowd_source_merged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_outcome": {
+          "name": "decision_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_status": {
+          "name": "decision_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforced_action": {
+          "name": "enforced_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforced_at": {
+          "name": "enforced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_snapshot_hash": {
+          "name": "content_snapshot_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivery_error": {
+          "name": "last_delivery_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_reports_reporter_object_key": {
+          "name": "moderation_reports_reporter_object_key",
+          "columns": [
+            {
+              "expression": "reporter_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reported_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reported_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_reports_local_status_created_idx": {
+          "name": "moderation_reports_local_status_created_idx",
+          "columns": [
+            {
+              "expression": "local_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_reports_object_idx": {
+          "name": "moderation_reports_object_idx",
+          "columns": [
+            {
+              "expression": "reported_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reported_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_reports_case_id_idx": {
+          "name": "moderation_reports_case_id_idx",
+          "columns": [
+            {
+              "expression": "crowd_source_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"moderation_reports\".\"crowd_source_case_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_reports_reported_type_check": {
+          "name": "moderation_reports_reported_type_check",
+          "value": "\"moderation_reports\".\"reported_type\" in ('property', 'review', 'eviction_case')"
+        },
+        "moderation_reports_local_status_check": {
+          "name": "moderation_reports_local_status_check",
+          "value": "\"moderation_reports\".\"local_status\" in ('received', 'queued', 'submitted', 'delivery_failed', 'closed')"
+        },
+        "moderation_reports_enforced_action_check": {
+          "name": "moderation_reports_enforced_action_check",
+          "value": "\"moderation_reports\".\"enforced_action\" in ('none', 'restrict', 'restore', 'flag_for_review', 'unflag', 'manual_review')"
+        },
+        "moderation_reports_decision_revision_check": {
+          "name": "moderation_reports_decision_revision_check",
+          "value": "\"moderation_reports\".\"decision_revision\" is null or \"moderation_reports\".\"decision_revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.neighborhoods": {
+      "name": "neighborhoods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_west": {
+          "name": "bbox_west",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_south": {
+          "name": "bbox_south",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_east": {
+          "name": "bbox_east",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_north": {
+          "name": "bbox_north",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "neighborhoods_city_name_key": {
+          "name": "neighborhoods_city_name_key",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "neighborhoods_name_lower_idx": {
+          "name": "neighborhoods_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "neighborhoods_city_name_lower_idx": {
+          "name": "neighborhoods_city_name_lower_idx",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "neighborhoods_name_trgm_idx": {
+          "name": "neighborhoods_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "neighborhoods_city_id_cities_id_fk": {
+          "name": "neighborhoods_city_id_cities_id_fk",
+          "tableFrom": "neighborhoods",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "neighborhoods_bbox_complete_check": {
+          "name": "neighborhoods_bbox_complete_check",
+          "value": "(\n        \"neighborhoods\".\"bbox_west\" is null and \"neighborhoods\".\"bbox_south\" is null\n        and \"neighborhoods\".\"bbox_east\" is null and \"neighborhoods\".\"bbox_north\" is null\n      ) or (\n        \"neighborhoods\".\"bbox_west\" is not null and \"neighborhoods\".\"bbox_south\" is not null\n        and \"neighborhoods\".\"bbox_east\" is not null and \"neighborhoods\".\"bbox_north\" is not null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_oxy_user_id": {
+          "name": "recipient_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'homiio'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_created_idx": {
+          "name": "notifications_recipient_created_idx",
+          "columns": [
+            {
+              "expression": "recipient_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_unread_idx": {
+          "name": "notifications_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "not \"notifications\".\"read\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_type_created_idx": {
+          "name": "notifications_recipient_type_created_idx",
+          "columns": [
+            {
+              "expression": "recipient_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_priority_check": {
+          "name": "notifications_priority_check",
+          "value": "\"notifications\".\"priority\" in ('low', 'medium', 'high', 'urgent')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.partners": {
+      "name": "partners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referral_code": {
+          "name": "referral_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "points": {
+          "name": "points",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "partners_oxy_user_id_key": {
+          "name": "partners_oxy_user_id_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partners_referral_code_key": {
+          "name": "partners_referral_code_key",
+          "columns": [
+            {
+              "expression": "referral_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partners_status_idx": {
+          "name": "partners_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "partners_status_check": {
+          "name": "partners_status_check",
+          "value": "\"partners\".\"status\" in ('active', 'inactive')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.place_poi_categories": {
+      "name": "place_poi_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "place_poi_id": {
+          "name": "place_poi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "present": {
+          "name": "present",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "count": {
+          "name": "count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "nearest_m": {
+          "name": "nearest_m",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "place_poi_categories_poi_key_key": {
+          "name": "place_poi_categories_poi_key_key",
+          "columns": [
+            {
+              "expression": "place_poi_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "place_poi_categories_place_poi_id_place_pois_id_fk": {
+          "name": "place_poi_categories_place_poi_id_place_pois_id_fk",
+          "tableFrom": "place_poi_categories",
+          "tableTo": "place_pois",
+          "columnsFrom": [
+            "place_poi_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "place_poi_categories_key_check": {
+          "name": "place_poi_categories_key_check",
+          "value": "\"place_poi_categories\".\"key\" in ('pharmacy', 'school', 'hospital', 'police', 'fire_station', 'supermarket', 'transit', 'park', 'bank', 'restaurant', 'gym', 'spa')"
+        },
+        "place_poi_categories_count_check": {
+          "name": "place_poi_categories_count_check",
+          "value": "\"place_poi_categories\".\"count\" >= 0"
+        },
+        "place_poi_categories_coherent_check": {
+          "name": "place_poi_categories_coherent_check",
+          "value": "(\"place_poi_categories\".\"present\" = (\"place_poi_categories\".\"count\" > 0))\n        and (\"place_poi_categories\".\"nearest_m\" is null or \"place_poi_categories\".\"present\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.place_pois": {
+      "name": "place_pois",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cell_key": {
+          "name": "cell_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "radius_m": {
+          "name": "radius_m",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "place_pois_cell_key_key": {
+          "name": "place_pois_cell_key_key",
+          "columns": [
+            {
+              "expression": "cell_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "place_pois_expires_at_idx": {
+          "name": "place_pois_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "place_pois_radius_check": {
+          "name": "place_pois_radius_check",
+          "value": "\"place_pois\".\"radius_m\" >= 1"
+        },
+        "place_pois_coordinates_range_check": {
+          "name": "place_pois_coordinates_range_check",
+          "value": "\"place_pois\".\"lat\" between -90 and 90 and \"place_pois\".\"lng\" between -180 and 180"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profile_chat_messages": {
+      "name": "profile_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_chat_messages_profile_position_idx": {
+          "name": "profile_chat_messages_profile_position_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_chat_messages_profile_id_profiles_id_fk": {
+          "name": "profile_chat_messages_profile_id_profiles_id_fk",
+          "tableFrom": "profile_chat_messages",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profile_chat_messages_role_check": {
+          "name": "profile_chat_messages_role_check",
+          "value": "\"profile_chat_messages\".\"role\" in ('user', 'assistant', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profile_preferred_locations": {
+      "name": "profile_preferred_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "radius": {
+          "name": "radius",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profile_preferred_locations_profile_id_idx": {
+          "name": "profile_preferred_locations_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_preferred_locations_profile_id_profiles_id_fk": {
+          "name": "profile_preferred_locations_profile_id_profiles_id_fk",
+          "tableFrom": "profile_preferred_locations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_references": {
+      "name": "profile_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "profile_references_profile_id_idx": {
+          "name": "profile_references_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_references_profile_id_profiles_id_fk": {
+          "name": "profile_references_profile_id_profiles_id_fk",
+          "tableFrom": "profile_references",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profile_references_relationship_check": {
+          "name": "profile_references_relationship_check",
+          "value": "\"profile_references\".\"relationship\" in ('landlord', 'employer', 'personal', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profile_rental_history": {
+      "name": "profile_rental_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_rent": {
+          "name": "monthly_rent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_for_leaving": {
+          "name": "reason_for_leaving",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landlord_contact_name": {
+          "name": "landlord_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landlord_contact_phone": {
+          "name": "landlord_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landlord_contact_email": {
+          "name": "landlord_contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "profile_rental_history_profile_id_idx": {
+          "name": "profile_rental_history_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_rental_history_profile_id_profiles_id_fk": {
+          "name": "profile_rental_history_profile_id_profiles_id_fk",
+          "tableFrom": "profile_rental_history",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profile_rental_history_reason_for_leaving_check": {
+          "name": "profile_rental_history_reason_for_leaving_check",
+          "value": "\"profile_rental_history\".\"reason_for_leaving\" in ('lease_ended', 'bought_home', 'job_relocation', 'family_reasons', 'upgrade', 'other')"
+        },
+        "profile_rental_history_order_check": {
+          "name": "profile_rental_history_order_check",
+          "value": "\"profile_rental_history\".\"end_date\" is null or \"profile_rental_history\".\"end_date\" >= \"profile_rental_history\".\"start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profile_roommate_history": {
+      "name": "profile_roommate_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roommate_count": {
+          "name": "roommate_count",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profile_roommate_history_profile_id_idx": {
+          "name": "profile_roommate_history_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_roommate_history_profile_id_profiles_id_fk": {
+          "name": "profile_roommate_history_profile_id_profiles_id_fk",
+          "tableFrom": "profile_roommate_history",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profile_roommate_history_order_check": {
+          "name": "profile_roommate_history_order_check",
+          "value": "\"profile_roommate_history\".\"end_date\" is null or \"profile_roommate_history\".\"end_date\" >= \"profile_roommate_history\".\"start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personal_info_bio": {
+          "name": "personal_info_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_occupation": {
+          "name": "personal_info_occupation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_employer": {
+          "name": "personal_info_employer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_annual_income": {
+          "name": "personal_info_annual_income",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_employment_status": {
+          "name": "personal_info_employment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_move_in_date": {
+          "name": "personal_info_move_in_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_lease_duration": {
+          "name": "personal_info_lease_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_property_types": {
+          "name": "preferences_property_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_max_rent": {
+          "name": "preferences_max_rent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_price_unit": {
+          "name": "preferences_price_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_min_bedrooms": {
+          "name": "preferences_min_bedrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_min_bathrooms": {
+          "name": "preferences_min_bathrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_preferred_amenities": {
+          "name": "preferences_preferred_amenities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_pet_friendly": {
+          "name": "preferences_pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_smoking_allowed": {
+          "name": "preferences_smoking_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_furnished": {
+          "name": "preferences_furnished",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_parking_required": {
+          "name": "preferences_parking_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_accessibility": {
+          "name": "preferences_accessibility",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_identity": {
+          "name": "verification_identity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_income": {
+          "name": "verification_income",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_background": {
+          "name": "verification_background",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_rental_history": {
+          "name": "verification_rental_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_references": {
+          "name": "verification_references",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_email": {
+          "name": "settings_notifications_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_push": {
+          "name": "settings_notifications_push",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_sms": {
+          "name": "settings_notifications_sms",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_property_alerts": {
+          "name": "settings_notifications_property_alerts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_viewing_reminders": {
+          "name": "settings_notifications_viewing_reminders",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_lease_updates": {
+          "name": "settings_notifications_lease_updates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_profile_visibility": {
+          "name": "settings_privacy_profile_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_show_contact_info": {
+          "name": "settings_privacy_show_contact_info",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_show_income": {
+          "name": "settings_privacy_show_income",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_show_rental_history": {
+          "name": "settings_privacy_show_rental_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_show_references": {
+          "name": "settings_privacy_show_references",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_enabled": {
+          "name": "settings_roommate_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_age_range_min": {
+          "name": "settings_roommate_preferences_age_range_min",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_age_range_max": {
+          "name": "settings_roommate_preferences_age_range_max",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_gender": {
+          "name": "settings_roommate_preferences_gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_smoking": {
+          "name": "settings_roommate_preferences_lifestyle_smoking",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_pets": {
+          "name": "settings_roommate_preferences_lifestyle_pets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_partying": {
+          "name": "settings_roommate_preferences_lifestyle_partying",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_cleanliness": {
+          "name": "settings_roommate_preferences_lifestyle_cleanliness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_schedule": {
+          "name": "settings_roommate_preferences_lifestyle_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_budget_min": {
+          "name": "settings_roommate_preferences_budget_min",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_budget_max": {
+          "name": "settings_roommate_preferences_budget_max",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_move_in_date": {
+          "name": "settings_roommate_preferences_move_in_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lease_duration": {
+          "name": "settings_roommate_preferences_lease_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_location": {
+          "name": "settings_roommate_preferences_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_interests": {
+          "name": "settings_roommate_preferences_interests",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_language": {
+          "name": "settings_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_timezone": {
+          "name": "settings_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_currency": {
+          "name": "settings_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "profiles_oxy_user_id_key": {
+          "name": "profiles_oxy_user_id_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profiles_personal_info_employment_status_check": {
+          "name": "profiles_personal_info_employment_status_check",
+          "value": "\"profiles\".\"personal_info_employment_status\" in ('employed', 'self_employed', 'student', 'retired', 'unemployed', 'other')"
+        },
+        "profiles_personal_info_lease_duration_check": {
+          "name": "profiles_personal_info_lease_duration_check",
+          "value": "\"profiles\".\"personal_info_lease_duration\" in ('monthly', '3_months', '6_months', 'yearly', 'flexible')"
+        },
+        "profiles_preferences_price_unit_check": {
+          "name": "profiles_preferences_price_unit_check",
+          "value": "\"profiles\".\"preferences_price_unit\" in ('day', 'night', 'week', 'month', 'year')"
+        },
+        "profiles_preferences_property_types_check": {
+          "name": "profiles_preferences_property_types_check",
+          "value": "\"profiles\".\"preferences_property_types\" <@ array['apartment', 'house', 'room', 'studio', 'couchsurfing', 'roommates', 'coliving', 'hostel', 'guesthouse', 'campsite', 'boat', 'treehouse', 'yurt', 'other']::text[]"
+        },
+        "profiles_settings_privacy_profile_visibility_check": {
+          "name": "profiles_settings_privacy_profile_visibility_check",
+          "value": "\"profiles\".\"settings_privacy_profile_visibility\" in ('public', 'private', 'contacts_only')"
+        },
+        "profiles_settings_roommate_gender_check": {
+          "name": "profiles_settings_roommate_gender_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_gender\" in ('male', 'female', 'any')"
+        },
+        "profiles_settings_roommate_smoking_check": {
+          "name": "profiles_settings_roommate_smoking_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_smoking\" in ('yes', 'no', 'prefer_not')"
+        },
+        "profiles_settings_roommate_pets_check": {
+          "name": "profiles_settings_roommate_pets_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_pets\" in ('yes', 'no', 'prefer_not')"
+        },
+        "profiles_settings_roommate_partying_check": {
+          "name": "profiles_settings_roommate_partying_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_partying\" in ('yes', 'no', 'prefer_not')"
+        },
+        "profiles_settings_roommate_cleanliness_check": {
+          "name": "profiles_settings_roommate_cleanliness_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_cleanliness\" in ('very_clean', 'clean', 'average', 'relaxed')"
+        },
+        "profiles_settings_roommate_schedule_check": {
+          "name": "profiles_settings_roommate_schedule_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_schedule\" in ('early_bird', 'night_owl', 'flexible')"
+        },
+        "profiles_settings_roommate_lease_duration_check": {
+          "name": "profiles_settings_roommate_lease_duration_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lease_duration\" in ('monthly', '3_months', '6_months', 'yearly', 'flexible')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.properties": {
+      "name": "properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_external": {
+          "name": "is_external",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourced_by_partner_id": {
+          "name": "sourced_by_partner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourced_by_referral_code": {
+          "name": "sourced_by_referral_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agency_id": {
+          "name": "agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_phone": {
+          "name": "external_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_email": {
+          "name": "external_contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_whatsapp": {
+          "name": "external_contact_whatsapp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_name": {
+          "name": "external_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_agency_name": {
+          "name": "external_contact_agency_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_kind": {
+          "name": "external_contact_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_students_only": {
+          "name": "listing_flags_students_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_room_not_full_unit": {
+          "name": "listing_flags_room_not_full_unit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_temporary_only": {
+          "name": "listing_flags_temporary_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_gender_restricted": {
+          "name": "listing_flags_gender_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_workers_only": {
+          "name": "listing_flags_workers_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_agency_fee_payable": {
+          "name": "listing_flags_agency_fee_payable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_no_pets": {
+          "name": "listing_flags_no_pets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_no_smoking": {
+          "name": "listing_flags_no_smoking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_no_couples": {
+          "name": "listing_flags_no_couples",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_no_dss": {
+          "name": "listing_flags_no_dss",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_detected_language": {
+          "name": "listing_flags_detected_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('homiio_simple', coalesce(description, ''))",
+            "type": "stored"
+          }
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_address_number": {
+          "name": "show_address_number",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'apartment'"
+        },
+        "housing_type": {
+          "name": "housing_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "layout_type": {
+          "name": "layout_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'traditional'"
+        },
+        "bedrooms": {
+          "name": "bedrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bathrooms": {
+          "name": "bathrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "square_footage": {
+          "name": "square_footage",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "floor": {
+          "name": "floor",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "year_built": {
+          "name": "year_built",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_elevator": {
+          "name": "has_elevator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_balcony": {
+          "name": "has_balcony",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_garden": {
+          "name": "has_garden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "utilities_included": {
+          "name": "utilities_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proximity_to_transport": {
+          "name": "proximity_to_transport",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proximity_to_schools": {
+          "name": "proximity_to_schools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proximity_to_shopping": {
+          "name": "proximity_to_shopping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_eco_friendly": {
+          "name": "is_eco_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "offerings": {
+          "name": "offerings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "amenities": {
+          "name": "amenities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "furnished_status": {
+          "name": "furnished_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_specified'"
+        },
+        "pet_policy": {
+          "name": "pet_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_specified'"
+        },
+        "pet_fee": {
+          "name": "pet_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "parking_type": {
+          "name": "parking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "parking_spaces": {
+          "name": "parking_spaces",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_term": {
+          "name": "lease_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "cancellation_policy": {
+          "name": "cancellation_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_from": {
+          "name": "available_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "smoking_allowed": {
+          "name": "smoking_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parties_allowed": {
+          "name": "parties_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "guests_allowed": {
+          "name": "guests_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "max_guests": {
+          "name": "max_guests",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "long_term_rent_monthly_amount": {
+          "name": "long_term_rent_monthly_amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_currency": {
+          "name": "long_term_rent_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_deposit": {
+          "name": "long_term_rent_deposit",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_application_fee": {
+          "name": "long_term_rent_application_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_late_fee": {
+          "name": "long_term_rent_late_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_utilities": {
+          "name": "long_term_rent_utilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_nightly_rate": {
+          "name": "short_term_rent_nightly_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_currency": {
+          "name": "short_term_rent_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_cleaning_fee": {
+          "name": "short_term_rent_cleaning_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_service_fee": {
+          "name": "short_term_rent_service_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_taxes_percent": {
+          "name": "short_term_rent_taxes_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_min_nights": {
+          "name": "short_term_rent_min_nights",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_max_nights": {
+          "name": "short_term_rent_max_nights",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_instant_book": {
+          "name": "short_term_rent_instant_book",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_deposit": {
+          "name": "short_term_rent_deposit",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_price": {
+          "name": "sale_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_currency": {
+          "name": "sale_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_price_per_sqm": {
+          "name": "sale_price_per_sqm",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_estimated_yield": {
+          "name": "sale_estimated_yield",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_is_price_reduced": {
+          "name": "sale_is_price_reduced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_chain_status": {
+          "name": "sale_chain_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_mode": {
+          "name": "exchange_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_min_stay": {
+          "name": "exchange_min_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_max_stay": {
+          "name": "exchange_max_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_welcome_note": {
+          "name": "exchange_welcome_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_languages": {
+          "name": "exchange_languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_meals_included": {
+          "name": "exchange_meals_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_requires_reciprocity": {
+          "name": "exchange_requires_reciprocity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_sleeping_arrangement": {
+          "name": "accommodation_details_sleeping_arrangement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_hostel_room_type": {
+          "name": "accommodation_details_hostel_room_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_campsite_type": {
+          "name": "accommodation_details_campsite_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_max_stay": {
+          "name": "accommodation_details_max_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_min_age": {
+          "name": "accommodation_details_min_age",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_max_age": {
+          "name": "accommodation_details_max_age",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_cultural_exchange": {
+          "name": "accommodation_details_cultural_exchange",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accommodation_details_meals_included": {
+          "name": "accommodation_details_meals_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accommodation_details_wifi_password": {
+          "name": "accommodation_details_wifi_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_roommate_preferences": {
+          "name": "accommodation_details_roommate_preferences",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "accommodation_details_coliving_features": {
+          "name": "accommodation_details_coliving_features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "accommodation_details_languages": {
+          "name": "accommodation_details_languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "accommodation_details_house_rules": {
+          "name": "accommodation_details_house_rules",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "availability_is_available": {
+          "name": "availability_is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "availability_available_from": {
+          "name": "availability_available_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "availability_minimum_stay": {
+          "name": "availability_minimum_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "availability_maximum_stay": {
+          "name": "availability_maximum_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 12
+        },
+        "rules_pets": {
+          "name": "rules_pets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_smoking": {
+          "name": "rules_smoking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_parties": {
+          "name": "rules_parties",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_guests": {
+          "name": "rules_guests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rules_max_occupancy": {
+          "name": "rules_max_occupancy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "moderation_restricted": {
+          "name": "moderation_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "moderation_restricted_at": {
+          "name": "moderation_restricted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_restricted_by_decision_id": {
+          "name": "moderation_restricted_by_decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_ethical_suggested": {
+          "name": "price_ethics_ethical_suggested",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_ethical_max": {
+          "name": "price_ethics_ethical_max",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_within_ethical": {
+          "name": "price_ethics_within_ethical",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_market_verdict": {
+          "name": "price_ethics_market_verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_percent_diff_from_avg": {
+          "name": "price_ethics_percent_diff_from_avg",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_is_fair_price": {
+          "name": "price_ethics_is_fair_price",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_fairness_score": {
+          "name": "price_ethics_fairness_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_scored_at": {
+          "name": "price_ethics_scored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_average": {
+          "name": "rating_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rating_count": {
+          "name": "rating_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "views": {
+          "name": "views",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_images": {
+          "name": "has_images",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_saved": {
+          "name": "last_saved",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "parent_property_id": {
+          "name": "parent_property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "properties_source_source_id_key": {
+          "name": "properties_source_source_id_key",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"properties\".\"source_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_has_images_created_at_idx": {
+          "name": "properties_has_images_created_at_idx",
+          "columns": [
+            {
+              "expression": "\"has_images\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_created_at_idx": {
+          "name": "properties_created_at_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_search_vector_gin": {
+          "name": "properties_search_vector_gin",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "properties_oxy_user_id_status_idx": {
+          "name": "properties_oxy_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_oxy_user_id_created_at_idx": {
+          "name": "properties_oxy_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_address_id_idx": {
+          "name": "properties_address_id_idx",
+          "columns": [
+            {
+              "expression": "address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_type_available_idx": {
+          "name": "properties_type_available_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "availability_is_available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_status_available_idx": {
+          "name": "properties_status_available_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "availability_is_available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_bedrooms_bathrooms_idx": {
+          "name": "properties_bedrooms_bathrooms_idx",
+          "columns": [
+            {
+              "expression": "bedrooms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bathrooms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_amenities_gin": {
+          "name": "properties_amenities_gin",
+          "columns": [
+            {
+              "expression": "amenities",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "properties_offerings_gin": {
+          "name": "properties_offerings_gin",
+          "columns": [
+            {
+              "expression": "offerings",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "properties_long_term_rent_amount_idx": {
+          "name": "properties_long_term_rent_amount_idx",
+          "columns": [
+            {
+              "expression": "long_term_rent_monthly_amount",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_short_term_rent_rate_idx": {
+          "name": "properties_short_term_rent_rate_idx",
+          "columns": [
+            {
+              "expression": "short_term_rent_nightly_rate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_sale_price_idx": {
+          "name": "properties_sale_price_idx",
+          "columns": [
+            {
+              "expression": "sale_price",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_price_ethics_is_fair_idx": {
+          "name": "properties_price_ethics_is_fair_idx",
+          "columns": [
+            {
+              "expression": "price_ethics_is_fair_price",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_price_ethics_score_idx": {
+          "name": "properties_price_ethics_score_idx",
+          "columns": [
+            {
+              "expression": "\"price_ethics_fairness_score\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_agency_id_idx": {
+          "name": "properties_agency_id_idx",
+          "columns": [
+            {
+              "expression": "agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"properties\".\"agency_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_sourced_by_partner_id_idx": {
+          "name": "properties_sourced_by_partner_id_idx",
+          "columns": [
+            {
+              "expression": "sourced_by_partner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"properties\".\"sourced_by_partner_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_parent_property_id_idx": {
+          "name": "properties_parent_property_id_idx",
+          "columns": [
+            {
+              "expression": "parent_property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"properties\".\"parent_property_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_expires_at_idx": {
+          "name": "properties_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"properties\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "properties_sourced_by_partner_id_partners_id_fk": {
+          "name": "properties_sourced_by_partner_id_partners_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "partners",
+          "columnsFrom": [
+            "sourced_by_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "properties_agency_id_agencies_id_fk": {
+          "name": "properties_agency_id_agencies_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "agencies",
+          "columnsFrom": [
+            "agency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "properties_address_id_addresses_id_fk": {
+          "name": "properties_address_id_addresses_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "properties_parent_property_id_properties_id_fk": {
+          "name": "properties_parent_property_id_properties_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "parent_property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "properties_source_check": {
+          "name": "properties_source_check",
+          "value": "\"properties\".\"source\" in ('internal', 'fixture', 'idealista', 'fotocasa', 'habitaclia', 'blueground', 'apartments_com', 'zillow', 'realtor_com', 'hotpads', 'redfin', 'pisos', 'milanuncios', 'yaencontre', 'indomio', 'idealista_it', 'immobiliare', 'casa_it', 'subito', 'rightmove', 'zoopla', 'onthemarket', 'openrent', 'immobilienscout24', 'immowelt', 'kleinanzeigen', 'storia', 'imobiliare_ro', 'olx_ro', 'bienici', 'leboncoin', 'seloger', 'properati_ec', 'zonaprop', 'argenprop', 'mercadolibre_ar', 'properati', 'plusvalia', 'mercadolibre_ec', 'propiedades', 'vivanuncios', 'lamudi', 'inmuebles24', 'mercadolibre_co', 'mercadolibre_cl', 'mercadolibre_pe', 'mercadolibre_mx', 'idealista_pt', 'metrocuadrado', 'realestate_com_au', 'realtor_ca', 'bayut', 'daft', 'immoweb', 'otodom', 'funda')"
+        },
+        "properties_type_check": {
+          "name": "properties_type_check",
+          "value": "\"properties\".\"type\" in ('apartment', 'house', 'room', 'studio', 'couchsurfing', 'roommates', 'coliving', 'hostel', 'guesthouse', 'campsite', 'boat', 'treehouse', 'yurt', 'other')"
+        },
+        "properties_status_check": {
+          "name": "properties_status_check",
+          "value": "\"properties\".\"status\" in ('draft', 'published', 'reserved', 'rented', 'sold', 'inactive', 'archived')"
+        },
+        "properties_housing_type_check": {
+          "name": "properties_housing_type_check",
+          "value": "\"properties\".\"housing_type\" in ('private', 'public')"
+        },
+        "properties_layout_type_check": {
+          "name": "properties_layout_type_check",
+          "value": "\"properties\".\"layout_type\" in ('open', 'shared', 'partitioned', 'traditional', 'studio', 'other')"
+        },
+        "properties_furnished_status_check": {
+          "name": "properties_furnished_status_check",
+          "value": "\"properties\".\"furnished_status\" in ('furnished', 'unfurnished', 'partially_furnished', 'not_specified')"
+        },
+        "properties_pet_policy_check": {
+          "name": "properties_pet_policy_check",
+          "value": "\"properties\".\"pet_policy\" in ('allowed', 'not_allowed', 'case_by_case', 'not_specified')"
+        },
+        "properties_parking_type_check": {
+          "name": "properties_parking_type_check",
+          "value": "\"properties\".\"parking_type\" in ('none', 'street', 'assigned', 'garage')"
+        },
+        "properties_lease_term_check": {
+          "name": "properties_lease_term_check",
+          "value": "\"properties\".\"lease_term\" in ('monthly', '3_months', '6_months', 'yearly', 'flexible')"
+        },
+        "properties_cancellation_policy_check": {
+          "name": "properties_cancellation_policy_check",
+          "value": "\"properties\".\"cancellation_policy\" in ('flexible', 'moderate', 'strict', 'super_strict')"
+        },
+        "properties_external_contact_kind_check": {
+          "name": "properties_external_contact_kind_check",
+          "value": "\"properties\".\"external_contact_kind\" in ('owner', 'agency', 'private', 'unknown')"
+        },
+        "properties_detected_language_check": {
+          "name": "properties_detected_language_check",
+          "value": "\"properties\".\"listing_flags_detected_language\" in ('es', 'ca', 'en', 'fr', 'nl', 'de', 'it')"
+        },
+        "properties_long_term_rent_currency_check": {
+          "name": "properties_long_term_rent_currency_check",
+          "value": "\"properties\".\"long_term_rent_currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        },
+        "properties_long_term_rent_utilities_check": {
+          "name": "properties_long_term_rent_utilities_check",
+          "value": "\"properties\".\"long_term_rent_utilities\" in ('included', 'excluded', 'partial')"
+        },
+        "properties_short_term_rent_currency_check": {
+          "name": "properties_short_term_rent_currency_check",
+          "value": "\"properties\".\"short_term_rent_currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        },
+        "properties_sale_currency_check": {
+          "name": "properties_sale_currency_check",
+          "value": "\"properties\".\"sale_currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        },
+        "properties_sale_chain_status_check": {
+          "name": "properties_sale_chain_status_check",
+          "value": "\"properties\".\"sale_chain_status\" in ('no_chain', 'chain', 'unknown')"
+        },
+        "properties_exchange_mode_check": {
+          "name": "properties_exchange_mode_check",
+          "value": "\"properties\".\"exchange_mode\" in ('swap', 'host', 'both')"
+        },
+        "properties_market_verdict_check": {
+          "name": "properties_market_verdict_check",
+          "value": "\"properties\".\"price_ethics_market_verdict\" in ('good_deal', 'below_average', 'average', 'above_average')"
+        },
+        "properties_sleeping_arrangement_check": {
+          "name": "properties_sleeping_arrangement_check",
+          "value": "\"properties\".\"accommodation_details_sleeping_arrangement\" in ('couch', 'air_mattress', 'floor', 'tent', 'hammock')"
+        },
+        "properties_hostel_room_type_check": {
+          "name": "properties_hostel_room_type_check",
+          "value": "\"properties\".\"accommodation_details_hostel_room_type\" in ('dormitory', 'private_room', 'mixed_dorm', 'female_dorm', 'male_dorm')"
+        },
+        "properties_campsite_type_check": {
+          "name": "properties_campsite_type_check",
+          "value": "\"properties\".\"accommodation_details_campsite_type\" in ('tent_site', 'rv_site', 'cabin', 'glamping', 'backcountry')"
+        },
+        "properties_offerings_check": {
+          "name": "properties_offerings_check",
+          "value": "\"properties\".\"offerings\" <@ array['long_term_rent', 'short_term_rent', 'sale', 'exchange']::text[]"
+        },
+        "properties_offering_long_term_rent_check": {
+          "name": "properties_offering_long_term_rent_check",
+          "value": "('long_term_rent' = any(\"properties\".\"offerings\")) = (\"properties\".\"long_term_rent_monthly_amount\" is not null)"
+        },
+        "properties_offering_short_term_rent_check": {
+          "name": "properties_offering_short_term_rent_check",
+          "value": "('short_term_rent' = any(\"properties\".\"offerings\")) = (\"properties\".\"short_term_rent_nightly_rate\" is not null)"
+        },
+        "properties_offering_sale_check": {
+          "name": "properties_offering_sale_check",
+          "value": "('sale' = any(\"properties\".\"offerings\")) = (\"properties\".\"sale_price\" is not null)"
+        },
+        "properties_offering_exchange_check": {
+          "name": "properties_offering_exchange_check",
+          "value": "('exchange' = any(\"properties\".\"offerings\")) = (\"properties\".\"exchange_mode\" is not null)"
+        },
+        "properties_long_term_rent_block_check": {
+          "name": "properties_long_term_rent_block_check",
+          "value": "\"properties\".\"long_term_rent_monthly_amount\" is not null or (\n        \"properties\".\"long_term_rent_currency\" is null and \"properties\".\"long_term_rent_deposit\" is null\n        and \"properties\".\"long_term_rent_application_fee\" is null and \"properties\".\"long_term_rent_late_fee\" is null\n        and \"properties\".\"long_term_rent_utilities\" is null\n      )"
+        },
+        "properties_short_term_rent_block_check": {
+          "name": "properties_short_term_rent_block_check",
+          "value": "\"properties\".\"short_term_rent_nightly_rate\" is not null or (\n        \"properties\".\"short_term_rent_currency\" is null and \"properties\".\"short_term_rent_cleaning_fee\" is null\n        and \"properties\".\"short_term_rent_service_fee\" is null and \"properties\".\"short_term_rent_taxes_percent\" is null\n        and \"properties\".\"short_term_rent_min_nights\" is null and \"properties\".\"short_term_rent_max_nights\" is null\n        and \"properties\".\"short_term_rent_instant_book\" is null and \"properties\".\"short_term_rent_deposit\" is null\n      )"
+        },
+        "properties_sale_block_check": {
+          "name": "properties_sale_block_check",
+          "value": "\"properties\".\"sale_price\" is not null or (\n        \"properties\".\"sale_currency\" is null and \"properties\".\"sale_price_per_sqm\" is null\n        and \"properties\".\"sale_estimated_yield\" is null and \"properties\".\"sale_is_price_reduced\" is null\n        and \"properties\".\"sale_chain_status\" is null\n      )"
+        },
+        "properties_exchange_block_check": {
+          "name": "properties_exchange_block_check",
+          "value": "\"properties\".\"exchange_mode\" is not null or (\n        \"properties\".\"exchange_min_stay\" is null and \"properties\".\"exchange_max_stay\" is null\n        and \"properties\".\"exchange_welcome_note\" is null and \"properties\".\"exchange_languages\" is null\n        and \"properties\".\"exchange_meals_included\" is null and \"properties\".\"exchange_requires_reciprocity\" is null\n      )"
+        },
+        "properties_external_source_url_check": {
+          "name": "properties_external_source_url_check",
+          "value": "not \"properties\".\"is_external\" or \"properties\".\"source_url\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.property_availability_windows": {
+      "name": "property_availability_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        }
+      },
+      "indexes": {
+        "property_availability_windows_range_gist": {
+          "name": "property_availability_windows_range_gist",
+          "columns": [
+            {
+              "expression": "tstzrange(\"starts_at\", \"ends_at\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "property_availability_windows_property_scope_idx": {
+          "name": "property_availability_windows_property_scope_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "property_availability_windows_property_id_properties_id_fk": {
+          "name": "property_availability_windows_property_id_properties_id_fk",
+          "tableFrom": "property_availability_windows",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "property_availability_windows_scope_check": {
+          "name": "property_availability_windows_scope_check",
+          "value": "\"property_availability_windows\".\"scope\" in ('listing', 'exchange')"
+        },
+        "property_availability_windows_status_check": {
+          "name": "property_availability_windows_status_check",
+          "value": "\"property_availability_windows\".\"status\" in ('available', 'blocked', 'booked')"
+        },
+        "property_availability_windows_order_check": {
+          "name": "property_availability_windows_order_check",
+          "value": "\"property_availability_windows\".\"ends_at\" > \"property_availability_windows\".\"starts_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.property_documents": {
+      "name": "property_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        }
+      },
+      "indexes": {
+        "property_documents_property_id_idx": {
+          "name": "property_documents_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "property_documents_property_id_properties_id_fk": {
+          "name": "property_documents_property_id_properties_id_fk",
+          "tableFrom": "property_documents",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "property_documents_type_check": {
+          "name": "property_documents_type_check",
+          "value": "\"property_documents\".\"type\" in ('lease', 'inspection', 'insurance', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.property_images": {
+      "name": "property_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "urls_original": {
+          "name": "urls_original",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urls_small": {
+          "name": "urls_small",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urls_medium": {
+          "name": "urls_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urls_large": {
+          "name": "urls_large",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "property_images_property_order_idx": {
+          "name": "property_images_property_order_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "property_images_one_primary_key": {
+          "name": "property_images_one_primary_key",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"property_images\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "property_images_image_id_idx": {
+          "name": "property_images_image_id_idx",
+          "columns": [
+            {
+              "expression": "image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "property_images_property_id_properties_id_fk": {
+          "name": "property_images_property_id_properties_id_fk",
+          "tableFrom": "property_images",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "property_images_image_id_images_id_fk": {
+          "name": "property_images_image_id_images_id_fk",
+          "tableFrom": "property_images",
+          "tableTo": "images",
+          "columnsFrom": [
+            "image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recently_viewed": {
+      "name": "recently_viewed",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "recently_viewed_owner_property_key": {
+          "name": "recently_viewed_owner_property_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recently_viewed_owner_viewed_at_idx": {
+          "name": "recently_viewed_owner_viewed_at_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"viewed_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recently_viewed_property_id_properties_id_fk": {
+          "name": "recently_viewed_property_id_properties_id_fk",
+          "tableFrom": "recently_viewed",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "regions_country_name_key": {
+          "name": "regions_country_name_key",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_name_lower_idx": {
+          "name": "regions_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_country_name_lower_idx": {
+          "name": "regions_country_name_lower_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "regions_country_id_countries_id_fk": {
+          "name": "regions_country_id_countries_id_fk",
+          "tableFrom": "regions",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "regions_cover_image_id_images_id_fk": {
+          "name": "regions_cover_image_id_images_id_fk",
+          "tableFrom": "regions",
+          "tableTo": "images",
+          "columnsFrom": [
+            "cover_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reservations": {
+      "name": "reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_oxy_user_id": {
+          "name": "guest_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_oxy_user_id": {
+          "name": "host_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_in": {
+          "name": "check_in",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_out": {
+          "name": "check_out",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_count": {
+          "name": "guest_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nights": {
+          "name": "nights",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nightly_rate": {
+          "name": "nightly_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cleaning_fee": {
+          "name": "cleaning_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "service_fee": {
+          "name": "service_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "taxes": {
+          "name": "taxes",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total": {
+          "name": "total",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "instant_booked": {
+          "name": "instant_booked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancellation_policy": {
+          "name": "cancellation_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "special_requests": {
+          "name": "special_requests",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "reservations_stay_range_gist": {
+          "name": "reservations_stay_range_gist",
+          "columns": [
+            {
+              "expression": "tstzrange(\"check_in\", \"check_out\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "reservations_property_check_in_idx": {
+          "name": "reservations_property_check_in_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "check_in",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reservations_guest_status_idx": {
+          "name": "reservations_guest_status_idx",
+          "columns": [
+            {
+              "expression": "guest_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reservations_host_status_created_idx": {
+          "name": "reservations_host_status_created_idx",
+          "columns": [
+            {
+              "expression": "host_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reservations_property_id_properties_id_fk": {
+          "name": "reservations_property_id_properties_id_fk",
+          "tableFrom": "reservations",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reservations_status_check": {
+          "name": "reservations_status_check",
+          "value": "\"reservations\".\"status\" in ('pending', 'confirmed', 'cancelled', 'completed', 'declined')"
+        },
+        "reservations_cancellation_policy_check": {
+          "name": "reservations_cancellation_policy_check",
+          "value": "\"reservations\".\"cancellation_policy\" in ('flexible', 'moderate', 'strict', 'super_strict')"
+        },
+        "reservations_stay_order_check": {
+          "name": "reservations_stay_order_check",
+          "value": "\"reservations\".\"check_out\" > \"reservations\".\"check_in\""
+        },
+        "reservations_nights_check": {
+          "name": "reservations_nights_check",
+          "value": "\"reservations\".\"nights\" >= 1"
+        },
+        "reservations_guest_count_check": {
+          "name": "reservations_guest_count_check",
+          "value": "\"reservations\".\"guest_count\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.review_helpful_votes": {
+      "name": "review_helpful_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "review_helpful_votes_review_user_key": {
+          "name": "review_helpful_votes_review_user_key",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_helpful_votes_review_id_reviews_id_fk": {
+          "name": "review_helpful_votes_review_id_reviews_id_fk",
+          "tableFrom": "review_helpful_votes",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_reports": {
+      "name": "review_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "review_reports_review_user_key": {
+          "name": "review_reports_review_user_key",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_reports_review_id_reviews_id_fk": {
+          "name": "review_reports_review_id_reviews_id_fk",
+          "tableFrom": "review_reports",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "review_reports_reason_check": {
+          "name": "review_reports_reason_check",
+          "value": "\"review_reports\".\"reason\" in ('fake', 'offensive', 'personal_data', 'spam', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_level": {
+          "name": "address_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street_level_id": {
+          "name": "street_level_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "building_level_id": {
+          "name": "building_level_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_level_id": {
+          "name": "unit_level_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neighborhood_id": {
+          "name": "neighborhood_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agency_id": {
+          "name": "agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "green_house": {
+          "name": "green_house",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "lived_from": {
+          "name": "lived_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lived_to": {
+          "name": "lived_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lived_for_months": {
+          "name": "lived_for_months",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation": {
+          "name": "recommendation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion": {
+          "name": "opinion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pros_items": {
+          "name": "pros_items",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "cons_items": {
+          "name": "cons_items",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "advice_to_agency": {
+          "name": "advice_to_agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advice_to_landlord": {
+          "name": "advice_to_landlord",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "positive_comment": {
+          "name": "positive_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "negative_comment": {
+          "name": "negative_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rating": {
+          "name": "rating",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summer_temperature": {
+          "name": "summer_temperature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winter_temperature": {
+          "name": "winter_temperature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise": {
+          "name": "noise",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "light": {
+          "name": "light",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition_and_maintenance": {
+          "name": "condition_and_maintenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "landlord_treatment": {
+          "name": "landlord_treatment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "problem_response": {
+          "name": "problem_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deposit_returned": {
+          "name": "deposit_returned",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "staircase_neighbors": {
+          "name": "staircase_neighbors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tourist_apartments": {
+          "name": "tourist_apartments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neighbor_relations": {
+          "name": "neighbor_relations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleaning": {
+          "name": "cleaning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_tourists": {
+          "name": "area_tourists",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_security": {
+          "name": "area_security",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_noise": {
+          "name": "area_noise",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_cleanliness": {
+          "name": "area_cleanliness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_status": {
+          "name": "moderation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "reviews_address_created_idx": {
+          "name": "reviews_address_created_idx",
+          "columns": [
+            {
+              "expression": "address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_street_level_idx": {
+          "name": "reviews_street_level_idx",
+          "columns": [
+            {
+              "expression": "street_level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_building_level_idx": {
+          "name": "reviews_building_level_idx",
+          "columns": [
+            {
+              "expression": "building_level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_unit_level_idx": {
+          "name": "reviews_unit_level_idx",
+          "columns": [
+            {
+              "expression": "unit_level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_agency_created_idx": {
+          "name": "reviews_agency_created_idx",
+          "columns": [
+            {
+              "expression": "agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_city_created_idx": {
+          "name": "reviews_city_created_idx",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_neighborhood_created_idx": {
+          "name": "reviews_neighborhood_created_idx",
+          "columns": [
+            {
+              "expression": "neighborhood_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_oxy_user_created_idx": {
+          "name": "reviews_oxy_user_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_moderation_queue_idx": {
+          "name": "reviews_moderation_queue_idx",
+          "columns": [
+            {
+              "expression": "moderation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_author_address_key": {
+          "name": "reviews_author_address_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_address_id_addresses_id_fk": {
+          "name": "reviews_address_id_addresses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_street_level_id_addresses_id_fk": {
+          "name": "reviews_street_level_id_addresses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "street_level_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_building_level_id_addresses_id_fk": {
+          "name": "reviews_building_level_id_addresses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "building_level_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_unit_level_id_addresses_id_fk": {
+          "name": "reviews_unit_level_id_addresses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "unit_level_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_city_id_cities_id_fk": {
+          "name": "reviews_city_id_cities_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_neighborhood_id_neighborhoods_id_fk": {
+          "name": "reviews_neighborhood_id_neighborhoods_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "neighborhoods",
+          "columnsFrom": [
+            "neighborhood_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_agency_id_agencies_id_fk": {
+          "name": "reviews_agency_id_agencies_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "agencies",
+          "columnsFrom": [
+            "agency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reviews_address_level_check": {
+          "name": "reviews_address_level_check",
+          "value": "\"reviews\".\"address_level\" in ('BUILDING', 'UNIT')"
+        },
+        "reviews_unit_level_check": {
+          "name": "reviews_unit_level_check",
+          "value": "(\"reviews\".\"address_level\" = 'UNIT') = (\"reviews\".\"unit_level_id\" is not null)"
+        },
+        "reviews_moderation_status_check": {
+          "name": "reviews_moderation_status_check",
+          "value": "\"reviews\".\"moderation_status\" in ('active', 'under_review', 'removed')"
+        },
+        "reviews_currency_check": {
+          "name": "reviews_currency_check",
+          "value": "\"reviews\".\"currency\" in ('USD', 'EUR', 'GBP', 'CAD')"
+        },
+        "reviews_summer_temperature_check": {
+          "name": "reviews_summer_temperature_check",
+          "value": "\"reviews\".\"summer_temperature\" in ('very_cold', 'cold', 'moderate', 'warm', 'very_warm')"
+        },
+        "reviews_winter_temperature_check": {
+          "name": "reviews_winter_temperature_check",
+          "value": "\"reviews\".\"winter_temperature\" in ('very_cold', 'cold', 'moderate', 'warm', 'very_warm')"
+        },
+        "reviews_noise_check": {
+          "name": "reviews_noise_check",
+          "value": "\"reviews\".\"noise\" in ('very_quiet', 'quiet', 'moderate', 'noisy', 'very_noisy')"
+        },
+        "reviews_light_check": {
+          "name": "reviews_light_check",
+          "value": "\"reviews\".\"light\" in ('very_dark', 'dark', 'moderate', 'bright', 'very_bright')"
+        },
+        "reviews_condition_check": {
+          "name": "reviews_condition_check",
+          "value": "\"reviews\".\"condition_and_maintenance\" in ('poor', 'fair', 'good', 'very_good', 'excellent')"
+        },
+        "reviews_services_check": {
+          "name": "reviews_services_check",
+          "value": "\"reviews\".\"services\" <@ array['internet', 'cable_tv', 'parking', 'laundry', 'gym', 'pool', 'concierge', 'security', 'maintenance', 'cleaning']::text[]"
+        },
+        "reviews_landlord_treatment_check": {
+          "name": "reviews_landlord_treatment_check",
+          "value": "\"reviews\".\"landlord_treatment\" in ('very_poor', 'poor', 'fair', 'good', 'excellent')"
+        },
+        "reviews_problem_response_check": {
+          "name": "reviews_problem_response_check",
+          "value": "\"reviews\".\"problem_response\" in ('never_responded', 'very_slow', 'slow', 'reasonable', 'fast', 'very_fast')"
+        },
+        "reviews_deposit_returned_check": {
+          "name": "reviews_deposit_returned_check",
+          "value": "\"reviews\".\"deposit_returned\" in ('full', 'partial', 'no')"
+        },
+        "reviews_staircase_neighbors_check": {
+          "name": "reviews_staircase_neighbors_check",
+          "value": "\"reviews\".\"staircase_neighbors\" in ('very_unfriendly', 'unfriendly', 'neutral', 'friendly', 'very_friendly')"
+        },
+        "reviews_neighbor_relations_check": {
+          "name": "reviews_neighbor_relations_check",
+          "value": "\"reviews\".\"neighbor_relations\" in ('very_poor', 'poor', 'fair', 'good', 'excellent')"
+        },
+        "reviews_cleaning_check": {
+          "name": "reviews_cleaning_check",
+          "value": "\"reviews\".\"cleaning\" in ('very_dirty', 'dirty', 'acceptable', 'clean', 'very_clean')"
+        },
+        "reviews_area_tourists_check": {
+          "name": "reviews_area_tourists_check",
+          "value": "\"reviews\".\"area_tourists\" in ('none', 'few', 'moderate', 'many', 'overwhelming')"
+        },
+        "reviews_area_security_check": {
+          "name": "reviews_area_security_check",
+          "value": "\"reviews\".\"area_security\" in ('very_unsafe', 'unsafe', 'neutral', 'safe', 'very_safe')"
+        },
+        "reviews_area_noise_check": {
+          "name": "reviews_area_noise_check",
+          "value": "\"reviews\".\"area_noise\" in ('very_quiet', 'quiet', 'moderate', 'noisy', 'very_noisy')"
+        },
+        "reviews_area_cleanliness_check": {
+          "name": "reviews_area_cleanliness_check",
+          "value": "\"reviews\".\"area_cleanliness\" in ('very_dirty', 'dirty', 'acceptable', 'clean', 'very_clean')"
+        },
+        "reviews_rating_check": {
+          "name": "reviews_rating_check",
+          "value": "\"reviews\".\"rating\" between 1 and 5"
+        },
+        "reviews_lived_order_check": {
+          "name": "reviews_lived_order_check",
+          "value": "\"reviews\".\"lived_to\" > \"reviews\".\"lived_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.roommate_relationships": {
+      "name": "roommate_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user1_id": {
+          "name": "oxy_user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user2_id": {
+          "name": "oxy_user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "roommate_relationships_active_pair_key": {
+          "name": "roommate_relationships_active_pair_key",
+          "columns": [
+            {
+              "expression": "oxy_user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"roommate_relationships\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roommate_relationships_user1_idx": {
+          "name": "roommate_relationships_user1_idx",
+          "columns": [
+            {
+              "expression": "oxy_user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roommate_relationships_user2_idx": {
+          "name": "roommate_relationships_user2_idx",
+          "columns": [
+            {
+              "expression": "oxy_user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roommate_relationships_request_id_roommate_requests_id_fk": {
+          "name": "roommate_relationships_request_id_roommate_requests_id_fk",
+          "tableFrom": "roommate_relationships",
+          "tableTo": "roommate_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "roommate_relationships_status_check": {
+          "name": "roommate_relationships_status_check",
+          "value": "\"roommate_relationships\".\"status\" in ('active', 'ended')"
+        },
+        "roommate_relationships_sorted_pair_check": {
+          "name": "roommate_relationships_sorted_pair_check",
+          "value": "\"roommate_relationships\".\"oxy_user1_id\" < \"roommate_relationships\".\"oxy_user2_id\""
+        },
+        "roommate_relationships_match_score_check": {
+          "name": "roommate_relationships_match_score_check",
+          "value": "\"roommate_relationships\".\"match_score\" between 0 and 100"
+        },
+        "roommate_relationships_order_check": {
+          "name": "roommate_relationships_order_check",
+          "value": "\"roommate_relationships\".\"end_date\" is null or \"roommate_relationships\".\"end_date\" >= \"roommate_relationships\".\"start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.roommate_requests": {
+      "name": "roommate_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_oxy_user_id": {
+          "name": "from_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_oxy_user_id": {
+          "name": "to_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "roommate_requests_pending_pair_key": {
+          "name": "roommate_requests_pending_pair_key",
+          "columns": [
+            {
+              "expression": "from_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"roommate_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roommate_requests_from_idx": {
+          "name": "roommate_requests_from_idx",
+          "columns": [
+            {
+              "expression": "from_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roommate_requests_to_status_idx": {
+          "name": "roommate_requests_to_status_idx",
+          "columns": [
+            {
+              "expression": "to_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "roommate_requests_status_check": {
+          "name": "roommate_requests_status_check",
+          "value": "\"roommate_requests\".\"status\" in ('pending', 'accepted', 'declined')"
+        },
+        "roommate_requests_distinct_parties_check": {
+          "name": "roommate_requests_distinct_parties_check",
+          "value": "\"roommate_requests\".\"from_oxy_user_id\" <> \"roommate_requests\".\"to_oxy_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_items": {
+      "name": "saved_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "saved_items_owner_target_key": {
+          "name": "saved_items_owner_target_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_items_folder_id_idx": {
+          "name": "saved_items_folder_id_idx",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"saved_items\".\"folder_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_items_target_idx": {
+          "name": "saved_items_target_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_items_target_id_properties_id_fk": {
+          "name": "saved_items_target_id_properties_id_fk",
+          "tableFrom": "saved_items",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_items_folder_id_saved_property_folders_id_fk": {
+          "name": "saved_items_folder_id_saved_property_folders_id_fk",
+          "tableFrom": "saved_items",
+          "tableTo": "saved_property_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "saved_items_target_type_check": {
+          "name": "saved_items_target_type_check",
+          "value": "\"saved_items\".\"target_type\" in ('property')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_property_folder_items": {
+      "name": "saved_property_folder_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "saved_property_folder_items_key": {
+          "name": "saved_property_folder_items_key",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_property_folder_items_property_id_idx": {
+          "name": "saved_property_folder_items_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_property_folder_items_folder_id_saved_property_folders_id_fk": {
+          "name": "saved_property_folder_items_folder_id_saved_property_folders_id_fk",
+          "tableFrom": "saved_property_folder_items",
+          "tableTo": "saved_property_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_property_folder_items_property_id_properties_id_fk": {
+          "name": "saved_property_folder_items_property_id_properties_id_fk",
+          "tableFrom": "saved_property_folder_items",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_property_folders": {
+      "name": "saved_property_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3B82F6'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder-outline'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "saved_property_folders_owner_name_key": {
+          "name": "saved_property_folders_owner_name_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_searches": {
+      "name": "saved_searches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "query_version": {
+          "name": "query_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "is_primary_area": {
+          "name": "is_primary_area",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cadence": {
+          "name": "cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "channels": {
+          "name": "channels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{in_app}'::text[]"
+        },
+        "muted_until": {
+          "name": "muted_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alerts_active_from": {
+          "name": "alerts_active_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "push_privacy_mode": {
+          "name": "push_privacy_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'discreet'"
+        },
+        "area": {
+          "name": "area",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_geo": {
+          "name": "area_geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "case when area is null then null else ST_GeomFromGeoJSON(area)::geography end",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "saved_searches_owner_name_key": {
+          "name": "saved_searches_owner_name_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_searches_owner_created_idx": {
+          "name": "saved_searches_owner_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_searches_notifications_enabled_idx": {
+          "name": "saved_searches_notifications_enabled_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"saved_searches\".\"notifications_enabled\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_searches_primary_area_key": {
+          "name": "saved_searches_primary_area_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"saved_searches\".\"is_primary_area\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_searches_area_geo_gist": {
+          "name": "saved_searches_area_geo_gist",
+          "columns": [
+            {
+              "expression": "area_geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"saved_searches\".\"area_geo\" is not null",
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "saved_searches_cadence_check": {
+          "name": "saved_searches_cadence_check",
+          "value": "\"saved_searches\".\"cadence\" in ('instant', 'daily', 'weekly', 'off')"
+        },
+        "saved_searches_push_privacy_mode_check": {
+          "name": "saved_searches_push_privacy_mode_check",
+          "value": "\"saved_searches\".\"push_privacy_mode\" in ('discreet', 'detailed')"
+        },
+        "saved_searches_channels_check": {
+          "name": "saved_searches_channels_check",
+          "value": "\"saved_searches\".\"channels\" <@ ARRAY['in_app', 'push', 'email']::text[]\n        and cardinality(\"saved_searches\".\"channels\") >= 1\n        and 'in_app' = any(\"saved_searches\".\"channels\")"
+        },
+        "saved_searches_query_version_check": {
+          "name": "saved_searches_query_version_check",
+          "value": "query_version >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenant_application_documents": {
+      "name": "tenant_application_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tenant_application_documents_application_id_idx": {
+          "name": "tenant_application_documents_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_application_documents_application_id_tenant_applications_id_fk": {
+          "name": "tenant_application_documents_application_id_tenant_applications_id_fk",
+          "tableFrom": "tenant_application_documents",
+          "tableTo": "tenant_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenant_application_documents_type_check": {
+          "name": "tenant_application_documents_type_check",
+          "value": "\"tenant_application_documents\".\"type\" in ('id', 'income', 'reference', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenant_application_references": {
+      "name": "tenant_application_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tenant_application_references_application_id_idx": {
+          "name": "tenant_application_references_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_application_references_application_id_tenant_applications_id_fk": {
+          "name": "tenant_application_references_application_id_tenant_applications_id_fk",
+          "tableFrom": "tenant_application_references",
+          "tableTo": "tenant_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenant_application_references_relationship_check": {
+          "name": "tenant_application_references_relationship_check",
+          "value": "\"tenant_application_references\".\"relationship\" in ('landlord', 'employer', 'personal', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenant_applications": {
+      "name": "tenant_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_oxy_user_id": {
+          "name": "applicant_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "landlord_oxy_user_id": {
+          "name": "landlord_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "move_in_date": {
+          "name": "move_in_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_term_months": {
+          "name": "lease_term_months",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_income": {
+          "name": "monthly_income",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employment_status": {
+          "name": "employment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "tenant_applications_property_status_idx": {
+          "name": "tenant_applications_property_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_applications_applicant_status_idx": {
+          "name": "tenant_applications_applicant_status_idx",
+          "columns": [
+            {
+              "expression": "applicant_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_applications_landlord_status_submitted_idx": {
+          "name": "tenant_applications_landlord_status_submitted_idx",
+          "columns": [
+            {
+              "expression": "landlord_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"submitted_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_applications_property_id_properties_id_fk": {
+          "name": "tenant_applications_property_id_properties_id_fk",
+          "tableFrom": "tenant_applications",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenant_applications_status_check": {
+          "name": "tenant_applications_status_check",
+          "value": "\"tenant_applications\".\"status\" in ('submitted', 'reviewing', 'approved', 'rejected', 'withdrawn')"
+        },
+        "tenant_applications_employment_status_check": {
+          "name": "tenant_applications_employment_status_check",
+          "value": "\"tenant_applications\".\"employment_status\" in ('employed', 'self_employed', 'student', 'retired', 'unemployed', 'other')"
+        },
+        "tenant_applications_decided_at_check": {
+          "name": "tenant_applications_decided_at_check",
+          "value": "(\"tenant_applications\".\"status\" in ('approved', 'rejected', 'withdrawn'))\n        = (\"tenant_applications\".\"decided_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.viewing_requests": {
+      "name": "viewing_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_oxy_user_id": {
+          "name": "requester_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_oxy_user_id": {
+          "name": "owner_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cancelled_by": {
+          "name": "cancelled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "viewing_requests_property_scheduled_status_idx": {
+          "name": "viewing_requests_property_scheduled_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "viewing_requests_owner_scheduled_status_idx": {
+          "name": "viewing_requests_owner_scheduled_status_idx",
+          "columns": [
+            {
+              "expression": "owner_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "viewing_requests_requester_idx": {
+          "name": "viewing_requests_requester_idx",
+          "columns": [
+            {
+              "expression": "requester_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "viewing_requests_property_id_properties_id_fk": {
+          "name": "viewing_requests_property_id_properties_id_fk",
+          "tableFrom": "viewing_requests",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "viewing_requests_status_check": {
+          "name": "viewing_requests_status_check",
+          "value": "\"viewing_requests\".\"status\" in ('pending', 'approved', 'declined', 'cancelled')"
+        },
+        "viewing_requests_cancelled_by_check": {
+          "name": "viewing_requests_cancelled_by_check",
+          "value": "\"viewing_requests\".\"cancelled_by\" in ('requester', 'owner')"
+        },
+        "viewing_requests_cancelled_by_status_check": {
+          "name": "viewing_requests_cancelled_by_status_check",
+          "value": "(\"viewing_requests\".\"status\" = 'cancelled') = (\"viewing_requests\".\"cancelled_by\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/drizzle/meta/_journal.json
+++ b/packages/backend/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1786348633522,
       "tag": "0013_evictions_local_privacy",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1786406907912,
+      "tag": "0014_housing_candidate_materialization",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/services/addressIdentity.ts
+++ b/packages/backend/services/addressIdentity.ts
@@ -1,0 +1,250 @@
+/**
+ * The LEVEL-AWARE address identity key — ADR 0001 §3.1 and §5.1.
+ *
+ * This module is deliberately PURE: no database, no network, no imports from
+ * the service that uses it. Everything here is a function of its arguments, so
+ * a fixture can exercise it directly and the key it produces cannot depend on
+ * which row happened to be written first — which is precisely the defect it
+ * replaces.
+ *
+ * ## What is wrong with the v1 key, in one paragraph
+ *
+ * `computeAddressNormalizedKey` (`addressService.ts`) hashes
+ * `street | number | unit | building_name | block | postal_code | city_id |
+ * country_code`. `addresses.address_level` — a `GENERATED ALWAYS` column —
+ * derives from `floor`, `unit`, `subunit`, `number`, `building_name`, `block`
+ * and `entrance`. **`floor`, `entrance` and `subunit` decide the LEVEL and are
+ * absent from the KEY**, so a building, the flat on its third floor, the flat on
+ * its fourth, and its entrance B all hash identically and collapse onto one row
+ * under `addresses_normalized_key_key`. ADR 0001 §1.3 measured it end to end:
+ * three distinct rows out of six inputs, and the surviving row's LEVEL depends
+ * on which advertisement was ingested first.
+ *
+ * Two flats then share one identity, the second household's reviews are
+ * published under the first one's floor label, and one person who lived in 3r
+ * and later in 4t can file exactly one review for both.
+ *
+ * ## Three changes, each with the case that forced it
+ *
+ * 1. **The level is hashed.** A BUILDING and a UNIT are two keys even when every
+ *    other field agrees, so no projection can be mistaken for its child.
+ * 2. **Positions are FIXED — absent fields contribute an empty slot rather than
+ *    being dropped.** v1 ends with `.filter(Boolean)`, so `['a', '', 'b']` and
+ *    `['a', 'b']` join to the same string: a building named `42` with no block
+ *    and a building with no number in a block named `42` hash identically.
+ * 3. **Internal whitespace is collapsed and diacritics are stripped.** v1 already
+ *    lowercases and trims, so `Torre Mapfre`, `torre mapfre` and `Torre Mapfre `
+ *    are one key today — but `Torre  Mapfre` (two spaces) is a SECOND building
+ *    (ADR 0001 §1.3, measured). The v1 key is simultaneously too coarse and too
+ *    fine, and this is the too-fine half.
+ *
+ * Normalization stops there on purpose. `Torre Mapfre I` and `Torre Mapfre II`
+ * are two real buildings in one development, so nothing here strips numerals,
+ * expands abbreviations or folds `c/` into `carrer`; a normalizer aggressive
+ * enough to merge those would be trading a split for a much worse merge.
+ *
+ * ## The version is IN the hash
+ *
+ * `ADDRESS_NORMALIZATION_VERSION` prefixes every digest, so a future
+ * normalization change produces a visibly different key rather than silently
+ * re-keying rows written under the old rules. It is also the value written to
+ * `address_candidates.normalization_version` and copied onto
+ * `address_materializations`, which is what lets an audit tell a genuine
+ * disagreement between two observations from a change in the rules between them.
+ */
+
+import * as crypto from 'crypto';
+import { ADDRESS_LEVELS } from '../db/schema/addresses';
+
+export type AddressLevel = (typeof ADDRESS_LEVELS)[number];
+
+/**
+ * The generation of the normalization + key rules below.
+ *
+ * Bump it in the same change that alters {@link normalizeIdentityValue},
+ * {@link deriveAddressLevel} or {@link computeAddressIdentityKey}'s field order.
+ * Never alter any of them without bumping it: the keys already stored would stop
+ * matching and every place would be re-created on its next materialization.
+ */
+export const ADDRESS_NORMALIZATION_VERSION = 2;
+
+/** The identity fields, per level, in the order they are hashed. */
+export interface AddressIdentityFields {
+  /** Required at every level. */
+  readonly street: string;
+  /** NULL when the source supplied none — never `''`, never `'00000'`. */
+  readonly postalCode?: string | null;
+  readonly cityId: string;
+  readonly countryCode: string;
+  // BUILDING adds these four.
+  readonly number?: string | null;
+  readonly buildingName?: string | null;
+  readonly block?: string | null;
+  readonly entrance?: string | null;
+  // UNIT adds these three.
+  readonly floor?: string | null;
+  readonly unit?: string | null;
+  readonly subunit?: string | null;
+}
+
+/**
+ * Lowercase, strip diacritics, collapse internal whitespace, trim.
+ *
+ * Returns `''` for anything that normalizes away, which callers treat as
+ * ABSENT — see {@link identityValueOrNull}, which is what the writer uses so
+ * that no identity column ever holds an empty string.
+ *
+ * Diacritics are removed by decomposing to NFD and dropping the Combining
+ * Diacritical Marks block, rather than by `\p{Diacritic}`: the block covers
+ * every accent Homiio's Spanish, Catalan, Portuguese and Italian corpus
+ * produces, and it avoids a Unicode property escape entirely.
+ */
+export function normalizeIdentityValue(value: string | null | undefined): string {
+  if (!value) return '';
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * The normalized value, or NULL when it normalizes away.
+ *
+ * **Every write of an identity column goes through this**, and that is what
+ * makes {@link deriveAddressLevel} agree with the `address_level` generated
+ * column by CONSTRUCTION rather than by two implementations of one predicate
+ * happening to match. The column's predicate is `coalesce(x, '') <> ''`, so a
+ * stored `''` and a stored `'  '` differ: `''` reads as absent and `'  '` reads
+ * as present and would promote a street to a building. If the writer never
+ * stores either, the distinction cannot arise.
+ *
+ * It is also the `sparse`-unique rule `CONVENTIONS.md` states, applied one level
+ * up: an empty string is a VALUE.
+ */
+export function identityValueOrNull(value: string | null | undefined): string | null {
+  const normalized = normalizeIdentityValue(value);
+  return normalized === '' ? null : normalized;
+}
+
+/**
+ * STREET / BUILDING / UNIT, from the values as they will be STORED.
+ *
+ * A TypeScript copy of a `GENERATED ALWAYS` column's predicate, which is a
+ * duplication worth naming rather than hiding: the level has to be known BEFORE
+ * the insert (it is hashed into the key) and the database only answers after.
+ * The copy is pinned by a test that inserts discriminating rows — including one
+ * carrying `''`, written by raw SQL because the writer above cannot produce
+ * one — and asserts this function and the column agree on every row. Without
+ * that test the two could drift silently, and the symptom would be a key
+ * claiming one level for a row the database labels another.
+ */
+export function deriveAddressLevel(fields: AddressIdentityFields): AddressLevel {
+  const present = (value: string | null | undefined): boolean => (value ?? '') !== '';
+  if (present(fields.floor) || present(fields.unit) || present(fields.subunit)) return 'UNIT';
+  if (
+    present(fields.number) ||
+    present(fields.buildingName) ||
+    present(fields.block) ||
+    present(fields.entrance)
+  ) {
+    return 'BUILDING';
+  }
+  return 'STREET';
+}
+
+/**
+ * The identity fields a row at `level` carries, with everything below that level
+ * cleared.
+ *
+ * This is what makes a PROJECTION deterministic: the building above a flat is
+ * the flat's fields minus `floor` / `unit` / `subunit`, so the building row a
+ * unit resolves to is byte-for-byte the building row an independent
+ * building-level candidate resolves to. `cityId` and `countryCode` are carried
+ * at every level because geo is relational and a street is a street IN a city.
+ */
+export function projectIdentityFields(
+  fields: AddressIdentityFields,
+  level: AddressLevel,
+): AddressIdentityFields {
+  const street: AddressIdentityFields = {
+    street: fields.street,
+    postalCode: fields.postalCode ?? null,
+    cityId: fields.cityId,
+    countryCode: fields.countryCode,
+  };
+  if (level === 'STREET') return street;
+
+  const building: AddressIdentityFields = {
+    ...street,
+    number: fields.number ?? null,
+    buildingName: fields.buildingName ?? null,
+    block: fields.block ?? null,
+    entrance: fields.entrance ?? null,
+  };
+  if (level === 'BUILDING') return building;
+
+  return {
+    ...building,
+    floor: fields.floor ?? null,
+    unit: fields.unit ?? null,
+    subunit: fields.subunit ?? null,
+  };
+}
+
+/**
+ * The v2 identity key: sha256 over the version, the level and eleven
+ * fixed-position fields.
+ *
+ * `cityId` and `countryCode` are NOT normalized as text — they are an id and an
+ * ISO code, so they are used verbatim (the code upper-cased). Normalizing an id
+ * would be meaningless and stripping a diacritic from it impossible.
+ *
+ * @param fields The identity fields, at the level being keyed.
+ * @param level The level to key AT. Pass the derived level for the row itself;
+ *   pass a higher level to key its projection.
+ */
+export function computeAddressIdentityKey(
+  fields: AddressIdentityFields,
+  level: AddressLevel,
+): string {
+  const projected = projectIdentityFields(fields, level);
+  // Fixed positions, and nothing is filtered out. An absent field contributes an
+  // empty slot so that `42` in `number` and `42` in `block` can never produce
+  // the same digest — the v1 defect this replaces.
+  const parts = [
+    `v${ADDRESS_NORMALIZATION_VERSION}`,
+    level,
+    normalizeIdentityValue(projected.street),
+    normalizeIdentityValue(projected.postalCode),
+    projected.cityId,
+    projected.countryCode.toUpperCase(),
+    normalizeIdentityValue(projected.number),
+    normalizeIdentityValue(projected.buildingName),
+    normalizeIdentityValue(projected.block),
+    normalizeIdentityValue(projected.entrance),
+    normalizeIdentityValue(projected.floor),
+    normalizeIdentityValue(projected.unit),
+    normalizeIdentityValue(projected.subunit),
+  ];
+  return crypto.createHash('sha256').update(parts.join('|')).digest('hex');
+}
+
+/**
+ * Whether two field sets name the same place at `level`.
+ *
+ * Used by the v1-key ADOPTION path, where an existing row was found by a key
+ * that does not hash every discriminating field: matching the v1 key proves
+ * only that the v1 SUBSET agrees, and adopting a row on that basis is exactly
+ * how a building acquires a flat's identity. This compares every v2 identity
+ * field, normalized, so adoption happens only when the two really are the same
+ * place.
+ */
+export function identityFieldsEqual(
+  left: AddressIdentityFields,
+  right: AddressIdentityFields,
+  level: AddressLevel,
+): boolean {
+  return computeAddressIdentityKey(left, level) === computeAddressIdentityKey(right, level);
+}

--- a/packages/backend/services/addressService.ts
+++ b/packages/backend/services/addressService.ts
@@ -53,7 +53,7 @@
 import * as crypto from 'crypto';
 import { and, eq, sql, type SQL } from 'drizzle-orm';
 
-import { getDb } from '../db/postgres';
+import { getDb, type DatabaseOrTransaction } from '../db/postgres';
 import { addresses, cities, countries, neighborhoods, regions } from '../db/schema';
 import {
   ADDRESS_GEO_NAME_COLUMNS,
@@ -187,8 +187,7 @@ export function normalizeAddressAliases(input: AddressCanonicalInput): AddressCa
 // place already exists) one indexed lookup and no write at all; the trailing
 // SELECT is the branch a concurrent inserter takes.
 
-async function upsertCountry(code: string, name: string): Promise<string> {
-  const db = getDb();
+async function upsertCountry(db: DatabaseOrTransaction, code: string, name: string): Promise<string> {
   const existing = await db.select({ id: countries.id }).from(countries).where(eq(countries.code, code)).limit(1);
   if (existing[0]) return existing[0].id;
 
@@ -204,8 +203,11 @@ async function upsertCountry(code: string, name: string): Promise<string> {
   return raced[0].id;
 }
 
-async function upsertRegion(countryId: string, name: string): Promise<string> {
-  const db = getDb();
+async function upsertRegion(
+  db: DatabaseOrTransaction,
+  countryId: string,
+  name: string,
+): Promise<string> {
   const match = and(eq(regions.countryId, countryId), eq(regions.name, name));
 
   const existing = await db.select({ id: regions.id }).from(regions).where(match).limit(1);
@@ -224,13 +226,13 @@ async function upsertRegion(countryId: string, name: string): Promise<string> {
 }
 
 async function upsertCity(
+  db: DatabaseOrTransaction,
   regionId: string,
   countryId: string,
   name: string,
   countryCode: string,
   coordinates?: [number, number],
 ): Promise<string> {
-  const db = getDb();
   const match = and(eq(cities.regionId, regionId), eq(cities.name, name));
 
   const existing = await db.select({ id: cities.id }).from(cities).where(match).limit(1);
@@ -259,8 +261,12 @@ async function upsertCity(
   return raced[0].id;
 }
 
-async function upsertNeighborhood(cityId: string, name: string, centroid?: [number, number]): Promise<string> {
-  const db = getDb();
+async function upsertNeighborhood(
+  db: DatabaseOrTransaction,
+  cityId: string,
+  name: string,
+  centroid?: [number, number],
+): Promise<string> {
   const match = and(eq(neighborhoods.cityId, cityId), eq(neighborhoods.name, name));
 
   const existing = await db.select({ id: neighborhoods.id }).from(neighborhoods).where(match).limit(1);
@@ -332,6 +338,27 @@ export async function resolveGeoChain(input: {
   coordinates?: [number, number];
   names?: GeoNames;
 }): Promise<ResolvedGeo> {
+  const names = await resolveGeoNames(input);
+  return upsertGeoChain(getDb(), names, input.coordinates);
+}
+
+/**
+ * The NETWORK half of {@link resolveGeoChain}: complete the caller's names from
+ * the geocoder, and nothing else.
+ *
+ * Split out for one reason, and it is not tidiness: a caller that has to do the
+ * upserts INSIDE a transaction must not hold that transaction open across an
+ * HTTP round trip to a geocoder. `materializeHousingCandidate` calls this before
+ * it opens its transaction and {@link upsertGeoChain} inside it, so the whole
+ * materialization is atomic without a network call ever sitting between `BEGIN`
+ * and `COMMIT`.
+ *
+ * @throws GeoResolutionError when neither names nor coordinates yield a city.
+ */
+export async function resolveGeoNames(input: {
+  coordinates?: [number, number];
+  names?: GeoNames;
+}): Promise<GeoNames> {
   let names = input.names;
   if (!namesAreComplete(names) && input.coordinates) {
     const [lng, lat] = input.coordinates;
@@ -346,21 +373,61 @@ export async function resolveGeoChain(input: {
   if (!names?.city) {
     throw new GeoResolutionError('Unable to resolve a city for the provided coordinates/names');
   }
+  return names;
+}
+
+/**
+ * The DATABASE half: upsert country → region → city → (neighborhood) and return
+ * the id chain.
+ *
+ * Takes a handle rather than reaching for {@link getDb} so it can join a
+ * caller's transaction. `DatabaseOrTransaction` and not `Database`, because a
+ * `Transaction` is not assignable to `Database` — a helper typed as the latter
+ * silently forces its caller to run OUTSIDE the transaction, which is how a
+ * write loses atomicity with the work it is supposed to be atomic WITH
+ * (`db/postgres.ts` states the same rule where the type is declared).
+ *
+ * Every statement is `ON CONFLICT DO NOTHING` plus a read-back, so no statement
+ * here can fail on a duplicate and abort a caller's transaction with `25P02`.
+ */
+export async function upsertGeoChain(
+  db: DatabaseOrTransaction,
+  names: GeoNames,
+  coordinates?: [number, number],
+): Promise<ResolvedGeo> {
+  if (!names.city) {
+    throw new GeoResolutionError('Unable to resolve a city for the provided coordinates/names');
+  }
 
   const { code: countryCode, name: countryName } = resolveCountryCodeAndName(names);
-  const countryId = await upsertCountry(countryCode, countryName);
+  const countryId = await upsertCountry(db, countryCode, countryName);
   // Fall back to a stable placeholder so the chain is always whole — the three
   // parent references on `addresses` are NOT NULL.
-  const regionId = await upsertRegion(countryId, names.state?.trim() || UNKNOWN_REGION);
-  const cityId = await upsertCity(regionId, countryId, names.city.trim(), countryCode, input.coordinates);
+  const regionId = await upsertRegion(db, countryId, names.state?.trim() || UNKNOWN_REGION);
+  const cityId = await upsertCity(db, regionId, countryId, names.city.trim(), countryCode, coordinates);
 
   let neighborhoodId: string | undefined;
   if (names.neighborhood?.trim()) {
-    neighborhoodId = await upsertNeighborhood(cityId, names.neighborhood.trim(), input.coordinates);
+    neighborhoodId = await upsertNeighborhood(db, cityId, names.neighborhood.trim(), coordinates);
   }
 
   return { countryId, regionId, cityId, neighborhoodId, countryCode };
 }
+
+/**
+ * The literal region name {@link upsertGeoChain} falls back to when a geocode
+ * returns no administrative region.
+ *
+ * Exported so a caller can REFUSE it rather than reproduce the string. ADR 0001
+ * §5.2 change 5 retires this fallback: two genuinely different `Santiago`s both
+ * land under one `Unknown` region and collapse into a single city row
+ * (measured). `findOrCreateCanonicalAddress` keeps the fallback, because
+ * dropping a listing is worse than bucketing one; `materializeHousingCandidate`
+ * refuses it, because a PERMANENT identity under a bucket is worse than no
+ * identity at all — the candidate is kept and the listing stays searchable at
+ * city scope, which is what the candidate table is for.
+ */
+export const UNRESOLVED_REGION_NAME = UNKNOWN_REGION;
 
 /** The fields {@link computeAddressNormalizedKey} hashes, in order. */
 export interface NormalizedKeyFields {

--- a/packages/backend/services/housingMaterialization.ts
+++ b/packages/backend/services/housingMaterialization.ts
@@ -1,0 +1,1348 @@
+/**
+ * `materializeHousingCandidate` — the ONE place an address candidate becomes a
+ * canonical Homiio place. Issue #360, ADR 0001 §2.2 / §3 / §5.
+ *
+ * ## The rule this module exists to make true
+ *
+ * **An autocomplete query never creates a permanent row.** Materialization
+ * happens only as a side effect of a DURABLE ACTION — creating or updating a
+ * listing, writing a review, following a dwelling, linking public data, creating
+ * an event that needs canonical identity, or an approved correction. There is no
+ * action value meaning "a read": `address_materializations.durable_action` is
+ * NOT NULL with a CHECK over that closed set, and this function is the only
+ * writer of `addresses.identity_key` and `addresses.parent_address_id`.
+ *
+ * A preview or a typeahead may record an `address_candidates` row freely. A
+ * candidate is internal, expiring and disposable, which is what lets a read path
+ * keep its evidence without acquiring the ability to mint identity.
+ *
+ * ## What it does NOT change
+ *
+ * `findOrCreateCanonicalAddress` is untouched, and every existing caller
+ * (`POST /api/addresses`, `reviewController`, `property/updateDelete`,
+ * `seedProperties`, ingestion) keeps its exact current behaviour — the v1
+ * `normalized_key` dedup and the `Unknown` region fallback included. Migrating
+ * those call sites onto this chokepoint is a separate change: landing both at
+ * once would alter what every listing in the catalogue resolves to in the same
+ * commit that introduces the mechanism.
+ *
+ * ## The order of the match, and why each step is where it is
+ *
+ * 0. **An idempotency key already used** → replay the recorded result, write
+ *    nothing. The only step that can answer without resolving geo.
+ * 1. **A caller-CONFIRMED address** → use it. This is how an `ambiguous` result
+ *    is settled, and the only path that accepts a probable match.
+ * 2. **The v2 identity key** → the ordinary exact hit.
+ * 3. **The v1 `normalized_key`** → ADOPT the pre-v2 row when every v2 identity
+ *    field agrees. This step exists only because 11,734 rows predate the v2 key,
+ *    and it is BEFORE the probable search on purpose: without it, every address
+ *    already in the catalogue would come back as an ambiguity the first time
+ *    anybody materialized it.
+ * 4. **A provider external ref, reconciled against the probable set.** A ref is a
+ *    portal's stable id, so it must survive that portal RELABELLING a place and
+ *    must never silently RELOCATE one. A ref pointing at a row this candidate
+ *    could plausibly be is label drift and the ref wins; a ref pointing anywhere
+ *    else is a `conflict`, decided before anything is created.
+ * 5. **Probable matches** → return `ambiguous`. Never merged automatically.
+ * 6. **Nothing** → create, in order: street, then building, then unit.
+ *
+ * ## Everything from step 0 onwards runs in ONE transaction
+ *
+ * Geo upserts included, which is why `addressService` grew
+ * `upsertGeoChain(db, …)`. The geocoder is consulted BEFORE `BEGIN`, so no HTTP
+ * round trip is ever held open inside the transaction.
+ *
+ * No statement inside is allowed to fail on a constraint: every insert that can
+ * conflict is `ON CONFLICT DO NOTHING` plus a read-back, never
+ * INSERT-and-catch. In PostgreSQL a failed statement aborts the WHOLE
+ * transaction (`25P02`), so the Mongo idiom — let the duplicate raise, then read
+ * the row that already existed — does not port: the recovery read is the
+ * statement that dies. `db/postgres.ts`'s `inSavepoint` is the escape hatch for
+ * a failure that genuinely must happen; nothing here needs one, which is better
+ * than needing one and remembering it.
+ *
+ * ## What is deliberately NOT here
+ *
+ * Merge and split (#360's second half). The schema leaves room for both —
+ * `addresses.merged_into_address_id` is the reversible redirect,
+ * `address_materializations` is the audit trail — and this module HONOURS the
+ * redirect from its first line ({@link followMergeRedirect} runs on every match),
+ * so a merge landing later cannot start handing callers a row it retired.
+ * Performing one is a follow-up.
+ */
+
+import * as crypto from 'crypto';
+import { and, eq, inArray, isNull, sql, type AnyColumn } from 'drizzle-orm';
+
+import { getDb, type DatabaseOrTransaction } from '../db/postgres';
+import {
+  addressCandidates,
+  addressExternalRefs,
+  addressMaterializations,
+  addresses,
+} from '../db/schema';
+import type {
+  CandidateOrigin,
+  CandidatePrecision,
+  DurableMaterializationAction,
+  MaterializationMatchKind,
+} from '../db/schema/addressMaterialization';
+import {
+  ADDRESS_NORMALIZATION_VERSION,
+  computeAddressIdentityKey,
+  deriveAddressLevel,
+  identityValueOrNull,
+  normalizeIdentityValue,
+  type AddressIdentityFields,
+  type AddressLevel,
+} from './addressIdentity';
+import {
+  UNRESOLVED_REGION_NAME,
+  computeAddressNormalizedKey,
+  resolveGeoNames,
+  upsertGeoChain,
+  type ResolvedGeo,
+} from './addressService';
+import { GeoResolutionError, type GeoNames } from './geoResolutionService';
+
+/**
+ * How long a candidate is kept when the caller does not say.
+ *
+ * Thirty days: long enough that an `ambiguous` result can still be confirmed
+ * days later by somebody who had to go and check, short enough that a table fed
+ * by autocomplete does not accumulate a year of keystrokes. Swept by
+ * `db/expiry.ts`.
+ */
+export const CANDIDATE_TTL_DAYS = 30;
+
+/**
+ * How similar two street names must be before they are even considered the same
+ * street, by `pg_trgm`'s `similarity()`.
+ *
+ * **Measured against a real server rather than chosen**, on Barcelona and Madrid
+ * street pairs (2026-08-11, PostgreSQL 17 / pg_trgm, normalized as this module
+ * normalizes — lowercased, unaccented):
+ *
+ * | pair | similarity | should be |
+ * |---|---|---|
+ * | `carrer de provenca 42` / `carrer de provenca` | 0.864 | same |
+ * | `gran via de les corts catalanes` / `…catalanas` | 0.848 | same (typo) |
+ * | `carrer de provenca` / `carrer de provenza` | 0.727 | same (typo) |
+ * | **`carrer de mallorca` / `carrer de menorca`** | **0.609** | **DIFFERENT** |
+ * | `carrer de arago` / `carrer de aribau` | 0.571 | different |
+ * | `calle de alcala` / `calle de atocha` | 0.476 | different |
+ * | `avinguda diagonal` / `avinguda meridiana` | 0.370 | different |
+ *
+ * So 0.7 sits in the gap between the closest measured typo (0.727) and the
+ * closest measured pair of genuinely different streets (0.609). The gap is
+ * NARROW and worth stating rather than hiding: Mallorca and Menorca really are
+ * two streets whose names differ by one letter, and no threshold separates that
+ * case from a typo by construction.
+ *
+ * It errs toward ASKING, because the two errors are not symmetric: a false
+ * ambiguity costs one confirmation prompt, while a false merge publishes one
+ * household's reviews under another household's address. Nothing above this
+ * floor is ever merged automatically — it only decides what a human is asked
+ * about.
+ */
+export const STREET_SIMILARITY_FLOOR = 0.7;
+
+/**
+ * How far apart two rows may be and still be proposed as the same place, in
+ * metres.
+ *
+ * Coordinates are the WEAKEST identity signal Homiio has — 94-100% of habitaclia
+ * and fotocasa listings geocode to the city centroid, and rural geocodes
+ * routinely differ by tens of metres between portals (ADR 0001 §1.4, §10.8). So
+ * distance only ever EXCLUDES: two rows further apart than this are not proposed
+ * as one place, and being close is never evidence that two rows ARE one place.
+ */
+export const PROBABLE_MATCH_RADIUS_METERS = 400;
+
+/** The most probable matches offered for confirmation. A human cannot use more. */
+export const MAX_PROBABLE_MATCHES = 5;
+
+/** The longest merge-redirect chain that is followed before it is called a cycle. */
+const MAX_MERGE_REDIRECTS = 8;
+
+/** What a caller may submit as a candidate. Free text; nothing is identity yet. */
+export interface HousingCandidateDraft {
+  readonly provider: string;
+  readonly providerRef?: string | null;
+  readonly rawText: string;
+  readonly origin: CandidateOrigin;
+  readonly precision: CandidatePrecision;
+  readonly longitude?: number | null;
+  readonly latitude?: number | null;
+  readonly submittedByOxyUserId?: string | null;
+  readonly sourceUrl?: string | null;
+  readonly confidence?: number | null;
+  readonly normalizedPayload?: Record<string, unknown>;
+  readonly expiresAt?: Date;
+
+  readonly proposedCountryCode?: string | null;
+  readonly proposedCountry?: string | null;
+  readonly proposedRegion?: string | null;
+  readonly proposedCity?: string | null;
+  readonly proposedNeighborhood?: string | null;
+
+  readonly proposedStreet?: string | null;
+  readonly proposedPostalCode?: string | null;
+  readonly proposedNumber?: string | null;
+  readonly proposedBuildingName?: string | null;
+  readonly proposedBlock?: string | null;
+  readonly proposedEntrance?: string | null;
+  readonly proposedFloor?: string | null;
+  readonly proposedUnit?: string | null;
+  readonly proposedSubunit?: string | null;
+}
+
+export interface MaterializeHousingCandidateInput {
+  /** An `address_candidates` row a preview already recorded. */
+  readonly candidateId?: string;
+  /** Or the candidate itself, recorded as part of this materialization. */
+  readonly candidate?: HousingCandidateDraft;
+  /**
+   * The address a caller picked out of a previous `ambiguous` result.
+   *
+   * The ONLY way a probable match is ever accepted. Supplying it skips the
+   * probable search entirely — the ambiguity has been settled by whoever is
+   * calling, which is the point — and the CONFIRMED row's own fields become
+   * authoritative, so no rival row is created beside it.
+   */
+  readonly confirmedAddressId?: string;
+}
+
+/** Who is materializing, and under what authority. */
+export interface MaterializationActorContext {
+  /** The durable action. There is deliberately no value meaning "a read". */
+  readonly action: DurableMaterializationAction;
+  readonly actorOxyUserId?: string | null;
+  /** The id of the row the action produced, when it exists yet. */
+  readonly actionRef?: string | null;
+  /**
+   * The caller's idempotency key for this action.
+   *
+   * Two calls carrying one key converge on one materialization and one address,
+   * whether they arrive in sequence or at the same instant.
+   */
+  readonly idempotencyKey?: string | null;
+}
+
+/** Why a candidate could not become a permanent row at all. */
+export type MaterializationRejection =
+  /** `centroid` or `area` — the observation is about an area, not a dwelling. */
+  | 'imprecise_location'
+  /** No street: there is nothing for an identity to be about. */
+  | 'missing_street'
+  /** No coordinates: `addresses.longitude` / `latitude` are NOT NULL. */
+  | 'missing_coordinates'
+  /** No city could be resolved. */
+  | 'unresolved_city'
+  /** No region could be resolved, and a bucket is not an identity. */
+  | 'unresolved_region';
+
+/** Why a materialization refused to write rather than overwrite something. */
+export type MaterializationConflictKind = 'provider_ref_bound_elsewhere';
+
+export interface MaterializationConflict {
+  readonly kind: MaterializationConflictKind;
+  /** The place the evidence currently points at. */
+  readonly existingAddressId: string;
+  /** The place this candidate resolved to. */
+  readonly proposedAddressId: string | null;
+  readonly detail: string;
+}
+
+/** One row a human is being asked to choose between. */
+export interface ProbableMatch {
+  readonly addressId: string;
+  readonly addressLevel: AddressLevel;
+  readonly street: string;
+  readonly number: string | null;
+  readonly buildingName: string | null;
+  readonly entrance: string | null;
+  readonly streetSimilarity: number;
+  readonly distanceMeters: number;
+  /** Why it is a candidate, in terms a person can check. */
+  readonly reason: string;
+}
+
+export interface MaterializationExplanation {
+  readonly matchKind: MaterializationMatchKind;
+  readonly detail: string;
+  readonly identityKey: string;
+}
+
+export type MaterializationResult =
+  | {
+      readonly status: 'materialized';
+      readonly candidateId: string;
+      /** The row the durable action should reference. */
+      readonly addressId: string;
+      readonly addressLevel: AddressLevel;
+      readonly streetAddressId: string;
+      readonly buildingAddressId: string | null;
+      readonly unitAddressId: string | null;
+      readonly materializationId: string;
+      readonly match: MaterializationExplanation;
+    }
+  | {
+      readonly status: 'ambiguous';
+      readonly candidateId: string;
+      readonly candidates: readonly ProbableMatch[];
+    }
+  | {
+      readonly status: 'conflict';
+      readonly candidateId: string;
+      readonly conflicts: readonly MaterializationConflict[];
+    }
+  | {
+      readonly status: 'rejected';
+      readonly candidateId: string;
+      readonly reason: MaterializationRejection;
+      readonly detail: string;
+    };
+
+type CandidateRow = typeof addressCandidates.$inferSelect;
+type AddressRow = typeof addresses.$inferSelect;
+
+/** A resolved row plus how it was arrived at. */
+interface ResolvedAddress {
+  readonly row: AddressRow;
+  readonly matchKind: MaterializationMatchKind;
+  readonly detail: string;
+}
+
+/** sha256 over the NORMALIZED raw text — ADR 0001 §2.2's `raw_text_hash`. */
+export function rawTextHashOf(rawText: string): string {
+  return crypto.createHash('sha256').update(normalizeIdentityValue(rawText)).digest('hex');
+}
+
+/**
+ * Follow `merged_into_address_id` to the surviving row.
+ *
+ * Called on EVERY match before it is returned. Nothing performs a merge today,
+ * so this is a no-op in every current test — which is exactly why it is here
+ * now rather than added later: retrofitting it would mean auditing each match
+ * path separately, and the one that was missed would silently hand callers a
+ * row a merge had retired.
+ *
+ * Bounded rather than looped until NULL. A CHAIN of redirects is legitimate (A
+ * merged into B, B later into C); a CYCLE is not, and a cycle here would hang a
+ * request rather than fail it. The one-row case is refused by
+ * `addresses_merge_not_self_check`; a longer cycle is not expressible as a
+ * CHECK, so this bound is the defence.
+ */
+async function followMergeRedirect(
+  db: DatabaseOrTransaction,
+  start: AddressRow,
+): Promise<AddressRow> {
+  let current = start;
+  for (let hop = 0; hop < MAX_MERGE_REDIRECTS; hop += 1) {
+    const next = current.mergedIntoAddressId;
+    if (!next) return current;
+    const [row] = await db.select().from(addresses).where(eq(addresses.id, next)).limit(1);
+    if (!row) {
+      throw new Error(
+        `Address ${current.id} redirects to ${next}, which does not exist. The redirect is a ` +
+        'foreign key, so this means the row was removed by something that bypassed it.',
+      );
+    }
+    current = row;
+  }
+  throw new Error(
+    `Address ${start.id} did not resolve to a survivor within ${MAX_MERGE_REDIRECTS} redirects — ` +
+    'the merge chain contains a cycle.',
+  );
+}
+
+/** The identity fields as they will be STORED: normalized, or NULL when empty. */
+function identityFieldsOfCandidate(
+  candidate: CandidateRow,
+  geo: ResolvedGeo,
+): AddressIdentityFields {
+  return {
+    // Asserted non-empty by `validateCandidate` before this runs.
+    street: normalizeIdentityValue(candidate.proposedStreet),
+    postalCode: identityValueOrNull(candidate.proposedPostalCode),
+    cityId: geo.cityId,
+    countryCode: geo.countryCode,
+    number: identityValueOrNull(candidate.proposedNumber),
+    buildingName: identityValueOrNull(candidate.proposedBuildingName),
+    block: identityValueOrNull(candidate.proposedBlock),
+    entrance: identityValueOrNull(candidate.proposedEntrance),
+    floor: identityValueOrNull(candidate.proposedFloor),
+    unit: identityValueOrNull(candidate.proposedUnit),
+    subunit: identityValueOrNull(candidate.proposedSubunit),
+  };
+}
+
+/**
+ * The same fields under V1's normalization — lowercase and trim only, NO
+ * diacritic stripping and no whitespace collapsing.
+ *
+ * Used exclusively to compute a v1 LOOKUP key, so an accented row written by
+ * `findOrCreateCanonicalAddress` can still be found. See
+ * {@link legacyKeyCandidates} for why this cannot be skipped.
+ */
+function legacyFieldsOf(
+  source: {
+    street: string | null;
+    postalCode: string | null;
+    number: string | null;
+    buildingName: string | null;
+    block: string | null;
+    entrance: string | null;
+    floor: string | null;
+    unit: string | null;
+    subunit: string | null;
+  },
+  geo: { cityId: string; countryCode: string },
+): AddressIdentityFields {
+  const v1 = (value: string | null): string | null => {
+    const trimmed = (value ?? '').toLowerCase().trim();
+    return trimmed === '' ? null : trimmed;
+  };
+  return {
+    street: v1(source.street) ?? '',
+    postalCode: v1(source.postalCode),
+    cityId: geo.cityId,
+    countryCode: geo.countryCode,
+    number: v1(source.number),
+    buildingName: v1(source.buildingName),
+    block: v1(source.block),
+    entrance: v1(source.entrance),
+    floor: v1(source.floor),
+    unit: v1(source.unit),
+    subunit: v1(source.subunit),
+  };
+}
+
+/** The v1-shaped fields of a candidate. */
+function legacyFieldsOfCandidate(candidate: CandidateRow, geo: ResolvedGeo): AddressIdentityFields {
+  return legacyFieldsOf(
+    {
+      street: candidate.proposedStreet,
+      postalCode: candidate.proposedPostalCode,
+      number: candidate.proposedNumber,
+      buildingName: candidate.proposedBuildingName,
+      block: candidate.proposedBlock,
+      entrance: candidate.proposedEntrance,
+      floor: candidate.proposedFloor,
+      unit: candidate.proposedUnit,
+      subunit: candidate.proposedSubunit,
+    },
+    geo,
+  );
+}
+
+/** The v1-shaped fields of an existing row, for ancestor projection. */
+function legacyFieldsOfRow(row: AddressRow): AddressIdentityFields {
+  return legacyFieldsOf(row, { cityId: row.cityId, countryCode: row.countryCode });
+}
+
+/** The same shape read back off a row, for adoption and for ancestor projection. */
+function identityFieldsOfRow(row: AddressRow): AddressIdentityFields {
+  return {
+    street: normalizeIdentityValue(row.street),
+    postalCode: identityValueOrNull(row.postalCode),
+    cityId: row.cityId,
+    countryCode: row.countryCode,
+    number: identityValueOrNull(row.number),
+    buildingName: identityValueOrNull(row.buildingName),
+    block: identityValueOrNull(row.block),
+    entrance: identityValueOrNull(row.entrance),
+    floor: identityValueOrNull(row.floor),
+    unit: identityValueOrNull(row.unit),
+    subunit: identityValueOrNull(row.subunit),
+  };
+}
+
+/**
+ * The v1 key for a projection, computed with the SAME field mapping
+ * `findOrCreateCanonicalAddress` uses.
+ *
+ * It must agree byte for byte, because this value is the LOOKUP into rows
+ * written under those rules — including their defect, which is reproduced
+ * faithfully rather than corrected: v1 hashes `unit` and neither `floor` nor
+ * `subunit` nor `entrance`.
+ */
+function legacyKeyOf(fields: AddressIdentityFields, level: AddressLevel): string {
+  return computeAddressNormalizedKey({
+    street: fields.street,
+    number: level === 'STREET' ? undefined : fields.number ?? undefined,
+    unit: level === 'UNIT' ? fields.unit ?? undefined : undefined,
+    buildingName: level === 'STREET' ? undefined : fields.buildingName ?? undefined,
+    block: level === 'STREET' ? undefined : fields.block ?? undefined,
+    postalCode: fields.postalCode ?? undefined,
+    cityId: fields.cityId,
+    countryCode: fields.countryCode,
+  });
+}
+
+/**
+ * The v1 keys a pre-v2 row for this place could be carrying — usually two.
+ *
+ * **The reason there is more than one is the whole point, and it is the common
+ * case in this corpus rather than an edge.** v1 lowercases and trims; v2 also
+ * STRIPS DIACRITICS. So a building stored as `Carrer de Provença 42` has a v1
+ * key over `carrer de provença`, while the same candidate normalized for v2
+ * hashes `carrer de provenca` — different strings, different v1 keys, no match.
+ * Looking up only the v2-normalized form would fail to adopt every accented
+ * street in Spain, Catalonia, Portugal and Italy, and would create a rival row
+ * beside each one. Measured: the adoption case failed exactly this way on its
+ * first run.
+ *
+ * So both forms are looked up. The set is deduped, because for an unaccented
+ * street they are the same string.
+ */
+function legacyKeyCandidates(
+  normalized: AddressIdentityFields,
+  raw: AddressIdentityFields,
+  level: AddressLevel,
+): string[] {
+  return [...new Set([legacyKeyOf(normalized, level), legacyKeyOf(raw, level)])];
+}
+
+/** The columns a new `addresses` row gets at `level`. */
+function addressValuesFor(
+  geo: ResolvedGeo,
+  fields: AddressIdentityFields,
+  level: AddressLevel,
+  point: { longitude: number; latitude: number },
+  keys: { identityKey: string; normalizedKey: string | null },
+  parentAddressId: string | null,
+): typeof addresses.$inferInsert {
+  const atBuildingOrBelow = level === 'BUILDING' || level === 'UNIT';
+  return {
+    countryId: geo.countryId,
+    regionId: geo.regionId,
+    cityId: geo.cityId,
+    neighborhoodId: geo.neighborhoodId ?? null,
+    countryCode: geo.countryCode,
+    street: fields.street,
+    // `postal_code` is NOT NULL on the table, so an unpostcoded place stores
+    // `''` — the column's existing contract, which
+    // `findOrCreateCanonicalAddress` also follows. It is safe HERE in a way it
+    // is not in the key: `identity_key` receives NULL for an absent postcode, so
+    // `''` never enters an identity. ADR 0001 §3.2's "a missing postcode is
+    // NULL" needs the column to become nullable, which is a separate migration
+    // and a separate decision about 11,734 existing rows.
+    postalCode: fields.postalCode ?? '',
+    number: atBuildingOrBelow ? fields.number ?? null : null,
+    buildingName: atBuildingOrBelow ? fields.buildingName ?? null : null,
+    block: atBuildingOrBelow ? fields.block ?? null : null,
+    entrance: atBuildingOrBelow ? fields.entrance ?? null : null,
+    floor: level === 'UNIT' ? fields.floor ?? null : null,
+    unit: level === 'UNIT' ? fields.unit ?? null : null,
+    subunit: level === 'UNIT' ? fields.subunit ?? null : null,
+    longitude: point.longitude,
+    latitude: point.latitude,
+    identityKey: keys.identityKey,
+    normalizedKey: keys.normalizedKey,
+    parentAddressId,
+  };
+}
+
+/**
+ * Find, adopt or create the row at `level`.
+ *
+ * The three-step lookup — v2 key, then v1 key, then insert — is what lets this
+ * module run BESIDE `findOrCreateCanonicalAddress` rather than instead of it.
+ */
+async function resolveLevel(
+  db: DatabaseOrTransaction,
+  geo: ResolvedGeo,
+  fields: AddressIdentityFields,
+  legacyFields: AddressIdentityFields,
+  level: AddressLevel,
+  point: { longitude: number; latitude: number },
+  parentAddressId: string | null,
+): Promise<ResolvedAddress> {
+  const identityKey = computeAddressIdentityKey(fields, level);
+
+  const byIdentity = await findByIdentityKey(db, identityKey);
+  if (byIdentity) return byIdentity;
+
+  const adopted = await adoptLegacyRow(db, fields, legacyFields, level, identityKey);
+  if (adopted) return adopted;
+
+  // The key this row would CARRY is computed over the values it will STORE, so
+  // the stored row stays self-consistent under v1's own rules. The keys it is
+  // checked AGAINST include the raw form as well, so an accented pre-v2 row is
+  // not overwritten by a rival carrying the stripped key.
+  const legacyKey = legacyKeyOf(fields, level);
+  const [legacyHolder] = await db
+    .select({ id: addresses.id })
+    .from(addresses)
+    .where(inArray(addresses.normalizedKey, legacyKeyCandidates(fields, legacyFields, level)))
+    .limit(1);
+
+  // The v1 key is TAKEN by a different place (or by a row that already carries
+  // another v2 identity), and `addresses_normalized_key_key` is UNIQUE — so this
+  // row cannot carry one. NULL is the honest answer rather than a workaround: v1
+  // hashes neither `floor` nor `entrance` nor `subunit`, so it genuinely cannot
+  // represent a third-floor flat as distinct from its building. The v1 caller
+  // keeps resolving to the row it already had; this row is reachable by its v2
+  // identity. ADR 0001 §5.1's plan is forward-only and says so.
+  const normalizedKey = legacyHolder ? null : legacyKey;
+  const values = addressValuesFor(geo, fields, level, point, { identityKey, normalizedKey }, parentAddressId);
+
+  const inserted = await db
+    .insert(addresses)
+    .values(values)
+    // The index PREDICATE, not a row filter. `addresses_identity_key_key` is
+    // PARTIAL (`where identity_key is not null`) and Postgres will not infer a
+    // partial index from its columns alone: without the matching predicate this
+    // fails at RUNTIME with `42P10 there is no unique or exclusion constraint
+    // matching the ON CONFLICT specification`, while `tsc` stays clean.
+    .onConflictDoNothing({
+      target: addresses.identityKey,
+      where: sql`${addresses.identityKey} is not null`,
+    })
+    .returning();
+  if (inserted[0]) {
+    return {
+      row: inserted[0],
+      matchKind: 'created',
+      detail: legacyHolder
+        ? `created at ${level}; normalized_key ${legacyKey.slice(0, 12)}… is held by ${legacyHolder.id}, which the v1 key cannot tell apart from this place`
+        : `created at ${level}`,
+    };
+  }
+
+  // Lost the race to a concurrent materialization of the same place. Reading the
+  // winner is the same answer a moment later, and it is the only one available:
+  // raising here would make two correct callers fight.
+  const raced = await findByIdentityKey(db, identityKey);
+  if (!raced) {
+    throw new Error(
+      `Address with identity_key ${identityKey} could not be resolved after an insert conflict`,
+    );
+  }
+  return { ...raced, detail: `identity_key ${identityKey.slice(0, 12)}… created concurrently at ${level}` };
+}
+
+/** An exact v2 hit, redirected to its merge survivor. */
+async function findByIdentityKey(
+  db: DatabaseOrTransaction,
+  identityKey: string,
+): Promise<ResolvedAddress | null> {
+  const [row] = await db
+    .select()
+    .from(addresses)
+    .where(eq(addresses.identityKey, identityKey))
+    .limit(1);
+  if (!row) return null;
+  const survivor = await followMergeRedirect(db, row);
+  return {
+    row: survivor,
+    matchKind: 'exact_identity_key',
+    detail:
+      survivor.id === row.id
+        ? `identity_key ${identityKey.slice(0, 12)}…`
+        : `identity_key ${identityKey.slice(0, 12)}…, redirected from ${row.id}`,
+  };
+}
+
+/**
+ * Stamp a v2 identity onto a pre-v2 row that is the SAME place.
+ *
+ * Matching the v1 key proves only that the v1 SUBSET agrees, and adopting on
+ * that basis alone is exactly how a building would acquire a flat's identity —
+ * so every v2 identity field is compared, and the level follows from those
+ * fields rather than being asserted.
+ *
+ * Returns NULL when there is no such row, when the row already carries a v2
+ * identity (it is a different place that merely shares a v1 key), or when the
+ * fields disagree.
+ */
+async function adoptLegacyRow(
+  db: DatabaseOrTransaction,
+  fields: AddressIdentityFields,
+  legacyFields: AddressIdentityFields,
+  level: AddressLevel,
+  identityKey: string,
+): Promise<ResolvedAddress | null> {
+  const legacyKeys = legacyKeyCandidates(fields, legacyFields, level);
+  const [candidateRow] = await db
+    .select()
+    .from(addresses)
+    .where(inArray(addresses.normalizedKey, legacyKeys))
+    .limit(1);
+  if (!candidateRow) return null;
+  const legacyKey = candidateRow.normalizedKey ?? legacyKeys[0];
+
+  const survivor = await followMergeRedirect(db, candidateRow);
+  if (survivor.identityKey !== null) return null;
+
+  const rowFields = identityFieldsOfRow(survivor);
+  if (computeAddressIdentityKey(rowFields, deriveAddressLevel(rowFields)) !== identityKey) {
+    return null;
+  }
+
+  const [adopted] = await db
+    .update(addresses)
+    .set({ identityKey })
+    .where(and(eq(addresses.id, survivor.id), isNull(addresses.identityKey)))
+    .returning();
+  if (adopted) {
+    return {
+      row: adopted,
+      matchKind: 'adopted_v1_key',
+      detail:
+        `pre-v2 row ${survivor.id} matched normalized_key ${legacyKey.slice(0, 12)}… ` +
+        'and every v2 identity field',
+    };
+  }
+
+  // A concurrent adopter stamped it first; its answer is this answer.
+  return findByIdentityKey(db, identityKey);
+}
+
+/**
+ * Rows that MIGHT be this place but are not certainly it.
+ *
+ * Two rules decide the set, and the second is what stops a whole street being
+ * ambiguous:
+ *
+ * - **Similar street, same city, same level, close enough.** Similarity is
+ *   `pg_trgm`; distance only excludes.
+ * - **Every discriminating field is COMPATIBLE**: for `number`,
+ *   `building_name`, `block`, `entrance`, `floor`, `unit` and `subunit`, the two
+ *   agree or at least one side is absent. Two rows that both name a number and
+ *   name DIFFERENT numbers are different places, not an ambiguity — `42` and
+ *   `43` on one street must materialize without asking anybody.
+ *
+ * So what comes back is the genuinely undecidable zone: `42` versus
+ * `42, entrance A`; `Carrer de Provença 42` versus `Carrer de Provenza 42`.
+ * Nothing in it is merged automatically (#360: *un match probable no debe
+ * fusionar automáticamente*) — the caller settles it with `confirmedAddressId`.
+ */
+async function findProbableMatches(
+  db: DatabaseOrTransaction,
+  fields: AddressIdentityFields,
+  level: AddressLevel,
+  point: { longitude: number; latitude: number },
+): Promise<ProbableMatch[]> {
+  // A NULL side cannot contradict anything, so it is compatible with every row;
+  // a non-null side is compatible with a row that agrees or says nothing.
+  const compatible = (column: AnyColumn, value: string | null) =>
+    value === null ? sql`true` : sql`(coalesce(${column}, '') = '' or lower(${column}) = ${value})`;
+
+  const similarity = sql<number>`similarity(lower(${addresses.street}), ${fields.street})`;
+  const distance = sql<number>`ST_Distance(${addresses.geo}, ST_MakePoint(${point.longitude}, ${point.latitude})::geography)`;
+
+  const rows = await db
+    .select({
+      id: addresses.id,
+      addressLevel: addresses.addressLevel,
+      street: addresses.street,
+      number: addresses.number,
+      buildingName: addresses.buildingName,
+      entrance: addresses.entrance,
+      streetSimilarity: similarity,
+      distanceMeters: distance,
+    })
+    .from(addresses)
+    .where(
+      and(
+        eq(addresses.cityId, fields.cityId),
+        eq(addresses.addressLevel, level),
+        isNull(addresses.mergedIntoAddressId),
+        sql`${similarity} >= ${STREET_SIMILARITY_FLOOR}`,
+        sql`ST_DWithin(${addresses.geo}, ST_MakePoint(${point.longitude}, ${point.latitude})::geography, ${PROBABLE_MATCH_RADIUS_METERS})`,
+        compatible(addresses.number, fields.number ?? null),
+        compatible(addresses.buildingName, fields.buildingName ?? null),
+        compatible(addresses.block, fields.block ?? null),
+        compatible(addresses.entrance, fields.entrance ?? null),
+        compatible(addresses.floor, fields.floor ?? null),
+        compatible(addresses.unit, fields.unit ?? null),
+        compatible(addresses.subunit, fields.subunit ?? null),
+      ),
+    )
+    // Every ordering ends in `id`, so a complete tie is still deterministic —
+    // the rule `db/geo/placeLookup.ts` states for place lookup, applied here.
+    .orderBy(sql`${similarity} desc`, sql`${distance} asc`, addresses.id)
+    .limit(MAX_PROBABLE_MATCHES);
+
+  return rows.map((row) => ({
+    addressId: row.id,
+    addressLevel: (row.addressLevel ?? level) as AddressLevel,
+    street: row.street,
+    number: row.number,
+    buildingName: row.buildingName,
+    entrance: row.entrance,
+    streetSimilarity: Number(row.streetSimilarity),
+    distanceMeters: Number(row.distanceMeters),
+    reason:
+      `street similarity ${Number(row.streetSimilarity).toFixed(2)} at ` +
+      `${Math.round(Number(row.distanceMeters))} m, and no identifying field contradicts this candidate`,
+  }));
+}
+
+/**
+ * The street / building / unit ids for a row, creating any ANCESTOR that does
+ * not exist yet and stamping `parent_address_id` where it is missing.
+ *
+ * Projected from the ROW's own fields, never the candidate's. That is what makes
+ * a confirmation safe: confirming means "this candidate IS that place", so the
+ * place's own identity is authoritative and no rival row is created beside it.
+ * A candidate for `42, entrance A` confirmed against `42` produces `42`'s
+ * hierarchy, not a second building.
+ */
+async function ensureAncestors(
+  db: DatabaseOrTransaction,
+  row: AddressRow,
+  geo: ResolvedGeo,
+): Promise<{ streetId: string; buildingId: string | null; unitId: string | null }> {
+  const fields = identityFieldsOfRow(row);
+  const legacyFields = legacyFieldsOfRow(row);
+  const level = deriveAddressLevel(fields);
+  const point = { longitude: row.longitude, latitude: row.latitude };
+
+  if (level === 'STREET') {
+    return { streetId: row.id, buildingId: null, unitId: null };
+  }
+
+  const street = await resolveLevel(db, geo, fields, legacyFields, 'STREET', point, null);
+  if (level === 'BUILDING') {
+    await stampParent(db, row, street.row.id);
+    return { streetId: street.row.id, buildingId: row.id, unitId: null };
+  }
+
+  const building = await resolveLevel(db, geo, fields, legacyFields, 'BUILDING', point, street.row.id);
+  await stampParent(db, row, building.row.id);
+  return { streetId: street.row.id, buildingId: building.row.id, unitId: row.id };
+}
+
+/**
+ * Give a row its parent, but only if it does not have one.
+ *
+ * `is null` in the predicate rather than an unconditional write: a row that
+ * already names a parent has one somebody decided about, and re-pointing it
+ * would move a place in the hierarchy as a side effect of an unrelated
+ * materialization.
+ */
+async function stampParent(
+  db: DatabaseOrTransaction,
+  row: AddressRow,
+  parentAddressId: string,
+): Promise<void> {
+  if (row.parentAddressId || row.id === parentAddressId) return;
+  await db
+    .update(addresses)
+    .set({ parentAddressId })
+    .where(and(eq(addresses.id, row.id), isNull(addresses.parentAddressId)));
+}
+
+/** Everything a candidate must have before it can become a permanent row. */
+function validateCandidate(
+  candidate: CandidateRow,
+): { reason: MaterializationRejection; detail: string } | null {
+  if (candidate.precision === 'centroid' || candidate.precision === 'area') {
+    return {
+      reason: 'imprecise_location',
+      detail:
+        `precision is "${candidate.precision}", which describes an area rather than a dwelling. ` +
+        'Materializing a building from a city centroid collapses every listing in that city onto ' +
+        'one fabricated address (ADR 0001 §10.6); the candidate is kept instead, and the listing ' +
+        'stays searchable at city scope.',
+    };
+  }
+  if (normalizeIdentityValue(candidate.proposedStreet) === '') {
+    return {
+      reason: 'missing_street',
+      detail: 'no proposed street — there is nothing for an identity key to be about',
+    };
+  }
+  if (candidate.longitude === null || candidate.latitude === null) {
+    return {
+      reason: 'missing_coordinates',
+      detail:
+        'no coordinates. `addresses.longitude` / `latitude` are NOT NULL and the PostGIS point is ' +
+        'generated from them, so an address without a location is unrepresentable rather than degraded.',
+    };
+  }
+  return null;
+}
+
+/** The names a candidate proposes, in `resolveGeoNames`'s shape. */
+function proposedNames(source: HousingCandidateDraft | CandidateRow): GeoNames {
+  return {
+    city: source.proposedCity ?? undefined,
+    state: source.proposedRegion ?? undefined,
+    country: source.proposedCountry ?? undefined,
+    countryCode: source.proposedCountryCode ?? undefined,
+    neighborhood: source.proposedNeighborhood ?? undefined,
+  };
+}
+
+/** The coordinate pair, or undefined when the candidate has none. */
+function coordinatesOf(
+  source: HousingCandidateDraft | CandidateRow,
+): [number, number] | undefined {
+  const { longitude, latitude } = source;
+  if (longitude === null || longitude === undefined) return undefined;
+  if (latitude === null || latitude === undefined) return undefined;
+  return [longitude, latitude];
+}
+
+/** Insert the candidate, or load the one a preview already recorded. */
+async function recordCandidate(
+  db: DatabaseOrTransaction,
+  input: MaterializeHousingCandidateInput,
+): Promise<CandidateRow> {
+  if (input.candidateId) {
+    const [existing] = await db
+      .select()
+      .from(addressCandidates)
+      .where(eq(addressCandidates.id, input.candidateId))
+      .limit(1);
+    if (!existing) throw new Error(`Address candidate ${input.candidateId} does not exist`);
+    return existing;
+  }
+
+  const draft = input.candidate;
+  if (!draft) {
+    throw new Error(
+      'materializeHousingCandidate needs either `candidateId` or `candidate`. A materialization ' +
+      'with no candidate has no provenance, which is the one thing this chokepoint exists to guarantee.',
+    );
+  }
+
+  const [created] = await db
+    .insert(addressCandidates)
+    .values({
+      submittedByOxyUserId: draft.submittedByOxyUserId ?? null,
+      provider: draft.provider,
+      providerRef: draft.providerRef ?? null,
+      rawText: draft.rawText,
+      rawTextHash: rawTextHashOf(draft.rawText),
+      normalizedPayload: draft.normalizedPayload ?? {},
+      normalizationVersion: ADDRESS_NORMALIZATION_VERSION,
+      longitude: draft.longitude ?? null,
+      latitude: draft.latitude ?? null,
+      precision: draft.precision,
+      proposedCountryCode: draft.proposedCountryCode ?? null,
+      proposedCountry: draft.proposedCountry ?? null,
+      proposedRegion: draft.proposedRegion ?? null,
+      proposedCity: draft.proposedCity ?? null,
+      proposedNeighborhood: draft.proposedNeighborhood ?? null,
+      proposedStreet: draft.proposedStreet ?? null,
+      // NULL, never `''` and never `'00000'`: both are VALUES and both would
+      // enter an identity as though a real postcode had been observed.
+      proposedPostalCode: identityValueOrNull(draft.proposedPostalCode) === null
+        ? null
+        : draft.proposedPostalCode ?? null,
+      proposedNumber: draft.proposedNumber ?? null,
+      proposedBuildingName: draft.proposedBuildingName ?? null,
+      proposedBlock: draft.proposedBlock ?? null,
+      proposedEntrance: draft.proposedEntrance ?? null,
+      proposedFloor: draft.proposedFloor ?? null,
+      proposedUnit: draft.proposedUnit ?? null,
+      proposedSubunit: draft.proposedSubunit ?? null,
+      origin: draft.origin,
+      sourceUrl: draft.sourceUrl ?? null,
+      confidence: draft.confidence ?? null,
+      expiresAt:
+        draft.expiresAt ?? new Date(Date.now() + CANDIDATE_TTL_DAYS * 24 * 60 * 60 * 1000),
+    })
+    .returning();
+  return created;
+}
+
+/**
+ * Turn a candidate confirmed by a durable action into canonical rows.
+ *
+ * @param input The candidate, by id or by value, plus an optional confirmation
+ *   of a previously-returned ambiguous match.
+ * @param actor The durable action authorising it, who performed it, and an
+ *   optional idempotency key.
+ * @param tx A transaction to JOIN. Supply it when the durable action's own write
+ *   must be atomic with the materialization; omit it and this opens its own.
+ * @throws {Error} When neither `candidateId` nor `candidate` is given, when a
+ *   named candidate or confirmed address does not exist, or when a merge chain
+ *   contains a cycle. Every OUTCOME a caller must handle — imprecise, ambiguous,
+ *   conflicting — is RETURNED rather than thrown, because none of them is
+ *   exceptional: an ingest producing a city centroid is the ordinary case.
+ */
+export async function materializeHousingCandidate(
+  input: MaterializeHousingCandidateInput,
+  actor: MaterializationActorContext,
+  tx?: DatabaseOrTransaction,
+): Promise<MaterializationResult> {
+  // The geocoder is consulted BEFORE the transaction opens, so no HTTP round
+  // trip is ever held between BEGIN and COMMIT. When the caller named an
+  // existing candidate, the row is read here — outside any transaction — purely
+  // to learn what names to resolve; it is read again inside.
+  const source = input.candidate ?? (await loadCandidateForNames(input.candidateId));
+  let names: GeoNames | null = null;
+  let namesError: string | null = null;
+  try {
+    names = await resolveGeoNames({ coordinates: coordinatesOf(source), names: proposedNames(source) });
+  } catch (error) {
+    if (!(error instanceof GeoResolutionError)) throw error;
+    namesError = error.message;
+  }
+
+  const run = async (db: DatabaseOrTransaction): Promise<MaterializationResult> => {
+    // 0. An idempotency key already used answers without touching anything else.
+    if (actor.idempotencyKey) {
+      const [previous] = await db
+        .select()
+        .from(addressMaterializations)
+        .where(eq(addressMaterializations.idempotencyKey, actor.idempotencyKey))
+        .limit(1);
+      if (previous) return replayMaterialization(db, previous);
+    }
+
+    const candidate = await recordCandidate(db, input);
+
+    const invalid = validateCandidate(candidate);
+    if (invalid) return { status: 'rejected', candidateId: candidate.id, ...invalid };
+    if (!names) {
+      return {
+        status: 'rejected',
+        candidateId: candidate.id,
+        reason: 'unresolved_city',
+        detail: namesError ?? 'no city could be resolved from this candidate',
+      };
+    }
+    if (!names.state?.trim()) {
+      return {
+        status: 'rejected',
+        candidateId: candidate.id,
+        reason: 'unresolved_region',
+        detail:
+          `no administrative region resolved, and this chokepoint refuses the "${UNRESOLVED_REGION_NAME}" ` +
+          'bucket: two genuinely different Santiagos both land in it and collapse into one city row ' +
+          '(ADR 0001 §5.2 change 5, measured). The candidate is kept.',
+      };
+    }
+
+    const point = {
+      // Non-null by `validateCandidate` above.
+      longitude: candidate.longitude ?? 0,
+      latitude: candidate.latitude ?? 0,
+    };
+    const geo = await upsertGeoChain(db, names, [point.longitude, point.latitude]);
+    const fields = identityFieldsOfCandidate(candidate, geo);
+    const legacyFields = legacyFieldsOfCandidate(candidate, geo);
+    const level = deriveAddressLevel(fields);
+    const identityKey = computeAddressIdentityKey(fields, level);
+
+    const providerRef = candidate.providerRef;
+    const [existingRef] = providerRef
+      ? await db
+          .select()
+          .from(addressExternalRefs)
+          .where(
+            and(
+              eq(addressExternalRefs.source, candidate.provider),
+              eq(addressExternalRefs.externalId, providerRef),
+            ),
+          )
+          .limit(1)
+      : [];
+
+    // 1-3: confirmation, the v2 key, then adoption of a pre-v2 row. Each returns
+    // the SURVIVING row.
+    let resolved = await resolveExactly(db, {
+      confirmedAddressId: input.confirmedAddressId,
+      identityKey,
+      fields,
+      legacyFields,
+      level,
+    });
+
+    // 4-5: what the provider ref says, and what the text says, reconciled.
+    //
+    // A ref is a portal's stable id for a place, so it must survive the portal
+    // relabelling that place — but it must NEVER silently relocate one. The
+    // discriminator is the probable-match set: a ref pointing at a row this
+    // candidate could plausibly BE is label drift and the ref wins; a ref
+    // pointing anywhere else is a conflict a human has to settle.
+    let refConflict = false;
+    if (existingRef) {
+      if (resolved) {
+        refConflict = existingRef.addressId !== resolved.row.id;
+      } else {
+        const probable = await findProbableMatches(db, fields, level, point);
+        if (probable.some((match) => match.addressId === existingRef.addressId)) {
+          const row = await loadAddress(db, existingRef.addressId);
+          if (row) {
+            resolved = {
+              row: await followMergeRedirect(db, row),
+              matchKind: 'exact_external_ref',
+              detail:
+                `${candidate.provider}:${providerRef} already names this place; the portal's ` +
+                'label has drifted but every identifying field still agrees',
+            };
+          }
+        } else {
+          refConflict = true;
+        }
+      }
+    } else if (!resolved) {
+      const probable = await findProbableMatches(db, fields, level, point);
+      if (probable.length > 0) {
+        return { status: 'ambiguous', candidateId: candidate.id, candidates: probable };
+      }
+    }
+
+    // The conflict is decided BEFORE anything is created, which is the whole
+    // point of refusing: a check placed after the chain was built would leave
+    // orphan rows behind whenever this function owns its own transaction, since
+    // returning normally COMMITS.
+    if (refConflict && existingRef) {
+      return {
+        status: 'conflict',
+        candidateId: candidate.id,
+        conflicts: [
+          {
+            kind: 'provider_ref_bound_elsewhere',
+            existingAddressId: existingRef.addressId,
+            proposedAddressId: resolved?.row.id ?? null,
+            detail:
+              `${candidate.provider}:${providerRef} is already bound to ${existingRef.addressId}, ` +
+              `but this candidate resolves to ${resolved?.row.id ?? 'a place that does not exist yet'}. ` +
+              'One of the two bindings is wrong, and moving the ref silently would republish one ' +
+              'place\'s history under another.',
+          },
+        ],
+      };
+    }
+
+    // 6. Create the chain, in order: street, then building, then unit. Each
+    // level's parent is the row resolved immediately before it, which is what
+    // makes the hierarchy a stored fact rather than a projection every reader
+    // recomputes.
+    if (!resolved) {
+      const street = await resolveLevel(db, geo, fields, legacyFields, 'STREET', point, null);
+      const building =
+        level === 'STREET'
+          ? null
+          : await resolveLevel(db, geo, fields, legacyFields, 'BUILDING', point, street.row.id);
+      resolved =
+        level === 'UNIT'
+          ? await resolveLevel(db, geo, fields, legacyFields, 'UNIT', point, (building ?? street).row.id)
+          : building ?? street;
+    }
+
+    const hierarchy = await ensureAncestors(db, resolved.row, geo);
+    const now = new Date();
+
+    if (providerRef) {
+      await db
+        .insert(addressExternalRefs)
+        .values({
+          addressId: resolved.row.id,
+          source: candidate.provider,
+          externalId: providerRef,
+          sourceUrl: candidate.sourceUrl,
+          rawLabel: candidate.rawText,
+          confidence: candidate.confidence,
+          firstSeenAt: now,
+          lastSeenAt: now,
+        })
+        // Seeing a ref again is the ordinary case, so this TOUCHES rather than
+        // raising. `first_seen_at` is deliberately absent from the `set`: it
+        // records when Homiio first saw the identifier, and re-stamping it would
+        // erase exactly the fact it exists to hold.
+        .onConflictDoUpdate({
+          target: [addressExternalRefs.source, addressExternalRefs.externalId],
+          set: { lastSeenAt: now, sourceUrl: candidate.sourceUrl, updatedAt: now },
+        });
+    }
+
+    const [materialization] = await db
+      .insert(addressMaterializations)
+      .values({
+        addressId: resolved.row.id,
+        candidateId: candidate.id,
+        provider: candidate.provider,
+        providerRef: candidate.providerRef,
+        rawText: candidate.rawText,
+        rawTextHash: candidate.rawTextHash,
+        normalizationVersion: candidate.normalizationVersion,
+        matchKind: resolved.matchKind,
+        matchDetail: resolved.detail,
+        identityKey: resolved.row.identityKey ?? identityKey,
+        durableAction: actor.action,
+        durableActionRef: actor.actionRef ?? null,
+        actorOxyUserId: actor.actorOxyUserId ?? null,
+        idempotencyKey: actor.idempotencyKey ?? null,
+      })
+      // Partial index, so the predicate is repeated verbatim — the same
+      // requirement as `addresses_identity_key_key` above, and the same `42P10`
+      // at runtime if it is omitted.
+      .onConflictDoNothing({
+        target: addressMaterializations.idempotencyKey,
+        where: sql`${addressMaterializations.idempotencyKey} is not null`,
+      })
+      .returning();
+
+    if (!materialization) {
+      // A concurrent call carrying the same idempotency key won. Its address is
+      // the answer, so this call returns that one rather than its own.
+      const [winner] = await db
+        .select()
+        .from(addressMaterializations)
+        .where(eq(addressMaterializations.idempotencyKey, actor.idempotencyKey ?? ''))
+        .limit(1);
+      if (!winner) {
+        throw new Error(
+          'A materialization was refused by the idempotency index, but the winning row could not be read back',
+        );
+      }
+      return replayMaterialization(db, winner);
+    }
+
+    await db
+      .update(addressCandidates)
+      .set({ materializedAddressId: resolved.row.id, materializedAt: now, updatedAt: now })
+      .where(eq(addressCandidates.id, candidate.id));
+
+    return {
+      status: 'materialized',
+      candidateId: candidate.id,
+      addressId: resolved.row.id,
+      addressLevel: deriveAddressLevel(identityFieldsOfRow(resolved.row)),
+      streetAddressId: hierarchy.streetId,
+      buildingAddressId: hierarchy.buildingId,
+      unitAddressId: hierarchy.unitId,
+      materializationId: materialization.id,
+      match: {
+        matchKind: resolved.matchKind,
+        detail: resolved.detail,
+        identityKey: resolved.row.identityKey ?? identityKey,
+      },
+    };
+  };
+
+  if (tx) return run(tx);
+  return getDb().transaction(async (opened) => run(opened));
+}
+
+/**
+ * Steps 1-3: confirmation, the v2 identity key, then adoption of a pre-v2 row —
+ * in that order, and none of them creates anything.
+ *
+ * The provider ref is deliberately NOT here: deciding whether a ref agrees needs
+ * the probable-match set, so it is reconciled by the caller where both are in
+ * scope.
+ */
+async function resolveExactly(
+  db: DatabaseOrTransaction,
+  options: {
+    confirmedAddressId?: string;
+    identityKey: string;
+    fields: AddressIdentityFields;
+    legacyFields: AddressIdentityFields;
+    level: AddressLevel;
+  },
+): Promise<ResolvedAddress | null> {
+  if (options.confirmedAddressId) {
+    const [confirmed] = await db
+      .select()
+      .from(addresses)
+      .where(eq(addresses.id, options.confirmedAddressId))
+      .limit(1);
+    if (!confirmed) {
+      throw new Error(`Confirmed address ${options.confirmedAddressId} does not exist`);
+    }
+    return {
+      row: await followMergeRedirect(db, confirmed),
+      matchKind: 'confirmed_probable',
+      detail: `confirmed by the caller as ${options.confirmedAddressId}`,
+    };
+  }
+
+  const byIdentity = await findByIdentityKey(db, options.identityKey);
+  if (byIdentity) return byIdentity;
+
+  // BEFORE the probable search on purpose: without this step every address
+  // already in the catalogue would come back as an ambiguity the first time
+  // anybody materialized it.
+  return adoptLegacyRow(
+    db,
+    options.fields,
+    options.legacyFields,
+    options.level,
+    options.identityKey,
+  );
+}
+
+/**
+ * The result a previously-recorded materialization stands for.
+ *
+ * Reads the hierarchy off the stored rows rather than recomputing it, so a
+ * replay cannot disagree with what the first call returned — which is the
+ * property "el mismo candidato confirmado dos veces devuelve la misma entidad"
+ * actually needs.
+ */
+async function replayMaterialization(
+  db: DatabaseOrTransaction,
+  row: typeof addressMaterializations.$inferSelect,
+): Promise<MaterializationResult> {
+  const [address] = await db
+    .select()
+    .from(addresses)
+    .where(eq(addresses.id, row.addressId))
+    .limit(1);
+  if (!address) {
+    throw new Error(
+      `Materialization ${row.id} names address ${row.addressId}, which does not exist`,
+    );
+  }
+
+  const level = deriveAddressLevel(identityFieldsOfRow(address));
+  const parent = address.parentAddressId ? await loadAddress(db, address.parentAddressId) : null;
+  const grandparent = parent?.parentAddressId
+    ? await loadAddress(db, parent.parentAddressId)
+    : null;
+
+  const streetId =
+    level === 'STREET' ? address.id : level === 'BUILDING' ? parent?.id ?? address.id : grandparent?.id ?? address.id;
+
+  return {
+    status: 'materialized',
+    candidateId: row.candidateId,
+    addressId: address.id,
+    addressLevel: level,
+    streetAddressId: streetId,
+    buildingAddressId:
+      level === 'BUILDING' ? address.id : level === 'UNIT' ? parent?.id ?? null : null,
+    unitAddressId: level === 'UNIT' ? address.id : null,
+    materializationId: row.id,
+    match: {
+      matchKind: row.matchKind,
+      detail: row.matchDetail ?? '',
+      identityKey: row.identityKey ?? '',
+    },
+  };
+}
+
+async function loadAddress(db: DatabaseOrTransaction, id: string): Promise<AddressRow | null> {
+  const [row] = await db.select().from(addresses).where(eq(addresses.id, id)).limit(1);
+  return row ?? null;
+}
+
+/** Read a candidate outside any transaction, purely to learn what to geocode. */
+async function loadCandidateForNames(candidateId: string | undefined): Promise<CandidateRow> {
+  if (!candidateId) {
+    throw new Error(
+      'materializeHousingCandidate needs either `candidateId` or `candidate`. A materialization ' +
+      'with no candidate has no provenance, which is the one thing this chokepoint exists to guarantee.',
+    );
+  }
+  const [row] = await getDb()
+    .select()
+    .from(addressCandidates)
+    .where(eq(addressCandidates.id, candidateId))
+    .limit(1);
+  if (!row) throw new Error(`Address candidate ${candidateId} does not exist`);
+  return row;
+}


### PR DESCRIPTION
Closes part of #360 — the **core**. Merge/split correction workflows are a follow-up; what they need from the schema is provided here and named below.

ADR [0001](docs/adr/0001-canonical-housing-graph.md) §2.2 / §3 / §5 is the authority and nothing here re-decides it.

---

## The candidate → canonical boundary I implemented

**`address_candidates`** (new, **Internal** — never in a public DTO) holds what somebody typed or a geocoder returned, before anybody decided it is a place. Per #360 it carries the provider and its ref, the normalized payload, coordinates and precision, the proposed country/region/city/neighborhood and street/number/building/unit, a normalization version, the evidence (origin, source URL, confidence) and an expiry.

Two decisions worth reading:

- **Free text lives here and only here.** ADR invariant 6 forbids copying administrative geo as text; the `proposed_*` columns are exactly that, and they are what makes the invariant keepable — the candidate is the quarantine, and geo is resolved to ids at materialization.
- **Deliberately NOT deduped globally** (ADR §2.2). Two people typing the same wrong thing is two events. So there is *no unique index on this table at all* — the ADR's `(submitted_by, raw_text_hash, created_at)` is a description of what identifies a row, and enforcing it would refuse a retried submit inside one millisecond (`created_at` is truncated to ms) and abort the enclosing durable action's transaction.

**`materializeHousingCandidate(input, actorContext, tx?)`** is the only thing that turns one into canonical rows, and the only writer of `addresses.identity_key` / `parent_address_id`. It does #360's nine steps: validate candidate and precision → resolve the geo chain → exact **and** probable matches → return ambiguity rather than guessing → create street/building/unit **in order** → record aliases, provider refs and provenance → link the originating action → all in **one transaction** → return canonical ids and an explanation of the match.

**`address_materializations`** is the provenance record — one row per *act*, not columns on `addresses`, because ADR §2.1.7 says a duplicate is recorded and never discarded and one place is materialized many times (three portals, a review years later). It copies the provider, ref, raw text, hash and normalization version **by value**, which is why `candidate_id` carries no foreign key: the candidate expires under its own sweep, and the two independent expiry regimes are the same refusal `moderation_outbox.event_id` already records.

**`address_external_refs`** (ADR §3.4) makes `(source, external_id)` unique. That is what turns "provider ref already bound to another entity" into a refusal instead of a silent rewrite. `entityType` from the issue's sketch is deliberately absent: street/building/unit are three *levels* of `addresses`, so the level is the `GENERATED ALWAYS` column and a copy here could disagree with it.

### Three additive columns on `addresses` (ADR 0001 phase 1)

All nullable, no backfill, written only by the new chokepoint:

| column | why it could not be deferred |
|---|---|
| `identity_key` | The v1 `normalized_key` hashes neither `floor` nor `entrance` nor `subunit`, while `address_level` derives **from** them — so a building and its third-floor flat collapse onto one row today, and which LEVEL survives depends on ingest order (ADR §1.3, measured). "Create street/building/unit in order" is not implementable on a key that cannot tell them apart. |
| `parent_address_id` | The hierarchy, stored instead of re-projected per review. |
| `merged_into_address_id` | The reversible merge redirect — see below. |

`normalized_key` is **untouched** and is still what `findOrCreateCanonicalAddress` dedupes on.

## What the ambiguity result looks like, and when it is returned

```ts
{ status: 'ambiguous', candidateId, candidates: [{ addressId, addressLevel, street, number,
  buildingName, entrance, streetSimilarity, distanceMeters, reason }] }
```

Nothing is written. The caller settles it by calling again with `confirmedAddressId`, which is the only path that ever accepts a probable match.

It is returned when no exact strategy answered **and** a row exists that is undecidably close. Two rules define "undecidably":

1. Same city, same level, not merged away, street similarity ≥ **0.7**, within **400 m**.
2. **Every discriminating field is COMPATIBLE** — for `number`, `building_name`, `block`, `entrance`, `floor`, `unit`, `subunit`, the two agree or one side is absent. Two rows that both name a number and name *different* numbers are different places, not an ambiguity.

Rule 2 is what makes the feature usable: without it every address on a street would be ambiguous. The zone left over is the genuinely undecidable one — `42` versus `42, entrance A`; `Carrer de Provença 42` versus `Carrer de Provenza 42`.

**The 0.7 threshold was measured, not chosen.** On a real server, against real street pairs:

| pair | similarity | should be |
|---|---|---|
| `carrer de provenca 42` / `carrer de provenca` | 0.864 | same |
| `gran via de les corts catalanes` / `…catalanas` | 0.848 | same (typo) |
| `carrer de provenca` / `carrer de provenza` | 0.727 | same (typo) |
| **`carrer de mallorca` / `carrer de menorca`** | **0.609** | **DIFFERENT** |
| `carrer de arago` / `carrer de aribau` | 0.571 | different |
| `avinguda diagonal` / `avinguda meridiana` | 0.370 | different |

The gap is narrow (0.609 → 0.727) and the constant says so rather than hiding it. It errs toward asking: a false ambiguity costs one prompt, a false merge publishes one household's reviews under another's address.

There is also a `conflict` status, decided **before anything is created**: a provider ref already bound to a place this candidate is not. A ref must survive a portal *relabelling* a place (that is a probable match, and the ref wins) and must never silently *relocate* one.

## What I left room for on merge/split

Merge/split themselves are **not built**. What is here so they remain possible:

- **`addresses.merged_into_address_id`** — a self-FK, `ON DELETE RESTRICT`, the reversible redirect ADR §8.1 specifies. A merge sets a pointer and never deletes, which is what makes it reversible.
- **The matcher already HONOURS it.** `followMergeRedirect` runs on every match, bounded against cycles. Nothing performs a merge today, so this is a no-op in every current test — which is exactly why it is here now: retrofitting it would mean auditing each match path separately, and the one that was missed would silently hand callers a retired row. A test writes a redirect by hand and asserts the survivor comes back.
- **`address_materializations` is the audit trail** a merge needs — it records which candidate, which match kind, which identity key, which durable action, which actor, at what time, and it outlives the candidate.
- **Idempotency** is a partial unique index on `idempotency_key`, so a merge/split workflow can be re-driven safely.
- `address_external_refs` CASCADEs from `addresses` while the two provenance references RESTRICT — so a merge that moved refs cannot orphan the record of the move.

## Mutation evidence

Baseline on the untouched branch point: **152 suites / 2115 tests, exit 0**. After: **155 / 2144, exit 0**. `bun run lint` is **0 errors** across all four packages (the `lint` job was armed by #425 while this branch was open, so it now actually runs).

Every load-bearing assertion was broken on purpose; each mutation was confirmed *landed* (grep) before the run, and restored from a namespaced pristine copy with my own markers re-asserted afterwards.

| # | mutation | result |
|---|---|---|
| 1 | Drop the arbiter predicate from `onConflictDoNothing` on the partial `addresses_identity_key_key` | **18 red**, naming `there is no unique or exclusion constraint matching the ON CONFLICT specification` (`42P10`) |
| 2 | Remove the seven `compatible(...)` predicates from the probable search | **6 red**, including the named control *"does NOT call two different numbers on one street ambiguous"* |
| 3 | Build the creation chain even when a match was confirmed | **1 red** — exactly *"accepts a confirmation and creates no rival row beside it"* |
| 4 | Point the read-path census at `countries` instead of the three real tables | **2 red** — the positive control catches a census measuring the wrong thing |
| 5 | Drop the raw (accented) form from `legacyKeyCandidates` | **1 red** — *"adopts a pre-v2 row rather than creating a rival beside it"* |

Two of these were **bugs found by the tests, not by review**, and both are fixed here:

- A confirmed ambiguous match still built the chain from the *candidate's* fields, so confirming `42, entrance A` against `42` created the rival row the confirmation existed to avoid.
- The v1 lookup used the v2-normalized street, which **strips diacritics** while v1 does not — so `Carrer de Provença` would never adopt its own pre-v2 row and would create a duplicate beside **every accented street in the corpus**. Both key forms are looked up now.

### Fixtures that sit on the right side of the line

- Ambiguity has a genuine near-duplicate **and** a control that must not be ambiguous — a fixture set with no near-duplicate cannot tell "returned ambiguity correctly" from "found nothing".
- Two units in one building, because one unit's parent is the same row whether the hierarchy works or collapses.
- An explicit-NULL fixture for the partial idempotency index — a suite whose calls all pass a key cannot tell it from a total index.
- A row carrying `''`, inserted by raw SQL because the writer can never produce one, for the TypeScript-vs-`GENERATED ALWAYS` level agreement.
- The CHECK violation is read through `constraintNameOf`, never `error.code`: drizzle wraps the driver error and the SQLSTATE lives on `cause`.

## A pre-existing defect I had to fix first — and the `0013_snapshot.json` diff, explained

**`drizzle-kit generate` could not run on `main` at all** (first commit):

```
Error: [drizzle/meta/0012_snapshot.json, drizzle/meta/0013_snapshot.json] are pointing to
a parent snapshot: drizzle/meta/0012_snapshot.json/snapshot.json which is a collision.
```

`0013_snapshot.json` carried `prevId = c209c091…`, which is **0011's** id — the same parent 0012 names. #356 (watches → 0012) and #358 (evictions → 0013) were each generated off 0011 and merged back to back, and nothing recomputes a snapshot.

**The diff on that file is semantic, not cosmetic, and here is exactly what it is.** `0013_snapshot.json` described **69** tables and was missing all three of 0012's (`housing_alerts`, `housing_domain_events`, `housing_watch_rules`) plus 0012's nine `saved_searches` columns — because it was taken on a tree that never had 0012. The repaired file is **72** tables. The set difference is exactly those three, and **the difference in the other direction is empty**, so this is a repair and not a replacement. Repairing the pointer alone would have left the content wrong, and the next generated migration would have re-emitted `CREATE TABLE housing_alerts …` — now that the deploy applies migrations, a release that fails at apply time.

**It cannot change what any database receives.** `_journal.json` is byte-identical to `HEAD` at that commit (`git diff` reports 0 lines) and no `.sql` file is touched; snapshots are read by drizzle-kit at GENERATE time and by nothing at apply time. `0013_snapshot.json` also keeps its own `id`, so nothing downstream sees an identity change.

### Verified against a database that ALREADY HAS 0013 applied, not only a fresh one

A fresh-database run cannot distinguish a correct chain from a broken one, which is the whole problem. So:

1. A probe database was brought to **production's exact state** — 0014's `.sql` and its journal entry hidden, `--phase=all` applied → **14 migrations**, ledger at 14.
2. Rows were seeded into `countries` / `regions` / `cities` / `addresses`, because production is not empty and the migration must apply over DATA.
3. 0014 restored from a namespaced pristine copy (git status clean, so byte-for-byte) and applied: **`Applying 1 migration(s): 0014_housing_candidate_materialization`, exit 0.** Exactly one — no re-emitted `CREATE TABLE`.
4. Pre-existing rows survived with the three new columns NULL; the three new tables exist and are empty.
5. The resulting catalogue was compared against a **fresh** 15-migration build: **identical across 1,722 rows** of columns, constraints (with their `ON DELETE` actions) and index definitions.

The comparison carries a negative control — adding a column to one side makes the diff report it, and removing it restores identity. That control earned its keep: the first attempt had an ambiguous `oid` in the catalogue query, both dumps came back **empty**, and `diff` cheerfully reported "IDENTICAL". Only the line-count floor exposed it.

### A gate, so this is caught at merge time (fourth commit)

`packages/backend/__tests__/unit/migrationSnapshotChain.test.ts` reads the files and needs no database. Two assertions, catching opposite halves:

1. **Every snapshot's `prevId` names its immediate predecessor, and no two share a parent** — the CAUSE, caught the moment the second branch merges. This would have fired the day #358 landed.
2. **The head snapshot describes exactly the tables the schema barrel declares** — the CONSEQUENCE, caught independently, because a pointer-only repair leaves the head still missing the other branch's objects and that is the half that reaches production.

Mutation-tested three ways, each killed by exactly its own assertion: reintroducing `main`'s real `prevId`; deleting `housing_alerts` from the head snapshot with the chain left intact; dropping a migration from `_journal.json`.

A fourth assertion — "every migration declares a deploy phase" — was written and then **removed**. Stripping the marker from 0014 did kill the run, but through `@oxyhq/db`'s migrator in `globalSetup` rather than through the assertion, which could therefore never fire. The migrator's check is strictly stronger (it also runs at apply time, in production), and an assertion that cannot fail is worse than none because a reader takes it for a gate. The finding is recorded in the test's own docblock.

The durable rule is written down in **`packages/backend/db/MIGRATION-CONTRACT.md`** — what the failure is, why the refused `generate` is the harmless half, why nothing that runs today could catch it, how to repair one, and the two measurements that make a repair verified rather than plausible.

## Verification

- Migration `0014` applied **from zero to a fresh PostGIS 17 database**: 15/15, exit 0. Both self-FKs (`parent_address_id`, `merged_into_address_id`) confirmed present in `pg_constraint` with `confdeltype = r`, and both partial unique indexes confirmed with their predicates in `pg_indexes` — the self-FK-vanishing trap and the `42P10` trap checked against the live catalogue, not the declaration.
- The migration declares `oxy:deploy-phase=pre` and carries no `$N` placeholder (scan run with a negative control proving the pattern matches a real placeholder).
- `tsc --noEmit` clean; `eslint` clean.

## Honestly, what I did not do

- **No merge and no split.** #360's second half is a follow-up; the room for it is listed above.
- **No consumer migrated.** `findOrCreateCanonicalAddress` and all five of its call sites (listings, reviews, ingestion, `seedProperties`, `POST /api/addresses`) are untouched and behave exactly as before, v1 key and `Unknown` region fallback included. Landing both at once would change what every listing in the catalogue resolves to in the same commit that introduces the mechanism.
- **No HTTP endpoint.** #360 asks for a materialization endpoint and a non-writing preview/match endpoint; both belong with #359, which owns preview. The service takes an optional `tx` so a controller can make it atomic with its own write.
- **No conflict TABLE.** A conflict is returned and nothing is written; the candidate persists as the durable record of the attempt. A stored conflict entity with state and evidence belongs with the correction workflow.
- **No `identity_key` backfill.** Existing rows keep it NULL, which is the honest state — populating them is ADR phase 2 and gated on a census that has not run. New writes stop collapsing; old rows are adopted opportunistically when a materialization meets one.
- **`postal_code` stays `NOT NULL`,** so an unpostcoded place still stores `''` in that column. ADR §3.2 wants NULL; that is a separate migration and a separate decision about 11,734 existing rows. It is safe here because the *identity key* receives NULL for an absent postcode, so `''` never enters an identity.
- **One unrelated test fixed** (third commit; the fourth adds the snapshot-chain gate and the `MIGRATION-CONTRACT.md` rule): `propertyImages.test.ts` asserted over an unscoped `where is_primary`, so it saw every row in the jest worker's database. Adding two test files changed jest's file distribution and made it fire deterministically, twice. It passes in isolation and nothing in this change touches `property_images`; the assertion is now scoped to its own two listings, which costs it nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)