### PR TITLE
docs(deploy): the frontend export is 59 seconds, not an hour

### DIFF
--- a/.github/scripts/deployment-scope.sh
+++ b/.github/scripts/deployment-scope.sh
@@ -8,9 +8,27 @@
 # `paths-ignore` filters. They now trigger on `workflow_run` after CI, because a
 # push must not reach production before the suite has run — and `workflow_run`
 # supports NO path filters. Without something in their place, a docs-only commit
-# would rebuild and roll out the backend, and a backend-only commit would spend an
-# hour re-exporting the web bundle. This restores the filters that the trigger
-# change took away, and nothing more.
+# would rebuild and roll out the backend, and a backend-only commit would
+# re-export the web bundle. This restores the filters that the trigger change
+# took away, and nothing more.
+#
+# THIS PARAGRAPH USED TO SAY THE RE-EXPORT COSTS "AN HOUR". IT DOES NOT.
+#
+# Measured on run 31449277315: the `Build frontend` step is **59 seconds** and
+# the whole `deploy-frontend` job — install, shared-types build, export,
+# Cloudflare publish — is **102 seconds**. The four other real frontend deploys
+# in the surrounding ten runs are all about a minute.
+#
+# The claim came from reading `timeout-minutes: 60` on that step as a duration.
+# **It is a CEILING, not a cost**, and that is the trap worth naming here: every
+# other number in this file is a measurement, and the one that was not is the one
+# that travelled — into this comment, into ci.yml, into this directory's test
+# script, and into an issue — without anybody running it. A figure repeated from
+# memory is an assertion; re-derive it before leaning on it.
+#
+# The frontend skip is still worth keeping, on FREQUENCY rather than cost. See
+# the backend section below for that comparison, and #435 for the hazard it
+# leaves open.
 #
 # IT FAILS OPEN, DELIBERATELY
 #
@@ -68,6 +86,23 @@
 # of not having an invariant that can rot. If documentation-only commits ever
 # become a large fraction of main — the measurement to re-run is the one above,
 # and 5% is the number to beat — the trade is worth revisiting.
+#
+# WHY THE FRONTEND ARM BELOW STILL SKIPS, AND IT IS NOT THE EXPORT COST
+#
+# Measured the same way, over the same 200 commits:
+#
+#   backend skip   avoided  10/200 commits (5%),  longest streak 4
+#   frontend skip  avoids  100/200 commits (50%), longest streak 34
+#
+# So the frontend skip buys ten times as much, which is the whole difference —
+# and what it strands is a BUNDLE, republished by the next frontend commit,
+# rather than a SCHEMA that sits unapplied under green CI.
+#
+# It is a trade and not a law. At 102 seconds a deploy, always deploying the
+# frontend would cost about 2.8 hours per 200 commits against the backend's 2 —
+# affordable, which is a materially different conversation from the one the
+# "hour" figure was supporting. #435 holds the hazard, the numbers and the
+# options; this comment only stops the argument resting on a wrong number.
 #
 # THE RANGE
 #

--- a/.github/scripts/test-deployment-scope.sh
+++ b/.github/scripts/test-deployment-scope.sh
@@ -115,7 +115,10 @@ expect "an evicted migration is not stranded by a docs-only next commit" \
 #     above comes from the new rule rather than from a fixture that quietly
 #     touched something;
 #   * the frontend has no migration to strand — the same combination costs a
-#     stale bundle, and an hour-long web export is not the same trade;
+#     stale bundle, and the frontend skip avoids 100 of 200 commits against the
+#     backend's 10, which is the actual difference between the two arms (it is
+#     NOT the export cost: that is 59 s, measured on run 31449277315, and the
+#     "hour" it used to cite was `timeout-minutes: 60` read as a duration);
 #   * it is one of the two assertions here that a stuck-open script fails.
 expect "the same pairing still skips the frontend" false "$(verdict_at_head frontend)"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,21 @@ on:
 # The FRONTEND still skips, deliberately: deploy-frontends.yml triggers on
 # `workflow_run` with `conclusion == 'success'`, so a cancelled run already skips
 # it, and the same combination costs a stale bundle rather than a schema/code
-# split. That is a smaller cost against an hour-long web export, and it is a
-# trade rather than an oversight — but it IS the same mechanism, and if a wire
-# contract ever splits across it, this is the paragraph to come back to.
+# split.
+#
+# The reason is FREQUENCY, not the cost of the export. An earlier version of this
+# paragraph said "an hour-long web export"; measured on run 31449277315 the
+# export is **59 seconds** and the whole `deploy-frontend` job is **102**. The
+# hour was `timeout-minutes: 60` read as a duration — a ceiling, not a cost. What
+# actually separates the two arms is that the frontend skip avoids 100 of 200
+# commits against the backend's 10, with a longest skip streak of 34, and that
+# what it strands is a bundle the next frontend commit republishes rather than a
+# schema sitting unapplied under green CI.
+#
+# It is a trade rather than an oversight — and at 102 seconds it is a closer one
+# than it looked, so #435 carries the hazard, the numbers and the options. It IS
+# the same mechanism, and if a wire contract ever splits across it, this is the
+# paragraph to come back to.
 concurrency:
   group: ci-${{ github.ref }}
   # An EXPRESSION, and a mistyped one degrades silently to falsy — which would


### PR DESCRIPTION
Comments only. Refs #435; fixes no behaviour.

## The measurement

Three places said the frontend scope filter exists because a backend-only commit would otherwise "spend **an hour** re-exporting the web bundle". Measured on run [`31449277315`](https://github.com/OxyHQ/Homiio/actions/runs/31449277315):

| step | measured |
|---|---|
| `Build frontend` — the expo export | **59 s** |
| whole `deploy-frontend` job, install → shared-types → export → Cloudflare publish | **102 s** |

The four other real frontend deploys in the surrounding ten runs are all about a minute.

**The hour was `timeout-minutes: 60` on that step, read as a duration.** It is a ceiling, not a cost — and naming that is the point of this PR, because it is the mechanism that produced the error and the one that would produce it again.

## How it travelled

Every other number in these files is a measurement. The one that was not is the one that spread: from `deployment-scope.sh` into `ci.yml`, into `test-deployment-scope.sh`, and into an issue — four hops, no run. Two of the three code sites were written by me in #432, quoting the third.

A figure repeated from memory is an assertion, not a measurement. That rule is written down in this ecosystem, and it is easy to quote and hard to apply to a number that is already in the file you are editing.

## What replaces it

The frontend skip is still worth keeping — on **frequency**, which is the argument that actually holds. Over the same 200 first-parent commits used to justify deleting the backend skip in #430:

| | backend (deleted in #430) | frontend (kept) |
|---|---|---|
| commits the skip avoids | 10 / 200 (**5%**) | 100 / 200 (**50%**) |
| longest skip streak | 4 | **34** |
| cost of one deploy | 10-13 min | **~102 s** |
| cost of always deploying | ~2 h / 200 | **~2.8 h / 200** |
| what a dropped deploy strands | a **schema** under green CI | a **bundle** the next frontend commit republishes |

The frontend skip buys ten times as much as the backend's did, and what it strands is recoverable. That is the real asymmetry.

The comments now also state what the correction changes rather than burying it: at 102 seconds a deploy, **always deploying the frontend is affordable** (~2.8 h against the backend's ~2 h). That is a materially different conversation from the one the "hour" figure was supporting, and whoever picks up #435 should see it. The decision stays in the issue; this PR only stops the argument resting on a wrong number.

## Verification

- **Comments only, checked rather than claimed.** Filtering the diff for changed lines that are not comments and not blank returns empty. The filter carries a negative control: run over #432's diff of the same file it returns the four changed `emit` lines, so it can see code when there is code to see. (The control initially returned empty because `origin/main` had advanced under me and the range no longer touched the file — a control pointed at the wrong thing, caught because "no code changes in a commit I know changed code" is impossible.)
- `test-deployment-scope.sh`: 11 cases, exit 0.
- `test-deploy-ecs-image.sh`: 18 release cases, exit 0.
- Backend suite: **156 suites / 2167 tests, exit 0**.
- `bun run lint`: 0 errors across all four packages.
- `ci.yml` parses; both scripts pass `bash -n`.

The one surviving occurrence of the old wording is in `ci.yml`, where it is quoted in order to be corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
