### PR TITLE
chore(deps): bloom 1.8.0, which is six minors of one feature

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -95,7 +95,7 @@
         "@bitdrift/react-native": "^0.12.12",
         "@expo/vector-icons": "^15.1.1",
         "@homiio/shared-types": "workspace:*",
-        "@oxyhq/bloom": "^1.2.1",
+        "@oxyhq/bloom": "^1.8.0",
         "@oxyhq/core": "^21.1.0",
         "@oxyhq/expo-splash": "^0.1.0",
         "@oxyhq/services": "^30.0.1",
@@ -232,7 +232,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^1.2.1",
+    "@oxyhq/bloom": "^1.8.0",
     "@oxyhq/core": "^21.1.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "12.0.1",
@@ -807,7 +807,7 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@1.2.1", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "expo-video": "*", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "expo-video", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-1XYMURQ3kNyLAaBiHGiwcND7MEe5lTJzv61zrhM091VPIxKfzGBhiusp0D/O4j0HBzTxirxk1jJl4dByioL4lA=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@1.8.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "@react-native-community/netinfo": ">=11.1.0", "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-glass-effect": ">=0.1.9", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "expo-symbols": ">=0.4.5", "expo-video": "*", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.16.1", "react-native-keyboard-controller": ">=1.11.4", "react-native-reanimated": ">=3.13.0", "react-native-safe-area-context": ">=5.0.0", "react-native-screens": ">=3.16.0", "react-native-svg": ">=13.0.0" }, "optionalPeers": ["@react-native-community/netinfo", "expo", "expo-font", "expo-haptics", "expo-router", "expo-video", "nativewind", "react-dom", "react-native-keyboard-controller"] }, "sha512-4xJhgpC9P/eL/Wec7Jc5tcgmS/2DuGB9m5NYhQtyk/+alm7rQTFJxOFxVirQZYWYVG+rRSA5RsrLWczGLpQVfg=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@0.31.0", "", { "dependencies": { "zod": "^3.25.64" } }, "sha512-xnqnjgqzCggotKuGDPd1xf0oumDSrId8mCEq/mt8l6WOEw/u/oyUm9vGt4g1OfDLpd9gSm2vcNFdDKBWt14wUg=="],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "overrides": {
     "@oxyhq/core": "^21.1.0",
-    "@oxyhq/bloom": "^1.2.1",
+    "@oxyhq/bloom": "^1.8.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -27,7 +27,7 @@
     "@bitdrift/react-native": "^0.12.12",
     "@expo/vector-icons": "^15.1.1",
     "@homiio/shared-types": "workspace:*",
-    "@oxyhq/bloom": "^1.2.1",
+    "@oxyhq/bloom": "^1.8.0",
     "@oxyhq/core": "^21.1.0",
     "@oxyhq/expo-splash": "^0.1.0",
     "@oxyhq/services": "^30.0.1",


### PR DESCRIPTION
`@oxyhq/bloom` `1.2.1` → `1.8.0`.

## Not the major it was briefed as

The task described this as `^0.84.0 → ^1.8.0`, a major crossing with the
`PortalProvider`/`PortalOutlet` migration and the 34→64 colour-preset expansion
to absorb. `origin/main` is already on **1.2.1** — #439 landed the 1.x crossing,
and `app/_layout.tsx` already mounts `PortalProvider`/`PortalOutlet` inside
`BloomProvider`. So the real change is six minors inside 1.x.

## What is in the range

`1.3.0`–`1.8.0` is one feature being built out: `media-flight`, a shared media
surface that survives a route change, plus the vendored JavaScript layer of
`react-native-teleport` and the `level-picker` component. Every release ADDS.
Nothing Homiio imports changed shape, and `media-flight`/`teleport` appear
nowhere in this app — the new surface is inert here.

The manifests agree: **3 dependencies and 20 peers, identical ranges to 1.2.1**.
Nothing else in the root `overrides` block needs a companion edit; in particular
`@react-native-community/netinfo` is still an optional peer of Bloom, so its pin
stays where it was.

## The bump itself

Three lines: the range in `packages/frontend/package.json`, the root `overrides`
entry that beats it, and the resolution record in `bun.lock` — committed
together.

- Installed package reports `1.8.0` (read back from its own `package.json`).
- One lockfile edge: `grep -oE '"[^"]*@oxyhq/bloom": \["@oxyhq/bloom@[0-9.]+' bun.lock | sort -u` prints exactly one line, and no nested `1.2.1` survived.
- `bun install --frozen-lockfile` is a no-op on the committed lockfile.

Homiio reaches Bloom through 25 subpath exports plus the root (`typography`
alone is 157 imports); all still resolve.

## Gates, run locally before pushing

Every step of every CI job, by job name:

| Job | Result |
| --- | --- |
| `backend` | typecheck clean · 17 migrations declare a phase · **156 suites / 2173 tests passed** (floor 1520) |
| `frontend` | **40 suites / 553 tests passed** (floor 110) |
| `frontend-typecheck` | `tsc --noEmit` clean |
| `frontend-bundle` | production web export succeeds |
| `lint` | 0 errors across all four packages (backend 101 warnings, frontend 23 — the counts already recorded in `ci.yml`) |
| `lockfile` | `check:lockfile` in sync · version pins undrifted · docs OK · AGENTS.md within budget · all 8 gate self-tests pass |

## Plus a real browser, because none of the above evaluates a component

`tsc` and `expo export` compile without rendering anything, and the one runtime
failure this migration family is known for — a provider mounted outside the
provider it needs — is invisible to both. So the exported bundle was served and
loaded in headless Chrome: React paints, **0 page errors, 0 console errors**.

That check was given a positive control first: with a `throw` appended to the
entry chunk the same harness reports `SMOKE FAILED`, so the green discriminates
rather than merely being green. (The error listener is what fired; the
paint-count assertion did not, since the throw lands after first paint.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
