### PR TITLE
feat(addresses): merge two canonical places, reversibly (#360)

### DIFF
--- a/packages/backend/__tests__/db/addressMerge.test.ts
+++ b/packages/backend/__tests__/db/addressMerge.test.ts
@@ -1,0 +1,593 @@
+/**
+ * Merging two canonical addresses, against a REAL Postgres server.
+ *
+ * A real server is not optional here, and the reasons are the ones this
+ * repository has already paid for once each: the review collision is a UNIQUE
+ * violation whose SQLSTATE lives on drizzle's `cause` rather than on
+ * `error.code`; a failed statement inside a transaction aborts the whole thing
+ * (`25P02`), so the savepoint that survives the collision is only observable at
+ * COMMIT; and the "you may not delete the loser" property is enforced by ten
+ * `ON DELETE RESTRICT` constraints that no mock has.
+ *
+ * ## The fixtures are built so the two READINGS DISAGREE
+ *
+ * A merge test where both rows carry the same relations cannot tell "moved the
+ * relations" from "did nothing" — both produce a survivor holding everything.
+ * So every case here gives the loser and the survivor DIFFERENT rows, and the
+ * assertions name row ids rather than counts wherever a count would be
+ * satisfied by the wrong set.
+ *
+ * The review-collision case needs the sharpest version of that: one author who
+ * reviewed BOTH addresses (the row that cannot move) AND a second author who
+ * reviewed only the loser (the row that must). A fixture with only the first
+ * cannot tell "left the colliding row in place" from "moved nothing at all".
+ */
+
+import { eq, sql } from 'drizzle-orm';
+import { uuidv7 } from '@oxyhq/db';
+
+import { closePostgres, connectPostgres, type Database } from '../../db/postgres';
+import {
+  addressExternalRefs,
+  addressMergeRelationMoves,
+  addressMerges,
+  addresses,
+  properties,
+  reviews,
+} from '../../db/schema';
+import {
+  addressForeignKeys,
+  addressRelations,
+  classifyAddressRelation,
+  movableAddressRelations,
+  POLYMORPHIC_ADDRESS_RELATIONS,
+} from '../../db/addresses/addressRelations';
+import {
+  AddressMergeRefusedError,
+  AddressMergeRevertRefusedError,
+  applyAddressMerge,
+  planAddressMerge,
+  revertAddressMerge,
+} from '../../services/addressMerge';
+
+let db: Database;
+
+const SUITE = uuidv7().slice(-12);
+let seq = 0;
+const nextId = (): string => {
+  seq += 1;
+  return `${SUITE}-${seq}`;
+};
+
+beforeAll(async () => {
+  db = await connectPostgres();
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+/**
+ * A geo chain shared by every case in this file.
+ *
+ * Created once with raw SQL rather than through the geo resolver: this file is
+ * about relation moves, and the resolver is exercised in its own suite. Sharing
+ * one chain is safe because every assertion here names row ids.
+ */
+let geo: { countryId: string; regionId: string; cityId: string };
+
+beforeAll(async () => {
+  const countryId = `c-${SUITE}`;
+  const regionId = `r-${SUITE}`;
+  const cityId = `ci-${SUITE}`;
+  // Only the columns the schema REQUIRES; everything else is defaulted or
+  // generated, and naming a column that does not exist fails every case in the
+  // file at once rather than the one that needed it.
+  await db.execute(
+    sql`insert into countries (id, name, code) values (${countryId}, ${'Testland ' + SUITE}, ${'T' + SUITE.slice(-1)})`,
+  );
+  await db.execute(
+    sql`insert into regions (id, country_id, name) values (${regionId}, ${countryId}, ${'Region ' + SUITE})`,
+  );
+  await db.execute(
+    sql`insert into cities (id, country_id, region_id, name) values (${cityId}, ${countryId}, ${regionId}, ${'City ' + SUITE})`,
+  );
+  geo = { countryId, regionId, cityId };
+});
+
+/** A canonical address, inserted directly so its id is the test's to name. */
+async function makeAddress(street: string, number?: string): Promise<string> {
+  const id = nextId();
+  await db.insert(addresses).values({
+    id,
+    countryId: geo.countryId,
+    regionId: geo.regionId,
+    cityId: geo.cityId,
+    countryCode: 'ES',
+    street,
+    postalCode: '08013',
+    number: number ?? null,
+    longitude: 2.17,
+    latitude: 41.39,
+  });
+  return id;
+}
+
+async function makeProperty(addressId: string): Promise<string> {
+  const id = nextId();
+  await db.insert(properties).values({ id, addressId });
+  return id;
+}
+
+/** A review by `author` of `addressId`, at every level the schema requires. */
+async function makeReview(addressId: string, author: string): Promise<string> {
+  const id = nextId();
+  await db.insert(reviews).values({
+    id,
+    addressId,
+    addressLevel: 'BUILDING',
+    streetLevelId: addressId,
+    buildingLevelId: addressId,
+    price: 950,
+    livedFrom: new Date('2024-01-01T00:00:00.000Z'),
+    livedTo: new Date('2025-01-01T00:00:00.000Z'),
+    livedForMonths: 12,
+    recommendation: true,
+    opinion: 'Fixture opinion, long enough to be a sentence somebody wrote.',
+    rating: 4,
+    oxyUserId: author,
+  });
+  return id;
+}
+
+async function makeExternalRef(addressId: string): Promise<string> {
+  const id = nextId();
+  await db.insert(addressExternalRefs).values({
+    id,
+    addressId,
+    source: 'osm',
+    externalId: `ref-${id}`,
+    firstSeenAt: new Date(),
+    lastSeenAt: new Date(),
+  });
+  return id;
+}
+
+async function addressOf(propertyId: string): Promise<string> {
+  const [row] = await db
+    .select({ addressId: properties.addressId })
+    .from(properties)
+    .where(eq(properties.id, propertyId))
+    .limit(1);
+  return row.addressId;
+}
+
+async function reviewAddress(reviewId: string): Promise<{
+  addressId: string;
+  streetLevelId: string;
+  buildingLevelId: string;
+}> {
+  const [row] = await db
+    .select({
+      addressId: reviews.addressId,
+      streetLevelId: reviews.streetLevelId,
+      buildingLevelId: reviews.buildingLevelId,
+    })
+    .from(reviews)
+    .where(eq(reviews.id, reviewId))
+    .limit(1);
+  return row;
+}
+
+async function redirectOf(addressId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ mergedInto: addresses.mergedIntoAddressId })
+    .from(addresses)
+    .where(eq(addresses.id, addressId))
+    .limit(1);
+  return row.mergedInto;
+}
+
+const merge = (survivor: string, loser: string) =>
+  applyAddressMerge({
+    survivorAddressId: survivor,
+    mergedAddressId: loser,
+    reasonCode: 'duplicate_identity_key',
+    reason: 'Two ingests of one building.',
+    actorOxyUserId: `oxy-${SUITE}`,
+  });
+
+describe('the relation registry cannot go stale', () => {
+  it('classifies every foreign key that targets addresses', () => {
+    // THE GATE. A column added tomorrow appears in `addressForeignKeys()`
+    // automatically and fails here until somebody decides what a merge does with
+    // it. There is no default, because a default is a decision made by absence.
+    const unclassified = addressForeignKeys().filter(
+      ({ table, column }) => classifyAddressRelation(table, column) === null,
+    );
+    expect(unclassified).toEqual([]);
+  });
+
+  it('derives enough relations that a broken derivation cannot pass as clean', () => {
+    // The vacuity floor. An empty derivation would satisfy the case above.
+    // Measured at 13 foreign keys on this tree (`pg_constraint` agrees — see the
+    // catalogue case below); the floor is deliberately below that so an ordinary
+    // deletion does not trip it.
+    expect(addressForeignKeys().length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('finds properties.address_id, which is known to exist', () => {
+    // The POSITIVE CONTROL for the derivation. Without it, a derivation that
+    // returned nothing would pass both cases above.
+    expect(addressForeignKeys()).toContainEqual({ table: 'properties', column: 'address_id' });
+  });
+
+  it('finds all FOUR review columns, not just address_id', () => {
+    // The census that stopped at "reviews has an address column" would have
+    // shipped a merge leaving a review filed under the retired row at two of its
+    // three levels.
+    const reviewColumns = addressForeignKeys()
+      .filter(({ table }) => table === 'reviews')
+      .map(({ column }) => column)
+      .sort();
+    expect(reviewColumns).toEqual([
+      'address_id',
+      'building_level_id',
+      'street_level_id',
+      'unit_level_id',
+    ]);
+  });
+
+  it('keeps the audit trail out of the movable set', () => {
+    // `address_merges` points at both rows by construction. Moving those columns
+    // would rewrite the record of the merge while performing it.
+    const movable = movableAddressRelations().map((r) => `${r.table}.${r.column}`);
+    expect(movable).not.toContain('address_merges.merged_address_id');
+    expect(movable).not.toContain('address_merges.survivor_address_id');
+    expect(movable).not.toContain('address_materializations.address_id');
+    expect(movable).toContain('properties.address_id');
+  });
+
+  it('still has a subject_type that admits an address, for each polymorphic entry', async () => {
+    // The declared half is the dangerous half: nothing derives these, so a
+    // discriminator that stopped accepting `'address'` would make the entries
+    // lies and no other check would notice. Read from the LIVE catalogue.
+    for (const relation of POLYMORPHIC_ADDRESS_RELATIONS) {
+      const rows = await db.execute<{ def: string }>(sql`
+        select pg_get_constraintdef(c.oid) as def
+        from pg_constraint c
+        where c.conrelid = ${relation.table}::regclass
+          and c.contype = 'c'
+          and pg_get_constraintdef(c.oid) like ${'%' + relation.discriminator!.column + '%'}
+      `);
+      const definitions = [...rows].map((row) => row.def);
+      expect(definitions.length).toBeGreaterThan(0);
+      expect(definitions.some((def) => def.includes(`'${relation.discriminator!.value}'`))).toBe(
+        true,
+      );
+    }
+  });
+
+  it('agrees with the live catalogue about which foreign keys exist', async () => {
+    // Two independent instruments — drizzle's schema objects and pg_constraint —
+    // must return the same set. A disagreement means the schema and the database
+    // have drifted, which is exactly what a migration generated off the wrong
+    // parent produces.
+    const rows = await db.execute<{ table_name: string; column_name: string }>(sql`
+      select c.conrelid::regclass::text as table_name, a.attname as column_name
+      from pg_constraint c
+      join unnest(c.conkey) as k(attnum) on true
+      join pg_attribute a on a.attrelid = c.conrelid and a.attnum = k.attnum
+      where c.contype = 'f' and c.confrelid = 'addresses'::regclass
+    `);
+    const fromCatalogue = [...rows]
+      .map((row) => `${row.table_name}.${row.column_name}`)
+      .sort();
+    const fromSchema = addressForeignKeys().map((fk) => `${fk.table}.${fk.column}`).sort();
+    expect(fromSchema).toEqual(fromCatalogue);
+  });
+});
+
+describe('a merge moves the relations and records what it did', () => {
+  it('repoints listings, reviews at every level, and provider refs', async () => {
+    const survivor = await makeAddress('Carrer de Provença', '42');
+    const loser = await makeAddress('Carrer de Provenca', '42');
+
+    // DIFFERENT rows on each side, so "moved" and "did nothing" disagree.
+    const survivorProperty = await makeProperty(survivor);
+    const loserProperty = await makeProperty(loser);
+    const loserReview = await makeReview(loser, `author-a-${SUITE}`);
+    const loserRef = await makeExternalRef(loser);
+
+    const result = await merge(survivor, loser);
+
+    expect(result.survivorAddressId).toBe(survivor);
+    expect(result.mergedAddressId).toBe(loser);
+    expect(result.leftInPlaceCount).toBe(0);
+
+    // Named by ID, not counted: a count of 2 would also be produced by moving
+    // the survivor's own property onto itself.
+    expect(await addressOf(loserProperty)).toBe(survivor);
+    expect(await addressOf(survivorProperty)).toBe(survivor);
+
+    // All THREE review columns, which is the half a one-column census misses.
+    const moved = await reviewAddress(loserReview);
+    expect(moved.addressId).toBe(survivor);
+    expect(moved.streetLevelId).toBe(survivor);
+    expect(moved.buildingLevelId).toBe(survivor);
+
+    const [ref] = await db
+      .select({ addressId: addressExternalRefs.addressId })
+      .from(addressExternalRefs)
+      .where(eq(addressExternalRefs.id, loserRef));
+    expect(ref.addressId).toBe(survivor);
+
+    // The redirect, which is what makes the loser still resolve.
+    expect(await redirectOf(loser)).toBe(survivor);
+  });
+
+  it('re-parents the children of the losing row', async () => {
+    const survivor = await makeAddress('Carrer del Consell', '10');
+    const loser = await makeAddress('Carrer del Consel', '10');
+    const child = await makeAddress('Carrer del Consell', '10');
+    await db
+      .update(addresses)
+      .set({ parentAddressId: loser })
+      .where(eq(addresses.id, child));
+
+    await merge(survivor, loser);
+
+    const [row] = await db
+      .select({ parentAddressId: addresses.parentAddressId })
+      .from(addresses)
+      .where(eq(addresses.id, child));
+    // Without this move the unit's building would be a retired row, and
+    // `parent_address_id` is what every other domain reads instead of
+    // recomputing the chain.
+    expect(row.parentAddressId).toBe(survivor);
+  });
+
+  it('leaves a colliding review in place and names the constraint', async () => {
+    const survivor = await makeAddress('Carrer de Girona', '7');
+    const loser = await makeAddress('Carrer de Gerona', '7');
+
+    const author = `author-both-${SUITE}`;
+    // The author who reviewed BOTH: their loser-side review cannot move,
+    // because `reviews_author_address_key` is unique on (oxy_user_id,
+    // address_id).
+    await makeReview(survivor, author);
+    const collidingReview = await makeReview(loser, author);
+    // The author who reviewed ONLY the loser. Without this row the case could
+    // not tell "left the colliding one in place" from "moved nothing at all".
+    const movableReview = await makeReview(loser, `author-only-${SUITE}`);
+
+    const result = await merge(survivor, loser);
+
+    expect(result.leftInPlaceCount).toBeGreaterThan(0);
+    expect(await reviewAddress(collidingReview)).toMatchObject({ addressId: loser });
+    expect(await reviewAddress(movableReview)).toMatchObject({ addressId: survivor });
+
+    const blocked = await db
+      .select()
+      .from(addressMergeRelationMoves)
+      .where(eq(addressMergeRelationMoves.mergeId, result.mergeId));
+    const leftInPlace = blocked.filter((move) => move.outcome === 'left_in_place');
+    expect(leftInPlace.length).toBeGreaterThan(0);
+    // The constraint name is the one fact an operator needs and the one that is
+    // gone by the time anybody reads the log.
+    expect(leftInPlace[0].blockedByConstraint).toBe('reviews_author_address_key');
+    // NOTHING was deleted. ADR 0001 §2.1.7, and the assertion that separates
+    // this implementation from the tempting one.
+    const [{ count }] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(reviews)
+      .where(eq(reviews.id, collidingReview));
+    expect(Number(count)).toBe(1);
+  });
+
+  it('records a move log whose size matches the count it stored', async () => {
+    const survivor = await makeAddress('Carrer de Roselló', '3');
+    const loser = await makeAddress('Carrer de Rossello', '3');
+    await makeProperty(loser);
+    await makeProperty(loser);
+
+    const result = await merge(survivor, loser);
+    const [row] = await db
+      .select()
+      .from(addressMerges)
+      .where(eq(addressMerges.id, result.mergeId));
+
+    expect(row.movedRelationCount).toBe(result.movedCount);
+    expect(row.status).toBe('applied');
+    expect(row.reason).toBe('Two ingests of one building.');
+    expect(row.revertedAt).toBeNull();
+  });
+});
+
+describe('the dry run writes nothing', () => {
+  it('reports the moves it would make and leaves the rows alone', async () => {
+    const survivor = await makeAddress('Carrer de Bailèn', '5');
+    const loser = await makeAddress('Carrer de Bailen', '5');
+    const property = await makeProperty(loser);
+
+    const plan = await planAddressMerge({
+      survivorAddressId: survivor,
+      mergedAddressId: loser,
+    });
+
+    expect(plan.moves).toContainEqual(
+      expect.objectContaining({ table: 'properties', column: 'address_id', rowId: property }),
+    );
+    expect(plan.countsByRelation['properties.address_id']).toBe(1);
+
+    // Nothing moved, and no redirect was written.
+    expect(await addressOf(property)).toBe(loser);
+    expect(await redirectOf(loser)).toBeNull();
+  });
+});
+
+describe('a merge is reversible, which is the requirement', () => {
+  it('puts every moved row back and clears the redirect', async () => {
+    const survivor = await makeAddress('Carrer de Muntaner', '11');
+    const loser = await makeAddress('Carrer de Montaner', '11');
+    const survivorProperty = await makeProperty(survivor);
+    const loserProperty = await makeProperty(loser);
+    const loserReview = await makeReview(loser, `author-rev-${SUITE}`);
+
+    const applied = await merge(survivor, loser);
+    expect(await addressOf(loserProperty)).toBe(survivor);
+
+    const { restoredCount } = await revertAddressMerge(applied.mergeId, `oxy-${SUITE}`, undefined);
+
+    expect(restoredCount).toBe(applied.movedCount);
+    expect(await addressOf(loserProperty)).toBe(loser);
+    // The survivor's OWN rows must not move. A revert that put everything on the
+    // survivor back onto the loser would pass a count assertion and destroy the
+    // survivor — which is why the log is replayed rather than re-derived.
+    expect(await addressOf(survivorProperty)).toBe(survivor);
+    expect(await reviewAddress(loserReview)).toMatchObject({
+      addressId: loser,
+      streetLevelId: loser,
+      buildingLevelId: loser,
+    });
+    expect(await redirectOf(loser)).toBeNull();
+
+    const [row] = await db
+      .select()
+      .from(addressMerges)
+      .where(eq(addressMerges.id, applied.mergeId));
+    expect(row.status).toBe('reverted');
+    expect(row.revertedAt).not.toBeNull();
+  });
+
+  it('refuses to revert twice', async () => {
+    const survivor = await makeAddress('Carrer de Balmes', '21');
+    const loser = await makeAddress('Carrer de Valmes', '21');
+    const applied = await merge(survivor, loser);
+    await revertAddressMerge(applied.mergeId, null, undefined);
+
+    await expect(revertAddressMerge(applied.mergeId, null, undefined)).rejects.toBeInstanceOf(
+      AddressMergeRevertRefusedError,
+    );
+  });
+
+  it('refuses when the move log no longer matches the count it recorded', async () => {
+    // The anti-vacuity floor of the whole operation: a merge whose log was
+    // partially lost must not be half-reverted silently. `0` is a legitimate
+    // count, so the assertion is EQUALITY and not `> 0`.
+    const survivor = await makeAddress('Carrer d’Aribau', '33');
+    const loser = await makeAddress('Carrer d’Aribao', '33');
+    await makeProperty(loser);
+    const applied = await merge(survivor, loser);
+    expect(applied.movedCount).toBeGreaterThan(0);
+
+    await db
+      .delete(addressMergeRelationMoves)
+      .where(eq(addressMergeRelationMoves.mergeId, applied.mergeId));
+
+    await expect(revertAddressMerge(applied.mergeId, null, undefined)).rejects.toMatchObject({
+      refusal: { kind: 'move_log_incomplete' },
+    });
+  });
+});
+
+describe('the refusals', () => {
+  it('refuses to merge a row into itself', async () => {
+    const address = await makeAddress('Carrer de Casanova', '1');
+    await expect(merge(address, address)).rejects.toMatchObject({
+      refusal: { kind: 'same_address' },
+    });
+  });
+
+  it('refuses a row that already lost a merge still in force', async () => {
+    const survivor = await makeAddress('Carrer de Villarroel', '2');
+    const loser = await makeAddress('Carrer de Vilarroel', '2');
+    const third = await makeAddress('Carrer de Villaroel', '2');
+    await merge(survivor, loser);
+
+    await expect(merge(third, loser)).rejects.toMatchObject({
+      refusal: { kind: 'already_merged' },
+    });
+  });
+
+  it('refuses a merge that would close a redirect cycle', async () => {
+    const first = await makeAddress('Carrer de Calàbria', '4');
+    const second = await makeAddress('Carrer de Calabria', '4');
+    await merge(first, second);
+    // `second` now redirects to `first`. Merging `first` INTO `second` would
+    // make the pair unreachable from either end — a two-row cycle that a
+    // self-referencing foreign key and the table's own CHECK cannot see.
+    await expect(merge(second, first)).rejects.toBeInstanceOf(AddressMergeRefusedError);
+  });
+
+  it('refuses to merge into an address that does not exist', async () => {
+    const loser = await makeAddress('Carrer de Rocafort', '6');
+    await expect(merge(`missing-${SUITE}`, loser)).rejects.toMatchObject({
+      refusal: { kind: 'address_not_found' },
+    });
+  });
+});
+
+describe('the database refuses to delete a merged address', () => {
+  it('will not delete the loser while a merge names it', async () => {
+    // The issue's mandatory mutation: "una mutación que borre source antes de
+    // mover FKs debe fallar". It is enforced by the database rather than by this
+    // service, which is the strongest place for it — ten of the twelve columns
+    // that can point at an address are ON DELETE RESTRICT, and the merge audit
+    // adds two more.
+    const survivor = await makeAddress('Carrer de Viladomat', '8');
+    const loser = await makeAddress('Carrer de Viladomad', '8');
+    await makeProperty(loser);
+    await merge(survivor, loser);
+
+    await expect(
+      db.execute(sql`delete from addresses where id = ${loser}`),
+    ).rejects.toBeDefined();
+
+    // Still there, which is the property that makes the merge reversible.
+    const [{ count }] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(addresses)
+      .where(eq(addresses.id, loser));
+    expect(Number(count)).toBe(1);
+  });
+});
+
+describe('the shared test cleanup can still reset the schema', () => {
+  it('deletes an address that lost a merge', async () => {
+    // A GATE on the fixture helper rather than on production code, and it earns
+    // its place: `address_merges` points at both addresses with ON DELETE
+    // RESTRICT, so a `resetGeoTables` that does not delete merges first fails —
+    // and it fails in whichever OTHER suite happens to share the worker database
+    // next, as a foreign-key error on a table that suite never touched. Measured
+    // while writing this: 337 failures across 27 suites, none of them here.
+    //
+    // Rather than reset the whole schema (which would take the fixtures every
+    // other case in this file depends on), this asserts the property that
+    // matters: once the merge audit is gone, the address can be deleted.
+    const survivor = await makeAddress('Carrer de Sepúlveda', '9');
+    const loser = await makeAddress('Carrer de Sepulveda', '9');
+    const applied = await merge(survivor, loser);
+
+    await db.delete(addressMerges).where(eq(addressMerges.id, applied.mergeId));
+    await expect(
+      db.delete(addresses).where(eq(addresses.id, loser)),
+    ).resolves.toBeDefined();
+  });
+});
+
+describe('the registry is the authority on what moves', () => {
+  it('lists every movable relation exactly once', () => {
+    const movable = movableAddressRelations().map((r) => `${r.table}.${r.column}`);
+    expect(movable.length).toBe(new Set(movable).size);
+  });
+
+  it('gives every relation a disposition', () => {
+    // The C0 discipline: being in NEITHER bucket must fail. `addressRelations()`
+    // throws rather than skipping, so this case is the one that reports it.
+    expect(() => addressRelations()).not.toThrow();
+    for (const relation of addressRelations()) {
+      expect(['move', 'keep', 'audit']).toContain(relation.disposition);
+    }
+  });
+});

--- a/packages/backend/__tests__/db/partialUniques.test.ts
+++ b/packages/backend/__tests__/db/partialUniques.test.ts
@@ -389,6 +389,10 @@ describe('the partial indexes really are partial', () => {
       // path, and an `ON CONFLICT` naming either has to repeat the predicate or
       // fail at RUNTIME with `42P10` while `tsc` stays clean.
       'address_materializations_idempotency_key',
+      // A row may lose at most ONE merge that is still in force (#360). Partial
+      // on `status = 'applied'`, because merged → reverted → merged again is an
+      // ordinary history and a total unique index would forbid the second one.
+      'address_merges_active_loser_key',
       'addresses_identity_key_key',
       'addresses_normalized_key_key',
       'billing_plus_stripe_subscription_id_key',

--- a/packages/backend/__tests__/helpers/postgresGeoFixtures.ts
+++ b/packages/backend/__tests__/helpers/postgresGeoFixtures.ts
@@ -57,6 +57,7 @@ import { syncHasImages } from '../../db/hasImages';
 import {
   addressCandidates,
   addressMaterializations,
+  addressMerges,
   addresses,
   agencies,
   commissions,
@@ -160,6 +161,17 @@ export async function resetGeoTables(): Promise<void> {
   // other two could have been solved the same way, and they could not.
   await db.delete(addressMaterializations);
   await db.delete(addressCandidates);
+  // The merge audit (#360), which points at BOTH addresses with ON DELETE
+  // RESTRICT — a merge is what makes the operation reversible, so an address may
+  // not be deleted while one names it. `address_merge_relation_moves` is
+  // deliberately absent for the same reason `address_external_refs` is: it
+  // CASCADEs from `address_merges`, so this one statement takes it.
+  //
+  // Omitting this line does not fail the suite that created the merge. It fails
+  // whichever OTHER file happens to share the worker database and call
+  // `resetGeoTables` next — measured, 337 failures across 27 suites, every one
+  // of them a foreign-key error on a table that file never touched.
+  await db.delete(addressMerges);
   await db.delete(addresses);
   await db.delete(neighborhoods);
   // `cities.cover_image_id` / `regions.cover_image_id` are ON DELETE SET NULL,

--- a/packages/backend/db/addresses/addressRelations.ts
+++ b/packages/backend/db/addresses/addressRelations.ts
@@ -1,0 +1,251 @@
+/**
+ * Every column that can point at an `addresses` row, and what a merge does with
+ * each one — issue #360's "mover todas las FKs".
+ *
+ * ## Derived, not written down
+ *
+ * The foreign keys are read out of the drizzle schema at module load
+ * ({@link addressForeignKeys}), so a column added tomorrow appears here without
+ * anybody remembering to add it. That is the whole design, and the reason is a
+ * failure this repository has already had twice: a hand-maintained list of
+ * not-an-id path segments in `RightBar` (#423) and a hand-maintained list of
+ * `PlaceType` values in `homeSectionsController` (#416) both had to name every
+ * case, and both did not.
+ *
+ * ## What derivation CANNOT see, and how that is handled
+ *
+ * Two columns hold an address id with **no foreign key at all**:
+ * `housing_domain_events.subject_id` and `housing_alerts.subject_id`, each
+ * discriminated by a `subject_type` column whose CHECK includes `'address'`
+ * (`deferredForeignKeys.ts` records why neither can carry a constraint). No
+ * catalogue query finds them, so they are declared in
+ * {@link POLYMORPHIC_ADDRESS_RELATIONS} by hand — and the declaration is the
+ * dangerous half, so `__tests__/db/addressRelations.test.ts` asserts against the
+ * live `subject_type` CHECK that `'address'` is still an accepted value. A
+ * discriminator that stopped accepting addresses would make these two entries
+ * lies, and nothing else would notice.
+ *
+ * Measured on a database migrated to 0014: `images.entity_type` is
+ * `property | city | region | country | profile` and does **not** include
+ * `address`, so images are not an address relation and there is no media for a
+ * merge to lose. Worth stating because the issue's must-not-lose list names
+ * media; the honest answer is that none is attached to a place.
+ *
+ * ## Every foreign key is classified, and being unclassified FAILS
+ *
+ * {@link classifyAddressRelation} returns a disposition for each derived key,
+ * and the gate refuses a key it does not recognise rather than defaulting it to
+ * anything. A default would be a decision made by absence: `move` would rewrite
+ * an audit row the first time somebody adds one, and `keep` would silently leave
+ * a real relation pointing at a retired address. Both are the shape of bug this
+ * module exists to prevent, so there is no default.
+ */
+
+import { getTableConfig, type PgTable } from 'drizzle-orm/pg-core';
+import { sqlColumnName } from '@oxyhq/db';
+
+import * as schema from '../schema';
+import { addresses } from '../schema/addresses';
+
+/**
+ * What a merge does with one column.
+ *
+ * `keep` is not "ignore" — it is the recorded decision that the column names a
+ * FACT ABOUT THE PAST, and rewriting it would falsify history rather than
+ * repair a reference.
+ */
+export type AddressRelationDisposition =
+  /** Repoint to the survivor, and record the move so a revert can undo it. */
+  | 'move'
+  /** Leave it. It records what happened, and what happened does not change. */
+  | 'keep'
+  /** The merge's own audit trail. Rewriting it would erase the merge. */
+  | 'audit';
+
+export interface AddressRelation {
+  /** The SQL table name, as it appears in `pg_class`. */
+  readonly table: string;
+  /** The SQL column name, as it appears in `pg_attribute`. */
+  readonly column: string;
+  readonly disposition: AddressRelationDisposition;
+  /**
+   * The `<type_column>` and value that make a polymorphic row an address row,
+   * or `null` for a real foreign key.
+   *
+   * A move over a polymorphic column MUST carry this predicate: without it the
+   * update would repoint every `property` and `review` subject whose id happens
+   * to collide, and ids here are uuid v7 so a collision is not the concern —
+   * the concern is that the statement would be semantically "rewrite every
+   * subject", which is only prevented by the predicate being present.
+   */
+  readonly discriminator: { readonly column: string; readonly value: string } | null;
+}
+
+/** The drizzle table objects, by SQL name, for the registry to resolve against. */
+function declaredTables(): Map<string, PgTable> {
+  const tables = new Map<string, PgTable>();
+  for (const value of Object.values(schema)) {
+    let config;
+    try {
+      config = getTableConfig(value as PgTable);
+    } catch {
+      // Not a table. The barrel is documented as tables-only, so this is a
+      // belt-and-braces skip rather than an expected branch.
+      continue;
+    }
+    tables.set(config.name, value as PgTable);
+  }
+  return tables;
+}
+
+/**
+ * Every foreign key in the schema whose target is `addresses`, derived.
+ *
+ * Returns SQL names on both sides — `sqlColumnName`, never `column.name`, which
+ * is the drizzle PROPERTY name and would silently match nothing in a catalogue
+ * query or produce `column "materializedAddressId" does not exist` in emitted
+ * SQL. `@oxyhq/db`'s own header records that trap.
+ */
+export function addressForeignKeys(): readonly { table: string; column: string }[] {
+  const found: { table: string; column: string }[] = [];
+  for (const [tableName, table] of declaredTables()) {
+    for (const foreignKey of getTableConfig(table).foreignKeys) {
+      const reference = foreignKey.reference();
+      if (reference.foreignTable !== addresses) continue;
+      for (const column of reference.columns) {
+        found.push({ table: tableName, column: sqlColumnName(column) });
+      }
+    }
+  }
+  return found.sort((a, b) => a.table.localeCompare(b.table) || a.column.localeCompare(b.column));
+}
+
+/**
+ * The two columns that hold an address id without a foreign key.
+ *
+ * Declared, because nothing can derive them — and every field is checked against
+ * the live catalogue by the gate, including that the discriminator's CHECK still
+ * admits `'address'`.
+ */
+export const POLYMORPHIC_ADDRESS_RELATIONS: readonly AddressRelation[] = [
+  {
+    table: 'housing_domain_events',
+    column: 'subject_id',
+    disposition: 'move',
+    discriminator: { column: 'subject_type', value: 'address' },
+  },
+  {
+    table: 'housing_alerts',
+    column: 'subject_id',
+    disposition: 'move',
+    discriminator: { column: 'subject_type', value: 'address' },
+  },
+];
+
+/**
+ * The disposition of one derived foreign key, or `null` when it is unknown.
+ *
+ * `null` is what makes the gate a gate: an unrecognised key fails
+ * `__tests__/db/addressRelations.test.ts` by name, and the person adding the
+ * column decides what a merge should do with it. That decision cannot be made
+ * correctly by a default, and it is cheap to make explicitly.
+ */
+export function classifyAddressRelation(
+  table: string,
+  column: string,
+): AddressRelationDisposition | null {
+  const key = `${table}.${column}`;
+  switch (key) {
+    // ── Relations that describe the PRESENT, and must follow the place ──
+    //
+    // A listing advertises a dwelling; after the merge the dwelling is the
+    // survivor. A review is filed against a dwelling at three levels plus the
+    // row itself, and moving only `address_id` would leave it filed under the
+    // retired row at two of the three — which is the failure a census that
+    // stopped at "reviews has an address column" would have shipped.
+    case 'properties.address_id':
+    case 'reviews.address_id':
+    case 'reviews.street_level_id':
+    case 'reviews.building_level_id':
+    case 'reviews.unit_level_id':
+      return 'move';
+
+    // A provider's id for a place. After the merge the place is the survivor, so
+    // the next ingest carrying that ref should land there directly rather than
+    // through a redirect. `(source, external_id)` is unique GLOBALLY and carries
+    // no address column, so this move can never collide.
+    case 'address_external_refs.address_id':
+      return 'move';
+
+    // The hierarchy. A unit whose building lost a merge must re-parent, or its
+    // parent is a retired row — and `parent_address_id` is what every other
+    // domain is meant to read instead of recomputing the chain.
+    case 'addresses.parent_address_id':
+      return 'move';
+
+    // A row that already redirected to the loser now redirects to the survivor.
+    // FLATTENED rather than chained, deliberately: the matcher follows at most
+    // `MAX_MERGE_REDIRECTS` hops, and a cap is a thing that gets hit. The chain
+    // is not lost — `address_merges` records every step — so flattening moves
+    // the history into the audit table where it is readable, instead of encoding
+    // it as a walk whose length is bounded.
+    case 'addresses.merged_into_address_id':
+      return 'move';
+
+    // ── Relations that describe the PAST ──
+    //
+    // "This candidate produced THAT row" and "this act of materialization
+    // resolved to THAT row" are facts about what happened. The row still exists
+    // and still redirects, so nothing is dangling; rewriting these would make
+    // the audit say a materialization produced a row it did not produce, which
+    // is the one thing a merge audit must never do.
+    case 'address_candidates.materialized_address_id':
+    case 'address_materializations.address_id':
+      return 'keep';
+
+    // ── The merge's own record ──
+    // `previous_address_id` is the value a revert restores TO. Rewriting any of
+    // these three would make the log say a row came from somewhere it did not,
+    // which is the one thing an undo cannot survive — and this gate is what
+    // caught the third one: giving it a foreign key made it appear in the
+    // derived set, and it failed here until somebody decided.
+    case 'address_merges.survivor_address_id':
+    case 'address_merges.merged_address_id':
+    case 'address_merge_relation_moves.previous_address_id':
+      return 'audit';
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * The full registry: every derived foreign key with its disposition, plus the
+ * declared polymorphic columns.
+ *
+ * Throws on an unclassified key rather than skipping it. A registry that
+ * silently omitted a relation would produce a merge that silently left it
+ * behind, and the whole point of deriving the set is that the omission cannot
+ * happen quietly.
+ */
+export function addressRelations(): readonly AddressRelation[] {
+  const relations: AddressRelation[] = [];
+  for (const { table, column } of addressForeignKeys()) {
+    const disposition = classifyAddressRelation(table, column);
+    if (disposition === null) {
+      throw new Error(
+        `Unclassified address relation ${table}.${column}. Add it to ` +
+          '`classifyAddressRelation` in db/addresses/addressRelations.ts: a merge ' +
+          'must know whether to move it (a relation), keep it (a record of the ' +
+          'past) or refuse it (the merge audit itself).',
+      );
+    }
+    relations.push({ table, column, disposition, discriminator: null });
+  }
+  return [...relations, ...POLYMORPHIC_ADDRESS_RELATIONS];
+}
+
+/** Just the relations a merge repoints. */
+export function movableAddressRelations(): readonly AddressRelation[] {
+  return addressRelations().filter((relation) => relation.disposition === 'move');
+}

--- a/packages/backend/db/schema/addressMerges.ts
+++ b/packages/backend/db/schema/addressMerges.ts
@@ -1,0 +1,297 @@
+/**
+ * The record of a merge — issue #360's second half, ADR 0001 §2.1.7 and §8.1.
+ *
+ * ## Why a merge is a ROW rather than a column update
+ *
+ * ADR 0001 §2.1.7: *a duplicate is recorded, never discarded. Merging is
+ * reversible; deleting is not.* Setting `addresses.merged_into_address_id` is
+ * enough to make the matcher redirect, and it is NOT enough to undo anything:
+ * it says which row survived and says nothing about which relations moved, so a
+ * revert would have to guess. Guessing here means handing one household's
+ * reviews back to the wrong address.
+ *
+ * These two tables are the difference between a merge and a delete with extra
+ * steps. {@link addressMerges} is the act; {@link addressMergeRelationMoves} is
+ * the itemised list of every row that changed, recorded BY VALUE, which is what
+ * a revert replays backwards.
+ *
+ * ## The measurement that decided "never delete"
+ *
+ * Twelve columns could point at an address before this migration (ten real
+ * foreign keys plus two polymorphic `subject_id` columns), and read off
+ * `pg_constraint` on a database migrated to 0014, **eleven of the twelve refuse
+ * a delete and exactly one CASCADES**: `address_external_refs.address_id`. So
+ * deleting a losing row
+ * would not merely be irreversible — it would be irreversible *quietly, on the
+ * one table that decides whether the next ingest of that place finds it again*.
+ * Everything else would at least raise. That asymmetry is the argument, and it
+ * is measured rather than assumed.
+ *
+ * ## Visibility
+ *
+ * INTERNAL. A merge names an actor and a reason, and neither belongs in a public
+ * DTO; the redirect it produces is observable through the matcher, which is the
+ * only part a caller ever sees.
+ */
+
+import { check, index, integer, pgTable, text, uniqueIndex } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { createdAt, generatedId, inList, timestamptz } from '@oxyhq/db';
+import { addresses } from './addresses';
+
+/**
+ * Why two rows were declared the same place.
+ *
+ * A closed set rather than free text, because it is the input to any later
+ * question about whether a class of merge was a good idea — "how often does
+ * `duplicate_identity_key` get reverted" is answerable, "how often does
+ * somebody's sentence get reverted" is not. The prose reason travels beside it
+ * in {@link addressMerges.reason}, which is required and is not this.
+ */
+export const ADDRESS_MERGE_REASONS = [
+  /** The two rows carry identity keys that resolve to the same dwelling. */
+  'duplicate_identity_key',
+  /** The same provider ref was seen naming both rows. */
+  'duplicate_external_ref',
+  /** A person proposed it and the community approved it. */
+  'approved_correction',
+  /** An import created a row that an existing one already described. */
+  'ingest_duplicate',
+] as const;
+
+export type AddressMergeReason = (typeof ADDRESS_MERGE_REASONS)[number];
+
+/**
+ * What happened to one relation row.
+ *
+ * `left_in_place` is the member that matters, and it exists because of a
+ * measured collision rather than as a hedge: `reviews_author_address_key` is
+ * UNIQUE on `(oxy_user_id, address_id)`, so an author who reviewed BOTH rows has
+ * a review that cannot be moved — the move would violate the constraint, and
+ * inside a transaction a violation aborts everything (`25P02`), taking the whole
+ * merge with it.
+ *
+ * The two wrong answers are deleting the loser's review and rewriting it; ADR
+ * 0001 §2.1.7 forbids both, and neither is reversible. So the row STAYS on the
+ * losing address, which still resolves — the matcher follows
+ * `merged_into_address_id` — and the fact that it stayed is recorded here so a
+ * revert does not try to move it back and an audit can see it happened.
+ */
+export const ADDRESS_MERGE_MOVE_OUTCOMES = [
+  /** The row now points at the survivor. A revert points it back. */
+  'moved',
+  /** A unique constraint refused the move; the row stayed on the loser. */
+  'left_in_place',
+] as const;
+
+export type AddressMergeMoveOutcome = (typeof ADDRESS_MERGE_MOVE_OUTCOMES)[number];
+
+/** A merge that is in force, or one that has been undone. */
+export const ADDRESS_MERGE_STATUSES = ['applied', 'reverted'] as const;
+
+export type AddressMergeStatus = (typeof ADDRESS_MERGE_STATUSES)[number];
+
+/**
+ * One act of declaring two canonical rows the same place.
+ *
+ * ## Both ends carry a real foreign key, and both are RESTRICT
+ *
+ * The audit is the thing that makes the operation reversible, so neither row may
+ * be deleted while a merge names it. That is the same reasoning
+ * `address_materializations.address_id` already applies, and it is what makes
+ * "no delete before the relations moved" a property of the DATABASE rather than
+ * a rule the service remembers.
+ */
+export const addressMerges = pgTable(
+  'address_merges',
+  {
+    id: generatedId(),
+
+    /** The row that survives. Every moved relation now points here. */
+    survivorAddressId: text()
+      .notNull()
+      .references(() => addresses.id, { onDelete: 'restrict' }),
+    /**
+     * The row that lost, and which keeps existing.
+     *
+     * It keeps its `identity_key` and its `normalized_key` too, deliberately: a
+     * later materialization that hashes to the loser's key hits the loser and is
+     * redirected by the matcher, which is both correct and what makes the merge
+     * undoable. Releasing the key on merge would make a revert unable to restore
+     * the row's identity — somebody else may have taken it in between.
+     */
+    mergedAddressId: text()
+      .notNull()
+      .references(() => addresses.id, { onDelete: 'restrict' }),
+
+    status: text({ enum: ADDRESS_MERGE_STATUSES }).notNull().default('applied'),
+    reasonCode: text({ enum: ADDRESS_MERGE_REASONS }).notNull(),
+    /**
+     * The human sentence. NOT NULL and not defaulted.
+     *
+     * A merge with no stated reason is the shape that becomes unauditable six
+     * months later, and the reason code above is a category rather than an
+     * explanation.
+     */
+    reason: text().notNull(),
+    /** Where the evidence can be seen — a correction thread, a dataset row. */
+    evidenceUrl: text(),
+
+    /** The Oxy account that performed it, or NULL for an operational job. */
+    actorOxyUserId: text(),
+
+    /**
+     * How many relation rows this merge moved, copied from the plan it executed.
+     *
+     * Denormalized ON PURPOSE, and it is the anti-vacuity floor for the whole
+     * operation rather than a convenience: a revert asserts that the number of
+     * `moved` rows it replays equals this number, so a merge whose move log was
+     * partially lost cannot be silently half-reverted. `0` is a legitimate value
+     * — merging a row nothing references is a real and ordinary case — which is
+     * why the assertion is equality against a recorded count and not `> 0`.
+     */
+    movedRelationCount: integer().notNull(),
+
+    appliedAt: timestamptz().notNull(),
+    /** Set when the merge is undone. NULL means it is still in force. */
+    revertedAt: timestamptz(),
+    revertedByOxyUserId: text(),
+
+    createdAt: createdAt(),
+  },
+  (table) => [
+    // A row may lose at most one merge that is still in force. PARTIAL on
+    // `status`, because a row that was merged, reverted and merged again is an
+    // ordinary history and a total unique index would forbid the second merge.
+    // The predicate must be repeated verbatim by any `ON CONFLICT` naming this
+    // index, or Postgres answers `42P10` at runtime with a clean `tsc`.
+    uniqueIndex('address_merges_active_loser_key')
+      .on(table.mergedAddressId)
+      .where(sql`${table.status} = 'applied'`),
+
+    index('address_merges_survivor_idx').on(table.survivorAddressId),
+    index('address_merges_merged_idx').on(table.mergedAddressId),
+
+    check(
+      'address_merges_status_check',
+      sql`${table.status} in (${sql.raw(inList(ADDRESS_MERGE_STATUSES))})`,
+    ),
+    check(
+      'address_merges_reason_code_check',
+      sql`${table.reasonCode} in (${sql.raw(inList(ADDRESS_MERGE_REASONS))})`,
+    ),
+    // A row cannot be merged into itself. Same one-row cycle a self-referencing
+    // foreign key cannot see, and the same CHECK `addresses` already carries for
+    // `merged_into_address_id`. Longer cycles are refused by the writer.
+    check(
+      'address_merges_not_self_check',
+      sql`${table.survivorAddressId} <> ${table.mergedAddressId}`,
+    ),
+    // `reverted` names both the instant and nothing else; `applied` names
+    // neither. Written with `is not null` spelled out on the positive branch,
+    // because a CHECK rejects only an explicit FALSE and the tidier spelling
+    // evaluates to NULL — admitting exactly the half-state it exists to refuse.
+    // `CONVENTIONS.md` records that trap shipping once already.
+    check(
+      'address_merges_reverted_coherence_check',
+      sql`(${table.status} = 'applied' and ${table.revertedAt} is null)
+          or (${table.status} = 'reverted' and ${table.revertedAt} is not null)`,
+    ),
+    check('address_merges_moved_count_check', sql`${table.movedRelationCount} >= 0`),
+  ],
+);
+
+/**
+ * One row per relation the merge touched — the itemised log a revert replays.
+ *
+ * ## Why the table and column are stored as TEXT
+ *
+ * They name a place in the schema, and a schema is not a table this database can
+ * reference. The alternative would be an enum, which would need a migration
+ * every time a relation is added — and the relation registry the service reads
+ * is derived from the catalogue precisely so that adding one cannot be forgotten.
+ * Storing the name keeps the log readable by a human running `psql` during an
+ * incident, which is the audience it has.
+ *
+ * The service validates both names against the registry before writing, so a
+ * typo cannot enter; what it cannot do is stop a relation being RENAMED later,
+ * and a rename that leaves this log behind is exactly the case
+ * {@link addressMergeRelationMoves.outcome} plus the revert's own preflight are
+ * there to refuse loudly rather than apply blindly.
+ *
+ * ## Why `previous_address_id` is stored even though it is always the loser
+ *
+ * For `moved` rows it is redundant with the merge's `merged_address_id` — and
+ * for a SPLIT, which reuses this engine, it is not, because a split moves rows
+ * off a survivor onto a new row and the previous value differs per relation.
+ * Recording it makes the log self-describing rather than only interpretable
+ * against its parent, which is what an audit read during an incident needs.
+ */
+export const addressMergeRelationMoves = pgTable(
+  'address_merge_relation_moves',
+  {
+    id: generatedId(),
+
+    /** CASCADE: a move has no meaning without the merge that made it. */
+    mergeId: text()
+      .notNull()
+      .references(() => addressMerges.id, { onDelete: 'cascade' }),
+
+    /** The table whose row was touched, as it appears in `pg_class`. */
+    relationTable: text().notNull(),
+    /** The column that was rewritten, as it appears in `pg_attribute`. */
+    relationColumn: text().notNull(),
+    /** The primary key of the row that was touched. */
+    relationRowId: text().notNull(),
+
+    /**
+     * What the column held before. See the docblock for why it is stored.
+     *
+     * A REAL foreign key rather than a classified exemption: the value is always
+     * an existing address, and RESTRICT here is the same guarantee the merge
+     * itself carries — the row a revert would restore to may not be deleted
+     * while a log entry names it. It appears in the derived relation registry as
+     * `audit`, which is what stops a merge from rewriting its own history.
+     */
+    previousAddressId: text()
+      .notNull()
+      .references(() => addresses.id, { onDelete: 'restrict' }),
+    outcome: text({ enum: ADDRESS_MERGE_MOVE_OUTCOMES }).notNull(),
+    /**
+     * Why a row was left in place, when it was.
+     *
+     * NULL for a `moved` row. For a `left_in_place` row it names the constraint
+     * that refused, which is the one thing an operator needs in order to decide
+     * whether to do anything about it.
+     */
+    blockedByConstraint: text(),
+
+    createdAt: createdAt(),
+  },
+  (table) => [
+    // The revert reads every move of one merge, in one go.
+    index('address_merge_relation_moves_merge_idx').on(table.mergeId),
+    // One merge touches one row of one relation at most once. This is what makes
+    // the replay idempotent: a double-write would move a row twice and a revert
+    // would put it back once.
+    uniqueIndex('address_merge_relation_moves_row_key').on(
+      table.mergeId,
+      table.relationTable,
+      table.relationColumn,
+      table.relationRowId,
+    ),
+
+    check(
+      'address_merge_relation_moves_outcome_check',
+      sql`${table.outcome} in (${sql.raw(inList(ADDRESS_MERGE_MOVE_OUTCOMES))})`,
+    ),
+    // A blocked row names its constraint; a moved row names none. The absence is
+    // as load-bearing as the presence: a `moved` row carrying a constraint name
+    // would mean the executor recorded a refusal it then went on to ignore.
+    check(
+      'address_merge_relation_moves_blocked_coherence_check',
+      sql`(${table.outcome} = 'moved' and ${table.blockedByConstraint} is null)
+          or (${table.outcome} = 'left_in_place' and ${table.blockedByConstraint} is not null)`,
+    ),
+  ],
+);

--- a/packages/backend/db/schema/deferredForeignKeys.ts
+++ b/packages/backend/db/schema/deferredForeignKeys.ts
@@ -38,6 +38,7 @@ import { getTableColumns, getTableName } from 'drizzle-orm';
 import type { PgColumn, PgTable, UpdateDeleteAction } from 'drizzle-orm/pg-core';
 import { sqlColumnName } from '../casing';
 import { addressExternalRefs, addressMaterializations } from './addressMaterialization';
+import { addressMergeRelationMoves } from './addressMerges';
 import { billing, billingProcessedSessions } from './billing';
 import { housingAlerts, housingDomainEvents } from './watches';
 import { images } from './images';
@@ -176,6 +177,11 @@ export const OXY_ACCOUNT_COLUMN_NAMES: ReadonlySet<string> = new Set([
   // the ingestion worker submits candidates with no human behind them, and that
   // absence is a different fact from any account id rather than a missing one.
   'submitted_by_oxy_user_id',
+  // Whoever UNDID a merge (#360). A separate role from `actor_oxy_user_id` on
+  // the same row rather than a synonym: the person who reverses a merge is
+  // routinely not the person who made it, and collapsing the two would erase
+  // exactly the fact an audit of a disputed merge is looking for.
+  'reverted_by_oxy_user_id',
 ]);
 
 /**
@@ -387,6 +393,19 @@ export const ID_COLUMNS_WITHOUT_FOREIGN_KEY: readonly IdColumnWithoutForeignKey[
       'provider calls this place X", and ADR 0001 §3.4 is explicit that an ' +
       'external identifier is an ATTRIBUTE and never identity, so a constraint ' +
       'here would be asserting the opposite of the decision.',
+  },
+  {
+    table: addressMergeRelationMoves,
+    column: addressMergeRelationMoves.relationRowId,
+    reason:
+      'The primary key of a row in whichever relation the merge touched — a ' +
+      '`properties.id` today, a `reviews.id`, an `addresses.id`, a ' +
+      '`housing_domain_events.id` — so it is polymorphic across EVERY table ' +
+      'that can point at an address, and the set is derived rather than fixed ' +
+      '(`db/addresses/addressRelations.ts`). One column cannot reference all of ' +
+      'them, the same permanent case as `images.entity_id`. `relation_table` ' +
+      'beside it names which one, and the revert validates both against the ' +
+      'registry before replaying anything.',
   },
   {
     table: addressMaterializations,

--- a/packages/backend/db/schema/index.ts
+++ b/packages/backend/db/schema/index.ts
@@ -31,6 +31,7 @@ export {
   addressExternalRefs,
   addressMaterializations,
 } from './addressMaterialization';
+export { addressMergeRelationMoves, addressMerges } from './addressMerges';
 export { agencies } from './agencies';
 export {
   tenantApplicationDocuments,

--- a/packages/backend/drizzle/0015_address_merge_workflow.sql
+++ b/packages/backend/drizzle/0015_address_merge_workflow.sql
@@ -1,0 +1,62 @@
+-- oxy:deploy-phase=pre
+--
+-- #360 — merging two canonical addresses, reversibly. `address_merges` is the
+-- act (survivor, loser, actor, reason, and the count of relations it moved) and
+-- `address_merge_relation_moves` is the itemised log a revert replays backwards.
+--
+-- PRE, and additive only: two new tables and no change to any existing one, so
+-- an image still serving the previous release is unaffected by their presence.
+-- Nothing writes them until `services/addressMerge.ts` is called, and nothing
+-- calls it yet — a merge is an operational act, never a request side effect.
+--
+-- The partial unique index is the load-bearing one: a row may lose at most one
+-- merge that is still in force, and `where status = 'applied'` is what allows a
+-- row to be merged, reverted and merged again. Any `ON CONFLICT` naming it must
+-- repeat that predicate verbatim or Postgres answers 42P10 at runtime.
+
+CREATE TABLE "address_merge_relation_moves" (
+	"id" text PRIMARY KEY NOT NULL,
+	"merge_id" text NOT NULL,
+	"relation_table" text NOT NULL,
+	"relation_column" text NOT NULL,
+	"relation_row_id" text NOT NULL,
+	"previous_address_id" text NOT NULL,
+	"outcome" text NOT NULL,
+	"blocked_by_constraint" text,
+	"created_at" timestamp with time zone DEFAULT date_trunc('milliseconds', now()) NOT NULL,
+	CONSTRAINT "address_merge_relation_moves_outcome_check" CHECK ("address_merge_relation_moves"."outcome" in ('moved', 'left_in_place')),
+	CONSTRAINT "address_merge_relation_moves_blocked_coherence_check" CHECK (("address_merge_relation_moves"."outcome" = 'moved' and "address_merge_relation_moves"."blocked_by_constraint" is null)
+          or ("address_merge_relation_moves"."outcome" = 'left_in_place' and "address_merge_relation_moves"."blocked_by_constraint" is not null))
+);
+--> statement-breakpoint
+CREATE TABLE "address_merges" (
+	"id" text PRIMARY KEY NOT NULL,
+	"survivor_address_id" text NOT NULL,
+	"merged_address_id" text NOT NULL,
+	"status" text DEFAULT 'applied' NOT NULL,
+	"reason_code" text NOT NULL,
+	"reason" text NOT NULL,
+	"evidence_url" text,
+	"actor_oxy_user_id" text,
+	"moved_relation_count" integer NOT NULL,
+	"applied_at" timestamp with time zone NOT NULL,
+	"reverted_at" timestamp with time zone,
+	"reverted_by_oxy_user_id" text,
+	"created_at" timestamp with time zone DEFAULT date_trunc('milliseconds', now()) NOT NULL,
+	CONSTRAINT "address_merges_status_check" CHECK ("address_merges"."status" in ('applied', 'reverted')),
+	CONSTRAINT "address_merges_reason_code_check" CHECK ("address_merges"."reason_code" in ('duplicate_identity_key', 'duplicate_external_ref', 'approved_correction', 'ingest_duplicate')),
+	CONSTRAINT "address_merges_not_self_check" CHECK ("address_merges"."survivor_address_id" <> "address_merges"."merged_address_id"),
+	CONSTRAINT "address_merges_reverted_coherence_check" CHECK (("address_merges"."status" = 'applied' and "address_merges"."reverted_at" is null)
+          or ("address_merges"."status" = 'reverted' and "address_merges"."reverted_at" is not null)),
+	CONSTRAINT "address_merges_moved_count_check" CHECK ("address_merges"."moved_relation_count" >= 0)
+);
+--> statement-breakpoint
+ALTER TABLE "address_merge_relation_moves" ADD CONSTRAINT "address_merge_relation_moves_merge_id_address_merges_id_fk" FOREIGN KEY ("merge_id") REFERENCES "public"."address_merges"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "address_merge_relation_moves" ADD CONSTRAINT "address_merge_relation_moves_previous_address_id_addresses_id_fk" FOREIGN KEY ("previous_address_id") REFERENCES "public"."addresses"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "address_merges" ADD CONSTRAINT "address_merges_survivor_address_id_addresses_id_fk" FOREIGN KEY ("survivor_address_id") REFERENCES "public"."addresses"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "address_merges" ADD CONSTRAINT "address_merges_merged_address_id_addresses_id_fk" FOREIGN KEY ("merged_address_id") REFERENCES "public"."addresses"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "address_merge_relation_moves_merge_idx" ON "address_merge_relation_moves" USING btree ("merge_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "address_merge_relation_moves_row_key" ON "address_merge_relation_moves" USING btree ("merge_id","relation_table","relation_column","relation_row_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "address_merges_active_loser_key" ON "address_merges" USING btree ("merged_address_id") WHERE "address_merges"."status" = 'applied';--> statement-breakpoint
+CREATE INDEX "address_merges_survivor_idx" ON "address_merges" USING btree ("survivor_address_id");--> statement-breakpoint
+CREATE INDEX "address_merges_merged_idx" ON "address_merges" USING btree ("merged_address_id");

--- a/packages/backend/drizzle/meta/0015_snapshot.json
+++ b/packages/backend/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,14017 @@
+{
+  "id": "0cdadc38-667b-4efc-8292-01e949392ffc",
+  "prevId": "7008d5c0-e162-4320-a172-c96ccc1801fa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.address_candidates": {
+      "name": "address_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submitted_by_oxy_user_id": {
+          "name": "submitted_by_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_text_hash": {
+          "name": "raw_text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_payload": {
+          "name": "normalized_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "normalization_version": {
+          "name": "normalization_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "precision": {
+          "name": "precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_country_code": {
+          "name": "proposed_country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_country": {
+          "name": "proposed_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_region": {
+          "name": "proposed_region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_city": {
+          "name": "proposed_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_neighborhood": {
+          "name": "proposed_neighborhood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_street": {
+          "name": "proposed_street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_postal_code": {
+          "name": "proposed_postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_number": {
+          "name": "proposed_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_building_name": {
+          "name": "proposed_building_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_block": {
+          "name": "proposed_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_entrance": {
+          "name": "proposed_entrance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_floor": {
+          "name": "proposed_floor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_unit": {
+          "name": "proposed_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_subunit": {
+          "name": "proposed_subunit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "materialized_address_id": {
+          "name": "materialized_address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "materialized_at": {
+          "name": "materialized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "address_candidates_submitter_raw_text_idx": {
+          "name": "address_candidates_submitter_raw_text_idx",
+          "columns": [
+            {
+              "expression": "submitted_by_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "raw_text_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_candidates_provider_ref_idx": {
+          "name": "address_candidates_provider_ref_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_candidates_expires_at_idx": {
+          "name": "address_candidates_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_candidates_materialized_address_id_idx": {
+          "name": "address_candidates_materialized_address_id_idx",
+          "columns": [
+            {
+              "expression": "materialized_address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "address_candidates_materialized_address_id_addresses_id_fk": {
+          "name": "address_candidates_materialized_address_id_addresses_id_fk",
+          "tableFrom": "address_candidates",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "materialized_address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "address_candidates_precision_check": {
+          "name": "address_candidates_precision_check",
+          "value": "\"address_candidates\".\"precision\" in ('exact', 'approximate', 'centroid', 'area')"
+        },
+        "address_candidates_origin_check": {
+          "name": "address_candidates_origin_check",
+          "value": "\"address_candidates\".\"origin\" in ('user_typed', 'autocomplete_selection', 'map_pin', 'geocoder', 'listing_ingest', 'public_dataset', 'approved_correction')"
+        },
+        "address_candidates_coordinates_check": {
+          "name": "address_candidates_coordinates_check",
+          "value": "(\"address_candidates\".\"longitude\" is null and \"address_candidates\".\"latitude\" is null)\n          or (\"address_candidates\".\"longitude\" is not null and \"address_candidates\".\"latitude\" is not null\n              and \"address_candidates\".\"longitude\" between -180 and 180\n              and \"address_candidates\".\"latitude\" between -90 and 90)"
+        },
+        "address_candidates_materialized_coherence_check": {
+          "name": "address_candidates_materialized_coherence_check",
+          "value": "(\"address_candidates\".\"materialized_address_id\" is null and \"address_candidates\".\"materialized_at\" is null)\n          or (\"address_candidates\".\"materialized_address_id\" is not null and \"address_candidates\".\"materialized_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.address_external_refs": {
+      "name": "address_external_refs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_label": {
+          "name": "raw_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "address_external_refs_source_external_id_key": {
+          "name": "address_external_refs_source_external_id_key",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_external_refs_address_id_idx": {
+          "name": "address_external_refs_address_id_idx",
+          "columns": [
+            {
+              "expression": "address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "address_external_refs_address_id_addresses_id_fk": {
+          "name": "address_external_refs_address_id_addresses_id_fk",
+          "tableFrom": "address_external_refs",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "address_external_refs_confidence_range_check": {
+          "name": "address_external_refs_confidence_range_check",
+          "value": "\"address_external_refs\".\"confidence\" between 0 and 1"
+        },
+        "address_external_refs_seen_order_check": {
+          "name": "address_external_refs_seen_order_check",
+          "value": "\"address_external_refs\".\"last_seen_at\" >= \"address_external_refs\".\"first_seen_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.address_materializations": {
+      "name": "address_materializations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_ref": {
+          "name": "provider_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_text_hash": {
+          "name": "raw_text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalization_version": {
+          "name": "normalization_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_kind": {
+          "name": "match_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_detail": {
+          "name": "match_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_key": {
+          "name": "identity_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durable_action": {
+          "name": "durable_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_action_ref": {
+          "name": "durable_action_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_oxy_user_id": {
+          "name": "actor_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "address_materializations_idempotency_key": {
+          "name": "address_materializations_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"address_materializations\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_materializations_address_id_idx": {
+          "name": "address_materializations_address_id_idx",
+          "columns": [
+            {
+              "expression": "address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_materializations_candidate_id_idx": {
+          "name": "address_materializations_candidate_id_idx",
+          "columns": [
+            {
+              "expression": "candidate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "address_materializations_address_id_addresses_id_fk": {
+          "name": "address_materializations_address_id_addresses_id_fk",
+          "tableFrom": "address_materializations",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "address_materializations_match_kind_check": {
+          "name": "address_materializations_match_kind_check",
+          "value": "\"address_materializations\".\"match_kind\" in ('created', 'exact_identity_key', 'exact_external_ref', 'adopted_v1_key', 'confirmed_probable')"
+        },
+        "address_materializations_durable_action_check": {
+          "name": "address_materializations_durable_action_check",
+          "value": "\"address_materializations\".\"durable_action\" in ('listing_upsert', 'review', 'follow_dwelling', 'public_data_link', 'canonical_event', 'approved_correction')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.address_merge_relation_moves": {
+      "name": "address_merge_relation_moves",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "merge_id": {
+          "name": "merge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_table": {
+          "name": "relation_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_column": {
+          "name": "relation_column",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_row_id": {
+          "name": "relation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_address_id": {
+          "name": "previous_address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_by_constraint": {
+          "name": "blocked_by_constraint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "address_merge_relation_moves_merge_idx": {
+          "name": "address_merge_relation_moves_merge_idx",
+          "columns": [
+            {
+              "expression": "merge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_merge_relation_moves_row_key": {
+          "name": "address_merge_relation_moves_row_key",
+          "columns": [
+            {
+              "expression": "merge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relation_table",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relation_column",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relation_row_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "address_merge_relation_moves_merge_id_address_merges_id_fk": {
+          "name": "address_merge_relation_moves_merge_id_address_merges_id_fk",
+          "tableFrom": "address_merge_relation_moves",
+          "tableTo": "address_merges",
+          "columnsFrom": [
+            "merge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "address_merge_relation_moves_previous_address_id_addresses_id_fk": {
+          "name": "address_merge_relation_moves_previous_address_id_addresses_id_fk",
+          "tableFrom": "address_merge_relation_moves",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "previous_address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "address_merge_relation_moves_outcome_check": {
+          "name": "address_merge_relation_moves_outcome_check",
+          "value": "\"address_merge_relation_moves\".\"outcome\" in ('moved', 'left_in_place')"
+        },
+        "address_merge_relation_moves_blocked_coherence_check": {
+          "name": "address_merge_relation_moves_blocked_coherence_check",
+          "value": "(\"address_merge_relation_moves\".\"outcome\" = 'moved' and \"address_merge_relation_moves\".\"blocked_by_constraint\" is null)\n          or (\"address_merge_relation_moves\".\"outcome\" = 'left_in_place' and \"address_merge_relation_moves\".\"blocked_by_constraint\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.address_merges": {
+      "name": "address_merges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "survivor_address_id": {
+          "name": "survivor_address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_address_id": {
+          "name": "merged_address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'applied'"
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_url": {
+          "name": "evidence_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_oxy_user_id": {
+          "name": "actor_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moved_relation_count": {
+          "name": "moved_relation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reverted_at": {
+          "name": "reverted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reverted_by_oxy_user_id": {
+          "name": "reverted_by_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "address_merges_active_loser_key": {
+          "name": "address_merges_active_loser_key",
+          "columns": [
+            {
+              "expression": "merged_address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"address_merges\".\"status\" = 'applied'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_merges_survivor_idx": {
+          "name": "address_merges_survivor_idx",
+          "columns": [
+            {
+              "expression": "survivor_address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "address_merges_merged_idx": {
+          "name": "address_merges_merged_idx",
+          "columns": [
+            {
+              "expression": "merged_address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "address_merges_survivor_address_id_addresses_id_fk": {
+          "name": "address_merges_survivor_address_id_addresses_id_fk",
+          "tableFrom": "address_merges",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "survivor_address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "address_merges_merged_address_id_addresses_id_fk": {
+          "name": "address_merges_merged_address_id_addresses_id_fk",
+          "tableFrom": "address_merges",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "merged_address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "address_merges_status_check": {
+          "name": "address_merges_status_check",
+          "value": "\"address_merges\".\"status\" in ('applied', 'reverted')"
+        },
+        "address_merges_reason_code_check": {
+          "name": "address_merges_reason_code_check",
+          "value": "\"address_merges\".\"reason_code\" in ('duplicate_identity_key', 'duplicate_external_ref', 'approved_correction', 'ingest_duplicate')"
+        },
+        "address_merges_not_self_check": {
+          "name": "address_merges_not_self_check",
+          "value": "\"address_merges\".\"survivor_address_id\" <> \"address_merges\".\"merged_address_id\""
+        },
+        "address_merges_reverted_coherence_check": {
+          "name": "address_merges_reverted_coherence_check",
+          "value": "(\"address_merges\".\"status\" = 'applied' and \"address_merges\".\"reverted_at\" is null)\n          or (\"address_merges\".\"status\" = 'reverted' and \"address_merges\".\"reverted_at\" is not null)"
+        },
+        "address_merges_moved_count_check": {
+          "name": "address_merges_moved_count_check",
+          "value": "\"address_merges\".\"moved_relation_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.addresses": {
+      "name": "addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "neighborhood_id": {
+          "name": "neighborhood_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "building_name": {
+          "name": "building_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block": {
+          "name": "block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entrance": {
+          "name": "entrance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "floor": {
+          "name": "floor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subunit": {
+          "name": "subunit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district": {
+          "name": "district",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_lines": {
+          "name": "address_lines",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "po_box": {
+          "name": "po_box",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_plot_block": {
+          "name": "land_plot_block",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_plot_lot": {
+          "name": "land_plot_lot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "land_plot_parcel": {
+          "name": "land_plot_parcel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extras": {
+          "name": "extras",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "ST_MakePoint(longitude, latitude)::geography",
+            "type": "stored"
+          }
+        },
+        "address_level": {
+          "name": "address_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "\n      case\n        when coalesce(floor, '') <> '' or coalesce(unit, '') <> ''\n          or coalesce(subunit, '') <> '' then 'UNIT'\n        when coalesce(number, '') <> '' or coalesce(building_name, '') <> ''\n          or coalesce(block, '') <> '' or coalesce(entrance, '') <> '' then 'BUILDING'\n        else 'STREET'\n      end\n    ",
+            "type": "stored"
+          }
+        },
+        "normalized_key": {
+          "name": "normalized_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_key": {
+          "name": "identity_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_address_id": {
+          "name": "parent_address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_into_address_id": {
+          "name": "merged_into_address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "addresses_normalized_key_key": {
+          "name": "addresses_normalized_key_key",
+          "columns": [
+            {
+              "expression": "normalized_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"addresses\".\"normalized_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_identity_key_key": {
+          "name": "addresses_identity_key_key",
+          "columns": [
+            {
+              "expression": "identity_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"addresses\".\"identity_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_parent_address_id_idx": {
+          "name": "addresses_parent_address_id_idx",
+          "columns": [
+            {
+              "expression": "parent_address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_merged_into_address_id_idx": {
+          "name": "addresses_merged_into_address_id_idx",
+          "columns": [
+            {
+              "expression": "merged_into_address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"addresses\".\"merged_into_address_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_geo_gist": {
+          "name": "addresses_geo_gist",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "addresses_city_id_idx": {
+          "name": "addresses_city_id_idx",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_region_id_idx": {
+          "name": "addresses_region_id_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_country_id_idx": {
+          "name": "addresses_country_id_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_neighborhood_id_idx": {
+          "name": "addresses_neighborhood_id_idx",
+          "columns": [
+            {
+              "expression": "neighborhood_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_postal_code_country_idx": {
+          "name": "addresses_postal_code_country_idx",
+          "columns": [
+            {
+              "expression": "postal_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "country_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "addresses_street_trgm_idx": {
+          "name": "addresses_street_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"street\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "addresses_country_id_countries_id_fk": {
+          "name": "addresses_country_id_countries_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "addresses_region_id_regions_id_fk": {
+          "name": "addresses_region_id_regions_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "addresses_city_id_cities_id_fk": {
+          "name": "addresses_city_id_cities_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "addresses_neighborhood_id_neighborhoods_id_fk": {
+          "name": "addresses_neighborhood_id_neighborhoods_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "neighborhoods",
+          "columnsFrom": [
+            "neighborhood_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "addresses_parent_address_id_addresses_id_fk": {
+          "name": "addresses_parent_address_id_addresses_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "parent_address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "addresses_merged_into_address_id_addresses_id_fk": {
+          "name": "addresses_merged_into_address_id_addresses_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "merged_into_address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "addresses_address_level_check": {
+          "name": "addresses_address_level_check",
+          "value": "\"addresses\".\"address_level\" in ('STREET', 'BUILDING', 'UNIT')"
+        },
+        "addresses_coordinates_range_check": {
+          "name": "addresses_coordinates_range_check",
+          "value": "\"addresses\".\"longitude\" between -180 and 180 and \"addresses\".\"latitude\" between -90 and 90"
+        },
+        "addresses_parent_not_self_check": {
+          "name": "addresses_parent_not_self_check",
+          "value": "\"addresses\".\"parent_address_id\" <> \"addresses\".\"id\""
+        },
+        "addresses_merge_not_self_check": {
+          "name": "addresses_merge_not_self_check",
+          "value": "\"addresses\".\"merged_into_address_id\" <> \"addresses\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agencies": {
+      "name": "agencies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "agencies_normalized_name_key": {
+          "name": "agencies_normalized_name_key",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agencies_slug_key": {
+          "name": "agencies_slug_key",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agencies_name_trgm_idx": {
+          "name": "agencies_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agencies_normalized_name_not_empty_check": {
+          "name": "agencies_normalized_name_not_empty_check",
+          "value": "length(\"agencies\".\"normalized_name\") > 0"
+        },
+        "agencies_slug_not_empty_check": {
+          "name": "agencies_slug_not_empty_check",
+          "value": "length(\"agencies\".\"slug\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing": {
+      "name": "billing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plus_active": {
+          "name": "plus_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "plus_since": {
+          "name": "plus_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plus_canceled_at": {
+          "name": "plus_canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plus_stripe_subscription_id": {
+          "name": "plus_stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_credits": {
+          "name": "file_credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_payment_at": {
+          "name": "last_payment_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founder_supporter": {
+          "name": "founder_supporter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "founder_since": {
+          "name": "founder_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "billing_oxy_user_id_key": {
+          "name": "billing_oxy_user_id_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_plus_active_idx": {
+          "name": "billing_plus_active_idx",
+          "columns": [
+            {
+              "expression": "plus_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"billing\".\"plus_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_plus_stripe_subscription_id_key": {
+          "name": "billing_plus_stripe_subscription_id_key",
+          "columns": [
+            {
+              "expression": "plus_stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"billing\".\"plus_stripe_subscription_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_file_credits_non_negative_check": {
+          "name": "billing_file_credits_non_negative_check",
+          "value": "\"billing\".\"file_credits\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_processed_sessions": {
+      "name": "billing_processed_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "billing_id": {
+          "name": "billing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "billing_processed_sessions_key": {
+          "name": "billing_processed_sessions_key",
+          "columns": [
+            {
+              "expression": "billing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_processed_sessions_billing_id_billing_id_fk": {
+          "name": "billing_processed_sessions_billing_id_billing_id_fk",
+          "tableFrom": "billing_processed_sessions",
+          "tableTo": "billing",
+          "columnsFrom": [
+            "billing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cities": {
+      "name": "cities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "regexp_replace(\n    regexp_replace(\n      translate(replace(replace(replace(replace(replace(regexp_replace(lower(name), '[\\u0300-\\u036F]', '', 'g'), 'ß', 'ss'), 'æ', 'ae'), 'œ', 'oe'), 'þ', 'th'), 'ĳ', 'ij'), 'àáâãäåāăąçćčĉċďđðèéêëēĕėęěĝğġģĥħìíîïĩīĭįıĵķĺļľłñńņňòóôõöøōŏőŕŗřśŝşšșţťŧțùúûüũūŭůűųŵýÿŷźżž', 'aaaaaaaaacccccdddeeeeeeeeegggghhiiiiiiiiijkllllnnnnooooooooorrrsssssttttuuuuuuuuuuwyyyzzz'),\n      '[^a-z0-9]+', '-', 'g'\n    ),\n    '^-+|-+$', '', 'g'\n  )",
+            "type": "stored"
+          }
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_west": {
+          "name": "bbox_west",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_south": {
+          "name": "bbox_south",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_east": {
+          "name": "bbox_east",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_north": {
+          "name": "bbox_north",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "population": {
+          "name": "population",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "average_rent": {
+          "name": "average_rent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "properties_count": {
+          "name": "properties_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "cities_region_name_key": {
+          "name": "cities_region_name_key",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_country_id_idx": {
+          "name": "cities_country_id_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_active_popularity_idx": {
+          "name": "cities_active_popularity_idx",
+          "columns": [
+            {
+              "expression": "\"properties_count\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"cities\".\"is_active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_name_lower_idx": {
+          "name": "cities_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_region_name_lower_idx": {
+          "name": "cities_region_name_lower_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cities_name_trgm_idx": {
+          "name": "cities_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "cities_slug_idx": {
+          "name": "cities_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cities_country_id_countries_id_fk": {
+          "name": "cities_country_id_countries_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cities_region_id_regions_id_fk": {
+          "name": "cities_region_id_regions_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "cities_cover_image_id_images_id_fk": {
+          "name": "cities_cover_image_id_images_id_fk",
+          "tableFrom": "cities",
+          "tableTo": "images",
+          "columnsFrom": [
+            "cover_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cities_currency_check": {
+          "name": "cities_currency_check",
+          "value": "\"cities\".\"currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        },
+        "cities_bbox_complete_check": {
+          "name": "cities_bbox_complete_check",
+          "value": "(\n        \"cities\".\"bbox_west\" is null and \"cities\".\"bbox_south\" is null\n        and \"cities\".\"bbox_east\" is null and \"cities\".\"bbox_north\" is null\n      ) or (\n        \"cities\".\"bbox_west\" is not null and \"cities\".\"bbox_south\" is not null\n        and \"cities\".\"bbox_east\" is not null and \"cities\".\"bbox_north\" is not null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.commissions": {
+      "name": "commissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "partner_id": {
+          "name": "partner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "basis_offering": {
+          "name": "basis_offering",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "basis_deal_value": {
+          "name": "basis_deal_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "basis_kind": {
+          "name": "basis_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "basis_rate": {
+          "name": "basis_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basis_flat": {
+          "name": "basis_flat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "commissions_property_id_key": {
+          "name": "commissions_property_id_key",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commissions_partner_created_idx": {
+          "name": "commissions_partner_created_idx",
+          "columns": [
+            {
+              "expression": "partner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commissions_status_idx": {
+          "name": "commissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commissions_partner_id_partners_id_fk": {
+          "name": "commissions_partner_id_partners_id_fk",
+          "tableFrom": "commissions",
+          "tableTo": "partners",
+          "columnsFrom": [
+            "partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "commissions_property_id_properties_id_fk": {
+          "name": "commissions_property_id_properties_id_fk",
+          "tableFrom": "commissions",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "commissions_status_check": {
+          "name": "commissions_status_check",
+          "value": "\"commissions\".\"status\" in ('pending', 'approved', 'paid', 'cancelled')"
+        },
+        "commissions_basis_offering_check": {
+          "name": "commissions_basis_offering_check",
+          "value": "\"commissions\".\"basis_offering\" in ('rent', 'sale', 'exchange')"
+        },
+        "commissions_basis_kind_check": {
+          "name": "commissions_basis_kind_check",
+          "value": "\"commissions\".\"basis_kind\" in ('percentOfMonthlyRent', 'flat')"
+        },
+        "commissions_basis_components_check": {
+          "name": "commissions_basis_components_check",
+          "value": "(\n        \"commissions\".\"basis_kind\" = 'percentOfMonthlyRent'\n          and \"commissions\".\"basis_rate\" is not null and \"commissions\".\"basis_flat\" is null\n      ) or (\n        \"commissions\".\"basis_kind\" = 'flat'\n          and \"commissions\".\"basis_flat\" is not null and \"commissions\".\"basis_rate\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_message_attachments": {
+      "name": "conversation_message_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_message_attachments_message_id_idx": {
+          "name": "conversation_message_attachments_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_message_attachments_message_id_conversation_messages_id_fk": {
+          "name": "conversation_message_attachments_message_id_conversation_messages_id_fk",
+          "tableFrom": "conversation_message_attachments",
+          "tableTo": "conversation_messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_message_attachments_type_check": {
+          "name": "conversation_message_attachments_type_check",
+          "value": "\"conversation_message_attachments\".\"type\" in ('file', 'image', 'document')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_messages": {
+      "name": "conversation_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversation_messages_conversation_position_key": {
+          "name": "conversation_messages_conversation_position_key",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_messages_conversation_id_conversations_id_fk": {
+          "name": "conversation_messages_conversation_id_conversations_id_fk",
+          "tableFrom": "conversation_messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_messages_role_check": {
+          "name": "conversation_messages_role_check",
+          "value": "\"conversation_messages\".\"role\" in ('user', 'assistant', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "metadata_initial_message": {
+          "name": "metadata_initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_source": {
+          "name": "metadata_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "metadata_language": {
+          "name": "metadata_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "metadata_tags": {
+          "name": "metadata_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "sharing_is_shared": {
+          "name": "sharing_is_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharing_share_token": {
+          "name": "sharing_share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharing_shared_at": {
+          "name": "sharing_shared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharing_expires_at": {
+          "name": "sharing_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analytics_last_activity": {
+          "name": "analytics_last_activity",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analytics_total_tokens": {
+          "name": "analytics_total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "conversations_oxy_user_created_idx": {
+          "name": "conversations_oxy_user_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_oxy_user_status_updated_idx": {
+          "name": "conversations_oxy_user_status_updated_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_share_token_key": {
+          "name": "conversations_share_token_key",
+          "columns": [
+            {
+              "expression": "sharing_share_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversations\".\"sharing_share_token\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_sharing_expires_at_idx": {
+          "name": "conversations_sharing_expires_at_idx",
+          "columns": [
+            {
+              "expression": "sharing_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations\".\"sharing_expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_status_check": {
+          "name": "conversations_status_check",
+          "value": "\"conversations\".\"status\" in ('active', 'archived', 'deleted')"
+        },
+        "conversations_topic_check": {
+          "name": "conversations_topic_check",
+          "value": "\"conversations\".\"topic\" in ('rent', 'repairs', 'lease', 'rights', 'general')"
+        },
+        "conversations_metadata_source_check": {
+          "name": "conversations_metadata_source_check",
+          "value": "\"conversations\".\"metadata_source\" in ('quick_action', 'example', 'manual', 'url_share')"
+        },
+        "conversations_sharing_coherent_check": {
+          "name": "conversations_sharing_coherent_check",
+          "value": "(\n        \"conversations\".\"sharing_is_shared\"\n          and \"conversations\".\"sharing_share_token\" is not null\n          and \"conversations\".\"sharing_shared_at\" is not null\n          and \"conversations\".\"sharing_expires_at\" is not null\n      ) or (\n        not \"conversations\".\"sharing_is_shared\"\n          and \"conversations\".\"sharing_share_token\" is null\n          and \"conversations\".\"sharing_shared_at\" is null\n          and \"conversations\".\"sharing_expires_at\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.countries": {
+      "name": "countries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "flag": {
+          "name": "flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_locale": {
+          "name": "default_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "countries_code_key": {
+          "name": "countries_code_key",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "countries_name_lower_idx": {
+          "name": "countries_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "countries_currency_check": {
+          "name": "countries_currency_check",
+          "value": "\"countries\".\"currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_attendees": {
+      "name": "eviction_case_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rsvped_at": {
+          "name": "rsvped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_basis": {
+          "name": "confirmation_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "eviction_case_attendees_case_user_key": {
+          "name": "eviction_case_attendees_case_user_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_attendees_case_id_eviction_cases_id_fk": {
+          "name": "eviction_case_attendees_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_case_attendees",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_case_attendees_confirmation_check": {
+          "name": "eviction_case_attendees_confirmation_check",
+          "value": "(\"eviction_case_attendees\".\"confirmed_at\" is null) = (\"eviction_case_attendees\".\"confirmation_basis\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_followers": {
+      "name": "eviction_case_followers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_case_followers_case_user_key": {
+          "name": "eviction_case_followers_case_user_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_case_followers_user_idx": {
+          "name": "eviction_case_followers_user_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_followers_case_id_eviction_cases_id_fk": {
+          "name": "eviction_case_followers_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_case_followers",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_help_needs": {
+      "name": "eviction_case_help_needs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "need_type": {
+          "name": "need_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_case_help_needs_key": {
+          "name": "eviction_case_help_needs_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "need_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_case_help_needs_type_idx": {
+          "name": "eviction_case_help_needs_type_idx",
+          "columns": [
+            {
+              "expression": "need_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_help_needs_case_id_eviction_cases_id_fk": {
+          "name": "eviction_case_help_needs_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_case_help_needs",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_case_help_needs_type_check": {
+          "name": "eviction_case_help_needs_type_check",
+          "value": "\"eviction_case_help_needs\".\"need_type\" in ('presence', 'legal_support', 'translation', 'transport', 'temporary_housing', 'outreach', 'organization_contact')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_updates": {
+      "name": "eviction_case_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'note'"
+        },
+        "actor_oxy_user_id": {
+          "name": "actor_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_scheduled_at": {
+          "name": "new_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_case_updates_case_position_idx": {
+          "name": "eviction_case_updates_case_position_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"position\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_case_updates_case_position_key": {
+          "name": "eviction_case_updates_case_position_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_updates_case_id_eviction_cases_id_fk": {
+          "name": "eviction_case_updates_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_case_updates",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_case_updates_new_status_check": {
+          "name": "eviction_case_updates_new_status_check",
+          "value": "\"eviction_case_updates\".\"new_status\" in ('upcoming', 'stopped', 'postponed', 'executed', 'cancelled')"
+        },
+        "eviction_case_updates_event_type_check": {
+          "name": "eviction_case_updates_event_type_check",
+          "value": "\"eviction_case_updates\".\"event_type\" in ('case_created', 'date_changed', 'location_precision_changed', 'instructions_updated', 'postponed', 'stopped', 'executed', 'cancelled', 'legal_resource_added', 'organization_verified', 'correction_published', 'precautionary_hold_applied', 'note')"
+        },
+        "eviction_case_updates_position_check": {
+          "name": "eviction_case_updates_position_check",
+          "value": "\"eviction_case_updates\".\"position\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_cases": {
+      "name": "eviction_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_label": {
+          "name": "location_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_longitude": {
+          "name": "location_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_latitude": {
+          "name": "location_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_radius_meters": {
+          "name": "location_radius_meters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2500
+        },
+        "location_geo": {
+          "name": "location_geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "ST_MakePoint(location_longitude, location_latitude)::geography",
+            "type": "stored"
+          }
+        },
+        "location_precision": {
+          "name": "location_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approximate_radius'"
+        },
+        "location_city": {
+          "name": "location_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_country_code": {
+          "name": "location_country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_exact_longitude": {
+          "name": "location_exact_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_exact_latitude": {
+          "name": "location_exact_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_exact_address": {
+          "name": "location_exact_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_household_authorized_at": {
+          "name": "location_household_authorized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        },
+        "precautionary_hold_at": {
+          "name": "precautionary_hold_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disputed_at": {
+          "name": "disputed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agency_id": {
+          "name": "agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_telegram": {
+          "name": "contact_telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_whatsapp": {
+          "name": "contact_whatsapp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_instructions": {
+          "name": "contact_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_unlock_min_tenure_days": {
+          "name": "contact_unlock_min_tenure_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome_reminder_sent_at": {
+          "name": "outcome_reminder_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_cases_status_scheduled_idx": {
+          "name": "eviction_cases_status_scheduled_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_cases_oxy_user_created_idx": {
+          "name": "eviction_cases_oxy_user_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_cases_location_geo_gist": {
+          "name": "eviction_cases_location_geo_gist",
+          "columns": [
+            {
+              "expression": "location_geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "eviction_cases_updated_idx": {
+          "name": "eviction_cases_updated_idx",
+          "columns": [
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_cases_agency_id_idx": {
+          "name": "eviction_cases_agency_id_idx",
+          "columns": [
+            {
+              "expression": "agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"eviction_cases\".\"agency_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_cases_organization_id_idx": {
+          "name": "eviction_cases_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"eviction_cases\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_cases_agency_id_agencies_id_fk": {
+          "name": "eviction_cases_agency_id_agencies_id_fk",
+          "tableFrom": "eviction_cases",
+          "tableTo": "agencies",
+          "columnsFrom": [
+            "agency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "eviction_cases_organization_id_eviction_organizations_id_fk": {
+          "name": "eviction_cases_organization_id_eviction_organizations_id_fk",
+          "tableFrom": "eviction_cases",
+          "tableTo": "eviction_organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "eviction_cases_cover_image_id_images_id_fk": {
+          "name": "eviction_cases_cover_image_id_images_id_fk",
+          "tableFrom": "eviction_cases",
+          "tableTo": "images",
+          "columnsFrom": [
+            "cover_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_cases_status_check": {
+          "name": "eviction_cases_status_check",
+          "value": "\"eviction_cases\".\"status\" in ('upcoming', 'stopped', 'postponed', 'executed', 'cancelled')"
+        },
+        "eviction_cases_location_precision_check": {
+          "name": "eviction_cases_location_precision_check",
+          "value": "\"eviction_cases\".\"location_precision\" in ('street', 'neighborhood', 'approximate_radius')"
+        },
+        "eviction_cases_coordinates_range_check": {
+          "name": "eviction_cases_coordinates_range_check",
+          "value": "\"eviction_cases\".\"location_longitude\" between -180 and 180\n        and \"eviction_cases\".\"location_latitude\" between -90 and 90"
+        },
+        "eviction_cases_exact_coordinates_range_check": {
+          "name": "eviction_cases_exact_coordinates_range_check",
+          "value": "(\"eviction_cases\".\"location_exact_longitude\" is null\n            or \"eviction_cases\".\"location_exact_longitude\" between -180 and 180)\n        and (\"eviction_cases\".\"location_exact_latitude\" is null\n            or \"eviction_cases\".\"location_exact_latitude\" between -90 and 90)"
+        },
+        "eviction_cases_exact_location_authorized_check": {
+          "name": "eviction_cases_exact_location_authorized_check",
+          "value": "(\"eviction_cases\".\"location_exact_longitude\" is null) = (\"eviction_cases\".\"location_exact_latitude\" is null)\n        and (\n          \"eviction_cases\".\"location_household_authorized_at\" is not null\n          or (\"eviction_cases\".\"location_exact_longitude\" is null\n              and \"eviction_cases\".\"location_exact_address\" is null)\n        )"
+        },
+        "eviction_cases_radius_positive_check": {
+          "name": "eviction_cases_radius_positive_check",
+          "value": "\"eviction_cases\".\"location_radius_meters\" > 0"
+        },
+        "eviction_cases_contact_tenure_check": {
+          "name": "eviction_cases_contact_tenure_check",
+          "value": "\"eviction_cases\".\"contact_unlock_min_tenure_days\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_comments": {
+      "name": "eviction_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_comments_case_created_idx": {
+          "name": "eviction_comments_case_created_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_comments_oxy_user_id_idx": {
+          "name": "eviction_comments_oxy_user_id_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_comments_case_id_eviction_cases_id_fk": {
+          "name": "eviction_comments_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_comments",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_location_access_audit": {
+      "name": "eviction_location_access_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_oxy_user_id": {
+          "name": "actor_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denial_reason": {
+          "name": "denial_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_location_access_audit_case_created_idx": {
+          "name": "eviction_location_access_audit_case_created_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_location_access_audit_case_id_eviction_cases_id_fk": {
+          "name": "eviction_location_access_audit_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_location_access_audit",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_location_access_audit_action_check": {
+          "name": "eviction_location_access_audit_action_check",
+          "value": "\"eviction_location_access_audit\".\"action\" in ('granted', 'revoked', 'read', 'denied')"
+        },
+        "eviction_location_access_audit_denial_check": {
+          "name": "eviction_location_access_audit_denial_check",
+          "value": "(\"eviction_location_access_audit\".\"action\" = 'denied') = (\"eviction_location_access_audit\".\"denial_reason\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_location_grants": {
+      "name": "eviction_location_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_oxy_user_id": {
+          "name": "grantee_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by_oxy_user_id": {
+          "name": "granted_by_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "eviction_location_grants_live_key": {
+          "name": "eviction_location_grants_live_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grantee_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"eviction_location_grants\".\"revoked_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_location_grants_case_idx": {
+          "name": "eviction_location_grants_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_location_grants_case_id_eviction_cases_id_fk": {
+          "name": "eviction_location_grants_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_location_grants",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_location_grants_purpose_check": {
+          "name": "eviction_location_grants_purpose_check",
+          "value": "\"eviction_location_grants\".\"purpose\" in ('legal_representation', 'accompaniment', 'emergency_housing')"
+        },
+        "eviction_location_grants_window_check": {
+          "name": "eviction_location_grants_window_check",
+          "value": "\"eviction_location_grants\".\"expires_at\" > \"eviction_location_grants\".\"granted_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_organizations": {
+      "name": "eviction_organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_channels": {
+          "name": "public_channels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_source": {
+          "name": "verification_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_organizations_normalized_name_key": {
+          "name": "eviction_organizations_normalized_name_key",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_organizations_verified_source_check": {
+          "name": "eviction_organizations_verified_source_check",
+          "value": "\"eviction_organizations\".\"verified_at\" is null or \"eviction_organizations\".\"verification_source\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_reports": {
+      "name": "eviction_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_oxy_user_id": {
+          "name": "reporter_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_reports_status_created_idx": {
+          "name": "eviction_reports_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_reports_case_status_idx": {
+          "name": "eviction_reports_case_status_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_reports_open_reporter_key": {
+          "name": "eviction_reports_open_reporter_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"eviction_reports\".\"status\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_reports_case_id_eviction_cases_id_fk": {
+          "name": "eviction_reports_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_reports",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_reports_reason_check": {
+          "name": "eviction_reports_reason_check",
+          "value": "\"eviction_reports\".\"reason\" in ('false_information', 'personal_data_exposed', 'location_too_precise', 'outdated', 'harassment', 'spam', 'dangerous_contact')"
+        },
+        "eviction_reports_status_check": {
+          "name": "eviction_reports_status_check",
+          "value": "\"eviction_reports\".\"status\" in ('open', 'reviewing', 'resolved', 'dismissed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_supporter_vouches": {
+      "name": "eviction_supporter_vouches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voucher_oxy_user_id": {
+          "name": "voucher_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vouched_oxy_user_id": {
+          "name": "vouched_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_supporter_vouches_key": {
+          "name": "eviction_supporter_vouches_key",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "voucher_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vouched_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_supporter_vouches_vouched_idx": {
+          "name": "eviction_supporter_vouches_vouched_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vouched_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_supporter_vouches_case_id_eviction_cases_id_fk": {
+          "name": "eviction_supporter_vouches_case_id_eviction_cases_id_fk",
+          "tableFrom": "eviction_supporter_vouches",
+          "tableTo": "eviction_cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "eviction_supporter_vouches_distinct_check": {
+          "name": "eviction_supporter_vouches_distinct_check",
+          "value": "\"eviction_supporter_vouches\".\"voucher_oxy_user_id\" <> \"eviction_supporter_vouches\".\"vouched_oxy_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.eviction_update_notifications": {
+      "name": "eviction_update_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "update_id": {
+          "name": "update_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_oxy_user_id": {
+          "name": "recipient_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "eviction_update_notifications_key": {
+          "name": "eviction_update_notifications_key",
+          "columns": [
+            {
+              "expression": "update_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_update_notifications_update_id_eviction_case_updates_id_fk": {
+          "name": "eviction_update_notifications_update_id_eviction_case_updates_id_fk",
+          "tableFrom": "eviction_update_notifications",
+          "tableTo": "eviction_case_updates",
+          "columnsFrom": [
+            "update_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exchange_requests": {
+      "name": "exchange_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_oxy_user_id": {
+          "name": "requester_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_oxy_user_id": {
+          "name": "host_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offered_property_id": {
+          "name": "offered_property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_window_start": {
+          "name": "requested_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_window_end": {
+          "name": "requested_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "offered_window_start": {
+          "name": "offered_window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offered_window_end": {
+          "name": "offered_window_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "exchange_requests_requested_window_gist": {
+          "name": "exchange_requests_requested_window_gist",
+          "columns": [
+            {
+              "expression": "tstzrange(\"requested_window_start\", \"requested_window_end\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "exchange_requests_property_status_idx": {
+          "name": "exchange_requests_property_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exchange_requests_requester_status_created_idx": {
+          "name": "exchange_requests_requester_status_created_idx",
+          "columns": [
+            {
+              "expression": "requester_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exchange_requests_host_status_created_idx": {
+          "name": "exchange_requests_host_status_created_idx",
+          "columns": [
+            {
+              "expression": "host_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_requests_property_id_properties_id_fk": {
+          "name": "exchange_requests_property_id_properties_id_fk",
+          "tableFrom": "exchange_requests",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "exchange_requests_offered_property_id_properties_id_fk": {
+          "name": "exchange_requests_offered_property_id_properties_id_fk",
+          "tableFrom": "exchange_requests",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "offered_property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exchange_requests_mode_check": {
+          "name": "exchange_requests_mode_check",
+          "value": "\"exchange_requests\".\"mode\" in ('swap', 'host', 'both')"
+        },
+        "exchange_requests_status_check": {
+          "name": "exchange_requests_status_check",
+          "value": "\"exchange_requests\".\"status\" in ('pending', 'confirmed', 'declined', 'cancelled', 'completed')"
+        },
+        "exchange_requests_requested_window_order_check": {
+          "name": "exchange_requests_requested_window_order_check",
+          "value": "\"exchange_requests\".\"requested_window_end\" > \"exchange_requests\".\"requested_window_start\""
+        },
+        "exchange_requests_offered_window_check": {
+          "name": "exchange_requests_offered_window_check",
+          "value": "(\n        \"exchange_requests\".\"offered_window_start\" is null and \"exchange_requests\".\"offered_window_end\" is null\n      ) or (\n        \"exchange_requests\".\"offered_window_start\" is not null and \"exchange_requests\".\"offered_window_end\" is not null\n          and \"exchange_requests\".\"offered_window_end\" > \"exchange_requests\".\"offered_window_start\"\n      )"
+        },
+        "exchange_requests_host_mode_offers_nothing_check": {
+          "name": "exchange_requests_host_mode_offers_nothing_check",
+          "value": "\"exchange_requests\".\"mode\" <> 'host' or (\n        \"exchange_requests\".\"offered_property_id\" is null\n        and \"exchange_requests\".\"offered_window_start\" is null\n        and \"exchange_requests\".\"offered_window_end\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.exchange_reviews": {
+      "name": "exchange_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "exchange_request_id": {
+          "name": "exchange_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_oxy_user_id": {
+          "name": "reviewer_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_oxy_user_id": {
+          "name": "subject_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories_communication": {
+          "name": "categories_communication",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories_cleanliness": {
+          "name": "categories_cleanliness",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories_accuracy": {
+          "name": "categories_accuracy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories_hospitality": {
+          "name": "categories_hospitality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "exchange_reviews_request_reviewer_key": {
+          "name": "exchange_reviews_request_reviewer_key",
+          "columns": [
+            {
+              "expression": "exchange_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reviewer_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "exchange_reviews_subject_created_idx": {
+          "name": "exchange_reviews_subject_created_idx",
+          "columns": [
+            {
+              "expression": "subject_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_reviews_exchange_request_id_exchange_requests_id_fk": {
+          "name": "exchange_reviews_exchange_request_id_exchange_requests_id_fk",
+          "tableFrom": "exchange_reviews",
+          "tableTo": "exchange_requests",
+          "columnsFrom": [
+            "exchange_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "exchange_reviews_rating_check": {
+          "name": "exchange_reviews_rating_check",
+          "value": "\"exchange_reviews\".\"rating\" between 1 and 5"
+        },
+        "exchange_reviews_categories_range_check": {
+          "name": "exchange_reviews_categories_range_check",
+          "value": "(\"exchange_reviews\".\"categories_communication\" is null or \"exchange_reviews\".\"categories_communication\" between 1 and 5)\n        and (\"exchange_reviews\".\"categories_cleanliness\" is null or \"exchange_reviews\".\"categories_cleanliness\" between 1 and 5)\n        and (\"exchange_reviews\".\"categories_accuracy\" is null or \"exchange_reviews\".\"categories_accuracy\" between 1 and 5)\n        and (\"exchange_reviews\".\"categories_hospitality\" is null or \"exchange_reviews\".\"categories_hospitality\" between 1 and 5)"
+        },
+        "exchange_reviews_distinct_parties_check": {
+          "name": "exchange_reviews_distinct_parties_check",
+          "value": "\"exchange_reviews\".\"reviewer_oxy_user_id\" <> \"exchange_reviews\".\"subject_oxy_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.housing_alerts": {
+      "name": "housing_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watch_id": {
+          "name": "watch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_type": {
+          "name": "rule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cooldown_bucket": {
+          "name": "cooldown_bucket",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_state": {
+          "name": "delivery_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "suppression_reason": {
+          "name": "suppression_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_channels": {
+          "name": "delivered_channels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "housing_alerts_idempotency_key": {
+          "name": "housing_alerts_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_alerts_cooldown_key": {
+          "name": "housing_alerts_cooldown_key",
+          "columns": [
+            {
+              "expression": "watch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rule_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cooldown_bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_alerts_owner_created_idx": {
+          "name": "housing_alerts_owner_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_alerts_watch_created_idx": {
+          "name": "housing_alerts_watch_created_idx",
+          "columns": [
+            {
+              "expression": "watch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_alerts_pending_idx": {
+          "name": "housing_alerts_pending_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_alerts\".\"delivery_state\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "housing_alerts_watch_id_saved_searches_id_fk": {
+          "name": "housing_alerts_watch_id_saved_searches_id_fk",
+          "tableFrom": "housing_alerts",
+          "tableTo": "saved_searches",
+          "columnsFrom": [
+            "watch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "housing_alerts_event_id_housing_domain_events_id_fk": {
+          "name": "housing_alerts_event_id_housing_domain_events_id_fk",
+          "tableFrom": "housing_alerts",
+          "tableTo": "housing_domain_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "housing_alerts_notification_id_notifications_id_fk": {
+          "name": "housing_alerts_notification_id_notifications_id_fk",
+          "tableFrom": "housing_alerts",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "housing_alerts_rule_type_check": {
+          "name": "housing_alerts_rule_type_check",
+          "value": "\"housing_alerts\".\"rule_type\" in ('new_listing', 'price_decrease', 'price_increase', 'cost_terms_changed', 'listing_removed', 'listing_reappeared', 'new_review', 'eviction_nearby', 'source_conflict')"
+        },
+        "housing_alerts_subject_type_check": {
+          "name": "housing_alerts_subject_type_check",
+          "value": "\"housing_alerts\".\"subject_type\" in ('property', 'address', 'eviction', 'review')"
+        },
+        "housing_alerts_delivery_state_check": {
+          "name": "housing_alerts_delivery_state_check",
+          "value": "\"housing_alerts\".\"delivery_state\" in ('pending', 'delivered', 'suppressed', 'failed')"
+        },
+        "housing_alerts_suppression_reason_check": {
+          "name": "housing_alerts_suppression_reason_check",
+          "value": "\"housing_alerts\".\"suppression_reason\" is null or \"housing_alerts\".\"suppression_reason\" in ('muted', 'cadence_off', 'channel_unavailable', 'rate_limited')"
+        },
+        "housing_alerts_suppression_coherence_check": {
+          "name": "housing_alerts_suppression_coherence_check",
+          "value": "(\"housing_alerts\".\"delivery_state\" = 'suppressed') = (\"housing_alerts\".\"suppression_reason\" is not null)"
+        },
+        "housing_alerts_delivered_channels_check": {
+          "name": "housing_alerts_delivered_channels_check",
+          "value": "\"housing_alerts\".\"delivery_state\" <> 'delivered' or cardinality(\"housing_alerts\".\"delivered_channels\") >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.housing_domain_events": {
+      "name": "housing_domain_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition": {
+          "name": "transition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "case when longitude is null or latitude is null then null\n          else ST_MakePoint(longitude, latitude)::geography end",
+            "type": "stored"
+          }
+        },
+        "is_backfill": {
+          "name": "is_backfill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "housing_domain_events_unprocessed_idx": {
+          "name": "housing_domain_events_unprocessed_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_domain_events\".\"processed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_domain_events_geo_gist": {
+          "name": "housing_domain_events_geo_gist",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_domain_events\".\"geo\" is not null",
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "housing_domain_events_subject_idx": {
+          "name": "housing_domain_events_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_domain_events_expires_at_idx": {
+          "name": "housing_domain_events_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_domain_events\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "housing_domain_events_type_check": {
+          "name": "housing_domain_events_type_check",
+          "value": "\"housing_domain_events\".\"type\" in ('new_listing', 'price_decrease', 'price_increase', 'cost_terms_changed', 'listing_removed', 'listing_reappeared', 'new_review', 'eviction_nearby', 'source_conflict')"
+        },
+        "housing_domain_events_subject_type_check": {
+          "name": "housing_domain_events_subject_type_check",
+          "value": "\"housing_domain_events\".\"subject_type\" in ('property', 'address', 'eviction', 'review')"
+        },
+        "housing_domain_events_coordinate_pair_check": {
+          "name": "housing_domain_events_coordinate_pair_check",
+          "value": "(\"housing_domain_events\".\"longitude\" is null) = (\"housing_domain_events\".\"latitude\" is null)"
+        },
+        "housing_domain_events_coordinate_range_check": {
+          "name": "housing_domain_events_coordinate_range_check",
+          "value": "\"housing_domain_events\".\"longitude\" is null or (\n        \"housing_domain_events\".\"longitude\" between -180 and 180 and \"housing_domain_events\".\"latitude\" between -90 and 90\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.housing_watch_rules": {
+      "name": "housing_watch_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "watch_id": {
+          "name": "watch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "housing_watch_rules_watch_type_key": {
+          "name": "housing_watch_rules_watch_type_key",
+          "columns": [
+            {
+              "expression": "watch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "housing_watch_rules_type_enabled_idx": {
+          "name": "housing_watch_rules_type_enabled_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"housing_watch_rules\".\"enabled\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "housing_watch_rules_watch_id_saved_searches_id_fk": {
+          "name": "housing_watch_rules_watch_id_saved_searches_id_fk",
+          "tableFrom": "housing_watch_rules",
+          "tableTo": "saved_searches",
+          "columnsFrom": [
+            "watch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "housing_watch_rules_type_check": {
+          "name": "housing_watch_rules_type_check",
+          "value": "\"housing_watch_rules\".\"type\" in ('new_listing', 'price_decrease', 'price_increase', 'cost_terms_changed', 'listing_removed', 'listing_reappeared', 'new_review', 'eviction_nearby', 'source_conflict')"
+        },
+        "housing_watch_rules_threshold_check": {
+          "name": "housing_watch_rules_threshold_check",
+          "value": "threshold is null or (threshold >= 0 and threshold <= 1000)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keys_original": {
+          "name": "keys_original",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keys_small": {
+          "name": "keys_small",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keys_medium": {
+          "name": "keys_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keys_large": {
+          "name": "keys_large",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urls_original": {
+          "name": "urls_original",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urls_small": {
+          "name": "urls_small",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urls_medium": {
+          "name": "urls_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urls_large": {
+          "name": "urls_large",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "images_entity_order_idx": {
+          "name": "images_entity_order_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "images_entity_type_check": {
+          "name": "images_entity_type_check",
+          "value": "\"images\".\"entity_type\" in ('property', 'city', 'region', 'country', 'profile')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.jurisdiction_resources": {
+      "name": "jurisdiction_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "jurisdiction_resources_country_type_idx": {
+          "name": "jurisdiction_resources_country_type_idx",
+          "columns": [
+            {
+              "expression": "country_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jurisdiction_resources_region_idx": {
+          "name": "jurisdiction_resources_region_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"jurisdiction_resources\".\"region_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "jurisdiction_resources_country_url_key": {
+          "name": "jurisdiction_resources_country_url_key",
+          "columns": [
+            {
+              "expression": "country_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "jurisdiction_resources_region_id_regions_id_fk": {
+          "name": "jurisdiction_resources_region_id_regions_id_fk",
+          "tableFrom": "jurisdiction_resources",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "jurisdiction_resources_type_check": {
+          "name": "jurisdiction_resources_type_check",
+          "value": "\"jurisdiction_resources\".\"resource_type\" in ('legal_aid', 'tenant_union', 'emergency_housing', 'official_info')"
+        },
+        "jurisdiction_resources_languages_check": {
+          "name": "jurisdiction_resources_languages_check",
+          "value": "cardinality(\"jurisdiction_resources\".\"languages\") >= 1"
+        },
+        "jurisdiction_resources_validity_check": {
+          "name": "jurisdiction_resources_validity_check",
+          "value": "\"jurisdiction_resources\".\"valid_until\" is null or \"jurisdiction_resources\".\"valid_until\" > \"jurisdiction_resources\".\"verified_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_co_tenants": {
+      "name": "lease_co_tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'secondary'"
+        },
+        "signed_date": {
+          "name": "signed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "lease_co_tenants_lease_id_idx": {
+          "name": "lease_co_tenants_lease_id_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_co_tenants_lease_id_leases_id_fk": {
+          "name": "lease_co_tenants_lease_id_leases_id_fk",
+          "tableFrom": "lease_co_tenants",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_co_tenants_role_check": {
+          "name": "lease_co_tenants_role_check",
+          "value": "\"lease_co_tenants\".\"role\" in ('primary', 'secondary', 'guarantor')"
+        },
+        "lease_co_tenants_status_check": {
+          "name": "lease_co_tenants_status_check",
+          "value": "\"lease_co_tenants\".\"status\" in ('pending', 'signed', 'declined')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_documents": {
+      "name": "lease_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "uploaded_by_oxy_user_id": {
+          "name": "uploaded_by_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_date": {
+          "name": "uploaded_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lease_documents_lease_id_idx": {
+          "name": "lease_documents_lease_id_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_documents_lease_id_leases_id_fk": {
+          "name": "lease_documents_lease_id_leases_id_fk",
+          "tableFrom": "lease_documents",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_documents_type_check": {
+          "name": "lease_documents_type_check",
+          "value": "\"lease_documents\".\"type\" in ('lease_agreement', 'addendum', 'inspection_report', 'insurance', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_inspection_findings": {
+      "name": "lease_inspection_findings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inspection_id": {
+          "name": "inspection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area": {
+          "name": "area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        }
+      },
+      "indexes": {
+        "lease_inspection_findings_inspection_id_idx": {
+          "name": "lease_inspection_findings_inspection_id_idx",
+          "columns": [
+            {
+              "expression": "inspection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_inspection_findings_inspection_id_lease_inspections_id_fk": {
+          "name": "lease_inspection_findings_inspection_id_lease_inspections_id_fk",
+          "tableFrom": "lease_inspection_findings",
+          "tableTo": "lease_inspections",
+          "columnsFrom": [
+            "inspection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_inspection_findings_condition_check": {
+          "name": "lease_inspection_findings_condition_check",
+          "value": "\"lease_inspection_findings\".\"condition\" in ('excellent', 'good', 'fair', 'poor', 'needs_repair')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_inspections": {
+      "name": "lease_inspections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inspector": {
+          "name": "inspector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_by_tenant": {
+          "name": "signed_by_tenant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signed_by_landlord": {
+          "name": "signed_by_landlord",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "lease_inspections_lease_id_idx": {
+          "name": "lease_inspections_lease_id_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_inspections_lease_id_leases_id_fk": {
+          "name": "lease_inspections_lease_id_leases_id_fk",
+          "tableFrom": "lease_inspections",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_inspections_type_check": {
+          "name": "lease_inspections_type_check",
+          "value": "\"lease_inspections\".\"type\" in ('move_in', 'move_out', 'periodic', 'maintenance')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_payment_schedule": {
+      "name": "lease_payment_schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "paid_date": {
+          "name": "paid_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lease_payment_schedule_lease_due_idx": {
+          "name": "lease_payment_schedule_lease_due_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lease_payment_schedule_due_status_idx": {
+          "name": "lease_payment_schedule_due_status_idx",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_payment_schedule_lease_id_leases_id_fk": {
+          "name": "lease_payment_schedule_lease_id_leases_id_fk",
+          "tableFrom": "lease_payment_schedule",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_payment_schedule_type_check": {
+          "name": "lease_payment_schedule_type_check",
+          "value": "\"lease_payment_schedule\".\"type\" in ('rent', 'deposit', 'fee', 'utility')"
+        },
+        "lease_payment_schedule_status_check": {
+          "name": "lease_payment_schedule_status_check",
+          "value": "\"lease_payment_schedule\".\"status\" in ('pending', 'paid', 'overdue', 'cancelled')"
+        },
+        "lease_payment_schedule_method_check": {
+          "name": "lease_payment_schedule_method_check",
+          "value": "\"lease_payment_schedule\".\"payment_method\" in ('cash', 'check', 'bank_transfer', 'credit_card', 'debit_card', 'digital_wallet')"
+        },
+        "lease_payment_schedule_paid_evidence_check": {
+          "name": "lease_payment_schedule_paid_evidence_check",
+          "value": "(\n        \"lease_payment_schedule\".\"status\" = 'paid'\n          and \"lease_payment_schedule\".\"paid_date\" is not null and \"lease_payment_schedule\".\"paid_amount\" is not null\n      ) or (\n        \"lease_payment_schedule\".\"status\" <> 'paid'\n          and \"lease_payment_schedule\".\"paid_date\" is null and \"lease_payment_schedule\".\"paid_amount\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lease_shared_utility_costs": {
+      "name": "lease_shared_utility_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lease_id": {
+          "name": "lease_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "utility": {
+          "name": "utility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "split_percentage": {
+          "name": "split_percentage",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lease_shared_utility_costs_lease_id_idx": {
+          "name": "lease_shared_utility_costs_lease_id_idx",
+          "columns": [
+            {
+              "expression": "lease_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lease_shared_utility_costs_lease_id_leases_id_fk": {
+          "name": "lease_shared_utility_costs_lease_id_leases_id_fk",
+          "tableFrom": "lease_shared_utility_costs",
+          "tableTo": "leases",
+          "columnsFrom": [
+            "lease_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lease_shared_utility_costs_utility_check": {
+          "name": "lease_shared_utility_costs_utility_check",
+          "value": "\"lease_shared_utility_costs\".\"utility\" in ('electricity', 'gas', 'water', 'trash', 'internet', 'cable', 'heat', 'air_conditioning')"
+        },
+        "lease_shared_utility_costs_split_check": {
+          "name": "lease_shared_utility_costs_split_check",
+          "value": "\"lease_shared_utility_costs\".\"split_percentage\" between 0 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.leases": {
+      "name": "leases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landlord_oxy_user_id": {
+          "name": "landlord_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_oxy_user_id": {
+          "name": "tenant_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_terms_start_date": {
+          "name": "lease_terms_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_terms_end_date": {
+          "name": "lease_terms_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_terms_renewal_options": {
+          "name": "lease_terms_renewal_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "lease_terms_renewal_notice_required": {
+          "name": "lease_terms_renewal_notice_required",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "lease_terms_termination_notice_required": {
+          "name": "lease_terms_termination_notice_required",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "rent_details_monthly_rent": {
+          "name": "rent_details_monthly_rent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rent_details_currency": {
+          "name": "rent_details_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "rent_details_due_date": {
+          "name": "rent_details_due_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "rent_details_late_fee_amount": {
+          "name": "rent_details_late_fee_amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rent_details_late_fee_grace_period": {
+          "name": "rent_details_late_fee_grace_period",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "rent_details_security_deposit": {
+          "name": "rent_details_security_deposit",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rent_details_pet_deposit": {
+          "name": "rent_details_pet_deposit",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "utilities_included": {
+          "name": "utilities_included",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "utilities_tenant_responsible": {
+          "name": "utilities_tenant_responsible",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rules_pets_allowed": {
+          "name": "rules_pets_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_pets_types": {
+          "name": "rules_pets_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rules_pets_max_number": {
+          "name": "rules_pets_max_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rules_pets_restrictions": {
+          "name": "rules_pets_restrictions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rules_smoking": {
+          "name": "rules_smoking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_guests_overnight_allowed": {
+          "name": "rules_guests_overnight_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rules_guests_overnight_max_consecutive_days": {
+          "name": "rules_guests_overnight_max_consecutive_days",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "rules_guests_overnight_max_days_per_month": {
+          "name": "rules_guests_overnight_max_days_per_month",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "rules_guests_parties": {
+          "name": "rules_guests_parties",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_subletting": {
+          "name": "rules_subletting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_alterations": {
+          "name": "rules_alterations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signatures_landlord_signed": {
+          "name": "signatures_landlord_signed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signatures_landlord_signed_date": {
+          "name": "signatures_landlord_signed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatures_landlord_digital_signature": {
+          "name": "signatures_landlord_digital_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatures_tenant_signed": {
+          "name": "signatures_tenant_signed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signatures_tenant_signed_date": {
+          "name": "signatures_tenant_signed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatures_tenant_digital_signature": {
+          "name": "signatures_tenant_digital_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_given_by_oxy_user_id": {
+          "name": "termination_notice_given_by_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_given_date": {
+          "name": "termination_notice_given_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_effective_date": {
+          "name": "termination_notice_effective_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_reason": {
+          "name": "termination_notice_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_notice_acknowledged": {
+          "name": "termination_notice_acknowledged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "termination_notice_acknowledged_date": {
+          "name": "termination_notice_acknowledged_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "leases_property_status_idx": {
+          "name": "leases_property_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "leases_landlord_status_idx": {
+          "name": "leases_landlord_status_idx",
+          "columns": [
+            {
+              "expression": "landlord_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "leases_tenant_status_idx": {
+          "name": "leases_tenant_status_idx",
+          "columns": [
+            {
+              "expression": "tenant_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "leases_term_range_gist": {
+          "name": "leases_term_range_gist",
+          "columns": [
+            {
+              "expression": "tstzrange(\"lease_terms_start_date\", \"lease_terms_end_date\", '[]')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "leases_active_end_date_idx": {
+          "name": "leases_active_end_date_idx",
+          "columns": [
+            {
+              "expression": "lease_terms_end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"leases\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "leases_property_id_properties_id_fk": {
+          "name": "leases_property_id_properties_id_fk",
+          "tableFrom": "leases",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "leases_room_id_properties_id_fk": {
+          "name": "leases_room_id_properties_id_fk",
+          "tableFrom": "leases",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "leases_status_check": {
+          "name": "leases_status_check",
+          "value": "\"leases\".\"status\" in ('draft', 'pending_signatures', 'active', 'expired', 'terminated', 'cancelled')"
+        },
+        "leases_renewal_options_check": {
+          "name": "leases_renewal_options_check",
+          "value": "\"leases\".\"lease_terms_renewal_options\" in ('none', 'automatic', 'optional')"
+        },
+        "leases_rent_currency_check": {
+          "name": "leases_rent_currency_check",
+          "value": "\"leases\".\"rent_details_currency\" in ('USD', 'EUR', 'GBP', 'CAD')"
+        },
+        "leases_utilities_included_check": {
+          "name": "leases_utilities_included_check",
+          "value": "\"leases\".\"utilities_included\" <@ array['electricity', 'gas', 'water', 'trash', 'internet', 'cable', 'heat', 'air_conditioning']::text[]"
+        },
+        "leases_utilities_tenant_responsible_check": {
+          "name": "leases_utilities_tenant_responsible_check",
+          "value": "\"leases\".\"utilities_tenant_responsible\" <@ array['electricity', 'gas', 'water', 'trash', 'internet', 'cable', 'heat', 'air_conditioning']::text[]"
+        },
+        "leases_rules_pets_types_check": {
+          "name": "leases_rules_pets_types_check",
+          "value": "\"leases\".\"rules_pets_types\" <@ array['dog', 'cat', 'bird', 'fish', 'reptile', 'other']::text[]"
+        },
+        "leases_rent_due_date_check": {
+          "name": "leases_rent_due_date_check",
+          "value": "\"leases\".\"rent_details_due_date\" between 1 and 31"
+        },
+        "leases_term_order_check": {
+          "name": "leases_term_order_check",
+          "value": "\"leases\".\"lease_terms_end_date\" > \"leases\".\"lease_terms_start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.listing_reports": {
+      "name": "listing_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_oxy_user_id": {
+          "name": "reporter_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "listing_reports_status_created_idx": {
+          "name": "listing_reports_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listing_reports_property_status_idx": {
+          "name": "listing_reports_property_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listing_reports_open_reporter_key": {
+          "name": "listing_reports_open_reporter_key",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporter_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"listing_reports\".\"status\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listing_reports_property_id_properties_id_fk": {
+          "name": "listing_reports_property_id_properties_id_fk",
+          "tableFrom": "listing_reports",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "listing_reports_reason_check": {
+          "name": "listing_reports_reason_check",
+          "value": "\"listing_reports\".\"reason\" in ('inaccurate', 'scam', 'inappropriate', 'unavailable', 'privacy', 'unsafe', 'other')"
+        },
+        "listing_reports_status_check": {
+          "name": "listing_reports_status_check",
+          "value": "\"listing_reports\".\"status\" in ('open', 'reviewing', 'resolved', 'dismissed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_enforcements": {
+      "name": "moderation_enforcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_action": {
+          "name": "recommended_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_reason": {
+          "name": "skipped_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state_property_moderation_restricted": {
+          "name": "previous_state_property_moderation_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state_review_moderation_status": {
+          "name": "previous_state_review_moderation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_enforcements_decision_action_key": {
+          "name": "moderation_enforcements_decision_action_key",
+          "columns": [
+            {
+              "expression": "decision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_enforcements_subject_created_idx": {
+          "name": "moderation_enforcements_subject_created_idx",
+          "columns": [
+            {
+              "expression": "subject_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_enforcements_case_id_idx": {
+          "name": "moderation_enforcements_case_id_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_enforcements_action_check": {
+          "name": "moderation_enforcements_action_check",
+          "value": "\"moderation_enforcements\".\"action\" in ('none', 'restrict', 'restore', 'flag_for_review', 'unflag', 'manual_review')"
+        },
+        "moderation_enforcements_mode_check": {
+          "name": "moderation_enforcements_mode_check",
+          "value": "\"moderation_enforcements\".\"mode\" in ('observe', 'manual', 'automatic')"
+        },
+        "moderation_enforcements_previous_review_status_check": {
+          "name": "moderation_enforcements_previous_review_status_check",
+          "value": "\"moderation_enforcements\".\"previous_state_review_moderation_status\" in ('active', 'under_review', 'removed')"
+        },
+        "moderation_enforcements_decision_revision_check": {
+          "name": "moderation_enforcements_decision_revision_check",
+          "value": "\"moderation_enforcements\".\"decision_revision\" >= 1"
+        },
+        "moderation_enforcements_applied_at_check": {
+          "name": "moderation_enforcements_applied_at_check",
+          "value": "\"moderation_enforcements\".\"applied\" = (\"moderation_enforcements\".\"applied_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_events": {
+      "name": "moderation_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claimed'"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_events_case_id_idx": {
+          "name": "moderation_events_case_id_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"moderation_events\".\"case_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_events_expires_at_idx": {
+          "name": "moderation_events_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_events_state_received_idx": {
+          "name": "moderation_events_state_received_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_events_state_check": {
+          "name": "moderation_events_state_check",
+          "value": "\"moderation_events\".\"state\" in ('claimed', 'queued', 'ignored')"
+        },
+        "moderation_events_queued_at_check": {
+          "name": "moderation_events_queued_at_check",
+          "value": "(\"moderation_events\".\"state\" = 'queued') = (\"moderation_events\".\"queued_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_outbox": {
+      "name": "moderation_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_id": {
+          "name": "report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_outbox_due_idx": {
+          "name": "moderation_outbox_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_outbox_lease_idx": {
+          "name": "moderation_outbox_lease_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_outbox_expires_at_idx": {
+          "name": "moderation_outbox_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_outbox_report_id_moderation_reports_id_fk": {
+          "name": "moderation_outbox_report_id_moderation_reports_id_fk",
+          "tableFrom": "moderation_outbox",
+          "tableTo": "moderation_reports",
+          "columnsFrom": [
+            "report_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_outbox_kind_check": {
+          "name": "moderation_outbox_kind_check",
+          "value": "\"moderation_outbox\".\"kind\" in ('report.submit', 'decision.apply')"
+        },
+        "moderation_outbox_status_check": {
+          "name": "moderation_outbox_status_check",
+          "value": "\"moderation_outbox\".\"status\" in ('pending', 'processing', 'processed', 'dead_letter')"
+        },
+        "moderation_outbox_attempts_check": {
+          "name": "moderation_outbox_attempts_check",
+          "value": "\"moderation_outbox\".\"attempts\" >= 0"
+        },
+        "moderation_outbox_lease_pair_check": {
+          "name": "moderation_outbox_lease_pair_check",
+          "value": "(\"moderation_outbox\".\"lease_owner\" is null) = (\"moderation_outbox\".\"lease_until\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_reports": {
+      "name": "moderation_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reported_type": {
+          "name": "reported_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_id": {
+          "name": "reported_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_oxy_user_id": {
+          "name": "reporter_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_status": {
+          "name": "local_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "local_status_reason": {
+          "name": "local_status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_report_id": {
+          "name": "crowd_source_report_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_case_id": {
+          "name": "crowd_source_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crowd_source_merged": {
+          "name": "crowd_source_merged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_outcome": {
+          "name": "decision_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_status": {
+          "name": "decision_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforced_action": {
+          "name": "enforced_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforced_at": {
+          "name": "enforced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_snapshot_hash": {
+          "name": "content_snapshot_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivery_error": {
+          "name": "last_delivery_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_reports_reporter_object_key": {
+          "name": "moderation_reports_reporter_object_key",
+          "columns": [
+            {
+              "expression": "reporter_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reported_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reported_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_reports_local_status_created_idx": {
+          "name": "moderation_reports_local_status_created_idx",
+          "columns": [
+            {
+              "expression": "local_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_reports_object_idx": {
+          "name": "moderation_reports_object_idx",
+          "columns": [
+            {
+              "expression": "reported_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reported_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_reports_case_id_idx": {
+          "name": "moderation_reports_case_id_idx",
+          "columns": [
+            {
+              "expression": "crowd_source_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"moderation_reports\".\"crowd_source_case_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "moderation_reports_reported_type_check": {
+          "name": "moderation_reports_reported_type_check",
+          "value": "\"moderation_reports\".\"reported_type\" in ('property', 'review', 'eviction_case')"
+        },
+        "moderation_reports_local_status_check": {
+          "name": "moderation_reports_local_status_check",
+          "value": "\"moderation_reports\".\"local_status\" in ('received', 'queued', 'submitted', 'delivery_failed', 'closed')"
+        },
+        "moderation_reports_enforced_action_check": {
+          "name": "moderation_reports_enforced_action_check",
+          "value": "\"moderation_reports\".\"enforced_action\" in ('none', 'restrict', 'restore', 'flag_for_review', 'unflag', 'manual_review')"
+        },
+        "moderation_reports_decision_revision_check": {
+          "name": "moderation_reports_decision_revision_check",
+          "value": "\"moderation_reports\".\"decision_revision\" is null or \"moderation_reports\".\"decision_revision\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.neighborhoods": {
+      "name": "neighborhoods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_west": {
+          "name": "bbox_west",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_south": {
+          "name": "bbox_south",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_east": {
+          "name": "bbox_east",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bbox_north": {
+          "name": "bbox_north",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "neighborhoods_city_name_key": {
+          "name": "neighborhoods_city_name_key",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "neighborhoods_name_lower_idx": {
+          "name": "neighborhoods_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "neighborhoods_city_name_lower_idx": {
+          "name": "neighborhoods_city_name_lower_idx",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "neighborhoods_name_trgm_idx": {
+          "name": "neighborhoods_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "neighborhoods_city_id_cities_id_fk": {
+          "name": "neighborhoods_city_id_cities_id_fk",
+          "tableFrom": "neighborhoods",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "neighborhoods_bbox_complete_check": {
+          "name": "neighborhoods_bbox_complete_check",
+          "value": "(\n        \"neighborhoods\".\"bbox_west\" is null and \"neighborhoods\".\"bbox_south\" is null\n        and \"neighborhoods\".\"bbox_east\" is null and \"neighborhoods\".\"bbox_north\" is null\n      ) or (\n        \"neighborhoods\".\"bbox_west\" is not null and \"neighborhoods\".\"bbox_south\" is not null\n        and \"neighborhoods\".\"bbox_east\" is not null and \"neighborhoods\".\"bbox_north\" is not null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_oxy_user_id": {
+          "name": "recipient_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'homiio'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_created_idx": {
+          "name": "notifications_recipient_created_idx",
+          "columns": [
+            {
+              "expression": "recipient_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_unread_idx": {
+          "name": "notifications_recipient_unread_idx",
+          "columns": [
+            {
+              "expression": "recipient_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "not \"notifications\".\"read\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_recipient_type_created_idx": {
+          "name": "notifications_recipient_type_created_idx",
+          "columns": [
+            {
+              "expression": "recipient_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_priority_check": {
+          "name": "notifications_priority_check",
+          "value": "\"notifications\".\"priority\" in ('low', 'medium', 'high', 'urgent')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.partners": {
+      "name": "partners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referral_code": {
+          "name": "referral_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "points": {
+          "name": "points",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "partners_oxy_user_id_key": {
+          "name": "partners_oxy_user_id_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partners_referral_code_key": {
+          "name": "partners_referral_code_key",
+          "columns": [
+            {
+              "expression": "referral_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partners_status_idx": {
+          "name": "partners_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "partners_status_check": {
+          "name": "partners_status_check",
+          "value": "\"partners\".\"status\" in ('active', 'inactive')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.place_poi_categories": {
+      "name": "place_poi_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "place_poi_id": {
+          "name": "place_poi_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "present": {
+          "name": "present",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "count": {
+          "name": "count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "nearest_m": {
+          "name": "nearest_m",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "place_poi_categories_poi_key_key": {
+          "name": "place_poi_categories_poi_key_key",
+          "columns": [
+            {
+              "expression": "place_poi_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "place_poi_categories_place_poi_id_place_pois_id_fk": {
+          "name": "place_poi_categories_place_poi_id_place_pois_id_fk",
+          "tableFrom": "place_poi_categories",
+          "tableTo": "place_pois",
+          "columnsFrom": [
+            "place_poi_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "place_poi_categories_key_check": {
+          "name": "place_poi_categories_key_check",
+          "value": "\"place_poi_categories\".\"key\" in ('pharmacy', 'school', 'hospital', 'police', 'fire_station', 'supermarket', 'transit', 'park', 'bank', 'restaurant', 'gym', 'spa')"
+        },
+        "place_poi_categories_count_check": {
+          "name": "place_poi_categories_count_check",
+          "value": "\"place_poi_categories\".\"count\" >= 0"
+        },
+        "place_poi_categories_coherent_check": {
+          "name": "place_poi_categories_coherent_check",
+          "value": "(\"place_poi_categories\".\"present\" = (\"place_poi_categories\".\"count\" > 0))\n        and (\"place_poi_categories\".\"nearest_m\" is null or \"place_poi_categories\".\"present\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.place_pois": {
+      "name": "place_pois",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cell_key": {
+          "name": "cell_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "radius_m": {
+          "name": "radius_m",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "place_pois_cell_key_key": {
+          "name": "place_pois_cell_key_key",
+          "columns": [
+            {
+              "expression": "cell_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "place_pois_expires_at_idx": {
+          "name": "place_pois_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "place_pois_radius_check": {
+          "name": "place_pois_radius_check",
+          "value": "\"place_pois\".\"radius_m\" >= 1"
+        },
+        "place_pois_coordinates_range_check": {
+          "name": "place_pois_coordinates_range_check",
+          "value": "\"place_pois\".\"lat\" between -90 and 90 and \"place_pois\".\"lng\" between -180 and 180"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profile_chat_messages": {
+      "name": "profile_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "profile_chat_messages_profile_position_idx": {
+          "name": "profile_chat_messages_profile_position_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_chat_messages_profile_id_profiles_id_fk": {
+          "name": "profile_chat_messages_profile_id_profiles_id_fk",
+          "tableFrom": "profile_chat_messages",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profile_chat_messages_role_check": {
+          "name": "profile_chat_messages_role_check",
+          "value": "\"profile_chat_messages\".\"role\" in ('user', 'assistant', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profile_preferred_locations": {
+      "name": "profile_preferred_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "radius": {
+          "name": "radius",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profile_preferred_locations_profile_id_idx": {
+          "name": "profile_preferred_locations_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_preferred_locations_profile_id_profiles_id_fk": {
+          "name": "profile_preferred_locations_profile_id_profiles_id_fk",
+          "tableFrom": "profile_preferred_locations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_references": {
+      "name": "profile_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "profile_references_profile_id_idx": {
+          "name": "profile_references_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_references_profile_id_profiles_id_fk": {
+          "name": "profile_references_profile_id_profiles_id_fk",
+          "tableFrom": "profile_references",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profile_references_relationship_check": {
+          "name": "profile_references_relationship_check",
+          "value": "\"profile_references\".\"relationship\" in ('landlord', 'employer', 'personal', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profile_rental_history": {
+      "name": "profile_rental_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_rent": {
+          "name": "monthly_rent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_for_leaving": {
+          "name": "reason_for_leaving",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landlord_contact_name": {
+          "name": "landlord_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landlord_contact_phone": {
+          "name": "landlord_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "landlord_contact_email": {
+          "name": "landlord_contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "profile_rental_history_profile_id_idx": {
+          "name": "profile_rental_history_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_rental_history_profile_id_profiles_id_fk": {
+          "name": "profile_rental_history_profile_id_profiles_id_fk",
+          "tableFrom": "profile_rental_history",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profile_rental_history_reason_for_leaving_check": {
+          "name": "profile_rental_history_reason_for_leaving_check",
+          "value": "\"profile_rental_history\".\"reason_for_leaving\" in ('lease_ended', 'bought_home', 'job_relocation', 'family_reasons', 'upgrade', 'other')"
+        },
+        "profile_rental_history_order_check": {
+          "name": "profile_rental_history_order_check",
+          "value": "\"profile_rental_history\".\"end_date\" is null or \"profile_rental_history\".\"end_date\" >= \"profile_rental_history\".\"start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profile_roommate_history": {
+      "name": "profile_roommate_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roommate_count": {
+          "name": "roommate_count",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "profile_roommate_history_profile_id_idx": {
+          "name": "profile_roommate_history_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_roommate_history_profile_id_profiles_id_fk": {
+          "name": "profile_roommate_history_profile_id_profiles_id_fk",
+          "tableFrom": "profile_roommate_history",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profile_roommate_history_order_check": {
+          "name": "profile_roommate_history_order_check",
+          "value": "\"profile_roommate_history\".\"end_date\" is null or \"profile_roommate_history\".\"end_date\" >= \"profile_roommate_history\".\"start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personal_info_bio": {
+          "name": "personal_info_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_occupation": {
+          "name": "personal_info_occupation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_employer": {
+          "name": "personal_info_employer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_annual_income": {
+          "name": "personal_info_annual_income",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_employment_status": {
+          "name": "personal_info_employment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_move_in_date": {
+          "name": "personal_info_move_in_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_info_lease_duration": {
+          "name": "personal_info_lease_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_property_types": {
+          "name": "preferences_property_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_max_rent": {
+          "name": "preferences_max_rent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_price_unit": {
+          "name": "preferences_price_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_min_bedrooms": {
+          "name": "preferences_min_bedrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_min_bathrooms": {
+          "name": "preferences_min_bathrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_preferred_amenities": {
+          "name": "preferences_preferred_amenities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_pet_friendly": {
+          "name": "preferences_pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_smoking_allowed": {
+          "name": "preferences_smoking_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_furnished": {
+          "name": "preferences_furnished",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_parking_required": {
+          "name": "preferences_parking_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences_accessibility": {
+          "name": "preferences_accessibility",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_identity": {
+          "name": "verification_identity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_income": {
+          "name": "verification_income",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_background": {
+          "name": "verification_background",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_rental_history": {
+          "name": "verification_rental_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_references": {
+          "name": "verification_references",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_email": {
+          "name": "settings_notifications_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_push": {
+          "name": "settings_notifications_push",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_sms": {
+          "name": "settings_notifications_sms",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_property_alerts": {
+          "name": "settings_notifications_property_alerts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_viewing_reminders": {
+          "name": "settings_notifications_viewing_reminders",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_notifications_lease_updates": {
+          "name": "settings_notifications_lease_updates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_profile_visibility": {
+          "name": "settings_privacy_profile_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_show_contact_info": {
+          "name": "settings_privacy_show_contact_info",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_show_income": {
+          "name": "settings_privacy_show_income",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_show_rental_history": {
+          "name": "settings_privacy_show_rental_history",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_privacy_show_references": {
+          "name": "settings_privacy_show_references",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_enabled": {
+          "name": "settings_roommate_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_age_range_min": {
+          "name": "settings_roommate_preferences_age_range_min",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_age_range_max": {
+          "name": "settings_roommate_preferences_age_range_max",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_gender": {
+          "name": "settings_roommate_preferences_gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_smoking": {
+          "name": "settings_roommate_preferences_lifestyle_smoking",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_pets": {
+          "name": "settings_roommate_preferences_lifestyle_pets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_partying": {
+          "name": "settings_roommate_preferences_lifestyle_partying",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_cleanliness": {
+          "name": "settings_roommate_preferences_lifestyle_cleanliness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lifestyle_schedule": {
+          "name": "settings_roommate_preferences_lifestyle_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_budget_min": {
+          "name": "settings_roommate_preferences_budget_min",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_budget_max": {
+          "name": "settings_roommate_preferences_budget_max",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_move_in_date": {
+          "name": "settings_roommate_preferences_move_in_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_lease_duration": {
+          "name": "settings_roommate_preferences_lease_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_location": {
+          "name": "settings_roommate_preferences_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_roommate_preferences_interests": {
+          "name": "settings_roommate_preferences_interests",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_language": {
+          "name": "settings_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_timezone": {
+          "name": "settings_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_currency": {
+          "name": "settings_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "profiles_oxy_user_id_key": {
+          "name": "profiles_oxy_user_id_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "profiles_personal_info_employment_status_check": {
+          "name": "profiles_personal_info_employment_status_check",
+          "value": "\"profiles\".\"personal_info_employment_status\" in ('employed', 'self_employed', 'student', 'retired', 'unemployed', 'other')"
+        },
+        "profiles_personal_info_lease_duration_check": {
+          "name": "profiles_personal_info_lease_duration_check",
+          "value": "\"profiles\".\"personal_info_lease_duration\" in ('monthly', '3_months', '6_months', 'yearly', 'flexible')"
+        },
+        "profiles_preferences_price_unit_check": {
+          "name": "profiles_preferences_price_unit_check",
+          "value": "\"profiles\".\"preferences_price_unit\" in ('day', 'night', 'week', 'month', 'year')"
+        },
+        "profiles_preferences_property_types_check": {
+          "name": "profiles_preferences_property_types_check",
+          "value": "\"profiles\".\"preferences_property_types\" <@ array['apartment', 'house', 'room', 'studio', 'couchsurfing', 'roommates', 'coliving', 'hostel', 'guesthouse', 'campsite', 'boat', 'treehouse', 'yurt', 'other']::text[]"
+        },
+        "profiles_settings_privacy_profile_visibility_check": {
+          "name": "profiles_settings_privacy_profile_visibility_check",
+          "value": "\"profiles\".\"settings_privacy_profile_visibility\" in ('public', 'private', 'contacts_only')"
+        },
+        "profiles_settings_roommate_gender_check": {
+          "name": "profiles_settings_roommate_gender_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_gender\" in ('male', 'female', 'any')"
+        },
+        "profiles_settings_roommate_smoking_check": {
+          "name": "profiles_settings_roommate_smoking_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_smoking\" in ('yes', 'no', 'prefer_not')"
+        },
+        "profiles_settings_roommate_pets_check": {
+          "name": "profiles_settings_roommate_pets_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_pets\" in ('yes', 'no', 'prefer_not')"
+        },
+        "profiles_settings_roommate_partying_check": {
+          "name": "profiles_settings_roommate_partying_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_partying\" in ('yes', 'no', 'prefer_not')"
+        },
+        "profiles_settings_roommate_cleanliness_check": {
+          "name": "profiles_settings_roommate_cleanliness_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_cleanliness\" in ('very_clean', 'clean', 'average', 'relaxed')"
+        },
+        "profiles_settings_roommate_schedule_check": {
+          "name": "profiles_settings_roommate_schedule_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lifestyle_schedule\" in ('early_bird', 'night_owl', 'flexible')"
+        },
+        "profiles_settings_roommate_lease_duration_check": {
+          "name": "profiles_settings_roommate_lease_duration_check",
+          "value": "\"profiles\".\"settings_roommate_preferences_lease_duration\" in ('monthly', '3_months', '6_months', 'yearly', 'flexible')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.properties": {
+      "name": "properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_external": {
+          "name": "is_external",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourced_by_partner_id": {
+          "name": "sourced_by_partner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourced_by_referral_code": {
+          "name": "sourced_by_referral_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agency_id": {
+          "name": "agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_phone": {
+          "name": "external_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_email": {
+          "name": "external_contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_whatsapp": {
+          "name": "external_contact_whatsapp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_name": {
+          "name": "external_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_agency_name": {
+          "name": "external_contact_agency_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_contact_kind": {
+          "name": "external_contact_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_students_only": {
+          "name": "listing_flags_students_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_room_not_full_unit": {
+          "name": "listing_flags_room_not_full_unit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_temporary_only": {
+          "name": "listing_flags_temporary_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_gender_restricted": {
+          "name": "listing_flags_gender_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_workers_only": {
+          "name": "listing_flags_workers_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_agency_fee_payable": {
+          "name": "listing_flags_agency_fee_payable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_no_pets": {
+          "name": "listing_flags_no_pets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_no_smoking": {
+          "name": "listing_flags_no_smoking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_no_couples": {
+          "name": "listing_flags_no_couples",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_no_dss": {
+          "name": "listing_flags_no_dss",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_flags_detected_language": {
+          "name": "listing_flags_detected_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('homiio_simple', coalesce(description, ''))",
+            "type": "stored"
+          }
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "show_address_number": {
+          "name": "show_address_number",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'apartment'"
+        },
+        "housing_type": {
+          "name": "housing_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "layout_type": {
+          "name": "layout_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'traditional'"
+        },
+        "bedrooms": {
+          "name": "bedrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bathrooms": {
+          "name": "bathrooms",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "square_footage": {
+          "name": "square_footage",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "floor": {
+          "name": "floor",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "year_built": {
+          "name": "year_built",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_elevator": {
+          "name": "has_elevator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_balcony": {
+          "name": "has_balcony",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_garden": {
+          "name": "has_garden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "utilities_included": {
+          "name": "utilities_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proximity_to_transport": {
+          "name": "proximity_to_transport",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proximity_to_schools": {
+          "name": "proximity_to_schools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "proximity_to_shopping": {
+          "name": "proximity_to_shopping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_eco_friendly": {
+          "name": "is_eco_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "offerings": {
+          "name": "offerings",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "amenities": {
+          "name": "amenities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "furnished_status": {
+          "name": "furnished_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_specified'"
+        },
+        "pet_policy": {
+          "name": "pet_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_specified'"
+        },
+        "pet_fee": {
+          "name": "pet_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "parking_type": {
+          "name": "parking_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "parking_spaces": {
+          "name": "parking_spaces",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_term": {
+          "name": "lease_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "cancellation_policy": {
+          "name": "cancellation_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_from": {
+          "name": "available_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "smoking_allowed": {
+          "name": "smoking_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parties_allowed": {
+          "name": "parties_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "guests_allowed": {
+          "name": "guests_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "max_guests": {
+          "name": "max_guests",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "long_term_rent_monthly_amount": {
+          "name": "long_term_rent_monthly_amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_currency": {
+          "name": "long_term_rent_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_deposit": {
+          "name": "long_term_rent_deposit",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_application_fee": {
+          "name": "long_term_rent_application_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_late_fee": {
+          "name": "long_term_rent_late_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_rent_utilities": {
+          "name": "long_term_rent_utilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_nightly_rate": {
+          "name": "short_term_rent_nightly_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_currency": {
+          "name": "short_term_rent_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_cleaning_fee": {
+          "name": "short_term_rent_cleaning_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_service_fee": {
+          "name": "short_term_rent_service_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_taxes_percent": {
+          "name": "short_term_rent_taxes_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_min_nights": {
+          "name": "short_term_rent_min_nights",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_max_nights": {
+          "name": "short_term_rent_max_nights",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_instant_book": {
+          "name": "short_term_rent_instant_book",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "short_term_rent_deposit": {
+          "name": "short_term_rent_deposit",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_price": {
+          "name": "sale_price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_currency": {
+          "name": "sale_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_price_per_sqm": {
+          "name": "sale_price_per_sqm",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_estimated_yield": {
+          "name": "sale_estimated_yield",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_is_price_reduced": {
+          "name": "sale_is_price_reduced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_chain_status": {
+          "name": "sale_chain_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_mode": {
+          "name": "exchange_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_min_stay": {
+          "name": "exchange_min_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_max_stay": {
+          "name": "exchange_max_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_welcome_note": {
+          "name": "exchange_welcome_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_languages": {
+          "name": "exchange_languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_meals_included": {
+          "name": "exchange_meals_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_requires_reciprocity": {
+          "name": "exchange_requires_reciprocity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_sleeping_arrangement": {
+          "name": "accommodation_details_sleeping_arrangement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_hostel_room_type": {
+          "name": "accommodation_details_hostel_room_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_campsite_type": {
+          "name": "accommodation_details_campsite_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_max_stay": {
+          "name": "accommodation_details_max_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_min_age": {
+          "name": "accommodation_details_min_age",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_max_age": {
+          "name": "accommodation_details_max_age",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_cultural_exchange": {
+          "name": "accommodation_details_cultural_exchange",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accommodation_details_meals_included": {
+          "name": "accommodation_details_meals_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accommodation_details_wifi_password": {
+          "name": "accommodation_details_wifi_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accommodation_details_roommate_preferences": {
+          "name": "accommodation_details_roommate_preferences",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "accommodation_details_coliving_features": {
+          "name": "accommodation_details_coliving_features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "accommodation_details_languages": {
+          "name": "accommodation_details_languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "accommodation_details_house_rules": {
+          "name": "accommodation_details_house_rules",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "availability_is_available": {
+          "name": "availability_is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "availability_available_from": {
+          "name": "availability_available_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "availability_minimum_stay": {
+          "name": "availability_minimum_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "availability_maximum_stay": {
+          "name": "availability_maximum_stay",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 12
+        },
+        "rules_pets": {
+          "name": "rules_pets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_smoking": {
+          "name": "rules_smoking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_parties": {
+          "name": "rules_parties",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_guests": {
+          "name": "rules_guests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rules_max_occupancy": {
+          "name": "rules_max_occupancy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "moderation_restricted": {
+          "name": "moderation_restricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "moderation_restricted_at": {
+          "name": "moderation_restricted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_restricted_by_decision_id": {
+          "name": "moderation_restricted_by_decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_ethical_suggested": {
+          "name": "price_ethics_ethical_suggested",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_ethical_max": {
+          "name": "price_ethics_ethical_max",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_within_ethical": {
+          "name": "price_ethics_within_ethical",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_market_verdict": {
+          "name": "price_ethics_market_verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_percent_diff_from_avg": {
+          "name": "price_ethics_percent_diff_from_avg",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_is_fair_price": {
+          "name": "price_ethics_is_fair_price",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_fairness_score": {
+          "name": "price_ethics_fairness_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_ethics_scored_at": {
+          "name": "price_ethics_scored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_average": {
+          "name": "rating_average",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rating_count": {
+          "name": "rating_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "views": {
+          "name": "views",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_images": {
+          "name": "has_images",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_saved": {
+          "name": "last_saved",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "parent_property_id": {
+          "name": "parent_property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "properties_source_source_id_key": {
+          "name": "properties_source_source_id_key",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"properties\".\"source_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_has_images_created_at_idx": {
+          "name": "properties_has_images_created_at_idx",
+          "columns": [
+            {
+              "expression": "\"has_images\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_created_at_idx": {
+          "name": "properties_created_at_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_search_vector_gin": {
+          "name": "properties_search_vector_gin",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "properties_oxy_user_id_status_idx": {
+          "name": "properties_oxy_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_oxy_user_id_created_at_idx": {
+          "name": "properties_oxy_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_address_id_idx": {
+          "name": "properties_address_id_idx",
+          "columns": [
+            {
+              "expression": "address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_type_available_idx": {
+          "name": "properties_type_available_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "availability_is_available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_status_available_idx": {
+          "name": "properties_status_available_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "availability_is_available",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_bedrooms_bathrooms_idx": {
+          "name": "properties_bedrooms_bathrooms_idx",
+          "columns": [
+            {
+              "expression": "bedrooms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bathrooms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_amenities_gin": {
+          "name": "properties_amenities_gin",
+          "columns": [
+            {
+              "expression": "amenities",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "properties_offerings_gin": {
+          "name": "properties_offerings_gin",
+          "columns": [
+            {
+              "expression": "offerings",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "properties_long_term_rent_amount_idx": {
+          "name": "properties_long_term_rent_amount_idx",
+          "columns": [
+            {
+              "expression": "long_term_rent_monthly_amount",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_short_term_rent_rate_idx": {
+          "name": "properties_short_term_rent_rate_idx",
+          "columns": [
+            {
+              "expression": "short_term_rent_nightly_rate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_sale_price_idx": {
+          "name": "properties_sale_price_idx",
+          "columns": [
+            {
+              "expression": "sale_price",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_price_ethics_is_fair_idx": {
+          "name": "properties_price_ethics_is_fair_idx",
+          "columns": [
+            {
+              "expression": "price_ethics_is_fair_price",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_price_ethics_score_idx": {
+          "name": "properties_price_ethics_score_idx",
+          "columns": [
+            {
+              "expression": "\"price_ethics_fairness_score\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_agency_id_idx": {
+          "name": "properties_agency_id_idx",
+          "columns": [
+            {
+              "expression": "agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"properties\".\"agency_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_sourced_by_partner_id_idx": {
+          "name": "properties_sourced_by_partner_id_idx",
+          "columns": [
+            {
+              "expression": "sourced_by_partner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"properties\".\"sourced_by_partner_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_parent_property_id_idx": {
+          "name": "properties_parent_property_id_idx",
+          "columns": [
+            {
+              "expression": "parent_property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"properties\".\"parent_property_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "properties_expires_at_idx": {
+          "name": "properties_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"properties\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "properties_sourced_by_partner_id_partners_id_fk": {
+          "name": "properties_sourced_by_partner_id_partners_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "partners",
+          "columnsFrom": [
+            "sourced_by_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "properties_agency_id_agencies_id_fk": {
+          "name": "properties_agency_id_agencies_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "agencies",
+          "columnsFrom": [
+            "agency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "properties_address_id_addresses_id_fk": {
+          "name": "properties_address_id_addresses_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "properties_parent_property_id_properties_id_fk": {
+          "name": "properties_parent_property_id_properties_id_fk",
+          "tableFrom": "properties",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "parent_property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "properties_source_check": {
+          "name": "properties_source_check",
+          "value": "\"properties\".\"source\" in ('internal', 'fixture', 'idealista', 'fotocasa', 'habitaclia', 'blueground', 'apartments_com', 'zillow', 'realtor_com', 'hotpads', 'redfin', 'pisos', 'milanuncios', 'yaencontre', 'indomio', 'idealista_it', 'immobiliare', 'casa_it', 'subito', 'rightmove', 'zoopla', 'onthemarket', 'openrent', 'immobilienscout24', 'immowelt', 'kleinanzeigen', 'storia', 'imobiliare_ro', 'olx_ro', 'bienici', 'leboncoin', 'seloger', 'properati_ec', 'zonaprop', 'argenprop', 'mercadolibre_ar', 'properati', 'plusvalia', 'mercadolibre_ec', 'propiedades', 'vivanuncios', 'lamudi', 'inmuebles24', 'mercadolibre_co', 'mercadolibre_cl', 'mercadolibre_pe', 'mercadolibre_mx', 'idealista_pt', 'metrocuadrado', 'realestate_com_au', 'realtor_ca', 'bayut', 'daft', 'immoweb', 'otodom', 'funda')"
+        },
+        "properties_type_check": {
+          "name": "properties_type_check",
+          "value": "\"properties\".\"type\" in ('apartment', 'house', 'room', 'studio', 'couchsurfing', 'roommates', 'coliving', 'hostel', 'guesthouse', 'campsite', 'boat', 'treehouse', 'yurt', 'other')"
+        },
+        "properties_status_check": {
+          "name": "properties_status_check",
+          "value": "\"properties\".\"status\" in ('draft', 'published', 'reserved', 'rented', 'sold', 'inactive', 'archived')"
+        },
+        "properties_housing_type_check": {
+          "name": "properties_housing_type_check",
+          "value": "\"properties\".\"housing_type\" in ('private', 'public')"
+        },
+        "properties_layout_type_check": {
+          "name": "properties_layout_type_check",
+          "value": "\"properties\".\"layout_type\" in ('open', 'shared', 'partitioned', 'traditional', 'studio', 'other')"
+        },
+        "properties_furnished_status_check": {
+          "name": "properties_furnished_status_check",
+          "value": "\"properties\".\"furnished_status\" in ('furnished', 'unfurnished', 'partially_furnished', 'not_specified')"
+        },
+        "properties_pet_policy_check": {
+          "name": "properties_pet_policy_check",
+          "value": "\"properties\".\"pet_policy\" in ('allowed', 'not_allowed', 'case_by_case', 'not_specified')"
+        },
+        "properties_parking_type_check": {
+          "name": "properties_parking_type_check",
+          "value": "\"properties\".\"parking_type\" in ('none', 'street', 'assigned', 'garage')"
+        },
+        "properties_lease_term_check": {
+          "name": "properties_lease_term_check",
+          "value": "\"properties\".\"lease_term\" in ('monthly', '3_months', '6_months', 'yearly', 'flexible')"
+        },
+        "properties_cancellation_policy_check": {
+          "name": "properties_cancellation_policy_check",
+          "value": "\"properties\".\"cancellation_policy\" in ('flexible', 'moderate', 'strict', 'super_strict')"
+        },
+        "properties_external_contact_kind_check": {
+          "name": "properties_external_contact_kind_check",
+          "value": "\"properties\".\"external_contact_kind\" in ('owner', 'agency', 'private', 'unknown')"
+        },
+        "properties_detected_language_check": {
+          "name": "properties_detected_language_check",
+          "value": "\"properties\".\"listing_flags_detected_language\" in ('es', 'ca', 'en', 'fr', 'nl', 'de', 'it')"
+        },
+        "properties_long_term_rent_currency_check": {
+          "name": "properties_long_term_rent_currency_check",
+          "value": "\"properties\".\"long_term_rent_currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        },
+        "properties_long_term_rent_utilities_check": {
+          "name": "properties_long_term_rent_utilities_check",
+          "value": "\"properties\".\"long_term_rent_utilities\" in ('included', 'excluded', 'partial')"
+        },
+        "properties_short_term_rent_currency_check": {
+          "name": "properties_short_term_rent_currency_check",
+          "value": "\"properties\".\"short_term_rent_currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        },
+        "properties_sale_currency_check": {
+          "name": "properties_sale_currency_check",
+          "value": "\"properties\".\"sale_currency\" in ('USD', 'EUR', 'GBP', 'CAD', 'PLN', 'MXN', 'ARS', 'RON', 'COP', 'CLP', 'PEN', 'BRL', 'AUD', 'AED', 'FAIR')"
+        },
+        "properties_sale_chain_status_check": {
+          "name": "properties_sale_chain_status_check",
+          "value": "\"properties\".\"sale_chain_status\" in ('no_chain', 'chain', 'unknown')"
+        },
+        "properties_exchange_mode_check": {
+          "name": "properties_exchange_mode_check",
+          "value": "\"properties\".\"exchange_mode\" in ('swap', 'host', 'both')"
+        },
+        "properties_market_verdict_check": {
+          "name": "properties_market_verdict_check",
+          "value": "\"properties\".\"price_ethics_market_verdict\" in ('good_deal', 'below_average', 'average', 'above_average')"
+        },
+        "properties_sleeping_arrangement_check": {
+          "name": "properties_sleeping_arrangement_check",
+          "value": "\"properties\".\"accommodation_details_sleeping_arrangement\" in ('couch', 'air_mattress', 'floor', 'tent', 'hammock')"
+        },
+        "properties_hostel_room_type_check": {
+          "name": "properties_hostel_room_type_check",
+          "value": "\"properties\".\"accommodation_details_hostel_room_type\" in ('dormitory', 'private_room', 'mixed_dorm', 'female_dorm', 'male_dorm')"
+        },
+        "properties_campsite_type_check": {
+          "name": "properties_campsite_type_check",
+          "value": "\"properties\".\"accommodation_details_campsite_type\" in ('tent_site', 'rv_site', 'cabin', 'glamping', 'backcountry')"
+        },
+        "properties_offerings_check": {
+          "name": "properties_offerings_check",
+          "value": "\"properties\".\"offerings\" <@ array['long_term_rent', 'short_term_rent', 'sale', 'exchange']::text[]"
+        },
+        "properties_offering_long_term_rent_check": {
+          "name": "properties_offering_long_term_rent_check",
+          "value": "('long_term_rent' = any(\"properties\".\"offerings\")) = (\"properties\".\"long_term_rent_monthly_amount\" is not null)"
+        },
+        "properties_offering_short_term_rent_check": {
+          "name": "properties_offering_short_term_rent_check",
+          "value": "('short_term_rent' = any(\"properties\".\"offerings\")) = (\"properties\".\"short_term_rent_nightly_rate\" is not null)"
+        },
+        "properties_offering_sale_check": {
+          "name": "properties_offering_sale_check",
+          "value": "('sale' = any(\"properties\".\"offerings\")) = (\"properties\".\"sale_price\" is not null)"
+        },
+        "properties_offering_exchange_check": {
+          "name": "properties_offering_exchange_check",
+          "value": "('exchange' = any(\"properties\".\"offerings\")) = (\"properties\".\"exchange_mode\" is not null)"
+        },
+        "properties_long_term_rent_block_check": {
+          "name": "properties_long_term_rent_block_check",
+          "value": "\"properties\".\"long_term_rent_monthly_amount\" is not null or (\n        \"properties\".\"long_term_rent_currency\" is null and \"properties\".\"long_term_rent_deposit\" is null\n        and \"properties\".\"long_term_rent_application_fee\" is null and \"properties\".\"long_term_rent_late_fee\" is null\n        and \"properties\".\"long_term_rent_utilities\" is null\n      )"
+        },
+        "properties_short_term_rent_block_check": {
+          "name": "properties_short_term_rent_block_check",
+          "value": "\"properties\".\"short_term_rent_nightly_rate\" is not null or (\n        \"properties\".\"short_term_rent_currency\" is null and \"properties\".\"short_term_rent_cleaning_fee\" is null\n        and \"properties\".\"short_term_rent_service_fee\" is null and \"properties\".\"short_term_rent_taxes_percent\" is null\n        and \"properties\".\"short_term_rent_min_nights\" is null and \"properties\".\"short_term_rent_max_nights\" is null\n        and \"properties\".\"short_term_rent_instant_book\" is null and \"properties\".\"short_term_rent_deposit\" is null\n      )"
+        },
+        "properties_sale_block_check": {
+          "name": "properties_sale_block_check",
+          "value": "\"properties\".\"sale_price\" is not null or (\n        \"properties\".\"sale_currency\" is null and \"properties\".\"sale_price_per_sqm\" is null\n        and \"properties\".\"sale_estimated_yield\" is null and \"properties\".\"sale_is_price_reduced\" is null\n        and \"properties\".\"sale_chain_status\" is null\n      )"
+        },
+        "properties_exchange_block_check": {
+          "name": "properties_exchange_block_check",
+          "value": "\"properties\".\"exchange_mode\" is not null or (\n        \"properties\".\"exchange_min_stay\" is null and \"properties\".\"exchange_max_stay\" is null\n        and \"properties\".\"exchange_welcome_note\" is null and \"properties\".\"exchange_languages\" is null\n        and \"properties\".\"exchange_meals_included\" is null and \"properties\".\"exchange_requires_reciprocity\" is null\n      )"
+        },
+        "properties_external_source_url_check": {
+          "name": "properties_external_source_url_check",
+          "value": "not \"properties\".\"is_external\" or \"properties\".\"source_url\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.property_availability_windows": {
+      "name": "property_availability_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        }
+      },
+      "indexes": {
+        "property_availability_windows_range_gist": {
+          "name": "property_availability_windows_range_gist",
+          "columns": [
+            {
+              "expression": "tstzrange(\"starts_at\", \"ends_at\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "property_availability_windows_property_scope_idx": {
+          "name": "property_availability_windows_property_scope_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "property_availability_windows_property_id_properties_id_fk": {
+          "name": "property_availability_windows_property_id_properties_id_fk",
+          "tableFrom": "property_availability_windows",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "property_availability_windows_scope_check": {
+          "name": "property_availability_windows_scope_check",
+          "value": "\"property_availability_windows\".\"scope\" in ('listing', 'exchange')"
+        },
+        "property_availability_windows_status_check": {
+          "name": "property_availability_windows_status_check",
+          "value": "\"property_availability_windows\".\"status\" in ('available', 'blocked', 'booked')"
+        },
+        "property_availability_windows_order_check": {
+          "name": "property_availability_windows_order_check",
+          "value": "\"property_availability_windows\".\"ends_at\" > \"property_availability_windows\".\"starts_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.property_documents": {
+      "name": "property_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        }
+      },
+      "indexes": {
+        "property_documents_property_id_idx": {
+          "name": "property_documents_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "property_documents_property_id_properties_id_fk": {
+          "name": "property_documents_property_id_properties_id_fk",
+          "tableFrom": "property_documents",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "property_documents_type_check": {
+          "name": "property_documents_type_check",
+          "value": "\"property_documents\".\"type\" in ('lease', 'inspection', 'insurance', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.property_images": {
+      "name": "property_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "urls_original": {
+          "name": "urls_original",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urls_small": {
+          "name": "urls_small",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urls_medium": {
+          "name": "urls_medium",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "urls_large": {
+          "name": "urls_large",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "property_images_property_order_idx": {
+          "name": "property_images_property_order_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "property_images_one_primary_key": {
+          "name": "property_images_one_primary_key",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"property_images\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "property_images_image_id_idx": {
+          "name": "property_images_image_id_idx",
+          "columns": [
+            {
+              "expression": "image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "property_images_property_id_properties_id_fk": {
+          "name": "property_images_property_id_properties_id_fk",
+          "tableFrom": "property_images",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "property_images_image_id_images_id_fk": {
+          "name": "property_images_image_id_images_id_fk",
+          "tableFrom": "property_images",
+          "tableTo": "images",
+          "columnsFrom": [
+            "image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recently_viewed": {
+      "name": "recently_viewed",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "recently_viewed_owner_property_key": {
+          "name": "recently_viewed_owner_property_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recently_viewed_owner_viewed_at_idx": {
+          "name": "recently_viewed_owner_viewed_at_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"viewed_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recently_viewed_property_id_properties_id_fk": {
+          "name": "recently_viewed_property_id_properties_id_fk",
+          "tableFrom": "recently_viewed",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "regions_country_name_key": {
+          "name": "regions_country_name_key",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_name_lower_idx": {
+          "name": "regions_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_country_name_lower_idx": {
+          "name": "regions_country_name_lower_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "regions_country_id_countries_id_fk": {
+          "name": "regions_country_id_countries_id_fk",
+          "tableFrom": "regions",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "regions_cover_image_id_images_id_fk": {
+          "name": "regions_cover_image_id_images_id_fk",
+          "tableFrom": "regions",
+          "tableTo": "images",
+          "columnsFrom": [
+            "cover_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reservations": {
+      "name": "reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_oxy_user_id": {
+          "name": "guest_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_oxy_user_id": {
+          "name": "host_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_in": {
+          "name": "check_in",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_out": {
+          "name": "check_out",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guest_count": {
+          "name": "guest_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nights": {
+          "name": "nights",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nightly_rate": {
+          "name": "nightly_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cleaning_fee": {
+          "name": "cleaning_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "service_fee": {
+          "name": "service_fee",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "taxes": {
+          "name": "taxes",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total": {
+          "name": "total",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "instant_booked": {
+          "name": "instant_booked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancellation_policy": {
+          "name": "cancellation_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "special_requests": {
+          "name": "special_requests",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "reservations_stay_range_gist": {
+          "name": "reservations_stay_range_gist",
+          "columns": [
+            {
+              "expression": "tstzrange(\"check_in\", \"check_out\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "reservations_property_check_in_idx": {
+          "name": "reservations_property_check_in_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "check_in",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reservations_guest_status_idx": {
+          "name": "reservations_guest_status_idx",
+          "columns": [
+            {
+              "expression": "guest_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reservations_host_status_created_idx": {
+          "name": "reservations_host_status_created_idx",
+          "columns": [
+            {
+              "expression": "host_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reservations_property_id_properties_id_fk": {
+          "name": "reservations_property_id_properties_id_fk",
+          "tableFrom": "reservations",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reservations_status_check": {
+          "name": "reservations_status_check",
+          "value": "\"reservations\".\"status\" in ('pending', 'confirmed', 'cancelled', 'completed', 'declined')"
+        },
+        "reservations_cancellation_policy_check": {
+          "name": "reservations_cancellation_policy_check",
+          "value": "\"reservations\".\"cancellation_policy\" in ('flexible', 'moderate', 'strict', 'super_strict')"
+        },
+        "reservations_stay_order_check": {
+          "name": "reservations_stay_order_check",
+          "value": "\"reservations\".\"check_out\" > \"reservations\".\"check_in\""
+        },
+        "reservations_nights_check": {
+          "name": "reservations_nights_check",
+          "value": "\"reservations\".\"nights\" >= 1"
+        },
+        "reservations_guest_count_check": {
+          "name": "reservations_guest_count_check",
+          "value": "\"reservations\".\"guest_count\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.review_helpful_votes": {
+      "name": "review_helpful_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "review_helpful_votes_review_user_key": {
+          "name": "review_helpful_votes_review_user_key",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_helpful_votes_review_id_reviews_id_fk": {
+          "name": "review_helpful_votes_review_id_reviews_id_fk",
+          "tableFrom": "review_helpful_votes",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_reports": {
+      "name": "review_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "review_reports_review_user_key": {
+          "name": "review_reports_review_user_key",
+          "columns": [
+            {
+              "expression": "review_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_reports_review_id_reviews_id_fk": {
+          "name": "review_reports_review_id_reviews_id_fk",
+          "tableFrom": "review_reports",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "review_reports_reason_check": {
+          "name": "review_reports_reason_check",
+          "value": "\"review_reports\".\"reason\" in ('fake', 'offensive', 'personal_data', 'spam', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_level": {
+          "name": "address_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street_level_id": {
+          "name": "street_level_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "building_level_id": {
+          "name": "building_level_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_level_id": {
+          "name": "unit_level_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neighborhood_id": {
+          "name": "neighborhood_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agency_id": {
+          "name": "agency_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "green_house": {
+          "name": "green_house",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "lived_from": {
+          "name": "lived_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lived_to": {
+          "name": "lived_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lived_for_months": {
+          "name": "lived_for_months",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation": {
+          "name": "recommendation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion": {
+          "name": "opinion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pros_items": {
+          "name": "pros_items",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "cons_items": {
+          "name": "cons_items",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "advice_to_agency": {
+          "name": "advice_to_agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "advice_to_landlord": {
+          "name": "advice_to_landlord",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "positive_comment": {
+          "name": "positive_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "negative_comment": {
+          "name": "negative_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "rating": {
+          "name": "rating",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summer_temperature": {
+          "name": "summer_temperature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winter_temperature": {
+          "name": "winter_temperature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noise": {
+          "name": "noise",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "light": {
+          "name": "light",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition_and_maintenance": {
+          "name": "condition_and_maintenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "services": {
+          "name": "services",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "landlord_treatment": {
+          "name": "landlord_treatment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "problem_response": {
+          "name": "problem_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deposit_returned": {
+          "name": "deposit_returned",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "staircase_neighbors": {
+          "name": "staircase_neighbors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tourist_apartments": {
+          "name": "tourist_apartments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neighbor_relations": {
+          "name": "neighbor_relations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleaning": {
+          "name": "cleaning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_tourists": {
+          "name": "area_tourists",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_security": {
+          "name": "area_security",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_noise": {
+          "name": "area_noise",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_cleanliness": {
+          "name": "area_cleanliness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_status": {
+          "name": "moderation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "reviews_address_created_idx": {
+          "name": "reviews_address_created_idx",
+          "columns": [
+            {
+              "expression": "address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_street_level_idx": {
+          "name": "reviews_street_level_idx",
+          "columns": [
+            {
+              "expression": "street_level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_building_level_idx": {
+          "name": "reviews_building_level_idx",
+          "columns": [
+            {
+              "expression": "building_level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_unit_level_idx": {
+          "name": "reviews_unit_level_idx",
+          "columns": [
+            {
+              "expression": "unit_level_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address_level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_agency_created_idx": {
+          "name": "reviews_agency_created_idx",
+          "columns": [
+            {
+              "expression": "agency_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_city_created_idx": {
+          "name": "reviews_city_created_idx",
+          "columns": [
+            {
+              "expression": "city_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_neighborhood_created_idx": {
+          "name": "reviews_neighborhood_created_idx",
+          "columns": [
+            {
+              "expression": "neighborhood_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'removed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_oxy_user_created_idx": {
+          "name": "reviews_oxy_user_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_moderation_queue_idx": {
+          "name": "reviews_moderation_queue_idx",
+          "columns": [
+            {
+              "expression": "moderation_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reviews\".\"moderation_status\" <> 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_author_address_key": {
+          "name": "reviews_author_address_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_address_id_addresses_id_fk": {
+          "name": "reviews_address_id_addresses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_street_level_id_addresses_id_fk": {
+          "name": "reviews_street_level_id_addresses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "street_level_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_building_level_id_addresses_id_fk": {
+          "name": "reviews_building_level_id_addresses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "building_level_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_unit_level_id_addresses_id_fk": {
+          "name": "reviews_unit_level_id_addresses_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "unit_level_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_city_id_cities_id_fk": {
+          "name": "reviews_city_id_cities_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_neighborhood_id_neighborhoods_id_fk": {
+          "name": "reviews_neighborhood_id_neighborhoods_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "neighborhoods",
+          "columnsFrom": [
+            "neighborhood_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "reviews_agency_id_agencies_id_fk": {
+          "name": "reviews_agency_id_agencies_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "agencies",
+          "columnsFrom": [
+            "agency_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reviews_address_level_check": {
+          "name": "reviews_address_level_check",
+          "value": "\"reviews\".\"address_level\" in ('BUILDING', 'UNIT')"
+        },
+        "reviews_unit_level_check": {
+          "name": "reviews_unit_level_check",
+          "value": "(\"reviews\".\"address_level\" = 'UNIT') = (\"reviews\".\"unit_level_id\" is not null)"
+        },
+        "reviews_moderation_status_check": {
+          "name": "reviews_moderation_status_check",
+          "value": "\"reviews\".\"moderation_status\" in ('active', 'under_review', 'removed')"
+        },
+        "reviews_currency_check": {
+          "name": "reviews_currency_check",
+          "value": "\"reviews\".\"currency\" in ('USD', 'EUR', 'GBP', 'CAD')"
+        },
+        "reviews_summer_temperature_check": {
+          "name": "reviews_summer_temperature_check",
+          "value": "\"reviews\".\"summer_temperature\" in ('very_cold', 'cold', 'moderate', 'warm', 'very_warm')"
+        },
+        "reviews_winter_temperature_check": {
+          "name": "reviews_winter_temperature_check",
+          "value": "\"reviews\".\"winter_temperature\" in ('very_cold', 'cold', 'moderate', 'warm', 'very_warm')"
+        },
+        "reviews_noise_check": {
+          "name": "reviews_noise_check",
+          "value": "\"reviews\".\"noise\" in ('very_quiet', 'quiet', 'moderate', 'noisy', 'very_noisy')"
+        },
+        "reviews_light_check": {
+          "name": "reviews_light_check",
+          "value": "\"reviews\".\"light\" in ('very_dark', 'dark', 'moderate', 'bright', 'very_bright')"
+        },
+        "reviews_condition_check": {
+          "name": "reviews_condition_check",
+          "value": "\"reviews\".\"condition_and_maintenance\" in ('poor', 'fair', 'good', 'very_good', 'excellent')"
+        },
+        "reviews_services_check": {
+          "name": "reviews_services_check",
+          "value": "\"reviews\".\"services\" <@ array['internet', 'cable_tv', 'parking', 'laundry', 'gym', 'pool', 'concierge', 'security', 'maintenance', 'cleaning']::text[]"
+        },
+        "reviews_landlord_treatment_check": {
+          "name": "reviews_landlord_treatment_check",
+          "value": "\"reviews\".\"landlord_treatment\" in ('very_poor', 'poor', 'fair', 'good', 'excellent')"
+        },
+        "reviews_problem_response_check": {
+          "name": "reviews_problem_response_check",
+          "value": "\"reviews\".\"problem_response\" in ('never_responded', 'very_slow', 'slow', 'reasonable', 'fast', 'very_fast')"
+        },
+        "reviews_deposit_returned_check": {
+          "name": "reviews_deposit_returned_check",
+          "value": "\"reviews\".\"deposit_returned\" in ('full', 'partial', 'no')"
+        },
+        "reviews_staircase_neighbors_check": {
+          "name": "reviews_staircase_neighbors_check",
+          "value": "\"reviews\".\"staircase_neighbors\" in ('very_unfriendly', 'unfriendly', 'neutral', 'friendly', 'very_friendly')"
+        },
+        "reviews_neighbor_relations_check": {
+          "name": "reviews_neighbor_relations_check",
+          "value": "\"reviews\".\"neighbor_relations\" in ('very_poor', 'poor', 'fair', 'good', 'excellent')"
+        },
+        "reviews_cleaning_check": {
+          "name": "reviews_cleaning_check",
+          "value": "\"reviews\".\"cleaning\" in ('very_dirty', 'dirty', 'acceptable', 'clean', 'very_clean')"
+        },
+        "reviews_area_tourists_check": {
+          "name": "reviews_area_tourists_check",
+          "value": "\"reviews\".\"area_tourists\" in ('none', 'few', 'moderate', 'many', 'overwhelming')"
+        },
+        "reviews_area_security_check": {
+          "name": "reviews_area_security_check",
+          "value": "\"reviews\".\"area_security\" in ('very_unsafe', 'unsafe', 'neutral', 'safe', 'very_safe')"
+        },
+        "reviews_area_noise_check": {
+          "name": "reviews_area_noise_check",
+          "value": "\"reviews\".\"area_noise\" in ('very_quiet', 'quiet', 'moderate', 'noisy', 'very_noisy')"
+        },
+        "reviews_area_cleanliness_check": {
+          "name": "reviews_area_cleanliness_check",
+          "value": "\"reviews\".\"area_cleanliness\" in ('very_dirty', 'dirty', 'acceptable', 'clean', 'very_clean')"
+        },
+        "reviews_rating_check": {
+          "name": "reviews_rating_check",
+          "value": "\"reviews\".\"rating\" between 1 and 5"
+        },
+        "reviews_lived_order_check": {
+          "name": "reviews_lived_order_check",
+          "value": "\"reviews\".\"lived_to\" > \"reviews\".\"lived_from\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.roommate_relationships": {
+      "name": "roommate_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user1_id": {
+          "name": "oxy_user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oxy_user2_id": {
+          "name": "oxy_user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "roommate_relationships_active_pair_key": {
+          "name": "roommate_relationships_active_pair_key",
+          "columns": [
+            {
+              "expression": "oxy_user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oxy_user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"roommate_relationships\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roommate_relationships_user1_idx": {
+          "name": "roommate_relationships_user1_idx",
+          "columns": [
+            {
+              "expression": "oxy_user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roommate_relationships_user2_idx": {
+          "name": "roommate_relationships_user2_idx",
+          "columns": [
+            {
+              "expression": "oxy_user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roommate_relationships_request_id_roommate_requests_id_fk": {
+          "name": "roommate_relationships_request_id_roommate_requests_id_fk",
+          "tableFrom": "roommate_relationships",
+          "tableTo": "roommate_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "roommate_relationships_status_check": {
+          "name": "roommate_relationships_status_check",
+          "value": "\"roommate_relationships\".\"status\" in ('active', 'ended')"
+        },
+        "roommate_relationships_sorted_pair_check": {
+          "name": "roommate_relationships_sorted_pair_check",
+          "value": "\"roommate_relationships\".\"oxy_user1_id\" < \"roommate_relationships\".\"oxy_user2_id\""
+        },
+        "roommate_relationships_match_score_check": {
+          "name": "roommate_relationships_match_score_check",
+          "value": "\"roommate_relationships\".\"match_score\" between 0 and 100"
+        },
+        "roommate_relationships_order_check": {
+          "name": "roommate_relationships_order_check",
+          "value": "\"roommate_relationships\".\"end_date\" is null or \"roommate_relationships\".\"end_date\" >= \"roommate_relationships\".\"start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.roommate_requests": {
+      "name": "roommate_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_oxy_user_id": {
+          "name": "from_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_oxy_user_id": {
+          "name": "to_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "roommate_requests_pending_pair_key": {
+          "name": "roommate_requests_pending_pair_key",
+          "columns": [
+            {
+              "expression": "from_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"roommate_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roommate_requests_from_idx": {
+          "name": "roommate_requests_from_idx",
+          "columns": [
+            {
+              "expression": "from_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "roommate_requests_to_status_idx": {
+          "name": "roommate_requests_to_status_idx",
+          "columns": [
+            {
+              "expression": "to_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "roommate_requests_status_check": {
+          "name": "roommate_requests_status_check",
+          "value": "\"roommate_requests\".\"status\" in ('pending', 'accepted', 'declined')"
+        },
+        "roommate_requests_distinct_parties_check": {
+          "name": "roommate_requests_distinct_parties_check",
+          "value": "\"roommate_requests\".\"from_oxy_user_id\" <> \"roommate_requests\".\"to_oxy_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_items": {
+      "name": "saved_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "saved_items_owner_target_key": {
+          "name": "saved_items_owner_target_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_items_folder_id_idx": {
+          "name": "saved_items_folder_id_idx",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"saved_items\".\"folder_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_items_target_idx": {
+          "name": "saved_items_target_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_items_target_id_properties_id_fk": {
+          "name": "saved_items_target_id_properties_id_fk",
+          "tableFrom": "saved_items",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_items_folder_id_saved_property_folders_id_fk": {
+          "name": "saved_items_folder_id_saved_property_folders_id_fk",
+          "tableFrom": "saved_items",
+          "tableTo": "saved_property_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "saved_items_target_type_check": {
+          "name": "saved_items_target_type_check",
+          "value": "\"saved_items\".\"target_type\" in ('property')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_property_folder_items": {
+      "name": "saved_property_folder_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "saved_property_folder_items_key": {
+          "name": "saved_property_folder_items_key",
+          "columns": [
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_property_folder_items_property_id_idx": {
+          "name": "saved_property_folder_items_property_id_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_property_folder_items_folder_id_saved_property_folders_id_fk": {
+          "name": "saved_property_folder_items_folder_id_saved_property_folders_id_fk",
+          "tableFrom": "saved_property_folder_items",
+          "tableTo": "saved_property_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_property_folder_items_property_id_properties_id_fk": {
+          "name": "saved_property_folder_items_property_id_properties_id_fk",
+          "tableFrom": "saved_property_folder_items",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_property_folders": {
+      "name": "saved_property_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3B82F6'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder-outline'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "saved_property_folders_owner_name_key": {
+          "name": "saved_property_folders_owner_name_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_searches": {
+      "name": "saved_searches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "oxy_user_id": {
+          "name": "oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "query_version": {
+          "name": "query_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "is_primary_area": {
+          "name": "is_primary_area",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cadence": {
+          "name": "cadence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "channels": {
+          "name": "channels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{in_app}'::text[]"
+        },
+        "muted_until": {
+          "name": "muted_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alerts_active_from": {
+          "name": "alerts_active_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "push_privacy_mode": {
+          "name": "push_privacy_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'discreet'"
+        },
+        "area": {
+          "name": "area",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_geo": {
+          "name": "area_geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "case when area is null then null else ST_GeomFromGeoJSON(area)::geography end",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "saved_searches_owner_name_key": {
+          "name": "saved_searches_owner_name_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_searches_owner_created_idx": {
+          "name": "saved_searches_owner_created_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_searches_notifications_enabled_idx": {
+          "name": "saved_searches_notifications_enabled_idx",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"saved_searches\".\"notifications_enabled\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_searches_primary_area_key": {
+          "name": "saved_searches_primary_area_key",
+          "columns": [
+            {
+              "expression": "oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"saved_searches\".\"is_primary_area\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "saved_searches_area_geo_gist": {
+          "name": "saved_searches_area_geo_gist",
+          "columns": [
+            {
+              "expression": "area_geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"saved_searches\".\"area_geo\" is not null",
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "saved_searches_cadence_check": {
+          "name": "saved_searches_cadence_check",
+          "value": "\"saved_searches\".\"cadence\" in ('instant', 'daily', 'weekly', 'off')"
+        },
+        "saved_searches_push_privacy_mode_check": {
+          "name": "saved_searches_push_privacy_mode_check",
+          "value": "\"saved_searches\".\"push_privacy_mode\" in ('discreet', 'detailed')"
+        },
+        "saved_searches_channels_check": {
+          "name": "saved_searches_channels_check",
+          "value": "\"saved_searches\".\"channels\" <@ ARRAY['in_app', 'push', 'email']::text[]\n        and cardinality(\"saved_searches\".\"channels\") >= 1\n        and 'in_app' = any(\"saved_searches\".\"channels\")"
+        },
+        "saved_searches_query_version_check": {
+          "name": "saved_searches_query_version_check",
+          "value": "query_version >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenant_application_documents": {
+      "name": "tenant_application_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tenant_application_documents_application_id_idx": {
+          "name": "tenant_application_documents_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_application_documents_application_id_tenant_applications_id_fk": {
+          "name": "tenant_application_documents_application_id_tenant_applications_id_fk",
+          "tableFrom": "tenant_application_documents",
+          "tableTo": "tenant_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenant_application_documents_type_check": {
+          "name": "tenant_application_documents_type_check",
+          "value": "\"tenant_application_documents\".\"type\" in ('id', 'income', 'reference', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenant_application_references": {
+      "name": "tenant_application_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tenant_application_references_application_id_idx": {
+          "name": "tenant_application_references_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_application_references_application_id_tenant_applications_id_fk": {
+          "name": "tenant_application_references_application_id_tenant_applications_id_fk",
+          "tableFrom": "tenant_application_references",
+          "tableTo": "tenant_applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenant_application_references_relationship_check": {
+          "name": "tenant_application_references_relationship_check",
+          "value": "\"tenant_application_references\".\"relationship\" in ('landlord', 'employer', 'personal', 'other')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tenant_applications": {
+      "name": "tenant_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicant_oxy_user_id": {
+          "name": "applicant_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "landlord_oxy_user_id": {
+          "name": "landlord_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "move_in_date": {
+          "name": "move_in_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_term_months": {
+          "name": "lease_term_months",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthly_income": {
+          "name": "monthly_income",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employment_status": {
+          "name": "employment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "tenant_applications_property_status_idx": {
+          "name": "tenant_applications_property_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_applications_applicant_status_idx": {
+          "name": "tenant_applications_applicant_status_idx",
+          "columns": [
+            {
+              "expression": "applicant_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tenant_applications_landlord_status_submitted_idx": {
+          "name": "tenant_applications_landlord_status_submitted_idx",
+          "columns": [
+            {
+              "expression": "landlord_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"submitted_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tenant_applications_property_id_properties_id_fk": {
+          "name": "tenant_applications_property_id_properties_id_fk",
+          "tableFrom": "tenant_applications",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tenant_applications_status_check": {
+          "name": "tenant_applications_status_check",
+          "value": "\"tenant_applications\".\"status\" in ('submitted', 'reviewing', 'approved', 'rejected', 'withdrawn')"
+        },
+        "tenant_applications_employment_status_check": {
+          "name": "tenant_applications_employment_status_check",
+          "value": "\"tenant_applications\".\"employment_status\" in ('employed', 'self_employed', 'student', 'retired', 'unemployed', 'other')"
+        },
+        "tenant_applications_decided_at_check": {
+          "name": "tenant_applications_decided_at_check",
+          "value": "(\"tenant_applications\".\"status\" in ('approved', 'rejected', 'withdrawn'))\n        = (\"tenant_applications\".\"decided_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.viewing_requests": {
+      "name": "viewing_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "property_id": {
+          "name": "property_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_oxy_user_id": {
+          "name": "requester_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_oxy_user_id": {
+          "name": "owner_oxy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "cancelled_by": {
+          "name": "cancelled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "viewing_requests_property_scheduled_status_idx": {
+          "name": "viewing_requests_property_scheduled_status_idx",
+          "columns": [
+            {
+              "expression": "property_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "viewing_requests_owner_scheduled_status_idx": {
+          "name": "viewing_requests_owner_scheduled_status_idx",
+          "columns": [
+            {
+              "expression": "owner_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "viewing_requests_requester_idx": {
+          "name": "viewing_requests_requester_idx",
+          "columns": [
+            {
+              "expression": "requester_oxy_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "viewing_requests_property_id_properties_id_fk": {
+          "name": "viewing_requests_property_id_properties_id_fk",
+          "tableFrom": "viewing_requests",
+          "tableTo": "properties",
+          "columnsFrom": [
+            "property_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "viewing_requests_status_check": {
+          "name": "viewing_requests_status_check",
+          "value": "\"viewing_requests\".\"status\" in ('pending', 'approved', 'declined', 'cancelled')"
+        },
+        "viewing_requests_cancelled_by_check": {
+          "name": "viewing_requests_cancelled_by_check",
+          "value": "\"viewing_requests\".\"cancelled_by\" in ('requester', 'owner')"
+        },
+        "viewing_requests_cancelled_by_status_check": {
+          "name": "viewing_requests_cancelled_by_status_check",
+          "value": "(\"viewing_requests\".\"status\" = 'cancelled') = (\"viewing_requests\".\"cancelled_by\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/backend/drizzle/meta/_journal.json
+++ b/packages/backend/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1786406907912,
       "tag": "0014_housing_candidate_materialization",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1786411778209,
+      "tag": "0015_address_merge_workflow",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/services/addressMerge.ts
+++ b/packages/backend/services/addressMerge.ts
@@ -1,0 +1,454 @@
+/**
+ * Merging two canonical addresses — issue #360's second half, ADR 0001 §8.1.
+ *
+ * ## The requirement is REVERSIBILITY, and it decides the whole shape
+ *
+ * ADR 0001 §2.1.7: *a duplicate is recorded, never discarded. Merging is
+ * reversible; deleting is not.* A merge that cannot be undone is a delete with
+ * extra steps, so nothing here deletes anything: the losing row keeps existing,
+ * keeps its identity keys, and gains a redirect that
+ * `materializeHousingCandidate` already follows.
+ *
+ * Reversibility needs more than the redirect. The redirect says which row
+ * survived; it says nothing about which relations moved, so an undo built on it
+ * alone would have to GUESS — and guessing here hands one household's reviews
+ * back to the wrong address. Every rewritten row is therefore itemised in
+ * `address_merge_relation_moves`, and {@link revertAddressMerge} replays that
+ * log backwards rather than re-deriving anything.
+ *
+ * ## Three phases, and the dry run is the same code
+ *
+ * {@link planAddressMerge} reads and writes nothing. {@link applyAddressMerge}
+ * calls it inside its own transaction and executes the plan it returns, so the
+ * preview a caller inspects is produced by the code that will do the work —
+ * a separate "plan" implementation would be a second thing to keep in step, and
+ * the one that drifted would be the one nobody ran.
+ *
+ * ## The collision that cannot be avoided, only decided
+ *
+ * `reviews_author_address_key` is UNIQUE on `(oxy_user_id, address_id)`. An
+ * author who reviewed BOTH rows has a review that cannot be moved. The two
+ * tempting answers — delete the loser's review, or overwrite it — are both
+ * forbidden by §2.1.7 and neither is reversible, so the row STAYS on the losing
+ * address, which still resolves through the redirect, and the fact that it
+ * stayed is recorded as `left_in_place` with the constraint that refused.
+ *
+ * That refusal has to happen without poisoning the transaction: in Postgres one
+ * failed statement aborts the whole thing (`25P02`), so each move runs inside a
+ * SAVEPOINT via `inSavepoint`. Hand-issuing `savepoint` / `rollback to` would
+ * look correct at every observable step and then fail at COMMIT with the
+ * original error — postgres.js records the failed query on the transaction and
+ * catching the rejection does not un-fail it.
+ */
+
+import { and, eq, sql } from 'drizzle-orm';
+import { constraintNameOf, isUniqueViolation } from '@oxyhq/db';
+
+import {
+  addressMergeRelationMoves,
+  addressMerges,
+  type AddressMergeReason,
+} from '../db/schema/addressMerges';
+import { addresses } from '../db/schema/addresses';
+import { getDb, inSavepoint, type DatabaseOrTransaction, type Transaction } from '../db/postgres';
+import { movableAddressRelations, type AddressRelation } from '../db/addresses/addressRelations';
+
+/**
+ * How far {@link resolveSurvivor} follows a redirect chain before refusing.
+ *
+ * The same bound `materializeHousingCandidate` applies to reads, for the same
+ * reason and deliberately the same number: a merge that produced a chain the
+ * matcher cannot walk would be a merge whose result is invisible to every
+ * caller. Because this service FLATTENS redirects, reaching the bound means a
+ * cycle or a chain built by something else, and both are refusals.
+ */
+const MAX_MERGE_REDIRECTS = 8;
+
+/** One relation row a merge would touch. */
+export interface PlannedMove {
+  readonly table: string;
+  readonly column: string;
+  readonly rowId: string;
+  readonly discriminator: AddressRelation['discriminator'];
+}
+
+export interface AddressMergePlan {
+  readonly survivorAddressId: string;
+  readonly mergedAddressId: string;
+  /** Every row that would be repointed, in a stable order. */
+  readonly moves: readonly PlannedMove[];
+  /** Rows per relation, for a caller that wants to eyeball the shape. */
+  readonly countsByRelation: Readonly<Record<string, number>>;
+}
+
+export type AddressMergeRefusal =
+  | { readonly kind: 'same_address' }
+  | { readonly kind: 'address_not_found'; readonly addressId: string }
+  /** The loser already lost a merge that is still in force. */
+  | { readonly kind: 'already_merged'; readonly intoAddressId: string }
+  /** Following the survivor's redirects came back to the loser. */
+  | { readonly kind: 'would_create_cycle' }
+  /** The survivor's own redirect chain is longer than the matcher can walk. */
+  | { readonly kind: 'redirect_chain_too_long' };
+
+export class AddressMergeRefusedError extends Error {
+  constructor(readonly refusal: AddressMergeRefusal) {
+    super(`Address merge refused: ${refusal.kind}`);
+    this.name = 'AddressMergeRefusedError';
+  }
+}
+
+export interface AddressMergeInput {
+  readonly survivorAddressId: string;
+  readonly mergedAddressId: string;
+  readonly reasonCode: AddressMergeReason;
+  /** The human sentence. Required — see the column's docblock. */
+  readonly reason: string;
+  readonly evidenceUrl?: string;
+  readonly actorOxyUserId?: string;
+}
+
+export interface AppliedMove extends PlannedMove {
+  readonly outcome: 'moved' | 'left_in_place';
+  readonly blockedByConstraint: string | null;
+}
+
+export interface AddressMergeResult {
+  readonly mergeId: string;
+  readonly survivorAddressId: string;
+  readonly mergedAddressId: string;
+  readonly moves: readonly AppliedMove[];
+  readonly movedCount: number;
+  readonly leftInPlaceCount: number;
+}
+
+/**
+ * A `WHERE` matching the rows of one relation that point at `addressId`.
+ *
+ * Both identifiers come from the registry, which derives them from the schema —
+ * they are never caller input — and they still go through `sql.identifier` so
+ * the statement cannot be malformed by a name needing quoting.
+ */
+function pointsAt(relation: AddressRelation, addressId: string) {
+  const column = sql`${sql.identifier(relation.table)}.${sql.identifier(relation.column)}`;
+  if (!relation.discriminator) return sql`${column} = ${addressId}`;
+  // The discriminator is REQUIRED on a polymorphic column: without it the
+  // statement means "every subject", which is a different query that happens to
+  // return the same rows today.
+  return sql`${column} = ${addressId} and ${sql.identifier(relation.table)}.${sql.identifier(
+    relation.discriminator.column,
+  )} = ${relation.discriminator.value}`;
+}
+
+/** Follow `merged_into_address_id` to the row a caller should really use. */
+async function resolveSurvivor(
+  db: DatabaseOrTransaction,
+  startId: string,
+): Promise<{ id: string } | AddressMergeRefusal> {
+  let currentId = startId;
+  for (let hop = 0; hop <= MAX_MERGE_REDIRECTS; hop += 1) {
+    const [row] = await db
+      .select({ id: addresses.id, mergedInto: addresses.mergedIntoAddressId })
+      .from(addresses)
+      .where(eq(addresses.id, currentId))
+      .limit(1);
+    if (!row) return { kind: 'address_not_found', addressId: currentId };
+    if (!row.mergedInto) return { id: row.id };
+    currentId = row.mergedInto;
+  }
+  return { kind: 'redirect_chain_too_long' };
+}
+
+/**
+ * What a merge would do. Reads only.
+ *
+ * Exported so a caller can inspect it — the issue's "permitir dry-run con plan
+ * completo" — and used by {@link applyAddressMerge} itself, so the preview and
+ * the execution cannot disagree.
+ */
+export async function planAddressMerge(
+  input: Pick<AddressMergeInput, 'survivorAddressId' | 'mergedAddressId'>,
+  db: DatabaseOrTransaction = getDb(),
+): Promise<AddressMergePlan> {
+  const { survivorAddressId, mergedAddressId } = input;
+  if (survivorAddressId === mergedAddressId) {
+    throw new AddressMergeRefusedError({ kind: 'same_address' });
+  }
+
+  const loser = await resolveExistingAddress(db, mergedAddressId);
+  if (loser.mergedInto) {
+    throw new AddressMergeRefusedError({
+      kind: 'already_merged',
+      intoAddressId: loser.mergedInto,
+    });
+  }
+
+  const survivor = await resolveSurvivor(db, survivorAddressId);
+  if ('kind' in survivor) throw new AddressMergeRefusedError(survivor);
+  // Following the survivor's redirects landed back on the row being retired, so
+  // applying this merge would make the pair unreachable from either end. A
+  // self-referencing foreign key cannot see a cycle of length two or more; this
+  // is where it is refused.
+  if (survivor.id === mergedAddressId) {
+    throw new AddressMergeRefusedError({ kind: 'would_create_cycle' });
+  }
+
+  const moves: PlannedMove[] = [];
+  const countsByRelation: Record<string, number> = {};
+
+  for (const relation of movableAddressRelations()) {
+    const rows = await db.execute<{ id: string }>(
+      sql`select ${sql.identifier(relation.table)}.id as id
+          from ${sql.identifier(relation.table)}
+          where ${pointsAt(relation, mergedAddressId)}
+          order by ${sql.identifier(relation.table)}.id`,
+    );
+    const ids = [...rows].map((row) => row.id);
+    countsByRelation[`${relation.table}.${relation.column}`] = ids.length;
+    for (const rowId of ids) {
+      moves.push({
+        table: relation.table,
+        column: relation.column,
+        rowId,
+        discriminator: relation.discriminator,
+      });
+    }
+  }
+
+  return { survivorAddressId: survivor.id, mergedAddressId, moves, countsByRelation };
+}
+
+async function resolveExistingAddress(
+  db: DatabaseOrTransaction,
+  addressId: string,
+): Promise<{ id: string; mergedInto: string | null }> {
+  const [row] = await db
+    .select({ id: addresses.id, mergedInto: addresses.mergedIntoAddressId })
+    .from(addresses)
+    .where(eq(addresses.id, addressId))
+    .limit(1);
+  if (!row) throw new AddressMergeRefusedError({ kind: 'address_not_found', addressId });
+  return { id: row.id, mergedInto: row.mergedInto };
+}
+
+/**
+ * Move one relation row, tolerating the unique violation that a legitimately
+ * duplicated relation produces.
+ *
+ * The savepoint is `inSavepoint` — a NESTED DRIZZLE TRANSACTION — and not a
+ * hand-issued `savepoint` / `rollback to`. The hand-rolled version behaves
+ * correctly at every step a test can observe and then rejects at COMMIT with the
+ * original duplicate-key error, because postgres.js records the failed query on
+ * the transaction object and catching the rejection does not un-fail it. Only a
+ * savepoint the DRIVER owns rolls its bookkeeping back too.
+ */
+async function moveOne(
+  tx: Transaction,
+  move: PlannedMove,
+  survivorAddressId: string,
+): Promise<AppliedMove> {
+  try {
+    await inSavepoint(tx, async (sp) =>
+      sp.execute(
+        sql`update ${sql.identifier(move.table)}
+            set ${sql.identifier(move.column)} = ${survivorAddressId}
+            where ${sql.identifier(move.table)}.id = ${move.rowId}`,
+      ),
+    );
+    return { ...move, outcome: 'moved', blockedByConstraint: null };
+  } catch (error) {
+    // `isUniqueViolation` reads the SQLSTATE off `cause`, because drizzle wraps
+    // the driver's error and `error.code` is undefined on the wrapper — a
+    // predicate written against `error.code` is permanently false and collapses
+    // this branch into the one below it.
+    if (!isUniqueViolation(error)) throw error;
+    return {
+      ...move,
+      outcome: 'left_in_place',
+      // Recorded rather than derived: which constraint refused is the one fact
+      // an operator needs, and it is gone by the time anybody reads the log.
+      blockedByConstraint: constraintNameOf(error) ?? 'unknown_unique_constraint',
+    };
+  }
+}
+
+/**
+ * Declare two rows the same place, in one transaction.
+ *
+ * The ORDER is the requirement the issue states as "no eliminar la entidad
+ * origen antes de validar que todas las referencias se movieron": relations
+ * move first, the redirect is written last, and both are inside one transaction
+ * so neither can be observed without the other. Nothing is deleted at any point,
+ * which is what makes the ordering a safety property rather than a race.
+ */
+export async function applyAddressMerge(
+  input: AddressMergeInput,
+  db: DatabaseOrTransaction = getDb(),
+): Promise<AddressMergeResult> {
+  const run = async (tx: Transaction): Promise<AddressMergeResult> => {
+    const plan = await planAddressMerge(input, tx);
+
+    const applied: AppliedMove[] = [];
+    for (const move of plan.moves) {
+      applied.push(await moveOne(tx, move, plan.survivorAddressId));
+    }
+
+    const movedCount = applied.filter((move) => move.outcome === 'moved').length;
+
+    // The redirect, written only now that every relation has been dealt with.
+    await tx
+      .update(addresses)
+      .set({ mergedIntoAddressId: plan.survivorAddressId })
+      .where(eq(addresses.id, plan.mergedAddressId));
+
+    const [merge] = await tx
+      .insert(addressMerges)
+      .values({
+        survivorAddressId: plan.survivorAddressId,
+        mergedAddressId: plan.mergedAddressId,
+        reasonCode: input.reasonCode,
+        reason: input.reason,
+        evidenceUrl: input.evidenceUrl ?? null,
+        actorOxyUserId: input.actorOxyUserId ?? null,
+        movedRelationCount: movedCount,
+        appliedAt: new Date(),
+      })
+      .returning({ id: addressMerges.id });
+
+    if (applied.length > 0) {
+      await tx.insert(addressMergeRelationMoves).values(
+        applied.map((move) => ({
+          mergeId: merge.id,
+          relationTable: move.table,
+          relationColumn: move.column,
+          relationRowId: move.rowId,
+          previousAddressId: plan.mergedAddressId,
+          outcome: move.outcome,
+          blockedByConstraint: move.blockedByConstraint,
+        })),
+      );
+    }
+
+    return {
+      mergeId: merge.id,
+      survivorAddressId: plan.survivorAddressId,
+      mergedAddressId: plan.mergedAddressId,
+      moves: applied,
+      movedCount,
+      leftInPlaceCount: applied.length - movedCount,
+    };
+  };
+
+  // A caller already inside a transaction gets its own; otherwise open one.
+  return 'transaction' in db
+    ? db.transaction((tx) => run(tx as Transaction))
+    : run(db as Transaction);
+}
+
+export type AddressMergeRevertRefusal =
+  | { readonly kind: 'merge_not_found'; readonly mergeId: string }
+  | { readonly kind: 'already_reverted' }
+  /** The loser has since lost ANOTHER merge; undoing out of order is unsafe. */
+  | { readonly kind: 'superseded'; readonly currentSurvivorId: string }
+  /** The move log does not carry the number of moves the merge recorded. */
+  | { readonly kind: 'move_log_incomplete'; readonly expected: number; readonly found: number };
+
+export class AddressMergeRevertRefusedError extends Error {
+  constructor(readonly refusal: AddressMergeRevertRefusal) {
+    super(`Address merge revert refused: ${refusal.kind}`);
+    this.name = 'AddressMergeRevertRefusedError';
+  }
+}
+
+/**
+ * Undo a merge by replaying its log backwards.
+ *
+ * ## It replays, and never re-derives
+ *
+ * "Move everything currently on the survivor back to the loser" would be the
+ * obvious implementation and is catastrophically wrong: the survivor has its own
+ * relations, and some arrived after the merge. Only the itemised log knows which
+ * rows this merge touched, which is the reason the log exists.
+ *
+ * ## The floor that makes a partial log a refusal rather than a partial undo
+ *
+ * `address_merges.moved_relation_count` was written by the apply, and the revert
+ * asserts the log still holds exactly that many `moved` rows. A merge whose log
+ * were truncated would otherwise be half-reverted silently — the shape of loss
+ * this whole file exists to prevent. `0` is a legitimate count (merging a row
+ * nothing references is ordinary), so the assertion is equality, never `> 0`.
+ */
+export async function revertAddressMerge(
+  mergeId: string,
+  actorOxyUserId: string | null,
+  db: DatabaseOrTransaction = getDb(),
+): Promise<{ restoredCount: number }> {
+  const run = async (tx: Transaction): Promise<{ restoredCount: number }> => {
+    const [merge] = await tx
+      .select()
+      .from(addressMerges)
+      .where(eq(addressMerges.id, mergeId))
+      .limit(1);
+    if (!merge) throw new AddressMergeRevertRefusedError({ kind: 'merge_not_found', mergeId });
+    if (merge.status === 'reverted') {
+      throw new AddressMergeRevertRefusedError({ kind: 'already_reverted' });
+    }
+
+    // The loser must still redirect to THIS merge's survivor. If it redirects
+    // somewhere else, a later merge moved it and undoing this one first would
+    // leave the two logs describing a state neither produced.
+    const loser = await resolveExistingAddress(tx, merge.mergedAddressId);
+    if (loser.mergedInto !== merge.survivorAddressId) {
+      throw new AddressMergeRevertRefusedError({
+        kind: 'superseded',
+        currentSurvivorId: loser.mergedInto ?? merge.mergedAddressId,
+      });
+    }
+
+    const moves = await tx
+      .select()
+      .from(addressMergeRelationMoves)
+      .where(eq(addressMergeRelationMoves.mergeId, mergeId));
+    const moved = moves.filter((move) => move.outcome === 'moved');
+    if (moved.length !== merge.movedRelationCount) {
+      throw new AddressMergeRevertRefusedError({
+        kind: 'move_log_incomplete',
+        expected: merge.movedRelationCount,
+        found: moved.length,
+      });
+    }
+
+    // Clear the redirect FIRST: a row moving back to the loser while the loser
+    // still redirects would be readable, through the matcher, as still living on
+    // the survivor — a window in which the undo is half-visible. Inside one
+    // transaction nobody can observe it, and doing it in the order that is
+    // correct anyway costs nothing.
+    await tx
+      .update(addresses)
+      .set({ mergedIntoAddressId: null })
+      .where(eq(addresses.id, merge.mergedAddressId));
+
+    for (const move of moved) {
+      await tx.execute(
+        sql`update ${sql.identifier(move.relationTable)}
+            set ${sql.identifier(move.relationColumn)} = ${move.previousAddressId}
+            where ${sql.identifier(move.relationTable)}.id = ${move.relationRowId}`,
+      );
+    }
+
+    await tx
+      .update(addressMerges)
+      .set({
+        status: 'reverted',
+        revertedAt: new Date(),
+        revertedByOxyUserId: actorOxyUserId,
+      })
+      .where(and(eq(addressMerges.id, mergeId), eq(addressMerges.status, 'applied')));
+
+    return { restoredCount: moved.length };
+  };
+
+  return 'transaction' in db
+    ? db.transaction((tx) => run(tx as Transaction))
+    : run(db as Transaction);
+}


### PR DESCRIPTION
Part 2 of #360: **MERGE**. Split is deliberately a follow-up — the reasoning and the measurement are at the bottom.

## The census, from the live catalogue

I migrated a namespaced database to 0014 and read `pg_constraint`, then cross-checked against a `git grep` of the schema. Both instruments returned the same set, which is the cross-check; the catalogue is the authority. **Positive control: it found `properties.address_id`, which I already knew existed.**

**The census corrected three things in the brief I was given, and I would rather say so than quietly work around them:**

- **`reviews` has FOUR address columns, not one** — `address_id` plus `street_level_id`, `building_level_id`, `unit_level_id`. A merge moving only `address_id` leaves a review filed under the retired row at two of its three levels. There is a test for exactly this, and the mutation that reclassifies the three level columns reds it and nothing else.
- **`evictions` has ZERO** foreign keys to addresses. `eviction_cases` references agencies, organisations and images.
- **`leases` has ZERO.** It reaches a place through `property_id`, so it follows a merge for free.

Two columns hold an address id with **no foreign key at all** — `housing_domain_events.subject_id` and `housing_alerts.subject_id`, both `CHECK (subject_type IN (…, 'address', …))`. A FK-only census misses both. `images.entity_type` does **not** include `address`, so there is no media for a merge to lose — worth stating because the issue's must-not-lose list names it.

## Nothing is deleted, and that is measured rather than asserted

ADR 0001 §2.1.7: *a duplicate is recorded, never discarded. Merging is reversible; deleting is not.*

Of the twelve columns that could point at an address before this PR, **eleven refuse a delete and exactly one CASCADES**: `address_external_refs.address_id`. Deleting a losing row would therefore not merely be irreversible — it would be irreversible *quietly, on the one table that decides whether the next ingest finds that place again*. Everything else would at least raise. That asymmetry is the argument for redirect-never-delete, and it is a `pg_constraint` reading rather than a principle.

## The registry is DERIVED, so it cannot go stale

`db/addresses/addressRelations.ts` reads the foreign keys out of the drizzle schema, so a column added tomorrow appears without anybody remembering. Each one is classified `move` / `keep` / `audit`, and **being unclassified throws** — no default, because a default is a decision made by absence: `move` would rewrite an audit row the first time somebody adds one, `keep` would leave a live relation pointing at a retired address.

- `move` — listings, all four review columns, provider refs, `parent_address_id` (a unit whose building lost a merge must re-parent), `merged_into_address_id` (flattened, so the redirect stays one hop inside the matcher's bound).
- `keep` — `address_materializations.address_id` and `address_candidates.materialized_address_id`. These say *"this act produced THAT row"*, a fact about the past; rewriting them would make the audit claim a materialization produced a row it did not.
- `audit` — the merge's own record.

The two polymorphic columns are declared by hand, and the declaration is the dangerous half — so the gate reads the LIVE `subject_type` CHECK and fails if it stops admitting `'address'`.

## The collision that can only be decided

`reviews_author_address_key` is unique on `(oxy_user_id, address_id)`, so an author who reviewed both rows has a review that cannot move. Deleting it and overwriting it are both forbidden by §2.1.7 and neither is reversible, so it **stays on the loser** — which still resolves through the redirect — recorded as `left_in_place` with the constraint that refused.

Each move runs inside `inSavepoint`, a nested drizzle transaction. A hand-issued `savepoint` / `rollback to` behaves correctly at every observable step and then **rejects at COMMIT** with the original error, because postgres.js records the failed query on the transaction object. The predicate is `isUniqueViolation`, not `error.code === '23505'` — drizzle wraps the driver error and the SQLSTATE lives on `cause`.

## Reversibility is the requirement

`revertAddressMerge` **replays the itemised log backwards** and never re-derives. "Move everything on the survivor back" is the obvious implementation and is catastrophic: the survivor has its own relations, some of which arrived after the merge. There is a test asserting the survivor's own property does *not* move back.

`address_merges.moved_relation_count` is the anti-vacuity floor: a revert asserts the log still holds exactly that many `moved` rows, so a truncated log is a refusal rather than a silent half-undo. `0` is legitimate (merging a row nothing references is ordinary), so the assertion is equality and never `> 0`.

## Migration 0015 — verified both ways, with a floor

`0015_address_merge_workflow`, `pre`, additive: two new tables, no change to any existing one.

| check | result |
|---|---|
| applied to a database **already holding 0014** | ✅ |
| built **fresh** 0000→0015 | ✅ |
| catalogue diff (columns + constraints + indexes) | **IDENTICAL**, 1,763 lines each |
| floor | 1,500 — *two empty dumps also compare equal* |
| positive control | deleting one line IS detected |
| `$<digit>` placeholders in the generated SQL | **0** |

## Mutation evidence — four, each reddening a different assertion

Each confirmed landed before running, each restored from a namespaced pristine copy (never `git checkout`), restore verified by md5 plus markers plus a negative control.

| # | mutation | result |
|---|---|---|
| **M1** | reclassify the three review LEVEL columns as `keep` | **1 red** — the "reviews at every level" case, and only it |
| **M2** | drop `properties.address_id` from the classifier | **8 red** including the registry gate; `properties` named 16× |
| **M3** | read the SQLSTATE off `error.code` instead of `cause` | **1 red** — the collision case, proving the documented drizzle trap is caught |
| **M4** | delete the move-log completeness floor from revert | **1 red** — the truncated-log case |

The first attempt at M1 was **broader than I intended** — the anchor caught a `case` fall-through group, so it also unclassified `properties.address_id` and `reviews.address_id` and reds 6 tests. Re-done precisely (an earlier `case` wins) it reds exactly one. Recorded because the wrong version would have overstated what the test proves.

## A gate this change BROKE, and how

`resetGeoTables` deletes tables in a hand-maintained order before `addresses`, and my new RESTRICT audit was not in it: **337 failures across 27 suites, none of them in the file that caused it** — precisely the symptom that helper's own comment warns about ("it does NOT look like a missing delete"). Fixed, and this PR's suite now carries a case that fails BY NAME if it regresses, so the next person gets a named failure instead of a mystery in somebody else's file.

Two other gates correctly demanded entries, and both were right to: the partial-unique list, and the id-column classifier. For the latter, `address_merge_relation_moves.previous_address_id` got a **real foreign key** rather than an exemption — after which the derived registry gate immediately failed on it as unclassified, which is the gate doing its job on its own author.

## Verification

| check | result |
|---|---|
| `typecheck` (backend) | exit **0** |
| `test` (backend, real Postgres) | exit **0** — **156 suites, 2,167 tests** |
| `lint` | exit **0** — 0 errors; one `no-fallthrough` I introduced is fixed, my files produce nothing |
| `scripts/check-docs.mjs` | exit **0** |
| lockfile | not re-run — no dependency change |

`tsc` needs `packages/listing-providers` built first, or it reports 100+ phantom `TS6305`s — the project-reference/`dist` skew, not a code error.

## Split is a follow-up, and here is the measurement

`services/housingMaterialization.ts` is 1,348 lines with 1,032 of tests at this repo's density; this PR is ~1,600 lines of source and test. Adding split would double it, on the identity of every place in the product, in a single reviewable pass.

Split is not blocked — the engine generalises: merge is *"move ALL relations, plus set the redirect"*, split is *"move an EXPLICITLY ENUMERATED subset to a new or selected row"*, and `address_merge_relation_moves.previous_address_id` is already stored per row rather than derived from the parent precisely so a split's differing previous values fit the same log.

**One thing I expect to be the real question in B, flagged now rather than discovered then:** splitting `reviews` needs per-review evidence about which dwelling the author meant, and no column carries it. The issue's own "no adivinar por completo qué pertenece a cada lado" says the caller must enumerate — which is implementable, but it means a split of reviews is an operator asserting authorship intent, and that deserves its own decision rather than riding in on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
