### PR TITLE
fix(deploy): the backend always deploys, because a skipped one can strand a migration (#430)

### DIFF
--- a/.github/scripts/deployment-scope.sh
+++ b/.github/scripts/deployment-scope.sh
@@ -19,6 +19,56 @@
 # green tick next to it. So every uncertainty resolves to deploy — an empty diff,
 # an unreadable range, an unknown target, a commit with no parent.
 #
+# THE BACKEND NOW RESOLVES TO DEPLOY UNCONDITIONALLY (#430)
+#
+# The docs-only skip was correct in isolation and unsafe in combination. A run
+# PENDING on `main` is EVICTED when a newer push arrives — `cancel-in-progress`
+# is false for main, which protects a run that has STARTED and not a queued one —
+# so a commit's own deploy can be dropped. If the NEXT commit is documentation,
+# this check said `false`, nothing deployed, and `main` stayed green. Since #417
+# armed migrations on deploy, what waits is a SCHEMA, and the symptom is the one
+# this repository has already paid for once: `/health` answering `200 database:
+# healthy` while queries fail on columns that do not exist.
+#
+# Measured on 2026-08-11 before choosing, over the last 200 first-parent commits
+# on main using THIS script rather than a re-implementation of it:
+#
+#   * 10 commits (5%) were documentation-only — the whole value of the skip.
+#   * 6 of those 10 landed immediately after a code commit, which is the exact
+#     pairing the hazard needs.
+#   * the longest run of consecutive documentation-only commits was 4, so the
+#     wait was not merely possible but unbounded.
+#   * 27 of the last 100 CI runs on main concluded `cancelled`, each with ZERO
+#     jobs, i.e. evicted while pending.
+#   * a backend deploy costs 10-13 minutes of runner time, so restoring those 10
+#     deploys costs about two hours per 200 commits.
+#
+# WHY NOT KEEP THE SKIP AND MAKE IT SAFE. Skipping is safe only when nothing
+# undeployed needs the backend, and this repository cannot answer "did an earlier
+# commit deploy?" from inside a run:
+#
+#   * the deployed artefact carries only a digest, and mapping it back to a tag
+#     needs `ecr:DescribeImages`, which is implicitDeny for oxy-github-deploy —
+#     recorded in deploy-aws.yml where the build resolves its own digest for the
+#     same reason;
+#   * the live task definition records no commit at all (measured on
+#     `oxy-homiio:80`: no SHA-shaped environment variable, `dockerLabels` null);
+#   * the run's outcome lives in the Actions API, which this job has no
+#     permission for — and an evicted run concluded `cancelled` with zero jobs,
+#     so its record cannot distinguish "did not deploy" from "was not reached".
+#
+# So a scope check with no external state must assume the worst about every
+# predecessor, walk back to the last code commit, and deploy — which, given that
+# 6 of the 10 documentation commits sat directly on top of one, is this.
+#
+# A marker (a git ref, or a commit stamped into the task definition) would keep
+# the optimisation and was rejected on failure DIRECTION, not on effort: a marker
+# that is ever wrong skips a deploy, which is the failure being fixed,
+# reintroduced by the fix. Two hours of runner time per 200 commits is the price
+# of not having an invariant that can rot. If documentation-only commits ever
+# become a large fraction of main — the measurement to re-run is the one above,
+# and 5% is the number to beat — the trade is worth revisiting.
+#
 # THE RANGE
 #
 # `<sha>^1..<sha>`: first-parent, which is the whole of what a merge commit
@@ -59,13 +109,14 @@ fi
 
 case "$TARGET" in
   backend)
-    # Mirrors the old `paths-ignore: ['**.md', 'docs/**']`. Asked as "is anything
-    # NOT documentation", so a file shape these two patterns do not describe
-    # counts as code and deploys.
-    if printf '%s\n' "$CHANGED" | grep -qvE '(\.md$|^docs/)'; then
-      emit true "a non-documentation file changed"
-    fi
-    emit false "documentation only"
+    # ALWAYS. The backend has no scope check any more, and the deletion is the
+    # fix for #430 rather than a simplification — see the header section above.
+    #
+    # `$CHANGED` is still computed, and deliberately: the two fail-open branches
+    # before this one (an unreadable diff, an empty diff) stay meaningful for the
+    # frontend, and a target that silently stopped reading the diff would be the
+    # kind of half-alive check this file exists to avoid.
+    emit true "the backend always deploys; a per-commit skip is not safe here (#430)"
     ;;
   frontend)
     # Mirrors the old `paths:` allowlist verbatim.

--- a/.github/scripts/test-deployment-scope.sh
+++ b/.github/scripts/test-deployment-scope.sh
@@ -5,7 +5,29 @@
 # something is a verdict of `false` that should have been `true`: production stays
 # on old code and the workflow reports success. A scope check that answered
 # `false` to everything would look identical to a quiet week. Both verdicts are
-# therefore asserted for both targets, on real commits with real diffs.
+# therefore asserted on real commits with real diffs.
+#
+# ## The case this file exists for now (#430)
+#
+# The backend hazard was never one rule being wrong. It was two correct rules in
+# combination — a run EVICTED while pending on main, and a documentation-only
+# commit landing next — so testing either separately proves nothing about the
+# interaction. `evicted_then_docs_only` below reproduces the pair.
+#
+# A harness cannot evict a GitHub run, and does not need to: the only thing an
+# eviction changes about THIS script's input is that the previous commit never
+# deployed and the next decision is taken one commit further along. That is
+# exactly the fixture — a backend commit carrying a migration, then a
+# documentation commit, with the verdict read at the documentation commit.
+#
+# ## Where the discrimination now lives
+#
+# Every backend verdict is `true` by design, so the backend cases can no longer
+# tell a working script from `emit true` at the top of the file. The FRONTEND
+# cases carry that weight: `frontend skips a backend-only commit` is the one
+# assertion here that a stuck-open script fails, and it is why the frontend arm
+# is exercised in both directions rather than only in the one this change
+# touched.
 
 set -uo pipefail
 
@@ -48,8 +70,8 @@ expect() {
 }
 
 expect "backend deploys on backend source" true "$(verdict backend packages/backend/server.ts)"
-expect "backend skips a docs-only commit" false "$(verdict backend docs/guide.md)"
-expect "backend skips a root markdown commit" false "$(verdict backend AGENTS.md)"
+expect "backend deploys on a docs-only commit" true "$(verdict backend docs/guide.md)"
+expect "backend deploys on a root markdown commit" true "$(verdict backend AGENTS.md)"
 expect "frontend deploys on frontend source" true "$(verdict frontend packages/frontend/app/index.tsx)"
 expect "frontend deploys on shared-types" true "$(verdict frontend packages/shared-types/src/index.ts)"
 expect "frontend deploys on the lockfile" true "$(verdict frontend bun.lock)"
@@ -57,8 +79,58 @@ expect "frontend skips a backend-only commit" false "$(verdict frontend packages
 # The fail-open direction: anything the script cannot judge must still deploy.
 expect "an unknown target deploys" true "$(verdict sideways packages/backend/server.ts)"
 
+# ── The combination, which is the whole point (#430) ──
+#
+# Commit A carries a migration and its run is evicted while pending, so nothing
+# deploys. Commit B is documentation. The verdict is read at B, which is the
+# decision that decides whether A's migration ever reaches production.
+#
+# Under the per-commit rule this answered `false` and A's migration waited
+# indefinitely behind however many documentation commits followed — measured at
+# up to four consecutive on real history — with main green throughout.
+
+# The verdict for a target at whatever HEAD already is, committing nothing.
+verdict_at_head() {
+  local target="$1" output
+  output=$(cd "$WORKDIR" && GITHUB_OUTPUT=/dev/null DEPLOY_SHA=HEAD bash "$SCRIPT" "$target" 2>&1)
+  printf '%s' "${output##*deploy=}" | cut -d' ' -f1
+}
+
+# A: the commit whose deploy is lost to the eviction.
+mkdir -p "$WORKDIR/packages/backend/drizzle" "$WORKDIR/docs"
+echo "create table t ();" >"$WORKDIR/packages/backend/drizzle/0099_probe.sql"
+git -C "$WORKDIR" add -A >/dev/null
+git -C "$WORKDIR" commit -qm "migration that never deployed" >/dev/null
+# B: the documentation commit that lands next and takes the decision.
+echo "$RANDOM" >>"$WORKDIR/docs/next.md"
+git -C "$WORKDIR" add -A >/dev/null
+git -C "$WORKDIR" commit -qm "docs only" >/dev/null
+
+expect "an evicted migration is not stranded by a docs-only next commit" \
+  true "$(verdict_at_head backend)"
+
+# The SAME pairing, read for the frontend, must still SKIP. Three things this
+# buys, and none of them is symmetry:
+#   * it proves the fixture really is documentation-only, so the backend verdict
+#     above comes from the new rule rather than from a fixture that quietly
+#     touched something;
+#   * the frontend has no migration to strand — the same combination costs a
+#     stale bundle, and an hour-long web export is not the same trade;
+#   * it is one of the two assertions here that a stuck-open script fails.
+expect "the same pairing still skips the frontend" false "$(verdict_at_head frontend)"
+
+# And the streak, because one documentation commit is not the worst case. Real
+# history carried FOUR consecutive documentation-only commits, so a fix that only
+# looks back one commit would strand a migration behind the second one and pass
+# the case above. A second documentation commit is appended and the verdict read
+# again.
+echo "$RANDOM" >>"$WORKDIR/docs/next2.md"
+git -C "$WORKDIR" add -A >/dev/null
+git -C "$WORKDIR" commit -qm "docs only, again" >/dev/null
+expect "nor by a SECOND consecutive docs-only commit" true "$(verdict_at_head backend)"
+
 if [ "$FAILURES" -gt 0 ]; then
   echo "Deployment scope tests failed: $FAILURES case(s)." >&2
   exit 1
 fi
-echo "Deployment scope check discriminated 8 case(s)."
+echo "Deployment scope check discriminated 11 case(s)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,36 @@ on:
 # newest DOES win; what is guaranteed is only that a run already executing is
 # left alone.
 #
+# Eviction is not rare, and the rate belongs beside the claim: 27 of the last 100
+# CI runs on main concluded `cancelled` (measured 2026-08-11), every one of them
+# with zero jobs. Roughly one main push in four never starts.
+#
 # For a rollout that is the property that matters: a run that never started
 # never called `update-service` and never started a migrator, so nothing is left
-# half-done. The cost lands elsewhere and is worth knowing — an intermediate
-# commit's deploy can be dropped entirely, and `deployment-scope.sh` reads a
-# single commit (`<sha>^1..<sha>`), so if the run that wins is documentation-only
-# it deploys nothing at all and the skipped commit's changes wait for the next
-# code merge.
+# half-done. The cost lands on the NEXT run, and #430 is what that cost turned
+# into once #417 armed migrations.
+#
+# An intermediate commit's deploy can be dropped entirely, so the next run has to
+# carry it. `deployment-scope.sh` used to read a single commit
+# (`<sha>^1..<sha>`), which meant a documentation-only winner deployed nothing at
+# all and the dropped commit's changes waited for the next code merge — measured
+# at up to FOUR consecutive documentation commits on real history, so the wait
+# was unbounded rather than merely long. With a migration in the dropped commit
+# that is a schema sitting behind the code with main green, which is the silent
+# shape this repository has already paid for once.
+#
+# **The backend no longer skips**: `deployment-scope.sh backend` always emits
+# `true`, so an evicted commit is picked up by whatever lands next regardless of
+# what that commit touched. The measurements behind deleting the optimisation
+# rather than making it stateful are in that script's header, and the pairing is
+# pinned by `.github/scripts/test-deployment-scope.sh`.
+#
+# The FRONTEND still skips, deliberately: deploy-frontends.yml triggers on
+# `workflow_run` with `conclusion == 'success'`, so a cancelled run already skips
+# it, and the same combination costs a stale bundle rather than a schema/code
+# split. That is a smaller cost against an hour-long web export, and it is a
+# trade rather than an oversight — but it IS the same mechanism, and if a wire
+# contract ever splits across it, this is the paragraph to come back to.
 concurrency:
   group: ci-${{ github.ref }}
   # An EXPRESSION, and a mistyped one degrades silently to falsy — which would


### PR DESCRIPTION
Closes #430.

## The combination, restated

- A run **PENDING** on `main` is **evicted** when a newer push arrives. `cancel-in-progress: false` protects a run that has STARTED, not a queued one.
- `deployment-scope.sh backend` skipped a documentation-only commit.

Neither is wrong alone. Together, the commit carrying a migration loses its deploy and the next commit declines to carry it — `main` green throughout. Since #417 armed migrations on deploy, what waits is a **schema**, and the symptom is the one this repo has already paid for once: `/health` answering `200 database: healthy` while queries fail on columns that do not exist.

It did not bite on #427 only because the next commit happened to touch non-documentation files.

## The direction, chosen by measurement

Measured **before** choosing, over the last 200 first-parent commits on `main`, running **the real script** rather than a re-implementation of its rule:

| measurement | value |
|---|---|
| documentation-only commits (the entire value of the skip) | **10 / 200 (5%)** |
| of those, landing immediately after a code commit — the exact pairing | **6** |
| longest run of consecutive documentation-only commits | **4** |
| CI runs on `main` concluding `cancelled`, each with ZERO jobs | **27 / 100** |
| cost of a backend deploy | **10-13 min** → ~2 h of runner time per 200 commits |

The 4-commit streak is the part that matters most: the wait was **unbounded**, not merely long.

### Why not keep the skip and make it safe

Skipping is safe only when nothing undeployed needs the backend — and this repository cannot answer *"did an earlier commit deploy?"* from inside a run:

- the deployed artefact carries only a **digest**, and mapping it back to a tag needs `ecr:DescribeImages`, which is **implicitDeny** for `oxy-github-deploy` (already recorded in `deploy-aws.yml`, where the build resolves its own digest for exactly this reason);
- the live task definition records **no commit at all** — measured on `oxy-homiio:80`: no SHA-shaped environment variable, `dockerLabels: null`;
- the run's outcome lives in the Actions API, which this job has no permission for — and an evicted run concluded `cancelled` **with zero jobs**, so its record cannot distinguish "did not deploy" from "was not reached".

So a scope check with no external state must assume the worst about every predecessor and walk back to the last code commit. Given that 6 of the 10 documentation commits sat directly on one, that walk-back **is** "always deploy". There is no stateless policy that is both safe and selective here.

### Why not a marker

A git ref, or the commit stamped into the task definition, would keep the optimisation. Rejected on **failure direction**, not effort: a marker that is ever wrong (stale, or claiming a newer SHA than reality) **skips a deploy** — this bug, reintroduced by its own fix. Two hours of runner time per 200 commits is the price of having no invariant that can rot.

**5% is the number to beat** if anyone wants the optimisation back; the measurement to re-run is in the script header.

## The test pins the COMBINATION

Each rule is correct alone, so testing them separately proves nothing about the interaction. `test-deployment-scope.sh` now builds a migration commit followed by a documentation commit and reads the verdict **at the documentation commit** — which is the only thing an eviction changes about this script's input. A harness cannot evict a GitHub run and does not need to.

Two mutations, killed by **different** cases, which is what makes the second case worth having rather than decorative:

| mutation | result |
|---|---|
| restore the per-commit backend decision | **3 red**, including `an evicted migration is not stranded by a docs-only next commit` |
| a plausible look-back-**ONE** half-fix | **passes** that case, **reds** `nor by a SECOND consecutive docs-only commit` |

The second mutation is the reason the streak case exists: a fix that looks back one commit is the obvious one to write, and the measured 4-commit streak is exactly what it strands.

### Where the discrimination now lives

Every backend verdict is `true` by design, so the backend cases can no longer tell a working script from `emit true` at the top of the file. The **frontend** cases carry that weight — `frontend skips a backend-only commit` and `the same pairing still skips the frontend` are the two assertions a stuck-open script fails, and the second also proves the combination fixture really is documentation-only, so the backend verdict comes from the new rule rather than from a fixture that quietly touched something.

## `ci.yml`'s comment

Corrected. It no longer claims `deployment-scope.sh` reads a single commit; it records the 27-in-100 eviction rate beside the claim that rate supports; and it states the frontend asymmetry as a deliberate trade rather than leaving it to read as an oversight.

The paragraph above it — pushes to `main` do **not** queue, a pending run IS evicted, only an in-progress one is protected — was already correct when I got here and is left alone.

## What I did NOT do

- **The frontend still skips.** `deploy-frontends.yml` triggers on `workflow_run` with `conclusion == 'success'`, so a cancelled run already skips it, and the same combination there costs a stale bundle rather than a schema/code split — against an hour-long web export. That is a trade, and `ci.yml` now says so; but it IS the same mechanism, and a wire contract splitting across it has cost this repo once before (`_id` → `id`). If that recurs, the frontend is the next place to look.
- **Nothing changes about eviction itself.** The queue-drain direction the issue lists third is outside this repository's control, and the two rules no longer combine badly without it.
- **No new permissions, no new state, no new AWS call.** The diff is three files.

## Verification

- `test-deployment-scope.sh`: **11 cases**, exit 0 — and it is wired into `ci.yml` already, so it runs on every PR.
- `test-deploy-ecs-image.sh`: 18 release cases, exit 0 (unchanged, but it shares the deploy path).
- Backend suite: **155 suites / 2144 tests, exit 0**.
- `bun run lint`: **0 errors** across all four packages.
- `ci.yml` parses as YAML; both scripts pass `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
