### PR TITLE
docs(migration): an empty answer needs a second number, because the control can break

### DIFF
--- a/packages/backend/db/MIGRATION-CONTRACT.md
+++ b/packages/backend/db/MIGRATION-CONTRACT.md
@@ -296,6 +296,48 @@ cutover: an image built before a migration existed prints `No migrations to
 apply`, exits 0, and is otherwise byte-identical to the correct case. Compare it
 against `meta/_journal.json` at the pinned SHA and refuse if they differ.
 
+## An empty answer needs a SECOND number, because the control can be the thing that broke
+
+`~/AGENTS.md` already says to ask what a check would report if the thing it
+measures were absent, and to give every census a positive control and a vacuity
+floor. This is the sharpening that rule does not cover: **in each of the three
+cases below the control was sound in principle and useless in practice, because
+the instrument returned nothing and "nothing" is what a correct answer looks
+like too.** What caught all three was a SECOND number, derived from the same data
+by a different route, that had to agree with the first.
+
+Measured on 2026-08-11, all three while verifying migration `0014` and the deploy
+work around it:
+
+| the check | what it returned | why it was wrong | what caught it |
+|---|---|---|---|
+| catalogue diff, production-shaped database vs a fresh one | `IDENTICAL` | an ambiguous `oid` made the query error; **both** dumps were empty and `diff` compared nothing to nothing | a line-count floor: 1,722 rows expected, 0 seen |
+| census of docs-only commits on `main` | `0 pairs`, `longest streak 0` | a `split(' ', 2)` put the verdict in the wrong field, so the predicate was always false | the same run also reported **10 docs-only commits**, and a streak of 0 is impossible alongside that |
+| control on a comments-only diff | empty, i.e. "the filter cannot see code" | `origin/main` had advanced, so the range no longer touched the file | a commit known to have changed that file must show changes |
+
+The first was a missing floor. The second and third are the ones worth keeping,
+because in both **the control itself was the broken part** — a positive control
+aimed at the wrong range reports absence exactly like a clean result, and adding
+more controls of the same kind does not help.
+
+**So: before believing an empty or zero answer, have an independent expectation
+of the answer's MAGNITUDE, and prefer one you can derive from the same run.** A
+floor works when you know roughly how big the answer should be. When you do not,
+two numbers computed from one dataset by different routes will disagree if either
+route is broken — 10 docs-only commits and a zero-length streak cannot both be
+true, and that contradiction needs no prior knowledge of the right answer.
+
+The corollary is the one that keeps costing time: **a grep answers the question
+you asked, not the question you meant.** The same day, a check for whether a
+false claim had been removed from `main` returned a hit — the corrective text
+quoting the old wording in order to correct it. Both are the same failure at
+different scales: an instrument reporting faithfully about something adjacent to
+what was wanted.
+
+Related, and deliberately not repeated here: the fixture rule above (a fixture
+has to sit on the side of the distinction the test exists to make) is the same
+principle applied to test inputs rather than to measurements.
+
 ## Two branches generating a migration off one parent fork the SNAPSHOT chain
 
 **Measured on `main` at `0a9a53f6` (2026-08-11).** `drizzle-kit generate` could


### PR DESCRIPTION
Docs only, one section. This is the lesson from tonight written down, as asked.

## Where, and why not somewhere else

**`packages/backend/db/MIGRATION-CONTRACT.md`, beside the snapshot-chain rule.** Three reasons:

- all three instances arose while verifying migration `0014` and the deploy work around it, which is what that file is for;
- it already carries the sibling rule — *a fixture has to sit on the side of the distinction the test exists to make* — which is the same principle applied to test inputs rather than to measurements;
- **not** this repo's `AGENTS.md`, because the general form already exists in `~/AGENTS.md`, and Homiio's own `AGENTS.md` forbids duplicating a rule on the grounds that the copy is what people read.

The general sharpening belongs beside that existing `~/AGENTS.md` line. That is docs-keeper's call, not this branch's, and I have deliberately not made it.

## What it adds to the rule that already exists

`~/AGENTS.md` says: *ask what a check would report if the thing it measures were absent; give every census a positive control and a vacuity floor.* That rule assumes the control is sound.

Tonight, twice, **the control was the broken part** — and a control aimed at the wrong range reports absence exactly like a clean result, so adding another control of the same kind does not help.

| the check | returned | why it was wrong | what caught it |
|---|---|---|---|
| catalogue diff, production-shaped vs fresh database | `IDENTICAL` | ambiguous `oid` made the query error; **both** dumps empty, so `diff` compared nothing to nothing | line-count floor: 1,722 expected, 0 seen |
| census of docs-only commits on `main` | `0 pairs`, `streak 0` | `split(' ', 2)` put the verdict in the wrong field, so the predicate was always false | the same run reported **10 docs-only commits** — a streak of 0 cannot coexist with that |
| control proving a diff-filter sees code changes | empty | `origin/main` had advanced; the range no longer touched the file | a commit known to have changed that file must show changes |

The first is a missing floor, which the existing rule covers. The second and third are the addition: what worked was **a second number derived from the same data by a different route**, which disagrees if either route is broken and needs no prior knowledge of the right answer.

The corollary is recorded with them because it cost time the same day and is the same failure at a different scale: **a grep answers the question you asked, not the question you meant.** Checking that the false "hour-long export" claim had left `main` returned a hit — the corrective text, quoting the old wording in order to correct it.

## Verification

- `bun run check:docs` — OK, 25 authoritative pages scanned of 39 tracked markdown files.
- `bun scripts/test-check-docs.mjs` — 41 assertions passed.
- No code touched; nothing else to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
