### PR TITLE
ci(lint): say why lint is absent from the deploy's needs, and correct why it is not

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,6 +461,23 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   deploy-backend:
     name: Deploy backend to AWS
+    # `lint` IS DELIBERATELY ABSENT FROM `needs`. Do not add it for symmetry.
+    #
+    # The five listed here are correctness gates — a red one means the code is
+    # wrong. `lint` is a quality gate, and a style or typing finding should not
+    # hold a production rollout.
+    #
+    # This is NOT a statement about lint being unable to see a direct push. It
+    # can: `lint` carries no `if:`, and this workflow triggers on `push:
+    # branches: [main]` as well as `pull_request`, so lint runs on every push to
+    # main whether or not it arrived through a pull request. Verified on run
+    # 31447194657 — `event=push`, `branch=main`, `lint: success` — which is the
+    # run that first executed it on the trunk after #425 armed it.
+    #
+    # So the coupling is only the one stated above: on main, lint runs beside
+    # this job rather than before it, and a lint failure is loud without being
+    # blocking. If that is ever the wrong trade, the change is to add `lint` to
+    # this list on purpose, not to assume it is missing by oversight.
     needs: [backend, frontend, frontend-typecheck, lockfile, frontend-bundle]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:


### PR DESCRIPTION
Follow-up to #425, which armed `lint` and deliberately left `deploy-backend`'s `needs` alone. Nothing recorded that decision, so the next reader sees a job missing from a list and adds it for symmetry. This writes the reason down.

**The reason:** the five jobs in `needs` are correctness gates — a red one means the code is wrong. `lint` is a quality gate, and a style or typing finding should not hold a production rollout.

**The reason it is NOT**, which is the part worth having in writing: *"lint cannot see a direct push."* This note was nearly written on that premise and the premise is false.

`lint` carries no `if:`, and this workflow triggers on `push: branches: [main]` as well as `pull_request`. So lint runs on every push to main whether or not it arrived through a pull request. Measured rather than reasoned — run [31447194657](https://github.com/OxyHQ/Homiio/actions/runs/31447194657) is `event=push`, `branch=main`, `lint: success`, and it is the run that first executed lint on the trunk after #425 armed it.

The real coupling is narrower than "PRs are the path to main": on main, lint runs *beside* `deploy-backend` rather than before it, so a lint failure is loud without being blocking.

Recording the wrong reason would have been worse than recording none. It reads as a constraint the workflow does not have, and the obvious repairs for it — requiring pull requests, or adding `lint` to `needs` — would be undertaken to fix a problem that does not exist. `docs/`, comments and log strings are exactly where a wrong statement survives forever, because nothing recomputes them.

## Verification

Comment-only, both directions checked:

- `yaml.safe_load` of this file **equals** `yaml.safe_load` of `origin/main`'s — parsed semantics identical.
- Of the 17 added lines, **0** are non-comment (`git diff -U0 | grep '^+' | grep -vcE '^\+\s*#'`).
- `lint` still has keys `['runs-on', 'steps']` (no `if:`), and `deploy-backend.needs` is unchanged at `[backend, frontend, frontend-typecheck, lockfile, frontend-bundle]` with `lint in needs: False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)